### PR TITLE
fix(content-releases): standardize icons size

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -104,7 +104,7 @@ const DeleteReleaseActionItem = ({ releaseId, actionId }: DeleteReleaseActionIte
     <CheckPermissions permissions={PERMISSIONS.deleteAction}>
       <StyledMenuItem variant="danger" onSelect={handleDeleteAction}>
         <Flex gap={2}>
-          <Icon as={Cross} padding={1} />
+          <Icon as={Cross} width={3} height={3} />
           <Typography textColor="danger600" variant="omega">
             {formatMessage({
               id: 'content-releases.content-manager-edit-view.remove-from-release',
@@ -164,7 +164,7 @@ const ReleaseActionEntryLinkItem = ({
               pathname: `/content-manager/collection-types/${contentTypeUid}/${entryId}`,
               search: locale && `?plugins[i18n][locale]=${locale}`,
             }}
-            startIcon={<Icon as={Pencil} padding={1} />}
+            startIcon={<Icon as={Pencil} width={3} height={3} />}
           >
             <Typography variant="omega">
               {formatMessage({

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -89,16 +89,16 @@ const StyledFlex = styled(Flex)<{ disabled?: boolean }>`
 `;
 
 const PencilIcon = styled(Pencil)`
-  width: ${({ theme }) => theme.spaces[4]};
-  height: ${({ theme }) => theme.spaces[4]};
+  width: ${({ theme }) => theme.spaces[3]};
+  height: ${({ theme }) => theme.spaces[3]};
   path {
     fill: ${({ theme }) => theme.colors.neutral600};
   }
 `;
 
 const TrashIcon = styled(Trash)`
-  width: ${({ theme }) => theme.spaces[4]};
-  height: ${({ theme }) => theme.spaces[4]};
+  width: ${({ theme }) => theme.spaces[3]};
+  height: ${({ theme }) => theme.spaces[3]};
   path {
     fill: ${({ theme }) => theme.colors.danger600};
   }


### PR DESCRIPTION
### What does it do?

Changed the icons width and height in the Release Details page

### Why is it needed?

To have a similar layout for them, because at the moment they have different sizes
![CleanShot 2024-01-18 at 08 27 33@2x](https://github.com/strapi/strapi/assets/2589748/87523c1d-dd20-4481-bd01-a6926c6a2ccd)
![CleanShot 2024-01-18 at 08 27 52@2x](https://github.com/strapi/strapi/assets/2589748/d1f4cfe5-533a-413e-b701-46c4d1c8947e)


### How to test it?
Go to the details page and check the icon size in the "More" menu and in every entry menu

### Related issue(s)/PR(s)

CS-557
