### PR TITLE
test: increase playwright timeouts again

### DIFF
--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -45,7 +45,7 @@ const createConfig = ({ port, testDir, appDir }) => ({
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: getEnvNum(process.env.PLAYWRIGHT_EXPECT_TIMEOUT, 10 * 1000),
+    timeout: getEnvNum(process.env.PLAYWRIGHT_EXPECT_TIMEOUT, 20 * 1000),
   },
   /* Run tests in files in parallel */
   fullyParallel: false,
@@ -63,7 +63,7 @@ const createConfig = ({ port, testDir, appDir }) => ({
     baseURL: `http://127.0.0.1:${port}`,
 
     /* Default time each action such as `click()` can take to 20s */
-    actionTimeout: getEnvNum(process.env.PLAYWRIGHT_ACTION_TIMEOUT, 15 * 1000),
+    actionTimeout: getEnvNum(process.env.PLAYWRIGHT_ACTION_TIMEOUT, 20 * 1000),
 
     /* Collect trace when a test failed on the CI. See https://playwright.dev/docs/trace-viewer
        Until https://github.com/strapi/strapi/issues/18196 is fixed we can't enable this locally,


### PR DESCRIPTION
### What does it do?

increase playwright expect timeouts again

### Why is it needed?

firefox e2e tests are failing sometimes from timeouts most likely

### How to test it?

e2e tests should pass every time

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
