### PR TITLE
fix(i18n): extract relatedEntityId from the query

### DIFF
--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -115,8 +115,8 @@ describe('i18n - Content API', () => {
           method: 'POST',
           url: `/content-manager/collection-types/api::category.category`,
           qs: {
-            plugins: { i18n: { relatedEntityId: data.categories[0].id } },
             locale,
+            relatedEntityId: data.categories[0].id,
           },
           body: {
             name: `category in ${locale}`,

--- a/api-tests/plugins/i18n/locales.test.api.js
+++ b/api-tests/plugins/i18n/locales.test.api.js
@@ -405,25 +405,30 @@ describe('CRUD locales', () => {
       await rq({
         url: '/content-manager/collection-types/api::product.product',
         method: 'POST',
-        qs: { plugins: { i18n: { locale: 'en', relatedEntityId: frenchProduct.id } } },
+        qs: { locale: 'en', relatedEntityId: frenchProduct.id },
         body: { name: 'product name' },
       });
 
       const {
-        body: { results: createdProducts },
+        body: { results: createdFrenchProducts },
       } = await rq({
         url: '/content-manager/collection-types/api::product.product',
         method: 'GET',
         qs: { locale: 'fr-FR' },
       });
 
-      expect(createdProducts).toHaveLength(1);
-      expect(createdProducts[0].localizations[0].locale).toBe('en');
+      expect(createdFrenchProducts).toHaveLength(1);
+
+      // We have related the english product to the french product
+      // The english entity should be present in the french product localizations
+      expect(createdFrenchProducts[0].localizations[0].locale).toBe('en');
 
       const res = await rq({
         url: `/i18n/locales/${data.locales[1].id}`,
         method: 'DELETE',
       });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject(omitTimestamps(data.locales[1]));
 
       const {
         body: { results: frenchProducts },
@@ -443,8 +448,6 @@ describe('CRUD locales', () => {
       });
       expect(englishProducts).toHaveLength(1);
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toMatchObject(omitTimestamps(data.locales[1]));
       data.deletedLocales.push(res.body);
       data.locales.splice(1, 1);
     });

--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -24,7 +24,7 @@ const validateLocaleCreation: Common.MiddlewareHandler = async (ctx, next) => {
   }
 
   const locale = get('locale', query);
-  const relatedEntityId = get('plugins.i18n.relatedEntityId', query);
+  const relatedEntityId = get('relatedEntityId', query);
   // cleanup to avoid creating duplicates in singletypes
   ctx.request.query = {};
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changes where we extract relatedEntityId from the query string

### Why is it needed?

i18n was broken as relatedEntityId was not nested in {plugins.i18n} as the BE was expecting

### How to test it?

QA
Updated API tests


Fixes https://github.com/strapi/strapi/issues/19486	

