### PR TITLE
chore: content-api response format header

### DIFF
--- a/packages/core/core/src/core-api/controller/__tests__/transform.test.ts
+++ b/packages/core/core/src/core-api/controller/__tests__/transform.test.ts
@@ -2,6 +2,137 @@ import type { Schema } from '@strapi/types';
 import * as transforms from '../transform';
 
 describe('Transforms', () => {
+  test('v4 - using json api format', () => {
+    const contentType: Schema.ContentType = {
+      globalId: 'test',
+      kind: 'collectionType',
+      modelName: 'test',
+      modelType: 'contentType',
+      uid: 'api::test.test',
+      info: {
+        displayName: 'test',
+        pluralName: 'tests',
+        singularName: 'test',
+      },
+      attributes: {
+        title: {
+          type: 'string',
+        },
+        relation: {
+          type: 'relation',
+          relation: 'oneToOne',
+          target: 'api::relation.relation',
+        },
+        media: {
+          type: 'media',
+        },
+        multiMedia: {
+          type: 'media',
+          multiple: true,
+        },
+        repeatableCompo: {
+          type: 'component',
+          repeatable: true,
+          component: 'default.test',
+        },
+        compo: {
+          type: 'component',
+          component: 'default.test',
+        },
+        dz: {
+          type: 'dynamiczone',
+          components: ['default.test'],
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return undefined;
+      },
+      components: {
+        'default.test': {
+          attributes: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    } as any;
+
+    expect(
+      transforms.transformResponse(
+        {
+          id: 1,
+          documentId: 'abcd',
+          title: 'Hello',
+          relation: { id: 1, documentId: 'abcd', value: 'test' },
+          media: { id: 1, documentId: 'abcd', value: 'test' },
+          multiMedia: [{ id: 1, documentId: 'abcd', value: 'test' }],
+          repeatableCompo: [{ id: 1, name: 'test' }],
+          compo: { id: 1, name: 'test' },
+          dz: [{ id: 2, name: 'test', __component: 'default.test' }],
+        },
+        undefined,
+        { contentType, useJsonAPIFormat: true }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        documentId: 'abcd',
+        attributes: {
+          title: 'Hello',
+          relation: {
+            data: {
+              id: 1,
+              documentId: 'abcd',
+              attributes: { value: 'test' },
+            },
+          },
+          media: {
+            data: {
+              id: 1,
+              documentId: 'abcd',
+              attributes: {
+                value: 'test',
+              },
+            },
+          },
+          multiMedia: {
+            data: [
+              {
+                id: 1,
+                documentId: 'abcd',
+                attributes: {
+                  value: 'test',
+                },
+              },
+            ],
+          },
+          repeatableCompo: [
+            {
+              id: 1,
+              name: 'test',
+            },
+          ],
+          compo: {
+            id: 1,
+            name: 'test',
+          },
+          dz: [
+            {
+              __component: 'default.test',
+              id: 2,
+              name: 'test',
+            },
+          ],
+        },
+      },
+      meta: {},
+    });
+  });
+
   test('Leaves nil values untouched', () => {
     expect(transforms.transformResponse()).toBeUndefined();
     expect(transforms.transformResponse(null)).toBe(null);
@@ -231,6 +362,76 @@ describe('Transforms', () => {
           {
             id: 1,
             value: 'test',
+          },
+        ],
+      },
+      meta: {},
+    });
+  });
+
+  test('Handles components & dynamic zones', () => {
+    const contentType: Schema.ContentType = {
+      globalId: 'test',
+      kind: 'collectionType',
+      modelName: 'test',
+      modelType: 'contentType',
+      uid: 'api::test.test',
+      info: {
+        displayName: 'test',
+        pluralName: 'tests',
+        singularName: 'test',
+      },
+      attributes: {
+        compo: {
+          type: 'component',
+          component: 'default.test',
+        },
+        dz: {
+          type: 'dynamiczone',
+          components: ['default.test'],
+        },
+      },
+    };
+
+    global.strapi = {
+      contentType() {
+        return undefined;
+      },
+      components: {
+        'default.test': {
+          attributes: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    } as any;
+
+    expect(
+      transforms.transformResponse(
+        {
+          id: 1,
+          title: 'Hello',
+          compo: { id: 1, name: 'test' },
+          dz: [{ id: 2, name: 'test', __component: 'default.test' }],
+        },
+        undefined,
+        { contentType }
+      )
+    ).toStrictEqual({
+      data: {
+        id: 1,
+        title: 'Hello',
+        compo: {
+          id: 1,
+          name: 'test',
+        },
+        dz: [
+          {
+            __component: 'default.test',
+            id: 2,
+            name: 'test',
           },
         ],
       },

--- a/packages/core/core/src/core-api/controller/index.ts
+++ b/packages/core/core/src/core-api/controller/index.ts
@@ -6,6 +6,7 @@ import type { CoreApi, Schema } from '@strapi/types';
 import { transformResponse } from './transform';
 import { createSingleTypeController } from './single-type';
 import { createCollectionTypeController } from './collection-type';
+import requestCtx from '../../services/request-context';
 
 const isSingleType = (contentType: Schema.ContentType): contentType is Schema.SingleType =>
   contentTypeUtils.isSingleType(contentType);
@@ -24,7 +25,11 @@ function createController({
 
   const proto: CoreApi.Controller.Base = {
     transformResponse(data, meta) {
-      return transformResponse(data, meta, { contentType });
+      const ctx = requestCtx.get();
+      return transformResponse(data, meta, {
+        contentType,
+        useJsonAPIFormat: ctx?.headers?.['strapi-response-format'] === 'v4',
+      });
     },
 
     async sanitizeOutput(data, ctx) {

--- a/packages/core/core/src/core-api/controller/transform.ts
+++ b/packages/core/core/src/core-api/controller/transform.ts
@@ -26,13 +26,18 @@ function isDZEntries(property: unknown): property is (Entry & { __component: UID
   return Array.isArray(property);
 }
 
+interface TransformOptions {
+  contentType?: Schema.ContentType | Schema.Component;
+  /**
+   * @deprecated this option is deprecated and will be removed in the next major version
+   */
+  useJsonAPIFormat?: boolean;
+}
+
 const transformResponse = (
   resource: any,
   meta: unknown = {},
-  opts: {
-    contentType?: Schema.ContentType | Schema.Component;
-    useJsonAPIFormat?: boolean;
-  } = {
+  opts: TransformOptions = {
     useJsonAPIFormat: false,
   }
 ) => {
@@ -68,8 +73,8 @@ function transformComponent(
     return res;
   }
 
-  const { id, documentId, attributes } = res;
-  return { id, documentId, ...attributes };
+  const { id, attributes } = res;
+  return { id, ...attributes };
 }
 
 function transformEntry<T extends Entry | Entry[] | null>(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a header to get a response format following v4 old shape to ease v5 migration.

### Why is it needed?

To help with migrating to v5

### How to test it?

Call the content-api (only affects core-api) with a `Strapi-Response-Format: v4` header to get the old format

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
