### PR TITLE
feat(i18n): add delete locale action

### DIFF
--- a/packages/plugins/i18n/admin/src/index.ts
+++ b/packages/plugins/i18n/admin/src/index.ts
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import * as yup from 'yup';
 
 import { CheckboxConfirmation } from './components/CheckboxConfirmation';
-import { LocalePickerAction } from './components/CMHeaderActions';
+import { DeleteLocaleAction, LocalePickerAction } from './components/CMHeaderActions';
 import {
   DeleteModalAdditionalInfo,
   PublishModalAdditionalInfo,
@@ -21,6 +21,8 @@ import { i18nApi } from './services/api';
 import { LOCALIZED_FIELDS } from './utils/fields';
 import { getTranslation } from './utils/getTranslation';
 import { mutateCTBContentTypeSchema } from './utils/schemas';
+
+import type { DocumentActionComponent } from '@strapi/strapi/admin';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -61,6 +63,11 @@ export default {
     const contentManager = app.getPlugin('content-manager');
 
     contentManager.apis.addDocumentHeaderAction([LocalePickerAction]);
+    contentManager.apis.addDocumentAction((actions: DocumentActionComponent[]) => {
+      const indexOfDeleteAction = actions.findIndex((action) => action.type === 'delete');
+      actions.splice(indexOfDeleteAction, 0, DeleteLocaleAction);
+      return actions;
+    });
 
     app.injectContentManagerComponent('listView', 'actions', {
       name: 'i18n-locale-filter',

--- a/packages/plugins/i18n/admin/src/translations/en.json
+++ b/packages/plugins/i18n/admin/src/translations/en.json
@@ -1,4 +1,8 @@
 {
+  "actions.delete.label": "Delete locale",
+  "actions.delete.dialog.title": "Confirmation",
+  "actions.delete.dialog.body": "Are you sure you want to delete this locale?",
+  "actions.delete.error": "An error occurred while trying to delete the document locale.",
   "CMEditViewCopyLocale.copy-failure": "Failed to copy locale",
   "CMEditViewCopyLocale.copy-success": "Locale copied",
   "CMEditViewCopyLocale.copy-text": "Fill in from another locale",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds the ability to delete a specific locale in the CM Edit & List View

### How to test it?

* As a user I want to make an entry in a non-default locale, save that entry & delete the specific locale with my original document remaining.

### Related issue(s)/PR(s)

* resolves CONTENT-2034
