### PR TITLE
fix(content-manager): compute document status based on locale

### DIFF
--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -122,8 +122,9 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   async getManyAvailableStatus(uid: Common.UID.SingleType, documents: DocumentVersion[]) {
     if (!documents.length) return [];
 
-    // The status of all documents should be the same
+    // The status and locale of all documents should be the same
     const status = documents[0].publishedAt !== null ? 'published' : 'draft';
+    const locale = documents[0]?.locale;
     const otherStatus = status === 'published' ? 'draft' : 'published';
 
     return strapi.documents(uid).findMany({
@@ -131,6 +132,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
         documentId: { $in: documents.map((d) => d.documentId).filter(Boolean) },
       },
       status: otherStatus,
+      locale,
       fields: ['documentId', 'locale', 'updatedAt', 'createdAt', 'publishedAt'],
     }) as unknown as DocumentMetadata['availableStatus'];
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Query with locale in getManyAvailableStatus

### Why is it needed?

For the status displayed in the CM list view. Every available status was being calculated for the default locale

### How to test it?

See JIRA ticket for scenario

### Related issue(s)/PR(s)

CONTENT-2276
