### PR TITLE
chore: fixes for flaky tests

### DIFF
--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -88,4 +88,8 @@ module.exports = {
   // Use `jest-watch-typeahead` version 0.6.5. Newest version 1.0.0 does not support jest@26
   // Reference: https://github.com/jest-community/jest-watch-typeahead/releases/tag/v1.0.0
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+
+  // NOTE: this doesn't work with projects due to a jest bug, so we also set it
+  // using jest.setTimeout() in the after-env script
+  testTimeout: 60 * 1000,
 };

--- a/packages/admin-test-utils/src/after-env.ts
+++ b/packages/admin-test-utils/src/after-env.ts
@@ -1,3 +1,7 @@
 import '@testing-library/jest-dom';
 import 'jest-styled-components';
 import 'whatwg-fetch';
+
+// Note: We set this here because setting it in the config is broken for projects: https://github.com/jestjs/jest/issues/9696
+// Also, there are issues with async tests unless it is set at global scope: https://github.com/jestjs/jest/issues/11543
+jest.setTimeout(60 * 1000);

--- a/packages/admin-test-utils/src/fixtures/store/index.ts
+++ b/packages/admin-test-utils/src/fixtures/store/index.ts
@@ -35,6 +35,12 @@ const reducers = {
 
 const store = configureStore({
   reducer: combineReducers(reducers),
+  middleware: (getDefaultMiddleware: any) =>
+    getDefaultMiddleware({
+      // Disable timing checks for test env
+      immutableCheck: false,
+      serializableCheck: false,
+    }),
 });
 
 export default {

--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -68,6 +68,15 @@ const configureStoreImpl = (
 ) => {
   const coreReducers = { ...staticReducers, ...injectedReducers } as const;
 
+  const defaultMiddlewareOptions = {} as any;
+
+  // These are already disabled in 'production' env but we also need to disable it in test environments
+  // However, we want to leave them on for development so any issues can still be caught
+  if (process.env.NODE_ENV === 'test') {
+    defaultMiddlewareOptions.serializableCheck = false;
+    defaultMiddlewareOptions.immutableCheck = false;
+  }
+
   const store = configureStore({
     preloadedState: {
       admin_app: preloadedState.admin_app,
@@ -75,7 +84,7 @@ const configureStoreImpl = (
     reducer: coreReducers,
     devTools: process.env.NODE_ENV !== 'production',
     middleware: (getDefaultMiddleware) => [
-      ...getDefaultMiddleware(),
+      ...getDefaultMiddleware(defaultMiddlewareOptions),
       adminApi.middleware,
       ...appMiddlewares.map((m) => m()),
     ],

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePlugins.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePlugins.test.tsx
@@ -6,8 +6,6 @@ import { Route } from 'react-router-dom';
 
 import { MarketplacePage } from '../MarketplacePage';
 
-// Increase the jest timeout to accommodate long running tests
-jest.setTimeout(50000);
 jest.mock('../hooks/useNavigatorOnline');
 jest.mock('../../../hooks/useDebounce', () => ({
   useDebounce: jest.fn((value) => value),

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
@@ -6,9 +6,6 @@ import { Route } from 'react-router-dom';
 
 import { MarketplacePage } from '../MarketplacePage';
 
-// Increase the jest timeout to accommodate long running tests
-jest.setTimeout(50000);
-
 /**
  * MOCKS
  */

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/tests/ListPage.test.tsx
@@ -43,6 +43,12 @@ const setup = () =>
               preloadedState: {
                 admin_app: { permissions: fixtures.permissions.app },
               },
+              middleware: (getDefaultMiddleware: any) =>
+                getDefaultMiddleware({
+                  // Disable timing checks for test env
+                  immutableCheck: false,
+                  serializableCheck: false,
+                }),
             })}
           >
             <IntlProvider messages={{}} defaultLocale="en" textComponent="span" locale="en">

--- a/packages/core/admin/admin/tests/utils.tsx
+++ b/packages/core/admin/admin/tests/utils.tsx
@@ -73,7 +73,14 @@ const Providers = ({ children, initialEntries }: ProvidersProps) => {
       'content-manager_editViewCrudReducer': crudReducer,
     },
     // @ts-expect-error – this fails.
-    middleware: (getDefaultMiddleware) => [...getDefaultMiddleware(), adminApi.middleware],
+    middleware: (getDefaultMiddleware) => [
+      ...getDefaultMiddleware({
+        // Disable timing checks for test env
+        immutableCheck: false,
+        serializableCheck: false,
+      }),
+      adminApi.middleware,
+    ],
   });
 
   // en is the default locale of the admin app.

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/Stage.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/Stage.test.tsx
@@ -172,6 +172,12 @@ const setup = ({ roles, ...props }: Setup = {}) => {
               },
             },
           },
+          middleware: (getDefaultMiddleware: any) =>
+            getDefaultMiddleware({
+              // Disable timing checks for test env
+              immutableCheck: false,
+              serializableCheck: false,
+            }),
         });
 
         return (

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/Stages.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/Stages.test.tsx
@@ -54,6 +54,12 @@ const setup = (props?: StagesProps) => ({
     wrapper({ children }) {
       const store = configureStore({
         reducer,
+        middleware: (getDefaultMiddleware: any) =>
+          getDefaultMiddleware({
+            // Disable timing checks for test env
+            immutableCheck: false,
+            serializableCheck: false,
+          }),
       });
 
       return (

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/WorkflowAttributes.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/tests/WorkflowAttributes.test.tsx
@@ -130,6 +130,12 @@ const setup = ({
             },
           },
         },
+        middleware: (getDefaultMiddleware: any) =>
+          getDefaultMiddleware({
+            // Disable timing checks for test env
+            immutableCheck: false,
+            serializableCheck: false,
+          }),
       });
 
       return (

--- a/packages/core/content-releases/admin/tests/utils.tsx
+++ b/packages/core/content-releases/admin/tests/utils.tsx
@@ -39,9 +39,8 @@ const Providers = ({ children, initialEntries }: ProvidersProps) => {
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
-        // We needed to increase the timeout because randomly the unit tests are failing for that.
-        immutableCheck: { warnAfter: 128 },
-        serializableCheck: { warnAfter: 128 },
+        immutableCheck: false,
+        serializableCheck: false,
       }).concat(releaseApi.middleware),
   });
 

--- a/packages/core/helper-plugin/src/components/tests/GenericInput.test.tsx
+++ b/packages/core/helper-plugin/src/components/tests/GenericInput.test.tsx
@@ -36,13 +36,6 @@ function renderField(
   };
 }
 
