### PR TITLE
feat(email-templates): authorize all user attributes in email templates

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/validation/__tests__/email-template.test.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/__tests__/email-template.test.js
@@ -2,12 +2,29 @@
 
 /* eslint-disable no-template-curly-in-string */
 
+global.strapi = {
+  getModel: jest.fn().mockReturnValue({
+    attributes: {
+      email: { type: 'string' },
+      username: { type: 'string' },
+      firstName: { type: 'string' },
+    },
+  }),
+};
+
 const { isValidEmailTemplate } = require('../email-template');
 
 describe('isValidEmailTemplate', () => {
   test('Accepts one valid pattern', () => {
     expect(isValidEmailTemplate('<%= CODE %>')).toBe(true);
     expect(isValidEmailTemplate('<%=CODE%>')).toBe(true);
+  });
+
+  test('Accepts user attributes', () => {
+    expect(isValidEmailTemplate('<%= USER.email %>')).toBe(true);
+    expect(isValidEmailTemplate('<%= USER.username %>')).toBe(true);
+    expect(isValidEmailTemplate('<%= USER.firstName %>')).toBe(true);
+    expect(isValidEmailTemplate('<%= USER.lastName %>')).toBe(false);
   });
 
   test('Refuses invalid patterns', () => {

--- a/packages/plugins/users-permissions/server/controllers/validation/email-template.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/email-template.js
@@ -12,14 +12,15 @@ const invalidPatternsRegexes = [
   /\${([^{}]*)}/m,
 ];
 
+const userSchema = strapi.getModel('plugin::users-permissions.user');
+
 const authorizedKeys = [
   'URL',
   'ADMIN_URL',
   'SERVER_URL',
   'CODE',
   'USER',
-  'USER.email',
-  'USER.username',
+  ...Object.entries(userSchema.attributes).map(([key]) => `USER.${key}`),
   'TOKEN',
 ];
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR changes the `email-template` validation rule used to update an email template in the `users-permissions` plugin. It changes the `authorizedKeys` that we can pass to the message to be able to use any field from user schema.

If your user schema defines a `firstName` attribute you will be able to pass a message containing `<%= USER.firstName %>`.

### Why is it needed?

Currently we can not use other fields than `USER.email` and `USER.username`. This PR gives us the ability to use any field from user schema.

### How to test it?

Unit tests included in the PR.

### Related issue(s)/PR(s)

#19442 
