### PR TITLE
Chore: fix playwright test issue

### DIFF
--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -1,10 +1,10 @@
 const { CUSTOM_TRANSFER_TOKEN_ACCESS_KEY } = require('./app-template/template/src/constants');
 
+// NOTE: anything included here needs to be included in all test datasets exports
 const ALLOWED_CONTENT_TYPES = [
   'admin::user',
   'admin::role',
   'admin::permission',
-  'plugin::i18n.locale',
   'api::article.article',
   'api::author.author',
   'api::homepage.homepage',

--- a/e2e/scripts/dts-import.js
+++ b/e2e/scripts/dts-import.js
@@ -21,6 +21,7 @@ const {
 export const resetDatabaseAndImportDataFromPath = async (filePath, contentTypesToWipe = []) => {
   const source = createSourceProvider(filePath);
   const destination = createDestinationProvider(contentTypesToWipe);
+  const includedTypes = [...ALLOWED_CONTENT_TYPES, ...contentTypesToWipe];
 
   const engine = createTransferEngine(source, destination, {
     versionStrategy: 'ignore',
@@ -29,18 +30,20 @@ export const resetDatabaseAndImportDataFromPath = async (filePath, contentTypesT
     transforms: {
       links: [
         {
+          // only transfer relations to+from requested content types
           filter(link) {
             return (
-              ALLOWED_CONTENT_TYPES.includes(link.left.type) &&
-              (ALLOWED_CONTENT_TYPES.includes(link.right.type) || link.right.type === undefined)
+              includedTypes.includes(link.left.type) &&
+              (includedTypes.includes(link.right.type) || link.right.type === undefined)
             );
           },
         },
       ],
       entities: [
         {
+          // only include entities of requested content types
           filter(entity) {
-            return ALLOWED_CONTENT_TYPES.includes(entity.type);
+            return includedTypes.includes(entity.type);
           },
         },
       ],

--- a/e2e/tests/content-manager/uniqueness.spec.js
+++ b/e2e/tests/content-manager/uniqueness.spec.js
@@ -6,7 +6,10 @@ test.describe('Uniqueness', () => {
   test.beforeEach(async ({ page }) => {
     // Reset the DB and also specify that we are wiping all entries of the unique content type each time
     // TODO: the default should be to wipe all entries, but we need to fix the import script first
-    await resetDatabaseAndImportDataFromPath('./e2e/data/with-admin.tar', ['api::unique.unique']);
+    await resetDatabaseAndImportDataFromPath('./e2e/data/with-admin.tar', [
+      'api::unique.unique',
+      'plugin::i18n.locale',
+    ]);
 
     await page.goto('/admin');
     await login({ page });


### PR DESCRIPTION
### What does it do?

Stops playwright tests from importing 'plugin::i18n.locale' from the datasets by default

### Why is it needed?

There were no locales exported in the `without-admin` export but on import we were saying to replace them, which left Strapi with no locales, so it couldn't load.

We could update the without-admin data to include locales but... they're only needed for one specific test and the fewer things we depend on, the less often we'll have to update ALL our test datasets.

### How to test it?

Playwright tests should run

### Related issue(s)/PR(s)
