### PR TITLE
Add sizeInBytes on resized and optimized images

### DIFF
--- a/api-tests/core/upload/admin/file-image.test.api.js
+++ b/api-tests/core/upload/admin/file-image.test.api.js
@@ -96,6 +96,7 @@ describe('Upload', () => {
               ext: '.png',
               mime: 'image/png',
               size: expect.any(Number),
+              sizeInBytes: expect.any(Number),
               width: expect.any(Number),
               height: expect.any(Number),
               url: expect.any(String),

--- a/api-tests/core/upload/content-api/upload.test.api.js
+++ b/api-tests/core/upload/content-api/upload.test.api.js
@@ -139,6 +139,7 @@ describe('Upload plugin', () => {
               ext: '.png',
               mime: 'image/png',
               size: expect.any(Number),
+              sizeInBytes: expect.any(Number),
               width: expect.any(Number),
               height: expect.any(Number),
               url: expect.any(String),

--- a/packages/core/upload/server/services/image-manipulation.js
+++ b/packages/core/upload/server/services/image-manipulation.js
@@ -59,7 +59,7 @@ const resizeFileTo = async (file, options, { name, hash }) => {
 
   const { width, height, size } = await getMetadata(newFile);
 
-  Object.assign(newFile, { width, height, size: bytesToKbytes(size) });
+  Object.assign(newFile, { width, height, size: bytesToKbytes(size), sizeInBytes: size });
   return newFile;
 };
 
@@ -112,13 +112,14 @@ const optimize = async (file) => {
 
   if (newSize > size) {
     // Ignore optimization if output is bigger than original
-    return { ...file, width, height, size: bytesToKbytes(size) };
+    return { ...file, width, height, size: bytesToKbytes(size), sizeInBytes: size };
   }
 
   return Object.assign(newFile, {
     width: newWidth,
     height: newHeight,
     size: bytesToKbytes(newSize),
+    sizeInBytes: newSize,
   });
 };
 


### PR DESCRIPTION
### What does it do?

Adds the `sizeInBytes` attribute for images that have been resized and update it for optimized images.

### Why is it needed?

The previous PR https://github.com/strapi/strapi/pull/19593 was incomplete, it added the attribute only for the original file and not thumbnails or responsive images.

### How to test it?

Upload an image and verify the the upload provider receives the file size for all sizes, as expected.

### Related issue(s)/PR(s)

Original PR https://github.com/strapi/strapi/pull/19593
