### PR TITLE
fix(dts): support morphToOne relations

### DIFF
--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -191,14 +191,12 @@ export const createLinkQuery = (strapi: LoadedStrapi, trx?: Knex.Transaction) =>
         for (const entry of entries) {
           const ref = entry[idColumn.name];
 
-          if (ref !== null) {
-            yield {
-              kind,
-              relation,
-              left: { type: uid, ref: entry.id, field: fieldName },
-              right: { type: entry[typeColumn.name], ref },
-            };
-          }
+          yield {
+            kind,
+            relation,
+            left: { type: uid, ref: entry.id, field: fieldName },
+            right: { type: entry[typeColumn.name], ref },
+          };
         }
       }
     }


### PR DESCRIPTION
### What does it do?

- Handles the morphToOne attribute on export

### Why is it needed?

- Currently the case is not handled which leaves morphToOne polymorphic relations as null on export and therefore null on import
- Releases uses this relation and although it is not currently included in the @strapi/data-transfer it is used via a DTS engine in the e2e tests

### How to test it?

In Strapi admin
- Create a kitchensink and a category

In your database explorer:
- Go to the kitchensinks, and pick an entry
- Add target_type: `api::category.category`
- Add target_id: `<id-of-existing-category>`

In your console:
- Run `strapi export -f test.tar --no-encrypt --no-compress`
- Run `strapi import -f test.tar`

In you database explorer
- Refresh and confirm kitchensinks has persisted the target_type, and target_id
- Note: the ids will have incremented but the relations should be consistent


Co-authored by: @Convly 