### PR TITLE
fix: prevent setting locale on non localized content types

### DIFF
--- a/api-tests/core/strapi/document-service/create.test.api.ts
+++ b/api-tests/core/strapi/document-service/create.test.api.ts
@@ -32,7 +32,6 @@ describe('Document Service', () => {
           publishedAt: null, // should be a draft
         });
 
-        // @ts-expect-error - TODO: doc service entry type should contain documentId
         const articles = await findArticlesDb({ documentId: article.documentId });
         // Only one article should have been created
         expect(articles).toHaveLength(1);
@@ -91,19 +90,23 @@ describe('Document Service', () => {
       })
     );
 
-    // TODO
-    it.skip(
+    it(
       'can not directly create a published document',
       testInTransaction(async () => {
-        const articlePromise = strapi.documents(ARTICLE_UID).create({
+        const article = await strapi.documents(ARTICLE_UID).create({
           locale: 'fr',
           status: 'published',
           data: { title: 'Article' },
         });
+
+        expect(article).toMatchObject({
+          title: 'Article',
+          locale: 'fr', // selected locale
+          publishedAt: null, // should be a draft
+        });
       })
     );
 
-    // TODO: Make publishedAt not editable
     it(
       'publishedAt attribute is ignored when creating document',
       testInTransaction(async () => {
@@ -125,7 +128,7 @@ describe('Document Service', () => {
         const author = await strapi.documents(AUTHOR_UID).create({
           // Should be ignored on non-localized content types
           locale: 'fr',
-          data: { name: 'Author' },
+          data: { name: 'Author', locale: 'fr' },
         });
 
         // verify that the returned document was updated

--- a/packages/core/core/src/services/document-service/middlewares/defaults/locales.ts
+++ b/packages/core/core/src/services/document-service/middlewares/defaults/locales.ts
@@ -41,7 +41,14 @@ export const localeToLookup: Middleware = async (ctx, next) => {
  * Translate locale status parameter into the data that will be saved
  */
 export const localeToData: Middleware = async (ctx, next) => {
-  if (!isLocalizedContentType(ctx.uid)) return next(ctx);
+  if (!isLocalizedContentType(ctx.uid)) {
+    // Remove data.locale if it is not a localized content type
+    if (ctx.params?.data?.locale) {
+      ctx.params.data.locale = null;
+    }
+
+    return next(ctx);
+  }
   if (!ctx.params) ctx.params = {};
 
   const data = ctx.params.data || {};


### PR DESCRIPTION
You could manually set the locale value on content types with i18n disabled like:

```ts
        const author = await strapi.documents(AUTHOR_UID).create({
          data: { name: 'Author', locale: 'fr' },
        });
```

This PR prevents this behaviour and filters this parameter if i18n is disabled