### PR TITLE
feat(history): delete expired history versions

### DIFF
--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -53,6 +53,7 @@
     "@strapi/utils": "4.20.1",
     "koa": "2.13.4",
     "lodash": "4.17.21",
+    "node-schedule": "2.1.0",
     "qs": "6.11.1"
   },
   "devDependencies": {

--- a/packages/core/content-manager/server/src/history/index.ts
+++ b/packages/core/content-manager/server/src/history/index.ts
@@ -20,6 +20,9 @@ const getFeature = (): Partial<Plugin.LoadedPlugin> => {
         // Start recording history and saving history versions
         getService(strapi, 'history').init();
       },
+      destroy({ strapi }) {
+        getService(strapi, 'history').destroy();
+      },
       controllers,
       services,
       routes,

--- a/packages/core/content-manager/server/src/history/index.ts
+++ b/packages/core/content-manager/server/src/history/index.ts
@@ -18,7 +18,7 @@ const getFeature = (): Partial<Plugin.LoadedPlugin> => {
       },
       bootstrap({ strapi }) {
         // Start recording history and saving history versions
-        getService(strapi, 'history').init();
+        getService(strapi, 'history').bootstrap();
       },
       destroy({ strapi }) {
         getService(strapi, 'history').destroy();

--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -78,8 +78,8 @@ describe('history-version service', () => {
   });
 
   it('inits service only once', () => {
-    historyService.init();
-    historyService.init();
+    historyService.bootstrap();
+    historyService.bootstrap();
     expect(mockStrapi.documents.middlewares.add).toHaveBeenCalledTimes(1);
   });
 
@@ -93,7 +93,7 @@ describe('history-version service', () => {
     };
 
     const next = jest.fn((context) => ({ ...context, documentId: 'document-id' }));
-    await historyService.init();
+    await historyService.bootstrap();
     const historyMiddlewareFunction = mockStrapi.documents.middlewares.add.mock.calls[0][2];
 
     // Check that we don't break the middleware chain
@@ -199,7 +199,7 @@ describe('history-version service', () => {
       jest.fn((rule, callback) => callback())
     );
 
-    await historyService.init();
+    await historyService.bootstrap();
 
     expect(mockScheduleJob).toHaveBeenCalledTimes(1);
     expect(mockScheduleJob).toHaveBeenCalledWith('0 0 * * *', expect.any(Function));

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -17,11 +17,6 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
     isInitialized: false,
   };
 
-  /**
-   * Use the query engine API, not the document service,
-   * since we'll refactor history version to be just a model instead of a content type.
-   * TODO: remove this comment once the refactor is done.
-   */
   const query = strapi.db.query(HISTORY_VERSION_UID);
 
   const getRetentionDays = (strapi: LoadedStrapi) => {
@@ -35,7 +30,7 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
     }
 
     // User didn't provide retention days value, use the license or fallback to default
-    return licenseRetentionDays ?? DEFAULT_RETENTION_DAYS;
+    return Math.min(licenseRetentionDays, DEFAULT_RETENTION_DAYS);
   };
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9787,6 +9787,7 @@ __metadata:
     koa: "npm:2.13.4"
     koa-body: "npm:4.2.0"
     lodash: "npm:4.17.21"
+    node-schedule: "npm:2.1.0"
     qs: "npm:6.11.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What does it do?

- Adds a node scheduler to clear expired history versions every day
- This is more or less a copy paste from augit log (I believe the rules are the same 🤔 )

### Why is it needed?

- To delete expired history versions base don the user or license config

### How to test it?

- Change the schedule to
```
state.deleteExpiredJob = scheduleJob('* * * * *', () => {
  // ... 
  console.log('did call cron')
  const expirationDate = new Date(Date.now());
```
- Create a history version and then in the database modify the created_at column so that it is a date before today
- run yarn develop
- Once you see the log refresh the db to confirm the history version was deleted

