### PR TITLE
feat: return metadata on content manager endpoints

### DIFF
--- a/api-tests/core/content-manager/api/basic-compo-repeatable.test.api.js
+++ b/api-tests/core/content-manager/api/basic-compo-repeatable.test.api.js
@@ -79,9 +79,9 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeDefined();
-    data.productsWithCompo.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.productsWithCompo.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -91,8 +91,8 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithCompo[0]);
-    expect(res.body.publishedAt).toBeDefined();
+    expect(res.body.data).toMatchObject(data.productsWithCompo[0]);
+    expect(res.body.data.publishedAt).toBeDefined();
   });
 
   test('Update product with compo', async () => {
@@ -113,10 +113,10 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithCompo[0].id);
-    expect(res.body.publishedAt).toBeDefined();
-    data.productsWithCompo[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithCompo[0].id);
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.productsWithCompo[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {

--- a/api-tests/core/content-manager/api/basic-compo.test.api.js
+++ b/api-tests/core/content-manager/api/basic-compo.test.api.js
@@ -76,9 +76,9 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeDefined();
-    data.productsWithCompo.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.productsWithCompo.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -88,8 +88,8 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithCompo[0]);
-    expect(res.body.publishedAt).toBeDefined();
+    expect(res.body.data).toMatchObject(data.productsWithCompo[0]);
+    expect(res.body.data.publishedAt).toBeDefined();
   });
 
   test('Update product with compo', async () => {
@@ -108,10 +108,10 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithCompo[0].id);
-    expect(res.body.publishedAt).toBeDefined();
-    data.productsWithCompo[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithCompo[0].id);
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.productsWithCompo[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {
@@ -141,11 +141,11 @@ describe('CM API - Basic + compo', () => {
 
     const res = await rq({
       method: 'POST',
-      url: `/content-manager/collection-types/api::product-with-compo.product-with-compo/clone/${createdProduct.id}`,
+      url: `/content-manager/collection-types/api::product-with-compo.product-with-compo/clone/${createdProduct.data.id}`,
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
+    expect(res.body.data).toMatchObject(product);
   });
 
   describe.skip('validation', () => {

--- a/api-tests/core/content-manager/api/basic-dp-compo-repeatable.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dp-compo-repeatable.test.api.js
@@ -81,9 +81,9 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithCompoAndDP.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithCompoAndDP.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -93,8 +93,8 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithCompoAndDP[0]);
-    expect(res.body.publishedAt).toBeNull();
+    expect(res.body.data).toMatchObject(data.productsWithCompoAndDP[0]);
+    expect(res.body.data.publishedAt).toBeNull();
   });
 
   test('Update product with compo', async () => {
@@ -115,10 +115,10 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithCompoAndDP[0].id);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithCompoAndDP[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithCompoAndDP[0].id);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithCompoAndDP[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {
@@ -145,8 +145,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
 
     test('Can create product with compo - minLength', async () => {
@@ -167,8 +167,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
 
     test('Cannot create product with compo - maxLength', async () => {
@@ -225,8 +225,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
   });
 });

--- a/api-tests/core/content-manager/api/basic-dp-compo.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dp-compo.test.api.js
@@ -78,9 +78,9 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithCompoAndDP.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithCompoAndDP.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -90,8 +90,8 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithCompoAndDP[0]);
-    expect(res.body.publishedAt).toBeNull();
+    expect(res.body.data).toMatchObject(data.productsWithCompoAndDP[0]);
+    expect(res.body.data.publishedAt).toBeNull();
   });
 
   test('Update product with compo', async () => {
@@ -110,10 +110,10 @@ describe('CM API - Basic + compo', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithCompoAndDP[0].id);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithCompoAndDP[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithCompoAndDP[0].id);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithCompoAndDP[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {
@@ -140,8 +140,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
 
     test('Can create product with compo - minLength', async () => {
@@ -160,8 +160,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
 
     test('Cannot create product with compo - maxLength', async () => {
@@ -214,8 +214,8 @@ describe('CM API - Basic + compo', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithCompoAndDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithCompoAndDP.push(res.body.data);
     });
   });
 
@@ -237,7 +237,7 @@ describe('CM API - Basic + compo', () => {
 
       const publishRes = await rq({
         method: 'POST',
-        url: `/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp/${res.body.id}/actions/publish`,
+        url: `/content-manager/collection-types/api::product-with-compo-and-dp.product-with-compo-and-dp/${res.body.data.id}/actions/publish`,
         body: product,
       });
 

--- a/api-tests/core/content-manager/api/basic-dp-dz.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dp-dz.test.api.js
@@ -81,9 +81,9 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithDzAndDP.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithDzAndDP.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -93,8 +93,8 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithDzAndDP[0]);
-    expect(res.body.publishedAt).toBeNull();
+    expect(res.body.data).toMatchObject(data.productsWithDzAndDP[0]);
+    expect(res.body.data.publishedAt).toBeNull();
   });
 
   test('Update product with compo', async () => {
@@ -116,10 +116,10 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithDzAndDP[0].id);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithDzAndDP[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithDzAndDP[0].id);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithDzAndDP[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {
@@ -152,16 +152,16 @@ describe('CM API - Basic + dz', () => {
 
     const res = await rq({
       method: 'POST',
-      url: `/content-manager/collection-types/api::product-with-dz-and-dp.product-with-dz-and-dp/clone/${createdProduct.id}`,
+      url: `/content-manager/collection-types/api::product-with-dz-and-dp.product-with-dz-and-dp/clone/${createdProduct.data.id}`,
       body: {
         publishedAt: new Date().toISOString(),
       },
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
+    expect(res.body.data).toMatchObject(product);
     // When cloning the new entry must be a draft
-    expect(res.body.publishedAt).toBeNull();
+    expect(res.body.data.publishedAt).toBeNull();
   });
 
   describe('validation', () => {
@@ -181,8 +181,8 @@ describe('CM API - Basic + dz', () => {
         });
 
         expect(res.statusCode).toBe(200);
-        expect(res.body).toMatchObject(product);
-        data.productsWithDzAndDP.push(res.body);
+        expect(res.body.data).toMatchObject(product);
+        data.productsWithDzAndDP.push(res.body.data);
       });
 
       test(`Can ${method} product with compo - minLength`, async () => {
@@ -206,8 +206,8 @@ describe('CM API - Basic + dz', () => {
         });
 
         expect(res.statusCode).toBe(200);
-        expect(res.body).toMatchObject(product);
-        data.productsWithDzAndDP.push(res.body);
+        expect(res.body.data).toMatchObject(product);
+        data.productsWithDzAndDP.push(res.body.data);
       });
 
       test(`Cannot ${method} product with compo - maxLength`, async () => {
@@ -270,8 +270,8 @@ describe('CM API - Basic + dz', () => {
         });
 
         expect(res.statusCode).toBe(200);
-        expect(res.body).toMatchObject(product);
-        data.productsWithDzAndDP.push(res.body);
+        expect(res.body.data).toMatchObject(product);
+        data.productsWithDzAndDP.push(res.body.data);
       });
 
       test(`Cannot ${method} product with compo - missing __component`, async () => {

--- a/api-tests/core/content-manager/api/basic-dp.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dp.test.api.js
@@ -72,9 +72,9 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithDP.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithDP.push(res.body.data);
   });
 
   test('Create a product + cannot overwrite publishedAt', async () => {
@@ -90,9 +90,9 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(_.omit(product, 'publishedAt'));
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithDP.push(res.body);
+    expect(res.body.data).toMatchObject(_.omit(product, 'publishedAt'));
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithDP.push(res.body.data);
   });
 
   test('Read all products', async () => {
@@ -129,10 +129,10 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(_.omit(product, 'publishedAt'));
-    expect(res.body.id).toEqual(data.productsWithDP[0].id);
-    expect(res.body.publishedAt).toBeNull();
-    data.productsWithDP[0] = res.body;
+    expect(res.body.data).toMatchObject(_.omit(product, 'publishedAt'));
+    expect(res.body.data.id).toEqual(data.productsWithDP[0].id);
+    expect(res.body.data.publishedAt).toBeNull();
+    data.productsWithDP[0] = res.body.data;
   });
 
   test('Update product + cannot overwrite publishedAt', async () => {
@@ -148,10 +148,10 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(_.omit(product, ['publishedAt']));
-    expect(res.body.publishedAt).toBeNull();
-    expect(res.body.id).toEqual(data.productsWithDP[0].id);
-    data.productsWithDP[0] = res.body;
+    expect(res.body.data).toMatchObject(_.omit(product, ['publishedAt']));
+    expect(res.body.data.publishedAt).toBeNull();
+    expect(res.body.data.id).toEqual(data.productsWithDP[0].id);
+    data.productsWithDP[0] = res.body.data;
   });
 
   test('Publish a product, expect publishedAt to be defined', async () => {
@@ -162,9 +162,9 @@ describe('CM API - Basic', () => {
       method: 'POST',
     });
 
-    data.productsWithDP[0] = body;
+    data.productsWithDP[0] = body.data;
 
-    expect(body.publishedAt).toBeISODate();
+    expect(body.data.publishedAt).toBeISODate();
   });
 
   // FIX
@@ -247,8 +247,8 @@ describe('CM API - Basic', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(product);
-      data.productsWithDP.push(res.body);
+      expect(res.body.data).toMatchObject(product);
+      data.productsWithDP.push(res.body.data);
     });
 
     test('Can create a product - required', async () => {
@@ -262,11 +262,11 @@ describe('CM API - Basic', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         ...product,
       });
-      expect(_.isNil(res.body.name)).toBe(true);
-      data.productsWithDP.push(res.body);
+      expect(_.isNil(res.body.data.name)).toBe(true);
+      data.productsWithDP.push(res.body.data);
     });
 
     test('Cannot create a product - maxLength', async () => {

--- a/api-tests/core/content-manager/api/basic-dz.test.api.js
+++ b/api-tests/core/content-manager/api/basic-dz.test.api.js
@@ -79,9 +79,9 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.publishedAt).toBe(null);
-    data.productsWithDz.push(res.body);
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.publishedAt).toBe(null);
+    data.productsWithDz.push(res.body.data);
   });
 
   test('Read product with compo', async () => {
@@ -91,8 +91,8 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(data.productsWithDz[0]);
-    expect(res.body.publishedAt).toBe(null);
+    expect(res.body.data).toMatchObject(data.productsWithDz[0]);
+    expect(res.body.data.publishedAt).toBe(null);
   });
 
   test('Update product with compo', async () => {
@@ -114,10 +114,10 @@ describe('CM API - Basic + dz', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
-    expect(res.body.id).toEqual(data.productsWithDz[0].id);
-    expect(res.body.publishedAt).toBe(null);
-    data.productsWithDz[0] = res.body;
+    expect(res.body.data).toMatchObject(product);
+    expect(res.body.data.id).toEqual(data.productsWithDz[0].id);
+    expect(res.body.data.publishedAt).toBe(null);
+    data.productsWithDz[0] = res.body.data;
   });
 
   test('Delete product with compo', async () => {
@@ -150,12 +150,12 @@ describe('CM API - Basic + dz', () => {
 
     const res = await rq({
       method: 'POST',
-      url: `/content-manager/collection-types/api::product-with-dz.product-with-dz/clone/${createdProduct.id}`,
+      url: `/content-manager/collection-types/api::product-with-dz.product-with-dz/clone/${createdProduct.data.id}`,
       body: {},
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(product);
+    expect(res.body.data).toMatchObject(product);
   });
 
   // TODO: Add document validator in document service

--- a/api-tests/core/content-manager/api/basic.test.api.js
+++ b/api-tests/core/content-manager/api/basic.test.api.js
@@ -68,10 +68,10 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(omit('hiddenAttribute', product));
-    expect(res.body).not.toHaveProperty('hiddenAttribute');
-    expect(res.body.publishedAt).toBeDefined();
-    data.products.push(res.body);
+    expect(res.body.data).toMatchObject(omit('hiddenAttribute', product));
+    expect(res.body.data).not.toHaveProperty('hiddenAttribute');
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.products.push(res.body.data);
   });
 
   test('Read product', async () => {
@@ -107,10 +107,10 @@ describe('CM API - Basic', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(omit('hiddenAttribute', product));
-    expect(res.body.id).toEqual(data.products[0].id);
-    expect(res.body.publishedAt).toBeDefined();
-    data.products[0] = res.body;
+    expect(res.body.data).toMatchObject(omit('hiddenAttribute', product));
+    expect(res.body.data.id).toEqual(data.products[0].id);
+    expect(res.body.data.publishedAt).toBeDefined();
+    data.products[0] = res.body.data;
   });
 
   test('Delete product', async () => {
@@ -137,12 +137,12 @@ describe('CM API - Basic', () => {
 
     const res = await rq({
       method: 'POST',
-      url: `/content-manager/collection-types/api::product.product/clone/${createdProduct.id}`,
+      url: `/content-manager/collection-types/api::product.product/clone/${createdProduct.data.id}`,
       body: {},
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject(omit('hiddenAttribute', product));
+    expect(res.body.data).toMatchObject(omit('hiddenAttribute', product));
   });
 
   test('Clone and update product', async () => {
@@ -159,14 +159,14 @@ describe('CM API - Basic', () => {
 
     const res = await rq({
       method: 'POST',
-      url: `/content-manager/collection-types/api::product.product/clone/${createdProduct.id}`,
+      url: `/content-manager/collection-types/api::product.product/clone/${createdProduct.data.id}`,
       body: {
         name: 'Product 1 updated',
       },
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       name: 'Product 1 updated',
       description: 'Product description',
     });

--- a/api-tests/core/content-manager/api/populate-dz.test.api.js
+++ b/api-tests/core/content-manager/api/populate-dz.test.api.js
@@ -149,9 +149,9 @@ describe.skip('CM API - Populate dz', () => {
 
     expect(productRes.status).toBe(200);
 
-    data.productsWithDz.push(productRes.body);
+    data.productsWithDz.push(productRes.body.data);
 
-    expect(productRes.body).toMatchObject({
+    expect(productRes.body.data).toMatchObject({
       name: 'name',
       dz: [
         {

--- a/api-tests/core/content-manager/components/repeatable-not-required-min-max.test.api.js
+++ b/api-tests/core/content-manager/components/repeatable-not-required-min-max.test.api.js
@@ -67,8 +67,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -153,7 +153,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual([]);
+      expect(res.body.data.field).toEqual([]);
     });
   });
 
@@ -175,18 +175,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'firstString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -238,7 +238,7 @@ describe('Non repeatable and Not required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -250,16 +250,16 @@ describe('Non repeatable and Not required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -281,14 +281,14 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      expect(res.body.field[0]).toMatchObject({
+      expect(res.body.data.field[0]).toMatchObject({
         name: 'someString',
       });
-      expect(res.body.field[1]).toMatchObject({
+      expect(res.body.data.field[1]).toMatchObject({
         name: 'otherString',
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -305,28 +305,28 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(Array.isArray(updateRes.body.field)).toBe(true);
+      expect(Array.isArray(updateRes.body.data.field)).toBe(true);
 
-      expect(updateRes.body.field[0]).toMatchObject({
+      expect(updateRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(updateRes.body.field[1]).toMatchObject({
+      expect(updateRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -348,7 +348,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -356,21 +356,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -391,7 +391,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -406,14 +406,14 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(400);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(res.body);
+      expect(getRes.body.data).toMatchObject(res.body.data);
     });
 
     test('Throws when too many items', async () => {
@@ -433,7 +433,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -463,14 +463,14 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(400);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(res.body);
+      expect(getRes.body.data).toMatchObject(res.body.data);
     });
 
     test('Replaces the previous components if sent without id', async () => {
@@ -488,7 +488,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -506,13 +506,13 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(200);
 
-      const oldIds = res.body.field.map((val) => val.id);
-      updateRes.body.field.forEach((val) => {
+      const oldIds = res.body.data.field.map((val) => val.id);
+      updateRes.body.data.field.forEach((val) => {
         expect(oldIds.includes(val.id)).toBe(false);
       });
 
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -523,15 +523,15 @@ describe('Non repeatable and Not required component', () => {
         ],
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -560,7 +560,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -597,18 +597,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
-              id: res.body.field[0].id, // send old id to update the previous component
+              id: res.body.data.field[0].id, // send old id to update the previous component
               name: 'newOne',
             },
             {
               name: 'newTwo',
             },
             {
-              id: res.body.field[2].id,
+              id: res.body.data.field[2].id,
               name: 'three',
             },
             {
@@ -622,17 +622,17 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [
           {
-            id: res.body.field[0].id,
+            id: res.body.data.field[0].id,
             name: 'newOne',
           },
           {
             name: 'newTwo',
           },
           {
-            id: res.body.field[2].id,
+            id: res.body.data.field[2].id,
             name: 'three',
           },
           {
@@ -643,16 +643,16 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(200);
 
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -677,7 +677,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -685,7 +685,7 @@ describe('Non repeatable and Not required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/components/repeatable-not-required.test.api.js
+++ b/api-tests/core/content-manager/components/repeatable-not-required.test.api.js
@@ -62,8 +62,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -97,7 +97,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual([]);
+      expect(res.body.data.field).toEqual([]);
     });
 
     test('Can send input without the component field', async () => {
@@ -109,7 +109,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual([]);
+      expect(res.body.data.field).toEqual([]);
     });
   });
 
@@ -131,19 +131,19 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'firstString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -192,7 +192,7 @@ describe('Non repeatable and Not required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -204,16 +204,16 @@ describe('Non repeatable and Not required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -235,14 +235,14 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      expect(res.body.field[0]).toMatchObject({
+      expect(res.body.data.field[0]).toMatchObject({
         name: 'someString',
       });
-      expect(res.body.field[1]).toMatchObject({
+      expect(res.body.data.field[1]).toMatchObject({
         name: 'otherString',
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -259,28 +259,28 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(Array.isArray(updateRes.body.field)).toBe(true);
+      expect(Array.isArray(updateRes.body.data.field)).toBe(true);
 
-      expect(updateRes.body.field[0]).toMatchObject({
+      expect(updateRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(updateRes.body.field[1]).toMatchObject({
+      expect(updateRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -302,7 +302,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -310,21 +310,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -342,7 +342,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [],
         },
@@ -352,21 +352,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [],
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectResult);
+      expect(updateRes.body.data).toMatchObject(expectResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectResult);
+      expect(getRes.body.data).toMatchObject(expectResult);
     });
 
     test('Replaces the previous components if sent without id', async () => {
@@ -383,7 +383,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -398,13 +398,13 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(200);
 
-      const oldIds = res.body.field.map((val) => val.id);
-      updateRes.body.field.forEach((val) => {
+      const oldIds = res.body.data.field.map((val) => val.id);
+      updateRes.body.data.field.forEach((val) => {
         expect(oldIds.includes(val.id)).toBe(false);
       });
 
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -412,15 +412,15 @@ describe('Non repeatable and Not required component', () => {
         ],
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -440,7 +440,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -474,18 +474,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
-              id: res.body.field[0].id, // send old id to update the previous component
+              id: res.body.data.field[0].id, // send old id to update the previous component
               name: 'newOne',
             },
             {
               name: 'newTwo',
             },
             {
-              id: res.body.field[2].id,
+              id: res.body.data.field[2].id,
               name: 'three',
             },
             {
@@ -499,17 +499,17 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [
           {
-            id: res.body.field[0].id,
+            id: res.body.data.field[0].id,
             name: 'newOne',
           },
           {
             name: 'newTwo',
           },
           {
-            id: res.body.field[2].id,
+            id: res.body.data.field[2].id,
             name: 'three',
           },
           {
@@ -519,16 +519,16 @@ describe('Non repeatable and Not required component', () => {
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -553,7 +553,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -561,7 +561,7 @@ describe('Non repeatable and Not required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/components/repeatable-required-min-max.test.api.js
+++ b/api-tests/core/content-manager/components/repeatable-required-min-max.test.api.js
@@ -64,8 +64,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -90,8 +90,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -181,18 +181,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'firstString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -241,7 +241,7 @@ describe('Non repeatable and Not required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -253,16 +253,16 @@ describe('Non repeatable and Not required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -284,14 +284,14 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      expect(res.body.field[0]).toMatchObject({
+      expect(res.body.data.field[0]).toMatchObject({
         name: 'someString',
       });
-      expect(res.body.field[1]).toMatchObject({
+      expect(res.body.data.field[1]).toMatchObject({
         name: 'otherString',
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -308,28 +308,28 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(Array.isArray(updateRes.body.field)).toBe(true);
+      expect(Array.isArray(updateRes.body.data.field)).toBe(true);
 
-      expect(updateRes.body.field[0]).toMatchObject({
+      expect(updateRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(updateRes.body.field[1]).toMatchObject({
+      expect(updateRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -351,7 +351,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -359,21 +359,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -391,7 +391,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [],
         },
@@ -402,14 +402,14 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(400);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(res.body);
+      expect(getRes.body.data).toMatchObject(res.body.data);
     });
 
     test('Throws when too many items', async () => {
@@ -426,7 +426,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -456,14 +456,14 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(400);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(res.body);
+      expect(getRes.body.data).toMatchObject(res.body.data);
     });
 
     test('Replaces the previous components if sent without id', async () => {
@@ -480,7 +480,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -495,13 +495,13 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(200);
 
-      const oldIds = res.body.field.map((val) => val.id);
-      updateRes.body.field.forEach((val) => {
+      const oldIds = res.body.data.field.map((val) => val.id);
+      updateRes.body.data.field.forEach((val) => {
         expect(oldIds.includes(val.id)).toBe(false);
       });
 
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -509,15 +509,15 @@ describe('Non repeatable and Not required component', () => {
         ],
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -540,7 +540,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -577,18 +577,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
-              id: res.body.field[0].id, // send old id to update the previous component
+              id: res.body.data.field[0].id, // send old id to update the previous component
               name: 'newOne',
             },
             {
               name: 'newTwo',
             },
             {
-              id: res.body.field[2].id,
+              id: res.body.data.field[2].id,
               name: 'three',
             },
             {
@@ -602,17 +602,17 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [
           {
-            id: res.body.field[0].id,
+            id: res.body.data.field[0].id,
             name: 'newOne',
           },
           {
             name: 'newTwo',
           },
           {
-            id: res.body.field[2].id,
+            id: res.body.data.field[2].id,
             name: 'three',
           },
           {
@@ -622,16 +622,16 @@ describe('Non repeatable and Not required component', () => {
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -656,7 +656,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -664,7 +664,7 @@ describe('Non repeatable and Not required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/components/repeatable-required.test.api.js
+++ b/api-tests/core/content-manager/components/repeatable-required.test.api.js
@@ -62,8 +62,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -88,8 +88,8 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual(
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             id: expect.anything(),
@@ -123,7 +123,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual([]);
+      expect(res.body.data.field).toEqual([]);
     });
 
     test('Throws when component is not provided', async () => {
@@ -139,7 +139,7 @@ describe('Non repeatable and Not required component', () => {
   });
 
   describe('GET entries', () => {
-    test('Data is orderd in the order sent', async () => {
+    test('Data is ordered in the order sent', async () => {
       const res = await rq.post('/', {
         body: {
           field: [
@@ -156,19 +156,19 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'firstString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -217,7 +217,7 @@ describe('Non repeatable and Not required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -229,16 +229,16 @@ describe('Non repeatable and Not required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -260,14 +260,14 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      expect(res.body.field[0]).toMatchObject({
+      expect(res.body.data.field[0]).toMatchObject({
         name: 'someString',
       });
-      expect(res.body.field[1]).toMatchObject({
+      expect(res.body.data.field[1]).toMatchObject({
         name: 'otherString',
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -284,28 +284,28 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(Array.isArray(updateRes.body.field)).toBe(true);
+      expect(Array.isArray(updateRes.body.data.field)).toBe(true);
 
-      expect(updateRes.body.field[0]).toMatchObject({
+      expect(updateRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(updateRes.body.field[1]).toMatchObject({
+      expect(updateRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(Array.isArray(getRes.body.field)).toBe(true);
+      expect(Array.isArray(getRes.body.data.field)).toBe(true);
 
-      expect(getRes.body.field[0]).toMatchObject({
+      expect(getRes.body.data.field[0]).toMatchObject({
         name: 'otherString',
       });
-      expect(getRes.body.field[1]).toMatchObject({
+      expect(getRes.body.data.field[1]).toMatchObject({
         name: 'someString',
       });
     });
@@ -327,7 +327,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -335,21 +335,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -367,7 +367,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [],
         },
@@ -377,21 +377,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [],
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectResult);
+      expect(updateRes.body.data).toMatchObject(expectResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectResult);
+      expect(getRes.body.data).toMatchObject(expectResult);
     });
 
     test('Replaces the previous components if sent without id', async () => {
@@ -408,7 +408,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -423,13 +423,13 @@ describe('Non repeatable and Not required component', () => {
 
       expect(updateRes.statusCode).toBe(200);
 
-      const oldIds = res.body.field.map((val) => val.id);
-      updateRes.body.field.forEach((val) => {
+      const oldIds = res.body.data.field.map((val) => val.id);
+      updateRes.body.data.field.forEach((val) => {
         expect(oldIds.includes(val.id)).toBe(false);
       });
 
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -437,15 +437,15 @@ describe('Non repeatable and Not required component', () => {
         ],
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: [
           {
             name: 'new String',
@@ -468,7 +468,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
@@ -505,18 +505,18 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: [
             {
-              id: res.body.field[0].id, // send old id to update the previous component
+              id: res.body.data.field[0].id, // send old id to update the previous component
               name: 'newOne',
             },
             {
               name: 'newTwo',
             },
             {
-              id: res.body.field[2].id,
+              id: res.body.data.field[2].id,
               name: 'three',
             },
             {
@@ -530,17 +530,17 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: [
           {
-            id: res.body.field[0].id,
+            id: res.body.data.field[0].id,
             name: 'newOne',
           },
           {
             name: 'newTwo',
           },
           {
-            id: res.body.field[2].id,
+            id: res.body.data.field[2].id,
             name: 'three',
           },
           {
@@ -550,16 +550,16 @@ describe('Non repeatable and Not required component', () => {
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -584,7 +584,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -592,7 +592,7 @@ describe('Non repeatable and Not required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/components/single-not-required.test.api.js
+++ b/api-tests/core/content-manager/components/single-not-required.test.api.js
@@ -61,7 +61,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual(
+      expect(res.body.data.field).toEqual(
         expect.objectContaining({
           id: expect.anything(),
           name: 'someString',
@@ -82,7 +82,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual(
+      expect(res.body.data.field).toEqual(
         expect.objectContaining({
           id: expect.anything(),
           name: 'someValue',
@@ -114,7 +114,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toBe(null);
+      expect(res.body.data.field).toBe(null);
     });
 
     test('Can send input without the component field', async () => {
@@ -126,7 +126,7 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toBe(null);
+      expect(res.body.data.field).toBe(null);
     });
   });
 
@@ -167,7 +167,7 @@ describe('Non repeatable and Not required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -179,16 +179,16 @@ describe('Non repeatable and Not required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -205,7 +205,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -213,21 +213,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -243,7 +243,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: null,
         },
@@ -253,21 +253,21 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: null,
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectResult);
+      expect(updateRes.body.data).toMatchObject(expectResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectResult);
+      expect(getRes.body.data).toMatchObject(expectResult);
     });
 
     test('Replaces the previous component if sent without id', async () => {
@@ -282,7 +282,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
             name: 'new String',
@@ -294,23 +294,23 @@ describe('Non repeatable and Not required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body.field.id).not.toBe(res.body.field.id);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data.field.id).not.toBe(res.body.data.field.id);
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: {
           name: 'new String',
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: {
           name: 'new String',
         },
@@ -326,7 +326,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
             id: 'invalid_id',
@@ -350,10 +350,10 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
-            id: res.body.field.id, // send old id to update the previous component
+            id: res.body.data.field.id, // send old id to update the previous component
             name: 'new String',
           },
         },
@@ -363,24 +363,24 @@ describe('Non repeatable and Not required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: {
-          id: res.body.field.id,
+          id: res.body.data.field.id,
           name: 'new String',
         },
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -394,7 +394,7 @@ describe('Non repeatable and Not required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -402,7 +402,7 @@ describe('Non repeatable and Not required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/components/single-required.test.api.js
+++ b/api-tests/core/content-manager/components/single-required.test.api.js
@@ -60,7 +60,7 @@ describe('Non repeatable and required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual(
+      expect(res.body.data.field).toEqual(
         expect.objectContaining({
           id: expect.anything(),
           name: 'someString',
@@ -81,7 +81,7 @@ describe('Non repeatable and required component', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body.field).toEqual(
+      expect(res.body.data.field).toEqual(
         expect.objectContaining({
           id: expect.anything(),
           name: 'someValue',
@@ -116,7 +116,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const res = await rq.post(`/${creationRes.body.id}/actions/publish`);
+      const res = await rq.post(`/${creationRes.body.data.id}/actions/publish`);
 
       expect(res.statusCode).toBe(400);
     });
@@ -129,7 +129,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const res = await rq.post(`/${creationRes.body.id}/actions/publish`);
+      const res = await rq.post(`/${creationRes.body.data.id}/actions/publish`);
 
       expect(res.statusCode).toBe(400);
     });
@@ -172,7 +172,7 @@ describe('Non repeatable and required component', () => {
           },
         });
 
-        const updateRes = await rq.put(`/${res.body.id}`, {
+        const updateRes = await rq.put(`/${res.body.data.id}`, {
           body: {
             field: value,
           },
@@ -184,16 +184,16 @@ describe('Non repeatable and required component', () => {
         expect(updateRes.statusCode).toBe(400);
 
         // shouldn't have been updated
-        const getRes = await rq.get(`/${res.body.id}`, {
+        const getRes = await rq.get(`/${res.body.data.id}`, {
           qs: {
             populate: ['field'],
           },
         });
 
         expect(getRes.statusCode).toBe(200);
-        expect(getRes.body).toMatchObject({
-          id: res.body.id,
-          field: res.body.field,
+        expect(getRes.body.data).toMatchObject({
+          id: res.body.data.id,
+          field: res.body.data.field,
         });
       }
     );
@@ -210,7 +210,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {},
         qs: {
           populate: ['field'],
@@ -218,21 +218,21 @@ describe('Non repeatable and required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
-        field: res.body.field,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
+        field: res.body.data.field,
       });
     });
 
@@ -249,7 +249,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${creationRes.body.id}`, {
+      const updateRes = await rq.put(`/${creationRes.body.data.id}`, {
         body: {
           field: null,
         },
@@ -258,18 +258,18 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const res = await rq.post(`/${updateRes.body.id}/actions/publish`);
+      const res = await rq.post(`/${updateRes.body.data.id}/actions/publish`);
 
       expect(res.statusCode).toBe(400);
 
-      const getRes = await rq.get(`/${creationRes.body.id}`, {
+      const getRes = await rq.get(`/${creationRes.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(updateRes.body);
+      expect(getRes.body.data).toMatchObject(updateRes.body.data);
     });
 
     test('Replaces the previous component if sent without id', async () => {
@@ -284,7 +284,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
             name: 'new String',
@@ -296,23 +296,23 @@ describe('Non repeatable and required component', () => {
       });
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body.field.id).not.toBe(res.body.field.id);
-      expect(updateRes.body).toMatchObject({
-        id: res.body.id,
+      expect(updateRes.body.data.field.id).not.toBe(res.body.data.field.id);
+      expect(updateRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: {
           name: 'new String',
         },
       });
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject({
-        id: res.body.id,
+      expect(getRes.body.data).toMatchObject({
+        id: res.body.data.id,
         field: {
           name: 'new String',
         },
@@ -331,7 +331,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
             id: 'invalid_id',
@@ -355,10 +355,10 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const updateRes = await rq.put(`/${res.body.id}`, {
+      const updateRes = await rq.put(`/${res.body.data.id}`, {
         body: {
           field: {
-            id: res.body.field.id, // send old id to update the previous component
+            id: res.body.data.field.id, // send old id to update the previous component
             name: 'new String',
           },
         },
@@ -368,24 +368,24 @@ describe('Non repeatable and required component', () => {
       });
 
       const expectedResult = {
-        id: res.body.id,
+        id: res.body.data.id,
         field: {
-          id: res.body.field.id,
+          id: res.body.data.field.id,
           name: 'new String',
         },
       };
 
       expect(updateRes.statusCode).toBe(200);
-      expect(updateRes.body).toMatchObject(expectedResult);
+      expect(updateRes.body.data).toMatchObject(expectedResult);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
       });
 
       expect(getRes.statusCode).toBe(200);
-      expect(getRes.body).toMatchObject(expectedResult);
+      expect(getRes.body.data).toMatchObject(expectedResult);
     });
   });
 
@@ -402,7 +402,7 @@ describe('Non repeatable and required component', () => {
         },
       });
 
-      const deleteRes = await rq.delete(`/${res.body.id}`, {
+      const deleteRes = await rq.delete(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },
@@ -410,7 +410,7 @@ describe('Non repeatable and required component', () => {
 
       expect(deleteRes.statusCode).toBe(200);
 
-      const getRes = await rq.get(`/${res.body.id}`, {
+      const getRes = await rq.get(`/${res.body.data.id}`, {
         qs: {
           populate: ['field'],
         },

--- a/api-tests/core/content-manager/dynamiczones/simple.test.api.js
+++ b/api-tests/core/content-manager/dynamiczones/simple.test.api.js
@@ -119,8 +119,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -152,8 +152,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field.length).toBe(0);
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field.length).toBe(0);
     });
 
     test('Throw if min items is not respected', async () => {
@@ -192,7 +192,7 @@ describe('Not required dynamiczone', () => {
   describe('Getting one entry', () => {
     test('The entry has its dynamic zone populated', async () => {
       const createRes = await createEntry();
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'GET',
@@ -203,8 +203,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -258,7 +258,7 @@ describe('Not required dynamiczone', () => {
       const createRes = await createEntry();
 
       expect(createRes.statusCode).toBe(200);
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'PUT',
@@ -272,15 +272,15 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body.field).toEqual([]);
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data.field).toEqual([]);
     });
 
     test('Can add items to empty dynamic zone', async () => {
       const createRes = await createEmpty();
 
       expect(createRes.statusCode).toBe(200);
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'PUT',
@@ -292,8 +292,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -316,7 +316,7 @@ describe('Not required dynamiczone', () => {
       const createRes = await createEntry();
 
       expect(createRes.statusCode).toBe(200);
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'PUT',
@@ -339,8 +339,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -360,7 +360,7 @@ describe('Not required dynamiczone', () => {
       const createRes = await createEntry();
 
       expect(createRes.statusCode).toBe(200);
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'PUT',
@@ -382,7 +382,7 @@ describe('Not required dynamiczone', () => {
       const createRes = await createEntry();
 
       expect(createRes.statusCode).toBe(200);
-      const entryId = createRes.body.id;
+      const entryId = createRes.body.data.id;
 
       const res = await rq({
         method: 'PUT',

--- a/api-tests/core/content-manager/dynamiczones/with-media.test.api.js
+++ b/api-tests/core/content-manager/dynamiczones/with-media.test.api.js
@@ -120,8 +120,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -172,7 +172,7 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
+      expect(Array.isArray(res.body.data.field)).toBe(true);
 
       const newImgRes = await uploadImg();
 
@@ -180,7 +180,7 @@ describe('Not required dynamiczone', () => {
       const newMediaId = newImgRes.body[0].id;
       const updateRes = await rq({
         method: 'PUT',
-        url: `/${res.body.id}`,
+        url: `/${res.body.data.id}`,
         body: {
           field: [
             {
@@ -198,7 +198,7 @@ describe('Not required dynamiczone', () => {
         },
       });
 
-      expect(updateRes.body).toMatchObject({
+      expect(updateRes.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -252,13 +252,13 @@ describe('Not required dynamiczone', () => {
 
       const getRes = await rq({
         method: 'GET',
-        url: `/${res.body.id}`,
+        url: `/${res.body.data.id}`,
         qs: {
           populate: ['field'],
         },
       });
 
-      expect(getRes.body).toMatchObject({
+      expect(getRes.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),
@@ -312,8 +312,8 @@ describe('Not required dynamiczone', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(Array.isArray(res.body.field)).toBe(true);
-      expect(res.body).toMatchObject({
+      expect(Array.isArray(res.body.data.field)).toBe(true);
+      expect(res.body.data).toMatchObject({
         field: [
           {
             id: expect.anything(),

--- a/api-tests/core/content-manager/fields/biginteger.test.api.js
+++ b/api-tests/core/content-manager/fields/biginteger.test.api.js
@@ -44,7 +44,7 @@ describe('Test type biginteger', () => {
     );
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: inputValue,
     });
   });
@@ -61,7 +61,7 @@ describe('Test type biginteger', () => {
     );
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: `${inputValue}`,
     });
   });
@@ -92,7 +92,7 @@ describe('Test type biginteger', () => {
 
     const newVal = '9882823782712112';
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withbiginteger.withbiginteger/${res.body.id}`,
+      `/content-manager/collection-types/api::withbiginteger.withbiginteger/${res.body.data.id}`,
       {
         body: {
           field: newVal,
@@ -101,8 +101,8 @@ describe('Test type biginteger', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: newVal,
     });
   });

--- a/api-tests/core/content-manager/fields/boolean.test.api.js
+++ b/api-tests/core/content-manager/fields/boolean.test.api.js
@@ -40,7 +40,7 @@ describe('Test type boolean', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: true,
     });
   });
@@ -59,7 +59,7 @@ describe('Test type boolean', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: true,
     });
 
@@ -68,7 +68,7 @@ describe('Test type boolean', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: false,
     });
   });
@@ -92,7 +92,7 @@ describe('Test type boolean', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withboolean.withboolean/${res.body.id}`,
+      `/content-manager/collection-types/api::withboolean.withboolean/${res.body.data.id}`,
       {
         body: {
           field: false,
@@ -101,8 +101,8 @@ describe('Test type boolean', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: false,
     });
   });

--- a/api-tests/core/content-manager/fields/date.test.api.js
+++ b/api-tests/core/content-manager/fields/date.test.api.js
@@ -41,7 +41,7 @@ describe.skip('Test type date', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: '2019-08-08',
     });
   });
@@ -63,7 +63,7 @@ describe.skip('Test type date', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: '2019-08-08',
     });
   });
@@ -103,7 +103,7 @@ describe.skip('Test type date', () => {
 
     const newDate = '2017-11-23';
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withdate.withdate/${res.body.id}`,
+      `/content-manager/collection-types/api::withdate.withdate/${res.body.data.id}`,
       {
         body: {
           field: newDate,
@@ -112,8 +112,8 @@ describe.skip('Test type date', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: '2017-11-23',
     });
   });

--- a/api-tests/core/content-manager/fields/datetime.test.api.js
+++ b/api-tests/core/content-manager/fields/datetime.test.api.js
@@ -41,7 +41,7 @@ describe.skip('Test type datetime', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: '2019-08-08T10:10:57.000Z',
     });
   });
@@ -56,7 +56,7 @@ describe.skip('Test type datetime', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: now.toISOString(),
     });
   });
@@ -71,7 +71,7 @@ describe.skip('Test type datetime', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: now.toISOString(),
     });
   });
@@ -108,7 +108,7 @@ describe.skip('Test type datetime', () => {
 
     const newDate = new Date(2017, 10, 23);
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withdatetime.withdatetime/${res.body.id}`,
+      `/content-manager/collection-types/api::withdatetime.withdatetime/${res.body.data.id}`,
       {
         body: {
           field: newDate,
@@ -117,8 +117,8 @@ describe.skip('Test type datetime', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: newDate.toISOString(),
     });
   });

--- a/api-tests/core/content-manager/fields/decimal.test.api.js
+++ b/api-tests/core/content-manager/fields/decimal.test.api.js
@@ -41,7 +41,7 @@ describe('Test type decimal', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: inputValue,
     });
   });
@@ -55,7 +55,7 @@ describe('Test type decimal', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 1821.0,
     });
   });
@@ -79,7 +79,7 @@ describe('Test type decimal', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withdecimal.withdecimal/${res.body.id}`,
+      `/content-manager/collection-types/api::withdecimal.withdecimal/${res.body.data.id}`,
       {
         body: {
           field: 14,
@@ -88,8 +88,8 @@ describe('Test type decimal', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 14.0,
     });
   });

--- a/api-tests/core/content-manager/fields/email.test.api.js
+++ b/api-tests/core/content-manager/fields/email.test.api.js
@@ -40,7 +40,7 @@ describe('Test type email', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'validemail@test.fr',
     });
   });
@@ -63,7 +63,7 @@ describe('Test type email', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'test@email.fr',
     });
   });
@@ -90,7 +90,7 @@ describe('Test type email', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withemail.withemail/${res.body.id}`,
+      `/content-manager/collection-types/api::withemail.withemail/${res.body.data.id}`,
       {
         body: {
           field: 'new-email@email.fr',
@@ -99,8 +99,8 @@ describe('Test type email', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 'new-email@email.fr',
     });
   });

--- a/api-tests/core/content-manager/fields/enumeration.test.api.js
+++ b/api-tests/core/content-manager/fields/enumeration.test.api.js
@@ -44,7 +44,7 @@ describe('Test type enumeration', () => {
     );
 
     expect(res.statusCode).toBe(200); // should return 201
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'one',
     });
   });
@@ -73,7 +73,7 @@ describe('Test type enumeration', () => {
     );
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withenumeration.withenumeration/${res.body.id}`,
+      `/content-manager/collection-types/api::withenumeration.withenumeration/${res.body.data.id}`,
       {
         body: {
           field: 'one',
@@ -82,8 +82,8 @@ describe('Test type enumeration', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 'one',
     });
   });
@@ -99,7 +99,7 @@ describe('Test type enumeration', () => {
     );
 
     expect(res.statusCode).toBe(200); // should return 201
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: null,
     });
   });

--- a/api-tests/core/content-manager/fields/float.test.api.js
+++ b/api-tests/core/content-manager/fields/float.test.api.js
@@ -41,7 +41,7 @@ describe('Test type float', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: inputValue,
     });
   });
@@ -55,7 +55,7 @@ describe('Test type float', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 1821.0,
     });
   });
@@ -79,7 +79,7 @@ describe('Test type float', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withfloat.withfloat/${res.body.id}`,
+      `/content-manager/collection-types/api::withfloat.withfloat/${res.body.data.id}`,
       {
         body: {
           field: 14,
@@ -88,8 +88,8 @@ describe('Test type float', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 14.0,
     });
   });

--- a/api-tests/core/content-manager/fields/integer.test.api.js
+++ b/api-tests/core/content-manager/fields/integer.test.api.js
@@ -40,7 +40,7 @@ describe('Test type integer', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 123456,
     });
   });
@@ -54,7 +54,7 @@ describe('Test type integer', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 123456,
     });
   });
@@ -78,7 +78,7 @@ describe('Test type integer', () => {
     });
 
     const updatedRes = await rq.put(
-      `/content-manager/collection-types/api::withinteger.withinteger/${res.body.id}`,
+      `/content-manager/collection-types/api::withinteger.withinteger/${res.body.data.id}`,
       {
         body: {
           field: 543,
@@ -87,8 +87,8 @@ describe('Test type integer', () => {
     );
 
     expect(updatedRes.statusCode).toBe(200);
-    expect(updatedRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updatedRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 543,
     });
   });

--- a/api-tests/core/content-manager/fields/json.test.api.js
+++ b/api-tests/core/content-manager/fields/json.test.api.js
@@ -43,7 +43,7 @@ describe('Test type json', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: inputValue,
     });
   });
@@ -64,7 +64,7 @@ describe('Test type json', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: inputValue,
     });
   });
@@ -94,7 +94,7 @@ describe('Test type json', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withjson.withjson/${res.body.id}`,
+      `/content-manager/collection-types/api::withjson.withjson/${res.body.data.id}`,
       {
         body: {
           field: {
@@ -105,8 +105,8 @@ describe('Test type json', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: { newKey: 'newVal' },
     });
   });

--- a/api-tests/core/content-manager/fields/password.test.api.js
+++ b/api-tests/core/content-manager/fields/password.test.api.js
@@ -40,7 +40,7 @@ describe('Test type password', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body.field).toBeUndefined();
+    expect(res.body.data.field).toBeUndefined();
   });
 
   test.todo('Should be private by default');
@@ -53,7 +53,7 @@ describe('Test type password', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body.field).toBeUndefined();
+    expect(res.body.data.field).toBeUndefined();
   });
 
   test('Reading entry returns correct value', async () => {
@@ -74,7 +74,7 @@ describe('Test type password', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withpassword.withpassword/${res.body.id}`,
+      `/content-manager/collection-types/api::withpassword.withpassword/${res.body.data.id}`,
       {
         body: {
           field: 'otherPwd',
@@ -83,9 +83,9 @@ describe('Test type password', () => {
     );
 
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
     });
-    expect(res.body.field).toBeUndefined();
+    expect(res.body.data.field).toBeUndefined();
   });
 });

--- a/api-tests/core/content-manager/fields/richtext.test.api.js
+++ b/api-tests/core/content-manager/fields/richtext.test.api.js
@@ -40,7 +40,7 @@ describe('Test type richtext', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'Some\ntext',
     });
   });
@@ -62,14 +62,14 @@ describe('Test type richtext', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withrichtext.withrichtext/${res.body.id}`,
+      `/content-manager/collection-types/api::withrichtext.withrichtext/${res.body.data.id}`,
       {
         body: { field: 'Updated \nstring' },
       }
     );
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 'Updated \nstring',
     });
   });

--- a/api-tests/core/content-manager/fields/string.test.api.js
+++ b/api-tests/core/content-manager/fields/string.test.api.js
@@ -40,7 +40,7 @@ describe('Test type string', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'Some string',
     });
   });
@@ -62,14 +62,14 @@ describe('Test type string', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withstring.withstring/${res.body.id}`,
+      `/content-manager/collection-types/api::withstring.withstring/${res.body.data.id}`,
       {
         body: { field: 'Updated string' },
       }
     );
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 'Updated string',
     });
   });

--- a/api-tests/core/content-manager/fields/text.test.api.js
+++ b/api-tests/core/content-manager/fields/text.test.api.js
@@ -40,7 +40,7 @@ describe('Test type text', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: 'Some\ntext',
     });
   });
@@ -62,14 +62,14 @@ describe('Test type text', () => {
     });
 
     const updateRes = await rq.put(
-      `/content-manager/collection-types/api::withtext.withtext/${res.body.id}`,
+      `/content-manager/collection-types/api::withtext.withtext/${res.body.data.id}`,
       {
         body: { field: 'Updated \nstring' },
       }
     );
     expect(updateRes.statusCode).toBe(200);
-    expect(updateRes.body).toMatchObject({
-      id: res.body.id,
+    expect(updateRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: 'Updated \nstring',
     });
   });

--- a/api-tests/core/content-manager/fields/time.test.api.js
+++ b/api-tests/core/content-manager/fields/time.test.api.js
@@ -41,7 +41,7 @@ describe.skip('Test type time', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       field: '10:10:57.123',
     });
   });
@@ -90,7 +90,7 @@ describe.skip('Test type time', () => {
     });
 
     const uptimeRes = await rq.put(
-      `/content-manager/collection-types/api::withtime.withtime/${res.body.id}`,
+      `/content-manager/collection-types/api::withtime.withtime/${res.body.data.id}`,
       {
         body: {
           field: '13:45:19.123',
@@ -99,8 +99,8 @@ describe.skip('Test type time', () => {
     );
 
     expect(uptimeRes.statusCode).toBe(200);
-    expect(uptimeRes.body).toMatchObject({
-      id: res.body.id,
+    expect(uptimeRes.body.data).toMatchObject({
+      id: res.body.data.id,
       field: '13:45:19.123',
     });
   });

--- a/api-tests/core/content-manager/fields/uid.test.api.js
+++ b/api-tests/core/content-manager/fields/uid.test.api.js
@@ -42,7 +42,7 @@ describe('Test type UID', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         slug: 'valid-uid',
       });
     });
@@ -56,7 +56,7 @@ describe('Test type UID', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         slug: 'duplicate-uid',
       });
 
@@ -77,7 +77,7 @@ describe('Test type UID', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         slug: null,
       });
     });
@@ -121,7 +121,7 @@ describe('Test type UID', () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         slug: 'valid-uid',
       });
     });
@@ -138,7 +138,7 @@ describe('Test type UID', () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject({
+      expect(res.body.data).toMatchObject({
         slug: 'duplicate-uid',
       });
 
@@ -166,7 +166,7 @@ describe('Test type UID', () => {
       );
 
       const res = await rq.post(
-        `/content-manager/collection-types/api::withrequireduid.withrequireduid/${createRes.body.id}/actions/publish`
+        `/content-manager/collection-types/api::withrequireduid.withrequireduid/${createRes.body.data.id}/actions/publish`
       );
 
       expect(res.statusCode).toBe(400);

--- a/api-tests/core/content-manager/index.test.api.js
+++ b/api-tests/core/content-manager/index.test.api.js
@@ -23,7 +23,7 @@ const getRelations = async (modelName, field, id) => {
     url: `/content-manager/relations/api::${modelName}.${modelName}/${id}/${field}`,
   });
 
-  return res.body;
+  return res.body.data;
 };
 
 const deleteFixtures = async () => {
@@ -88,19 +88,19 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.tags.push(body);
+      data.tags.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('tag1');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('tag1');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
     });
 
     test('Create tag2', async () => {
@@ -112,19 +112,19 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.tags.push(body);
+      data.tags.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('tag2');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('tag2');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
     });
 
     test('Create tag3', async () => {
@@ -136,19 +136,19 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.tags.push(body);
+      data.tags.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('tag3');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('tag3');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
     });
 
     test('Create article1 without relation', async () => {
@@ -164,22 +164,22 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
     });
 
@@ -196,22 +196,22 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(1);
       expect(tags[0].id).toBe(data.tags[0].id);
     });
@@ -227,22 +227,22 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles[0] = body;
+      data.articles[0] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(1);
       expect(tags[0].id).toBe(data.tags[1].id);
     });
@@ -256,20 +256,20 @@ describe.skip('Relations', () => {
         },
       });
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(data.articles[0].title);
-      expect(body.content).toBe(data.articles[0].content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(data.articles[0].title);
+      expect(body.data.content).toBe(data.articles[0].content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(3);
     });
 
@@ -282,20 +282,20 @@ describe.skip('Relations', () => {
         },
       });
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(data.articles[0].title);
-      expect(body.content).toBe(data.articles[0].content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(data.articles[0].title);
+      expect(body.data.content).toBe(data.articles[0].content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(2);
     });
 
@@ -310,27 +310,29 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles[0] = body;
+      data.articles[0] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
     });
 
     test('Delete all articles should remove the association in each tags related to them', async () => {
-      const { body: createdTag } = await rq({
+      const {
+        body: { data: createdTag },
+      } = await rq({
         url: '/content-manager/collection-types/api::tag.tag',
         method: 'POST',
         body: {
@@ -338,7 +340,9 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: article12 } = await rq({
+      const {
+        body: { data: article12 },
+      } = await rq({
         url: '/content-manager/collection-types/api::article.article',
         method: 'POST',
         body: {
@@ -348,12 +352,16 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: updatedTag } = await rq({
+      const {
+        body: { data: updatedTag },
+      } = await rq({
         url: `/content-manager/collection-types/api::tag.tag/${createdTag.id}`,
         method: 'GET',
       });
 
-      const { body: article13 } = await rq({
+      const {
+        body: { data: article13 },
+      } = await rq({
         url: '/content-manager/collection-types/api::article.article',
         method: 'POST',
         body: {
@@ -363,7 +371,9 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: foundTag } = await rq({
+      const {
+        body: { data: foundTag },
+      } = await rq({
         url: `/content-manager/collection-types/api::tag.tag/${createdTag.id}`,
         method: 'GET',
       });
@@ -378,7 +388,9 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: foundTag2 } = await rq({
+      const {
+        body: { data: foundTag2 },
+      } = await rq({
         url: `/content-manager/collection-types/api::tag.tag/${createdTag.id}`,
         method: 'GET',
       });
@@ -414,7 +426,9 @@ describe.skip('Relations', () => {
     });
 
     test('Creating an article with some many way tags', async () => {
-      const { body: createdTag } = await rq({
+      const {
+        body: { data: createdTag },
+      } = await rq({
         url: '/content-manager/collection-types/api::tag.tag',
         method: 'POST',
         body: {
@@ -434,19 +448,19 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articlesWithTag.push(body);
+      data.articlesWithTag.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const tags = (await getRelations('articlewithtag', 'tags', body.id)).results;
+      const tags = (await getRelations('articlewithtag', 'tags', body.data.id)).results;
       expect(tags.length).toBe(1);
       expect(tags[0].id).toBe(data.tags[0].id);
     });
@@ -473,21 +487,21 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.categories.push(body);
+      data.categories.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('cat1');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('cat1');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const articles = (await getRelations('category', 'articles', body.id)).results;
+      const articles = (await getRelations('category', 'articles', body.data.id)).results;
       expect(articles.length).toBe(0);
     });
 
@@ -500,20 +514,20 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.categories.push(body);
+      data.categories.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('cat2');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('cat2');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
-      const articles = (await getRelations('category', 'articles', body.id)).results;
+      expect(body.data.publishedAt).toBeDefined();
+      const articles = (await getRelations('category', 'articles', body.data.id)).results;
       expect(articles.length).toBe(0);
     });
 
@@ -530,25 +544,25 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
 
-      const category = (await getRelations('article', 'category', body.id)).data;
+      const category = (await getRelations('article', 'category', body.data.id)).data;
       expect(category.name).toBe(data.categories[0].name);
     });
 
@@ -561,24 +575,24 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.articles[0] = body;
+      data.articles[0] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(data.articles[0].title);
-      expect(body.content).toBe(data.articles[0].content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(data.articles[0].title);
+      expect(body.data.content).toBe(data.articles[0].content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
 
-      const category = (await getRelations('article', 'category', body.id)).data;
+      const category = (await getRelations('article', 'category', body.data.id)).data;
       expect(category.name).toBe(data.categories[1].name);
     });
 
@@ -594,21 +608,21 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
     });
 
@@ -621,24 +635,24 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.articles[1] = body;
+      data.articles[1] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(data.articles[1].title);
-      expect(body.content).toBe(data.articles[1].content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(data.articles[1].title);
+      expect(body.data.content).toBe(data.articles[1].content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const tags = (await getRelations('article', 'tags', body.id)).results;
+      const tags = (await getRelations('article', 'tags', body.data.id)).results;
       expect(tags.length).toBe(0);
 
-      const category = (await getRelations('article', 'category', body.id)).data;
+      const category = (await getRelations('article', 'category', body.data.id)).data;
       expect(category.name).toBe(data.categories[1].name);
     });
 
@@ -651,20 +665,20 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.categories[0] = body;
+      data.categories[0] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe(data.categories[0].name);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe(data.categories[0].name);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const articles = (await getRelations('category', 'articles', body.id)).results;
+      const articles = (await getRelations('category', 'articles', body.data.id)).results;
       expect(articles.length).toBe(1);
     });
 
@@ -680,20 +694,20 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.categories.push(body);
+      data.categories.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe(entry.name);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe(entry.name);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const articles = (await getRelations('category', 'articles', body.id)).results;
+      const articles = (await getRelations('category', 'articles', body.data.id)).results;
       expect(articles.length).toBe(1);
     });
 
@@ -703,7 +717,7 @@ describe.skip('Relations', () => {
         method: 'GET',
       });
 
-      expect(body).toMatchObject({ data: { name: 'cat3' } });
+      expect(body.data).toMatchObject({ data: { name: 'cat3' } });
     });
 
     test('Get article2 with cat2', async () => {
@@ -712,7 +726,7 @@ describe.skip('Relations', () => {
         method: 'GET',
       });
 
-      expect(body).toMatchObject({ data: { name: 'cat2' } });
+      expect(body.data).toMatchObject({ data: { name: 'cat2' } });
     });
 
     test('Get cat1 without relations', async () => {
@@ -721,7 +735,7 @@ describe.skip('Relations', () => {
         method: 'GET',
       });
 
-      expect(body).toMatchObject({
+      expect(body.data).toMatchObject({
         results: [],
         pagination: {
           total: 0,
@@ -738,7 +752,7 @@ describe.skip('Relations', () => {
         method: 'GET',
       });
 
-      expect(body).toMatchObject({
+      expect(body.data).toMatchObject({
         pagination: { page: 1, pageCount: 1, pageSize: 10, total: 1 },
         results: [{ title: 'Article 2' }],
       });
@@ -750,7 +764,7 @@ describe.skip('Relations', () => {
         method: 'GET',
       });
 
-      expect(body).toMatchObject({
+      expect(body.data).toMatchObject({
         pagination: { page: 1, pageCount: 1, pageSize: 10, total: 1 },
         results: [{ title: 'Article 1' }],
       });
@@ -778,15 +792,15 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.references.push(body);
+      data.references.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.name).toBe('ref1');
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.name).toBe('ref1');
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
@@ -804,20 +818,20 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.publishedAt).toBeDefined();
+      expect(body.data.publishedAt).toBeDefined();
     });
 
     test('Update article1 with ref1', async () => {
@@ -829,21 +843,21 @@ describe.skip('Relations', () => {
         },
       });
 
-      data.articles[0] = body;
+      data.articles[0] = body.data;
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(data.articles[0].title);
-      expect(body.content).toBe(data.articles[0].content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(data.articles[0].title);
+      expect(body.data.content).toBe(data.articles[0].content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
 
-      const reference = (await getRelations('article', 'reference', body.id)).data;
+      const reference = (await getRelations('article', 'reference', body.data.id)).data;
       expect(reference.id).toBe(data.references[0].id);
     });
 
@@ -860,20 +874,20 @@ describe.skip('Relations', () => {
         body: entry,
       });
 
-      data.articles.push(body);
+      data.articles.push(body.data);
 
-      expect(body.id).toBeDefined();
-      expect(body.title).toBe(entry.title);
-      expect(body.content).toBe(entry.content);
-      expect(body.createdBy).toMatchObject({
+      expect(body.data.id).toBeDefined();
+      expect(body.data.title).toBe(entry.title);
+      expect(body.data.content).toBe(entry.content);
+      expect(body.data.createdBy).toMatchObject({
         id: 1,
         username: null,
       });
-      expect(body.updatedBy).toMatchObject({
+      expect(body.data.updatedBy).toMatchObject({
         id: 1,
         username: null,
       });
-      const reference = (await getRelations('article', 'reference', body.id)).data;
+      const reference = (await getRelations('article', 'reference', body.data.id)).data;
       expect(reference.id).toBe(data.references[0].id);
     });
   });
@@ -904,7 +918,9 @@ describe.skip('Relations', () => {
     });
 
     test('Detach Tag to a Reference', async () => {
-      const { body: createdTag } = await rq({
+      const {
+        body: { data: createdTag },
+      } = await rq({
         url: '/content-manager/collection-types/api::tag.tag',
         method: 'POST',
         body: {
@@ -912,7 +928,9 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: createdReference } = await rq({
+      const {
+        body: { data: createdReference },
+      } = await rq({
         url: '/content-manager/collection-types/api::reference.reference',
         method: 'POST',
         body: {
@@ -924,7 +942,9 @@ describe.skip('Relations', () => {
       let tag = (await getRelations('reference', 'tag', createdReference.id)).data;
       expect(tag.id).toBe(createdTag.id);
 
-      const { body: referenceToUpdate } = await rq({
+      const {
+        body: { data: referenceToUpdate },
+      } = await rq({
         url: `/content-manager/collection-types/api::reference.reference/${createdReference.id}`,
         method: 'PUT',
         body: {
@@ -937,7 +957,9 @@ describe.skip('Relations', () => {
     });
 
     test('Delete Tag so the relation in the Reference side should be removed', async () => {
-      const { body: createdTag } = await rq({
+      const {
+        body: { data: createdTag },
+      } = await rq({
         url: '/content-manager/collection-types/api::tag.tag',
         method: 'POST',
         body: {
@@ -945,7 +967,9 @@ describe.skip('Relations', () => {
         },
       });
 
-      const { body: createdReference } = await rq({
+      const {
+        body: { data: createdReference },
+      } = await rq({
         url: '/content-manager/collection-types/api::reference.reference',
         method: 'POST',
         body: {
@@ -959,7 +983,9 @@ describe.skip('Relations', () => {
         method: 'DELETE',
       });
 
-      const { body: foundReference } = await rq({
+      const {
+        body: { data: foundReference },
+      } = await rq({
         url: `/content-manager/collection-types/api::reference.reference/${createdReference.id}`,
         method: 'GET',
       });

--- a/api-tests/core/content-manager/search.test.api.js
+++ b/api-tests/core/content-manager/search.test.api.js
@@ -131,7 +131,7 @@ const bedFixtures = [
   },
 ];
 
-const bedAttrs = describe('Search query', () => {
+describe('Search query', () => {
   beforeAll(async () => {
     await builder.addContentType(bedModel).addFixtures(bedModel.singularName, bedFixtures).build();
 

--- a/api-tests/core/content-manager/single-type.test.api.js
+++ b/api-tests/core/content-manager/single-type.test.api.js
@@ -55,7 +55,7 @@ describe.skip('Content Manager single types', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       id: expect.anything(),
       title: 'Title',
     });
@@ -68,7 +68,7 @@ describe.skip('Content Manager single types', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toMatchObject({
+    expect(res.body.data).toMatchObject({
       id: expect.anything(),
       title: 'Title',
     });

--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -73,12 +73,12 @@ describe('i18n - Content API', () => {
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      expect(body).toMatchObject({
+      expect(body.data).toMatchObject({
         locale: 'en',
         localizations: [],
         name: 'category in english',
       });
-      data.categories.push(res.body);
+      data.categories.push(res.body.data);
     });
 
     test('non-default locale', async () => {
@@ -94,11 +94,11 @@ describe('i18n - Content API', () => {
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      expect(body).toMatchObject({
+      expect(body.data).toMatchObject({
         locale: 'ko',
         name: 'category in korean',
       });
-      data.categories.push(res.body);
+      data.categories.push(body.data);
     });
 
     // This tests is sensible to foreign keys deadlocks
@@ -116,13 +116,13 @@ describe('i18n - Content API', () => {
           },
         });
         expect(res.statusCode).toBe(200);
-        expect(res.body.locale).toBe(locale);
+        expect(res.body.data.locale).toBe(locale);
       }
 
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      data.categories.push(res.body);
+      data.categories.push(body.data);
     });
   });
 
@@ -140,7 +140,7 @@ describe('i18n - Content API', () => {
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      expect(body).toMatchObject({ count: 1 });
+      expect(body.data).toMatchObject({ count: 1 });
       data.categories.shift();
     });
 
@@ -156,7 +156,7 @@ describe('i18n - Content API', () => {
       const { statusCode, body } = res;
 
       expect(statusCode).toBe(200);
-      expect(body).toMatchObject({ count: 1 });
+      expect(body.data).toMatchObject({ count: 1 });
       data.categories.shift();
     });
   });

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -96,9 +96,9 @@ export default ({ strapi }: { strapi: Strapi }) => ({
     if (!document) return document;
 
     // TODO: Sanitize output of metadata
-    // @ts-expect-error -  TODO: Return { data, meta } format when UI is ready
-    document.__meta__ = await this.getMetadata(uid, document, opts);
-
-    return document;
+    return {
+      data: document,
+      metadata: await this.getMetadata(uid, document, opts),
+    };
   },
 });

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -98,7 +98,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
     // TODO: Sanitize output of metadata
     return {
       data: document,
-      metadata: await this.getMetadata(uid, document, opts),
+      meta: await this.getMetadata(uid, document, opts),
     };
   },
 });

--- a/packages/core/content-manager/shared/contracts/collection-types-v5.ts
+++ b/packages/core/content-manager/shared/contracts/collection-types-v5.ts
@@ -167,6 +167,7 @@ export declare namespace Delete {
 
   export interface Response {
     data: Document;
+    // TODO: Should we return metadata here? It is not returned atm
     meta: DocumentMetadata;
     error?: errors.ApplicationError;
   }


### PR DESCRIPTION
### What does it do?

Return metadata on Content Manager endpoints formatted as:
```
{
	data: ...
	meta: ...
}
```

Most of the PR is api tests changes

