### PR TITLE
fix: uniqueness on document publish

### DIFF
--- a/api-tests/core/strapi/document-service/uniqueness.test.api.ts
+++ b/api-tests/core/strapi/document-service/uniqueness.test.api.ts
@@ -9,6 +9,7 @@ describe('Document Service', () => {
 
   let testName;
   let createdCategory;
+
   beforeAll(async () => {
     testUtils = await createTestSetup(resources);
     strapi = testUtils.strapi;
@@ -44,30 +45,23 @@ describe('Document Service', () => {
     });
 
     it('cannot publish a document to have a duplicated unique field value in the same publication state', async () => {
-      const updatedName = `${createdCategory.name}-1`;
-      // Update the previously created category to have a new name
-      const category: Category = await strapi.documents(CATEGORY_UID).update(createdCategory.id, {
-        data: { name: updatedName },
-      });
+      const name = `unique-name`;
+
+      const category = await strapi.documents(CATEGORY_UID).create({ data: { name } });
 
       // Publish that category
       const publishRes = strapi.documents(CATEGORY_UID).publish(category.id);
       await expect(publishRes).resolves.not.toThrowError();
 
       // Reset the name of the draft category
-      await strapi.documents(CATEGORY_UID).update(createdCategory.id, {
-        data: { name: createdCategory.name },
-      });
+      await strapi
+        .documents(CATEGORY_UID)
+        .update(category.id, { data: { name: 'other-not-unique-name' } });
 
       // Now we can create a new category with the same name as the published category
       // When we try to publish it, it should throw an error
-      const newCategory: Category = await strapi.documents(CATEGORY_UID).create({
-        data: { name: updatedName },
-      });
-
-      expect(async () => {
-        await strapi.documents(CATEGORY_UID).publish(newCategory.id);
-      }).rejects.toThrow();
+      const newCategory = await strapi.documents(CATEGORY_UID).create({ data: { name } });
+      expect(strapi.documents(CATEGORY_UID).publish(newCategory.id)).rejects.toThrow();
     });
   });
 });

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -149,14 +149,11 @@ const addUniqueValidator = <T extends strapiUtils.yup.AnySchema>(
   return validator.test('unique', 'This attribute must be unique', async (value) => {
     const isPublish = options.isDraft === false;
 
-    // When publishing, the value will not have changed so we take the value from the entity
-    const valueToCheck = isPublish ? entity?.[updatedAttribute.name] : value;
-
     /**
      * If the attribute value is `null` we want to skip the unique validation.
      * Otherwise it'll only accept a single `null` entry in the database.
      */
-    if (_.isNil(valueToCheck)) {
+    if (_.isNil(value)) {
       return true;
     }
 
@@ -166,7 +163,7 @@ const addUniqueValidator = <T extends strapiUtils.yup.AnySchema>(
      * unique constraint after already creating multiple entries with
      * the same attribute value for that field.
      */
-    if (!isPublish && valueToCheck === entity?.[updatedAttribute.name]) {
+    if (!isPublish && value === entity?.[updatedAttribute.name]) {
       return true;
     }
 
@@ -174,12 +171,11 @@ const addUniqueValidator = <T extends strapiUtils.yup.AnySchema>(
      * At this point we know that we are creating a new entry, publishing an entry or that the unique field value has changed
      * We check if there is an entry of this content type in the same locale, publication state and with the same unique field value
      */
-
     const record = await strapi.documents(model.uid).findFirst({
       locale: options.locale,
       status: options.isDraft ? 'draft' : 'published',
       filters: {
-        [updatedAttribute.name]: valueToCheck,
+        [updatedAttribute.name]: value,
         ...(entity?.id ? { id: { $ne: entity.id } } : {}),
       },
     });


### PR DESCRIPTION
### What does it do?

Uniqueness stoped working after refactoring the publish method, before we were using a clone method, but now we are loading the entries in memory and creating the entry as a published version.

