### PR TITLE
Prevent Type Generation From Failing on Functions as Default Value

### DIFF
--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -798,6 +798,16 @@ describe('Attributes', () => {
             ts.SyntaxKind.TrueKeyword
           );
         });
+
+        test('Default: <function>', () => {
+          const anyFunction = jest.fn();
+          const attribute = { default: anyFunction };
+
+          const modifiers = getAttributeModifiers(attribute);
+
+          // The default modifier shouldn't be processed when encountering a function
+          expect(modifiers).toHaveLength(0);
+        });
       });
     });
   });

--- a/packages/utils/typescript/lib/generators/common/models/attributes.js
+++ b/packages/utils/typescript/lib/generators/common/models/attributes.js
@@ -151,8 +151,8 @@ const getAttributeModifiers = (attribute) => {
     );
   }
 
-  // Default
-  if (!_.isNil(attribute.default)) {
+  // Default (ignore if default is a function)
+  if (!_.isNil(attribute.default) && !_.isFunction(attribute.default)) {
     const defaultLiteral = toTypeLiteral(attribute.default);
 
     modifiers.push(


### PR DESCRIPTION
### What does it do?

Skip the `default` modifier on type generation when its value is a function.

### Why is it needed?

Trying to convert a function to a type literal is not working (at least for now), and it was crashing the type generation process

### How to test it?

- `cd examples/getstarted`
- `yarn strapi ts:generate-types --verbose`

The process should be completed successfully

### Related issue(s)/PR(s)

- was preventing us from doing QA on https://github.com/strapi/strapi/pull/19338 and https://github.com/strapi/strapi/pull/19336