### PR TITLE
test(e2e): fix content-releases bug by advancing time by a day

### DIFF
--- a/e2e/tests/content-releases/releases-page.spec.ts
+++ b/e2e/tests/content-releases/releases-page.spec.ts
@@ -71,7 +71,9 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
       })
       .click();
 
-    const formattedDate = new Date().toLocaleDateString('en-US', {
+    const date = new Date();
+    date.setDate(date.getDate() + 1);
+    const formattedDate = date.toLocaleDateString('en-US', {
       weekday: 'long',
       month: 'long',
       day: 'numeric',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* advances the date by a day to ensure the tests will pass even if it's after 2pm

### Why is it needed?

* e2e EE mode fails after 2pm
