### PR TITLE
fix: prevent infinite loop opening pool connections in mysql

### DIFF
--- a/packages/core/database/src/dialects/mysql/database-inspector.ts
+++ b/packages/core/database/src/dialects/mysql/database-inspector.ts
@@ -17,11 +17,13 @@ export default class MysqlDatabaseInspector {
     this.db = db;
   }
 
-  async getInformation(): Promise<Information> {
+  async getInformation(nativeConnection?: unknown): Promise<Information> {
     let database: Information['database'];
     let versionNumber: Information['version'];
     try {
-      const [results] = await this.db.connection.raw(SQL_QUERIES.VERSION);
+      const [results] = await this.db.connection
+        .raw(SQL_QUERIES.VERSION)
+        .connection(nativeConnection);
       const versionSplit = results[0].version.split('-');
       const databaseName = versionSplit[1];
       versionNumber = versionSplit[0];

--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -62,8 +62,13 @@ export default class MysqlDialect extends Dialect {
     }
 
     // We only need to get info on the first connection in the pool
+    /**
+     * Note: There is a race condition here where if two connections are opened at the same time, both will retrieve
+     * db info, but it doesn't cause issues, it's just one wasted query one time, so we can safely leave it to avoid
+     * adding extra complexity
+     * */
     if (!this.info) {
-      this.info = await this.databaseInspector.getInformation();
+      this.info = await this.databaseInspector.getInformation(nativeConnection);
     }
   }
 


### PR DESCRIPTION
### What does it do?

- pass nativeconnection to getInformation to be reused...

### Why is it needed?

- ...so that each raw query doesn't create a new connection, causing an infinite loop that overflows the pool

### How to test it?

Using mysql as the db should now work fine everywhere and in all cases (such as the [doc id migration](https://github.com/strapi/strapi/pull/19514))

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/19527

https://github.com/strapi/strapi/pull/19514