### PR TITLE
Feat/input crop image

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
@@ -286,10 +286,11 @@ export const PreviewBox = ({
 
 const Input = styled.input`
   border: 0;
-  width: 60px;
+  width: 50px;
   &:focus {
     outline: none;
   }
+  text-align: center;
 `;
 
 PreviewBox.defaultProps = {

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
@@ -5,6 +5,7 @@ import { useTracking } from '@strapi/helper-plugin';
 import { Crop as Resize, Download as DownloadIcon, Trash } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import styled from 'styled-components';
 
 import { AssetDefinition, AssetType } from '../../../constants';
 import { useCropImg } from '../../../hooks/useCropImg';
@@ -49,7 +50,7 @@ export const PreviewBox = ({
   const [thumbnailUrl, setThumbnailUrl] = useState(createAssetUrl(asset, true));
   const { formatMessage } = useIntl();
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const { crop, produceFile, stopCropping, isCropping, isCropperReady, width, height } =
+  const { crop, produceFile, stopCropping, isCropping, isCropperReady, width, height, cropperRef } =
     useCropImg();
   const { editAsset, error, isLoading, progress, cancel } = useEditAsset();
 
@@ -141,6 +142,24 @@ export const PreviewBox = ({
     setHasCropIntent(true);
   };
 
+  const onChangeWidth = (e) => {
+    if (cropperRef) {
+      const imageData = cropperRef.current?.getImageData();
+      const ratio = imageData.width / imageData.naturalWidth;
+      cropperRef.current?.setCropBoxData({
+        width: parseFloat(e.target.value * ratio),
+      });
+    }
+  };
+
+  const onChangeHeight = (e) => {
+    const imageData = cropperRef.current?.getImageData();
+    const ratio = imageData.height / imageData.naturalHeight;
+    cropperRef.current?.setCropBoxData({
+      height: parseFloat(e.target.value * ratio),
+    });
+  };
+
   return (
     <>
       <RelativeBox hasRadius background="neutral150" borderColor="neutral200">
@@ -226,9 +245,11 @@ export const PreviewBox = ({
           justifyContent="flex-end"
           blurry={isInCroppingMode}
         >
-          {isInCroppingMode && width && height && (
+          {isInCroppingMode && (
             <BadgeOverride background="neutral900" color="neutral0">
-              {width && height ? `${height}✕${width}` : 'N/A'}
+              <Input label="height" type="text" min={0} value={height} onChange={onChangeHeight} />
+              x
+              <Input label="width" type="text" min={0} value={width} onChange={onChangeWidth} />
             </BadgeOverride>
           )}
         </ActionRow>
@@ -246,6 +267,14 @@ export const PreviewBox = ({
     </>
   );
 };
+
+const Input = styled.input`
+  border: 0;
+  width: 60px;
+  &:focus {
+    outline: none;
+  }
+`;
 
 PreviewBox.defaultProps = {
   replacementFile: undefined,

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/index.jsx
@@ -202,6 +202,7 @@ export const PreviewBox = ({
                 label={formatMessage({ id: getTrad('control-card.crop'), defaultMessage: 'Crop' })}
                 icon={<Resize />}
                 onClick={handleCropStart}
+                data-testid="crop"
               />
             )}
           </Flex>
@@ -230,6 +231,7 @@ export const PreviewBox = ({
             ref={previewRef}
             mime={asset.mime}
             name={asset.name}
+            data-testid="preview"
             url={hasCropIntent ? assetUrl : thumbnailUrl}
             onLoad={() => {
               if (asset.isLocal || hasCropIntent) {
@@ -246,10 +248,24 @@ export const PreviewBox = ({
           blurry={isInCroppingMode}
         >
           {isInCroppingMode && (
-            <BadgeOverride background="neutral900" color="neutral0">
-              <Input label="height" type="text" min={0} value={height} onChange={onChangeHeight} />
+            <BadgeOverride background="neutral900" color="neutral0" data-testid="crop-size">
+              <Input
+                data-testid="cropbox-height"
+                label="height"
+                type="text"
+                min={0}
+                value={height}
+                onChange={onChangeHeight}
+              />
               x
-              <Input label="width" type="text" min={0} value={width} onChange={onChangeWidth} />
+              <Input
+                data-testid="cropbox-width"
+                label="width"
+                type="text"
+                min={0}
+                value={width}
+                onChange={onChangeWidth}
+              />
             </BadgeOverride>
           )}
         </ActionRow>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/PreviewBox/__snapshots__/index.test.jsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/PreviewBox/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,399 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewBox renders and matches the snapshot 1`] = `
+.c10 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c15 {
+  font-size: 0.75rem;
+  line-height: 1.33;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.c0 {
+  background: #eaeaef;
+  border-radius: 4px;
+  border-color: #dcdce4;
+  border: 1px solid #dcdce4;
+}
+
+.c2 {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.c13 {
+  background: #212134;
+  padding: 8px;
+  border-radius: 4px;
+  position: absolute;
+}
+
+.c6 {
+  background: #ffffff;
+  padding: 8px;
+  border-radius: 4px;
+  border-color: #dcdce4;
+  border: 1px solid #dcdce4;
+  cursor: pointer;
+}
+
+.c12 {
+  padding-right: 8px;
+  padding-left: 8px;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  position: relative;
+  outline: none;
+}
+
+.c8 > svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c8 > svg > g,
+.c8 > svg path {
+  fill: #ffffff;
+}
+
+.c8[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c8:after {
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-duration: 0.2s;
+  transition-duration: 0.2s;
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  left: -4px;
+  right: -4px;
+  border: 2px solid transparent;
+}
+
+.c8:focus-visible {
+  outline: none;
+}
+
+.c8:focus-visible:after {
+  border-radius: 8px;
+  content: '';
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+  border: 2px solid #4945ff;
+}
+
+.c14 {
+  z-index: 4;
+  display: none;
+}
+
+.c9 {
+  border-color: #dcdce4;
+  height: 2rem;
+  width: 2rem;
+}
+
+.c9 svg g,
+.c9 svg path {
+  fill: #8e8ea9;
+}
+
+.c9:hover svg g,
+.c9:focus svg g,
+.c9:hover svg path,
+.c9:focus svg path {
+  fill: #666687;
+}
+
+.c9[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c11 {
+  position: relative;
+  text-align: center;
+  background: repeating-conic-gradient( #f6f6f9 0% 25%, transparent 0% 50% ) 50% / 20px 20px;
+}
+
+.c11 svg {
+  font-size: 3rem;
+  height: 16.5rem;
+}
+
+.c11 img,
+.c11 video {
+  margin: 0;
+  padding: 0;
+  max-height: 16.5rem;
+  max-width: 100%;
+}
+
+.c4 {
+  height: 3.25rem;
+}
+
+<body>
+  <div>
+    <div
+      class="c0 c1"
+    >
+      <div
+        class="c2 c3 c4"
+      >
+        <div
+          class="c5"
+        >
+          <span>
+            <button
+              aria-disabled="false"
+              aria-labelledby=":r0:"
+              class="c6 c7 c8 c9"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="c10"
+              >
+                Download
+              </span>
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="1rem"
+                viewBox="0 0 24 25"
+                width="1rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M13.571 5.85H10.43v8.47H2.487a.2.2 0 0 0-.14.343l9.512 9.401a.2.2 0 0 0 .282 0l9.513-9.401a.2.2 0 0 0-.14-.342H13.57V5.85ZM2.2 3.027a.2.2 0 0 1-.2-.2V.402c0-.11.09-.2.2-.2h19.6c.11 0 .2.09.2.2v2.423a.2.2 0 0 1-.2.2H2.2Z"
+                  fill="#212134"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </span>
+          <span>
+            <button
+              aria-disabled="false"
+              aria-labelledby=":r2:"
+              class="c6 c7 c8 c9"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="c10"
+              >
+                Copy link
+              </span>
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="1rem"
+                viewBox="0 0 24 24"
+                width="1rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21.415 1.344a6.137 6.137 0 0 0-8.525.838L11.095 4.33a1.53 1.53 0 1 0 2.35 1.963l1.794-2.148a3.054 3.054 0 0 1 4.365-.324 3.117 3.117 0 0 1 .255 4.301l-3.73 4.467-.035.038a3.048 3.048 0 0 1-4.53.078 1.531 1.531 0 0 0-2.241 2.086 6.114 6.114 0 0 0 9.159-.245l3.721-4.454a6.289 6.289 0 0 0 1.418-4.62 6.01 6.01 0 0 0-2.206-4.128Z"
+                  fill="#212134"
+                />
+                <path
+                  d="m10.399 17.884-1.604 1.92a3.118 3.118 0 0 1-4.278.513 3.052 3.052 0 0 1-.457-4.353l3.795-4.542.028-.031a3.042 3.042 0 0 1 4.584-.022 1.529 1.529 0 0 0 1.794.37c.197-.094.37-.228.51-.395l.018-.022a1.51 1.51 0 0 0-.025-1.977 6.11 6.11 0 0 0-9.27.126l-3.784 4.53a6.137 6.137 0 0 0 .692 8.539 6.01 6.01 0 0 0 4.454 1.437 6.289 6.289 0 0 0 4.294-2.217l1.598-1.913a1.53 1.53 0 0 0-2.35-1.963Z"
+                  fill="#212134"
+                />
+              </svg>
+            </button>
+          </span>
+          <span>
+            <button
+              aria-disabled="false"
+              aria-labelledby=":r4:"
+              class="c6 c7 c8 c9"
+              data-testid="crop"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="c10"
+              >
+                Crop
+              </span>
+              <svg
+                aria-hidden="true"
+                fill="none"
+                focusable="false"
+                height="1rem"
+                viewBox="0 0 24 24"
+                width="1rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20.571 21.429h-3.428V24h3.428v-2.571ZM20.571 17.143V3.429H7.714v3.428h9.429v10.286H6.857V0H3.43v3.429H0v3.428h3.429v13.714H24v-3.428h-3.429Z"
+                  fill="#212134"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+      </div>
+      <div
+        class="c11"
+      >
+        <img
+          alt="Screenshot 2.png"
+          data-testid="preview"
+          src="/uploads/Screenshot_2_5d4a574d61.png"
+        />
+      </div>
+      <div
+        class="c12 c3 c4"
+      />
+    </div>
+    <div
+      class="c10"
+    >
+      <p
+        aria-live="polite"
+        aria-relevant="all"
+        id="live-region-log"
+        role="log"
+      />
+      <p
+        aria-live="polite"
+        aria-relevant="all"
+        id="live-region-status"
+        role="status"
+      />
+      <p
+        aria-live="assertive"
+        aria-relevant="all"
+        id="live-region-alert"
+        role="alert"
+      />
+    </div>
+  </div>
+  <div
+    class=""
+  >
+    <div
+      class="c13 c14"
+      id=":r0:"
+      role="tooltip"
+    >
+      <p
+        class="c15"
+      >
+        Download
+      </p>
+    </div>
+  </div>
+  <div
+    class=""
+  >
+    <div
+      class="c13 c14"
+      id=":r2:"
+      role="tooltip"
+    >
+      <p
+        class="c15"
+      >
+        Copy link
+      </p>
+    </div>
+  </div>
+  <div
+    class=""
+  >
+    <div
+      class="c13 c14"
+      id=":r4:"
+      role="tooltip"
+    >
+      <p
+        class="c15"
+      >
+        Crop
+      </p>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/PreviewBox/index.test.jsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/PreviewBox/index.test.jsx
@@ -1,0 +1,156 @@
+/**
+ *
+ * Tests for PreviewBox
+ *
+ */
+
+import React from 'react';
+
+import { lightTheme, ThemeProvider } from '@strapi/design-system';
+import { TrackingProvider } from '@strapi/helper-plugin';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import en from '../../../../translations/en.json';
+import { PreviewBox } from '../../PreviewBox';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+const messageForPlugin = Object.keys(en).reduce((acc, curr) => {
+  acc[curr] = `upload.${en[curr]}`;
+
+  return acc;
+}, {});
+
+const asset = {
+  id: 8,
+  name: 'Screenshot 2.png',
+  alternativeText: null,
+  caption: null,
+  width: 1476,
+  height: 780,
+  formats: {
+    thumbnail: {
+      name: 'thumbnail_Screenshot 2.png',
+      hash: 'thumbnail_Screenshot_2_5d4a574d61',
+      ext: '.png',
+      mime: 'image/png',
+      width: 245,
+      height: 129,
+      size: 10.7,
+      path: null,
+      url: '/uploads/thumbnail_Screenshot_2_5d4a574d61.png',
+    },
+    large: {
+      name: 'large_Screenshot 2.png',
+      hash: 'large_Screenshot_2_5d4a574d61',
+      ext: '.png',
+      mime: 'image/png',
+      width: 1000,
+      height: 528,
+      size: 97.1,
+      path: null,
+      url: '/uploads/large_Screenshot_2_5d4a574d61.png',
+    },
+    medium: {
+      name: 'medium_Screenshot 2.png',
+      hash: 'medium_Screenshot_2_5d4a574d61',
+      ext: '.png',
+      mime: 'image/png',
+      width: 750,
+      height: 396,
+      size: 58.7,
+      path: null,
+      url: '/uploads/medium_Screenshot_2_5d4a574d61.png',
+    },
+    small: {
+      name: 'small_Screenshot 2.png',
+      hash: 'small_Screenshot_2_5d4a574d61',
+      ext: '.png',
+      mime: 'image/png',
+      width: 500,
+      height: 264,
+      size: 31.06,
+      path: null,
+      url: '/uploads/small_Screenshot_2_5d4a574d61.png',
+    },
+  },
+  hash: 'Screenshot_2_5d4a574d61',
+  ext: '.png',
+  mime: 'image/png',
+  size: 102.01,
+  url: '/uploads/Screenshot_2_5d4a574d61.png',
+  previewUrl: null,
+  provider: 'local',
+  provider_metadata: null,
+  createdAt: '2021-10-04T09:42:31.670Z',
+  updatedAt: '2021-10-04T09:42:31.670Z',
+  isLocal: true,
+};
+
+const mockOnCropStart = jest.fn();
+
+const renderCompo = () =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TrackingProvider>
+        <ThemeProvider theme={lightTheme}>
+          <IntlProvider locale="en" messages={messageForPlugin} defaultLocale="en">
+            <PreviewBox
+              asset={asset}
+              canUpdate
+              canCopyLink
+              canDownload
+              onDelete={jest.fn()}
+              onCropFinish={jest.fn()}
+              onCropStart={mockOnCropStart}
+              onCropCancel={jest.fn()}
+            />
+          </IntlProvider>
+        </ThemeProvider>
+      </TrackingProvider>
+    </QueryClientProvider>,
+    { container: document.getElementById('app') }
+  );
+
+describe('PreviewBox', () => {
+  it('renders and matches the snapshot', () => {
+    renderCompo();
+
+    expect(document.body).toMatchSnapshot();
+  });
+
+  it('triggers crop start on click', () => {
+    renderCompo();
+
+    const cropButton = screen.getByTestId('crop');
+    fireEvent.click(cropButton);
+    fireEvent.load(screen.getByTestId('preview'));
+
+    expect(mockOnCropStart).toHaveBeenCalled();
+  });
+
+  it('triggers crop start on click and change cropbox dimensions input', () => {
+    renderCompo();
+
+    const cropButton = screen.getByTestId('crop');
+    fireEvent.click(cropButton);
+    fireEvent.load(screen.getByTestId('preview'));
+
+    const heightInput = screen.getByTestId('cropbox-height');
+    fireEvent.change(heightInput, { target: { value: '10' } });
+    expect(heightInput.value).toBe('10');
+    expect(heightInput.value).not.toBe('11');
+
+    const widthInput = screen.getByTestId('cropbox-width');
+    fireEvent.change(widthInput, { target: { value: '20' } });
+    expect(widthInput.value).toBe('20');
+  });
+});

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.jsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.jsx.snap
@@ -955,6 +955,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                             aria-disabled="false"
                             aria-labelledby=":r6:"
                             class="c15 c8 c16 c17"
+                            data-testid="crop"
                             tabindex="0"
                             type="button"
                           >
@@ -986,6 +987,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                     >
                       <img
                         alt="Screenshot 2.png"
+                        data-testid="preview"
                         src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
                       />
                     </div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.jsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/index.test.jsx.snap
@@ -955,6 +955,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                             aria-disabled="false"
                             aria-labelledby=":r6:"
                             class="c15 c8 c16 c17"
+                            data-testid="crop"
                             tabindex="0"
                             type="button"
                           >
@@ -986,6 +987,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                     >
                       <img
                         alt="Screenshot 2.png"
+                        data-testid="preview"
                         src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
                       />
                     </div>

--- a/packages/core/upload/admin/src/hooks/useCropImg.js
+++ b/packages/core/upload/admin/src/hooks/useCropImg.js
@@ -28,7 +28,6 @@ export const useCropImg = () => {
     if (!cropperRef.current) {
       cropperRef.current = new Cropper(image, {
         modal: true,
-        initialAspectRatio: 16 / 9,
         movable: true,
         zoomable: false,
         cropBoxResizable: true,
@@ -81,5 +80,6 @@ export const useCropImg = () => {
     isCropping,
     isCropperReady: Boolean(cropperRef.current),
     ...size,
+    cropperRef,
   };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR introduces custom input fields for the image cropping feature. This allows users to specify the dimensions of the cropping area freely. Additionally, the change I have made is in the media library feature (@strapi/upload). You can see it in the picture below.

![Screenshot 2567-02-14 at 15 23 50](https://github.com/strapi/strapi/assets/139952351/cb68449a-b8e0-41e7-bb0f-95b8c3413c65)

P.S. This change will make the cropping ratio free instead of 16/9.

### Why is it needed?

Currently, we are unable to specify the input for image cropping by typing. This makes it difficult for our content team to specify the image pixels. While it's manageable for a single image, it becomes time-consuming for multiple images as they have to manually drag the crop box area each time.

### How to test it?

In the Media Library's cropping feature, you can click on the image dimensions to input custom pixels.

![Screenshot 2567-02-14 at 15 23 54](https://github.com/strapi/strapi/assets/139952351/ccb6763f-6c49-42d8-9a62-e31cc40388aa)

### Related issue(s)/PR(s)

Issue that has already been created: https://feedback.strapi.io/customization/p/add-option-to-manually-specify-dimensions-in-the-crop-tool
