### PR TITLE
feat(content-releases): show release scheduled date

### DIFF
--- a/e2e/tests/content-releases/release-details-page.spec.ts
+++ b/e2e/tests/content-releases/release-details-page.spec.ts
@@ -34,7 +34,7 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await login({ page });
 
     await page.getByRole('link', { name: 'Releases' }).click();
-    page.getByRole('link', { name: `${releaseName} 6 entries` }).click();
+    page.getByRole('link', { name: `${releaseName}` }).click();
     await page.waitForURL('/admin/plugins/content-releases/*');
   });
 
@@ -57,7 +57,7 @@ describeOnCondition(edition === 'EE')('Release page', () => {
 
     // Publish the release
     await page.getByRole('link', { name: 'Releases' }).click();
-    await page.getByRole('link', { name: `${releaseName} 8 entries` }).click();
+    await page.getByRole('link', { name: `${releaseName}` }).click();
     await page.getByRole('button', { name: 'Publish' }).click();
     expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Publish' })).not.toBeVisible();
@@ -86,9 +86,7 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await page.getByRole('button', { name: 'Confirm' }).click();
     // Wait for client side redirect to the releases page
     await page.waitForURL('/admin/plugins/content-releases');
-    await expect(
-      page.getByRole('link', { name: `${editedEntryName} 6 entries` })
-    ).not.toBeVisible();
+    await expect(page.getByRole('link', { name: `${editedEntryName}` })).not.toBeVisible();
   });
 
   test("A user should be able to change the entry groupings, update an entry's action, remove an entry from a release, and navigate to the entry in the content manager", async ({

--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -25,13 +25,11 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
     // Navigate to the releases page
     await page.getByRole('link', { name: 'Releases' }).click();
 
-    await expect(
-      page.getByRole('link', { name: `Trent Crimm: The Independent 6 entries` })
-    ).toBeVisible();
+    await expect(page.getByRole('link', { name: `Trent Crimm: The Independent` })).toBeVisible();
 
     // Open the 'Done' tab panel
     await page.getByRole('tab', { name: 'Done' }).click();
-    await expect(page.getByRole('link', { name: `Nate: A wonder kid 2 entries` })).toBeVisible();
+    await expect(page.getByRole('link', { name: `Nate: A wonder kid` })).toBeVisible();
 
     // Open the create release dialog
     await page.getByRole('button', { name: 'New release' }).click();
@@ -49,7 +47,7 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
 
     // Navigate back to the release page to see the newly created release
     await page.getByRole('link', { name: 'Releases' }).click();
-    await expect(page.getByRole('link', { name: `${newReleaseName} No entries` })).toBeVisible();
+    await expect(page.getByRole('link', { name: `${newReleaseName}` })).toBeVisible();
   });
 
   test('A user should be able to create a release with scheduling info and view their pending and done releases', async ({
@@ -88,6 +86,6 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
 
     // Navigate back to the release page to see the newly created release
     await page.getByRole('link', { name: 'Releases' }).click();
-    await expect(page.getByRole('link', { name: `${newReleaseName} No entries` })).toBeVisible();
+    await expect(page.getByRole('link', { name: `${newReleaseName}` })).toBeVisible();
   });
 });

