### PR TITLE
feat: overload document service middlewares

### DIFF
--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -1,9 +1,10 @@
 import { LoadedStrapi } from '@strapi/types';
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import resources from './resources/index';
-import { ARTICLE_UID } from './utils';
+import { ARTICLE_UID, CATEGORY_UID } from './utils';
+import { createStrapiInstance } from 'api-tests/strapi';
 
-describe('Document Service', () => {
+describe('Document Service Middlewares', () => {
   let testUtils;
   let strapi: LoadedStrapi;
 
@@ -12,32 +13,72 @@ describe('Document Service', () => {
     strapi = testUtils.strapi;
   });
 
+  beforeEach(async () => {
+    await strapi.destroy();
+    // TODO: Do this in a better way that doesn't slow down tests
+    // Create a new strapi instance to reset middlewares
+    strapi = (await createStrapiInstance()) as LoadedStrapi;
+    testUtils.strapi = strapi;
+  });
+
   afterAll(async () => {
     await destroyTestSetup(testUtils);
   });
 
-  describe('Middlewares', () => {
-    it('Add filters', async () => {
-      strapi.documents.use('findMany', (ctx, next) => {
-        // @ts-expect-error - this is using a generic ContentType.UID , so article attributes are not typed
-        ctx.params.filters = { title: 'Article1-Draft-EN' };
-        return next(ctx);
-      });
-
-      const articles = await strapi.documents('api::article.article').findMany({});
-      expect(articles).toHaveLength(1);
-    });
-  });
-
-  describe('Middleware on uid', () => {
+  describe('Middleware on ANY uid and ANY action', () => {
     it('Add filters on uid', async () => {
-      strapi.documents(ARTICLE_UID).use('findMany', (ctx, next) => {
-        ctx.params.filters = { title: 'Article1-Draft-EN' };
+      strapi.documents.use(async (ctx, next) => {
+        ctx.params.limit = 1;
         return next(ctx);
       });
 
       const articles = await strapi.documents(ARTICLE_UID).findMany({});
       expect(articles).toHaveLength(1);
+      const categories = await strapi.documents(CATEGORY_UID).findMany({});
+      expect(categories).toHaveLength(1);
+    });
+  });
+
+  describe('Middleware on ANY action', () => {
+    it('Add filters on uid', async () => {
+      strapi.documents(ARTICLE_UID).use((ctx, next) => {
+        ctx.params.limit = 1;
+        return next(ctx);
+      });
+
+      const articles = await strapi.documents(ARTICLE_UID).findMany({});
+      expect(articles).toHaveLength(1);
+    });
+  });
+
+  describe('Middleware on ANY uid', () => {
+    it('Add filters on uid', async () => {
+      strapi.documents.use('findMany', (ctx, next) => {
+        ctx.params.limit = 1;
+        return next(ctx);
+      });
+
+      const articles = await strapi.documents(ARTICLE_UID).findMany({});
+      expect(articles).toHaveLength(1);
+
+      const categories = await strapi.documents(CATEGORY_UID).findMany({});
+      expect(categories).toHaveLength(1);
+    });
+  });
+
+  describe('Middleware on specific uid and specific action', () => {
+    it('Add filters', async () => {
+      strapi.documents(ARTICLE_UID).use('findMany', (ctx, next) => {
+        // @ts-expect-error - this is using a generic ContentType.UID , so article attributes are not typed
+        ctx.params.limit = 1;
+        return next(ctx);
+      });
+
+      const articles = await strapi.documents(ARTICLE_UID).findMany({});
+      expect(articles).toHaveLength(1);
+
+      const categories = await strapi.documents(CATEGORY_UID).findMany({});
+      expect(categories.length).toBeGreaterThan(1);
     });
   });
 

--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -28,8 +28,9 @@ describe('Document Service Middlewares', () => {
   describe('Middleware on ANY uid and ANY action', () => {
     it('Add filters on uid', async () => {
       strapi.documents.use(async (ctx, next) => {
-        // @ts-expect-error
-        ctx.params.limit = 1;
+        if ('limit' in ctx.params) {
+          ctx.params.limit = 1;
+        }
         return next(ctx);
       });
 
@@ -43,8 +44,9 @@ describe('Document Service Middlewares', () => {
   describe('Middleware on ANY action', () => {
     it('Add filters on uid', async () => {
       strapi.documents(ARTICLE_UID).use((ctx, next) => {
-        // @ts-expect-error
-        ctx.params.limit = 1;
+        if ('limit' in ctx.params) {
+          ctx.params.limit = 1;
+        }
         return next(ctx);
       });
 

--- a/api-tests/core/strapi/document-service/middlewares.test.api.ts
+++ b/api-tests/core/strapi/document-service/middlewares.test.api.ts
@@ -28,6 +28,7 @@ describe('Document Service Middlewares', () => {
   describe('Middleware on ANY uid and ANY action', () => {
     it('Add filters on uid', async () => {
       strapi.documents.use(async (ctx, next) => {
+        // @ts-expect-error
         ctx.params.limit = 1;
         return next(ctx);
       });
@@ -42,6 +43,7 @@ describe('Document Service Middlewares', () => {
   describe('Middleware on ANY action', () => {
     it('Add filters on uid', async () => {
       strapi.documents(ARTICLE_UID).use((ctx, next) => {
+        // @ts-expect-error
         ctx.params.limit = 1;
         return next(ctx);
       });
@@ -69,7 +71,6 @@ describe('Document Service Middlewares', () => {
   describe('Middleware on specific uid and specific action', () => {
     it('Add filters', async () => {
       strapi.documents(ARTICLE_UID).use('findMany', (ctx, next) => {
-        // @ts-expect-error - this is using a generic ContentType.UID , so article attributes are not typed
         ctx.params.limit = 1;
         return next(ctx);
       });

--- a/packages/core/core/src/services/document-service/document-service.ts
+++ b/packages/core/core/src/services/document-service/document-service.ts
@@ -137,16 +137,34 @@ export const createDocumentService = (
         })(uid);
       },
 
-      use(action, cb, opts) {
-        middlewareManager.add(uid, action, cb, opts);
+      use(...args: Parameters<Documents.ServiceInstance['use']>) {
+        if (typeof args[0] === 'string') {
+          const [action, cb, opts] = args;
+          middlewareManager.add(uid, action, cb, opts);
+        } else {
+          // cb: () => any, opts?: any
+          const [cb, opts] = args;
+          middlewareManager.add(uid, '_all', cb, opts);
+        }
         return this;
       },
     };
   }
 
   Object.assign(create, {
-    use(action: any, cb: any, opts?: any) {
-      middlewareManager.add('_all', action, cb, opts);
+    // use(action: any, cb: any, opts?: any) {
+    use(...args: Parameters<Documents.Service['use']>) {
+      // middlewareManager.add('_all', action, cb, opts);
+      if (typeof args[0] === 'string') {
+        const [action, cb, opts] = args;
+        // Add middleware for all uids for a given action
+        middlewareManager.add('_all', action, cb, opts);
+      } else {
+        // cb: () => any, opts?: any
+        const [cb, opts] = args;
+        // Add middleware for all actions for all uids
+        middlewareManager.add('_all', '_all', cb, opts);
+      }
       return create;
     },
     middlewares: middlewareManager,

--- a/packages/core/core/src/services/document-service/document-service.ts
+++ b/packages/core/core/src/services/document-service/document-service.ts
@@ -137,7 +137,8 @@ export const createDocumentService = (
         })(uid);
       },
 
-      use(...args: Parameters<Documents.ServiceInstance['use']>) {
+      // TODO: Handle type with function overloads
+      use(...args: any) {
         if (typeof args[0] === 'string') {
           const [action, cb, opts] = args;
           middlewareManager.add(uid, action, cb, opts);
@@ -153,8 +154,7 @@ export const createDocumentService = (
 
   Object.assign(create, {
     // use(action: any, cb: any, opts?: any) {
-    use(...args: Parameters<Documents.Service['use']>) {
-      // middlewareManager.add('_all', action, cb, opts);
+    use(...args: any) {
       if (typeof args[0] === 'string') {
         const [action, cb, opts] = args;
         // Add middleware for all uids for a given action

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -74,20 +74,19 @@ export type ServiceInstance<
    *    return result;
    *  })
    */
-  use:
-    | (<TAction extends keyof DocumentEngine>(
-        action: TAction,
-        // QUESTION: How do we type the result type of next?
-        //           Should we send params + document id attribute?
-        cb:
-          | Middleware.Middleware<Common.UID.ContentType, TAction>
-          | Middleware.Middleware<Common.UID.ContentType, TAction>[],
-        opts?: Middleware.Options
-      ) => ThisType<ServiceInstance<TContentTypeUID>>) &
-        ((
-          cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
-          opts?: Middleware.Options
-        ) => ThisType<ServiceInstance<TContentTypeUID>>);
+  use<TAction extends keyof DocumentEngine>(
+    action: TAction,
+    // QUESTION: How do we type the result type of next?
+    //           Should we send params + document id attribute?
+    cb:
+      | Middleware.Middleware<Common.UID.ContentType, TAction>
+      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
+    opts?: Middleware.Options
+  ): ThisType<ServiceInstance<TContentTypeUID>>;
+  use(
+    cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+    opts?: Middleware.Options
+  ): ThisType<ServiceInstance<TContentTypeUID>>;
 
   /**
    * `.with()` instantiates a new document repository with default parameters
@@ -126,18 +125,17 @@ export type Service = {
    *    return result;
    *   })
    */
-  use:
-    | (<TAction extends keyof DocumentEngine>(
-        action: TAction,
-        cb:
-          | Middleware.Middleware<Common.UID.ContentType, TAction>
-          | Middleware.Middleware<Common.UID.ContentType, TAction>[],
-        opts?: Middleware.Options
-      ) => Service) &
-        ((
-          cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
-          opts?: Middleware.Options
-        ) => Service);
+  use<TAction extends keyof DocumentEngine>(
+    action: TAction,
+    cb:
+      | Middleware.Middleware<Common.UID.ContentType, TAction>
+      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
+    opts?: Middleware.Options
+  ): Service;
+  use(
+    cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+    opts?: Middleware.Options
+  ): Service;
 
   middlewares: Middleware.Manager;
 } & DocumentEngine;

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -83,11 +83,11 @@ export type ServiceInstance<
           | Middleware.Middleware<Common.UID.ContentType, TAction>
           | Middleware.Middleware<Common.UID.ContentType, TAction>[],
         opts?: Middleware.Options
-      ) => ThisType<ServiceInstance<TContentTypeUID>>)
-    | ((
-        cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
-        opts?: Middleware.Options
-      ) => ThisType<ServiceInstance<TContentTypeUID>>);
+      ) => ThisType<ServiceInstance<TContentTypeUID>>) &
+        ((
+          cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+          opts?: Middleware.Options
+        ) => ThisType<ServiceInstance<TContentTypeUID>>);
 
   /**
    * `.with()` instantiates a new document repository with default parameters
@@ -133,11 +133,11 @@ export type Service = {
           | Middleware.Middleware<Common.UID.ContentType, TAction>
           | Middleware.Middleware<Common.UID.ContentType, TAction>[],
         opts?: Middleware.Options
-      ) => Service)
-    | ((
-        cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
-        opts?: Middleware.Options
-      ) => Service);
+      ) => Service) &
+        ((
+          cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+          opts?: Middleware.Options
+        ) => Service);
 
   middlewares: Middleware.Manager;
 } & DocumentEngine;

--- a/packages/core/types/src/modules/documents/index.ts
+++ b/packages/core/types/src/modules/documents/index.ts
@@ -74,15 +74,20 @@ export type ServiceInstance<
    *    return result;
    *  })
    */
-  use: <TAction extends keyof DocumentEngine>(
-    action: TAction,
-    // QUESTION: How do we type the result type of next?
-    //           Should we send params + document id attribute?
-    cb:
-      | Middleware.Middleware<Common.UID.ContentType, TAction>
-      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
-    opts?: Middleware.Options
-  ) => ThisType<ServiceInstance<TContentTypeUID>>;
+  use:
+    | (<TAction extends keyof DocumentEngine>(
+        action: TAction,
+        // QUESTION: How do we type the result type of next?
+        //           Should we send params + document id attribute?
+        cb:
+          | Middleware.Middleware<Common.UID.ContentType, TAction>
+          | Middleware.Middleware<Common.UID.ContentType, TAction>[],
+        opts?: Middleware.Options
+      ) => ThisType<ServiceInstance<TContentTypeUID>>)
+    | ((
+        cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+        opts?: Middleware.Options
+      ) => ThisType<ServiceInstance<TContentTypeUID>>);
 
   /**
    * `.with()` instantiates a new document repository with default parameters
@@ -107,20 +112,32 @@ export type Service = {
     uid: TContentTypeUID
   ): ServiceInstance<TContentTypeUID>;
 
-  /** Add a middleware for all uid's and a specific action
+  /** Add a middleware for all uid's and a specific action, or also all actions
    *  @example - Add a default locale
-   *  strapi.documents.use('findMany', (ctx, next) => {
-   *    if (!params.locale) params.locale = 'en'
-   *    return next(ctx)
-   *  })
+   *    strapi.documents.use('findMany', (ctx, next) => {
+   *      if (!params.locale) params.locale = 'en'
+   *      return next(ctx)
+   *    })
+   *
+   *  @example - Filter private fields
+   *   strapi.documents.use(async (ctx, next) => {
+   *    // Filter private fields
+   *    const { privateField, ...result } = await next(ctx)
+   *    return result;
+   *   })
    */
-  use: <TAction extends keyof DocumentEngine>(
-    action: TAction,
-    cb:
-      | Middleware.Middleware<Common.UID.ContentType, TAction>
-      | Middleware.Middleware<Common.UID.ContentType, TAction>[],
-    opts?: Middleware.Options
-  ) => Service;
+  use:
+    | (<TAction extends keyof DocumentEngine>(
+        action: TAction,
+        cb:
+          | Middleware.Middleware<Common.UID.ContentType, TAction>
+          | Middleware.Middleware<Common.UID.ContentType, TAction>[],
+        opts?: Middleware.Options
+      ) => Service)
+    | ((
+        cb: Middleware.Middleware<Common.UID.ContentType, keyof DocumentEngine>,
+        opts?: Middleware.Options
+      ) => Service);
 
   middlewares: Middleware.Manager;
 } & DocumentEngine;


### PR DESCRIPTION
### What does it do?

Improvement on document service middleware. Now you can: 

```
// Middleware on any uid and any action
strapi.documents.use(async (ctx, next) => ...)
```

```
// Middleware on any action
strapi.documents('api::article.article').use(async (ctx, next) => ...)
```

These two use cases where not possible before.

I know @alexandrebodin  was not fully convinced about this approach, so let me know if we can provide other api alternatives :)!


