### PR TITLE
feat: return available locales when not finding locale

### DIFF
--- a/api-tests/plugins/i18n/content-manager/crud.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/crud.test.api.js
@@ -194,7 +194,12 @@ describe('i18n - Content API', () => {
         },
       });
 
-      expect(locale.statusCode).toBe(204);
+      expect(locale.statusCode).toBe(200);
+      expect(locale.body.data).toMatchObject({});
+      expect(locale.body.meta).toMatchObject({
+        availableStatus: [],
+        availableLocales: [{ locale: 'en' }],
+      });
     });
   });
   // V5: Fix bulk actions

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -198,7 +198,13 @@ export default {
       }
 
       // If the requested locale doesn't exist, return an empty response
-      ctx.status = 204;
+      const { meta } = await documentMetadata.formatDocumentWithMetadata(
+        model,
+        { id, locale, publishedAt: null },
+        { availableLocales: true, availableStatus: false }
+      );
+      ctx.body = { data: {}, meta };
+
       return;
     }
 


### PR DESCRIPTION
When finding a specific document locale, if the locale doesn't exist but the document does, the content manager response will be:
```
status: 200 // 204 was removing everything from the response body
body: {
  data: {},
  meta: {
    availableLocales: [...],
    availbleStatus: []
}
```

works for collection types and single types ✌️ 