### PR TITLE
fix(content-manager): fix strange behaviours when you change position on Dynamic Zones and solve issue with ids not unique

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.ts
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/tests/reducer.test.ts
@@ -926,6 +926,88 @@ describe('EditViewDataManagerProvider | reducer', () => {
     });
   });
 
+  it('should add a component with a __temp_key__ that is higher than the highest id to not get rendering conflicts', () => {
+    const components = {
+      'blog.simple': {
+        uid: 'blog.simple',
+        attributes: {
+          id: {
+            type: 'integer',
+          },
+          name: {
+            type: 'string',
+          },
+        },
+      },
+    } as unknown as Record<string, FormattedComponentLayout>;
+
+    const state = {
+      ...initialState,
+      componentsDataStructure: {
+        'blog.simple': { name: 'test' },
+      },
+      initialData: {
+        name: 'name',
+        dz: [
+          { name: 'test', __component: 'blog.simple', id: 14 },
+          { name: 'test', __component: 'blog.simple', id: 3 },
+        ],
+      },
+      modifiedData: {
+        name: 'name',
+        dz: [
+          { name: 'test', __component: 'blog.simple', id: 14 },
+          { name: 'test', __component: 'blog.simple', id: 3 },
+        ],
+      },
+    };
+
+    const expected = {
+      ...initialState,
+      componentsDataStructure: {
+        'blog.simple': { name: 'test' },
+      },
+      initialData: {
+        name: 'name',
+        dz: [
+          { name: 'test', __component: 'blog.simple', id: 14 },
+          { name: 'test', __component: 'blog.simple', id: 3 },
+        ],
+      },
+      modifiedData: {
+        name: 'name',
+        dz: [
+          { name: 'test', __component: 'blog.simple', __temp_key__: 15 },
+          { name: 'test', __component: 'blog.simple', id: 14 },
+          { name: 'test', __component: 'blog.simple', id: 3 },
+        ],
+      },
+      modifiedDZName: 'dz',
+      shouldCheckErrors: true,
+    };
+
+    const action = {
+      type: 'ADD_COMPONENT_TO_DYNAMIC_ZONE' as const,
+      componentLayoutData: {
+        uid: 'blog.simple',
+        attributes: {
+          id: {
+            type: 'integer',
+          },
+          name: {
+            type: 'string',
+          },
+        },
+      } as unknown as FormattedComponentLayout,
+      allComponents: components,
+      keys: ['dz'],
+      shouldCheckErrors: true,
+      position: -1,
+    };
+
+    expect(reducer(state, action)).toEqual(expected);
+  });
+
   describe('CONNECT_RELATION', () => {
     it('should add a relation in the modifiedData', () => {
       const state = {

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.tsx
@@ -45,19 +45,21 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
     const onChangeRef = React.useRef(onChange);
 
     React.useEffect(() => {
-      editorRef.current = CodeMirror.fromTextArea(textareaRef.current!, {
-        lineWrapping: true,
-        extraKeys: {
-          Enter: 'newlineAndIndentContinueMarkdownList',
-          Tab: false,
-          'Shift-Tab': false,
-        },
-        readOnly: false,
-        smartIndent: false,
-        placeholder,
-        spellcheck: true,
-        inputStyle: 'contenteditable',
-      });
+      if (!editorRef.current) {
+        editorRef.current = CodeMirror.fromTextArea(textareaRef.current!, {
+          lineWrapping: true,
+          extraKeys: {
+            Enter: 'newlineAndIndentContinueMarkdownList',
+            Tab: false,
+            'Shift-Tab': false,
+          },
+          readOnly: false,
+          smartIndent: false,
+          placeholder,
+          spellcheck: true,
+          inputStyle: 'contenteditable',
+        });
+      }
 
       // @ts-expect-error – doesn't think command exists?
       CodeMirror.commands.newlineAndIndentContinueMarkdownList =

--- a/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Wysiwyg/Editor.tsx
@@ -45,21 +45,24 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
     const onChangeRef = React.useRef(onChange);
 
     React.useEffect(() => {
-      if (!editorRef.current) {
-        editorRef.current = CodeMirror.fromTextArea(textareaRef.current!, {
-          lineWrapping: true,
-          extraKeys: {
-            Enter: 'newlineAndIndentContinueMarkdownList',
-            Tab: false,
-            'Shift-Tab': false,
-          },
-          readOnly: false,
-          smartIndent: false,
-          placeholder,
-          spellcheck: true,
-          inputStyle: 'contenteditable',
-        });
+      if (editorRef.current) {
+        // Ensure the editor and its wrapper are cleaned up whenever this view is re-rendered
+        // e.g. in case of re-ordering wysiwyg components in a DynamicZone
+        editorRef.current.toTextArea();
       }
+      editorRef.current = CodeMirror.fromTextArea(textareaRef.current!, {
+        lineWrapping: true,
+        extraKeys: {
+          Enter: 'newlineAndIndentContinueMarkdownList',
+          Tab: false,
+          'Shift-Tab': false,
+        },
+        readOnly: false,
+        smartIndent: false,
+        placeholder,
+        spellcheck: true,
+        inputStyle: 'contenteditable',
+      });
 
       // @ts-expect-error – doesn't think command exists?
       CodeMirror.commands.newlineAndIndentContinueMarkdownList =

--- a/packages/core/admin/admin/src/content-manager/utils/fields.ts
+++ b/packages/core/admin/admin/src/content-manager/utils/fields.ts
@@ -3,14 +3,14 @@ import isNaN from 'lodash/isNaN';
 const getFieldName = (stringName: string) =>
   stringName.split('.').filter((string) => isNaN(parseInt(string, 10)));
 
-const getMaxTempKey = (arr: Array<{ __temp_key__?: number }>) => {
+const getMaxTempKey = (arr: Array<{ __temp_key__?: number; id?: number }>) => {
   if (arr.length === 0) {
     return -1;
   }
 
-  const maxTempKey = Math.max(...arr.map((o) => o.__temp_key__ ?? 0));
+  const maxValue = Math.max(...arr.map((o) => Number(o.id ?? o.__temp_key__ ?? 0)));
 
-  return Number.isNaN(maxTempKey) ? -1 : maxTempKey;
+  return Number.isNaN(maxValue) ? -1 : maxValue;
 };
 
 const isFieldTypeNumber = (type: string) => {


### PR DESCRIPTION
### What does it do?

It resolves a lot of rendering bugs in DZ when using for example Rich Text markdown fields.
In particular when you change the position of a markdown field inside a Dynamic Zone.
It ensures to generate unique IDs when we add new components in the DZ

### Why is it needed?
To avoid strange behaviours like when a component was added in a Dynamic Zone above a component containing the rich text editor, the wrapper would show up twice.

We want to add a temporary key when we add a new component which has a unique value to avoid conflicts between components, so to do this we want to find the maxValue between previous components ids and temp keys

### How to test it?

Please take a look at the video to have an idea of the previous bug and read the instructions to replicate it:
- in a collection create a dynamic zone with a markdown field and an image field for example
- then in the CM create an entry with values in the dynamic zone for both, the markdown field and the image and save
- then try to change the position of the image and move it before the markdown for example
- you will have an empty space added before your content in the markdown editor
- then if you try to add more content after the one you originally saved in the markdown editor, save and refresh the new content won't be stored

https://github.com/strapi/strapi/assets/2589748/c1924f73-1a2b-453c-b27e-08958928c697


It solves also this error:
 - Add 2 components in a dynamic zone, one must contain a richtext
 - Remove a component before the richtext one
 - Try to type in the richtext, you don't need to see an error "Woops! Something went wrong. Please, try again."

and this one
 - create a collection with a dynamic zone on it
 - add a component with a rich text field on it
 - create an item of the collection and add some values for the rich text field
 - Add another component above the richtext using the arrow menu
 - Richtext original content needs to stay the same and not to have content duplicated

### Related issue(s)/PR(s)

* resolves https://github.com/strapi/strapi/issues/17858
* resolves https://github.com/strapi/strapi/issues/18939
* resolves https://github.com/strapi/strapi/issues/18701
* resolves https://github.com/strapi/strapi/issues/17858
* closes https://github.com/strapi/strapi/pull/18532
