### PR TITLE
fix: q search flakey test

### DIFF
--- a/api-tests/core/strapi/api/validate-query/validate-query.test.api.js
+++ b/api-tests/core/strapi/api/validate-query/validate-query.test.api.js
@@ -873,7 +873,7 @@ describe('Core API - Validate', () => {
         describe('Basic (no modifiers)', () => {
           it.each([
             ['Document A', 1],
-            ['OO', 2],
+            [' OO', 2],
             ['Document', documentsLength],
           ])('Successfully applies search: %s', async (search, expectedLength) => {
             const res = await rq.get('/api/documents', { qs: { _q: search } });

--- a/api-tests/core/strapi/deep-filtering.test.api.js
+++ b/api-tests/core/strapi/deep-filtering.test.api.js
@@ -233,7 +233,8 @@ describe('Deep Filtering API', () => {
         expect(res.body.data).toEqual(expect.arrayContaining(data.collector.slice(0, 2)));
       });
 
-      test('cards.name + _q=25', async () => {
+      // Searching by short strings could randomnly match with the document id
+      test('cards.name + _q=Bernard', async () => {
         const res = await rq({
           method: 'GET',
           url: '/collectors',
@@ -243,7 +244,7 @@ describe('Deep Filtering API', () => {
                 name: data.card[0].attributes.name,
               },
             },
-            _q: 25,
+            _q: 'Bernard',
           },
         });
 


### PR DESCRIPTION
### What does it do?

@innerdvations spotted this flakey test, that was sometimes matching the document id of the document. The solution was to search by a longer element.
