### PR TITLE
Restore proper pagination object

### DIFF
--- a/api-tests/core/content-manager/api/x-to-many-rf-preview.test.api.js
+++ b/api-tests/core/content-manager/api/x-to-many-rf-preview.test.api.js
@@ -170,9 +170,9 @@ describe('x-to-many RF Preview', () => {
       const product = data.product[0];
 
       const { body, statusCode } = await rq.get(`${cmProductUrl}/${product.id}/shops`);
-
       expect(statusCode).toBe(200);
       expect(body.results).toHaveLength(10);
+      expect(body.pagination).toMatchObject({ page: 1, pageSize: 10, pageCount: 2, total: 12 });
       expect(difference(toIds(body.results), toIds(data.shop))).toHaveLength(0);
     });
 
@@ -183,6 +183,7 @@ describe('x-to-many RF Preview', () => {
 
       expect(statusCode).toBe(200);
       expect(body.results).toHaveLength(5);
+      expect(body.pagination).toMatchObject({ page: 1, pageSize: 10, pageCount: 1, total: 5 });
       expect(difference(toIds(body.results), toIds(data.category))).toHaveLength(0);
     });
   });

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -254,7 +254,7 @@ export default {
     const permissionQuery = await permissionChecker.sanitizedQuery.read(queryParams);
 
     if (isAnyToMany(attribute)) {
-      const resWithOnlyIds = await strapi.entityService.loadPages(
+      const res = await strapi.entityService.loadPages(
         model,
         { id },
         targetField,
@@ -267,11 +267,11 @@ export default {
           pageSize: ctx.request.query.pageSize,
         }
       );
-      const ids = resWithOnlyIds.results.map((item: any) => item.id);
+      const ids = res.results.map((item: any) => item.id);
 
       addFiltersClause(permissionQuery, { id: { $in: ids } });
 
-      const res = await strapi.entityService.loadPages(
+      const sanitizedRes = await strapi.entityService.loadPages(
         model,
         { id },
         targetField,
@@ -285,7 +285,7 @@ export default {
         }
       );
 
-      res.results = uniqBy('id', concat(res.results, resWithOnlyIds.results));
+      res.results = uniqBy('id', concat(sanitizedRes.results, res.results));
 
       ctx.body = res;
     } else {


### PR DESCRIPTION
### What does it do?

- Add some Api tests for pagination
- used correct pagination result for existing relations

### Why is it needed?

- Load More was not appearing because of incorrect pagination values

### How to test it?

- Make sure that the load more appears when you have 5+ relations present
- check the test explanation in this other PR: #19227 

### Related issue(s)/PR(s)

fix #19402 
