### PR TITLE
fix(content-releases): fix UI details

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -376,7 +376,7 @@ export const CMReleasesContainer = () => {
                             timeZone: release.timezone,
                           }),
                           time: formatTime(new Date(release.scheduledAt), {
-                            hour12: false,
+                            hourCycle: 'h23',
                             timeZone: release.timezone,
                           }),
                           offset: getTimezoneOffset(

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -58,10 +58,10 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     color: ${({ theme }) => theme.colors.neutral700};
     background-color: ${({ theme }) => theme.colors.neutral100};
     border-color: ${({ theme }) => theme.colors.neutral200};
-  }
 
-  &[data-checked='false'][data-disabled='false']:hover > label {
-    cursor: pointer;
+    & > label {
+      cursor: pointer;
+    }
   }
 
   &[data-disabled='true'] {

--- a/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionOptions.tsx
@@ -60,6 +60,10 @@ const FieldWrapper = styled(Field)<FieldWrapperProps>`
     border-color: ${({ theme }) => theme.colors.neutral200};
   }
 
+  &[data-checked='false'][data-disabled='false']:hover > label {
+    cursor: pointer;
+  }
+
   &[data-disabled='true'] {
     color: ${({ theme }) => theme.colors.neutral600};
     background-color: ${({ theme }) => theme.colors.neutral150};

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -330,8 +330,8 @@ export const ReleaseDetailsLayout = ({
             timeZone: release.timezone!,
           }),
           time: formatTime(new Date(release.scheduledAt!), {
-            hour12: false,
             timeZone: release.timezone!,
+            hourCycle: 'h23',
           }),
           offset: getTimezoneOffset(release.timezone!, new Date(release.scheduledAt!)),
         }
@@ -343,7 +343,7 @@ export const ReleaseDetailsLayout = ({
       <HeaderLayout
         title={release.name}
         subtitle={
-          numberOfEntriesText + (IsSchedulingEnabled && isScheduled ? `- ${scheduledText}` : '')
+          numberOfEntriesText + (IsSchedulingEnabled && isScheduled ? ` - ${scheduledText}` : '')
         }
         navigationAction={
           <Link startIcon={<ArrowLeft />} to="/plugins/content-releases">


### PR DESCRIPTION
### What does it do?

This PR fix some small UI details on Content Releases Scheduling new feature.

1. Show times in 23h format (This means that we start with 00:00 and end on 23:59)
2. A typo on the Release Details subtitle
3. Add cursor pointer to change release action type
