### PR TITLE
fix: history page back button

### DIFF
--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -6,7 +6,7 @@ import { useQueryParams } from '@strapi/helper-plugin';
 import { ArrowLeft } from '@strapi/icons';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
+import { NavLink, type To, useParams } from 'react-router-dom';
 
 import { useHistoryContext } from '../pages/History';
 
@@ -23,20 +23,25 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
   }>();
+  const params = useParams<{ collectionType: string; slug: string }>();
 
   const mainFieldValue = version.data[layout.contentType.settings.mainField];
 
-  const backLink = (() => {
+  const getBackLink = (): To => {
     const pluginsQueryParams = stringify({ plugins: query.plugins }, { encode: false });
 
     if (layout.contentType.kind === 'collectionType') {
-      // TODO: use the constant from constants/collections.ts once D&P v5 is merged
-      return `../collection-types/${version.contentType}/${version.relatedDocumentId}?${pluginsQueryParams}`;
+      return {
+        pathname: `../${params.collectionType}/${version.contentType}/${version.relatedDocumentId}`,
+        search: pluginsQueryParams,
+      };
     }
 
-    // TODO: use the constant from constants/collections.ts once D&P v5 is merged
-    return `../single-types/${version.contentType}/${version.relatedDocumentId}?${pluginsQueryParams}`;
-  })();
+    return {
+      pathname: `../${params.collectionType}/${version.contentType}`,
+      search: pluginsQueryParams,
+    };
+  };
 
   return (
     <HeaderLayout
@@ -69,7 +74,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
           startIcon={<ArrowLeft />}
           as={NavLink}
           // @ts-expect-error - types are not inferred correctly through the as prop.
-          to={backLink}
+          to={getBackLink()}
         >
           {formatMessage({
             id: 'global.back',

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import { HeaderLayout, Typography } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
+import { useQueryParams } from '@strapi/helper-plugin';
 import { ArrowLeft } from '@strapi/icons';
+import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 
@@ -18,8 +20,23 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
     version: state.selectedVersion,
     layout: state.layout,
   }));
+  const [{ query }] = useQueryParams<{
+    plugins?: Record<string, unknown>;
+  }>();
 
   const mainFieldValue = version.data[layout.contentType.settings.mainField];
+
+  const backLink = (() => {
+    const pluginsQueryParams = stringify({ plugins: query.plugins }, { encode: false });
+
+    if (layout.contentType.kind === 'collectionType') {
+      // TODO: use the constant from constants/collections.ts once D&P v5 is merged
+      return `../collection-types/${version.contentType}/${version.relatedDocumentId}?${pluginsQueryParams}`;
+    }
+
+    // TODO: use the constant from constants/collections.ts once D&P v5 is merged
+    return `../single-types/${version.contentType}/${version.relatedDocumentId}?${pluginsQueryParams}`;
+  })();
 
   return (
     <HeaderLayout
@@ -52,7 +69,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
           startIcon={<ArrowLeft />}
           as={NavLink}
           // @ts-expect-error - types are not inferred correctly through the as prop.
-          to=".."
+          to={backLink}
         >
           {formatMessage({
             id: 'global.back',

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionsList.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionsList.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 
 import { Box, Flex, Typography, type BoxProps } from '@strapi/design-system';
 import { RelativeTime, useQueryParams } from '@strapi/helper-plugin';
-import { Contracts } from '@strapi/plugin-content-manager/_internal/shared';
 import { stringify } from 'qs';
 import { type MessageDescriptor, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { getDisplayName } from '../../utils/users';
 import { useHistoryContext } from '../pages/History';
+
+import type { Contracts } from '@strapi/plugin-content-manager/_internal/shared';
 
 /* -------------------------------------------------------------------------------------------------
  * BlueText

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
@@ -10,6 +10,7 @@ import type { UID } from '@strapi/types';
 // Mocks
 const layout = {
   contentType: {
+    kind: 'collectionType',
     info: {
       singularName: 'kitchensink',
     },
@@ -30,6 +31,18 @@ const selectedVersion = {
     title: 'Test Title',
   },
 };
+const useParamsMock = jest.fn();
+const useQueryParamsMock = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => useParamsMock(),
+}));
+
+jest.mock('@strapi/helper-plugin', () => ({
+  ...jest.requireActual('@strapi/helper-plugin'),
+  useQueryParams: () => useQueryParamsMock(),
+}));
 
 const render = (props: HistoryContextValue) =>
   renderRTL(
@@ -40,6 +53,9 @@ const render = (props: HistoryContextValue) =>
 
 describe('VersionHeader', () => {
   it('should display the correct title and subtitle for a non-localized entry', () => {
+    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
+    useQueryParamsMock.mockReturnValue([{ query: {} }]);
+
     render({
       selectedVersion,
       // @ts-expect-error ignore missing properties
@@ -48,9 +64,18 @@ describe('VersionHeader', () => {
 
     expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
     expect(screen.getByText('Test Title (kitchensink)')).toBeInTheDocument();
+
+    const backLink = screen.getByRole('link', { name: 'Back' });
+    expect(backLink).toHaveAttribute(
+      'href',
+      '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr'
+    );
   });
 
   it('should display the correct title and subtitle for a localized entry', () => {
+    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
+    useQueryParamsMock.mockReturnValue([{ query: { plugins: { i18n: { locale: 'en' } } } }]);
+
     render({
       selectedVersion: {
         ...selectedVersion,
@@ -65,9 +90,18 @@ describe('VersionHeader', () => {
 
     expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
     expect(screen.getByText('Test Title (kitchensink), in English (en)')).toBeInTheDocument();
+
+    const backLink = screen.getByRole('link', { name: 'Back' });
+    expect(backLink).toHaveAttribute(
+      'href',
+      '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr?plugins[i18n][locale]=en'
+    );
   });
 
   it('should display the correct subtitle without an entry title (mainField)', () => {
+    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
+    useQueryParamsMock.mockReturnValue([{ query: {} }]);
+
     render({
       selectedVersion,
       layout: {

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
@@ -1,123 +1,203 @@
 import * as React from 'react';
 
-import { render as renderRTL, screen } from '@tests/utils';
+import { RenderOptions, render as renderRTL, screen } from '@tests/utils';
+import { Route, Routes } from 'react-router-dom';
 
 import { type HistoryContextValue, HistoryProvider } from '../../pages/History';
 import { VersionHeader } from '../VersionHeader';
 
 import type { UID } from '@strapi/types';
 
-// Mocks
-const layout = {
-  contentType: {
-    kind: 'collectionType',
-    info: {
-      singularName: 'kitchensink',
-    },
-    settings: {
-      mainField: 'title',
-    },
-  },
-};
-const selectedVersion = {
-  id: '26',
-  contentType: 'api::kitchensink.kitchensink' as UID.ContentType,
-  relatedDocumentId: 'pcwmq3rlmp5w0be3cuplhnpr',
-  createdAt: '2022-01-01T00:00:00Z',
-  status: 'draft' as const,
-  schema: {},
-  locale: null,
-  data: {
-    title: 'Test Title',
-  },
-};
-const useParamsMock = jest.fn();
-const useQueryParamsMock = jest.fn();
+const render = (
+  props: HistoryContextValue,
+  initialEntry: Exclude<RenderOptions['initialEntries'], undefined>[number]
+) => {
+  const path =
+    props.layout.contentType.kind === 'singleType'
+      ? '/:collectionType/:slug/history'
+      : '/:collectionType/:slug/:id/history';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => useParamsMock(),
-}));
-
-jest.mock('@strapi/helper-plugin', () => ({
-  ...jest.requireActual('@strapi/helper-plugin'),
-  useQueryParams: () => useQueryParamsMock(),
-}));
-
-const render = (props: HistoryContextValue) =>
-  renderRTL(
+  return renderRTL(
     <HistoryProvider {...props}>
-      <VersionHeader headerId="123" />
-    </HistoryProvider>
+      <Routes>
+        <Route path={path} element={<VersionHeader headerId="123" />} />
+      </Routes>
+    </HistoryProvider>,
+    { initialEntries: [initialEntry] }
   );
+};
 
 describe('VersionHeader', () => {
-  it('should display the correct title and subtitle for a non-localized entry', () => {
-    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
-    useQueryParamsMock.mockReturnValue([{ query: {} }]);
-
-    render({
-      selectedVersion,
-      // @ts-expect-error ignore missing properties
-      layout,
-    });
-
-    expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
-    expect(screen.getByText('Test Title (kitchensink)')).toBeInTheDocument();
-
-    const backLink = screen.getByRole('link', { name: 'Back' });
-    expect(backLink).toHaveAttribute(
-      'href',
-      '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr'
-    );
-  });
-
-  it('should display the correct title and subtitle for a localized entry', () => {
-    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
-    useQueryParamsMock.mockReturnValue([{ query: { plugins: { i18n: { locale: 'en' } } } }]);
-
-    render({
-      selectedVersion: {
-        ...selectedVersion,
-        locale: {
-          code: 'en',
-          name: 'English (en)',
+  describe('collection types', () => {
+    // Mocks
+    const layout = {
+      contentType: {
+        kind: 'collectionType',
+        info: {
+          singularName: 'kitchensink',
+        },
+        settings: {
+          mainField: 'title',
         },
       },
-      // @ts-expect-error ignore missing properties
-      layout,
+    };
+    const selectedVersion = {
+      id: '26',
+      contentType: 'api::kitchensink.kitchensink' as UID.ContentType,
+      relatedDocumentId: 'pcwmq3rlmp5w0be3cuplhnpr',
+      createdAt: '2022-01-01T00:00:00Z',
+      status: 'draft' as const,
+      schema: {},
+      locale: null,
+      data: {
+        title: 'Test Title',
+      },
+    };
+
+    it('should display the correct title and subtitle for a non-localized entry', () => {
+      render(
+        {
+          selectedVersion,
+          // @ts-expect-error ignore missing properties
+          layout,
+        },
+        '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
+      );
+
+      expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
+      expect(screen.getByText('Test Title (kitchensink)')).toBeInTheDocument();
+
+      const backLink = screen.getByRole('link', { name: 'Back' });
+      expect(backLink).toHaveAttribute(
+        'href',
+        '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr'
+      );
     });
 
-    expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
-    expect(screen.getByText('Test Title (kitchensink), in English (en)')).toBeInTheDocument();
-
-    const backLink = screen.getByRole('link', { name: 'Back' });
-    expect(backLink).toHaveAttribute(
-      'href',
-      '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr?plugins[i18n][locale]=en'
-    );
-  });
-
-  it('should display the correct subtitle without an entry title (mainField)', () => {
-    useParamsMock.mockReturnValue({ collectionType: 'collection-types' });
-    useQueryParamsMock.mockReturnValue([{ query: {} }]);
-
-    render({
-      selectedVersion,
-      layout: {
-        ...layout,
-        contentType: {
-          ...layout.contentType,
+    it('should display the correct title and subtitle for a localized entry', () => {
+      render(
+        {
+          selectedVersion: {
+            ...selectedVersion,
+            locale: {
+              code: 'en',
+              name: 'English (en)',
+            },
+          },
           // @ts-expect-error ignore missing properties
-          settings: {
-            ...layout.contentType.settings,
-            mainField: 'id', // id or null does will not return a value from version.data
+          layout,
+        },
+        {
+          pathname:
+            '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history',
+          search: '?plugins[i18n][locale]=en',
+        }
+      );
+
+      expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
+      expect(screen.getByText('Test Title (kitchensink), in English (en)')).toBeInTheDocument();
+
+      const backLink = screen.getByRole('link', { name: 'Back' });
+      expect(backLink).toHaveAttribute(
+        'href',
+        '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr?plugins[i18n][locale]=en'
+      );
+    });
+
+    it('should display the correct subtitle without an entry title (mainField)', () => {
+      render(
+        {
+          selectedVersion,
+          layout: {
+            ...layout,
+            contentType: {
+              ...layout.contentType,
+              // @ts-expect-error ignore missing properties
+              settings: {
+                ...layout.contentType.settings,
+                mainField: 'id', // id or null does will not return a value from version.data
+              },
+            },
           },
         },
+        '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
+      );
+
+      expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
+      expect(screen.getByText('(kitchensink)')).toBeInTheDocument();
+    });
+  });
+
+  describe('single types', () => {
+    // Mocks
+    const layout = {
+      contentType: {
+        kind: 'singleType',
+        info: {
+          singularName: 'homepage',
+        },
+        settings: {
+          mainField: 'title',
+        },
       },
+    };
+    const selectedVersion = {
+      id: '26',
+      contentType: 'api::homepage.homepage' as UID.ContentType,
+      relatedDocumentId: 'documentid',
+      createdAt: '2022-01-01T00:00:00Z',
+      status: 'draft' as const,
+      schema: {},
+      locale: null,
+      data: {
+        title: 'Test Title',
+      },
+    };
+
+    it('should display the correct title and subtitle for a non-localized entry', () => {
+      render(
+        {
+          selectedVersion,
+          // @ts-expect-error ignore missing properties
+          layout,
+        },
+        '/single-types/api::homepage.homepage/history'
+      );
+
+      expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
+      expect(screen.getByText('Test Title (homepage)')).toBeInTheDocument();
+
+      const backLink = screen.getByRole('link', { name: 'Back' });
+      expect(backLink).toHaveAttribute('href', '/single-types/api::homepage.homepage');
     });
 
-    expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
-    expect(screen.getByText('(kitchensink)')).toBeInTheDocument();
+    it('should display the correct title and subtitle for a localized entry', () => {
+      render(
+        {
+          selectedVersion: {
+            ...selectedVersion,
+            locale: {
+              code: 'en',
+              name: 'English (en)',
+            },
+          },
+          // @ts-expect-error ignore missing properties
+          layout,
+        },
+        {
+          pathname: '/collection-types/api::homepage.homepage/history',
+          search: '?plugins[i18n][locale]=en',
+        }
+      );
+
+      expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
+      expect(screen.getByText('Test Title (homepage), in English (en)')).toBeInTheDocument();
+
+      const backLink = screen.getByRole('link', { name: 'Back' });
+      expect(backLink).toHaveAttribute(
+        'href',
+        '/collection-types/api::homepage.homepage?plugins[i18n][locale]=en'
+      );
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

Makes sure the back button of the history page takes you to the edit view of the right component
