### PR TITLE
fix(releases): Added timezone select filter

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -292,6 +292,7 @@ const TimezoneComponent = ({ timezoneOptions }: { timezoneOptions: ITimezoneOpti
         id: 'content-releases.modal.form.input.label.timezone',
         defaultMessage: 'Timezone',
       })}
+      autocomplete={{ type: 'list', filter: 'contains' }}
       name="timezone"
       value={values.timezone || undefined}
       textValue={values.timezone ? values.timezone.replace('_', ' ') : undefined} // textValue is required to show the updated DST timezone


### PR DESCRIPTION
### What does it do?

added timezone select filter "contains" to filter by substring

### Why is it needed?

As timezone values in dropdown are quite big, its a need to search by any substring value.

### How to test it?

When you create a scheduled release, you should be able to filter timezones by any timezone value, eg: Europe/Paris, Asia/Mumbai.
