### PR TITLE
fix(content-manager): send locale when deleting i18n single type

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -88,7 +88,13 @@ const ContentTypeFormWrapper = ({
   const { setCurrentStep } = useGuidedTour();
   const { trackUsage } = useTracking();
   const { push, replace } = useHistory();
-  const [{ query, rawQuery }] = useQueryParams();
+  const [{ query, rawQuery }] = useQueryParams<{
+    plugins?: {
+      i18n?: {
+        locale?: string;
+      };
+    };
+  }>();
   const dispatch = useTypedDispatch();
   const { componentsDataStructure, contentTypeDataStructure, data, isLoading, status } =
     useTypedSelector((state) => state['content-manager_editViewCrudReducer']);
@@ -252,8 +258,12 @@ const ContentTypeFormWrapper = ({
       try {
         trackUsage('willDeleteEntry', trackerProperty);
 
+        const locale = query?.plugins?.i18n?.locale;
+        const params = isSingleType && locale ? { locale } : {};
+
         const { data } = await del<Contracts.CollectionTypes.Delete.Response>(
-          `/content-manager/${collectionType}/${slug}/${id}`
+          `/content-manager/${collectionType}/${slug}/${id}`,
+          { params }
         );
 
         toggleNotification({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Send locale for DELETE requests to i18n singleTypes

### Why is it needed?

We don't send an id for single types DELETE requests so every delete request was deleting the default locale as we were only specifying the single type UID

### How to test it?

- Create multiple locales of an i18n single type
- Delete a non default locale from the CM edit view
- Verify it has deleting the correct entry

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/19559
CONTENT-2281
