### PR TITLE
fix: change actions locale when changes on localization

### DIFF
--- a/packages/core/content-releases/server/src/register.ts
+++ b/packages/core/content-releases/server/src/register.ts
@@ -7,6 +7,8 @@ import {
   deleteActionsOnDisableDraftAndPublish,
   migrateIsValidAndStatusReleases,
   revalidateChangedContentTypes,
+  disableContentTypeLocalized,
+  enableContentTypeLocalized,
 } from './migrations';
 
 const { features } = require('@strapi/strapi/dist/utils/ee');
@@ -15,10 +17,14 @@ export const register = async ({ strapi }: { strapi: LoadedStrapi }) => {
   if (features.isEnabled('cms-content-releases')) {
     await strapi.admin.services.permission.actionProvider.registerMany(ACTIONS);
 
-    strapi.hook('strapi::content-types.beforeSync').register(deleteActionsOnDisableDraftAndPublish);
+    strapi
+      .hook('strapi::content-types.beforeSync')
+      .register(deleteActionsOnDisableDraftAndPublish)
+      .register(disableContentTypeLocalized);
     strapi
       .hook('strapi::content-types.afterSync')
       .register(deleteActionsOnDeleteContentType)
+      .register(enableContentTypeLocalized)
       .register(revalidateChangedContentTypes)
       .register(migrateIsValidAndStatusReleases);
   }


### PR DESCRIPTION
### What does it do?

When localisation is enabled/disabled on a ContentType we update the locale of the actions from that ContentType.

### How to test it?

1. Create a Release and add entries to it.
2. Try to enabled/disabled i18n on the entries' content type.
3. When you disabled i18n all actions should change its locale to null ('-')
4. When you enabled i18n all actions should change from null to the default locale
