### PR TITLE
fix: i18n keys

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksContent.tsx
@@ -228,7 +228,7 @@ const DragAndDropElement = ({
             role="button"
             tabIndex={0}
             aria-label={formatMessage({
-              id: getTranslation('content-manager.content-manager.components.DragHandle-label'),
+              id: getTranslation('content-manager.components.DragHandle-label'),
               defaultMessage: 'Drag',
             })}
             onClick={(e) => e.stopPropagation()}
@@ -262,7 +262,7 @@ const CloneDragItem = ({ children, dragHandleTopMargin }: CloneDragItemProps) =>
         forwardedAs="div"
         role="button"
         aria-label={formatMessage({
-          id: getTranslation('content-manager.content-manager.components.DragHandle-label'),
+          id: getTranslation('content-manager.components.DragHandle-label'),
           defaultMessage: 'Drag',
         })}
         dragHandleTopMargin={dragHandleTopMargin}

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksContent.tsx
@@ -228,7 +228,7 @@ const DragAndDropElement = ({
             role="button"
             tabIndex={0}
             aria-label={formatMessage({
-              id: getTranslation('components.DragHandle-label'),
+              id: getTranslation('content-manager.content-manager.components.DragHandle-label'),
               defaultMessage: 'Drag',
             })}
             onClick={(e) => e.stopPropagation()}
@@ -262,7 +262,7 @@ const CloneDragItem = ({ children, dragHandleTopMargin }: CloneDragItemProps) =>
         forwardedAs="div"
         role="button"
         aria-label={formatMessage({
-          id: getTranslation('components.DragHandle-label'),
+          id: getTranslation('content-manager.content-manager.components.DragHandle-label'),
           defaultMessage: 'Drag',
         })}
         dragHandleTopMargin={dragHandleTopMargin}

--- a/packages/core/admin/admin/src/content-manager/components/ComponentInitializer.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ComponentInitializer.tsx
@@ -37,7 +37,7 @@ const ComponentInitializer = ({ error, isReadOnly, onClick }: ComponentInitializ
           <Flex justifyContent="center">
             <Typography textColor="primary600" variant="pi" fontWeight="bold">
               {formatMessage({
-                id: getTranslation('components.empty-repeatable'),
+                id: getTranslation('content-manager.components.empty-repeatable'),
                 defaultMessage: 'No entry yet. Click on the button below to add one.',
               })}
             </Typography>

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -335,7 +335,7 @@ const ContentTypeFormWrapper = ({
         trackUsage('didCreateEntry', trackerProperty);
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('content-manager.content-manager.success.record.save') },
+          message: { id: getTranslation('content-manager.success.record.save') },
         });
 
         setCurrentStep('contentManager.success');
@@ -482,7 +482,7 @@ const ContentTypeFormWrapper = ({
         trackUsage('didEditEntry', trackerProperty);
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('content-manager.content-manager.success.record.save') },
+          message: { id: getTranslation('content-manager.success.record.save') },
         });
 
         // TODO: need to find a better place, or a better abstraction

--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -268,7 +268,7 @@ const ContentTypeFormWrapper = ({
 
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('success.record.delete') },
+          message: { id: getTranslation('content-manager.success.record.delete') },
         });
 
         trackUsage('didDeleteEntry', trackerProperty);
@@ -335,7 +335,7 @@ const ContentTypeFormWrapper = ({
         trackUsage('didCreateEntry', trackerProperty);
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('success.record.save') },
+          message: { id: getTranslation('content-manager.content-manager.success.record.save') },
         });
 
         setCurrentStep('contentManager.success');
@@ -437,7 +437,7 @@ const ContentTypeFormWrapper = ({
 
       toggleNotification({
         type: 'success',
-        message: { id: getTranslation('success.record.publish') },
+        message: { id: getTranslation('content-manager.success.record.publish') },
       });
 
       return Promise.resolve(data);
@@ -482,7 +482,7 @@ const ContentTypeFormWrapper = ({
         trackUsage('didEditEntry', trackerProperty);
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('success.record.save') },
+          message: { id: getTranslation('content-manager.content-manager.success.record.save') },
         });
 
         // TODO: need to find a better place, or a better abstraction
@@ -539,7 +539,7 @@ const ContentTypeFormWrapper = ({
       trackUsage('didUnpublishEntry');
       toggleNotification({
         type: 'success',
-        message: { id: getTranslation('success.record.unpublish') },
+        message: { id: getTranslation('content-manager.success.record.unpublish') },
       });
 
       dispatch(submitSucceeded(cleanReceivedData(data)));

--- a/packages/core/admin/admin/src/content-manager/components/DragPreviews/RelationDragPreview.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/DragPreviews/RelationDragPreview.tsx
@@ -22,12 +22,12 @@ const RelationDragPreview = ({ status, displayedValue, width }: RelationDragPrev
 
   const stateMessage = {
     [PUBLICATION_STATES.DRAFT]: formatMessage({
-      id: getTranslation('relation.publicationState.draft'),
+      id: getTranslation('content-manager.relation.publicationState.draft'),
       defaultMessage: 'Draft',
     }),
 
     [PUBLICATION_STATES.PUBLISHED]: formatMessage({
-      id: getTranslation('relation.publicationState.published'),
+      id: getTranslation('content-manager.relation.publicationState.published'),
       defaultMessage: 'Published',
     }),
   };

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/ComponentPicker.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/ComponentPicker.tsx
@@ -57,7 +57,7 @@ const ComponentPicker = ({
       <Flex justifyContent="center">
         <Typography fontWeight="bold" textColor="neutral600">
           {formatMessage({
-            id: getTranslation('components.DynamicZone.ComponentPicker-label'),
+            id: getTranslation('content-manager.components.DynamicZone.ComponentPicker-label'),
             defaultMessage: 'Pick one component',
           })}
         </Typography>

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/DynamicComponent.tsx
@@ -90,7 +90,7 @@ const DynamicComponent = ({
 
   if (fieldsErrors.length > 0) {
     errorMessage = formatMessage({
-      id: getTranslation('components.DynamicZone.error-message'),
+      id: getTranslation('content-manager.components.DynamicZone.error-message'),
       defaultMessage: 'The component contains error(s)',
     });
   }
@@ -126,7 +126,7 @@ const DynamicComponent = ({
         noBorder
         label={formatMessage(
           {
-            id: getTranslation('components.DynamicZone.delete-label'),
+            id: getTranslation('content-manager.components.DynamicZone.delete-label'),
             defaultMessage: 'Delete {name}',
           },
           { name: friendlyName }
@@ -144,7 +144,7 @@ const DynamicComponent = ({
         data-handler-id={handlerId}
         ref={dragRef}
         label={formatMessage({
-          id: getTranslation('components.DragHandle-label'),
+          id: getTranslation('content-manager.components.DragHandle-label'),
           defaultMessage: 'Drag',
         })}
         onKeyDown={handleKeyDown}

--- a/packages/core/admin/admin/src/content-manager/components/DynamicZone/Field.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/DynamicZone/Field.tsx
@@ -116,7 +116,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     } else {
       toggleNotification({
         type: 'info',
-        message: { id: getTranslation('components.notification.info.maximum-requirement') },
+        message: { id: getTranslation('content-manager.components.notification.info.maximum-requirement') },
       });
     }
   };
@@ -125,7 +125,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.reorder'),
+          id: getTranslation('components.Blocks.dnd.reorder'),
           defaultMessage: '{item}, moved. New position in list: {position}.',
         },
         {
@@ -148,7 +148,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.cancel-item'),
+          id: getTranslation('content-manager.dnd.cancel-item'),
           defaultMessage: '{item}, dropped. Re-order cancelled.',
         },
         {
@@ -162,7 +162,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.grab-item'),
+          id: getTranslation('content-manager.dnd.grab-item'),
           defaultMessage: `{item}, grabbed. Current position in list: {position}. Press up and down arrow to change position, Spacebar to drop, Escape to cancel.`,
         },
         {
@@ -177,7 +177,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.drop-item'),
+          id: getTranslation('content-manager.dnd.drop-item'),
           defaultMessage: `{item}, dropped. Final position in list: {position}.`,
         },
         {
@@ -207,7 +207,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
     if (hasError && dynamicZoneError.id?.includes('min')) {
       return formatMessage(
         {
-          id: getTranslation(`components.DynamicZone.missing-components`),
+          id: getTranslation(`content-manager.components.DynamicZone.missing-components`),
           defaultMessage:
             'There {number, plural, =0 {are # missing components} one {is # missing component} other {are # missing components}}',
         },
@@ -217,7 +217,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
 
     return formatMessage(
       {
-        id: getTranslation('components.DynamicZone.add-component'),
+        id: getTranslation('content-manager.components.DynamicZone.add-component'),
         defaultMessage: 'Add a component to {componentName}',
       },
       { componentName: metadatas.label || name }
@@ -251,7 +251,7 @@ const DynamicZone = ({ name, labelAction, fieldSchema, metadatas }: DynamicZoneP
           />
           <VisuallyHidden id={ariaDescriptionId}>
             {formatMessage({
-              id: getTranslation('dnd.instructions'),
+              id: getTranslation('content-manager.dnd.instructions'),
               defaultMessage: `Press spacebar to grab and re-order`,
             })}
           </VisuallyHidden>

--- a/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/FieldComponent.tsx
@@ -178,7 +178,7 @@ const FieldComponent = ({
         {showResetComponent && (
           <IconButton
             label={formatMessage({
-              id: getTranslation('components.reset-entry'),
+              id: getTranslation('content-manager.components.reset-entry'),
               defaultMessage: 'Reset Entry',
             })}
             icon={<Trash />}

--- a/packages/core/admin/admin/src/content-manager/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/LeftMenu.tsx
@@ -36,7 +36,7 @@ const LeftMenu = () => {
         {
           id: 'collectionTypes',
           title: formatMessage({
-            id: getTranslation('components.LeftMenu.collection-types'),
+            id: getTranslation('content-manager.components.LeftMenu.collection-types'),
             defaultMessage: 'Collection Types',
           }),
           searchable: true,
@@ -45,7 +45,7 @@ const LeftMenu = () => {
         {
           id: 'singleTypes',
           title: formatMessage({
-            id: getTranslation('components.LeftMenu.single-types'),
+            id: getTranslation('content-manager.components.LeftMenu.single-types'),
             defaultMessage: 'Single Types',
           }),
           searchable: true,
@@ -84,7 +84,7 @@ const LeftMenu = () => {
   };
 
   const label = formatMessage({
-    id: getTranslation('header.name'),
+    id: getTranslation('list.table.header.name'),
     defaultMessage: 'Content',
   });
 

--- a/packages/core/admin/admin/src/content-manager/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/LeftMenu.tsx
@@ -84,7 +84,7 @@ const LeftMenu = () => {
   };
 
   const label = formatMessage({
-    id: getTranslation('list.table.header.name'),
+    id: getTranslation('content-manager.header.name'),
     defaultMessage: 'Content',
   });
 

--- a/packages/core/admin/admin/src/content-manager/components/Relations/RelationInput.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/RelationInput.tsx
@@ -388,11 +388,11 @@ const Option = ({
   if (publicationState) {
     const isDraft = publicationState === 'draft';
     const draftMessage = {
-      id: getTranslation('components.Select.draft-info-title'),
+      id: getTranslation('content-manager.components.Select.draft-info-title'),
       defaultMessage: 'State: Draft',
     };
     const publishedMessage = {
-      id: getTranslation('components.Select.publish-info-title'),
+      id: getTranslation('content-manager.components.Select.publish-info-title'),
       defaultMessage: 'State: Published',
     };
     const title = isDraft ? formatMessage(draftMessage) : formatMessage(publishedMessage);

--- a/packages/core/admin/admin/src/content-manager/components/Relations/RelationInputDataManager.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/Relations/RelationInputDataManager.tsx
@@ -272,7 +272,7 @@ const RelationInputDataManager = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.reorder'),
+          id: getTranslation('components.Blocks.dnd.reorder'),
           defaultMessage: '{item}, moved. New position in list: {position}.',
         },
         {
@@ -295,7 +295,7 @@ const RelationInputDataManager = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.grab-item'),
+          id: getTranslation('content-manager.dnd.grab-item'),
           defaultMessage: `{item}, grabbed. Current position in list: {position}. Press up and down arrow to change position, Spacebar to drop, Escape to cancel.`,
         },
         {
@@ -312,7 +312,7 @@ const RelationInputDataManager = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.drop-item'),
+          id: getTranslation('content-manager.dnd.drop-item'),
           defaultMessage: `{item}, dropped. Final position in list: {position}.`,
         },
         {
@@ -329,7 +329,7 @@ const RelationInputDataManager = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.cancel-item'),
+          id: getTranslation('content-manager.dnd.cancel-item'),
           defaultMessage: '{item}, dropped. Re-order cancelled.',
         },
         {
@@ -375,7 +375,7 @@ const RelationInputDataManager = ({
       description={description}
       disabled={isDisabled}
       iconButtonAriaLabel={formatMessage({
-        id: getTranslation('components.RelationInput.icon-button-aria-label'),
+        id: getTranslation('content-manager.components.RelationInput.icon-button-aria-label'),
         defaultMessage: 'Drag',
       })}
       id={name}
@@ -387,27 +387,27 @@ const RelationInputDataManager = ({
       labelLoadMore={
         !isCreatingEntry || isCloningEntry
           ? formatMessage({
-              id: getTranslation('relation.loadMore'),
+              id: getTranslation('content-manager.relation.loadMore'),
               defaultMessage: 'Load More',
             })
           : undefined
       }
       labelDisconnectRelation={formatMessage({
-        id: getTranslation('relation.disconnect'),
+        id: getTranslation('content-manager.relation.disconnect'),
         defaultMessage: 'Remove',
       })}
       listAriaDescription={formatMessage({
-        id: getTranslation('dnd.instructions'),
+        id: getTranslation('content-manager.dnd.instructions'),
         defaultMessage: `Press spacebar to grab and re-order`,
       })}
       liveText={liveText}
       loadingMessage={formatMessage({
-        id: getTranslation('relation.isLoading'),
+        id: getTranslation('content-manager.relation.isLoading'),
         defaultMessage: 'Relations are loading',
       })}
       name={name}
       noRelationsMessage={formatMessage({
-        id: getTranslation('relation.notAvailable'),
+        id: getTranslation('content-manager.relation.notAvailable'),
         defaultMessage: 'No relations available',
       })}
       numberOfRelationsToDisplay={RELATIONS_TO_DISPLAY}
@@ -422,18 +422,18 @@ const RelationInputDataManager = ({
       onSearchNextPage={() => handleSearchMore()}
       placeholder={formatMessage(
         placeholder || {
-          id: getTranslation('relation.add'),
+          id: getTranslation('content-manager.relation.add'),
           defaultMessage: 'Add relation',
         }
       )}
       publicationStateTranslations={{
         [PUBLICATION_STATES.DRAFT]: formatMessage({
-          id: getTranslation('relation.publicationState.draft'),
+          id: getTranslation('content-manager.relation.publicationState.draft'),
           defaultMessage: 'Draft',
         }),
 
         [PUBLICATION_STATES.PUBLISHED]: formatMessage({
-          id: getTranslation('relation.publicationState.published'),
+          id: getTranslation('content-manager.relation.publicationState.published'),
           defaultMessage: 'Published',
         }),
       }}

--- a/packages/core/admin/admin/src/content-manager/components/RepeatableComponent.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/RepeatableComponent.tsx
@@ -129,7 +129,7 @@ const RepeatableComponent = ({
       } else if (componentValueLength >= max) {
         toggleNotification({
           type: 'info',
-          message: { id: getTranslation('components.notification.info.maximum-requirement') },
+          message: { id: getTranslation('content-manager.components.notification.info.maximum-requirement') },
         });
       }
     }
@@ -142,7 +142,7 @@ const RepeatableComponent = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.reorder'),
+          id: getTranslation('components.Blocks.dnd.reorder'),
           defaultMessage: '{item}, moved. New position in list: {position}.',
         },
         {
@@ -176,7 +176,7 @@ const RepeatableComponent = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.cancel-item'),
+          id: getTranslation('content-manager.dnd.cancel-item'),
           defaultMessage: '{item}, dropped. Re-order cancelled.',
         },
         {
@@ -190,7 +190,7 @@ const RepeatableComponent = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.grab-item'),
+          id: getTranslation('content-manager.dnd.grab-item'),
           defaultMessage: `{item}, grabbed. Current position in list: {position}. Press up and down arrow to change position, Spacebar to drop, Escape to cancel.`,
         },
         {
@@ -205,7 +205,7 @@ const RepeatableComponent = ({
     setLiveText(
       formatMessage(
         {
-          id: getTranslation('dnd.drop-item'),
+          id: getTranslation('content-manager.dnd.drop-item'),
           defaultMessage: `{item}, dropped. Final position in list: {position}.`,
         },
         {
@@ -220,14 +220,14 @@ const RepeatableComponent = ({
 
   if (hasMinError) {
     errorMessage = {
-      id: getTranslation('components.DynamicZone.missing-components'),
+      id: getTranslation('content-manager.components.DynamicZone.missing-components'),
       defaultMessage:
         'There {number, plural, =0 {are # missing components} one {is # missing component} other {are # missing components}}',
       values: { number: missingComponentsValue },
     };
   } else if (componentErrorKeys.some((error) => error.split('.').length > 1) && !hasMinError) {
     errorMessage = {
-      id: getTranslation('components.RepeatableComponent.error-message'),
+      id: getTranslation('content-manager.components.RepeatableComponent.error-message'),
       defaultMessage: 'The component(s) contain error(s)',
     };
   }
@@ -244,7 +244,7 @@ const RepeatableComponent = ({
     <Box hasRadius>
       <VisuallyHidden id={ariaDescriptionId}>
         {formatMessage({
-          id: getTranslation('dnd.instructions'),
+          id: getTranslation('content-manager.dnd.instructions'),
           defaultMessage: `Press spacebar to grab and re-order`,
         })}
       </VisuallyHidden>
@@ -274,7 +274,7 @@ const RepeatableComponent = ({
           <Flex justifyContent="center" height="48px" background="neutral0">
             <TextButtonCustom disabled={isReadOnly} onClick={handleClick} startIcon={<Plus />}>
               {formatMessage({
-                id: getTranslation('containers.EditView.add.new-entry'),
+                id: getTranslation('content-manager.containers.EditView.add.new-entry'),
                 defaultMessage: 'Add an entry',
               })}
             </TextButtonCustom>
@@ -504,7 +504,7 @@ const Component = ({
                       toggleCollapses();
                     }}
                     label={formatMessage({
-                      id: getTranslation('containers.Edit.delete'),
+                      id: getTranslation('content-manager.containers.Edit.delete'),
                       defaultMessage: 'Delete',
                     })}
                     icon={<Trash />}
@@ -519,7 +519,7 @@ const Component = ({
                     onClick={(e) => e.stopPropagation()}
                     data-handler-id={handlerId}
                     label={formatMessage({
-                      id: getTranslation('components.DragHandle-label'),
+                      id: getTranslation('content-manager.components.DragHandle-label'),
                       defaultMessage: 'Drag',
                     })}
                     onKeyDown={handleKeyDown}

--- a/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
@@ -57,7 +57,7 @@ const useContentManagerInitData = () => {
       } = await get<Contracts.Init.GetInitData.Response>('/content-manager/init');
       notifyStatus(
         formatMessage({
-          id: getTranslation('App.schemas.data-loaded'),
+          id: getTranslation('content-manager.App.schemas.data-loaded'),
           defaultMessage: 'The schemas have been successfully loaded.',
         })
       );

--- a/packages/core/admin/admin/src/content-manager/pages/App.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/App.tsx
@@ -67,7 +67,7 @@ const App = () => {
         />
         <HeaderLayout
           title={formatMessage({
-            id: getTranslation('header.name'),
+            id: getTranslation('list.table.header.name'),
             defaultMessage: 'Content',
           })}
         />

--- a/packages/core/admin/admin/src/content-manager/pages/App.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/App.tsx
@@ -67,7 +67,7 @@ const App = () => {
         />
         <HeaderLayout
           title={formatMessage({
-            id: getTranslation('list.table.header.name'),
+            id: getTranslation('content-manager.header.name'),
             defaultMessage: 'Content',
           })}
         />

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ComponentFieldList.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ComponentFieldList.jsx
@@ -46,7 +46,7 @@ const ComponentFieldList = ({ componentUid }) => {
           to={`/content-manager/components/${componentUid}/configurations/edit`}
         >
           {formatMessage({
-            id: getTranslation('components.FieldItem.linkToComponentLayout'),
+            id: getTranslation('content-manager.components.FieldItem.linkToComponentLayout'),
             defaultMessage: "Set the component's layout",
           })}
         </Link>

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFields.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/DisplayedFields.jsx
@@ -21,7 +21,7 @@ const DisplayedFields = ({ editLayout, fields, onRemoveField, onAddField }) => {
           <Box>
             <Typography fontWeight="bold">
               {formatMessage({
-                id: getTranslation('containers.ListPage.displayedFields'),
+                id: getTranslation('content-manager.containers.ListPage.displayedFields'),
                 defaultMessage: 'Displayed fields',
               })}
             </Typography>
@@ -51,7 +51,7 @@ const DisplayedFields = ({ editLayout, fields, onRemoveField, onAddField }) => {
               variant="secondary"
             >
               {formatMessage({
-                id: getTranslation('containers.SettingPage.add.field'),
+                id: getTranslation('content-manager.containers.SettingPage.add.field'),
                 defaultMessage: 'Insert another field',
               })}
             </Menu.Trigger>

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FieldButtonContent.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FieldButtonContent.jsx
@@ -31,7 +31,7 @@ const FieldButtonContent = ({ attribute, onEditField, onDeleteField, children })
           <CustomIconButton
             label={formatMessage(
               {
-                id: getTranslation('containers.ListSettingsView.modal-form.edit-label'),
+                id: getTranslation('content-manager.containers.ListSettingsView.modal-form.edit-label'),
                 defaultMessage: `Edit {fieldName}`,
               },
               { fieldName: children }

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/FormModal.jsx
@@ -54,7 +54,7 @@ const FormModal = ({ onToggle, onMetaChange, onSizeChange, onSubmit, type, custo
             <Typography fontWeight="bold" textColor="neutral800" as="h2" id="title">
               {formatMessage(
                 {
-                  id: getTranslation('containers.ListSettingsView.modal-form.edit-label'),
+                  id: getTranslation('content-manager.containers.ListSettingsView.modal-form.edit-label'),
                   defaultMessage: 'Edit {fieldName}',
                 },
                 { fieldName: upperFirst(selectedField) }

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.jsx
@@ -86,7 +86,7 @@ const ModalForm = ({ onMetaChange, onSizeChange }) => {
             meta === 'mainField'
               ? formatMessage({
                   id: getTranslation(
-                    'containers.SettingPage.editSettings.relation-field.description'
+                    'content-manager.containers.SettingPage.editSettings.relation-field.description'
                   ),
                 })
               : ''

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.jsx
@@ -301,7 +301,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
                       })}
                       hint={formatMessage({
                         id: getTranslation(
-                          'content-manager.content-manager.containers.SettingPage.editSettings.entry.title.description'
+                          'content-manager.containers.SettingPage.editSettings.entry.title.description'
                         ),
                         defaultMessage: 'Set the display field of your entry',
                       })}
@@ -357,7 +357,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
           </ContentLayout>
           <ConfirmDialog
             bodyText={{
-              id: getTranslation('config.popUpWarning.warning.updateAllSettings'),
+              id: getTranslation('content-manager.popUpWarning.warning.updateAllSettings'),
               defaultMessage: 'This will modify all your settings',
             }}
             iconRightButton={<Check />}

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/index.jsx
@@ -239,14 +239,14 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
           <HeaderLayout
             title={formatMessage(
               {
-                id: getTranslation('components.SettingsViewWrapper.pluginHeader.title'),
+                id: getTranslation('content-manager.components.SettingsViewWrapper.pluginHeader.title'),
                 defaultMessage: `Configure the view - ${upperFirst(modelName)}`,
               },
               { name: upperFirst(modelName) }
             )}
             subtitle={formatMessage({
               id: getTranslation(
-                'components.SettingsViewWrapper.pluginHeader.description.edit-settings'
+                'content-manager.components.SettingsViewWrapper.pluginHeader.description.edit-settings'
               ),
               defaultMessage: 'Customize how the edit view will look like.',
             })}
@@ -288,7 +288,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
               <Flex direction="column" alignItems="stretch" gap={4}>
                 <Typography variant="delta" as="h2">
                   {formatMessage({
-                    id: getTranslation('containers.SettingPage.settings'),
+                    id: getTranslation('content-manager.containers.SettingPage.settings'),
                     defaultMessage: 'Settings',
                   })}
                 </Typography>
@@ -296,12 +296,12 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
                   <GridItem col={6} s={12}>
                     <Select
                       label={formatMessage({
-                        id: getTranslation('containers.SettingPage.editSettings.entry.title'),
+                        id: getTranslation('content-manager.containers.SettingPage.editSettings.entry.title'),
                         defaultMessage: 'Entry title',
                       })}
                       hint={formatMessage({
                         id: getTranslation(
-                          'containers.SettingPage.editSettings.entry.title.description'
+                          'content-manager.content-manager.containers.SettingPage.editSettings.entry.title.description'
                         ),
                         defaultMessage: 'Set the display field of your entry',
                       })}
@@ -328,7 +328,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
                 </Box>
                 <Typography variant="delta" as="h3">
                   {formatMessage({
-                    id: getTranslation('containers.SettingPage.view'),
+                    id: getTranslation('content-manager.containers.SettingPage.view'),
                     defaultMessage: 'View',
                   })}
                 </Typography>
@@ -357,7 +357,7 @@ const EditSettingsView = ({ mainLayout, components, isContentTypeView, slug, upd
           </ContentLayout>
           <ConfirmDialog
             bodyText={{
-              id: getTranslation('popUpWarning.warning.updateAllSettings'),
+              id: getTranslation('config.popUpWarning.warning.updateAllSettings'),
               defaultMessage: 'This will modify all your settings',
             }}
             iconRightButton={<Check />}

--- a/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/getInputProps.js
+++ b/packages/core/admin/admin/src/content-manager/pages/EditSettingsView/utils/getInputProps.js
@@ -21,7 +21,7 @@ const getInputProps = (fieldName) => {
 
   const labelId =
     fieldName === 'mainField'
-      ? getTranslation('containers.SettingPage.editSettings.entry.title')
+      ? getTranslation('content-manager.containers.SettingPage.editSettings.entry.title')
       : getTranslation(`form.Input.${fieldName}`);
 
   return { type, label: { id: labelId } };

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/EditViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/EditViewPage.tsx
@@ -310,7 +310,7 @@ const EditViewPage = ({
                                 variant="secondary"
                               >
                                 {formatMessage({
-                                  id: getTranslation('link-to-ctb'),
+                                  id: getTranslation('content-manager.link-to-ctb'),
                                   defaultMessage: 'Edit the model',
                                 })}
                               </LinkButton>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/DeleteLink.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/DeleteLink.tsx
@@ -63,7 +63,7 @@ const DeleteLink = ({ onDelete }: DeleteLinkProps) => {
     <>
       <Button onClick={toggleWarningDelete} size="S" startIcon={<Trash />} variant="danger-light">
         {formatMessage({
-          id: getTranslation('containers.Edit.delete-entry'),
+          id: getTranslation('content-manager.containers.Edit.delete-entry'),
           defaultMessage: 'Delete this entry',
         })}
       </Button>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/DraftAndPublishBadge.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/DraftAndPublishBadge.tsx
@@ -52,7 +52,7 @@ const DraftAndPublishBadge = () => {
         <Box paddingLeft={3}>
           <Typography textColor={colorProps.textColor}>
             {formatMessage({
-              id: getTranslation('containers.Edit.information.editing'),
+              id: getTranslation('content-manager.containers.Edit.information.editing'),
               defaultMessage: 'Editing',
             })}
             &nbsp;
@@ -60,12 +60,12 @@ const DraftAndPublishBadge = () => {
           <Typography fontWeight="bold" textColor={colorProps.textColor}>
             {isPublished &&
               formatMessage({
-                id: getTranslation('containers.Edit.information.publishedVersion'),
+                id: getTranslation('content-manager.containers.Edit.information.publishedVersion'),
                 defaultMessage: 'published version',
               })}
             {!isPublished &&
               formatMessage({
-                id: getTranslation('containers.Edit.information.draftVersion'),
+                id: getTranslation('content-manager.containers.Edit.information.draftVersion'),
                 defaultMessage: 'draft version',
               })}
           </Typography>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
@@ -49,7 +49,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
     (isCreatingEntry && Object.keys(modifiedData).length > 0);
 
   const createEntryIntlTitle = formatMessage({
-    id: getTranslation('containers.Edit.pluginHeader.title.new'),
+    id: getTranslation('content-manager.containers.Edit.pluginHeader.title.new'),
     defaultMessage: 'Create an entry',
   });
 
@@ -75,7 +75,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
         )}
         <Button disabled={!didChangeData} loading={status === 'submit-pending'} type="submit">
           {formatMessage({
-            id: getTranslation('containers.Edit.submit'),
+            id: getTranslation('content-manager.content-manager.containers.Edit.submit'),
             defaultMessage: 'Save',
           })}
         </Button>
@@ -111,7 +111,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
         <Box paddingLeft={shouldShowPublishButton ? 2 : 0}>
           <Button disabled={!didChangeData} loading={status === 'submit-pending'} type="submit">
             {formatMessage({
-              id: getTranslation('containers.Edit.submit'),
+              id: getTranslation('content-manager.content-manager.containers.Edit.submit'),
               defaultMessage: 'Save',
             })}
           </Button>
@@ -128,7 +128,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
   };
 
   const subtitle = `${formatMessage({
-    id: getTranslation('api.id'),
+    id: getTranslation('content-manager.api.id'),
     defaultMessage: 'API ID',
     // @ts-expect-error – issue comes from the context not having the correct layout from the admin.
   })}: ${layout?.apiID}`;
@@ -172,7 +172,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
             <Flex justifyContent="center" style={{ textAlign: 'center' }}>
               <Typography id="confirm-description">
                 {formatMessage({
-                  id: getTranslation('popUpWarning.warning.unpublish'),
+                  id: getTranslation('content-manager.popUpWarning.warning.unpublish'),
                   defaultMessage: 'Unpublish this content will automatically change it to a draft.',
                 })}
               </Typography>
@@ -180,7 +180,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
             <Flex justifyContent="center" style={{ textAlign: 'center' }}>
               <Typography id="confirm-description">
                 {formatMessage({
-                  id: getTranslation('popUpWarning.warning.unpublish-question'),
+                  id: getTranslation('content-manager.content-manager.popUpWarning.warning.unpublish-question'),
                   defaultMessage: 'Are you sure you want to unpublish it?',
                 })}
               </Typography>
@@ -210,7 +210,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
         // @ts-expect-error – Context issue with it living in the helper-plugin
         onClose={onPublishPromptDismissal}
         title={formatMessage({
-          id: getTranslation(`popUpWarning.warning.has-draft-relations.title`),
+          id: getTranslation(`content-manager.popUpWarning.warning.has-draft-relations.title`),
           defaultMessage: 'Confirmation',
         })}
         labelledBy="confirmation"
@@ -225,7 +225,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
               {/* @ts-expect-error – this is an issue with rendering a component with the formatMessage helper, perhaps a mis-match in types? */}
               {formatMessage(
                 {
-                  id: getTranslation(`popUpwarning.warning.has-draft-relations.message`),
+                  id: getTranslation(`content-manager.popUpwarning.warning.has-draft-relations.message`),
                   defaultMessage:
                     '<b>{count, plural, one { relation is} other { relations are}}</b> not published yet and might lead to unexpected behavior.',
                 },
@@ -237,7 +237,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
             </Typography>
             <Typography textAlign="center" id="confirm-description">
               {formatMessage({
-                id: getTranslation('popUpWarning.warning.publish-question'),
+                id: getTranslation('content-manager.popUpWarning.warning.publish-question'),
                 defaultMessage: 'Do you still want to publish?',
               })}
             </Typography>
@@ -255,7 +255,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
           endAction={
             <Button variant="success" onClick={onPublish}>
               {formatMessage({
-                id: getTranslation('popUpwarning.warning.has-draft-relations.button-confirm'),
+                id: getTranslation('content-manager.popUpwarning.warning.has-draft-relations.button-confirm'),
                 defaultMessage: 'Publish',
               })}
             </Button>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
@@ -180,7 +180,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
             <Flex justifyContent="center" style={{ textAlign: 'center' }}>
               <Typography id="confirm-description">
                 {formatMessage({
-                  id: getTranslation('content-manager.content-manager.popUpWarning.warning.unpublish-question'),
+                  id: getTranslation('content-manager.popUpWarning.warning.unpublish-question'),
                   defaultMessage: 'Are you sure you want to unpublish it?',
                 })}
               </Typography>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
@@ -75,7 +75,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
         )}
         <Button disabled={!didChangeData} loading={status === 'submit-pending'} type="submit">
           {formatMessage({
-            id: getTranslation('content-manager.content-manager.containers.Edit.submit'),
+            id: getTranslation('content-manager.containers.Edit.submit'),
             defaultMessage: 'Save',
           })}
         </Button>
@@ -111,7 +111,7 @@ const Header = ({ allowedActions: { canUpdate, canCreate, canPublish } }: Header
         <Box paddingLeft={shouldShowPublishButton ? 2 : 0}>
           <Button disabled={!didChangeData} loading={status === 'submit-pending'} type="submit">
             {formatMessage({
-              id: getTranslation('content-manager.content-manager.containers.Edit.submit'),
+              id: getTranslation('content-manager.containers.Edit.submit'),
               defaultMessage: 'Save',
             })}
           </Button>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
@@ -34,7 +34,7 @@ const Title = () => {
     <Flex direction="column" alignItems="stretch" gap={2}>
       <Typography variant="sigma" textColor="neutral600" id="additional-information">
         {formatMessage({
-          id: getTranslation('containers.Edit.information'),
+          id: getTranslation('content-manager.containers.Edit.information'),
           defaultMessage: 'Information',
         })}
       </Typography>
@@ -78,7 +78,7 @@ const Body = () => {
       <Flex direction="column" alignItems="stretch" gap={2} as="dl">
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('containers.Edit.information.created'),
+            id: getTranslation('content-manager.content-manager.containers.Edit.information.created'),
             defaultMessage: 'Created',
           })}
           value={created.at}
@@ -86,7 +86,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('containers.Edit.information.by'),
+            id: getTranslation('content-manager.content-manager.content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={created.by}
@@ -96,7 +96,7 @@ const Body = () => {
       <Flex direction="column" alignItems="stretch" gap={2} as="dl">
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('containers.Edit.information.lastUpdate'),
+            id: getTranslation('content-manager.content-manager.containers.Edit.information.lastUpdate'),
             defaultMessage: 'Last update',
           })}
           value={updated.at}
@@ -104,7 +104,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('containers.Edit.information.by'),
+            id: getTranslation('content-manager.content-manager.content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={updated.by}

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
@@ -86,7 +86,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.content-manager.containers.Edit.information.by'),
+            id: getTranslation('content-manager.content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={created.by}
@@ -104,7 +104,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.content-manager.containers.Edit.information.by'),
+            id: getTranslation('content-manager.content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={updated.by}

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Information.tsx
@@ -78,7 +78,7 @@ const Body = () => {
       <Flex direction="column" alignItems="stretch" gap={2} as="dl">
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.containers.Edit.information.created'),
+            id: getTranslation('content-manager.containers.Edit.information.created'),
             defaultMessage: 'Created',
           })}
           value={created.at}
@@ -86,7 +86,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.containers.Edit.information.by'),
+            id: getTranslation('content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={created.by}
@@ -96,7 +96,7 @@ const Body = () => {
       <Flex direction="column" alignItems="stretch" gap={2} as="dl">
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.containers.Edit.information.lastUpdate'),
+            id: getTranslation('content-manager.containers.Edit.information.lastUpdate'),
             defaultMessage: 'Last update',
           })}
           value={updated.at}
@@ -104,7 +104,7 @@ const Body = () => {
 
         <KeyValuePair
           label={formatMessage({
-            id: getTranslation('content-manager.content-manager.containers.Edit.information.by'),
+            id: getTranslation('content-manager.containers.Edit.information.by'),
             defaultMessage: 'By',
           })}
           value={updated.by}

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/DraggableCard.jsx
@@ -195,7 +195,7 @@ const DraggableCard = ({
               as="span"
               aria-label={formatMessage(
                 {
-                  id: getTranslation('components.DraggableCard.move.field'),
+                  id: getTranslation('content-manager.components.DraggableCard.move.field'),
                   defaultMessage: 'Move {item}',
                 },
                 { item: labelField }
@@ -217,7 +217,7 @@ const DraggableCard = ({
               }}
               aria-label={formatMessage(
                 {
-                  id: getTranslation('components.DraggableCard.edit.field'),
+                  id: getTranslation('content-manager.components.DraggableCard.edit.field'),
                   defaultMessage: 'Edit {item}',
                 },
                 { item: labelField }
@@ -231,7 +231,7 @@ const DraggableCard = ({
               data-testid={`delete-${name}`}
               aria-label={formatMessage(
                 {
-                  id: getTranslation('components.DraggableCard.delete.field'),
+                  id: getTranslation('content-manager.components.DraggableCard.delete.field'),
                   defaultMessage: 'Delete {item}',
                 },
                 { item: labelField }

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.jsx
@@ -57,7 +57,7 @@ export const EditFieldForm = ({
             <Typography fontWeight="bold" textColor="neutral800" as="h2" id="title">
               {formatMessage(
                 {
-                  id: getTranslation('containers.ListSettingsView.modal-form.edit-label'),
+                  id: getTranslation('content-manager.containers.ListSettingsView.modal-form.edit-label'),
                   defaultMessage: 'Edit {fieldName}',
                 },
                 { fieldName: upperFirst(fieldToEdit) }
@@ -71,14 +71,14 @@ export const EditFieldForm = ({
               <TextInput
                 id="label-input"
                 label={formatMessage({
-                  id: getTranslation('form.Input.label'),
+                  id: getTranslation('content-manager.form.Input.label'),
                   defaultMessage: 'Label',
                 })}
                 name="label"
                 onChange={(e) => onChangeEditLabel(e)}
                 value={fieldForm.label}
                 hint={formatMessage({
-                  id: getTranslation('form.Input.label.inputDescription'),
+                  id: getTranslation('content-manager.content-manager.form.Input.label.inputDescription'),
                   defaultMessage: "This value overrides the label displayed in the table's head",
                 })}
               />
@@ -89,7 +89,7 @@ export const EditFieldForm = ({
                   data-testid="Enable sort on this field"
                   checked={fieldForm.sortable}
                   label={formatMessage({
-                    id: getTranslation('form.Input.sort.field'),
+                    id: getTranslation('content-manager.form.Input.sort.field'),
                     defaultMessage: 'Enable sort on this field',
                   })}
                   name="sortable"

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/EditFieldForm.jsx
@@ -78,7 +78,7 @@ export const EditFieldForm = ({
                 onChange={(e) => onChangeEditLabel(e)}
                 value={fieldForm.label}
                 hint={formatMessage({
-                  id: getTranslation('content-manager.content-manager.form.Input.label.inputDescription'),
+                  id: getTranslation('content-manager.form.Input.label.inputDescription'),
                   defaultMessage: "This value overrides the label displayed in the table's head",
                 })}
               />

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.jsx
@@ -53,7 +53,7 @@ export const Settings = ({
     <Flex direction="column" alignItems="stretch" gap={4}>
       <Typography variant="delta" as="h2">
         {formatMessage({
-          id: getTranslation('containers.SettingPage.settings'),
+          id: getTranslation('content-manager.containers.SettingPage.settings'),
           defaultMessage: 'Settings',
         })}
       </Typography>
@@ -62,7 +62,7 @@ export const Settings = ({
         <Box width="100%">
           <ToggleInput
             label={formatMessage({
-              id: getTranslation('form.Input.search'),
+              id: getTranslation('content-manager.form.Input.search'),
               defaultMessage: 'Enable search',
             })}
             onChange={(e) => {
@@ -84,7 +84,7 @@ export const Settings = ({
         <Box width="100%">
           <ToggleInput
             label={formatMessage({
-              id: getTranslation('form.Input.filters'),
+              id: getTranslation('content-manager.form.Input.filters'),
               defaultMessage: 'Enable filters',
             })}
             onChange={(e) => {
@@ -106,7 +106,7 @@ export const Settings = ({
         <Box width="100%">
           <ToggleInput
             label={formatMessage({
-              id: getTranslation('form.Input.bulkActions'),
+              id: getTranslation('content-manager.form.Input.bulkActions'),
               defaultMessage: 'Enable bulk actions',
             })}
             onChange={(e) => {
@@ -130,11 +130,11 @@ export const Settings = ({
         <GridItem s={12} col={6}>
           <Select
             label={formatMessage({
-              id: getTranslation('form.Input.pageEntries'),
+              id: getTranslation('content-manager.form.Input.pageEntries'),
               defaultMessage: 'Entries per page',
             })}
             hint={formatMessage({
-              id: getTranslation('form.Input.pageEntries.inputDescription'),
+              id: getTranslation('content-manager.content-manager.form.Input.pageEntries.inputDescription'),
               defaultMessage:
                 'Note: You can override this value in the Collection Type settings page.',
             })}
@@ -152,7 +152,7 @@ export const Settings = ({
         <GridItem s={12} col={3}>
           <Select
             label={formatMessage({
-              id: getTranslation('form.Input.defaultSort'),
+              id: getTranslation('content-manager.form.Input.defaultSort'),
               defaultMessage: 'Default sort attribute',
             })}
             onChange={(value) => onChange({ target: { name: 'settings.defaultSortBy', value } })}
@@ -169,7 +169,7 @@ export const Settings = ({
         <GridItem s={12} col={3}>
           <Select
             label={formatMessage({
-              id: getTranslation('form.Input.sort.order'),
+              id: getTranslation('content-manager.form.Input.sort.order'),
               defaultMessage: 'Default sort order',
             })}
             onChange={(value) => onChange({ target: { name: 'settings.defaultSortOrder', value } })}

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/Settings.jsx
@@ -134,7 +134,7 @@ export const Settings = ({
               defaultMessage: 'Entries per page',
             })}
             hint={formatMessage({
-              id: getTranslation('content-manager.content-manager.form.Input.pageEntries.inputDescription'),
+              id: getTranslation('content-manager.form.Input.pageEntries.inputDescription'),
               defaultMessage:
                 'Note: You can override this value in the Collection Type settings page.',
             })}

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/components/SortDisplayedFields.jsx
@@ -44,7 +44,7 @@ export const SortDisplayedFields = ({
     <Flex alignItems="stretch" direction="column" gap={4}>
       <Typography variant="delta" as="h2">
         {formatMessage({
-          id: getTranslation('containers.SettingPage.view'),
+          id: getTranslation('content-manager.containers.SettingPage.view'),
           defaultMessage: 'View',
         })}
       </Typography>
@@ -79,7 +79,7 @@ export const SortDisplayedFields = ({
           >
             <VisuallyHidden as="span">
               {formatMessage({
-                id: getTranslation('components.FieldSelect.label'),
+                id: getTranslation('content-manager.components.FieldSelect.label'),
                 defaultMessage: 'Add a field',
               })}
             </VisuallyHidden>

--- a/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListSettingsView/index.jsx
@@ -93,7 +93,7 @@ export const ListSettingsView = ({ layout, slug }) => {
     if (displayedFields.length === 1) {
       toggleNotification({
         type: 'info',
-        message: { id: getTranslation('notification.info.minimumFields') },
+        message: { id: getTranslation('content-manager.notification.info.minimumFields') },
       });
     } else {
       dispatch({
@@ -214,13 +214,13 @@ export const ListSettingsView = ({ layout, slug }) => {
             }
             subtitle={formatMessage({
               id: getTranslation(
-                'components.SettingsViewWrapper.pluginHeader.description.list-settings'
+                'content-manager.components.SettingsViewWrapper.pluginHeader.description.list-settings'
               ),
               defaultMessage: 'Define the settings of the list view.',
             })}
             title={formatMessage(
               {
-                id: getTranslation('components.SettingsViewWrapper.pluginHeader.title'),
+                id: getTranslation('content-manager.components.SettingsViewWrapper.pluginHeader.title'),
                 defaultMessage: 'Configure the view - {name}',
               },
               { name: upperFirst(modifiedData.info.displayName) }

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
@@ -504,7 +504,7 @@ const ListViewPage = ({
   };
 
   const defaultHeaderLayoutTitle = formatMessage({
-    id: getTranslation('list.table.header.name'),
+    id: getTranslation('content-manager.header.name'),
     defaultMessage: 'Content',
   });
   const headerLayoutTitle = formatMessage({
@@ -530,11 +530,11 @@ const ListViewPage = ({
           metadatas: {
             ...header.metadatas,
             label: formatMessage({
-              id: getTranslation(`containers.ListPage.table-headers.${list.table.header.name}`),
+              id: getTranslation(`containers.ListPage.table-headers.${header.name}`),
               defaultMessage: header.metadatas.label,
             }),
           },
-          name: `${list.table.header.name}.${header.metadatas.mainField?.name ?? ''}`,
+          name: `${header.name}.${header.metadatas.mainField?.name ?? ''}`,
         } satisfies TableHeader;
       }
 
@@ -543,7 +543,7 @@ const ListViewPage = ({
         metadatas: {
           ...header.metadatas,
           label: formatMessage({
-            id: getTranslation(`containers.ListPage.table-headers.${list.table.header.name}`),
+            id: getTranslation(`containers.ListPage.table-headers.${header.name}`),
             defaultMessage: header.metadatas.label,
           }),
         },

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
@@ -374,7 +374,7 @@ const ListViewPage = ({
 
         toggleNotification({
           type: 'warning',
-          message: { id: getTranslation('error.model.fetch') },
+          message: { id: getTranslation('content-manager.error.model.fetch') },
         });
       },
       onSuccess({ pagination, results }) {
@@ -397,7 +397,7 @@ const ListViewPage = ({
         notifyStatus(
           formatMessage(
             {
-              id: getTranslation('utils.data-loaded'),
+              id: getTranslation('content-manager.utils.data-loaded'),
               defaultMessage:
                 '{number, plural, =1 {# entry has} other {# entries have}} successfully been loaded',
             },
@@ -483,7 +483,7 @@ const ListViewPage = ({
 
         toggleNotification({
           type: 'success',
-          message: { id: getTranslation('success.record.delete') },
+          message: { id: getTranslation('content-manager.success.record.delete') },
         });
       } catch (err) {
         if (err instanceof AxiosError) {
@@ -504,7 +504,7 @@ const ListViewPage = ({
   };
 
   const defaultHeaderLayoutTitle = formatMessage({
-    id: getTranslation('header.name'),
+    id: getTranslation('list.table.header.name'),
     defaultMessage: 'Content',
   });
   const headerLayoutTitle = formatMessage({
@@ -530,11 +530,11 @@ const ListViewPage = ({
           metadatas: {
             ...header.metadatas,
             label: formatMessage({
-              id: getTranslation(`containers.ListPage.table-headers.${header.name}`),
+              id: getTranslation(`containers.ListPage.table-headers.${list.table.header.name}`),
               defaultMessage: header.metadatas.label,
             }),
           },
-          name: `${header.name}.${header.metadatas.mainField?.name ?? ''}`,
+          name: `${list.table.header.name}.${header.metadatas.mainField?.name ?? ''}`,
         } satisfies TableHeader;
       }
 
@@ -543,7 +543,7 @@ const ListViewPage = ({
         metadatas: {
           ...header.metadatas,
           label: formatMessage({
-            id: getTranslation(`containers.ListPage.table-headers.${header.name}`),
+            id: getTranslation(`containers.ListPage.table-headers.${list.table.header.name}`),
             defaultMessage: header.metadatas.label,
           }),
         },
@@ -559,7 +559,7 @@ const ListViewPage = ({
         },
         metadatas: {
           label: formatMessage({
-            id: getTranslation(`containers.ListPage.table-headers.publishedAt`),
+            id: getTranslation(`content-manager.containers.ListPage.table-headers.publishedAt`),
             defaultMessage: 'publishedAt',
           }),
           searchable: false,
@@ -652,7 +652,7 @@ const ListViewPage = ({
           canRead
             ? formatMessage(
                 {
-                  id: getTranslation('pages.ListView.header-subtitle'),
+                  id: getTranslation('content-manager.pages.ListView.header-subtitle'),
                   defaultMessage:
                     '{number, plural, =0 {# entries} one {# entry} other {# entries}} found',
                 },
@@ -928,7 +928,7 @@ const CreateButton = ({ hasDraftAndPublish = false, params = '', variant }: Crea
       }}
     >
       {formatMessage({
-        id: getTranslation('HeaderLayout.button.label-add-entry'),
+        id: getTranslation('content-manager.HeaderLayout.button.label-add-entry'),
         defaultMessage: 'Create new entry',
       })}
     </Button>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/AutoCloneFailureModal.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/AutoCloneFailureModal.tsx
@@ -61,7 +61,7 @@ const AutoCloneFailureModal = ({
       <ModalHeader>
         <Typography variant="omega" fontWeight="bold" as="h2" id="title">
           {formatMessage({
-            id: getTranslation('containers.ListPage.autoCloneModal.header'),
+            id: getTranslation('content-manager.containers.ListPage.autoCloneModal.header'),
             defaultMessage: 'Duplicate',
           })}
         </Typography>
@@ -69,14 +69,14 @@ const AutoCloneFailureModal = ({
       <ModalBody>
         <Typography variant="beta">
           {formatMessage({
-            id: getTranslation('containers.ListPage.autoCloneModal.title'),
+            id: getTranslation('content-manager.containers.ListPage.autoCloneModal.title'),
             defaultMessage: "This entry can't be duplicated directly.",
           })}
         </Typography>
         <Box marginTop={2}>
           <Typography textColor="neutral600">
             {formatMessage({
-              id: getTranslation('containers.ListPage.autoCloneModal.description'),
+              id: getTranslation('content-manager.containers.ListPage.autoCloneModal.description'),
               defaultMessage:
                 "A new entry will be created with the same content, but you'll have to change the following fields to save it.",
             })}
@@ -133,7 +133,7 @@ const AutoCloneFailureModal = ({
           // @ts-expect-error - types are not inferred correctly through the as prop.
           <LinkButton as={NavLink} to={editPath}>
             {formatMessage({
-              id: getTranslation('containers.ListPage.autoCloneModal.create'),
+              id: getTranslation('content-manager.containers.ListPage.autoCloneModal.create'),
               defaultMessage: 'Create',
             })}
           </LinkButton>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/Buttons.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/Buttons.tsx
@@ -34,7 +34,7 @@ const ConfirmDialogUnpublishAll = ({
         <>
           <Typography id="confirm-description" textAlign="center">
             {formatMessage({
-              id: getTranslation('popUpWarning.bodyMessage.contentType.unpublish.all'),
+              id: getTranslation('content-manager.popUpWarning.bodyMessage.contentType.unpublish.all'),
               defaultMessage: 'Are you sure you want to unpublish these entries?',
             })}
           </Typography>
@@ -78,7 +78,7 @@ const ConfirmDialogDeleteAll = ({
         <>
           <Typography id="confirm-description" textAlign="center">
             {formatMessage({
-              id: getTranslation('popUpWarning.bodyMessage.contentType.delete.all'),
+              id: getTranslation('content-manager.popUpWarning.bodyMessage.contentType.delete.all'),
               defaultMessage: 'Are you sure you want to delete these entries?',
             })}
           </Typography>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
@@ -157,7 +157,7 @@ const ConfirmDialogPublishAll = ({
             {countDraftRelations > 0 &&
               formatMessage(
                 {
-                  id: getTranslation(`popUpwarning.warning.bulk-has-draft-relations.message`),
+                  id: getTranslation(`content-manager.popUpwarning.warning.bulk-has-draft-relations.message`),
                   defaultMessage:
                     '<b>{count} {count, plural, one { relation } other { relations } } out of {entities} { entities, plural, one { entry } other { entries } } {count, plural, one { is } other { are } }</b> not published yet and might lead to unexpected behavior. ',
                 },
@@ -168,7 +168,7 @@ const ConfirmDialogPublishAll = ({
                 }
               )}
             {formatMessage({
-              id: getTranslation('popUpWarning.bodyMessage.contentType.publish.all'),
+              id: getTranslation('content-manager.popUpWarning.bodyMessage.contentType.publish.all'),
               defaultMessage: 'Are you sure you want to publish these entries?',
             })}
           </Typography>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/SelectedEntriesModal.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/BulkActions/SelectedEntriesModal.tsx
@@ -326,7 +326,7 @@ const SelectedEntriesModalContent = ({
     if (publishedCount) {
       return formatMessage(
         {
-          id: getTranslation('containers.ListPage.selectedEntriesModal.publishedCount'),
+          id: getTranslation('content-manager.containers.ListPage.selectedEntriesModal.publishedCount'),
           defaultMessage:
             '<b>{publishedCount}</b> {publishedCount, plural, =0 {entries} one {entry} other {entries}} published. <b>{withErrorsCount}</b> {withErrorsCount, plural, =0 {entries} one {entry} other {entries}} waiting for action.',
         },
@@ -340,7 +340,7 @@ const SelectedEntriesModalContent = ({
 
     return formatMessage(
       {
-        id: getTranslation('containers.ListPage.selectedEntriesModal.selectedCount'),
+        id: getTranslation('content-manager.containers.ListPage.selectedEntriesModal.selectedCount'),
         defaultMessage:
           '<b>{alreadyPublishedCount}</b> {alreadyPublishedCount, plural, =0 {entries} one {entry} other {entries}} already published. <b>{readyToPublishCount}</b> {readyToPublishCount, plural, =0 {entries} one {entry} other {entries}} ready to publish. <b>{withErrorsCount}</b> {withErrorsCount, plural, =0 {entries} one {entry} other {entries}} waiting for action.',
       },
@@ -366,7 +366,7 @@ const SelectedEntriesModalContent = ({
       <ModalHeader>
         <Typography fontWeight="bold" textColor="neutral800" as="h2" id="title">
           {formatMessage({
-            id: getTranslation('containers.ListPage.selectedEntriesModal.title'),
+            id: getTranslation('content-manager.containers.ListPage.selectedEntriesModal.title'),
             defaultMessage: 'Publish entries',
           })}
         </Typography>

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableCells/Relations.tsx
@@ -116,7 +116,7 @@ const RelationMultiple = ({ metadatas, name, entityId, content, uid }: RelationM
           <Menu.Item disabled>
             <Loader small>
               {formatMessage({
-                id: getTranslation('ListViewTable.relation-loading'),
+                id: getTranslation('content-manager.ListViewTable.relation-loading'),
                 defaultMessage: 'Relations are loading',
               })}
             </Loader>
@@ -141,7 +141,7 @@ const RelationMultiple = ({ metadatas, name, entityId, content, uid }: RelationM
               <Menu.Item
                 aria-disabled
                 aria-label={formatMessage({
-                  id: getTranslation('ListViewTable.relation-more'),
+                  id: getTranslation('content-manager.ListViewTable.relation-more'),
                   defaultMessage: 'This relation contains more entities than displayed',
                 })}
               >

--- a/packages/core/admin/admin/src/content-manager/pages/NoContentTypePage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/NoContentTypePage.tsx
@@ -15,7 +15,7 @@ const NoContentType = () => {
     <Main>
       <HeaderLayout
         title={formatMessage({
-          id: getTranslation('header.name'),
+          id: getTranslation('list.table.header.name'),
           defaultMessage: 'Content',
         })}
       />

--- a/packages/core/admin/admin/src/content-manager/pages/NoContentTypePage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/NoContentTypePage.tsx
@@ -15,7 +15,7 @@ const NoContentType = () => {
     <Main>
       <HeaderLayout
         title={formatMessage({
-          id: getTranslation('list.table.header.name'),
+          id: getTranslation('content-manager.header.name'),
           defaultMessage: 'Content',
         })}
       />

--- a/packages/core/admin/admin/src/content-manager/pages/NoPermissionsPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/NoPermissionsPage.tsx
@@ -15,7 +15,7 @@ const NoPermissions = () => {
     <Main>
       <HeaderLayout
         title={formatMessage({
-          id: getTranslation('list.table.header.name'),
+          id: getTranslation('content-manager.header.name'),
           defaultMessage: 'Content',
         })}
       />

--- a/packages/core/admin/admin/src/content-manager/pages/NoPermissionsPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/NoPermissionsPage.tsx
@@ -15,7 +15,7 @@ const NoPermissions = () => {
     <Main>
       <HeaderLayout
         title={formatMessage({
-          id: getTranslation('header.name'),
+          id: getTranslation('list.table.header.name'),
           defaultMessage: 'Content',
         })}
       />


### PR DESCRIPTION
### What does it do?

It fixes i18n keys in JS that are outdated compared to the English JSON files.

### Why is it needed?

i18n doesn't work when keys don't match a string from the JSON files.

### How to test it?

These changes were automatically generated by the following Bun script that I wrote :

```js
import { $ } from 'bun';
const
  keys = (await Promise.all((await $`find . -type f -name "en.json"`.text()).trim().split('\n').map(i18nPath => (async () => Object.keys((await import(i18nPath)).default))()))).flat(),
  invalidKeys = [];
let replacedKeyCount = 0;
for(const path of (await $`find ./packages -type f -name "*.ts*" -o -name "*.js*"`.text()).trim().split('\n')){
  const content = await Bun.file(path).text();
  let editedTsContent;
  for(const key of new Set([...content.matchAll(new RegExp(/getTranslation[\n ]*?\([\n ]*?['"`]([a-z0-9.-]+?)['"`][\n ]*?\)/gsi))].map(_ => _[1]))){
    if(keys.includes(key)) continue;
    const replacementKey = keys.find(_key => _key.endsWith(key));
    if(replacementKey){
      editedTsContent = (editedTsContent || content).replace(new RegExp(`(?<=['"\`])${key}(?=['"\`])`, 'g'), replacementKey);
      replacedKeyCount++;
    }
    else
      invalidKeys.push({
        path,
        key
      });
  }
  if(editedTsContent)
    await Bun.write(path, editedTsContent);
}
console.log(`
Automatically replaced ${replacedKeyCount} keys.
Remaining invalid keys :
${invalidKeys.map(({ path, key }) => `- ${path}: ${key}`).join('\n')}
`);
```

Which returns the following output as of d100408 :

```
Automatically replaced 126 keys.
Remaining invalid keys :
- ./packages/plugins/i18n/admin/src/components/CMEditViewCopyLocale.tsx: CMEditViewCopyLocale.ModalConfirm.content
- ./packages/core/admin/ee/admin/src/content-manager/pages/ListView/constants.ts: containers.ListPage.table-headers.reviewWorkflows.stage
- ./packages/core/admin/ee/admin/src/content-manager/pages/ListView/constants.ts: containers.ListPage.table-headers.reviewWorkflows.assignee
- ./packages/core/admin/ee/admin/src/content-manager/pages/ListView/constants.ts: containers.ListPage.table-headers.reviewWorkflows.assignee.label
- ./packages/core/admin/admin/src/content-manager/pages/ListView/components/TableCells/Relations.tsx: DynamicTable.relation-loaded
- ./packages/core/admin/admin/src/content-manager/pages/EditSettingsView/components/ModalForm.jsx: containers.SettingPage.editSettings.size.label
- ./packages/core/admin/admin/src/content-manager/components/DynamicZone/DynamicComponent.tsx: components.DynamicZone.more-actions
- ./packages/core/admin/admin/src/content-manager/components/DynamicZone/DynamicComponent.tsx: components.DynamicZone.add-item-above
- ./packages/core/admin/admin/src/content-manager/components/DynamicZone/DynamicComponent.tsx: components.DynamicZone.add-item-below
```

### Related issue(s)/PR(s)

N/A

---

cc. @derrickmehaffy

Thanks