### PR TITLE
strapi-content-manager: Add permissions filter on the relation field

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -138,6 +138,26 @@ export default {
       ...permissionQuery,
     };
 
+    if (attribute.target !== 'plugin::users-permissions.role') {
+      const relationPermissionChecker = getService('permission-checker').create({
+        userAbility,
+        model: attribute.target
+      });
+
+      if (relationPermissionChecker.cannot.read()) {
+        return ctx.forbidden();
+      }
+
+      const relationCheckerQuery = omit(['entityId'], query);
+
+      const relationPermissionQuery = await relationPermissionChecker.sanitizedQuery.read(relationCheckerQuery);
+
+      queryParams.filters = {
+        ...queryParams.filters,
+        ...relationPermissionQuery.filters,
+      };
+    }
+
     if (!isEmpty(idsToOmit)) {
       addFiltersClause(queryParams, { id: { $notIn: idsToOmit } });
     }


### PR DESCRIPTION
### What does it do?

Based on that issue: 

https://github.com/strapi/strapi/issues/18889
https://github.com/strapi/strapi/pull/18926

### Why is it needed?

It's necessary to respect the READ permission the role has.

### How to test it?

I manually tested it, and everything working fine, I am using this code in production as well.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/18889
https://github.com/strapi/strapi/pull/18926
