### PR TITLE
fix(review-workflows): pass data not body 

### DIFF
--- a/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
+++ b/packages/core/admin/ee/admin/src/services/reviewWorkflows.ts
@@ -109,10 +109,10 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
       Contracts.ReviewWorkflows.UpdateStage.Request['body'] &
         Contracts.ReviewWorkflows.UpdateStage.Params & { slug: string }
     >({
-      query: ({ model, slug, id, ...body }) => ({
+      query: ({ model, slug, id, ...data }) => ({
         url: `/admin/content-manager/${slug}/${model}/${id}/stage`,
         method: 'PUT',
-        body,
+        data,
       }),
       transformResponse: (res: Contracts.ReviewWorkflows.UpdateStage.Response) => res.data,
       invalidatesTags: (res, _err, arg) => [{ type: 'ReviewWorkflowStage' as const, id: arg.id }],
@@ -122,10 +122,10 @@ const reviewWorkflowsApi = adminApi.injectEndpoints({
       Contracts.ReviewWorkflows.UpdateAssignee.Request['body'] &
         Contracts.ReviewWorkflows.UpdateAssignee.Params & { slug: string }
     >({
-      query: ({ model, slug, id, ...body }) => ({
+      query: ({ model, slug, id, ...data }) => ({
         url: `/admin/content-manager/${slug}/${model}/${id}/assignee`,
         method: 'PUT',
-        body,
+        data,
       }),
       transformResponse: (res: Contracts.ReviewWorkflows.UpdateAssignee.Response) => res.data,
     }),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Passes `data` instead of `body` to the API

### Why is it needed?

* Users were unable to update the stage or assignee of an entity in the CM

### How to test it?

* As a user I should be able to update the stage of an entity in the CM
* As a user I should be able to update the assignee of an entity in the CM

### Related issue(s)/PR(s)

* resolves #19340
