### PR TITLE
feat(content-releases): sync all scheduled releases on bootstrap and cancel them on destroy

### DIFF
--- a/packages/core/content-releases/server/src/bootstrap.ts
+++ b/packages/core/content-releases/server/src/bootstrap.ts
@@ -2,6 +2,7 @@
 import type { LoadedStrapi, Entity as StrapiEntity } from '@strapi/types';
 
 import { RELEASE_ACTION_MODEL_UID } from './constants';
+import { getService } from './utils';
 
 const { features } = require('@strapi/strapi/dist/utils/ee');
 
@@ -57,5 +58,9 @@ export const bootstrap = async ({ strapi }: { strapi: LoadedStrapi }) => {
         }
       },
     });
+
+    if (strapi.features.future.isEnabled('contentReleasesScheduling')) {
+      getService('scheduling', { strapi }).syncFromDatabase();
+    }
   }
 };

--- a/packages/core/content-releases/server/src/destroy.ts
+++ b/packages/core/content-releases/server/src/destroy.ts
@@ -1,0 +1,17 @@
+import { Job } from 'node-schedule';
+import { LoadedStrapi } from '@strapi/types';
+
+import { Release } from '../../shared/contracts/releases';
+import { getService } from './utils';
+
+export const destroy = async ({ strapi }: { strapi: LoadedStrapi }) => {
+  if (strapi.features.future.isEnabled('contentReleasesScheduling')) {
+    const scheduledJobs: Map<Release['id'], Job> = getService('scheduling', {
+      strapi,
+    }).syncFromDatabase();
+
+    for (const [, job] of scheduledJobs) {
+      job.cancel();
+    }
+  }
+};

--- a/packages/core/content-releases/server/src/index.ts
+++ b/packages/core/content-releases/server/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { register } from './register';
 import { bootstrap } from './bootstrap';
+import { destroy } from './destroy';
 import { contentTypes } from './content-types';
 import { services } from './services';
 import { controllers } from './controllers';
@@ -13,6 +14,7 @@ const getPlugin = () => {
     return {
       register,
       bootstrap,
+      destroy,
       contentTypes,
       services,
       controllers,


### PR DESCRIPTION
### What does it do?

We get all the scheduled releases not publish yet from the database on bootstrap to allow persistence. And we also cancel all the crons on destroy.

## Testing

### Enabling the future flags

The scheduling functionality is implemented through future flags. To begin, ensure the future flag is set to true. Navigate to `config/features.js` and include `contentReleasesScheduling` as an option within your future object. Create the future object if it does not exist.

Example:
```js
// config/features.js

module.exports = ({ env }) => ({
  future: {
    contentReleasesScheduling: true,
  },
});

```

### How to test it

1. Create multiple releases with scheduled date using the create release endpoint.
2. Shutdown your Strapi application and start it again
3. All the crons should be created again and the scheduled publish works 