### PR TITLE
chore(strapi): make watch-admin default on develop

### DIFF
--- a/packages/core/strapi/src/cli/commands/develop.ts
+++ b/packages/core/strapi/src/cli/commands/develop.ts
@@ -33,7 +33,7 @@ const command: StrapiCommand = ({ ctx }) => {
     .option('--silent', "Don't log anything", false)
     .option('--ignore-prompts', 'Ignore all prompts', false)
     .option('--polling', 'Watch for file changes in network directories', false)
-    .option('--watch-admin', 'Watch the admin panel for hot changes', false)
+    .option('--watch-admin', 'Watch the admin panel for hot changes', true)
     .option('--open', 'Open the admin in your browser', true)
     .description('Start your Strapi application in development mode')
     .action(async (options: DevelopCLIOptions) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* makes watch-admin default behaviour

### Why is it needed?

* the develop command becomes _really_ fast in new projects now
