### PR TITLE
Add new LinkedIn opendid provider

### DIFF
--- a/packages/plugins/users-permissions/server/bootstrap/grant-config.js
+++ b/packages/plugins/users-permissions/server/bootstrap/grant-config.js
@@ -84,6 +84,13 @@ module.exports = (baseURL) => ({
     callback: `${baseURL}/linkedin/callback`,
     scope: ['r_liteprofile', 'r_emailaddress'],
   },
+  linkedin_openid: {
+    enabled: false,
+    icon: 'linkedin',
+    key: '',
+    secret: '',
+    callback: `${baseURL}/linkedin_openid/callback`,
+  },
   cognito: {
     enabled: false,
     icon: 'aws',

--- a/packages/plugins/users-permissions/server/services/providers-registry.js
+++ b/packages/plugins/users-permissions/server/services/providers-registry.js
@@ -230,6 +230,17 @@ const getInitialProviders = ({ purest }) => ({
       email: email.emailAddress,
     };
   },
+  async linkedin_openid({ accessToken }) {
+    const linkedIn = purest({ provider: 'linkedin' });
+    const {
+      body: { given_name, email },
+    } = await linkedIn.get('userinfo').auth(accessToken).request();
+
+    return {
+      username: given_name,
+      email: email,
+    };
+  },
   async reddit({ accessToken }) {
     const reddit = purest({
       provider: 'reddit',


### PR DESCRIPTION
This PR is based on https://github.com/strapi/strapi/pull/15216

### What does it do?

This PR adds support for the new LinkedIn OpenID Authentication (https://www.linkedin.com/developers/news/featured-updates/openid-connect-authentication)

### Why is it needed?

All new LinkedIn apps are now forced to use the new OpenID standard and will therefore have to use this provider.

### How to test it?

![image](https://github.com/strapi/strapi/assets/504059/554804ba-b250-4ae9-b36e-c9b1124e8d2c)


### Related issue(s)/PR(s)
- https://github.com/strapi/strapi/pull/15216
