### PR TITLE
fix(types): Allow readonly arrays to be used with ArrayNotation

### DIFF
--- a/packages/core/types/src/modules/entity-service/params/fields.ts
+++ b/packages/core/types/src/modules/entity-service/params/fields.ts
@@ -48,7 +48,7 @@ export type StringNotation<TSchemaUID extends Common.UID.Schema> =
  * type F = ['populatableField']; // ❌
  * type G = ['<random_string>']; // ❌
  */
-export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Exclude<
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = readonly Exclude<
   StringNotation<TSchemaUID>,
   WildcardNotation
 >[];

--- a/packages/core/types/src/modules/entity-service/params/populate.ts
+++ b/packages/core/types/src/modules/entity-service/params/populate.ts
@@ -37,7 +37,7 @@ export type StringNotation<TSchemaUID extends Common.UID.Schema> =
  * type D = ['<random_string>']; // ❌
  * type E = ['*']; // ❌
  */
-export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Exclude<
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = readonly Exclude<
   StringNotation<TSchemaUID>,
   WildcardNotation
 >[];

--- a/packages/core/types/src/modules/entity-service/params/sort.ts
+++ b/packages/core/types/src/modules/entity-service/params/sort.ts
@@ -61,7 +61,7 @@ export type StringNotation<TSchemaUID extends Common.UID.Schema> =
  * type E = [42]; // ❌
  * type F = 'title'; // ❌
  */
-export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = Any<TSchemaUID>[];
+export type ArrayNotation<TSchemaUID extends Common.UID.Schema> = readonly Any<TSchemaUID>[];
 
 /**
  * Object notation for a sort

--- a/packages/core/types/src/types/core/plugins/config/strapi-server/routes.ts
+++ b/packages/core/types/src/types/core/plugins/config/strapi-server/routes.ts
@@ -1,9 +1,9 @@
 import type { Common } from '../../..';
 
-export type ArrayNotation = Common.RouteInput[];
+export type ArrayNotation = readonly Common.RouteInput[];
 
 export interface ObjectNotation {
-  routes: Common.RouteInput[];
+  routes: readonly Common.RouteInput[];
   type?: Common.RouterType;
 }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It allows `ArrayNotation` to be readonly arrays

### Why is it needed?

If you are reusing an array of populate parameters you currently can't do the following

```ts
const populate = ['image']

await strapi.entityService.findOne(uid, id, {
  populate,
})
```

as `populate` in this example is of type `string[]`. This won't work because strapi expects an `('image')[]`.
A common solution to this is using `as const`

```ts
cosnt populate = ['image'] as const
```

now the type is `readonly ['image']` and currently this won't work either, becuase readonly arrays are not accepted by strapi. But they should, since the entityService is not mutating the array.

This PR aims to solve this issue.

### How to test it?

It can be tested by providing a readonly array to the entityService in the populate fields.

