### PR TITLE
Fix Type Generation Checks for Min/Max Default Values

### DIFF
--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -671,6 +671,38 @@ describe('Attributes', () => {
           // Check for string keyword on the second typeArgument
           expect(typeofMinMax.kind).toBe(ts.SyntaxKind.StringKeyword);
         });
+
+        test('Min: 0', () => {
+          const attribute = { min: 0 };
+          const modifiers = getAttributeModifiers(attribute);
+
+          expect(modifiers).toHaveLength(1);
+
+          expect(modifiers[0].kind).toBe(ts.SyntaxKind.TypeReference);
+          expect(modifiers[0].typeName.escapedText).toBe('Attribute.SetMinMax');
+
+          const [setMinMax] = modifiers;
+          const { typeArguments } = setMinMax;
+
+          expect(typeArguments).toBeDefined();
+          expect(typeArguments).toHaveLength(2);
+
+          const [definition, typeofMinMax] = typeArguments;
+
+          // Min/Max
+          expect(definition.kind).toBe(ts.SyntaxKind.TypeLiteral);
+          expect(definition.members).toHaveLength(1);
+
+          const [min] = definition.members;
+
+          expect(min.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+          expect(min.name.escapedText).toBe('min');
+          expect(min.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
+          expect(min.type.text).toBe('0');
+
+          // Check for string keyword on the second typeArgument
+          expect(typeofMinMax.kind).toBe(ts.SyntaxKind.NumberKeyword);
+        });
       });
 
       describe('MinLength / MaxLength', () => {

--- a/packages/utils/typescript/lib/generators/common/models/attributes.js
+++ b/packages/utils/typescript/lib/generators/common/models/attributes.js
@@ -114,21 +114,21 @@ const getAttributeModifiers = (attribute) => {
       throw new Error('typeof min/max values mismatch');
     }
 
-    const typeofMinMax = (max && typeofMax) ?? (min && typeofMin);
     let typeKeyword;
 
-    // Determines type keyword (string/number) based on min/max options, throws error for invalid types
-    switch (typeofMinMax) {
-      case 'string':
-        typeKeyword = ts.SyntaxKind.StringKeyword;
-        break;
-      case 'number':
-        typeKeyword = ts.SyntaxKind.NumberKeyword;
-        break;
-      default:
-        throw new Error(
-          `Invalid data type for min/max options. Must be string or number, but found ${typeofMinMax}`
-        );
+    // use 'string'
+    if (typeofMin === 'string' || typeofMax === 'string') {
+      typeKeyword = ts.SyntaxKind.StringKeyword;
+    }
+    // use 'number'
+    else if (typeofMin === 'number' || typeofMax === 'number') {
+      typeKeyword = ts.SyntaxKind.NumberKeyword;
+    }
+    // invalid type
+    else {
+      throw new Error(
+        `Invalid data type for min/max options. Must be string, number or undefined, but found { min: ${min} (${typeofMin}), max: ${max} (${typeofMax}) }`
+      );
     }
 
     modifiers.push(


### PR DESCRIPTION
### What does it do?

Fix a behavior where the type generation could fail when min/max values for an attribute were set to a falsy value (e.g. `0`)

### Why is it needed?

It prevents the generation of the type

### How to test it?

- Add a numeric attribute to a schema such as the following
  ```json
  {
    "totalPrice": {
      "type": "decimal",
      "min": 0
    }
  }
  ```

- Run `yarn strapi ts:generate-types`
- The types should be generated correctly, without throwing an error

### Related issue(s)/PR(s)

fix #19482
