### PR TITLE
fix: nested on commit on rollback transactions

### DIFF
--- a/packages/core/database/src/transaction-context.ts
+++ b/packages/core/database/src/transaction-context.ts
@@ -17,9 +17,15 @@ export interface Store {
 const storage = new AsyncLocalStorage<Store>();
 
 const transactionCtx = {
-  async run<TCallback extends Callback>(store: Knex.Transaction, cb: TCallback) {
+  async run<TCallback extends Callback>(trx: Knex.Transaction, cb: TCallback) {
+    const store = storage.getStore();
     return storage.run<ReturnType<TCallback>, void[]>(
-      { trx: store, commitCallbacks: [], rollbackCallbacks: [] },
+      {
+        trx,
+        // Fill with existing callbacks if nesting transactions
+        commitCallbacks: store?.commitCallbacks || [],
+        rollbackCallbacks: store?.rollbackCallbacks || [],
+      },
       cb
     );
   },


### PR DESCRIPTION
### What does it do?

onCommit and onRollback callbacks were not properly working when nesting transactions.
Checked why audit logs was working, when executing the audit log storage, the main transaction was already closed.
