### PR TITLE
fix(history): fetch single-types

### DIFF
--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -181,7 +181,7 @@ const VersionContent = () => {
                             return JSON.stringify(value);
                           case 'date':
                           case 'datetime':
-                            return new Date(value as string);
+                            return value;
                           default:
                             return value;
                         }

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -176,15 +176,11 @@ const VersionContent = () => {
                       const getValue = () => {
                         const value = version.data[column.name];
 
-                        switch (attribute.type) {
-                          case 'json':
-                            return JSON.stringify(value);
-                          case 'date':
-                          case 'datetime':
-                            return value;
-                          default:
-                            return value;
+                        if (attribute.type === 'json') {
+                          return JSON.stringify(value);
                         }
+
+                        return value;
                       };
 
                       return (

--- a/packages/core/content-manager/server/src/history/controllers/__tests__/history-version.test.ts
+++ b/packages/core/content-manager/server/src/history/controllers/__tests__/history-version.test.ts
@@ -92,7 +92,7 @@ describe('History version controller', () => {
 
     const historyVersionController = createHistoryVersionController({
       // @ts-expect-error - we're not mocking the entire strapi object
-      strapi: { getModel: jest.fn(() => 'collectionType') },
+      strapi: { getModel: jest.fn(() => ({ kind: 'collectionType' })) },
     });
 
     // @ts-expect-error partial context
@@ -125,7 +125,7 @@ describe('History version controller', () => {
 
     const historyVersionController = createHistoryVersionController({
       // @ts-expect-error - we're not mocking the entire strapi object
-      strapi: { getModel: jest.fn(() => 'singleType') },
+      strapi: { getModel: jest.fn(() => ({ kind: 'singleType' })) },
     });
 
     // @ts-expect-error partial context

--- a/packages/core/content-manager/server/src/history/controllers/__tests__/history-version.test.ts
+++ b/packages/core/content-manager/server/src/history/controllers/__tests__/history-version.test.ts
@@ -40,14 +40,13 @@ describe('History version controller', () => {
 
       const historyVersionController = createHistoryVersionController({
         // @ts-expect-error - we're not mocking the entire strapi object
-        strapi: { getModel: jest.fn(() => 'collectionType') },
+        strapi: { getModel: jest.fn(() => ({ kind: 'collectionType' })) },
       });
 
       // @ts-expect-error partial context
       expect(historyVersionController.findMany(ctx)).rejects.toThrow(
         /contentType and documentId are required/
       );
-
       expect(mockFindVersionsPage).not.toHaveBeenCalled();
     });
 
@@ -61,14 +60,11 @@ describe('History version controller', () => {
 
       const historyVersionController = createHistoryVersionController({
         // @ts-expect-error - we're not mocking the entire strapi object
-        strapi: { getModel: jest.fn(() => 'singleType') },
+        strapi: { getModel: jest.fn(() => ({ kind: 'singleType' })) },
       });
 
       // @ts-expect-error partial context
-      expect(historyVersionController.findMany(ctx)).rejects.toThrow(
-        /contentType and documentId are required/
-      );
-
+      expect(historyVersionController.findMany(ctx)).rejects.toThrow(/contentType is required/);
       expect(mockFindVersionsPage).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/content-manager/server/src/history/controllers/history-version.ts
+++ b/packages/core/content-manager/server/src/history/controllers/history-version.ts
@@ -1,5 +1,5 @@
 import { errors } from '@strapi/utils';
-import type { Common, Strapi } from '@strapi/types';
+import type { Common, Strapi, UID } from '@strapi/types';
 import { getService as getContentManagerService } from '../../utils';
 import { getService } from '../utils';
 import { HistoryVersions } from '../../../../shared/contracts';
@@ -7,7 +7,14 @@ import { HistoryVersions } from '../../../../shared/contracts';
 const createHistoryVersionController = ({ strapi }: { strapi: Strapi }) => {
   return {
     async findMany(ctx) {
-      if (!ctx.query.contentType || !ctx.query.documentId) {
+      const contentTypeUid = ctx.query.contentType as UID.ContentType;
+      const isSingleType = strapi.getModel(contentTypeUid).kind === 'singleType';
+
+      if (isSingleType && !contentTypeUid) {
+        throw new errors.ForbiddenError('contentType is required');
+      }
+
+      if (!contentTypeUid && !ctx.query.documentId) {
         throw new errors.ForbiddenError('contentType and documentId are required');
       }
 

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -112,7 +112,7 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
           where: {
             $and: [
               { contentType: params.contentType },
-              { relatedDocumentId: params.documentId },
+              ...(params.documentId ? [{ relatedDocumentId: params.documentId }] : []),
               ...(params.locale ? [{ locale: params.locale }] : []),
             ],
           },


### PR DESCRIPTION
### What does it do?

- Do not require `documentId` when fetching singleType history versions since only a single document can exist for single-type content types.

### Why is it needed?

- Otherwise can't fetch single-types 
- It doesn't seem necessary for single types (tbd 🙃 ).


### How to test it

- Go to a single-type
- Make a change and save
- Click the history button, you should see a single version
- Go back to the single type
- Make another change and save
- Click the history button, you should see two versions.
- Move between them to see the data changes between versions

NOTE: It seems to be working but I am unable to create an entry in another locale to test that is working
