### PR TITLE
fix: media cloning

### DIFF
--- a/packages/core/database/src/entity-manager/relations/cloning/morph-relations.ts
+++ b/packages/core/database/src/entity-manager/relations/cloning/morph-relations.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+import type { ID, Relation } from '../../../types';
+
+export const cloneMorphMediaRelations = async ({
+  uid,
+  targetId,
+  sourceId,
+  attribute,
+  transaction: trx,
+}: {
+  uid: string;
+  targetId: ID;
+  sourceId: ID;
+  attribute: Relation.MorphOne | Relation.MorphMany;
+  transaction?: Knex.Transaction;
+}) => {
+  const { attributes } = strapi.db.metadata.get(attribute.target);
+  const { related } = attributes;
+  const { joinTable } = related;
+
+  const records = await strapi.db.entityManager
+    .createQueryBuilder(joinTable.name)
+    .select('*')
+    .where({
+      [joinTable.morphColumn.typeColumn.name]:  uid,
+      [joinTable.morphColumn.idColumn.name]: sourceId
+    })
+    .transacting(trx)
+    .execute();
+
+  await strapi.db.entityManager
+    .createQueryBuilder(joinTable.name)
+    .insert(
+      records.map((record: Record<string, unknown>) => {
+        const { id, ...rest } = record;
+
+        return {
+          ...rest,
+          [joinTable.morphColumn.idColumn.name]: targetId
+        };
+      })
+    )
+    .ignore()
+    .transacting(trx)
+    .execute();
+};


### PR DESCRIPTION
### What does it do?

When creating a new entry record from a duplicate item button in Strapi, the system was failing to include images in the duplicated record. This issue was occurring due to a flaw in the morph cloning process of media types. The fix addresses this by ensuring that media is correctly cloned along with other content when duplicating items.

### Why is it needed?

Fix resolves the issue reported in ticket #18403.

### How to test it?

1. Create a new collection type and add a media field.
2. Go to 'Content Manager' and create a new entry with an image.
3. Click on the 'Duplicate item' button
4. Strapi creates a new entry record with images.

### Related issue(s)/PR(s)

This fix resolves the issue reported in ticket #18403.