### PR TITLE
Fix #19576 : database '$contains' route read escaped values with underscore

### DIFF
--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -308,8 +308,10 @@ const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, v
       qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${value}`]);
       break;
     }
-    case '$contains': {
-      qb.where(column, 'like', `%${value}%`);
+    case "$contains": {
+      const escapedValue = value.replace(/_/g, '\\_');
+
+      qb.whereRaw(`${column} LIKE ? ESCAPE '\\'`, [`%${escapedValue}%`]);
       break;
     }
 


### PR DESCRIPTION
### What does it do?

Escaping the underscore (which is used as a wildcard in SQL) with a backwards slash (adding a backwards slash before the underscore), so it is interpreted as a normal character by SQL.

### Why is it needed?

Underscore was not being recognized as a normal character, therefore the search results when the criteria involved an underscore were misleading.

### How to test it?

Build the application with the new fix. Afterwards, use the contains filter with any underscore, results will now be valid. 

Check [underlying issue](https://github.com/strapi/strapi/issues/19576) for further details on the problem.

### Alternatives

This will run for all values, even if they don't contain an underscore. Nontheless, these won't be affected by the replace function.
However, if feasible, there is the possibility of adding an if block that would only convert the value to an escaped one if the actual string contains an underscore character.