### PR TITLE
fix(content-releases): Limit min date selection to schedule a release

### DIFF
--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -96,8 +96,17 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
         name: 'Time *',
       })
       .click();
-    await page.getByRole('option', { name: '14:00' }).click();
 
+    const currentDate = new Date();
+    currentDate.setHours(currentDate.getHours() + 4); // set 4hrs ahead of current time
+    currentDate.setMinutes(0); // set minutes to 0 so that it's a valid time
+    const currentTime = currentDate.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    await page.getByRole('option', { name: currentTime }).click();
     await page.getByRole('button', { name: 'Continue' }).click();
     // Wait for client side redirect to created release
     await page.waitForURL('/admin/plugins/content-releases/*');

--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -50,6 +50,17 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
     await expect(page.getByRole('link', { name: `${newReleaseName}` })).toBeVisible();
   });
 
+  test('A user should be able to click new release button and see new release dialog', async ({
+    page,
+  }) => {
+    // Navigate to the releases page
+    await page.getByRole('link', { name: 'Releases' }).click();
+
+    // Open the create release dialog
+    await page.getByRole('button', { name: 'New release' }).click();
+    await expect(page.getByRole('dialog', { name: 'New release' })).toBeVisible();
+  });
+
   test('A user should be able to create a release with scheduling info and view their pending and done releases', async ({
     page,
   }) => {

--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -50,17 +50,6 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
     await expect(page.getByRole('link', { name: `${newReleaseName}` })).toBeVisible();
   });
 
-  test('A user should be able to click new release button and see new release dialog', async ({
-    page,
-  }) => {
-    // Navigate to the releases page
-    await page.getByRole('link', { name: 'Releases' }).click();
-
-    // Open the create release dialog
-    await page.getByRole('button', { name: 'New release' }).click();
-    await expect(page.getByRole('dialog', { name: 'New release' })).toBeVisible();
-  });
-
   test('A user should be able to create a release with scheduling info and view their pending and done releases', async ({
     page,
   }) => {
@@ -99,15 +88,7 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
       })
       .click();
 
-    const currentDate = new Date();
-    currentDate.setMinutes(45); // set 45 minutes ahead so its a valid time
-    const currentTime = currentDate.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-
-    await page.getByRole('option', { name: currentTime }).click();
+    await page.getByRole('option', { name: '14:00' }).click();
     await page.getByRole('button', { name: 'Continue' }).click();
     // Wait for client side redirect to created release
     await page.waitForURL('/admin/plugins/content-releases/*');

--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -98,8 +98,7 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
       .click();
 
     const currentDate = new Date();
-    currentDate.setHours(currentDate.getHours() + 4); // set 4hrs ahead of current time
-    currentDate.setMinutes(0); // set minutes to 0 so that it's a valid time
+    currentDate.setMinutes(45); // set 45 minutes ahead so its a valid time
     const currentTime = currentDate.toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',

--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -70,7 +70,15 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
         name: 'Date',
       })
       .click();
