### PR TITLE
fix(cm): fetch the init data on every mount

### DIFF
--- a/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
+++ b/packages/core/admin/admin/src/content-manager/hooks/useContentManagerInitData.ts
@@ -45,7 +45,13 @@ const useContentManagerInitData = (): ContentManagerAppState => {
 
   const state = useTypedSelector((state) => state['content-manager_app']);
 
-  const initialDataQuery = useGetInitialDataQuery();
+  const initialDataQuery = useGetInitialDataQuery(undefined, {
+    /**
+     * TODO: remove this when the CTB has been refactored to use redux-toolkit-query
+     * and it can invalidate the cache on mutation
+     */
+    refetchOnMountOrArgChange: true,
+  });
 
   useEffect(() => {
     if (initialDataQuery.data) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `refetchOnMountOrArgChange` to the `useGetInitialDataQuery` call in `useContentManagerInitData`

### Why is it needed?

* this ensures we refetch the schemas all the time so if there are changes from the CTB we can see them updated accurately

### How to test it?

* As a user I want to enable or disable i18n in the CTB and have the changes reflected in the content-manager

### Related issue(s)/PR(s)

* resolves CONTENT-2889
