### PR TITLE
fix: documentation updated to match the new aws sdk requirements

### DIFF
--- a/packages/providers/upload-aws-s3/README.md
+++ b/packages/providers/upload-aws-s3/README.md
@@ -113,7 +113,7 @@ module.exports = ({ env }) => ({
 
 #### Configuration for S3 compatible services
 
-This plugin may work with S3 compatible services by using the `endpoint` option instead of `region`. Scaleway example:
+This plugin may work with S3 compatible services by using the `endpoint`. Scaleway example:
 `./config/plugins.js`
 
 ```js
@@ -127,7 +127,8 @@ module.exports = ({ env }) => ({
           accessKeyId: env('SCALEWAY_ACCESS_KEY_ID'),
           secretAccessKey: env('SCALEWAY_ACCESS_SECRET'),
         },
-        endpoint: env('SCALEWAY_ENDPOINT'), // e.g. "s3.fr-par.scw.cloud"
+        region: env('SCALEWAY_REGION'), // e.g "fr-par"
+        endpoint: env('SCALEWAY_ENDPOINT'), // e.g. "https://s3.fr-par.scw.cloud"
         params: {
           Bucket: env('SCALEWAY_BUCKET'),
         },


### PR DESCRIPTION
### What does it do?

Updates the documentation to set up a different provider than AWS, which was wrong.

### Why is it needed?

To avoid misleading the users

### How to test it?

Check this project's configuration and see that it works. If you set up the previously documented configuration it won't.
[s3-test.zip](https://github.com/strapi/strapi/files/14493708/s3-test.zip)


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/19085
