### PR TITLE
chore: update History with new v5 APIs

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/FormInputs/Date.tsx
@@ -16,6 +16,7 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
     const fieldRef = useFocusInputField(name);
 
     const composedRefs = useComposedRefs<HTMLInputElement | null>(ref, fieldRef);
+    const value = typeof field.value === 'string' ? new Date(field.value) : field.value;
 
     return (
       <DatePicker
@@ -33,7 +34,7 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
         onClear={() => field.onChange(name, undefined)}
         placeholder={placeholder}
         required={required}
-        selectedDate={field.value}
+        selectedDate={value}
       />
     );
   }

--- a/packages/core/admin/admin/src/content-manager/components/FormInputs/DateTime.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/FormInputs/DateTime.tsx
@@ -16,6 +16,7 @@ const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
     const fieldRef = useFocusInputField(name);
 
     const composedRefs = useComposedRefs<HTMLInputElement | null>(ref, fieldRef);
+    const value = typeof field.value === 'string' ? new Date(field.value) : field.value;
 
     return (
       <DateTimePicker
@@ -33,7 +34,7 @@ const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
         onClear={() => field.onChange(name, undefined)}
         placeholder={placeholder}
         required={required}
-        value={field.value}
+        value={value}
       />
     );
   }

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
 import { ContentLayout } from '@strapi/design-system';
+import { useQueryParams } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
+import { DocumentRBAC } from '../../features/DocumentRBAC';
+import { useSyncRbac } from '../../hooks/useSyncRbac';
 import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { useHistoryContext } from '../pages/History';
 
