### PR TITLE
fix(review-workflows): cannot create or update workflow & data doesn't invalidate correctly

### DIFF
--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/CreatePage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/CreatePage.tsx
@@ -71,18 +71,20 @@ export const ReviewWorkflowsCreatePage = () => {
     setSavePrompts({});
 
     try {
-      // @ts-expect-error – currentWorkflow will have already been validated by formik before it gets here.
-      const res = await createWorkflow(currentWorkflow);
+      const res = await createWorkflow({
+        // @ts-expect-error – currentWorkflow will have already been validated by formik before it gets here.
+        data: currentWorkflow,
+      });
 
       if ('error' in res) {
         if (isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
           setInitialErrors(formatValidationErrors(res.error));
-        } else {
-          toggleNotification({
-            type: 'warning',
-            message: formatAPIError(res.error),
-          });
         }
+
+        toggleNotification({
+          type: 'warning',
+          message: formatAPIError(res.error),
+        });
 
         return;
       }

--- a/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
+++ b/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
@@ -67,7 +67,7 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
       query: ({ id, ...data }) => ({
         url: `/admin/review-workflows/workflows/${id}`,
         method: 'PUT',
-        data: data,
+        data,
       }),
       transformResponse: (res: ReviewWorkflows.Update.Response) => res.data,
       invalidatesTags: (res, _err, arg) => [{ type: 'ReviewWorkflow' as const, id: arg.id }],

--- a/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
+++ b/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
@@ -38,8 +38,8 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
         };
       },
       providesTags: (res, _err, arg) => {
-        if (typeof arg === 'object' && 'id' in arg) {
-          return [{ type: 'User' as const, id: arg.id }];
+        if (typeof arg === 'object' && 'id' in arg && arg.id !== '') {
+          return [{ type: 'ReviewWorkflow' as const, id: arg.id }];
         } else {
           return [
             ...(res?.workflows.map(({ id }) => ({ type: 'ReviewWorkflow' as const, id })) ?? []),
@@ -52,10 +52,10 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
       ReviewWorkflows.Create.Response['data'],
       ReviewWorkflows.Create.Request['body']
     >({
-      query: (body) => ({
+      query: (data) => ({
         url: '/admin/review-workflows/workflows',
         method: 'POST',
-        body,
+        data,
       }),
       transformResponse: (res: ReviewWorkflows.Create.Response) => res.data,
       invalidatesTags: [{ type: 'ReviewWorkflow' as const, id: 'LIST' }],
@@ -64,10 +64,10 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
       ReviewWorkflows.Update.Response['data'],
       ReviewWorkflows.Update.Request['body'] & ReviewWorkflows.Update.Params
     >({
-      query: ({ id, ...body }) => ({
+      query: ({ id, ...data }) => ({
         url: `/admin/review-workflows/workflows/${id}`,
         method: 'PUT',
-        body,
+        data: data,
       }),
       transformResponse: (res: ReviewWorkflows.Update.Response) => res.data,
       invalidatesTags: (res, _err, arg) => [{ type: 'ReviewWorkflow' as const, id: arg.id }],

--- a/packages/core/admin/shared/contracts/review-workflows.ts
+++ b/packages/core/admin/shared/contracts/review-workflows.ts
@@ -50,7 +50,9 @@ namespace Get {
 
 namespace Update {
   export interface Request {
-    body: Partial<Workflow>;
+    body: {
+      data: Partial<Workflow>;
+    };
     query: {};
   }
 
@@ -66,7 +68,9 @@ namespace Update {
 
 namespace Create {
   export interface Request {
-    body: Omit<Workflow, 'id' | 'createdAt' | 'updatedAt'>;
+    body: {
+      data: Omit<Workflow, 'id' | 'createdAt' | 'updatedAt'>;
+    };
     query: {};
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* The types we're incorrect so they're amended to highlight we send the data nested under `data` in the body
* The provides tag set up was wrong where `id===""` but we should be checking it's not an empty string to correctly provide the list tag & in addition provide a single `ReviewWorkflow` not `User`
* We use the param from react-router instead of redux to update the workflow with it's correct `id` 

### Why is it needed?

* Users could not create or update workflows
* Data was not invalidated correctly

### How to test it?

* As a user I should be able to create a workflow
* then update that workflow
* then go to the list view of workflows see that workflow
* edit that workflow again
* go back to the list view and delete the workflow 
* it should not be in the list view no longer

### Related issue(s)/PR(s)

* resolves #19439
