### PR TITLE
feat: update locale using query params

### DIFF
--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -20,7 +20,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
  */
 const addContentManagerLocaleMiddleware = (strapi: Strapi) => {
   strapi.server.router.use('/content-manager/collection-types/:model', (ctx, next) => {
-    if (ctx.method === 'POST') {
+    if (ctx.method === 'POST' || ctx.method === 'PUT') {
       return validateLocaleCreation(ctx, next);
     }
 


### PR DESCRIPTION
This is just a quick fix to make locale work when updating a document, locale needs to be validated both when creating a document and when updating it.

I would like to revisit this implementation, because at the moment we are supporting both query parameters and body parameters for locale, and once the frontend is working we should standarize it.