### PR TITLE
fix(content-releases): add disabled state to action radio buttons

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -54,7 +54,7 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     border-right: ${({ actionType }) => actionType === 'publish' && 'none'};
   }
 
-  &:hover {
+  &[data-checked='false']:hover {
     color: ${({ theme }) => theme.colors.neutral700};
     background-color: ${({ theme }) => theme.colors.neutral100};
     border-color: ${({ theme }) => theme.colors.neutral200};

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -40,16 +40,30 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     text-transform: capitalize;
   }
 
-  &:active,
   &[data-checked='true'] {
-    color: ${({ theme }) => theme.colors.primary700};
-    background-color: ${({ theme }) => theme.colors.primary100};
-    border-color: ${({ theme }) => theme.colors.primary700};
+    color: ${({ theme, actionType }) =>
+      actionType === 'publish' ? theme.colors.primary700 : theme.colors.danger600};
+    background-color: ${({ theme, actionType }) =>
+      actionType === 'publish' ? theme.colors.primary100 : theme.colors.danger100};
+    border-color: ${({ theme, actionType }) =>
+      actionType === 'publish' ? theme.colors.primary700 : theme.colors.danger600};
   }
 
   &[data-checked='false'] {
     border-left: ${({ actionType }) => actionType === 'unpublish' && 'none'};
     border-right: ${({ actionType }) => actionType === 'publish' && 'none'};
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.neutral700};
+    background-color: ${({ theme }) => theme.colors.neutral100};
+    border-color: ${({ theme }) => theme.colors.neutral200};
+  }
+
+  &[data-disabled='true'] {
+    color: ${({ theme }) => theme.colors.neutral600};
+    background-color: ${({ theme }) => theme.colors.neutral150};
+    border-color: ${({ theme }) => theme.colors.neutral300};
   }
 `;
 
@@ -57,13 +71,20 @@ interface ActionOptionProps {
   selected: 'publish' | 'unpublish';
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   name: string;
+  disabled?: boolean;
 }
 
 interface OptionProps extends ActionOptionProps {
   actionType: 'publish' | 'unpublish';
 }
 
-const ActionOption = ({ selected, actionType, handleChange, name }: OptionProps) => {
+const ActionOption = ({
+  selected,
+  actionType,
+  handleChange,
+  name,
+  disabled = false,
+}: OptionProps) => {
   return (
     <FieldWrapper
       actionType={actionType}
@@ -73,6 +94,7 @@ const ActionOption = ({ selected, actionType, handleChange, name }: OptionProps)
       position="relative"
       cursor="pointer"
       data-checked={selected === actionType}
+      data-disabled={disabled && selected !== actionType}
     >
       <FieldLabel htmlFor={`${name}-${actionType}`}>
         <VisuallyHidden>
@@ -83,6 +105,7 @@ const ActionOption = ({ selected, actionType, handleChange, name }: OptionProps)
             checked={selected === actionType}
             onChange={handleChange}
             value={actionType}
+            disabled={disabled}
           />
         </VisuallyHidden>
         {actionType}
@@ -91,7 +114,12 @@ const ActionOption = ({ selected, actionType, handleChange, name }: OptionProps)
   );
 };
 
-export const ReleaseActionOptions = ({ selected, handleChange, name }: ActionOptionProps) => {
+export const ReleaseActionOptions = ({
+  selected,
+  handleChange,
+  name,
+  disabled = false,
+}: ActionOptionProps) => {
   return (
     <Flex>
       <ActionOption
@@ -99,12 +127,14 @@ export const ReleaseActionOptions = ({ selected, handleChange, name }: ActionOpt
         selected={selected}
         handleChange={handleChange}
         name={name}
+        disabled={disabled}
       />
       <ActionOption
         actionType="unpublish"
         selected={selected}
         handleChange={handleChange}
         name={name}
+        disabled={disabled}
       />
     </Flex>
   );

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -54,7 +54,7 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     border-right: ${({ actionType }) => actionType === 'publish' && 'none'};
   }
 
-  &[data-checked='false']:hover {
+  &[data-checked='false'][data-disabled='false']:hover {
     color: ${({ theme }) => theme.colors.neutral700};
     background-color: ${({ theme }) => theme.colors.neutral100};
     border-color: ${({ theme }) => theme.colors.neutral200};

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -483,6 +483,9 @@ const ReleaseDetailsBody = () => {
     isError: isReleaseError,
     error: releaseError,
   } = useGetReleaseQuery({ id: releaseId });
+  const {
+    allowedActions: { canPublish, canUpdate },
+  } = useRBAC(PERMISSIONS);
 
   const release = releaseData?.data;
   const selectedGroupBy = query?.groupBy || 'contentType';
@@ -736,6 +739,7 @@ const ReleaseDetailsBody = () => {
                               selected={type}
                               handleChange={(e) => handleChangeType(e, id, [key, actionIndex])}
                               name={`release-action-${id}-type`}
+                              disabled={!canPublish || !canUpdate}
                             />
                           )}
                         </Td>

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -484,7 +484,7 @@ const ReleaseDetailsBody = () => {
     error: releaseError,
   } = useGetReleaseQuery({ id: releaseId });
   const {
-    allowedActions: { canPublish, canUpdate },
+    allowedActions: { canUpdate },
   } = useRBAC(PERMISSIONS);
 
   const release = releaseData?.data;
@@ -739,7 +739,7 @@ const ReleaseDetailsBody = () => {
                               selected={type}
                               handleChange={(e) => handleChangeType(e, id, [key, actionIndex])}
                               name={`release-action-${id}-type`}
-                              disabled={!canPublish || !canUpdate}
+                              disabled={!canUpdate}
                             />
                           )}
                         </Td>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds some UI to the Unpublish radio button, the hover effect to both the radio buttons and the disabled state when the user has no permission to change the action type in the Release Details page

### Why is it needed?

We need to improve the UX of the two radio buttons and avoid the possibility to change action type if the user doesn't have the right permissions

### How to test it?

- create an Editor user from the settings and login as Editor in an other tab
- in the Tab where you are logged as admin create a new release and add some items to the release
- then in the Settings for the Editor role disabled the Edit and Publish permissions for Content Releases plugin
- then in the tab where you are logged as Editor you can see the Radio button related to the action type not selected disabled (in this way you cannot change action type)
- do the same flow enabling Publish permission and then Edit permission (you need to have the action Type disabled again)
- finally try to enable both Publish and Edit permissions, now in the tab where you are logged as Editor you can see the radio buttons enabled

Please take a look to this figma https://www.figma.com/file/7YA3cGhgS11lWffL44hsLJ/Releases?type=design&node-id=2981-16154&mode=design&t=9ARchdsa3cidkANY-0 to have an idea of the desired ui

### Related issue(s)/PR(s)

CS-558