@@ -10,16 +13,20 @@ import { useHistoryContext } from '../pages/History';
 const UNSUPPORTED_TYPES = ['media', 'relation'];
 
 const VersionContent = () => {
+  const [{ query }] = useQueryParams();
   const { version, layout } = useHistoryContext('VersionContent', (state) => ({
     version: state.selectedVersion,
     layout: state.layout,
   }));
+  const { permissions = [] } = useSyncRbac(version.contentType, query, 'VersionContent');
 
   return (
     <ContentLayout>
-      <Form disabled={true} method="PUT" initialValues={version}>
-        <FormLayout layout={layout} />
-      </Form>
+      <DocumentRBAC permissions={permissions}>
+        <Form disabled={true} method="PUT" initialValues={version.data}>
+          <FormLayout layout={layout} />
+        </Form>
+      </DocumentRBAC>
     </ContentLayout>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -6,7 +6,10 @@ import { useQueryParams } from '@strapi/helper-plugin';
 import { Form } from '../../components/Form';
 import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { useSyncRbac } from '../../hooks/useSyncRbac';
-import { InputRenderer } from '../../pages/EditView/components/InputRenderer';
+import {
+  InputRenderer,
+  type InputRendererProps,
+} from '../../pages/EditView/components/InputRenderer';
 import { useHistoryContext } from '../pages/History';
 
 /* -------------------------------------------------------------------------------------------------
@@ -16,7 +19,7 @@ import { useHistoryContext } from '../pages/History';
 // The renderers for these types will be added in future PRs, they need special handling
 const UNSUPPORTED_TYPES = ['media', 'relation'];
 
-const CustomInputRenderer = (props: React.ComponentPropsWithoutRef<typeof InputRenderer>) => {
+const CustomInputRenderer = (props: InputRendererProps) => {
   if (UNSUPPORTED_TYPES.includes(props.type)) {
     return <Typography>TODO: support {props.type}</Typography>;
   }

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 
 import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
-import { useQueryParams } from '@strapi/helper-plugin';
+import { type Permission } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
 import { DocumentRBAC } from '../../features/DocumentRBAC';
-import { useSyncRbac } from '../../hooks/useSyncRbac';
 import {
   InputRenderer,
   type InputRendererProps,
@@ -31,13 +30,15 @@ const CustomInputRenderer = (props: InputRendererProps) => {
  * VersionContent
  * -----------------------------------------------------------------------------------------------*/
 
-const VersionContent = () => {
-  const [{ query }] = useQueryParams();
+interface VersionContentProps {
+  permissions: Permission[];
+}
+
+const VersionContent = ({ permissions }: VersionContentProps) => {
   const { version, layout } = useHistoryContext('VersionContent', (state) => ({
     version: state.selectedVersion,
     layout: state.layout,
   }));
-  const { permissions = [] } = useSyncRbac(version.contentType, query, 'VersionContent');
 
   return (
     <ContentLayout>

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,16 +1,32 @@
 import * as React from 'react';
 
-import { ContentLayout } from '@strapi/design-system';
+import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 import { useQueryParams } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
 import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { useSyncRbac } from '../../hooks/useSyncRbac';
-import { FormLayout } from '../../pages/EditView/components/FormLayout';
+import { InputRenderer } from '../../pages/EditView/components/InputRenderer';
 import { useHistoryContext } from '../pages/History';
 
-// These types will be added in future PRs, they need special handling
+/* -------------------------------------------------------------------------------------------------
+ * CustomInputRenderer
+ * -----------------------------------------------------------------------------------------------*/
+
+// The renderers for these types will be added in future PRs, they need special handling
 const UNSUPPORTED_TYPES = ['media', 'relation'];
+
+const CustomInputRenderer = (props: React.ComponentPropsWithoutRef<typeof InputRenderer>) => {
+  if (UNSUPPORTED_TYPES.includes(props.type)) {
+    return <Typography>TODO: support {props.type}</Typography>;
+  }
+
+  return <InputRenderer {...props} />;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * VersionContent
+ * -----------------------------------------------------------------------------------------------*/
 
 const VersionContent = () => {
   const [{ query }] = useQueryParams();
@@ -24,7 +40,49 @@ const VersionContent = () => {
     <ContentLayout>
       <DocumentRBAC permissions={permissions}>
         <Form disabled={true} method="PUT" initialValues={version.data}>
-          <FormLayout layout={layout} />
+          <Flex direction="column" alignItems="stretch" gap={6}>
+            {layout.map((panel, index) => {
+              if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
+                const [row] = panel;
+                const [field] = row;
+                return (
+                  <Grid key={field.name} gap={4}>
+                    <GridItem col={12} s={12} xs={12}>
+                      <CustomInputRenderer {...field} />
+                    </GridItem>
+                  </Grid>
+                );
+              }
+
+              return (
+                <Box
+                  key={index}
+                  hasRadius
+                  background="neutral0"
+                  shadow="tableShadow"
+                  paddingLeft={6}
+                  paddingRight={6}
+                  paddingTop={6}
+                  paddingBottom={6}
+                  borderColor="neutral150"
+                >
+                  <Flex direction="column" alignItems="stretch" gap={6}>
+                    {panel.map((row, gridRowIndex) => (
+                      <Grid key={gridRowIndex} gap={4}>
+                        {row.map(({ size, ...field }) => {
+                          return (
+                            <GridItem col={size} key={field.name} s={12} xs={12}>
+                              <CustomInputRenderer {...field} />
+                            </GridItem>
+                          );
+                        })}
+                      </Grid>
+                    ))}
+                  </Flex>
+                </Box>
+              );
+            })}
+          </Flex>
         </Form>
       </DocumentRBAC>
     </ContentLayout>

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,23 +1,9 @@
 import * as React from 'react';
 
-import { ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
-import {
-  ContentManagerEditViewDataManagerContext,
-  GenericInput,
-  useQueryParams,
-  useStrapiApp,
-} from '@strapi/helper-plugin';
+import { ContentLayout } from '@strapi/design-system';
 
-import { HOOKS } from '../../../constants';
-import { useTypedDispatch } from '../../../core/store/hooks';
-import { DynamicZone } from '../../components/DynamicZone/Field';
-import { FieldComponent } from '../../components/FieldComponent';
-import { getInputType, useCustomInputs } from '../../components/Inputs';
-import { useLazyComponents } from '../../hooks/useLazyComponents';
-import { useSyncRbac } from '../../hooks/useSyncRbac';
-import { isDynamicZone, splitLayoutIntoPanes } from '../../pages/EditView/EditViewPage';
-import { setLayout } from '../../pages/EditViewLayoutManager';
-import { getFieldsActionMatchingPermissions } from '../../utils/permissions';
+import { Form } from '../../components/Form';
+import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { useHistoryContext } from '../pages/History';
 
 // These types will be added in future PRs, they need special handling
@@ -28,194 +14,12 @@ const VersionContent = () => {
     version: state.selectedVersion,
     layout: state.layout,
   }));
-  const [{ query }] = useQueryParams();
-  const dispatch = useTypedDispatch();
-
-  const { runHookWaterfall } = useStrapiApp();
-  const mutatedLayout = runHookWaterfall(HOOKS.MUTATE_EDIT_VIEW_LAYOUT, { layout, query });
-
-  React.useEffect(() => {
-    if (mutatedLayout.layout) {
-      dispatch(setLayout(mutatedLayout.layout, query));
-    }
-  }, [dispatch, mutatedLayout, query]);
-
-  const { permissions } = useSyncRbac(query, layout.contentType.uid, 'editView');
-
-  const { readActionAllowedFields } = getFieldsActionMatchingPermissions(
-    permissions ?? [],
-    mutatedLayout.layout!.contentType.uid
-  );
-
-  const getCustomFields = React.useCallback(() => {
-    if (!mutatedLayout.layout) {
-      return [];
-    }
-
-    const customFields: string[] = [];
-    Object.values(mutatedLayout.layout.contentType.attributes).forEach((value) => {
-      if ('customField' in value) {
-        customFields.push(value.customField as string);
-      }
-    });
-
-    Object.values(mutatedLayout.layout.components).forEach((component) => {
-      Object.values(component.attributes).forEach((value) => {
-        if ('customField' in value) {
-          customFields.push(value.customField as string);
-        }
-      });
-    });
-
-    return customFields;
-  }, [mutatedLayout.layout]);
-
-  const { isLazyLoading, lazyComponentStore } = useLazyComponents(getCustomFields());
-  const customInputs = useCustomInputs(lazyComponentStore);
-
-  // TODO: better loading
-  if (isLazyLoading) {
-    return null;
-  }
-
-  const layoutPanes = splitLayoutIntoPanes(mutatedLayout.layout);
 
   return (
     <ContentLayout>
-      <ContentManagerEditViewDataManagerContext.Provider
-        value={{
-          isCreatingEntry: false,
-          modifiedData: version.data,
-          allLayoutData: mutatedLayout.layout,
-          readActionAllowedFields,
-          /**
-           * We're not passing create and update actions on purpose, even though we have them
-           * because not giving them disables all the nested fields, which is what we want
-           */
-          createActionAllowedFields: [],
-          updateActionAllowedFields: [],
-          formErrors: {},
-          initialData: version.data,
-          isSingleType: mutatedLayout.layout.contentType.kind === 'singleType',
-        }}
-      >
-        {/* Position relative is needed to prevent VisuallyHidden from breaking the layout */}
-        <Flex direction="column" alignItems="stretch" gap={6} position="relative" marginBottom={6}>
-          {layoutPanes.map((pane, paneIndex) => {
-            if (isDynamicZone(pane)) {
-              const [[{ name, fieldSchema, metadatas, ...restProps }]] = pane;
-
-              return (
-                <DynamicZone
-                  name={name}
-                  fieldSchema={fieldSchema}
-                  metadatas={metadatas}
-                  key={paneIndex}
-                  {...restProps}
-                />
-              );
-            }
-
-            return (
-              <Flex
-                direction="column"
-                alignItems="stretch"
-                gap={4}
-                background="neutral0"
-                shadow="tableShadow"
-                paddingLeft={6}
-                paddingRight={6}
-                paddingTop={6}
-                paddingBottom={6}
-                borderColor="neutral150"
-                hasRadius
-                key={paneIndex}
-              >
-                {pane.map((row, rowIndex) => (
-                  <Grid gap={4} key={rowIndex}>
-                    {row.map((column, columnIndex) => {
-                      const attribute = mutatedLayout.layout!.contentType.attributes[column.name];
-                      const { type } = attribute;
-                      const customFieldUid = (attribute as { customField?: string }).customField;
-
-                      if (UNSUPPORTED_TYPES.includes(type)) {
-                        return (
-                          <GridItem col={column.size} key={columnIndex}>
-                            <Typography>TODO {type}</Typography>
-                          </GridItem>
-                        );
-                      }
-
-                      if (type === 'component') {
-                        const {
-                          component,
-                          max,
-                          min,
-                          repeatable = false,
-                          required = false,
-                        } = attribute;
-
-                        return (
-                          <GridItem col={column.size} s={12} xs={12} key={component}>
-                            <FieldComponent
-                              componentUid={component}
-                              isRepeatable={repeatable}
-                              intlLabel={{
-                                id: column.metadatas.label,
-                                defaultMessage: column.metadatas.label,
-                              }}
-                              max={max}
-                              min={min}
-                              name={column.name}
-                              required={required}
-                            />
-                          </GridItem>
-                        );
-                      }
-
-                      const getValue = () => {
-                        const value = version.data[column.name];
-
-                        switch (attribute.type) {
-                          case 'json':
-                            return JSON.stringify(value);
-                          case 'date':
-                          case 'datetime':
-                            if (!value) {
-                              return null;
-                            }
-
-                            return new Date(value as string);
-                          default:
-                            return value;
-                        }
-                      };
-
-                      return (
-                        <GridItem col={column.size} key={columnIndex}>
-                          <GenericInput
-                            name={column.name}
-                            intlLabel={{
-                              id: column.metadatas.label,
-                              defaultMessage: column.metadatas.label,
-                            }}
-                            type={customFieldUid || getInputType(type)}
-                            onChange={() => {}}
-                            disabled={true}
-                            customInputs={customInputs}
-                            value={getValue()}
-                            attribute={attribute}
-                          />
-                        </GridItem>
-                      );
-                    })}
-                  </Grid>
-                ))}
-              </Flex>
-            );
-          })}
-        </Flex>
-      </ContentManagerEditViewDataManagerContext.Provider>
+      <Form disabled={true} method="PUT" initialValues={version}>
+        <FormLayout layout={layout} />
+      </Form>
     </ContentLayout>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
 import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
-import { type Permission } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
-import { DocumentRBAC } from '../../features/DocumentRBAC';
 import {
   InputRenderer,
   type InputRendererProps,
@@ -30,11 +28,7 @@ const CustomInputRenderer = (props: InputRendererProps) => {
  * VersionContent
  * -----------------------------------------------------------------------------------------------*/
 
-interface VersionContentProps {
-  permissions: Permission[];
-}
-
-const VersionContent = ({ permissions }: VersionContentProps) => {
+const VersionContent = () => {
   const { version, layout } = useHistoryContext('VersionContent', (state) => ({
     version: state.selectedVersion,
     layout: state.layout,
@@ -42,53 +36,51 @@ const VersionContent = ({ permissions }: VersionContentProps) => {
 
   return (
     <ContentLayout>
-      <DocumentRBAC permissions={permissions}>
-        <Form disabled={true} method="PUT" initialValues={version.data}>
-          <Flex direction="column" alignItems="stretch" gap={6}>
-            {layout.map((panel, index) => {
-              if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
-                const [row] = panel;
-                const [field] = row;
-                return (
-                  <Grid key={field.name} gap={4}>
-                    <GridItem col={12} s={12} xs={12}>
-                      <CustomInputRenderer {...field} />
-                    </GridItem>
-                  </Grid>
-                );
-              }
-
+      <Form disabled={true} method="PUT" initialValues={version.data}>
+        <Flex direction="column" alignItems="stretch" gap={6}>
+          {layout.map((panel, index) => {
+            if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
+              const [row] = panel;
+              const [field] = row;
               return (
-                <Box
-                  key={index}
-                  hasRadius
-                  background="neutral0"
-                  shadow="tableShadow"
-                  paddingLeft={6}
-                  paddingRight={6}
-                  paddingTop={6}
-                  paddingBottom={6}
-                  borderColor="neutral150"
-                >
-                  <Flex direction="column" alignItems="stretch" gap={6}>
-                    {panel.map((row, gridRowIndex) => (
-                      <Grid key={gridRowIndex} gap={4}>
-                        {row.map(({ size, ...field }) => {
-                          return (
-                            <GridItem col={size} key={field.name} s={12} xs={12}>
-                              <CustomInputRenderer {...field} />
-                            </GridItem>
-                          );
-                        })}
-                      </Grid>
-                    ))}
-                  </Flex>
-                </Box>
+                <Grid key={field.name} gap={4}>
+                  <GridItem col={12} s={12} xs={12}>
+                    <CustomInputRenderer {...field} />
+                  </GridItem>
+                </Grid>
               );
-            })}
-          </Flex>
-        </Form>
-      </DocumentRBAC>
+            }
+
+            return (
+              <Box
+                key={index}
+                hasRadius
+                background="neutral0"
+                shadow="tableShadow"
+                paddingLeft={6}
+                paddingRight={6}
+                paddingTop={6}
+                paddingBottom={6}
+                borderColor="neutral150"
+              >
+                <Flex direction="column" alignItems="stretch" gap={6}>
+                  {panel.map((row, gridRowIndex) => (
+                    <Grid key={gridRowIndex} gap={4}>
+                      {row.map(({ size, ...field }) => {
+                        return (
+                          <GridItem col={size} key={field.name} s={12} xs={12}>
+                            <CustomInputRenderer {...field} />
+                          </GridItem>
+                        );
+                      })}
+                    </Grid>
+                  ))}
+                </Flex>
+              </Box>
+            );
+          })}
+        </Flex>
+      </Form>
     </ContentLayout>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
-import { useQueryParams } from '@strapi/helper-plugin';
+import { useQueryParams, useRBAC } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
 import { DocumentRBAC } from '../../features/DocumentRBAC';

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
-import { useQueryParams, useRBAC } from '@strapi/helper-plugin';
+import { useQueryParams } from '@strapi/helper-plugin';
 
 import { Form } from '../../components/Form';
 import { DocumentRBAC } from '../../features/DocumentRBAC';

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -18,23 +18,15 @@ interface VersionHeaderProps {
 
 export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const { formatMessage, formatDate } = useIntl();
-  const { version, mainField } = useHistoryContext('VersionHeader', (state) => ({
+  const { version, mainField, schema } = useHistoryContext('VersionHeader', (state) => ({
     version: state.selectedVersion,
     mainField: state.mainField,
+    schema: state.schema,
   }));
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
   }>();
   const { collectionType } = useParams<{ collectionType: string }>();
-
-  const { isLoading: isLoadingDocument, schema } = useDocument({
-    collectionType: collectionType!,
-    model: version.contentType,
-  });
-
-  if (isLoadingDocument) {
-    return <LoadingIndicatorPage />;
-  }
 
   const mainFieldValue = version.data[mainField];
 
@@ -74,7 +66,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
             },
             {
               hasLocale: Boolean(version.locale),
-              subtitle: `${mainFieldValue || ''} (${schema!.info.singularName})`.trim(),
+              subtitle: `${mainFieldValue || ''} (${schema.info.singularName})`.trim(),
               locale: version.locale?.name,
             }
           )}

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 
 import { HeaderLayout, Typography } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
-import { useQueryParams } from '@strapi/helper-plugin';
+import { useQueryParams, LoadingIndicatorPage } from '@strapi/helper-plugin';
 import { ArrowLeft } from '@strapi/icons';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { NavLink, type To, useParams } from 'react-router-dom';
 
+import { COLLECTION_TYPES } from '../../constants/collections';
+import { useDocument } from '../../hooks/useDocument';
+import { useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { useHistoryContext } from '../pages/History';
 
 interface VersionHeaderProps {
@@ -16,29 +19,45 @@ interface VersionHeaderProps {
 
 export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const { formatMessage, formatDate } = useIntl();
-  const { version, layout } = useHistoryContext('VersionHeader', (state) => ({
+  const { version } = useHistoryContext('VersionHeader', (state) => ({
     version: state.selectedVersion,
     layout: state.layout,
   }));
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
   }>();
-  const params = useParams<{ collectionType: string; slug: string }>();
+  const { collectionType } = useParams<{ collectionType: string }>();
 
-  const mainFieldValue = version.data[layout.contentType.settings.mainField];
+  const {
+    isLoading: isLoadingLayout,
+    edit: {
+      settings: { mainField },
+    },
+  } = useDocumentLayout(version.contentType);
+
+  const { isLoading: isLoadingDocument, schema } = useDocument({
+    collectionType: collectionType!,
+    model: version.contentType,
+  });
+
+  if (isLoadingLayout || isLoadingDocument) {
+    return <LoadingIndicatorPage />;
+  }
+
+  const mainFieldValue = version.data[mainField];
 
   const getBackLink = (): To => {
     const pluginsQueryParams = stringify({ plugins: query.plugins }, { encode: false });
 
-    if (layout.contentType.kind === 'collectionType') {
+    if (collectionType === COLLECTION_TYPES) {
       return {
-        pathname: `../${params.collectionType}/${version.contentType}/${version.relatedDocumentId}`,
+        pathname: `../${collectionType}/${version.contentType}/${version.relatedDocumentId}`,
         search: pluginsQueryParams,
       };
     }
 
     return {
-      pathname: `../${params.collectionType}/${version.contentType}`,
+      pathname: `../${collectionType}/${version.contentType}`,
       search: pluginsQueryParams,
     };
   };
@@ -63,7 +82,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
             },
             {
               hasLocale: Boolean(version.locale),
-              subtitle: `${mainFieldValue || ''} (${layout.contentType.info.singularName})`.trim(),
+              subtitle: `${mainFieldValue || ''} (${schema!.info.singularName})`.trim(),
               locale: version.locale?.name,
             }
           )}

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -21,7 +21,6 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const { formatMessage, formatDate } = useIntl();
   const { version } = useHistoryContext('VersionHeader', (state) => ({
     version: state.selectedVersion,
-    layout: state.layout,
   }));
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -10,7 +10,6 @@ import { NavLink, type To, useParams } from 'react-router-dom';
 
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { useDocument } from '../../hooks/useDocument';
-import { useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { useHistoryContext } from '../pages/History';
 
 interface VersionHeaderProps {
@@ -19,27 +18,21 @@ interface VersionHeaderProps {
 
 export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const { formatMessage, formatDate } = useIntl();
-  const { version } = useHistoryContext('VersionHeader', (state) => ({
+  const { version, mainField } = useHistoryContext('VersionHeader', (state) => ({
     version: state.selectedVersion,
+    mainField: state.mainField,
   }));
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
   }>();
   const { collectionType } = useParams<{ collectionType: string }>();
 
-  const {
-    isLoading: isLoadingLayout,
-    edit: {
-      settings: { mainField },
-    },
-  } = useDocumentLayout(version.contentType);
-
   const { isLoading: isLoadingDocument, schema } = useDocument({
     collectionType: collectionType!,
     model: version.contentType,
   });
 
-  if (isLoadingLayout || isLoadingDocument) {
+  if (isLoadingDocument) {
     return <LoadingIndicatorPage />;
   }
 

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionHeader.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 
 import { HeaderLayout, Typography } from '@strapi/design-system';
 import { Link } from '@strapi/design-system/v2';
-import { useQueryParams, LoadingIndicatorPage } from '@strapi/helper-plugin';
+import { useQueryParams } from '@strapi/helper-plugin';
 import { ArrowLeft } from '@strapi/icons';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { NavLink, type To, useParams } from 'react-router-dom';
 
 import { COLLECTION_TYPES } from '../../constants/collections';
-import { useDocument } from '../../hooks/useDocument';
 import { useHistoryContext } from '../pages/History';
 
 interface VersionHeaderProps {

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
@@ -8,11 +8,6 @@ import { VersionHeader } from '../VersionHeader';
 
 import type { UID } from '@strapi/types';
 
-const useDocumentMock = jest.fn();
-jest.mock('../../../hooks/useDocument', () => ({
-  useDocument: () => useDocumentMock(),
-}));
-
 const render = (
   context: Partial<HistoryContextValue>,
   initialEntry: Exclude<RenderOptions['initialEntries'], undefined>[number]
@@ -26,9 +21,19 @@ const render = (
     ? '/:collectionType/:slug/history'
     : '/:collectionType/:slug/:id/history';
 
+  const contextWithSchema: Partial<HistoryContextValue> = {
+    ...context,
+    schema: {
+      // @ts-expect-error ignore missing properties
+      info: {
+        singularName: isSingleType ? 'homepage' : 'kitchensink',
+      },
+    },
+  };
+
   return renderRTL(
     // @ts-expect-error ignore missing properties
-    <HistoryProvider {...context}>
+    <HistoryProvider {...contextWithSchema}>
       <Routes>
         <Route path={path} element={<VersionHeader headerId="123" />} />
       </Routes>
@@ -38,10 +43,6 @@ const render = (
 };
 
 describe('VersionHeader', () => {
-  afterEach(() => {
-    useDocumentMock.mockReset();
-  });
-
   describe('collection types', () => {
     // Mocks
     const selectedVersion = {
@@ -57,20 +58,12 @@ describe('VersionHeader', () => {
       },
     };
 
-    beforeEach(() => {
-      useDocumentMock.mockReturnValue({
-        isLoading: false,
-        schema: {
-          info: {
-            singularName: 'kitchensink',
-          },
-        },
-      });
-    });
-
     it('should display the correct title and subtitle for a non-localized entry', () => {
       render(
-        { selectedVersion, mainField: 'title' },
+        {
+          selectedVersion,
+          mainField: 'title',
+        },
         '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
       );
 
@@ -138,17 +131,6 @@ describe('VersionHeader', () => {
         title: 'Test Title',
       },
     };
-
-    beforeEach(() => {
-      useDocumentMock.mockReturnValue({
-        isLoading: false,
-        schema: {
-          info: {
-            singularName: 'homepage',
-          },
-        },
-      });
-    });
 
     it('should display the correct title and subtitle for a non-localized entry', () => {
       render(

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
@@ -8,11 +8,6 @@ import { VersionHeader } from '../VersionHeader';
 
 import type { UID } from '@strapi/types';
 
-const useDocumentLayoutMock = jest.fn();
-jest.mock('../../../hooks/useDocumentLayout', () => ({
-  useDocumentLayout: () => useDocumentLayoutMock(),
-}));
-
 const useDocumentMock = jest.fn();
 jest.mock('../../../hooks/useDocument', () => ({
   useDocument: () => useDocumentMock(),
@@ -44,7 +39,6 @@ const render = (
 
 describe('VersionHeader', () => {
   afterEach(() => {
-    useDocumentLayoutMock.mockReset();
     useDocumentMock.mockReset();
   });
 
@@ -72,20 +66,11 @@ describe('VersionHeader', () => {
           },
         },
       });
-
-      useDocumentLayoutMock.mockReturnValue({
-        isLoading: false,
-        edit: {
-          settings: {
-            mainField: 'title',
-          },
-        },
-      });
     });
 
     it('should display the correct title and subtitle for a non-localized entry', () => {
       render(
-        { selectedVersion },
+        { selectedVersion, mainField: 'title' },
         '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
       );
 
@@ -109,6 +94,7 @@ describe('VersionHeader', () => {
               name: 'English (en)',
             },
           },
+          mainField: 'title',
         },
         {
           pathname:
@@ -128,18 +114,8 @@ describe('VersionHeader', () => {
     });
 
     it('should display the correct subtitle without an entry title (mainField)', () => {
-      useDocumentLayoutMock.mockReturnValue({
-        isLoading: false,
-        edit: {
-          settings: {
-            // id or null will not return a value from version.data
-            mainField: 'id',
-          },
-        },
-      });
-
       render(
-        { selectedVersion },
+        { selectedVersion, mainField: 'id' },
         '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
       );
 
@@ -172,19 +148,13 @@ describe('VersionHeader', () => {
           },
         },
       });
-
-      useDocumentLayoutMock.mockReturnValue({
-        isLoading: false,
-        edit: {
-          settings: {
-            mainField: 'title',
-          },
-        },
-      });
     });
 
     it('should display the correct title and subtitle for a non-localized entry', () => {
-      render({ selectedVersion }, '/single-types/api::homepage.homepage/history');
+      render(
+        { selectedVersion, mainField: 'title' },
+        '/single-types/api::homepage.homepage/history'
+      );
 
       expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
       expect(screen.getByText('Test Title (homepage)')).toBeInTheDocument();
@@ -203,6 +173,7 @@ describe('VersionHeader', () => {
               name: 'English (en)',
             },
           },
+          mainField: 'title',
         },
         {
           pathname: '/single-types/api::homepage.homepage/history',

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionHeader.test.tsx
@@ -20,11 +20,16 @@ jest.mock('../../../hooks/useDocument', () => ({
 
 const render = (
   context: Partial<HistoryContextValue>,
-  kind: 'singleType' | 'collectionType',
   initialEntry: Exclude<RenderOptions['initialEntries'], undefined>[number]
 ) => {
-  const path =
-    kind === 'singleType' ? '/:collectionType/:slug/history' : '/:collectionType/:slug/:id/history';
+  const isSingleType =
+    typeof initialEntry === 'string'
+      ? initialEntry.startsWith('/single-types')
+      : initialEntry.pathname!.startsWith('/single-types');
+
+  const path = isSingleType
+    ? '/:collectionType/:slug/history'
+    : '/:collectionType/:slug/:id/history';
 
   return renderRTL(
     // @ts-expect-error ignore missing properties
@@ -81,7 +86,6 @@ describe('VersionHeader', () => {
     it('should display the correct title and subtitle for a non-localized entry', () => {
       render(
         { selectedVersion },
-        'collectionType',
         '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
       );
 
@@ -106,7 +110,6 @@ describe('VersionHeader', () => {
             },
           },
         },
-        'collectionType',
         {
           pathname:
             '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history',
@@ -137,7 +140,6 @@ describe('VersionHeader', () => {
 
       render(
         { selectedVersion },
-        'collectionType',
         '/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr/history'
       );
 
@@ -182,7 +184,7 @@ describe('VersionHeader', () => {
     });
 
     it('should display the correct title and subtitle for a non-localized entry', () => {
-      render({ selectedVersion }, 'singleType', '/single-types/api::homepage.homepage/history');
+      render({ selectedVersion }, '/single-types/api::homepage.homepage/history');
 
       expect(screen.getByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
       expect(screen.getByText('Test Title (homepage)')).toBeInTheDocument();
@@ -202,7 +204,6 @@ describe('VersionHeader', () => {
             },
           },
         },
-        'singleType',
         {
           pathname: '/single-types/api::homepage.homepage/history',
           search: '?plugins[i18n][locale]=en',

--- a/packages/core/admin/admin/src/content-manager/history/components/tests/VersionsList.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/tests/VersionsList.test.tsx
@@ -35,14 +35,8 @@ const render = (ui: React.ReactElement) =>
 describe('VersionsList', () => {
   it('renders a list of history versions', async () => {
     render(
-      <HistoryProvider
-        page={1}
-        contentType="api::kitchensink.kitchensink"
-        // @ts-expect-error – we don't need to bother formatting the layout
-        layout={mockData.contentManager.collectionTypeLayout}
-        versions={mockHistoryVersionsData.historyVersions}
-        selectedVersion={mockHistoryVersionsData.historyVersions.data[0]}
-      >
+      // @ts-expect-error we don't need all the context
+      <HistoryProvider page={1} versions={mockHistoryVersionsData.historyVersions}>
         <VersionsList />
       </HistoryProvider>
     );

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -93,6 +93,11 @@ const HistoryPage = () => {
     return <LoadingIndicatorPage />;
   }
 
+  /**
+   * Ensure that we have the necessary data to render the page:
+   * - slug for single types
+   * - slug _and_ documentId for collection types
+   */
   if (!slug || (!documentId && collectionType === COLLECTION_TYPES)) {
     return <Navigate to="/content-manager" />;
   }

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -30,6 +30,7 @@ interface HistoryContextValue {
   selectedVersion: Contracts.HistoryVersions.HistoryVersionDataResponse;
   versions: Contracts.HistoryVersions.GetHistoryVersions.Response;
   page: number;
+  mainField: string;
 }
 
 const [HistoryProvider, useHistoryContext] = createContext<HistoryContextValue>('HistoryPage');
@@ -56,7 +57,7 @@ const HistoryPage = () => {
     isLoading: isLoadingLayout,
     edit: {
       layout,
-      settings: { displayName },
+      settings: { displayName, mainField },
     },
   } = useDocumentLayout(slug!);
 
@@ -136,6 +137,7 @@ const HistoryPage = () => {
         selectedVersion={selectedVersion}
         versions={versionsResponse.data}
         page={page}
+        mainField={mainField}
       >
         <Flex direction="row" alignItems="flex-start">
           <Main grow={1} height="100vh" overflow="auto" labelledBy={headerId}>

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -12,6 +12,7 @@ import { createContext } from '../../../components/Context';
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { useDocument } from '../../hooks/useDocument';
 import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
+import { useSyncRbac } from '../../hooks/useSyncRbac';
 import { buildValidParams } from '../../utils/api';
 import { VersionContent } from '../components/VersionContent';
 import { VersionHeader } from '../components/VersionHeader';
@@ -97,7 +98,9 @@ const HistoryPage = () => {
     }
   }, [versionsResponse.isLoading, navigate, query.id, versionsResponse.data?.data, query]);
 
-  if (isLoadingDocument || isLoadingLayout || versionsResponse.isLoading) {
+  const { permissions, isLoading: isLoadingPermissions } = useSyncRbac(slug!, query, 'History');
+
+  if (isLoadingDocument || isLoadingLayout || versionsResponse.isLoading || isLoadingPermissions) {
     return <LoadingIndicatorPage />;
   }
 
@@ -111,7 +114,7 @@ const HistoryPage = () => {
   }
 
   // TODO: real error state when designs are ready
-  if (versionsResponse.isError || !versionsResponse.data || !layout || !schema) {
+  if (versionsResponse.isError || !versionsResponse.data || !layout || !schema || !permissions) {
     return null;
   }
 
@@ -150,7 +153,7 @@ const HistoryPage = () => {
         <Flex direction="row" alignItems="flex-start">
           <Main grow={1} height="100vh" overflow="auto" labelledBy={headerId}>
             <VersionHeader headerId={headerId} />
-            <VersionContent />
+            <VersionContent permissions={permissions} />
           </Main>
           <VersionsList />
         </Flex>

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -10,6 +10,7 @@ import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { createContext } from '../../../components/Context';
 import { COLLECTION_TYPES } from '../../constants/collections';
+import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { useDocument } from '../../hooks/useDocument';
 import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { useSyncRbac } from '../../hooks/useSyncRbac';
@@ -153,7 +154,9 @@ const HistoryPage = () => {
         <Flex direction="row" alignItems="flex-start">
           <Main grow={1} height="100vh" overflow="auto" labelledBy={headerId}>
             <VersionHeader headerId={headerId} />
-            <VersionContent permissions={permissions} />
+            <DocumentRBAC permissions={permissions}>
+              <VersionContent />
+            </DocumentRBAC>
           </Main>
           <VersionsList />
         </Flex>

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -10,6 +10,7 @@ import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { createContext } from '../../../components/Context';
 import { COLLECTION_TYPES } from '../../constants/collections';
+import { useDocument } from '../../hooks/useDocument';
 import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { buildValidParams } from '../../utils/api';
 import { VersionContent } from '../components/VersionContent';
@@ -31,6 +32,7 @@ interface HistoryContextValue {
   versions: Contracts.HistoryVersions.GetHistoryVersions.Response;
   page: number;
   mainField: string;
+  schema: Contracts.ContentTypes.ContentType;
 }
 
 const [HistoryProvider, useHistoryContext] = createContext<HistoryContextValue>('HistoryPage');
@@ -52,6 +54,11 @@ const HistoryPage = () => {
     slug: UID.ContentType;
     id: string;
   }>();
+
+  const { isLoading: isLoadingDocument, schema } = useDocument({
+    collectionType: collectionType!,
+    model: slug!,
+  });
 
   const {
     isLoading: isLoadingLayout,
@@ -90,7 +97,7 @@ const HistoryPage = () => {
     }
   }, [versionsResponse.isLoading, navigate, query.id, versionsResponse.data?.data, query]);
 
-  if (isLoadingLayout || versionsResponse.isLoading) {
+  if (isLoadingDocument || isLoadingLayout || versionsResponse.isLoading) {
     return <LoadingIndicatorPage />;
   }
 
@@ -104,7 +111,7 @@ const HistoryPage = () => {
   }
 
   // TODO: real error state when designs are ready
-  if (versionsResponse.isError || !versionsResponse.data || !layout) {
+  if (versionsResponse.isError || !versionsResponse.data || !layout || !schema) {
     return null;
   }
 
@@ -133,6 +140,7 @@ const HistoryPage = () => {
       <HistoryProvider
         contentType={slug}
         id={documentId}
+        schema={schema}
         layout={layout}
         selectedVersion={selectedVersion}
         versions={versionsResponse.data}

--- a/packages/core/admin/admin/src/content-manager/history/routes.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/routes.tsx
@@ -16,7 +16,7 @@ const routes: RouteObject[] = [
     },
   },
   {
-    path: ':singleType/:slug/history',
+    path: ':collectionType/:slug/history',
     lazy: async () => {
       const { HistoryPage } = await import('./pages/History');
 

--- a/packages/core/admin/admin/src/content-manager/hooks/useDocumentLayout.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useDocumentLayout.ts
@@ -146,6 +146,7 @@ const DEFAULT_SETTINGS = {
  * ```
  *
  */
+
 const useDocumentLayout: UseDocumentLayout = (model) => {
   const { schema, components } = useDocument({ model, collectionType: '' }, { skip: true });
   const [{ query }] = useQueryParams();

--- a/packages/core/admin/admin/src/content-manager/layout.tsx
+++ b/packages/core/admin/admin/src/content-manager/layout.tsx
@@ -10,13 +10,13 @@ import { useIntl } from 'react-intl';
 import { Navigate, Outlet, useLocation, useMatch } from 'react-router-dom';
 
 import { DragLayer, DragLayerProps } from '../components/DragLayer';
-import { useIsHistoryRoute } from '../history/routes';
 
 import { CardDragPreview } from './components/DragPreviews/CardDragPreview';
 import { ComponentDragPreview } from './components/DragPreviews/ComponentDragPreview';
 import { RelationDragPreview } from './components/DragPreviews/RelationDragPreview';
 import { LeftMenu } from './components/LeftMenu';
 import { ItemTypes } from './constants/dragAndDrop';
+import { useIsHistoryRoute } from './history/routes';
 import { useContentManagerInitData } from './hooks/useContentManagerInitData';
 import { getTranslation } from './utils/translations';
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Component/Input.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Component/Input.tsx
@@ -83,7 +83,12 @@ const ComponentInput = ({
           <Initializer disabled={disabled} name={name} onClick={handleInitialisationClick} />
         )}
         {!attribute.repeatable && field.value ? (
-          <NonRepeatableComponent attribute={attribute} name={name} {...props} />
+          <NonRepeatableComponent
+            attribute={attribute}
+            name={name}
+            disabled={disabled}
+            {...props}
+          />
         ) : null}
         {attribute.repeatable && (
           <RepeatableComponent attribute={attribute} name={name} disabled={disabled} {...props} />

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Component/Input.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Component/Input.tsx
@@ -86,7 +86,7 @@ const ComponentInput = ({
           <NonRepeatableComponent attribute={attribute} name={name} {...props} />
         ) : null}
         {attribute.repeatable && (
-          <RepeatableComponent attribute={attribute} name={name} {...props} />
+          <RepeatableComponent attribute={attribute} name={name} disabled={disabled} {...props} />
         )}
       </Flex>
     </Box>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/InputRenderer.tsx
@@ -20,6 +20,8 @@ import type { Attribute } from '@strapi/types';
 
 type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
 
+type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'>;
+
 /**
  * @internal
  *
@@ -28,11 +30,7 @@ type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : nev
  * the complete EditFieldLayout and will handle RBAC conditions and rendering CM specific
  * components such as Blocks / Relations.
  */
-const InputRenderer = ({
-  visible,
-  hint: providedHint,
-  ...props
-}: DistributiveOmit<EditFieldLayout, 'size'>) => {
+const InputRenderer = ({ visible, hint: providedHint, ...props }: InputRendererProps) => {
   const { id } = useDoc();
   const isFormDisabled = useForm('InputRenderer', (state) => state.disabled);
 
@@ -209,4 +207,5 @@ const getMinMax = (attribute: Attribute.Any) => {
   }
 };
 
+export type { InputRendererProps };
 export { InputRenderer };

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -22,52 +22,52 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
       }
 
       // TODO: replace by strapi.documents.use once it supports multiple actions at once
-      strapi.documents?.middlewares.add('_all', '_all', async (context, next) => {
-        // Ignore actions that don't mutate documents
-        if (!['create', 'update', 'publish', 'unpublish'].includes(context.action)) {
-          return next(context);
-        }
+      // strapi.documents?.middlewares.add('_all', '_all', async (context, next) => {
+      //   // Ignore actions that don't mutate documents
+      //   if (!['create', 'update', 'publish', 'unpublish'].includes(context.action)) {
+      //     return next(context);
+      //   }
 
-        // Ignore content types not created by the user
-        if (!context.uid.startsWith('api::')) {
-          return next(context);
-        }
+      //   // Ignore content types not created by the user
+      //   if (!context.uid.startsWith('api::')) {
+      //     return next(context);
+      //   }
 
-        const fieldsToIgnore = [
-          'createdAt',
-          'updatedAt',
-          'publishedAt',
-          'createdBy',
-          'updatedBy',
-          'localizations',
-          'locale',
-          'strapi_stage',
-          'strapi_assignee',
-        ];
+      //   const fieldsToIgnore = [
+      //     'createdAt',
+      //     'updatedAt',
+      //     'publishedAt',
+      //     'createdBy',
+      //     'updatedBy',
+      //     'localizations',
+      //     'locale',
+      //     'strapi_stage',
+      //     'strapi_assignee',
+      //   ];
 
-        /**
-         * Await the middleware stack because for create actions,
-         * the document ID only exists after the creation, which is later in the stack.
-         */
-        const result = await next(context);
+      //   /**
+      //    * Await the middleware stack because for create actions,
+      //    * the document ID only exists after the creation, which is later in the stack.
+      //    */
+      //   const result = await next(context);
 
-        // Prevent creating a history version for an action that wasn't actually executed
-        await strapi.db.transaction(async ({ onCommit }) => {
-          onCommit(() => {
-            this.createVersion({
-              contentType: context.uid,
-              relatedDocumentId: result.documentId,
-              locale: context.params.locale,
-              // TODO: check if drafts should should be "modified" once D&P is ready
-              status: context.params.status,
-              data: omit(fieldsToIgnore, context.params.data),
-              schema: omit(fieldsToIgnore, strapi.contentType(context.uid).attributes),
-            });
-          });
-        });
+      //   // Prevent creating a history version for an action that wasn't actually executed
+      //   await strapi.db.transaction(async ({ onCommit }) => {
+      //     onCommit(() => {
+      //       this.createVersion({
+      //         contentType: context.uid,
+      //         relatedDocumentId: result.documentId,
+      //         locale: context.params.locale,
+      //         // TODO: check if drafts should should be "modified" once D&P is ready
+      //         status: context.params.status,
+      //         data: omit(fieldsToIgnore, context.params.data),
+      //         schema: omit(fieldsToIgnore, strapi.contentType(context.uid).attributes),
+      //       });
+      //     });
+      //   });
 
-        return result;
-      });
+      //   return result;
+      // });
 
       isInitialized = true;
     },

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -20,54 +20,58 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
       if (isInitialized) {
         return;
       }
+      /**
+       * TODO: Fix the types for the middleware
+       */
+      strapi.documents.use(async (context, next) => {
+        // @ts-expect-error ContentType is not typed correctly on the context
+        const contentTypeUid = context.contentType.uid;
+        const params = context.args.at(-1) as any;
+        // Ignore actions that don't mutate documents
+        if (!['create', 'update', 'publish', 'unpublish'].includes(context.action)) {
+          return next(context);
+        }
 
-      // TODO: replace by strapi.documents.use once it supports multiple actions at once
-      // strapi.documents?.middlewares.add('_all', '_all', async (context, next) => {
-      //   // Ignore actions that don't mutate documents
-      //   if (!['create', 'update', 'publish', 'unpublish'].includes(context.action)) {
-      //     return next(context);
-      //   }
+        // Ignore content types not created by the user
+        if (!contentTypeUid.startsWith('api::')) {
+          return next(context);
+        }
 
-      //   // Ignore content types not created by the user
-      //   if (!context.uid.startsWith('api::')) {
-      //     return next(context);
-      //   }
+        const fieldsToIgnore = [
+          'createdAt',
+          'updatedAt',
+          'publishedAt',
+          'createdBy',
+          'updatedBy',
+          'localizations',
+          'locale',
+          'strapi_stage',
+          'strapi_assignee',
+        ];
 
-      //   const fieldsToIgnore = [
-      //     'createdAt',
-      //     'updatedAt',
-      //     'publishedAt',
-      //     'createdBy',
-      //     'updatedBy',
-      //     'localizations',
-      //     'locale',
-      //     'strapi_stage',
-      //     'strapi_assignee',
-      //   ];
+        /**
+         * Await the middleware stack because for create actions,
+         * the document ID only exists after the creation, which is later in the stack.
+         */
+        const result = (await next(context)) as any;
 
-      //   /**
-      //    * Await the middleware stack because for create actions,
-      //    * the document ID only exists after the creation, which is later in the stack.
-      //    */
-      //   const result = await next(context);
+        // Prevent creating a history version for an action that wasn't actually executed
+        await strapi.db.transaction(async ({ onCommit }) => {
+          onCommit(() => {
+            this.createVersion({
+              contentType: contentTypeUid,
+              relatedDocumentId: 'id' in result ? result.id : context.args[0],
+              locale: params.locale,
+              // TODO: check if drafts should should be "modified" once D&P is ready
+              status: params.status,
+              data: omit(fieldsToIgnore, params.data),
+              schema: omit(fieldsToIgnore, strapi.contentType(contentTypeUid).attributes),
+            });
+          });
+        });
 
-      //   // Prevent creating a history version for an action that wasn't actually executed
-      //   await strapi.db.transaction(async ({ onCommit }) => {
-      //     onCommit(() => {
-      //       this.createVersion({
-      //         contentType: context.uid,
-      //         relatedDocumentId: result.documentId,
-      //         locale: context.params.locale,
-      //         // TODO: check if drafts should should be "modified" once D&P is ready
-      //         status: context.params.status,
-      //         data: omit(fieldsToIgnore, context.params.data),
-      //         schema: omit(fieldsToIgnore, strapi.contentType(context.uid).attributes),
-      //       });
-      //     });
-      //   });
-
-      //   return result;
-      // });
+        return result;
+      });
 
       isInitialized = true;
     },


### PR DESCRIPTION
### What does it do?

The goal of this PR is to make History work again with v5/main following the merge of Draft & Publish. The actual merge and the conflict fixes were done in the branch this PR targets. This PR is just about isolating the changes that make the feature actually work.

- use the new Form component to disable everything at once
- copy the FormLayout (don't import it directly because we need to hijack some input components, e.g. relations)
- use the proper document middleware API

### How to test it?

Everything should work like it did before
