### PR TITLE
fix: use nativeconnection for mysql getinformation

### DIFF
--- a/packages/core/database/src/dialects/mysql/database-inspector.ts
+++ b/packages/core/database/src/dialects/mysql/database-inspector.ts
@@ -17,11 +17,13 @@ export default class MysqlDatabaseInspector {
     this.db = db;
   }
 
-  async getInformation(): Promise<Information> {
+  async getInformation(nativeConnection?: unknown): Promise<Information> {
     let database: Information['database'];
     let versionNumber: Information['version'];
     try {
-      const [results] = await this.db.connection.raw(SQL_QUERIES.VERSION);
+      const [results] = await this.db.connection
+        .raw(SQL_QUERIES.VERSION)
+        .connection(nativeConnection);
       const versionSplit = results[0].version.split('-');
       const databaseName = versionSplit[1];
       versionNumber = versionSplit[0];

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -62,6 +62,11 @@ export default class MysqlDialect extends Dialect {
     }
 
     // We only need to get info on the first connection in the pool
+    /**
+     * Note: There is a race condition here where if two connections are opened at the same time, both will retrieve
+     * db info, but it doesn't cause issues, it's just one wasted query one time, so we can safely leave it to avoid
+     * adding extra complexity
+     * */
     if (!this.info) {
       this.info = await this.databaseInspector.getInformation(nativeConnection);
     }

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -63,7 +63,7 @@ export default class MysqlDialect extends Dialect {
 
     // We only need to get info on the first connection in the pool
     if (!this.info) {
-      this.info = await this.databaseInspector.getInformation();
+      this.info = await this.databaseInspector.getInformation(nativeConnection);
     }
   }
 

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -58,11 +58,7 @@ export default class MysqlDialect extends Dialect {
         .raw(`set session sql_require_primary_key = 0;`)
         .connection(nativeConnection);
     } catch (err) {
-      if ((err as any)?.code === 'ER_SPECIFIC_ACCESS_DENIED_ERROR') {
-        console.warn('Failed to set session sql_require_primary_key = 0');
-      } else {
-        throw err;
-      }
+      // Ignore error due to lack of session permissions
     }
 
     // We only need to get info on the first connection in the pool
@@ -76,11 +72,7 @@ export default class MysqlDialect extends Dialect {
     try {
       await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
     } catch (err) {
-      if ((err as any)?.code === 'ER_SPECIFIC_ACCESS_DENIED_ERROR') {
-        console.warn('Failed to set session sql_require_primary_key = 0');
-      } else {
-        throw err;
-      }
+      // Ignore error due to lack of session permissions
     }
   }
 

--- a/packages/providers/email-sendmail/README.md
+++ b/packages/providers/email-sendmail/README.md
@@ -75,7 +75,7 @@ module.exports = ({ env }) => ({
     providerOptions: {
       dkim: {
         privateKey: 'replace-with-dkim-private-key',
-        keySelector: 'abcd', // the same as the one set in DNS txt record, use online dns lookup tools to be sure that is retreivable
+        keySelector: 'abcd', // the same as the one set in DNS txt record, use online dns lookup tools to be sure that is retrievable
       },
     },
     settings: {


### PR DESCRIPTION
### What does it do?

- pass nativeconnection to getInformation to be reused...

### Why is it needed?

- ...so that each raw query doesn't create a new connection, causing an infinite loop that overflows the pool

### How to test it?

the v5 docid migrations should now work

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
