### PR TITLE
chore: refactor CM, CTB & i18n to accomodate option D&P

### DIFF
--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -8,7 +8,9 @@
     "description": "",
     "name": "Address"
   },
-  "options": {},
+  "options": {
+    "draftAndPublish": false
+  },
   "pluginOptions": {},
   "attributes": {
     "postal_code": {

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/EditViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/EditViewPage.tsx
@@ -54,11 +54,24 @@ const EditViewPage = () => {
     };
   }>(null);
 
+  const {
+    document,
+    meta,
+    isLoading: isLoadingDocument,
+    schema,
+    components,
+    collectionType,
+    id,
+    model,
+  } = useDoc();
+
+  const hasDraftAndPublished = schema?.options?.draftAndPublish ?? false;
+
   React.useEffect(() => {
-    if (tabApi.current) {
+    if (tabApi.current && hasDraftAndPublished) {
       tabApi.current._handlers.setSelectedTabIndex(!status || status === 'draft' ? 0 : 1);
     }
-  }, [status]);
+  }, [hasDraftAndPublished, status]);
 
   useOnce(() => {
     /**
@@ -76,16 +89,6 @@ const EditViewPage = () => {
   });
 
   const isLoadingActionsRBAC = useDocumentRBAC('EditViewPage', (state) => state.isLoading);
-  const {
-    document,
-    meta,
-    isLoading: isLoadingDocument,
-    schema,
-    components,
-    collectionType,
-    id,
-    model,
-  } = useDoc();
 
   const isSingleType = collectionType === SINGLE_TYPES;
 
@@ -158,14 +161,14 @@ const EditViewPage = () => {
   return (
     <Main paddingLeft={10} paddingRight={10}>
       <Form
-        disabled={status === 'published'}
+        disabled={hasDraftAndPublished && status === 'published'}
         initialValues={initialValues}
         method={isCreatingDocument ? 'POST' : 'PUT'}
         validationSchema={createYupSchema(schema?.attributes, components)}
       >
         <Header
           isCreating={isCreatingDocument}
-          status={getDocumentStatus(document, meta)}
+          status={hasDraftAndPublished ? getDocumentStatus(document, meta) : undefined}
           title={documentTitle}
         />
         <TabGroup
@@ -175,23 +178,25 @@ const EditViewPage = () => {
             id: getTranslation('containers.edit.tabs.label'),
             defaultMessage: 'Document status',
           })}
-          initialSelectedTabIndex={status === 'published' ? 1 : 0}
+          initialSelectedTabIndex={hasDraftAndPublished && status === 'published' ? 1 : 0}
           onTabChange={handleTabChange}
         >
-          <Tabs>
-            <StatusTab>
-              {formatMessage({
-                id: getTranslation('containers.edit.tabs.draft'),
-                defaultMessage: 'draft',
-              })}
-            </StatusTab>
-            <StatusTab disabled={!meta || meta.availableStatus.length === 0}>
-              {formatMessage({
-                id: getTranslation('containers.edit.tabs.published'),
-                defaultMessage: 'published',
-              })}
-            </StatusTab>
-          </Tabs>
+          {hasDraftAndPublished ? (
+            <Tabs>
+              <StatusTab>
+                {formatMessage({
+                  id: getTranslation('containers.edit.tabs.draft'),
+                  defaultMessage: 'draft',
+                })}
+              </StatusTab>
+              <StatusTab disabled={!meta || meta.availableStatus.length === 0}>
+                {formatMessage({
+                  id: getTranslation('containers.edit.tabs.published'),
+                  defaultMessage: 'published',
+                })}
+              </StatusTab>
+            </Tabs>
+          ) : null}
           <Grid paddingTop={8} gap={4}>
             <GridItem col={9} s={12}>
               <TabPanels>

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/DocumentActions.tsx
@@ -29,6 +29,7 @@ import { isBaseQueryError } from '../../../../utils/baseQuery';
 import { PUBLISHED_AT_ATTRIBUTE_NAME } from '../../../constants/attributes';
 import { SINGLE_TYPES } from '../../../constants/collections';
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
+import { useDoc } from '../../../hooks/useDocument';
 import { useDocumentActions } from '../../../hooks/useDocumentActions';
 import { CLONE_PATH } from '../../../router';
 import { buildValidParams } from '../../../utils/api';
@@ -486,6 +487,7 @@ const PublishAction: DocumentActionComponent = ({
   meta,
   document,
 }) => {
+  const { schema } = useDoc();
   const navigate = useNavigate();
   const toggleNotification = useNotification();
   const { _unstableFormatValidationErrors: formatValidationErrors } = useAPIErrorHandler();
@@ -509,6 +511,10 @@ const PublishAction: DocumentActionComponent = ({
     (document?.[PUBLISHED_AT_ATTRIBUTE_NAME] ||
       meta?.availableStatus.some((doc) => doc[PUBLISHED_AT_ATTRIBUTE_NAME] !== null)) &&
     document?.status !== 'modified';
+
+  if (!schema?.options?.draftAndPublish) {
+    return null;
+  }
 
   return {
     /**
@@ -740,6 +746,7 @@ const UnpublishAction: DocumentActionComponent = ({
   document,
 }) => {
   const { formatMessage } = useIntl();
+  const { schema } = useDoc();
   const canPublish = useDocumentRBAC('UnpublishAction', ({ canPublish }) => canPublish);
   const { unpublish } = useDocumentActions();
   const [{ query }] = useQueryParams();
@@ -755,6 +762,10 @@ const UnpublishAction: DocumentActionComponent = ({
       setShouldKeepDraft(e.target.value === UNPUBLISH_DRAFT_OPTIONS.KEEP);
     }
   };
+
+  if (!schema?.options?.draftAndPublish) {
+    return null;
+  }
 
   return {
     disabled:
@@ -890,10 +901,15 @@ const DiscardAction: DocumentActionComponent = ({
   document,
 }) => {
   const { formatMessage } = useIntl();
+  const { schema } = useDoc();
   const canUpdate = useDocumentRBAC('DiscardAction', ({ canUpdate }) => canUpdate);
   const { discard } = useDocumentActions();
   const [{ query }] = useQueryParams();
   const params = React.useMemo(() => buildValidParams(query), [query]);
+
+  if (!schema?.options?.draftAndPublish) {
+    return null;
+  }
 
   return {
     disabled: !canUpdate || activeTab === 'published' || document?.status !== 'modified',

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
@@ -50,11 +50,7 @@ interface HeaderProps {
   title?: string;
 }
 
-const Header = ({
-  isCreating,
-  status = 'draft',
-  title: documentTitle = 'Untitled',
-}: HeaderProps) => {
+const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: HeaderProps) => {
   const { formatMessage } = useIntl();
   const isCloning = useMatch(CLONE_PATH) !== null;
 
@@ -89,11 +85,13 @@ const Header = ({
         </Typography>
         <HeaderToolbar />
       </Flex>
-      <Status showBullet={false} size={'S'} variant={isCloning ? 'primary' : statusVariant}>
-        <Typography as="span" variant="omega" fontWeight="bold">
-          {capitalise(isCloning ? 'draft' : status)}
-        </Typography>
-      </Status>
+      {status ? (
+        <Status showBullet={false} size={'S'} variant={isCloning ? 'primary' : statusVariant}>
+          <Typography as="span" variant="omega" fontWeight="bold">
+            {capitalise(isCloning ? 'draft' : status)}
+          </Typography>
+        </Status>
+      ) : null}
     </Flex>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/tests/Header.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/tests/Header.test.tsx
@@ -44,7 +44,7 @@ describe('Header', () => {
     });
 
   it('should render the create entry title when isCreating is true', async () => {
-    const { rerender } = render({ isCreating: true });
+    const { rerender } = render({ isCreating: true, status: 'draft' });
 
     expect(screen.getByRole('heading', { name: 'Create an entry' })).toBeInTheDocument();
     expect(screen.getByText('Draft')).toBeInTheDocument();
@@ -76,6 +76,18 @@ describe('Header', () => {
     rerender(<Header status="modified" />);
 
     expect(screen.getByText('Modified')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'More actions' })).toBeDisabled()
+    );
+  });
+
+  it('should not render any status if there is no prop', async () => {
+    render();
+
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
+    expect(screen.queryByText('Published')).not.toBeInTheDocument();
+    expect(screen.queryByText('Modified')).not.toBeInTheDocument();
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'More actions' })).toBeDisabled()

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
@@ -187,24 +187,32 @@ const ListViewPage = () => {
       };
     });
 
-    formattedHeaders.push({
-      attribute: {
-        type: 'custom',
-      },
-      name: 'status',
-      label: {
-        id: getTranslation(`containers.list.table-headers.status`),
-        defaultMessage: 'status',
-      },
-      searchable: false,
-      sortable: false,
-    } satisfies ListFieldLayout);
+    if (schema?.options?.draftAndPublish) {
+      formattedHeaders.push({
+        attribute: {
+          type: 'custom',
+        },
+        name: 'status',
+        label: {
+          id: getTranslation(`containers.list.table-headers.status`),
+          defaultMessage: 'status',
+        },
+        searchable: false,
+        sortable: false,
+      } satisfies ListFieldLayout);
+    }
 
     if (reviewWorkflowColumns) {
       formattedHeaders.push(...reviewWorkflowColumns);
     }
     return formattedHeaders;
-  }, [displayedHeaders, list, reviewWorkflowColumns, runHookWaterfall]);
+  }, [
+    displayedHeaders,
+    list,
+    reviewWorkflowColumns,
+    runHookWaterfall,
+    schema?.options?.draftAndPublish,
+  ]);
 
   /* -------------------------------------------------------------------------------------------------
    * Methods

--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -191,29 +191,35 @@ export const FormModal = () => {
         });
       }
 
-      // Create content type
+      // Create content type we need to add the default option draftAndPublish
       if (modalType === 'contentType' && actionType === 'create') {
         dispatch({
           type: SET_DATA_TO_EDIT,
           modalType,
           actionType,
-          data: {},
+          data: {
+            draftAndPublish: true,
+          },
           pluginOptions: {},
         });
       }
 
       // Edit content type
       if (modalType === 'contentType' && actionType === 'edit') {
-        const { displayName, kind, pluginOptions, pluralName, reviewWorkflows, singularName } = get(
-          allDataSchema,
-          [...pathToSchema, 'schema'],
-          {
-            displayName: null,
-            pluginOptions: {},
-            singularName: null,
-            pluralName: null,
-          }
-        );
+        const {
+          displayName,
+          draftAndPublish,
+          kind,
+          pluginOptions,
+          pluralName,
+          reviewWorkflows,
+          singularName,
+        } = get(allDataSchema, [...pathToSchema, 'schema'], {
+          displayName: null,
+          pluginOptions: {},
+          singularName: null,
+          pluralName: null,
+        });
 
         dispatch({
           type: SET_DATA_TO_EDIT,
@@ -221,6 +227,7 @@ export const FormModal = () => {
           modalType,
           data: {
             displayName,
+            draftAndPublish,
             kind,
             pluginOptions,
             pluralName,

--- a/packages/core/content-type-builder/admin/src/components/FormModal/contentType/contentTypeForm.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/contentType/contentTypeForm.ts
@@ -15,7 +15,22 @@ export const contentTypeForm = {
       return {
         sections: [
           {
-            items: [],
+            items: [
+              {
+                intlLabel: {
+                  id: getTrad('contentType.draftAndPublish.label'),
+                  defaultMessage: 'Draft & publish',
+                },
+                description: {
+                  id: getTrad('contentType.draftAndPublish.description'),
+                  defaultMessage:
+                    'Allows writing a draft version of an entry, before it is published',
+                },
+                name: 'draftAndPublish',
+                type: 'toggle-draft-publish',
+                validations: {},
+              },
+            ],
           },
         ],
       };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.ts
@@ -188,6 +188,7 @@ export const createContentTypeSchema = ({
         },
       })
       .required(errorsTrads.required),
+    draftAndPublish: yup.boolean(),
     kind: yup.string().oneOf(['singleType', 'collectionType']),
     reviewWorkflows: yup.boolean(),
   };

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -5,12 +5,12 @@ import { useNotification, useQueryParams } from '@strapi/helper-plugin';
 import { ExclamationMarkCircle, Trash } from '@strapi/icons';
 import {
   type HeaderActionComponent,
-  unstable_useDocument,
+  unstable_useDocument as useDocument,
   unstable_useDocumentActions as useDocumentActions,
   type DocumentActionComponent,
 } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useI18n } from '../hooks/useI18n';
@@ -24,11 +24,18 @@ import type { I18nBaseQuery } from '../types';
  * LocalePickerAction
  * -----------------------------------------------------------------------------------------------*/
 
-const LocalePickerAction: HeaderActionComponent = ({ document, meta }) => {
+const LocalePickerAction: HeaderActionComponent = ({
+  document,
+  meta,
+  model,
+  collectionType,
+  documentId,
+}) => {
   const { formatMessage } = useIntl();
   const [{ query }, setQuery] = useQueryParams<I18nBaseQuery>();
   const { hasI18n, canCreate, canRead } = useI18n();
   const { data: locales = [] } = useGetLocalesQuery();
+  const { schema } = useDocument({ model, collectionType, documentId });
 
   const handleSelect = React.useCallback(
     (value: string) => {
@@ -91,7 +98,7 @@ const LocalePickerAction: HeaderActionComponent = ({ document, meta }) => {
         disabled: !permissionsToCheck.includes(locale.code),
         value: locale.code,
         label: locale.name,
-        startIcon: (
+        startIcon: schema?.options?.draftAndPublish ? (
           <Status
             display="flex"
             paddingLeft="6px"
@@ -106,7 +113,7 @@ const LocalePickerAction: HeaderActionComponent = ({ document, meta }) => {
               {capitalize(status)}
             </Typography>
           </Status>
-        ),
+        ) : null,
       };
     }),
     onSelect: handleSelect,
@@ -114,7 +121,7 @@ const LocalePickerAction: HeaderActionComponent = ({ document, meta }) => {
   };
 };
 
-type UseDocument = typeof unstable_useDocument;
+type UseDocument = typeof useDocument;
 
 const getDocumentStatus = (
   document: ReturnType<UseDocument>['document'],

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -10,7 +10,7 @@ import {
   type DocumentActionComponent,
 } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useI18n } from '../hooks/useI18n';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds the option in the CTB to disable D&P
* refactors the EditView/Header to not show a status if it does not exist as a prop
* does not add the status column to the list-view if D&P is disabled
* does not display tabs or enable status query to manage tabs in the edit-view if D&P is disabled
* does not display the status in the locale picker from i18n

### Related issue(s)/PR(s)

* resolves CONTENT-2224
* resolves CONTENT-2232
* resolves CONTENT-2233
* resolves CONTENT-2234
* resolves CONTENT-2236
* resolves CONTENT-2237