-/**
- * We extend the timeout of these tests because the DS
- * DateTimePicker has a slow rendering issue at the moment.
- * It passes locally, but fails in the CI.
- */
-jest.setTimeout(50000);
-
 describe('GenericInput', () => {
   describe('number', () => {
     const renderNumber = (props: Partial<GenericInputProps>) => {

--- a/packages/plugins/color-picker/admin/src/components/tests/ColorPickerInput.test.tsx
+++ b/packages/plugins/color-picker/admin/src/components/tests/ColorPickerInput.test.tsx
@@ -33,21 +33,6 @@ const render = () => ({
 });
 
 describe('<ColorPickerInput />', () => {
-  /**
-   * We do this because –
-   * https://github.com/facebook/jest/issues/12670
-   */
-  beforeAll(() => {
-    jest.setTimeout(30000);
-  });
-
-  /**
-   * Reset timeout to what is expected
-   */
-  afterAll(() => {
-    jest.setTimeout(5000);
-  });
-
   it('renders and matches the snapshot', () => {
     const { container } = render();
 

--- a/packages/plugins/i18n/admin/tests/utils.tsx
+++ b/packages/plugins/i18n/admin/tests/utils.tsx
@@ -53,6 +53,12 @@ const Providers = ({ children, initialEntries }: ProvidersProps) => {
       admin_app: (state = initialState) => state,
       rbacProvider: (state = initialState) => state,
     }),
+    middleware: (getDefaultMiddleware: any) =>
+      getDefaultMiddleware({
+        // Disable timing checks for test env
+        immutableCheck: false,
+        serializableCheck: false,
+      }),
   });
 
   const i18nPermissions = Object.values(PERMISSIONS).flat();

--- a/packages/utils/pack-up/src/__tests__/cli.test.ts
+++ b/packages/utils/pack-up/src/__tests__/cli.test.ts
@@ -3,7 +3,8 @@ import { spawn } from '../../tests/spawn';
 /**
  * This has issues running in the CI due to how yarn3 works.
  */
-describe('cli', () => {
+// TODO: move this to an actual CLI test since it's too flaky and isn't really necessary since it is already de-facto tested by building everything
+describe.skip('cli', () => {
   const timeout = 1000 * 120;
 
   describe('build & check', () => {

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -28,7 +28,7 @@ const createConfig = ({ port, testDir, appDir }) => ({
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000,
+    timeout: getEnvNum(process.env.PLAYWRIGHT_EXPECT_TIMEOUT, 30 * 1000),
   },
   /* Run tests in files in parallel */
   fullyParallel: false,


### PR DESCRIPTION
### What does it do?

- disable react default middleware timeouts for tests
- set jest timeout globally for front-end tests
- increase playwright expect timeout
- skips the pack-up cli test since it was also a major headache and doesn't really test anything that isn't already de facto tested by the fact strapi is built with it. We will add it back as a CLI e2e test once those are merged

### Why is it needed?

Randomly failing tests are killing us; this should solve the vast majority of them

### How to test it?

CI tests should work the first time without driving you bonkers

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
