### PR TITLE
fix(history): refetch history versions on mount

### DIFF
--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -176,11 +176,15 @@ const VersionContent = () => {
                       const getValue = () => {
                         const value = version.data[column.name];
 
-                        if (attribute.type === 'json') {
-                          return JSON.stringify(value);
+                        switch (attribute.type) {
+                          case 'json':
+                            return JSON.stringify(value);
+                          case 'date':
+                          case 'datetime':
+                            return new Date(value as string);
+                          default:
+                            return value;
                         }
-
-                        return value;
                       };
 
                       return (

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -181,6 +181,10 @@ const VersionContent = () => {
                             return JSON.stringify(value);
                           case 'date':
                           case 'datetime':
+                            if (!value) {
+                              return null;
+                            }
+
                             return new Date(value as string);
                           default:
                             return value;

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -58,11 +58,14 @@ const HistoryPage = () => {
   const validQueryParams = buildValidGetParams(query);
   const page = validQueryParams.page ? Number(validQueryParams.page) : 1;
 
-  const versionsResponse = useGetHistoryVersionsQuery({
-    contentType: slug!,
-    ...(documentId ? { documentId } : {}),
-    ...validQueryParams,
-  });
+  const versionsResponse = useGetHistoryVersionsQuery(
+    {
+      contentType: slug!,
+      ...(documentId ? { documentId } : {}),
+      ...validQueryParams,
+    },
+    { refetchOnMountOrArgChange: true }
+  );
 
   // Make sure the user lands on a selected history version
   React.useEffect(() => {

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Flex, Main } from '@strapi/design-system';
 import { LoadingIndicatorPage, useQueryParams } from '@strapi/helper-plugin';
 import { Contracts } from '@strapi/plugin-content-manager/_internal/shared';
+import { omit } from 'lodash/fp';
 import { stringify } from 'qs';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
@@ -62,7 +63,8 @@ const HistoryPage = () => {
     {
       contentType: slug!,
       ...(documentId ? { documentId } : {}),
-      ...validQueryParams,
+      // Omit id since it's not needed by the endpoint and caused extra refetches
+      ...omit(['id'], validQueryParams),
     },
     { refetchOnMountOrArgChange: true }
   );
@@ -71,7 +73,7 @@ const HistoryPage = () => {
   React.useEffect(() => {
     const versions = versionsResponse.data?.data;
 
-    if (!query.id && versions?.[0]) {
+    if (!query.id && !versionsResponse.isLoading && versions?.[0]) {
       navigate({ search: stringify({ ...query, id: versions[0].id }) }, { replace: true });
     }
   }, [versionsResponse.isLoading, navigate, query.id, versionsResponse.data?.data, query]);

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -69,14 +69,13 @@ const HistoryPage = () => {
     { refetchOnMountOrArgChange: true }
   );
 
-  // Make sure the user lands on a selected history version
+  const versionsLength = versionsResponse.data?.data.length;
+  const firstVersionId = versionsResponse.data?.data?.[0].id;
   React.useEffect(() => {
-    const versions = versionsResponse.data?.data;
-
-    if (!query.id && !versionsResponse.isLoading && versions?.[0]) {
-      navigate({ search: stringify({ ...query, id: versions[0].id }) }, { replace: true });
+    if (versionsLength) {
+      navigate({ search: stringify({ ...query, id: firstVersionId }) }, { replace: true });
     }
-  }, [versionsResponse.isLoading, navigate, query.id, versionsResponse.data?.data, query]);
+  }, [versionsLength, navigate, query, firstVersionId]);
 
   if (!layout || versionsResponse.isLoading) {
     return <LoadingIndicatorPage />;

--- a/packages/core/admin/admin/src/content-manager/history/services/historyVersion.ts
+++ b/packages/core/admin/admin/src/content-manager/history/services/historyVersion.ts
@@ -17,6 +17,7 @@ const historyVersionsApi = contentManagerApi.injectEndpoints({
           },
         };
       },
+      providesTags: ['HistoryVersion'],
     }),
   }),
 });


### PR DESCRIPTION

### What does it do?

Forces a refetch of history versions when the history page is mounted. The cached entries are still displayed while we're refetching.

A consequence of this design is that you may not land on the most recent version anymore. If the refetching finds a more recent version than the one that was the 1st when you opened the page, then that newer version will appear as the new n°1 but you won't have it selected, you'll still have the previous one (now n°2).

Why not invalidate the cache when a content update is made? Because the history version creation is not awaited, so we don't know for sure that the history version has already been created when the PUT request is done. We could await the history version creation, but that would slow down all content updates, which I don't think is a good tradeoff.

### Why is it needed?

If you had already visited the history page, then made a content update, then got back to the history page, you didn't see your last update, because it didn't refetch in time

This is also a problem for E2E tests where the history page is visited instantly after making the update.

### How to test it?

make updates, check history, go back, makes updates, check history, etc.

