### PR TITLE
feat(history): protect history page

### DIFF
--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -54,7 +54,7 @@ const Error = (props: ErrorProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Main height="100%">
+    <Main height="100vh">
       <Flex alignItems="center" height="100%" justifyContent="center">
         <EmptyStateLayout
           icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
@@ -85,7 +85,7 @@ const NoPermissions = (props: NoPermissionsProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Main height="100%">
+    <Main height="100vh">
       <Flex alignItems="center" height="100%" justifyContent="center">
         <EmptyStateLayout
           icon={<EmptyPermissions width="10rem" />}

--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -57,16 +57,14 @@ const Error = (props: ErrorProps) => {
   return (
     <Main height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
-        <Box minWidth="50%">
-          <EmptyStateLayout
-            icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
-            content={formatMessage({
-              id: 'anErrorOccurred',
-              defaultMessage: 'Woops! Something went wrong. Please, try again.',
-            })}
-            {...props}
-          />
-        </Box>
+        <EmptyStateLayout
+          icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
+          content={formatMessage({
+            id: 'anErrorOccurred',
+            defaultMessage: 'Woops! Something went wrong. Please, try again.',
+          })}
+          {...props}
+        />
       </Flex>
     </Main>
   );

--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -9,7 +9,7 @@ import {
   Main,
 } from '@strapi/design-system';
 import { useAPIErrorHandler, useNotification, useRBACProvider } from '@strapi/helper-plugin';
-import { EmptyPermissions, ExclamationMarkCircle } from '@strapi/icons';
+import { EmptyPermissions, ExclamationMarkCircle, EmptyDocuments } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { Permission } from '../../../shared/contracts/shared';
@@ -54,7 +54,7 @@ const Error = (props: ErrorProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Main height="100vh">
+    <Main height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
         <EmptyStateLayout
           icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
@@ -85,13 +85,44 @@ const NoPermissions = (props: NoPermissionsProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Main height="100vh">
+    <Main height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
         <EmptyStateLayout
           icon={<EmptyPermissions width="10rem" />}
           content={formatMessage({
             id: 'app.components.EmptyStateLayout.content-permissions',
             defaultMessage: "You don't have the permissions to access that content",
+          })}
+          {...props}
+        />
+      </Flex>
+    </Main>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * NoData
+ * -----------------------------------------------------------------------------------------------*/
+interface NoDataProps extends Partial<EmptyStateLayoutProps> {}
+
+/**
+ * @public
+ * @description A component that should be rendered as the page
+ * when there is no data available to display.
+ * This component does not check any permissions, it's up to you to decide
+ * when it should be rendered.
+ */
+const NoData = (props: NoDataProps) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Main height="100%">
+      <Flex alignItems="center" height="100%" justifyContent="center">
+        <EmptyStateLayout
+          icon={<EmptyDocuments width="10rem" />}
+          content={formatMessage({
+            id: 'app.components.EmptyStateLayout.content-document',
+            defaultMessage: 'No content found',
           })}
           {...props}
         />
@@ -187,6 +218,7 @@ const Page = {
   Loading,
   NoPermissions,
   Protect,
+  NoData,
 };
 
 export { Page };

--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
 import {
+  Box,
   EmptyStateLayout,
-  EmptyStateLayoutProps,
+  type EmptyStateLayoutProps,
   Flex,
   Icon,
   Loader,
@@ -56,14 +57,16 @@ const Error = (props: ErrorProps) => {
   return (
     <Main height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
-        <EmptyStateLayout
-          icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
-          content={formatMessage({
-            id: 'anErrorOccurred',
-            defaultMessage: 'Woops! Something went wrong. Please, try again.',
-          })}
-          {...props}
-        />
+        <Box minWidth="50%">
+          <EmptyStateLayout
+            icon={<Icon as={ExclamationMarkCircle} width="10rem" />}
+            content={formatMessage({
+              id: 'anErrorOccurred',
+              defaultMessage: 'Woops! Something went wrong. Please, try again.',
+            })}
+            {...props}
+          />
+        </Box>
       </Flex>
     </Main>
   );
@@ -87,14 +90,16 @@ const NoPermissions = (props: NoPermissionsProps) => {
   return (
     <Main height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
-        <EmptyStateLayout
-          icon={<EmptyPermissions width="10rem" />}
-          content={formatMessage({
-            id: 'app.components.EmptyStateLayout.content-permissions',
-            defaultMessage: "You don't have the permissions to access that content",
-          })}
-          {...props}
-        />
+        <Box minWidth="50%">
+          <EmptyStateLayout
+            icon={<EmptyPermissions width="10rem" />}
+            content={formatMessage({
+              id: 'app.components.EmptyStateLayout.content-permissions',
+              defaultMessage: "You don't have the permissions to access that content",
+            })}
+            {...props}
+          />
+        </Box>
       </Flex>
     </Main>
   );
@@ -117,15 +122,17 @@ const NoData = (props: NoDataProps) => {
 
   return (
     <Main height="100%">
-      <Flex alignItems="center" height="100%" justifyContent="center">
-        <EmptyStateLayout
-          icon={<EmptyDocuments width="10rem" />}
-          content={formatMessage({
-            id: 'app.components.EmptyStateLayout.content-document',
-            defaultMessage: 'No content found',
-          })}
-          {...props}
-        />
+      <Flex alignItems="center" height="100%" width="100%" justifyContent="center">
+        <Box minWidth="50%">
+          <EmptyStateLayout
+            icon={<EmptyDocuments width="10rem" />}
+            content={formatMessage({
+              id: 'app.components.EmptyStateLayout.content-document',
+              defaultMessage: 'No content found',
+            })}
+            {...props}
+          />
+        </Box>
       </Flex>
     </Main>
   );

--- a/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/components/VersionContent.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 
 import { Form } from '../../../components/Form';
+import { Page } from '../../../components/PageHelpers';
 import {
   InputRenderer,
   type InputRendererProps,

--- a/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/pages/History.tsx
@@ -6,7 +6,7 @@ import { Contracts } from '@strapi/plugin-content-manager/_internal/shared';
 import { stringify } from 'qs';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import { createContext } from '../../../components/Context';
 import { Page } from '../../../components/PageHelpers';
@@ -115,7 +115,7 @@ const HistoryPage = () => {
   if (versionsResponse.data?.data.length && !selectedVersionId) {
     return (
       <Navigate
-        to={`?${stringify({ ...query, id: versionsResponse?.data?.data[0].id })}`}
+        to={{ search: stringify({ ...query, id: versionsResponse?.data?.data[0].id }) }}
         replace
       />
     );

--- a/packages/core/admin/admin/src/content-manager/history/routes.tsx
+++ b/packages/core/admin/admin/src/content-manager/history/routes.tsx
@@ -8,20 +8,20 @@ const routes: RouteObject[] = [
   {
     path: ':collectionType/:slug/:id/history',
     lazy: async () => {
-      const { HistoryPage } = await import('./pages/History');
+      const { ProtectedHistoryPage } = await import('./pages/History');
 
       return {
-        Component: HistoryPage,
+        Component: ProtectedHistoryPage,
       };
     },
   },
   {
     path: ':collectionType/:slug/history',
     lazy: async () => {
-      const { HistoryPage } = await import('./pages/History');
+      const { ProtectedHistoryPage } = await import('./pages/History');
 
       return {
-        Component: HistoryPage,
+        Component: ProtectedHistoryPage,
       };
     },
   },


### PR DESCRIPTION
### What does it do?

- Wraps the history page in Page.Protect to guard it from users without permissions
- The ticket says to redirect when the user doesn't have permissions but here I implemented the same behavior as the EditViewPage to be consistent. Open to discussion.

### Why is it needed?

- So users without permissions can't access the page

### How to test it?

- Crete a user with an editor role
- Revoke all permissions from a content-type
- As a super admin make some changes to an entry in that content-type, copy the history page url
- Try to access the url as an editor. 
- You should see a "No permissions" state

NOTE: 
- Custom conditions throw an error. I believe this is a known issue according to the v5 bug board

### Related issue(s)/PR(s)

CS-496
