### PR TITLE
fix: do not validate locale if not creating

### DIFF
--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -31,7 +31,7 @@ const isUrlForCreation = (url: string) => {
 
   // Get the last element of the array
   // api::category.category / 1 / publish
-  const model = splitUrl[splittedUrl.length - 1];
+  const model = splitUrl[splitUrl.length - 1];
 
   // If the model contains :: it means it's a uid
   return model.includes('::');

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -15,12 +15,35 @@ export default ({ strapi }: { strapi: Strapi }) => {
 };
 
 /**
+ * Match urls for model creation
+ *  /content-manager/collection-types/api::category.category/
+ *  /content-manager/collection-types/api::category.category
+ * And not match:
+ *  /content-manager/collection-types/api::category.category/1
+ *  /content-manager/collection-types/api::category.category/1/actions/publish
+ */
+const isUrlForCreation = (url: string) => {
+  if (!url) return false;
+
+  // Split path and remove empty strings
+  // [ 'content-manager', 'collection-types', 'api::category.category' ]
+  const splittedUrl = url.split('/').filter(Boolean);
+
+  // Get the last element of the array
+  // api::category.category / 1 / publish
+  const model = splittedUrl[splittedUrl.length - 1];
+
+  // If the model contains :: it means it's a uid
+  return model.includes('::');
+};
+
+/**
  * Adds middleware on CM creation routes to use i18n locale passed in a specific param
  * @param {Strapi} strapi
  */
 const addContentManagerLocaleMiddleware = (strapi: Strapi) => {
   strapi.server.router.use('/content-manager/collection-types/:model', (ctx, next) => {
-    if (ctx.method === 'POST') {
+    if (ctx.method === 'POST' && isUrlForCreation(ctx.originalUrl)) {
       return validateLocaleCreation(ctx, next);
     }
 
@@ -28,7 +51,7 @@ const addContentManagerLocaleMiddleware = (strapi: Strapi) => {
   });
 
   strapi.server.router.use('/content-manager/single-types/:model', (ctx, next) => {
-    if (ctx.method === 'PUT') {
+    if (ctx.method === 'PUT' && isUrlForCreation(ctx.originalUrl)) {
       return validateLocaleCreation(ctx, next);
     }
 

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -27,11 +27,11 @@ const isUrlForCreation = (url: string) => {
 
   // Split path and remove empty strings
   // [ 'content-manager', 'collection-types', 'api::category.category' ]
-  const splittedUrl = url.split('/').filter(Boolean);
+  const splitUrl = url.split('/').filter(Boolean);
 
   // Get the last element of the array
   // api::category.category / 1 / publish
-  const model = splittedUrl[splittedUrl.length - 1];
+  const model = splitUrl[splittedUrl.length - 1];
 
   // If the model contains :: it means it's a uid
   return model.includes('::');

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -18,6 +18,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
  * Match urls for model creation
  *  /content-manager/collection-types/api::category.category/
  *  /content-manager/collection-types/api::category.category
+ *
  * And not match:
  *  /content-manager/collection-types/api::category.category/1
  *  /content-manager/collection-types/api::category.category/1/actions/publish


### PR DESCRIPTION
### What does it do?

I18n Backend koa middlweare was matching all CM routes, and validating locale creation even for actions that were not related (publishing, unpublishing)

If the API received the "relatedEntityId" param when publishing, it assumed this was for creating a new locale (and checked if the locale already existed), and failed because the action was to publish an existing locale.

My only worry here is that the url matching is not smart enough and we miss some cases


### How to test?

Create single types and collection type locales, and publish them. You should not get an error

### Related issues

* resolves CONTENT-2279
* resolves #19528 