### PR TITLE
Fix: audit logs content type

### DIFF
--- a/packages/providers/audit-logs-local/src/index.ts
+++ b/packages/providers/audit-logs-local/src/index.ts
@@ -16,6 +16,11 @@ export default {
   async register({ strapi }: { strapi: Strapi }) {
     const contentTypes = strapi.get('content-types');
     if (!contentTypes.keys().includes('admin::audit-log')) {
+      const { schema } = auditLogContentType;
+      Object.assign(schema, {
+        plugin: 'admin',
+        globalId: `admin-${schema.info.singularName}`,
+      });
       strapi.get('content-types').add('admin::', { 'audit-log': auditLogContentType });
     }
 


### PR DESCRIPTION
### What does it do?

- Adds two missing properties from audit logs schema (plugin and globalId)

### Why is it needed?

- The CTB creation and edit breaks if those properties are missing
- It seems the refactoring of how we register admin contentTypes broke this in V5

### How to test it?

- Run a strapi project in EE with audit-logs, check if you can edit and create contentTypes in the CTB

