### PR TITLE
feat(content-releases): add timezone to releases

### DIFF
--- a/packages/core/content-releases/server/src/content-types/release/schema.ts
+++ b/packages/core/content-releases/server/src/content-types/release/schema.ts
@@ -29,6 +29,9 @@ export default {
     scheduledAt: {
       type: 'datetime',
     },
+    timezone: {
+      type: 'string',
+    },
     actions: {
       type: 'relation',
       relation: 'oneToMany',

--- a/packages/core/content-releases/shared/contracts/releases.ts
+++ b/packages/core/content-releases/shared/contracts/releases.ts
@@ -8,6 +8,8 @@ export interface Release extends Entity {
   name: string;
   releasedAt: string | null;
   scheduledAt: string | null;
+  // We save scheduledAt always in UTC, but users can set the release in a different timezone to show that in the UI for everyone
+  timezone: string | null;
   actions: ReleaseAction[];
 }
 
@@ -98,6 +100,7 @@ export declare namespace CreateRelease {
     body: {
       name: string;
       scheduledAt?: Date;
+      timezone?: string;
     };
   }
 
@@ -122,6 +125,7 @@ export declare namespace UpdateRelease {
       name: string;
       // When editing a release, scheduledAt always need to be explicitly sended, so it can be null to unschedule it
       scheduledAt?: Date | null;
+      timezone?: string | null;
     };
   }
 

--- a/packages/core/content-releases/shared/validation-schemas.ts
+++ b/packages/core/content-releases/shared/validation-schemas.ts
@@ -6,6 +6,11 @@ export const RELEASE_SCHEMA = yup
     name: yup.string().trim().required(),
     // scheduledAt is a date, but we always receive strings from the client
     scheduledAt: yup.string().nullable(),
+    timezone: yup.string().when('scheduledAt', {
+      is: (scheduledAt) => !!scheduledAt,
+      then: yup.string().required(),
+      otherwise: yup.string().nullable(),
+    }),
   })
   .required()
   .noUnknown();

--- a/packages/core/content-releases/shared/validation-schemas.ts
+++ b/packages/core/content-releases/shared/validation-schemas.ts
@@ -7,7 +7,7 @@ export const RELEASE_SCHEMA = yup
     // scheduledAt is a date, but we always receive strings from the client
     scheduledAt: yup.string().nullable(),
     timezone: yup.string().when('scheduledAt', {
-      is: (scheduledAt) => !!scheduledAt,
+      is: (scheduledAt: string) => !!scheduledAt,
       then: yup.string().required(),
       otherwise: yup.string().nullable(),
     }),


### PR DESCRIPTION
### What does it do?

This PR add a new string field to "Release" Content Type to save the Timezone selected by the user in the UI. 

⚠️ We are saving the `scheduledAt` **always** using UTC, as we do for any time in all Strapi. This new timezone field is **only** for showing the time in the Release UI with the timezone selected by the user. 

## Testing

### Enabling the future flags

The scheduling functionality is implemented through future flags. To begin, ensure the future flag is set to true. Navigate to `config/features.js` and include `contentReleasesScheduling` as an option within your future object. Create the future object if it does not exist.

Example:
```js
// config/features.js

module.exports = ({ env }) => ({
  future: {
    contentReleasesScheduling: true,
  },
});

```

### How to test it

1. Create a new release with scheduledAt field, it should ask you to send the timezone.
2. If scheduledAt is null or undefined, timezone is not required. 

