### PR TITLE
fix(core): check value of publishedAt when building idMap

### DIFF
--- a/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
@@ -102,7 +102,8 @@ const extractDataIds = (
               sourceUid: opts.uid,
               sourceLocale: opts.locale,
             }),
-            isDraft: opts.isDraft,
+            // @ts-expect-error TODO: fix types
+            isDraft: !value?.publishedAt && opts.isDraft,
           });
         });
       }

--- a/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
@@ -147,7 +147,8 @@ const transformDataIdsVisitor = (
                 sourceLocale: opts.locale,
               }
             ),
-            isDraft: opts.isDraft,
+            // @ts-expect-error - TODO: fix types
+            isDraft: !value?.publishedAt && opts.isDraft,
           });
 
           if (entryId) return entryId;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Also rely on the publishedAt value when building the idMap for doc ID transformation

### Why is it needed?

- To support upload plugin folders, this CT doesn't have D&P. This allows us to save content with media inside folders
- Will we need this to support non D&P content types anyway @Marc-Roig ?

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

CONTENT-2252
