### PR TITLE
fix: send empty object if locale does not exist on document

### DIFF
--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -146,6 +146,57 @@ describe('i18n - Content API', () => {
     });
   });
 
+  describe('Find locale', () => {
+    it('Can find a locale if it exists', async () => {
+      // Create locale
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/api::category.category',
+        body: {
+          name: 'categoría',
+          locale: 'es-AR',
+        },
+      });
+
+      // Can find it
+      const locale = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/api::category.category/${res.body.data.id}`,
+        qs: {
+          locale: 'es-AR',
+        },
+      });
+
+      expect(locale.statusCode).toBe(200);
+      expect(locale.body).toMatchObject({
+        locale: 'es-AR',
+        name: 'categoría',
+      });
+    });
+
+    it.only('Not existing locale in an existing document returns empty body', async () => {
+      // Create default locale
+      const res = await rq({
+        method: 'POST',
+        url: '/content-manager/collection-types/api::category.category',
+        body: {
+          name: 'category in english',
+          locale: 'en',
+        },
+      });
+
+      // Find by another language
+      const locale = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/api::category.category/${res.body.data.id}`,
+        qs: {
+          locale: 'es-AR',
+        },
+      });
+
+      expect(locale.statusCode).toBe(204);
+    });
+  });
   // V5: Fix bulk actions
   describe.skip('Bulk Delete', () => {
     test('default locale', async () => {

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -184,23 +184,31 @@ export default {
 
     const { locale, status = 'draft' } = getDocumentDimensions(ctx.query);
 
-    const document = await entityManager.findOne(id, model, {
+    const version = await entityManager.findOne(id, model, {
       populate,
       locale,
       status,
     });
 
-    if (!document) {
-      return ctx.notFound();
+    if (!version) {
+      // Check if document exists
+      const exists = await entityManager.exists(model, id);
+      if (!exists) {
+        return ctx.notFound();
+      }
+
+      // If the requested locale doesn't exist, return an empty response
+      ctx.status = 204;
+      return;
     }
 
     // if the user has condition that needs populated content, it's not applied because entity don't have relations populated
-    if (permissionChecker.cannot.read(document)) {
+    if (permissionChecker.cannot.read(version)) {
       return ctx.forbidden();
     }
 
     // TODO: Count populated relations by permissions
-    const sanitizedDocument = await permissionChecker.sanitizeOutput(document);
+    const sanitizedDocument = await permissionChecker.sanitizeOutput(version);
     ctx.body = await documentMetadata.formatDocumentWithMetadata(model, sanitizedDocument);
   },
 

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -103,8 +103,15 @@ export default {
       if (permissionChecker.cannot.create()) {
         return ctx.forbidden();
       }
+      // Check if document exists
+      const exists = await getService('entity-manager').exists(model);
+      if (!exists) {
+        return ctx.notFound();
+      }
 
-      return ctx.notFound();
+      // If the requested locale doesn't exist, return an empty response
+      ctx.status = 204;
+      return;
     }
 
     if (permissionChecker.cannot.read(document)) {

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -20,7 +20,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
  */
 const addContentManagerLocaleMiddleware = (strapi: Strapi) => {
   strapi.server.router.use('/content-manager/collection-types/:model', (ctx, next) => {
-    if (ctx.method === 'POST') {
+    if (ctx.method === 'POST' || ctx.method === 'PUT') {
       return validateLocaleCreation(ctx, next);
     }
 


### PR DESCRIPTION
Get an empty body object and a 204 status if document does not have requested locale