--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,5 +1,5 @@
 module.exports = ({ env }) => ({
   future: {
-    contentReleasesScheduling: env('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
+    contentReleasesScheduling: env.bool('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
   },
 });

--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -34,6 +34,7 @@ import { CreateReleaseAction } from '../../../shared/contracts/release-actions';
 import { GetContentTypeEntryReleases } from '../../../shared/contracts/releases';
 import { PERMISSIONS } from '../constants';
 import { useCreateReleaseActionMutation, useGetReleasesForEntryQuery } from '../services/release';
+import { getTimezoneOffset } from '../utils/time';
 
 import { ReleaseActionMenu } from './ReleaseActionMenu';
 import { ReleaseActionOptions } from './ReleaseActionOptions';
@@ -249,7 +250,7 @@ const AddActionToReleaseModal = ({
 
 export const CMReleasesContainer = () => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatDate, formatTime } = useIntl();
   const {
     isCreatingEntry,
     hasDraftAndPublish,
@@ -356,10 +357,36 @@ export const CMReleasesContainer = () => {
                     )}
                   </Typography>
                 </Box>
-                <Flex padding={4} direction="column" gap={3} width="100%" alignItems="flex-start">
+                <Flex padding={4} direction="column" gap={2} width="100%" alignItems="flex-start">
                   <Typography fontSize={2} fontWeight="bold" variant="omega" textColor="neutral700">
                     {release.name}
                   </Typography>
+                  {release.scheduledAt && release.timezone && (
+                    <Typography variant="pi" textColor="neutral600">
+                      {formatMessage(
+                        {
+                          id: 'content-releases.content-manager-edit-view.scheduled.date',
+                          defaultMessage: '{date} at {time} ({offset})',
+                        },
+                        {
+                          date: formatDate(new Date(release.scheduledAt), {
+                            day: '2-digit',
+                            month: '2-digit',
+                            year: 'numeric',
+                            timeZone: release.timezone,
+                          }),
+                          time: formatTime(new Date(release.scheduledAt), {
+                            hour12: false,
+                            timeZone: release.timezone,
+                          }),
+                          offset: getTimezoneOffset(
+                            release.timezone,
+                            new Date(release.scheduledAt)
+                          ),
+                        }
+                      )}
+                    </Typography>
+                  )}
                   <CheckPermissions permissions={PERMISSIONS.deleteAction}>
                     <ReleaseActionMenu.Root hasTriggerBorder>
                       <ReleaseActionMenu.DeleteReleaseActionItem

--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -259,7 +259,7 @@ export const CMReleasesContainer = () => {
   } = useCMEditViewDataManager();
 
   const contentTypeUid = slug as Common.UID.ContentType;
-
+  const IsSchedulingEnabled = window.strapi.future.isEnabled('contentReleasesScheduling');
   const canFetch = entryId != null && contentTypeUid != null;
   const fetchParams = canFetch
     ? {
@@ -361,7 +361,7 @@ export const CMReleasesContainer = () => {
                   <Typography fontSize={2} fontWeight="bold" variant="omega" textColor="neutral700">
                     {release.name}
                   </Typography>
-                  {release.scheduledAt && release.timezone && (
+                  {IsSchedulingEnabled && release.scheduledAt && release.timezone && (
                     <Typography variant="pi" textColor="neutral600">
                       {formatMessage(
                         {

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -24,6 +24,7 @@ import { useLocation } from 'react-router-dom';
 
 import { RELEASE_SCHEMA } from '../../../shared/validation-schemas';
 import { pluginId } from '../pluginId';
+import { getTimezoneOffset } from '../utils/time';
 
 export interface FormValues {
   name: string;
@@ -250,22 +251,7 @@ const getTimezones = (selectedDate: Date) => {
   const timezoneList: ITimezoneOption[] = Intl.supportedValuesOf('timeZone').map((timezone) => {
     // Timezone will be in the format GMT${OFFSET} where offset could be nothing,
     // a four digit string e.g. +05:00 or -08:00
-    const offsetPart = new Intl.DateTimeFormat('en', {
-      timeZone: timezone,
-      timeZoneName: 'longOffset',
-    })
-      .formatToParts(selectedDate)
-      .find((part) => part.type === 'timeZoneName');
-
-    const offset = offsetPart ? offsetPart.value : '';
-
-    // We want to show time based on UTC, not GMT so we swap that.
-    let utcOffset = offset.replace('GMT', 'UTC');
-
-    // For perfect UTC (UTC+0:00) we only get the string UTC, So we need to append the 0's.
-    if (!utcOffset.includes('+') && !utcOffset.includes('-')) {
-      utcOffset = `${utcOffset}+00:00`;
-    }
+    const utcOffset = getTimezoneOffset(timezone, selectedDate);
 
     // Offset and timezone are concatenated with '-', so to split and save the required timezone in DB
     return { offset: utcOffset, value: `${utcOffset}-${timezone}` } satisfies ITimezoneOption;

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -58,6 +58,7 @@ import {
   releaseApi,
 } from '../services/release';
 import { useTypedDispatch } from '../store/hooks';
+import { getTimezoneOffset } from '../utils/time';
 
 import type {
   ReleaseAction,
@@ -200,7 +201,7 @@ export const ReleaseDetailsLayout = ({
   toggleWarningSubmit,
   children,
 }: ReleaseDetailsLayoutProps) => {
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatDate, formatTime } = useIntl();
   const { releaseId } = useParams<{ releaseId: string }>();
   const {
     data,
@@ -305,17 +306,47 @@ export const ReleaseDetailsLayout = ({
   const totalEntries = release.actions.meta.count || 0;
   const hasCreatedByUser = Boolean(getCreatedByUser());
 
+  const isScheduled = release.scheduledAt && release.timezone;
+  const numberOfEntriesText = formatMessage(
+    {
+      id: 'content-releases.pages.Details.header-subtitle',
+      defaultMessage: '{number, plural, =0 {No entries} one {# entry} other {# entries}}',
+    },
+    { number: totalEntries }
+  );
+  const scheduledText = isScheduled
+    ? formatMessage(
+        {
+          id: 'content-releases.pages.ReleaseDetails.header-subtitle.scheduled',
+          defaultMessage: 'Scheduled for {date} at {time} ({offset})',
+        },
+        {
+          date: formatDate(new Date(release.scheduledAt!), {
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+            timeZone: release.timezone!,
+          }),
+          time: formatTime(new Date(release.scheduledAt!), {
+            hour12: false,
+            timeZone: release.timezone!,
+          }),
+          offset: getTimezoneOffset(release.timezone!, new Date(release.scheduledAt!)),
+        }
+      )
+    : '';
+
   return (
     <Main aria-busy={isLoadingDetails}>
       <HeaderLayout
         title={release.name}
-        subtitle={formatMessage(
-          {
-            id: 'content-releases.pages.Details.header-subtitle',
-            defaultMessage: '{number, plural, =0 {No entries} one {# entry} other {# entries}}',
-          },
-          { number: totalEntries }
-        )}
+        subtitle={
+          <>
+            {numberOfEntriesText}
+            {isScheduled && `- ${scheduledText}`}
+          </>
+        }
         navigationAction={
           <Link startIcon={<ArrowLeft />} to="/plugins/content-releases">
             {formatMessage({

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -306,6 +306,7 @@ export const ReleaseDetailsLayout = ({
   const totalEntries = release.actions.meta.count || 0;
   const hasCreatedByUser = Boolean(getCreatedByUser());
 
+  const IsSchedulingEnabled = window.strapi.future.isEnabled('contentReleasesScheduling');
   const isScheduled = release.scheduledAt && release.timezone;
   const numberOfEntriesText = formatMessage(
     {
@@ -342,10 +343,7 @@ export const ReleaseDetailsLayout = ({
       <HeaderLayout
         title={release.name}
         subtitle={
-          <>
-            {numberOfEntriesText}
-            {isScheduled && `- ${scheduledText}`}
-          </>
+          numberOfEntriesText + (IsSchedulingEnabled && isScheduled ? `- ${scheduledText}` : '')
         }
         navigationAction={
           <Link startIcon={<ArrowLeft />} to="/plugins/content-releases">

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -63,7 +63,7 @@ const LinkCard = styled(Link)`
 `;
 
 const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: ReleasesGridProps) => {
-  const { formatMessage, formatRelativeTime } = useIntl();
+  const { formatMessage } = useIntl();
   const IsSchedulingEnabled = window.strapi.future.isEnabled('contentReleasesScheduling');
 
   if (isError) {

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -64,6 +64,7 @@ const LinkCard = styled(Link)`
 
 const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: ReleasesGridProps) => {
   const { formatMessage, formatRelativeTime } = useIntl();
+  const IsSchedulingEnabled = window.strapi.future.isEnabled('contentReleasesScheduling');
 
   if (isError) {
     return <AnErrorOccurred />;
@@ -88,7 +89,7 @@ const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: Releases
 
   return (
     <Grid gap={4}>
-      {releases.map(({ id, name, scheduledAt }) => (
+      {releases.map(({ id, name, actions, scheduledAt }) => (
         <GridItem col={3} s={6} xs={12} key={id}>
           <LinkCard href={`content-releases/${id}`} isExternal={false}>
             <Flex
@@ -106,14 +107,25 @@ const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: Releases
               <Typography as="h3" variant="delta" fontWeight="bold">
                 {name}
               </Typography>
-              <Typography variant="pi">
-                {scheduledAt ? (
-                  <RelativeTime timestamp={new Date(scheduledAt)} />
+              <Typography variant="pi" textColor="neutral600">
+                {IsSchedulingEnabled ? (
+                  scheduledAt ? (
+                    <RelativeTime timestamp={new Date(scheduledAt)} />
+                  ) : (
+                    formatMessage({
+                      id: 'content-releases.pages.Releases.not-scheduled',
+                      defaultMessage: 'Not scheduled',
+                    })
+                  )
                 ) : (
-                  formatMessage({
-                    id: 'content-releases.pages.Releases.not-scheduled',
-                    defaultMessage: 'Not scheduled',
-                  })
+                  formatMessage(
+                    {
+                      id: 'content-releases.page.Releases.release-item.entries',
+                      defaultMessage:
+                        '{number, plural, =0 {No entries} one {# entry} other {# entries}}',
+                    },
+                    { number: actions.meta.count }
+                  )
                 )}
               </Typography>
             </Flex>

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -32,6 +32,7 @@ import {
   useAPIErrorHandler,
   useNotification,
   useTracking,
+  RelativeTime,
 } from '@strapi/helper-plugin';
 import { EmptyDocuments, Plus } from '@strapi/icons';
 import { useIntl } from 'react-intl';
@@ -62,7 +63,7 @@ const LinkCard = styled(Link)`
 `;
 
 const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: ReleasesGridProps) => {
-  const { formatMessage } = useIntl();
+  const { formatMessage, formatRelativeTime } = useIntl();
 
   if (isError) {
     return <AnErrorOccurred />;
@@ -87,7 +88,7 @@ const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: Releases
 
   return (
     <Grid gap={4}>
-      {releases.map(({ id, name, actions }) => (
+      {releases.map(({ id, name, scheduledAt }) => (
         <GridItem col={3} s={6} xs={12} key={id}>
           <LinkCard href={`content-releases/${id}`} isExternal={false}>
             <Flex
@@ -106,13 +107,13 @@ const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: Releases
                 {name}
               </Typography>
               <Typography variant="pi">
-                {formatMessage(
-                  {
-                    id: 'content-releases.page.Releases.release-item.entries',
-                    defaultMessage:
-                      '{number, plural, =0 {No entries} one {# entry} other {# entries}}',
-                  },
-                  { number: actions.meta.count }
+                {scheduledAt ? (
+                  <RelativeTime timestamp={new Date(scheduledAt)} />
+                ) : (
+                  formatMessage({
+                    id: 'content-releases.pages.Releases.not-scheduled',
+                    defaultMessage: 'Not scheduled',
+                  })
                 )}
               </Typography>
             </Flex>

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -10,6 +10,7 @@
   "content-manager-edit-view.add-to-release.redirect-button": "Open the list of releases",
   "content-manager-edit-view.list-releases.title": "{isPublish, select, true {Will be published in} other {Will be unpublished in}}",
   "content-manager-edit-view.remove-from-release": "Remove from release",
+  "content-manager-edit-view.scheduled.date": "{date} at {time} ({offset})",
   "content-releases.content-manager-edit-view.edit-entry": "Edit entry",
   "content-manager-edit-view.remove-from-release.notification.success": "Entry removed from release",
   "content-manager-edit-view.release-action-menu": "Release action options",
@@ -46,7 +47,6 @@
   "pages.Releases.tab.done": "Done",
   "page.Releases.tab.emptyEntries": "No releases",
   "pages.Details.tab.emptyEntries": "This release is empty. Open the Content Manager, select an entry and add it to the release.",
-  "page.Releases.release-item.entries": "{number, plural, =0 {No entries} one {# entry} other {# entries}}",
   "page.ReleaseDetails.table.header.label.name": "name",
   "page.ReleaseDetails.table.header.label.locale": "locale",
   "page.ReleaseDetails.table.header.label.content-type": "content-type",
@@ -58,6 +58,7 @@
   "page.Details.button.openContentManager": "Open the Content Manager",
   "pages.Releases.notification.error.title": "Your request could not be processed.",
   "pages.Releases.notification.error.message": "Please try again or open another release.",
+  "pages.Releases.not-scheduled": "Not scheduled",
   "pages.ReleaseDetails.groupBy.label": "Group by {groupBy}",
   "pages.ReleaseDetails.groupBy.aria-label": "Group by",
   "pages.ReleaseDetails.entry-validation.already-published": "Already published",
@@ -66,5 +67,6 @@
   "pages.ReleaseDetails.entry-validation.ready-to-unpublish": "Ready to unpublish",
   "pages.ReleaseDetails.groupBy.option.content-type": "Content-Types",
   "pages.ReleaseDetails.groupBy.option.locales": "Locales",
-  "pages.ReleaseDetails.groupBy.option.actions": "Actions"
+  "pages.ReleaseDetails.groupBy.option.actions": "Actions",
+  "pages.ReleaseDetails.header-subtitle.scheduled": "Scheduled for {date} at {time} ({offset})"
 }

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -47,6 +47,7 @@
   "pages.Releases.tab.done": "Done",
   "page.Releases.tab.emptyEntries": "No releases",
   "pages.Details.tab.emptyEntries": "This release is empty. Open the Content Manager, select an entry and add it to the release.",
+  "page.Releases.release-item.entries": "{number, plural, =0 {No entries} one {# entry} other {# entries}}",
   "page.ReleaseDetails.table.header.label.name": "name",
   "page.ReleaseDetails.table.header.label.locale": "locale",
   "page.ReleaseDetails.table.header.label.content-type": "content-type",

--- a/packages/core/content-releases/admin/src/utils/tests/time.test.ts
+++ b/packages/core/content-releases/admin/src/utils/tests/time.test.ts
@@ -1,0 +1,27 @@
+import { getTimezoneOffset } from '../time';
+
+describe('getTimezoneOffset', () => {
+  it('should return correct offset for UTC timezone', () => {
+    const date = new Date('2024-01-01T00:00:00Z');
+    const offset = getTimezoneOffset('UTC', date);
+    expect(offset).toBe('UTC+00:00');
+  });
+
+  it('should return correct offset for timezone without daylight', () => {
+    const date = new Date('2024-01-01T00:00:00Z');
+    const offset = getTimezoneOffset('Europe/Paris', date);
+    expect(offset).toBe('UTC+01:00');
+  });
+
+  it('should return correct offset for timezone with daylight', () => {
+    const date = new Date('2024-06-06T00:00:00Z');
+    const offset = getTimezoneOffset('Europe/Paris', date);
+    expect(offset).toBe('UTC+02:00');
+  });
+
+  it('should return empty string for invalid timezone', () => {
+    const date = new Date('2024-01-01T00:00:00Z');
+    const offset = getTimezoneOffset('Invalid/Timezone', date);
+    expect(offset).toBe('');
+  });
+});

--- a/packages/core/content-releases/admin/src/utils/time.ts
+++ b/packages/core/content-releases/admin/src/utils/time.ts
@@ -1,0 +1,25 @@
+export const getTimezoneOffset = (timezone: string, date: Date) => {
+  try {
+    const offsetPart = new Intl.DateTimeFormat('en', {
+      timeZone: timezone,
+      timeZoneName: 'longOffset',
+    })
+      .formatToParts(date)
+      .find((part) => part.type === 'timeZoneName');
+
+    const offset = offsetPart ? offsetPart.value : '';
+
+    // We want to show time based on UTC, not GMT so we swap that.
+    let utcOffset = offset.replace('GMT', 'UTC');
+
+    // For perfect UTC (UTC+0:00) we only get the string UTC, So we need to append the 0's.
+    if (!utcOffset.includes('+') && !utcOffset.includes('-')) {
+      utcOffset = `${utcOffset}+00:00`;
+    }
+
+    return utcOffset;
+  } catch (error) {
+    // When timezone is invalid we catch the error and return empty to don't break the app
+    return '';
+  }
+};


### PR DESCRIPTION
### What does it do?

Adds the scheduled date (when release has one) on the Edit Entry View, Release list view and Release Details view.

### How to test it?

1. Go to an entry attached to a release with scheduled date. You should see the scheduled date (with the timezone selected on the release, even if it's different from yours, this is the same for all the other cases)
2. Go to the Releases List view, you should see a relative time on releases with scheduled date.
3. Go to the Releases Details view, you should see the scheduled date on the top.