### PR TITLE
fix(content-releases): release details action styles 

### DIFF
--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -78,12 +78,19 @@ const ReleaseInfoWrapper = styled(Flex)`
   border-top: 1px solid ${({ theme }) => theme.colors.neutral150};
 `;
 
-const StyledMenuItem = styled(Menu.Item)<{ disabled?: boolean }>`
+const StyledMenuItem = styled(Menu.Item)<{
+  disabled?: boolean;
+  variant?: 'neutral' | 'danger';
+}>`
   svg path {
     fill: ${({ theme, disabled }) => disabled && theme.colors.neutral500};
   }
   span {
     color: ${({ theme, disabled }) => disabled && theme.colors.neutral500};
+  }
+
+  &:hover {
+    background: ${({ theme, variant = 'neutral' }) => theme.colors[`${variant}100`]};
   }
 `;
 
@@ -387,14 +394,7 @@ export const ReleaseDetailsLayout = ({
                     width="100%"
                   >
                     <StyledMenuItem disabled={!canUpdate} onSelect={toggleEditReleaseModal}>
-                      <Flex
-                        paddingTop={2}
-                        paddingBottom={2}
-                        alignItems="center"
-                        gap={2}
-                        hasRadius
-                        width="100%"
-                      >
+                      <Flex alignItems="center" gap={2} hasRadius width="100%">
                         <PencilIcon />
                         <Typography ellipsis>
                           {formatMessage({
@@ -404,15 +404,12 @@ export const ReleaseDetailsLayout = ({
                         </Typography>
                       </Flex>
                     </StyledMenuItem>
-                    <StyledMenuItem disabled={!canDelete} onSelect={toggleWarningSubmit}>
-                      <Flex
-                        paddingTop={2}
-                        paddingBottom={2}
-                        alignItems="center"
-                        gap={2}
-                        hasRadius
-                        width="100%"
-                      >
+                    <StyledMenuItem
+                      disabled={!canDelete}
+                      onSelect={toggleWarningSubmit}
+                      variant="danger"
+                    >
+                      <Flex alignItems="center" gap={2} hasRadius width="100%">
                         <TrashIcon />
                         <Typography ellipsis textColor="danger600">
                           {formatMessage({


### PR DESCRIPTION
### What does it do?
Removed extra padding for action buttons, background color added for delete action

### Why is it needed?
https://strapi-inc.atlassian.net/browse/CS-624

### How to test it?
On release details page, when you click 3 dots, you will see "Edit" and "Delete" action buttons.
