### PR TITLE
fix(content-releases): exclude release content-types from graphql

### DIFF
--- a/packages/core/content-releases/server/src/__tests__/index.test.ts
+++ b/packages/core/content-releases/server/src/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable node/no-missing-require */
 
-import { ACTIONS } from '../constants';
+import { ACTIONS, RELEASE_ACTION_MODEL_UID, RELEASE_MODEL_UID } from '../constants';
 
 const { features } = require('@strapi/strapi/dist/utils/ee');
 const { register } = require('../register');
@@ -18,18 +18,31 @@ jest.mock('../utils', () => ({
   getService: jest.fn(),
 }));
 
+const mockGraphQlDisable = jest.fn();
+const mockGraphQlShadowCrud = jest.fn(() => ({
+  disable: mockGraphQlDisable,
+}));
 describe('register', () => {
   const strapi = {
     features: {
       future: {
-        isEnabled: () => true,
+        isEnabled: jest.fn(() => true),
       },
     },
-    plugin: jest.fn(() => ({
-      service: jest.fn(() => ({
-        addDestroyListenerCallback: jest.fn(),
-      })),
-    })),
+    plugins: {
+      'content-releases': {
+        service: jest.fn(() => ({
+          addDestroyListenerCallback: jest.fn(),
+        })),
+      },
+      graphql: {
+        service: jest.fn(() => ({
+          shadowCRUD: mockGraphQlShadowCrud,
+        })),
+      },
+    },
+    // @ts-expect-error ignore
+    plugin: (plugin) => strapi.plugins[plugin],
     hook: jest.fn(() => ({
       register: jest.fn().mockReturnThis(),
     })),
@@ -50,7 +63,9 @@ describe('register', () => {
 
   it('should register permissions if cms-content-releases feature is enabled', () => {
     features.isEnabled.mockReturnValue(true);
+
     register({ strapi });
+
     expect(strapi.admin.services.permission.actionProvider.registerMany).toHaveBeenCalledWith(
       ACTIONS
     );
@@ -58,8 +73,30 @@ describe('register', () => {
 
   it('should not register permissions if cms-content-releases feature is disabled', () => {
     features.isEnabled.mockReturnValue(false);
+
     register({ strapi });
+
     expect(strapi.admin.services.permission.actionProvider.registerMany).not.toHaveBeenCalled();
+  });
+
+  it('should exclude the release and release action models from the GraphQL schema when the feature is enabled', async () => {
+    features.isEnabled.mockReturnValue(true);
+
+    await register({ strapi });
+
+    expect(mockGraphQlShadowCrud).toHaveBeenNthCalledWith(1, RELEASE_MODEL_UID);
+    expect(mockGraphQlShadowCrud).toHaveBeenNthCalledWith(2, RELEASE_ACTION_MODEL_UID);
+    expect(mockGraphQlDisable).toHaveBeenCalledTimes(2);
+  });
+
+  it('should exclude the release and release action models from the GraphQL schema when the feature is disabled', async () => {
+    features.isEnabled.mockReturnValue(false);
+
+    await register({ strapi });
+
+    expect(mockGraphQlShadowCrud).toHaveBeenNthCalledWith(1, RELEASE_MODEL_UID);
+    expect(mockGraphQlShadowCrud).toHaveBeenNthCalledWith(2, RELEASE_ACTION_MODEL_UID);
+    expect(mockGraphQlDisable).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/core/content-releases/server/src/index.ts
+++ b/packages/core/content-releases/server/src/index.ts
@@ -22,8 +22,10 @@ const getPlugin = () => {
     };
   }
 
-  // We keep returning contentTypes to avoid lost the data if feature is disabled
   return {
+    // Always return register, it handles its own feature check
+    register,
+    // Always return contentTypes to avoid losing data when the feature is disabled
     contentTypes,
   };
 };

--- a/packages/core/content-releases/server/src/register.ts
+++ b/packages/core/content-releases/server/src/register.ts
@@ -24,8 +24,9 @@ export const register = async ({ strapi }: { strapi: LoadedStrapi }) => {
   }
 
   if (strapi.plugin('graphql')) {
+    const graphqlExtensionService = strapi.plugin('graphql').service('extension');
     // Exclude the release and release action models from the GraphQL schema
-    strapi.plugin('graphql').service('extension').shadowCRUD(RELEASE_MODEL_UID).disable();
-    strapi.plugin('graphql').service('extension').shadowCRUD(RELEASE_ACTION_MODEL_UID).disable();
+    graphqlExtensionService.shadowCRUD(RELEASE_MODEL_UID).disable();
+    graphqlExtensionService.shadowCRUD(RELEASE_ACTION_MODEL_UID).disable();
   }
 };

--- a/packages/core/content-releases/server/src/register.ts
+++ b/packages/core/content-releases/server/src/register.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import type { LoadedStrapi } from '@strapi/types';
 
-import { ACTIONS } from './constants';
+import { ACTIONS, RELEASE_MODEL_UID, RELEASE_ACTION_MODEL_UID } from './constants';
 import {
   deleteActionsOnDeleteContentType,
   deleteActionsOnDisableDraftAndPublish,
@@ -21,5 +21,11 @@ export const register = async ({ strapi }: { strapi: LoadedStrapi }) => {
       .register(deleteActionsOnDeleteContentType)
       .register(revalidateChangedContentTypes)
       .register(migrateIsValidAndStatusReleases);
+  }
+
+  if (strapi.plugin('graphql')) {
+    // Exclude the release and release action models from the GraphQL schema
+    strapi.plugin('graphql').service('extension').shadowCRUD(RELEASE_MODEL_UID).disable();
+    strapi.plugin('graphql').service('extension').shadowCRUD(RELEASE_ACTION_MODEL_UID).disable();
   }
 };


### PR DESCRIPTION
### What does it do?
- Exclude release content types from graphql
- Alway run register function from graphql. Since the content types are registered with or without a license we also need to exclude them with or without a license

### Why is it needed?

- Release data should not be exposed to the content-api or graphql

### How to test it?

- Run yarn setup
- Run yarn develop in examples/getstarted
- Go to localhost:1337/graphql, click schema on the right hand side
- Search for 'release'
- You should not find anything related to releases in the schema

Do the above with and without a license
