### PR TITLE
feat(content-releases): Add edit release button on edit view

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -389,6 +389,7 @@ export const CMReleasesContainer = () => {
                   )}
                   <CheckPermissions permissions={PERMISSIONS.deleteAction}>
                     <ReleaseActionMenu.Root hasTriggerBorder>
+                      <ReleaseActionMenu.EditReleaseItem releaseId={release.id} />
                       <ReleaseActionMenu.DeleteReleaseActionItem
                         releaseId={release.id}
                         actionId={release.action.id}

--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -10,6 +10,7 @@ import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { DeleteReleaseAction, ReleaseAction } from '../../../shared/contracts/release-actions';
+import { Release } from '../../../shared/contracts/releases';
 import { PERMISSIONS } from '../constants';
 import { useDeleteReleaseActionMutation } from '../services/release';
 import { useTypedSelector } from '../store/hooks';
@@ -180,6 +181,35 @@ const ReleaseActionEntryLinkItem = ({
 };
 
 /* -------------------------------------------------------------------------------------------------
+ * EditReleaseItem
+ * -----------------------------------------------------------------------------------------------*/
+interface EditReleaseItemProps {
+  releaseId: Release['id'];
+}
+
+const EditReleaseItem = ({ releaseId }: EditReleaseItemProps) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <StyledMenuItem>
+      <Link
+        as={NavLink}
+        // @ts-expect-error TODO: This component from DS is not using types from NavLink
+        to={`/plugins/content-releases/${releaseId}`}
+        startIcon={<Icon as={Pencil} width={3} height={3} />}
+      >
+        <Typography variant="omega">
+          {formatMessage({
+            id: 'content-releases.content-manager-edit-view.edit-release',
+            defaultMessage: 'Edit release',
+          })}
+        </Typography>
+      </Link>
+    </StyledMenuItem>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
  * Root
  * -----------------------------------------------------------------------------------------------*/
 
@@ -225,6 +255,7 @@ const Root = ({ children, hasTriggerBorder = false }: RootProps) => {
 
 export const ReleaseActionMenu = {
   Root,
+  EditReleaseItem,
   DeleteReleaseActionItem,
   ReleaseActionEntryLinkItem,
 };

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -11,6 +11,7 @@
   "content-manager-edit-view.list-releases.title": "{isPublish, select, true {Will be published in} other {Will be unpublished in}}",
   "content-manager-edit-view.remove-from-release": "Remove from release",
   "content-manager-edit-view.scheduled.date": "{date} at {time} ({offset})",
+  "content-manager-edit-view.edit-release": "Edit release",
   "content-releases.content-manager-edit-view.edit-entry": "Edit entry",
   "content-manager-edit-view.remove-from-release.notification.success": "Entry removed from release",
   "content-manager-edit-view.release-action-menu": "Release action options",


### PR DESCRIPTION
### What does it do?

Add missing "Edit Release" button on Edit View.

### How to test it

1. Go to edit an entry attached to a release
2. Click the "3 dots" button on the Releases box
3. You should see "Edit Release" link and it should work
