### PR TITLE
fix: return available status when content type doesnt have i18n enabled

### DIFF
--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -44,12 +44,11 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   },
 
   async getAvailableStatus(uid: Common.UID.ContentType, document: DocumentVersionSelector) {
-    if (!document.locale) return null;
-
     // Find if the other status of the document is available
     const otherStatus = document.status === 'published' ? 'draft' : 'published';
 
     return strapi.documents(uid).findOne(document.id, {
+      // TODO: Do not filter by locale if i18n is disabled
       locale: document.locale,
       status: otherStatus,
       fields: ['id', 'updatedAt', 'createdAt', 'publishedAt'],
@@ -95,9 +94,10 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   ) {
     if (!document) return document;
 
+    // const meta = await this.getMetadata(uid, document, opts);
     // TODO: Sanitize output of metadata
     return {
-      data: document,
+      data: { ...document, status: await this.getStatus(uid, document) },
       meta: await this.getMetadata(uid, document, opts),
     };
   },

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -94,7 +94,6 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   ) {
     if (!document) return document;
 
-    // const meta = await this.getMetadata(uid, document, opts);
     // TODO: Sanitize output of metadata
     return {
       data: { ...document, status: await this.getStatus(uid, document) },


### PR DESCRIPTION
Available status array was returned empty if the requested Content Type didnt have i18n enabled.