### PR TITLE
Add sizeInBytes for upload providers

### DIFF
--- a/packages/core/upload/server/services/upload.js
+++ b/packages/core/upload/server/services/upload.js
@@ -89,6 +89,7 @@ module.exports = ({ strapi }) => ({
       ext,
       mime: type,
       size: bytesToKbytes(size),
+      sizeInBytes: size,
     };
 
     const { refId, ref, field } = metas;

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -27,6 +27,7 @@ export interface File {
   ext?: string;
   mime: string;
   size: number;
+  sizeInBytes: number;
   url: string;
   previewUrl?: string;
   path?: string;

--- a/packages/providers/upload-cloudinary/src/index.ts
+++ b/packages/providers/upload-cloudinary/src/index.ts
@@ -14,6 +14,7 @@ interface File {
   ext?: string;
   mime: string;
   size: number;
+  sizeInBytes: number;
   url: string;
   previewUrl?: string;
   path?: string;

--- a/packages/providers/upload-local/src/index.ts
+++ b/packages/providers/upload-local/src/index.ts
@@ -15,6 +15,7 @@ interface File {
   ext?: string;
   mime: string;
   size: number;
+  sizeInBytes: number;
   url: string;
   previewUrl?: string;
   path?: string;


### PR DESCRIPTION
### What does it do?

Added a `sizeInBytes` attribute to the `File` object that we send to upload providers. This property adds to the current `size` property which expressed the size in kilobytes rounded to the 2 most significant digits.

### Why is it needed?

Strapi Cloud need to know the exact size in bytes of a file to be able to upload it to an object storage using streams. The conversion from bytes to kilobytes is "lossy" and doesn't let us get the exact size of the file.

### How to test it?

Upload a file and verify the the upload provider receives the file size ad expected.

### Related issue(s)/PR(s)

**Jira task**: [CLOUD-808](https://strapi-inc.atlassian.net/browse/CLOUD-808)


[CLOUD-808]: https://strapi-inc.atlassian.net/browse/CLOUD-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