### PR TITLE
chore(workflows): update unit_front skipped test to use node 20

### DIFF
--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - run: echo "Skipped"
 


### PR DESCRIPTION
### What does it do?

Now that unit_front with node 20 is the required one we should also change the version on the skipped test for PRs where the tests are skipped (for [example](https://github.com/strapi/strapi/pull/19302))
