### PR TITLE
fix(content-releases): remove argument passed to test render

### DIFF
--- a/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
@@ -138,7 +138,7 @@ describe('CMReleasesContainer', () => {
       })
     );
 
-    render(<CMReleasesContainer />);
+    render();
 
     const informationBox = await screen.findByRole('complementary', { name: 'Releases' });
     const release1 = await within(informationBox).findByText('01/01/2024 at 11:00 (UTC+01:00)');


### PR DESCRIPTION
### What does it do?

- Fixes an incorrect argument that is breaking unit tests and throwing typescript errors

### Why is it needed?

- The CI is failing 

### How to test it?

- The CI should pass with no TS or frontend unit tests failing

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/19604