-    await page.getByRole('gridcell', { name: 'Sunday, March 3, 2024' }).click();
+
+    const formattedDate = new Date().toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+    await page.getByRole('gridcell', { name: formattedDate }).click();
 
     await page
       .getByRole('combobox', {

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -17,7 +17,7 @@ import {
   ComboboxOption,
 } from '@strapi/design-system';
 import { formatISO, parse } from 'date-fns';
-import { zonedTimeToUtc } from 'date-fns-tz';
+import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import { Formik, Form, useFormikContext } from 'formik';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
@@ -64,7 +64,7 @@ export const ReleaseModal = ({
     const { date, time, timezone } = values;
     if (!date || !time || !timezone) return null;
     const formattedDate = parse(time, 'HH:mm', new Date(date));
-    const timezoneWithoutOffset = timezone.split('_')[1];
+    const timezoneWithoutOffset = timezone.slice(timezone.indexOf('_') + 1);
     return zonedTimeToUtc(formattedDate, timezoneWithoutOffset);
   };
 
@@ -73,7 +73,7 @@ export const ReleaseModal = ({
    */
   const getTimezoneWithOffset = () => {
     const currentTimezone = timezoneList.find(
-      (timezone) => timezone.value.split('_')[1] === initialValues.timezone
+      (timezone) => timezone.value.slice(timezone.value.indexOf('_') + 1) === initialValues.timezone
     );
     return currentTimezone?.value || systemTimezone.value;
   };
@@ -96,7 +96,9 @@ export const ReleaseModal = ({
         onSubmit={(values) => {
           handleSubmit({
             ...values,
-            timezone: values.timezone ? values.timezone.split('_')[1] : null,
+            timezone: values.timezone
+              ? values.timezone.slice(values.timezone.indexOf('_') + 1)
+              : null,
             scheduledAt: values.isScheduled ? getScheduledTimestamp(values) : null,
           });
         }}
@@ -184,6 +186,10 @@ export const ReleaseModal = ({
                               }}
                               selectedDate={values.date || undefined}
                               required
+                              minDate={utcToZonedTime(
+                                new Date(),
+                                values.timezone.slice(values.timezone.indexOf('_') + 1)
+                              )}
                             />
                           </Box>
                           <Box width="100%">
@@ -260,7 +266,9 @@ const getTimezones = (selectedDate: Date) => {
   });
 
   const systemTimezone = timezoneList.find(
-    (timezone) => timezone.value.split('_')[1] === Intl.DateTimeFormat().resolvedOptions().timeZone
+    (timezone) =>
+      timezone.value.slice(timezone.value.indexOf('_') + 1) ===
+      Intl.DateTimeFormat().resolvedOptions().timeZone
   );
 
   return { timezoneList, systemTimezone };
@@ -279,7 +287,11 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
 
       const updatedTimezone =
         values.timezone &&
-        timezoneList.find((tz) => tz.value.split('_')[1] === values.timezone!.split('_')[1]);
+        timezoneList.find(
+          (tz) =>
+            tz.value.slice(tz.value.indexOf('_') + 1) ===
+            values.timezone!.slice(values.timezone!.indexOf('_') + 1)
+        );
       if (updatedTimezone) {
         setFieldValue('timezone', updatedTimezone!.value);
       }

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -295,7 +295,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
       })}
       name="timezone"
       value={values.timezone || undefined}
-      textValue={values.timezone ? values.timezone.replace('&', ' ') : undefined} // textValue is required to show the updated DST timezone
+      textValue={values.timezone ? values.timezone.replace(/&/, ' ') : undefined} // textValue is required to show the updated DST timezone
       onChange={(timezone) => {
         setFieldValue('timezone', timezone);
       }}
@@ -310,7 +310,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
     >
       {timezoneList.map((timezone) => (
         <ComboboxOption key={timezone.value} value={timezone.value}>
-          {timezone.value.replace('&', ' ')}
+          {timezone.value.replace(/&/, ' ')}
         </ComboboxOption>
       ))}
     </Combobox>

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -64,7 +64,7 @@ export const ReleaseModal = ({
     const { date, time, timezone } = values;
     if (!date || !time || !timezone) return null;
     const formattedDate = parse(time, 'HH:mm', new Date(date));
-    const timezoneWithoutOffset = timezone.split('_')[1];
+    const timezoneWithoutOffset = timezone.split('&')[1];
     return zonedTimeToUtc(formattedDate, timezoneWithoutOffset);
   };
 
@@ -73,7 +73,7 @@ export const ReleaseModal = ({
    */
   const getTimezoneWithOffset = () => {
     const currentTimezone = timezoneList.find(
-      (timezone) => timezone.value.split('_')[1] === initialValues.timezone
+      (timezone) => timezone.value.split('&')[1] === initialValues.timezone
     );
     return currentTimezone?.value || systemTimezone.value;
   };
@@ -96,7 +96,7 @@ export const ReleaseModal = ({
         onSubmit={(values) => {
           handleSubmit({
             ...values,
-            timezone: values.timezone ? values.timezone.split('_')[1] : null,
+            timezone: values.timezone ? values.timezone.split('&')[1] : null,
             scheduledAt: values.isScheduled ? getScheduledTimestamp(values) : null,
           });
         }}
@@ -184,7 +184,7 @@ export const ReleaseModal = ({
                               }}
                               selectedDate={values.date || undefined}
                               required
-                              minDate={utcToZonedTime(new Date(), values.timezone.split('_')[1])}
+                              minDate={utcToZonedTime(new Date(), values.timezone.split('&')[1])}
                             />
                           </Box>
                           <Box width="100%">
@@ -256,12 +256,12 @@ const getTimezones = (selectedDate: Date) => {
     // a four digit string e.g. +05:00 or -08:00
     const utcOffset = getTimezoneOffset(timezone, selectedDate);
 
-    // Offset and timezone are concatenated with '_', so to split and save the required timezone in DB
-    return { offset: utcOffset, value: `${utcOffset}_${timezone}` } satisfies ITimezoneOption;
+    // Offset and timezone are concatenated with '&', so to split and save the required timezone in DB
+    return { offset: utcOffset, value: `${utcOffset}&${timezone}` } satisfies ITimezoneOption;
   });
 
   const systemTimezone = timezoneList.find(
-    (timezone) => timezone.value.split('_')[1] === Intl.DateTimeFormat().resolvedOptions().timeZone
+    (timezone) => timezone.value.split('&')[1] === Intl.DateTimeFormat().resolvedOptions().timeZone
   );
 
   return { timezoneList, systemTimezone };
@@ -280,7 +280,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
 
       const updatedTimezone =
         values.timezone &&
-        timezoneList.find((tz) => tz.value.split('_')[1] === values.timezone!.split('_')[1]);
+        timezoneList.find((tz) => tz.value.split('&')[1] === values.timezone!.split('&')[1]);
       if (updatedTimezone) {
         setFieldValue('timezone', updatedTimezone!.value);
       }
@@ -295,7 +295,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
       })}
       name="timezone"
       value={values.timezone || undefined}
-      textValue={values.timezone ? values.timezone.replace('_', ' ') : undefined} // textValue is required to show the updated DST timezone
+      textValue={values.timezone ? values.timezone.replace('&', ' ') : undefined} // textValue is required to show the updated DST timezone
       onChange={(timezone) => {
         setFieldValue('timezone', timezone);
       }}
@@ -310,7 +310,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
     >
       {timezoneList.map((timezone) => (
         <ComboboxOption key={timezone.value} value={timezone.value}>
-          {timezone.value.replace('_', ' ')}
+          {timezone.value.replace('&', ' ')}
         </ComboboxOption>
       ))}
     </Combobox>

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -64,7 +64,7 @@ export const ReleaseModal = ({
     const { date, time, timezone } = values;
     if (!date || !time || !timezone) return null;
     const formattedDate = parse(time, 'HH:mm', new Date(date));
-    const timezoneWithoutOffset = timezone.slice(timezone.indexOf('_') + 1);
+    const timezoneWithoutOffset = timezone.split('_')[1];
     return zonedTimeToUtc(formattedDate, timezoneWithoutOffset);
   };
 
@@ -73,7 +73,7 @@ export const ReleaseModal = ({
    */
   const getTimezoneWithOffset = () => {
     const currentTimezone = timezoneList.find(
-      (timezone) => timezone.value.slice(timezone.value.indexOf('_') + 1) === initialValues.timezone
+      (timezone) => timezone.value.split('_')[1] === initialValues.timezone
     );
     return currentTimezone?.value || systemTimezone.value;
   };
@@ -96,9 +96,7 @@ export const ReleaseModal = ({
         onSubmit={(values) => {
           handleSubmit({
             ...values,
-            timezone: values.timezone
-              ? values.timezone.slice(values.timezone.indexOf('_') + 1)
-              : null,
+            timezone: values.timezone ? values.timezone.split('_')[1] : null,
             scheduledAt: values.isScheduled ? getScheduledTimestamp(values) : null,
           });
         }}
@@ -186,10 +184,7 @@ export const ReleaseModal = ({
                               }}
                               selectedDate={values.date || undefined}
                               required
-                              minDate={utcToZonedTime(
-                                new Date(),
-                                values.timezone.slice(values.timezone.indexOf('_') + 1)
-                              )}
+                              minDate={utcToZonedTime(new Date(), values.timezone.split('_')[1])}
                             />
                           </Box>
                           <Box width="100%">
@@ -266,9 +261,7 @@ const getTimezones = (selectedDate: Date) => {
   });
 
   const systemTimezone = timezoneList.find(
-    (timezone) =>
-      timezone.value.slice(timezone.value.indexOf('_') + 1) ===
-      Intl.DateTimeFormat().resolvedOptions().timeZone
+    (timezone) => timezone.value.split('_')[1] === Intl.DateTimeFormat().resolvedOptions().timeZone
   );
 
   return { timezoneList, systemTimezone };
@@ -287,11 +280,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
 
       const updatedTimezone =
         values.timezone &&
-        timezoneList.find(
-          (tz) =>
-            tz.value.slice(tz.value.indexOf('_') + 1) ===
-            values.timezone!.slice(values.timezone!.indexOf('_') + 1)
-        );
+        timezoneList.find((tz) => tz.value.split('_')[1] === values.timezone!.split('_')[1]);
       if (updatedTimezone) {
         setFieldValue('timezone', updatedTimezone!.value);
       }


### PR DESCRIPTION
### What does it do?

Min date considering selected timezone added for scheduling.

### Why is it needed?

https://strapi-inc.atlassian.net/browse/CS-627

### How to test it?
- Try to to create a scheduled release and check that you should not be allowed to select date past today. 
- Also try to check with timezones with `UTC-HH:00`, should display correct minimun date for selected timezone.
- Also BE validation should throw if you select a time earlier in the day which is passed.

