### PR TITLE
chore: import and export as type whenever possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/preset-react": "7.18.6",
     "@playwright/test": "1.38.1",
     "@strapi/admin-test-utils": "workspace:*",
-    "@strapi/eslint-config": "0.2.0",
+    "@strapi/eslint-config": "0.2.1",
     "@swc/cli": "0.1.62",
     "@swc/core": "1.3.58",
     "@swc/helpers": "0.5.1",

--- a/packages/admin-test-utils/src/fixtures/collection-types/address.ts
+++ b/packages/admin-test-utils/src/fixtures/collection-types/address.ts
@@ -421,4 +421,5 @@ const address = {
 
 type Address = typeof address;
 
-export { address, Address };
+export type { Address };
+export { address };

--- a/packages/admin-test-utils/src/fixtures/collection-types/index.ts
+++ b/packages/admin-test-utils/src/fixtures/collection-types/index.ts
@@ -1,3 +1,4 @@
 import { address, type Address } from './address';
 
-export { Address, address };
+export type { Address };
+export { address };

--- a/packages/admin-test-utils/src/fixtures/meta-data/address.ts
+++ b/packages/admin-test-utils/src/fixtures/meta-data/address.ts
@@ -98,4 +98,5 @@ const address = {
 
 type Address = typeof address;
 
-export { address, Address };
+export type { Address };
+export { address };

--- a/packages/admin-test-utils/src/fixtures/meta-data/index.ts
+++ b/packages/admin-test-utils/src/fixtures/meta-data/index.ts
@@ -1,3 +1,4 @@
 import { address, type Address } from './address';
 
-export { Address, address };
+export type { Address };
+export { address };

--- a/packages/admin-test-utils/src/fixtures/permissions/admin-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/admin-permissions.ts
@@ -1907,4 +1907,5 @@ const app = {
 type Admin = typeof admin;
 type App = typeof app;
 
-export { admin, Admin, app, App };
+export type { Admin, App };
+export { admin, app };

--- a/packages/admin-test-utils/src/fixtures/permissions/content-manager-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/content-manager-permissions.ts
@@ -60,4 +60,5 @@ const contentManager = [
 
 type ContentManager = typeof contentManager;
 
-export { contentManager, ContentManager };
+export type { ContentManager };
+export { contentManager };

--- a/packages/admin-test-utils/src/fixtures/permissions/content-type-builder-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/content-type-builder-permissions.ts
@@ -39,4 +39,5 @@ const contentTypeBuilder = [
 
 type ContentTypeBuilder = typeof contentTypeBuilder;
 
-export { contentTypeBuilder, ContentTypeBuilder };
+export type { ContentTypeBuilder };
+export { contentTypeBuilder };

--- a/packages/admin-test-utils/src/fixtures/permissions/documentation-permissions.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/documentation-permissions.ts
@@ -31,4 +31,5 @@ const documentation = [
 
 type Documentation = typeof documentation;
 
-export { documentation, Documentation };
+export type { Documentation };
+export { documentation };

--- a/packages/admin-test-utils/src/fixtures/permissions/index.ts
+++ b/packages/admin-test-utils/src/fixtures/permissions/index.ts
@@ -14,16 +14,5 @@ const allPermissions = [...admin, ...contentManager, ...contentTypeBuilder, ...d
 
 type AdminPermissions = typeof allPermissions;
 
-export {
-  admin,
-  Admin,
-  app,
-  App,
-  contentManager,
-  ContentManager,
-  contentTypeBuilder,
-  ContentTypeBuilder,
-  allPermissions,
-  AdminPermissions,
-  Documentation,
-};
+export type { Admin, App, ContentManager, ContentTypeBuilder, AdminPermissions, Documentation };
+export { admin, app, contentManager, contentTypeBuilder, allPermissions };

--- a/packages/core/content-manager/server/src/middlewares/routing.ts
+++ b/packages/core/content-manager/server/src/middlewares/routing.ts
@@ -1,4 +1,4 @@
-import { UID, Common, Schema } from '@strapi/types';
+import type { UID, Common, Schema } from '@strapi/types';
 import type { Context, Next } from 'koa';
 import isNil from 'lodash/isNil';
 

--- a/packages/core/content-manager/server/src/policies/has-draft-and-publish.ts
+++ b/packages/core/content-manager/server/src/policies/has-draft-and-publish.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'koa';
 import { contentTypes } from '@strapi/utils';
-import { Strapi, UID } from '@strapi/types';
+import type { Strapi, UID } from '@strapi/types';
 
 const { hasDraftAndPublish } = contentTypes;
 

--- a/packages/core/content-manager/server/src/services/components.ts
+++ b/packages/core/content-manager/server/src/services/components.ts
@@ -1,6 +1,6 @@
 import { has, isNil, mapValues } from 'lodash/fp';
 
-import { Strapi, UID, Schema } from '@strapi/types';
+import type { Strapi, UID, Schema } from '@strapi/types';
 import type { Configuration } from '../../../shared/contracts/content-types';
 import type { ConfigurationUpdate } from './configuration';
 

--- a/packages/core/content-manager/server/src/services/content-types.ts
+++ b/packages/core/content-manager/server/src/services/content-types.ts
@@ -1,7 +1,7 @@
 import { isNil, mapValues } from 'lodash/fp';
 import { contentTypes as contentTypesUtils } from '@strapi/utils';
 
-import { LoadedStrapi as Strapi, UID, Schema } from '@strapi/types';
+import type { LoadedStrapi as Strapi, UID, Schema } from '@strapi/types';
 
 import type { ConfigurationUpdate } from './configuration';
 

--- a/packages/core/content-manager/server/src/services/data-mapper.ts
+++ b/packages/core/content-manager/server/src/services/data-mapper.ts
@@ -1,6 +1,6 @@
 import { pick, getOr } from 'lodash/fp';
 import { contentTypes as contentTypesUtils } from '@strapi/utils';
-import { Attribute, Schema } from '@strapi/types';
+import type { Attribute, Schema } from '@strapi/types';
 
 const dtoFields = [
   'uid',

--- a/packages/core/content-manager/server/src/services/field-sizes.ts
+++ b/packages/core/content-manager/server/src/services/field-sizes.ts
@@ -1,5 +1,5 @@
 import { errors } from '@strapi/utils';
-import { LoadedStrapi as Strapi, CustomFields } from '@strapi/types';
+import type { LoadedStrapi as Strapi, CustomFields } from '@strapi/types';
 
 const { ApplicationError } = errors;
 

--- a/packages/core/content-manager/server/src/services/metrics.ts
+++ b/packages/core/content-manager/server/src/services/metrics.ts
@@ -1,6 +1,6 @@
 import { intersection, prop } from 'lodash/fp';
 import { relations } from '@strapi/utils';
-import { LoadedStrapi as Strapi, Schema } from '@strapi/types';
+import type { LoadedStrapi as Strapi, Schema } from '@strapi/types';
 import type { Configuration } from '../../../shared/contracts/content-types';
 
 const { getRelationalFields } = relations;

--- a/packages/core/content-manager/server/src/services/permission-checker.ts
+++ b/packages/core/content-manager/server/src/services/permission-checker.ts
@@ -1,5 +1,5 @@
 import { pipeAsync } from '@strapi/utils';
-import { LoadedStrapi as Strapi, EntityService, Common } from '@strapi/types';
+import type { LoadedStrapi as Strapi, EntityService, Common } from '@strapi/types';
 
 const ACTIONS = {
   read: 'plugin::content-manager.explorer.read',

--- a/packages/core/content-manager/server/src/services/permission.ts
+++ b/packages/core/content-manager/server/src/services/permission.ts
@@ -1,6 +1,6 @@
 import { prop } from 'lodash/fp';
 import { contentTypes as contentTypesUtils } from '@strapi/utils';
-import { LoadedStrapi as Strapi, Schema } from '@strapi/types';
+import type { LoadedStrapi as Strapi, Schema } from '@strapi/types';
 
 import { getService } from '../utils';
 

--- a/packages/core/content-manager/server/src/services/uid.ts
+++ b/packages/core/content-manager/server/src/services/uid.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import slugify from '@sindresorhus/slugify';
 
-import { LoadedStrapi as Strapi, UID, Attribute } from '@strapi/types';
+import type { LoadedStrapi as Strapi, UID, Attribute } from '@strapi/types';
 
 export default ({ strapi }: { strapi: Strapi }) => ({
   async generateUIDField({

--- a/packages/core/content-manager/server/src/services/utils/count.ts
+++ b/packages/core/content-manager/server/src/services/utils/count.ts
@@ -1,4 +1,4 @@
-import { Common, Schema } from '@strapi/types';
+import type { Common, Schema } from '@strapi/types';
 import { contentTypes } from '@strapi/utils';
 import type { Entity } from '../entity-manager';
 

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -1,6 +1,6 @@
 import { merge, isEmpty, set, propEq } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
-import { Common, Attribute, EntityService } from '@strapi/types';
+import type { Common, Attribute, EntityService } from '@strapi/types';
 
 const { hasDraftAndPublish, isVisibleAttribute } = strapiUtils.contentTypes;
 const { isAnyToMany } = strapiUtils.relations;

--- a/packages/core/data-transfer/src/commands/commander.ts
+++ b/packages/core/data-transfer/src/commands/commander.ts
@@ -3,7 +3,8 @@
  */
 
 import inquirer from 'inquirer';
-import { Command, InvalidOptionArgumentError, Option } from 'commander';
+import type { Command } from 'commander';
+import { InvalidOptionArgumentError, Option } from 'commander';
 import chalk from 'chalk';
 import { isNaN } from 'lodash/fp';
 import { exitWith } from './helpers';

--- a/packages/core/data-transfer/src/commands/data-transfer.ts
+++ b/packages/core/data-transfer/src/commands/data-transfer.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
-import { Command, Option } from 'commander';
+import type { Command } from 'commander';
+import { Option } from 'commander';
 import { configs, createLogger } from '@strapi/logger';
 import strapiFactory from '@strapi/strapi';
 import ora from 'ora';
@@ -10,7 +11,7 @@ import type { LoadedStrapi, Strapi } from '@strapi/types';
 import { readableBytes, exitWith } from './helpers';
 import { getParseListWithChoices, parseInteger, confirmMessage } from './commander';
 import * as engineDatatransfer from '../engine';
-import * as strapiDataTransfer from '../strapi';
+import type * as strapiDataTransfer from '../strapi';
 
 const {
   errors: { TransferEngineInitializationError },

--- a/packages/core/data-transfer/src/commands/export/action.ts
+++ b/packages/core/data-transfer/src/commands/export/action.ts
@@ -16,7 +16,8 @@ import {
   setSignalHandler,
 } from '../data-transfer';
 import { exitWith } from '../helpers';
-import { TransferGroupFilter, createTransferEngine, ITransferResults, errors } from '../../engine';
+import type { TransferGroupFilter, ITransferResults } from '../../engine';
+import { createTransferEngine, errors } from '../../engine';
 import * as strapiDatatransfer from '../../strapi';
 import * as file from '../../file';
 

--- a/packages/core/data-transfer/src/commands/export/command.ts
+++ b/packages/core/data-transfer/src/commands/export/command.ts
@@ -1,4 +1,5 @@
-import { Command, Option } from 'commander';
+import type { Command } from 'commander';
+import { Option } from 'commander';
 import { excludeOption, onlyOption, throttleOption, validateExcludeOnly } from '../data-transfer';
 import { promptEncryptionKey } from '../commander';
 import action from './action';

--- a/packages/core/data-transfer/src/commands/import/command.ts
+++ b/packages/core/data-transfer/src/commands/import/command.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { Command, Option } from 'commander';
+import type { Command } from 'commander';
+import { Option } from 'commander';
 import inquirer from 'inquirer';
 import { excludeOption, onlyOption, throttleOption, validateExcludeOnly } from '../data-transfer';
 import { getCommanderConfirmMessage, forceOption } from '../commander';

--- a/packages/core/data-transfer/src/commands/transfer/command.ts
+++ b/packages/core/data-transfer/src/commands/transfer/command.ts
@@ -1,5 +1,6 @@
 import inquirer from 'inquirer';
-import { Command, Option } from 'commander';
+import type { Command } from 'commander';
+import { Option } from 'commander';
 import { getCommanderConfirmMessage, forceOption, parseURL } from '../commander';
 import { exitWith, assertUrlHasProtocol, ifOptions } from '../helpers';
 import { excludeOption, onlyOption, throttleOption, validateExcludeOnly } from '../data-transfer';

--- a/packages/core/data-transfer/src/engine/errors.ts
+++ b/packages/core/data-transfer/src/engine/errors.ts
@@ -1,4 +1,5 @@
-import { DataTransferError, Severity, SeverityKind } from '../errors';
+import type { Severity } from '../errors';
+import { DataTransferError, SeverityKind } from '../errors';
 
 type TransferEngineStep = 'initialization' | 'validation' | 'transfer';
 

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -37,12 +37,8 @@ import type { Diff } from '../utils/json';
 import { compareSchemas, validateProvider } from './validation';
 
 import { TransferEngineError, TransferEngineValidationError } from './errors';
-import type {
-  IDiagnosticReporter,
-  ErrorDiagnosticSeverity } from './diagnostic';
-import {
-  createDiagnosticReporter
-} from './diagnostic';
+import type { IDiagnosticReporter, ErrorDiagnosticSeverity } from './diagnostic';
+import { createDiagnosticReporter } from './diagnostic';
 import type { DataTransferError } from '../errors';
 import * as utils from '../utils';
 import { ProviderTransferError } from '../errors/providers';

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -1,4 +1,5 @@
-import { PassThrough, Transform, Readable, Writable } from 'stream';
+import type { Readable, Writable } from 'stream';
+import { PassThrough, Transform } from 'stream';
 import { extname } from 'path';
 import { EOL } from 'os';
 import type Chain from 'stream-chain';
@@ -36,12 +37,13 @@ import type { Diff } from '../utils/json';
 import { compareSchemas, validateProvider } from './validation';
 
 import { TransferEngineError, TransferEngineValidationError } from './errors';
-import {
-  createDiagnosticReporter,
+import type {
   IDiagnosticReporter,
-  ErrorDiagnosticSeverity,
+  ErrorDiagnosticSeverity } from './diagnostic';
+import {
+  createDiagnosticReporter
 } from './diagnostic';
-import { DataTransferError } from '../errors';
+import type { DataTransferError } from '../errors';
 import * as utils from '../utils';
 import { ProviderTransferError } from '../errors/providers';
 

--- a/packages/core/data-transfer/src/errors/base.ts
+++ b/packages/core/data-transfer/src/errors/base.ts
@@ -1,4 +1,4 @@
-import { Severity } from './constants';
+import type { Severity } from './constants';
 
 class DataTransferError<T = unknown> extends Error {
   origin: string;

--- a/packages/core/data-transfer/src/errors/constants.ts
+++ b/packages/core/data-transfer/src/errors/constants.ts
@@ -1,4 +1,4 @@
-import { ErrorDiagnosticSeverity } from '../engine/diagnostic';
+import type { ErrorDiagnosticSeverity } from '../engine/diagnostic';
 
 export const SeverityKind: Record<string, ErrorDiagnosticSeverity> = {
   FATAL: 'fatal',

--- a/packages/core/data-transfer/src/errors/providers.ts
+++ b/packages/core/data-transfer/src/errors/providers.ts
@@ -1,6 +1,7 @@
-import { ErrorCode } from '../../types';
+import type { ErrorCode } from '../../types';
 import { DataTransferError } from './base';
-import { Severity, SeverityKind } from './constants';
+import type { Severity } from './constants';
+import { SeverityKind } from './constants';
 
 type ProviderStep = 'initialization' | 'validation' | 'transfer';
 

--- a/packages/core/data-transfer/src/file/providers/destination/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/file/providers/destination/__tests__/index.test.ts
@@ -5,7 +5,8 @@ jest.mock('fs');
 
 import fs from 'fs-extra';
 import { Writable } from 'stream-chain';
-import { createLocalFileDestinationProvider, ILocalFileDestinationProviderOptions } from '..';
+import type { ILocalFileDestinationProviderOptions } from '..';
+import { createLocalFileDestinationProvider } from '..';
 import * as encryption from '../../../../utils/encryption';
 import { createFilePathFactory, createTarEntryStream } from '../utils';
 

--- a/packages/core/data-transfer/src/file/providers/destination/utils.ts
+++ b/packages/core/data-transfer/src/file/providers/destination/utils.ts
@@ -1,6 +1,6 @@
 import { Writable } from 'stream';
 import { posix } from 'path';
-import tar from 'tar-stream';
+import type tar from 'tar-stream';
 
 /**
  * Create a file path factory for a given path & prefix.

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
@@ -5,7 +5,7 @@ import {
   getContentTypes,
   setGlobalStrapi,
 } from '../../../../__tests__/test-utils';
-import { IConfiguration } from '../../../../../types';
+import type { IConfiguration } from '../../../../../types';
 
 const entities = [
   {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/configuration.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/configuration.ts
@@ -3,7 +3,7 @@ import { omit } from 'lodash/fp';
 import chalk from 'chalk';
 import type { LoadedStrapi } from '@strapi/types';
 import { ProviderTransferError } from '../../../../../errors/providers';
-import { IConfiguration, Transaction } from '../../../../../../types';
+import type { IConfiguration, Transaction } from '../../../../../../types';
 
 const omitInvalidCreationAttributes = omit(['id']);
 

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/links.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/links.ts
@@ -1,7 +1,7 @@
 import { Writable } from 'stream';
 import type { LoadedStrapi } from '@strapi/types';
 import { ProviderTransferError } from '../../../../../errors/providers';
-import { ILink, Transaction } from '../../../../../../types';
+import type { ILink, Transaction } from '../../../../../../types';
 import { createLinkQuery } from '../../../../queries/link';
 
 interface ErrorWithCode extends Error {

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -1,8 +1,10 @@
 import { join } from 'path';
 import https from 'https';
 import http from 'http';
-import { Duplex, PassThrough, Readable } from 'stream';
-import { stat, createReadStream, ReadStream } from 'fs-extra';
+import type { Readable } from 'stream';
+import { Duplex, PassThrough } from 'stream';
+import type { ReadStream } from 'fs-extra';
+import { stat, createReadStream } from 'fs-extra';
 import type { LoadedStrapi } from '@strapi/types';
 
 import type { IAsset } from '../../../../types';

--- a/packages/core/data-transfer/src/strapi/providers/local-source/entities.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/entities.ts
@@ -2,7 +2,7 @@ import { Readable, Transform } from 'stream';
 import type { LoadedStrapi, Schema } from '@strapi/types';
 
 import * as shared from '../../queries';
-import { IEntity } from '../../../../types';
+import type { IEntity } from '../../../../types';
 
 /**
  * Generate and consume content-types streams in order to stream each entity individually

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/__tests__/utils.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from 'ws';
 import { TRANSFER_PATH } from '../../../remote/constants';
-import { CommandMessage } from '../../../../../types/remote/protocol/client';
+import type { CommandMessage } from '../../../../../types/remote/protocol/client';
 import { createDispatcher } from '../../utils';
 
 jest.useFakeTimers();

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { Writable } from 'stream';
-import { WebSocket } from 'ws';
+import type { WebSocket } from 'ws';
 import { once } from 'lodash/fp';
 import type { Schema, Utils } from '@strapi/types';
 

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -1,6 +1,7 @@
-import { PassThrough, Readable, Writable } from 'stream';
+import type { Readable, Writable } from 'stream';
+import { PassThrough } from 'stream';
 import type { Schema, Utils } from '@strapi/types';
-import { WebSocket } from 'ws';
+import type { WebSocket } from 'ws';
 import { castArray } from 'lodash/fp';
 
 import type {
@@ -13,10 +14,10 @@ import type {
   ProviderType,
   TransferStage,
 } from '../../../../types';
-import { Client, Server, Auth } from '../../../../types/remote/protocol';
+import type { Client, Server, Auth } from '../../../../types/remote/protocol';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
 import { TRANSFER_PATH } from '../../remote/constants';
-import { ILocalStrapiSourceProviderOptions } from '../local-source';
+import type { ILocalStrapiSourceProviderOptions } from '../local-source';
 import { createDispatcher, connectToWebsocket, trimTrailingSlash } from '../utils';
 
 export interface IRemoteStrapiSourceProviderOptions extends ILocalStrapiSourceProviderOptions {

--- a/packages/core/data-transfer/src/strapi/providers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/providers/utils.ts
@@ -1,14 +1,16 @@
 import { randomUUID } from 'crypto';
-import { RawData, WebSocket } from 'ws';
+import type { RawData } from 'ws';
+import { WebSocket } from 'ws';
 
 import type { Client, Server } from '../../../types/remote/protocol';
 
+import type {
+  ProviderErrorDetails } from '../../errors/providers';
 import {
   ProviderError,
   ProviderTransferError,
   ProviderInitializationError,
-  ProviderValidationError,
-  ProviderErrorDetails,
+  ProviderValidationError
 } from '../../errors/providers';
 
 interface IDispatcherState {

--- a/packages/core/data-transfer/src/strapi/providers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/providers/utils.ts
@@ -4,13 +4,12 @@ import { WebSocket } from 'ws';
 
 import type { Client, Server } from '../../../types/remote/protocol';
 
-import type {
-  ProviderErrorDetails } from '../../errors/providers';
+import type { ProviderErrorDetails } from '../../errors/providers';
 import {
   ProviderError,
   ProviderTransferError,
   ProviderInitializationError,
-  ProviderValidationError
+  ProviderValidationError,
 } from '../../errors/providers';
 
 interface IDispatcherState {

--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -2,7 +2,7 @@ import type { Knex } from 'knex';
 import { clone, isNil } from 'lodash/fp';
 import type { LoadedStrapi } from '@strapi/types';
 
-import { ILink } from '../../../types';
+import type { ILink } from '../../../types';
 
 // TODO: Remove any types when we'll have types for DB metadata
 

--- a/packages/core/data-transfer/src/strapi/remote/handlers/pull.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/pull.ts
@@ -2,12 +2,13 @@ import { Readable } from 'stream';
 import { randomUUID } from 'crypto';
 import type { LoadedStrapi } from '@strapi/types';
 
-import { Handler } from './abstract';
+import type { Handler } from './abstract';
 import { handlerControllerFactory, isDataTransferMessage } from './utils';
-import { createLocalStrapiSourceProvider, ILocalStrapiSourceProvider } from '../../providers';
+import type { ILocalStrapiSourceProvider } from '../../providers';
+import { createLocalStrapiSourceProvider } from '../../providers';
 import { ProviderTransferError } from '../../../errors/providers';
 import type { IAsset, TransferStage, Protocol } from '../../../../types';
-import { Client } from '../../../../types/remote/protocol';
+import type { Client } from '../../../../types/remote/protocol';
 
 const TRANSFER_KIND = 'pull';
 const VALID_TRANSFER_ACTIONS = ['bootstrap', 'close', 'getMetadata', 'getSchemas'] as const;

--- a/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
@@ -8,7 +8,7 @@ import type { TransferStage, IAsset, Protocol } from '../../../../types';
 import { ProviderTransferError } from '../../../errors/providers';
 import { createLocalStrapiDestinationProvider } from '../../providers';
 import { createFlow, DEFAULT_TRANSFER_FLOW } from '../flows';
-import { Handler } from './abstract';
+import type { Handler } from './abstract';
 import { handlerControllerFactory, isDataTransferMessage } from './utils';
 
 const VALID_TRANSFER_ACTIONS = [

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -1,14 +1,15 @@
 import type { IncomingMessage } from 'http';
 import { randomUUID } from 'crypto';
 import type { Context } from 'koa';
-import type { RawData, ServerOptions } from 'ws';
-import { WebSocket, WebSocketServer } from 'ws';
+import type { RawData, ServerOptions, WebSocketServer } from 'ws';
+import { WebSocket } from 'ws';
 
 import type { Handler, TransferState } from './abstract';
 import type { Protocol } from '../../../../types';
 import { ProviderError, ProviderTransferError } from '../../../errors/providers';
-import { VALID_TRANSFER_COMMANDS, ValidTransferCommand } from './constants';
-import { TransferMethod } from '../constants';
+import type { ValidTransferCommand } from './constants';
+import { VALID_TRANSFER_COMMANDS } from './constants';
+import type { TransferMethod } from '../constants';
 
 type WSCallback = (client: WebSocket, request: IncomingMessage) => void;
 

--- a/packages/core/data-transfer/src/utils/encryption/decrypt.ts
+++ b/packages/core/data-transfer/src/utils/encryption/decrypt.ts
@@ -1,5 +1,6 @@
-import { Cipher, scryptSync, CipherKey, BinaryLike, createDecipheriv } from 'crypto';
-import { EncryptionStrategy, Strategies, Algorithm } from '../../../types';
+import type { Cipher, CipherKey, BinaryLike } from 'crypto';
+import { scryptSync, createDecipheriv } from 'crypto';
+import type { EncryptionStrategy, Strategies, Algorithm } from '../../../types';
 
 // different key values depending on algorithm chosen
 const getDecryptionStrategy = (algorithm: Algorithm): EncryptionStrategy => {

--- a/packages/core/data-transfer/src/utils/encryption/encrypt.ts
+++ b/packages/core/data-transfer/src/utils/encryption/encrypt.ts
@@ -1,5 +1,6 @@
-import { createCipheriv, Cipher, scryptSync, CipherKey, BinaryLike } from 'crypto';
-import { EncryptionStrategy, Strategies, Algorithm } from '../../../types';
+import type { Cipher, CipherKey, BinaryLike } from 'crypto';
+import { createCipheriv, scryptSync } from 'crypto';
+import type { EncryptionStrategy, Strategies, Algorithm } from '../../../types';
 
 // different key values depending on algorithm chosen
 const getEncryptionStrategy = (algorithm: Algorithm): EncryptionStrategy => {

--- a/packages/core/data-transfer/src/utils/middleware.ts
+++ b/packages/core/data-transfer/src/utils/middleware.ts
@@ -1,4 +1,4 @@
-import { Middleware } from '../../types';
+import type { Middleware } from '../../types';
 
 export const runMiddleware = async <T>(context: T, middlewares: Middleware<T>[]): Promise<void> => {
   if (!middlewares.length) {

--- a/packages/core/data-transfer/src/utils/stream.ts
+++ b/packages/core/data-transfer/src/utils/stream.ts
@@ -1,4 +1,5 @@
-import { Transform, Readable } from 'stream';
+import type { Readable } from 'stream';
+import { Transform } from 'stream';
 
 type TransformOptions = ConstructorParameters<typeof Transform>[0];
 

--- a/packages/core/data-transfer/src/utils/transaction.ts
+++ b/packages/core/data-transfer/src/utils/transaction.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { randomUUID } from 'crypto';
 import type { LoadedStrapi } from '@strapi/types';
 
-import { Transaction, TransactionCallback } from '../../types/utils';
+import type { Transaction, TransactionCallback } from '../../types/utils';
 
 export const createTransaction = (strapi: LoadedStrapi): Transaction => {
   const fns: { fn: TransactionCallback; uuid: string }[] = [];

--- a/packages/core/data-transfer/types/remote/protocol/client/transfer/pull.d.ts
+++ b/packages/core/data-transfer/types/remote/protocol/client/transfer/pull.d.ts
@@ -1,5 +1,5 @@
 import type { IEntity, ILink, IConfiguration } from '../../../../common-entities';
-import { CreateTransferMessage, TransferAssetFlow } from './utils';
+import type { CreateTransferMessage, TransferAssetFlow } from './utils';
 
 export type TransferPullMessage = CreateTransferMessage<
   'step',

--- a/packages/core/data-transfer/types/remote/protocol/server/messaging.d.ts
+++ b/packages/core/data-transfer/types/remote/protocol/server/messaging.d.ts
@@ -1,4 +1,4 @@
-import { TransferKind } from '../client';
+import type { TransferKind } from '../client';
 import type { ServerError } from './error';
 
 export type Message<T = unknown> = {

--- a/packages/core/database/src/__tests__/index.test.ts
+++ b/packages/core/database/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
-import { Database, DatabaseConfig } from '../index';
+import type { DatabaseConfig } from '../index';
+import { Database } from '../index';
 
 jest.mock('../connection', () => ({
   createConnection: jest.fn(() => {

--- a/packages/core/database/src/__tests__/lifecycles.test.ts
+++ b/packages/core/database/src/__tests__/lifecycles.test.ts
@@ -1,4 +1,5 @@
-import { createLifecyclesProvider, LifecycleProvider, Event, Subscriber } from '../lifecycles';
+import type { LifecycleProvider, Event, Subscriber } from '../lifecycles';
+import { createLifecyclesProvider } from '../lifecycles';
 import type { Database } from '..';
 
 describe('LifecycleProvider', () => {

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -53,7 +53,7 @@ import { DatabaseError } from '../errors';
 import type { Database } from '..';
 import type { Meta } from '../metadata';
 import type { ID } from '../types';
-import { EntityManager, Repository, Entity } from './types';
+import type { EntityManager, Repository, Entity } from './types';
 
 export * from './types';
 

--- a/packages/core/database/src/entity-manager/relations/cloning/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/relations/cloning/regular-relations.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 
 import { cleanInverseOrderColumn } from '../../regular-relations';
 import type { ID, Relation } from '../../../types';

--- a/packages/core/database/src/entity-manager/types.ts
+++ b/packages/core/database/src/entity-manager/types.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex';
 import type { ID } from '../types';
-import { QueryBuilder } from '../query/query-builder';
+import type { QueryBuilder } from '../query/query-builder';
 
 export type Data = Record<string, unknown>;
 

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -1,19 +1,26 @@
 import type { Knex } from 'knex';
 
-import { Dialect, getDialect } from './dialects';
-import { createSchemaProvider, SchemaProvider } from './schema';
-import { createMetadata, Metadata } from './metadata';
-import { createEntityManager, EntityManager } from './entity-manager';
-import { createMigrationsProvider, MigrationProvider } from './migrations';
-import { createLifecyclesProvider, LifecycleProvider } from './lifecycles';
+import type { Dialect } from './dialects';
+import { getDialect } from './dialects';
+import type { SchemaProvider } from './schema';
+import { createSchemaProvider } from './schema';
+import type { Metadata } from './metadata';
+import { createMetadata } from './metadata';
+import type { EntityManager } from './entity-manager';
+import { createEntityManager } from './entity-manager';
+import type { MigrationProvider } from './migrations';
+import { createMigrationsProvider } from './migrations';
+import type { LifecycleProvider } from './lifecycles';
+import { createLifecyclesProvider } from './lifecycles';
 import { createConnection } from './connection';
 import * as errors from './errors';
-import { Callback, transactionCtx, TransactionObject } from './transaction-context';
+import type { Callback, TransactionObject } from './transaction-context';
+import { transactionCtx } from './transaction-context';
 
 // TODO: move back into strapi
 import { transformContentTypes } from './utils/content-types';
 import { validateDatabase } from './validations';
-import { Model } from './types';
+import type { Model } from './types';
 
 export { isKnexQuery } from './utils/knex';
 

--- a/packages/core/database/src/metadata/index.ts
+++ b/packages/core/database/src/metadata/index.ts
@@ -12,7 +12,8 @@ import {
   hasInverseOrderColumn,
   isManyToAny,
 } from './relations';
-import { Metadata, Meta, ComponentLinkMeta } from './metadata';
+import type { Meta, ComponentLinkMeta } from './metadata';
+import { Metadata } from './metadata';
 import type { Attribute, Model, Relation } from '../types';
 
 export type { Metadata, Meta };

--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -4,7 +4,7 @@ import { fromRow } from '../transform';
 import type { QueryBuilder } from '../../query-builder';
 import type { Database } from '../../..';
 import type { Meta } from '../../../metadata';
-import { ID, RelationalAttribute, Relation } from '../../../types';
+import type { ID, RelationalAttribute, Relation } from '../../../types';
 
 type Context = {
   db: Database;

--- a/packages/core/database/src/query/helpers/streams/readable.ts
+++ b/packages/core/database/src/query/helpers/streams/readable.ts
@@ -6,7 +6,7 @@ import type { Database } from '../../..';
 
 import { applyPopulate } from '../populate';
 import { fromRow } from '../transform';
-import { Meta } from '../../../metadata';
+import type { Meta } from '../../../metadata';
 
 const knexQueryDone = Symbol('knexQueryDone');
 const knexPerformingQuery = Symbol('knexPerformingQuery');

--- a/packages/core/database/src/transaction-context.ts
+++ b/packages/core/database/src/transaction-context.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { Knex } from 'knex';
+import type { Knex } from 'knex';
 
 export type Callback = (...args: any[]) => Promise<any> | any;
 

--- a/packages/core/permissions/src/engine/index.ts
+++ b/packages/core/permissions/src/engine/index.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import qs from 'qs';
-import { Ability } from '@casl/ability';
-import { providerFactory } from '@strapi/utils';
+import type { Ability } from '@casl/ability';
+import type { providerFactory } from '@strapi/utils';
 
 import {
   createEngineHooks,
@@ -12,7 +12,7 @@ import {
 import type { PermissionEngineHooks, HookName } from './hooks';
 
 import * as abilities from './abilities';
-import { Permission } from '../domain/permission';
+import type { Permission } from '../domain/permission';
 import type { PermissionRule } from '../types';
 
 export { abilities };

--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -4,7 +4,8 @@
 import path from 'path';
 import _ from 'lodash';
 import { isFunction } from 'lodash/fp';
-import { Logger, createLogger } from '@strapi/logger';
+import type { Logger } from '@strapi/logger';
+import { createLogger } from '@strapi/logger';
 import { Database } from '@strapi/database';
 import { hooks } from '@strapi/utils';
 import type {
@@ -40,7 +41,8 @@ import { createContainer } from './container';
 import createStrapiFs from './services/fs';
 import createEventHub from './services/event-hub';
 import { createServer } from './services/server';
-import createWebhookRunner, { WebhookRunner } from './services/webhook-runner';
+import type { WebhookRunner } from './services/webhook-runner';
+import createWebhookRunner from './services/webhook-runner';
 import { webhookModel, createWebhookStore } from './services/webhook-store';
 import { createCoreStore, coreStoreModel } from './services/core-store';
 import createEntityService from './services/entity-service';
@@ -77,7 +79,8 @@ import convertCustomFieldType from './utils/convert-custom-field-type';
 
 // TODO: move somewhere else
 import * as draftAndPublishSync from './migrations/draft-publish';
-import { FeaturesService, createFeaturesService } from './services/features';
+import type { FeaturesService } from './services/features';
+import { createFeaturesService } from './services/features';
 
 /**
  * Resolve the working directories based on the instance options.

--- a/packages/core/strapi/src/admin.ts
+++ b/packages/core/strapi/src/admin.ts
@@ -1,4 +1,5 @@
-import { RenderAdminArgs, renderAdmin, Store } from '@strapi/admin/strapi-admin';
+import type { RenderAdminArgs, Store } from '@strapi/admin/strapi-admin';
+import { renderAdmin } from '@strapi/admin/strapi-admin';
 import contentTypeBuilder from '@strapi/plugin-content-type-builder/strapi-admin';
 import email from '@strapi/plugin-email/strapi-admin';
 // @ts-expect-error – No types, yet.

--- a/packages/core/strapi/src/commands/actions/plugin/build-command/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/build-command/action.ts
@@ -1,9 +1,11 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
-import { BuildCLIOptions, ConfigBundle, build } from '@strapi/pack-up';
+import type { BuildCLIOptions, ConfigBundle } from '@strapi/pack-up';
+import { build } from '@strapi/pack-up';
 import { notifyExperimentalCommand } from '../../../utils/helpers';
-import { Export, loadPkg, validatePkg } from '../../../utils/pkg';
-import { CLIContext } from '../../../types';
+import type { Export } from '../../../utils/pkg';
+import { loadPkg, validatePkg } from '../../../utils/pkg';
+import type { CLIContext } from '../../../types';
 
 interface ActionOptions extends BuildCLIOptions {
   force?: boolean;

--- a/packages/core/strapi/src/commands/actions/plugin/init/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/action.ts
@@ -3,21 +3,22 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import getLatestVersion from 'get-latest-version';
 import gitUrlParse from 'git-url-parse';
-import {
+import type {
   InitOptions,
+  TemplateFile } from '@strapi/pack-up';
+import {
   definePackageFeature,
   definePackageOption,
   defineTemplate,
-  init,
-  TemplateFile,
+  init
 } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 import { notifyExperimentalCommand } from '../../../utils/helpers';
 
-import { CLIContext } from '../../../types';
+import type { CLIContext } from '../../../types';
 import { gitIgnoreFile } from './files/gitIgnore';
 
-interface ActionOptions extends Pick<InitOptions, 'silent' | 'debug'> {}
+type ActionOptions = Pick<InitOptions, 'silent' | 'debug'>;
 
 export default async (
   packagePath: string,

--- a/packages/core/strapi/src/commands/actions/plugin/init/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/action.ts
@@ -3,15 +3,8 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import getLatestVersion from 'get-latest-version';
 import gitUrlParse from 'git-url-parse';
-import type {
-  InitOptions,
-  TemplateFile } from '@strapi/pack-up';
-import {
-  definePackageFeature,
-  definePackageOption,
-  defineTemplate,
-  init
-} from '@strapi/pack-up';
+import type { InitOptions, TemplateFile } from '@strapi/pack-up';
+import { definePackageFeature, definePackageOption, defineTemplate, init } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 import { notifyExperimentalCommand } from '../../../utils/helpers';
 

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/admin.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/admin.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const PLUGIN_ICON_CODE = outdent`

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/editorConfig.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/editorConfig.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const editorConfigFile: TemplateFile = {

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/eslint.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/eslint.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const eslintIgnoreFile: TemplateFile = {

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/gitIgnore.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/gitIgnore.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const gitIgnoreFile: TemplateFile = {

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/prettier.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/prettier.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const prettierFile: TemplateFile = {

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/server.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/server.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 const TYPESCRIPT = (pluginName: string): TemplateFile[] => [

--- a/packages/core/strapi/src/commands/actions/plugin/init/files/typescript.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/init/files/typescript.ts
@@ -1,4 +1,4 @@
-import { TemplateFile } from '@strapi/pack-up';
+import type { TemplateFile } from '@strapi/pack-up';
 import { outdent } from 'outdent';
 
 interface TsConfigFiles {

--- a/packages/core/strapi/src/commands/actions/plugin/link-watch/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/link-watch/action.ts
@@ -7,7 +7,7 @@ import nodemon from 'nodemon';
 import { outdent } from 'outdent';
 
 import { notifyExperimentalCommand } from '../../../utils/helpers';
-import { CLIContext } from '../../../types';
+import type { CLIContext } from '../../../types';
 import { loadPkg, validatePkg } from '../../../utils/pkg';
 
 interface ActionOptions {}

--- a/packages/core/strapi/src/commands/actions/plugin/verify/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/verify/action.ts
@@ -1,10 +1,11 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
-import { CheckOptions, check } from '@strapi/pack-up';
+import type { CheckOptions } from '@strapi/pack-up';
+import { check } from '@strapi/pack-up';
 import { notifyExperimentalCommand } from '../../../utils/helpers';
-import { CLIContext } from '../../../types';
+import type { CLIContext } from '../../../types';
 
-interface ActionOptions extends CheckOptions {}
+type ActionOptions = CheckOptions;
 
 export default async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {

--- a/packages/core/strapi/src/commands/actions/plugin/watch/action.ts
+++ b/packages/core/strapi/src/commands/actions/plugin/watch/action.ts
@@ -1,11 +1,13 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
-import { ConfigBundle, WatchCLIOptions, watch } from '@strapi/pack-up';
+import type { ConfigBundle, WatchCLIOptions } from '@strapi/pack-up';
+import { watch } from '@strapi/pack-up';
 import { notifyExperimentalCommand } from '../../../utils/helpers';
-import { Export, loadPkg, validatePkg } from '../../../utils/pkg';
-import { CLIContext } from '../../../types';
+import type { Export } from '../../../utils/pkg';
+import { loadPkg, validatePkg } from '../../../utils/pkg';
+import type { CLIContext } from '../../../types';
 
-interface ActionOptions extends WatchCLIOptions {}
+type ActionOptions = WatchCLIOptions;
 
 export default async (opts: ActionOptions, _cmd: unknown, { cwd, logger }: CLIContext) => {
   try {

--- a/packages/core/strapi/src/commands/actions/watch-admin/action.ts
+++ b/packages/core/strapi/src/commands/actions/watch-admin/action.ts
@@ -1,5 +1,5 @@
 import { watchAdmin } from '@strapi/admin';
-import { CLIContext } from '../../types';
+import type { CLIContext } from '../../types';
 
 interface WatchAdminOptions {
   browser: boolean;

--- a/packages/core/strapi/src/commands/index.ts
+++ b/packages/core/strapi/src/commands/index.ts
@@ -34,7 +34,7 @@ import verifyPluginCommand from './actions/plugin/verify/command';
 
 import { createLogger } from './utils/logger';
 import { loadTsConfig } from './utils/tsconfig';
-import { CLIContext } from './types';
+import type { CLIContext } from './types';
 
 const strapiCommands = {
   createAdminUser,

--- a/packages/core/strapi/src/commands/types.ts
+++ b/packages/core/strapi/src/commands/types.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'commander';
-import { Logger } from './utils/logger';
-import { TsConfig } from './utils/tsconfig';
+import type { Logger } from './utils/logger';
+import type { TsConfig } from './utils/tsconfig';
 
 export interface CLIContext {
   cwd: string;

--- a/packages/core/strapi/src/commands/utils/commander.ts
+++ b/packages/core/strapi/src/commands/utils/commander.ts
@@ -3,7 +3,8 @@
  */
 
 import inquirer from 'inquirer';
-import { Command, InvalidOptionArgumentError, Option } from 'commander';
+import type { Command } from 'commander';
+import { InvalidOptionArgumentError, Option } from 'commander';
 import chalk from 'chalk';
 import { isNaN } from 'lodash/fp';
 import { exitWith } from './helpers';

--- a/packages/core/strapi/src/commands/utils/pkg.ts
+++ b/packages/core/strapi/src/commands/utils/pkg.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import pkgUp from 'pkg-up';
 import * as yup from 'yup';
 import chalk from 'chalk';
-import { Logger } from './logger';
+import type { Logger } from './logger';
 
 interface Export {
   types?: string;

--- a/packages/core/strapi/src/core-api/service/__tests__/index.test.ts
+++ b/packages/core/strapi/src/core-api/service/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@strapi/types';
+import type { Schema } from '@strapi/types';
 import { createService } from '../index';
 
 describe('Default Service', () => {

--- a/packages/core/strapi/src/core/registries/config.ts
+++ b/packages/core/strapi/src/core/registries/config.ts
@@ -1,5 +1,6 @@
 import type { ConfigProvider } from '@strapi/types';
-import _, { PropertyName } from 'lodash';
+import type { PropertyName } from 'lodash';
+import _ from 'lodash';
 
 type Config = Record<string, unknown>;
 

--- a/packages/core/strapi/src/core/registries/content-types.ts
+++ b/packages/core/strapi/src/core/registries/content-types.ts
@@ -1,6 +1,7 @@
 import { pickBy, has } from 'lodash/fp';
 import type { Common, Schema } from '@strapi/types';
-import { createContentType, ContentTypeDefinition } from '../domain/content-type';
+import type { ContentTypeDefinition } from '../domain/content-type';
+import { createContentType } from '../domain/content-type';
 import { addNamespace, hasNamespace } from '../utils';
 
 type ContentTypesInput = Record<string, ContentTypeDefinition>;

--- a/packages/core/strapi/src/core/registries/modules.ts
+++ b/packages/core/strapi/src/core/registries/modules.ts
@@ -1,6 +1,7 @@
 import { pickBy, has } from 'lodash/fp';
 import type { Strapi } from '@strapi/types';
-import { createModule, RawModule, Module } from '../domain/module';
+import type { RawModule, Module } from '../domain/module';
+import { createModule } from '../domain/module';
 
 type ModuleMap = { [namespace: string]: Module };
 

--- a/packages/core/strapi/src/core/registries/sanitizers.ts
+++ b/packages/core/strapi/src/core/registries/sanitizers.ts
@@ -1,4 +1,5 @@
-import _, { PropertyName } from 'lodash';
+import type { PropertyName } from 'lodash';
+import _ from 'lodash';
 
 type Sanitizer = (value: unknown) => unknown;
 

--- a/packages/core/strapi/src/core/registries/validators.ts
+++ b/packages/core/strapi/src/core/registries/validators.ts
@@ -1,4 +1,5 @@
-import _, { PropertyName } from 'lodash';
+import type { PropertyName } from 'lodash';
+import _ from 'lodash';
 
 type Validator = unknown;
 

--- a/packages/core/strapi/src/load/glob.ts
+++ b/packages/core/strapi/src/load/glob.ts
@@ -1,4 +1,5 @@
-import glob, { IOptions } from 'glob';
+import type { IOptions } from 'glob';
+import glob from 'glob';
 
 /**
  * Promise based glob

--- a/packages/core/strapi/src/middlewares/query.ts
+++ b/packages/core/strapi/src/middlewares/query.ts
@@ -1,4 +1,5 @@
-import qs, { IParseOptions } from 'qs';
+import type { IParseOptions } from 'qs';
+import qs from 'qs';
 import type Koa from 'koa';
 import type { Strapi, Common } from '@strapi/types';
 

--- a/packages/core/strapi/src/middlewares/security.ts
+++ b/packages/core/strapi/src/middlewares/security.ts
@@ -1,5 +1,6 @@
 import { defaultsDeep, merge } from 'lodash/fp';
-import helmet, { KoaHelmet } from 'koa-helmet';
+import type { KoaHelmet } from 'koa-helmet';
+import helmet from 'koa-helmet';
 
 import type { Common } from '@strapi/types';
 

--- a/packages/core/strapi/src/migrations/draft-publish.ts
+++ b/packages/core/strapi/src/migrations/draft-publish.ts
@@ -1,5 +1,5 @@
 import { contentTypes as contentTypesUtils } from '@strapi/utils';
-import { Schema } from '@strapi/types';
+import type { Schema } from '@strapi/types';
 
 interface Input {
   oldContentTypes: Record<string, Schema.ContentType>;

--- a/packages/core/strapi/src/services/entity-validator/index.ts
+++ b/packages/core/strapi/src/services/entity-validator/index.ts
@@ -6,7 +6,7 @@
 import { uniqBy, castArray, isNil, isArray, mergeWith } from 'lodash';
 import { has, prop, isObject, isEmpty } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
-import { EntityValidator, Common, Schema, Attribute, Shared, EntityService } from '@strapi/types';
+import type { EntityValidator, Common, Schema, Attribute, Shared, EntityService } from '@strapi/types';
 import validators from './validators';
 
 type CreateOrUpdate = 'creation' | 'update';

--- a/packages/core/strapi/src/services/entity-validator/index.ts
+++ b/packages/core/strapi/src/services/entity-validator/index.ts
@@ -6,7 +6,14 @@
 import { uniqBy, castArray, isNil, isArray, mergeWith } from 'lodash';
 import { has, prop, isObject, isEmpty } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
-import type { EntityValidator, Common, Schema, Attribute, Shared, EntityService } from '@strapi/types';
+import type {
+  EntityValidator,
+  Common,
+  Schema,
+  Attribute,
+  Shared,
+  EntityService,
+} from '@strapi/types';
 import validators from './validators';
 
 type CreateOrUpdate = 'creation' | 'update';

--- a/packages/core/strapi/src/services/metrics/__tests__/admin-user-hash.test.ts
+++ b/packages/core/strapi/src/services/metrics/__tests__/admin-user-hash.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import createContext from "strapi/test/helpers/create-context";
+import createContext from 'strapi/test/helpers/create-context';
 import { generateAdminUserHash } from '../admin-user-hash';
 
 describe('user email hash', () => {

--- a/packages/core/strapi/src/services/metrics/__tests__/admin-user-hash.test.ts
+++ b/packages/core/strapi/src/services/metrics/__tests__/admin-user-hash.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
+import createContext from "strapi/test/helpers/create-context";
 import { generateAdminUserHash } from '../admin-user-hash';
-import createContext from '../../../../../../../test/helpers/create-context';
 
 describe('user email hash', () => {
   test('should create a hash from admin user email', () => {

--- a/packages/core/strapi/src/services/metrics/index.ts
+++ b/packages/core/strapi/src/services/metrics/index.ts
@@ -3,7 +3,8 @@
  * You can learn more at https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html
  */
 
-import { Job, scheduleJob } from 'node-schedule';
+import type { Job } from 'node-schedule';
+import { scheduleJob } from 'node-schedule';
 import type { Strapi } from '@strapi/types';
 
 import wrapWithRateLimit from './rate-limiter';

--- a/packages/core/strapi/src/services/server/compose-endpoint.ts
+++ b/packages/core/strapi/src/services/server/compose-endpoint.ts
@@ -1,7 +1,7 @@
 import { toLower, castArray, trim, prop, isNil } from 'lodash/fp';
 import type { Strapi, Common } from '@strapi/types';
 import { errors } from '@strapi/utils';
-import Router from '@koa/router';
+import type Router from '@koa/router';
 
 import compose from 'koa-compose';
 import { resolveRouteMiddlewares } from './middleware';

--- a/packages/core/strapi/src/services/server/http-server.ts
+++ b/packages/core/strapi/src/services/server/http-server.ts
@@ -1,6 +1,6 @@
 import http from 'http';
 import type { Socket } from 'net';
-import Koa from 'koa';
+import type Koa from 'koa';
 import type { Strapi } from '@strapi/types';
 
 export interface Server extends http.Server {

--- a/packages/core/strapi/src/services/server/policy.ts
+++ b/packages/core/strapi/src/services/server/policy.ts
@@ -1,5 +1,5 @@
 import { policy as policyUtils, errors } from '@strapi/utils';
-import { Common } from '@strapi/types';
+import type { Common } from '@strapi/types';
 
 const resolvePolicies = (route: Common.Route) => {
   const policiesConfig = route?.config?.policies ?? [];

--- a/packages/core/strapi/src/services/utils/dynamic-zones.ts
+++ b/packages/core/strapi/src/services/utils/dynamic-zones.ts
@@ -1,5 +1,5 @@
 import { map, values, sumBy, pipe, flatMap } from 'lodash/fp';
-import { Schema } from '@strapi/types';
+import type { Schema } from '@strapi/types';
 
 const getNumberOfDynamicZones = () => {
   return pipe(

--- a/packages/core/strapi/src/utils/fetch.ts
+++ b/packages/core/strapi/src/utils/fetch.ts
@@ -1,5 +1,7 @@
-import nodeFetch, { RequestInit, Response } from 'node-fetch';
-import { HttpsProxyAgent, HttpsProxyAgentOptions } from 'https-proxy-agent';
+import type { RequestInit, Response } from 'node-fetch';
+import nodeFetch from 'node-fetch';
+import type { HttpsProxyAgentOptions } from 'https-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import type { Strapi } from '@strapi/types';
 

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -29,28 +29,8 @@ import type { FeaturesService, FeaturesConfig } from './modules/features';
 
 export type * from './types';
 
-export {
-  Container,
-  Server,
-  EventHub,
-  CronService,
-  Webhook,
-  WebhookRunner,
-  WebhookStore,
-  CoreStore,
-  EntityValidator,
-  EntityService,
-  TelemetryService,
-  RequestContext,
-  CustomFields,
-  FeaturesService,
-  FeaturesConfig,
-  Fetch,
-  AuthenticationService,
-  ContentApi,
-  SanitizersRegistry,
-  ValidatorsRegistry,
-};
+export type { Container, Server, EventHub, CronService, Webhook, WebhookRunner, WebhookStore, CoreStore, EntityValidator, TelemetryService, RequestContext, FeaturesService, FeaturesConfig, Fetch, AuthenticationService, ContentApi, SanitizersRegistry, ValidatorsRegistry };
+export { EntityService, CustomFields };
 
 declare global {
   var strapi: LoadedStrapi;

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -29,7 +29,26 @@ import type { FeaturesService, FeaturesConfig } from './modules/features';
 
 export type * from './types';
 
-export type { Container, Server, EventHub, CronService, Webhook, WebhookRunner, WebhookStore, CoreStore, EntityValidator, TelemetryService, RequestContext, FeaturesService, FeaturesConfig, Fetch, AuthenticationService, ContentApi, SanitizersRegistry, ValidatorsRegistry };
+export type {
+  Container,
+  Server,
+  EventHub,
+  CronService,
+  Webhook,
+  WebhookRunner,
+  WebhookStore,
+  CoreStore,
+  EntityValidator,
+  TelemetryService,
+  RequestContext,
+  FeaturesService,
+  FeaturesConfig,
+  Fetch,
+  AuthenticationService,
+  ContentApi,
+  SanitizersRegistry,
+  ValidatorsRegistry,
+};
 export { EntityService, CustomFields };
 
 declare global {

--- a/packages/core/types/src/modules/content-api.ts
+++ b/packages/core/types/src/modules/content-api.ts
@@ -1,6 +1,6 @@
-import permissions from '@strapi/permissions';
-import { providerFactory } from '@strapi/utils';
-import { Common } from '../types';
+import type permissions from '@strapi/permissions';
+import type { providerFactory } from '@strapi/utils';
+import type { Common } from '../types';
 
 export interface Condition {
   name: string;

--- a/packages/core/types/src/modules/entity-validator.ts
+++ b/packages/core/types/src/modules/entity-validator.ts
@@ -1,4 +1,4 @@
-import { Common, Shared } from '../types';
+import type { Common, Shared } from '../types';
 import type * as Types from './entity-service';
 
 type Entity = {

--- a/packages/core/types/src/types/__tests__/definitions/utils/array.d.ts
+++ b/packages/core/types/src/types/__tests__/definitions/utils/array.d.ts
@@ -1,4 +1,4 @@
-import { Utils } from '../../..';
+import type { Utils } from '../../..';
 
 type Obj = {
   foo: 'bar';
@@ -30,7 +30,7 @@ type IsEmptyWithNotEmptyTuple = Utils.Array.IsEmpty<['foo', 'bar']>;
 type IsNotEmptyWithNotEmptyTuple = Utils.Array.IsNotEmpty<['foo', 'bar']>;
 type IsNotEmptyWithEmptyTuple = Utils.Array.IsNotEmpty<[]>;
 
-export {
+export type {
   StringValues,
   NumberValues,
   BoolValues,

--- a/packages/core/types/src/types/__tests__/definitions/utils/expression.d.ts
+++ b/packages/core/types/src/types/__tests__/definitions/utils/expression.d.ts
@@ -1,4 +1,4 @@
-import { Utils } from '../../..';
+import type { Utils } from '../../..';
 
 // IsNever
 type IsNeverGivenNever = Utils.Expression.IsNever<never>;
@@ -194,7 +194,7 @@ type OrTrueFalse = Utils.Expression.Or<
   Utils.Expression.IsTrue<Utils.Expression.False>
 >;
 
-export {
+export type {
   // IsNever
   IsNeverGivenNever,
   IsNeverNotGivenNever,

--- a/packages/core/types/src/types/__tests__/definitions/utils/guard.d.ts
+++ b/packages/core/types/src/types/__tests__/definitions/utils/guard.d.ts
@@ -1,4 +1,4 @@
-import { Utils } from '../../..';
+import type { Utils } from '../../..';
 
 // Never Guard
 type NeverGuardGetsNeverWithDefaultFallback = Utils.Guard.Never<never>;
@@ -34,7 +34,7 @@ type OfTypesStringAndNumberGetsUnionOfStringNumber = Utils.Guard.OfTypes<
 >;
 type OfTypesStringAndNumberGetsBoolean = Utils.Guard.OfTypes<[string, number], boolean>;
 
-export {
+export type {
   // Never
   NeverGuardGetsNeverWithDefaultFallback,
   NeverGuardGetsNeverWithCustomFallback,

--- a/packages/core/types/src/types/__tests__/definitions/utils/object.d.ts
+++ b/packages/core/types/src/types/__tests__/definitions/utils/object.d.ts
@@ -1,4 +1,4 @@
-import { Utils } from '../../..';
+import type { Utils } from '../../..';
 
 // Aux
 type Base = { x: 'foo' | 'bar' };
@@ -33,7 +33,7 @@ type ValuesContainNever = Utils.Object.Values<{ foo: 'bar'; bar: 'foo'; foobar: 
 // Replace
 type Replace = Utils.Object.Replace<{ foo: 'bar'; bar: 'foo' }, { foo: 2 }>;
 
-export {
+export type {
   // KeysBy
   KeysByString,
   KeysByNumber,

--- a/packages/core/types/src/types/__tests__/definitions/utils/string.d.ts
+++ b/packages/core/types/src/types/__tests__/definitions/utils/string.d.ts
@@ -56,7 +56,7 @@ type SplitBySpace = Utils.String.Split<'Hello World, How are you?', ' '>;
 type SplitByEmptyString = Utils.String.Split<'Hello', ''>;
 type SplitByString = Utils.String.Split<'Hello', string>;
 
-export {
+export type {
   // String
   // String > Dict
   NumberDict,

--- a/packages/core/types/src/types/__tests__/utils/array.test.ts
+++ b/packages/core/types/src/types/__tests__/utils/array.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { AssertTypeSelector, t } from '@strapi/ts-zen';
+import type { AssertTypeSelector } from '@strapi/ts-zen';
+import { t } from '@strapi/ts-zen';
 
 import { createTypeSelector } from '../test.utils';
 

--- a/packages/core/types/src/types/__tests__/utils/expression.test.ts
+++ b/packages/core/types/src/types/__tests__/utils/expression.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { t, AssertTypeSelector } from '@strapi/ts-zen';
+import type { AssertTypeSelector } from '@strapi/ts-zen';
+import { t } from '@strapi/ts-zen';
 
 import { createTypeSelector } from '../test.utils';
 

--- a/packages/core/types/src/types/__tests__/utils/guard.test.ts
+++ b/packages/core/types/src/types/__tests__/utils/guard.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { AssertTypeSelector, t } from '@strapi/ts-zen';
+import type { AssertTypeSelector } from '@strapi/ts-zen';
+import { t } from '@strapi/ts-zen';
 
 import { createTypeSelector } from '../test.utils';
 

--- a/packages/core/types/src/types/__tests__/utils/object.test.ts
+++ b/packages/core/types/src/types/__tests__/utils/object.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { t, AssertTypeSelector } from '@strapi/ts-zen';
+import type { AssertTypeSelector } from '@strapi/ts-zen';
+import { t } from '@strapi/ts-zen';
 import type ObjectUtils from '../definitions/utils/object';
 import { createTypeSelector } from '../test.utils';
 

--- a/packages/core/types/src/types/__tests__/utils/string.test.ts
+++ b/packages/core/types/src/types/__tests__/utils/string.test.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
-import { AssertTypeSelector, t } from '@strapi/ts-zen';
+import type { AssertTypeSelector } from '@strapi/ts-zen';
+import { t } from '@strapi/ts-zen';
 
 import { createTypeSelector } from '../test.utils';
 import type StringUtils from '../definitions/utils/string';

--- a/packages/core/types/src/types/core/commands/index.ts
+++ b/packages/core/types/src/types/core/commands/index.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import type { Command } from 'commander';
 
 export type AddCommandOptions = {
   command: Command;

--- a/packages/core/types/src/types/core/common/api.ts
+++ b/packages/core/types/src/types/core/common/api.ts
@@ -1,3 +1,3 @@
 import type { Common } from '..';
 
-export interface API extends Common.Module {}
+export type API = Common.Module;

--- a/packages/core/types/src/types/core/common/policy.ts
+++ b/packages/core/types/src/types/core/common/policy.ts
@@ -1,4 +1,4 @@
-import { ExtendableContext } from 'koa';
+import type { ExtendableContext } from 'koa';
 import type { Strapi } from '../../..';
 
 export type PolicyContext = Omit<ExtendableContext, 'is'> & {

--- a/packages/core/types/src/types/core/plugins/config/strapi-server/config.ts
+++ b/packages/core/types/src/types/core/plugins/config/strapi-server/config.ts
@@ -1,4 +1,4 @@
-import { env } from '@strapi/utils';
+import type { env } from '@strapi/utils';
 
 export interface Config {
   validator: (config: Record<string, unknown>) => void;

--- a/packages/core/types/src/types/core/plugins/index.ts
+++ b/packages/core/types/src/types/core/plugins/index.ts
@@ -1,4 +1,4 @@
-import { env } from '@strapi/utils';
+import type { env } from '@strapi/utils';
 
 import type { Common, Shared, Utils, Schema } from '../..';
 import type { Strapi } from '../../..';

--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,5 +1,5 @@
 import convertQueryParams from '../convert-query-params';
-import { Model } from '../types';
+import type { Model } from '../types';
 
 const schema: Model = {
   kind: 'collectionType',

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -23,7 +23,7 @@ import parseType from './parse-type';
 import * as contentTypesUtils from './content-types';
 import { PaginationError } from './errors';
 import { isDynamicZoneAttribute, isMorphToRelationalAttribute } from './content-types';
-import { Model } from './types';
+import type { Model } from './types';
 import { isOperator } from './operators';
 
 const { PUBLISHED_AT_ATTRIBUTE } = contentTypesUtils.constants;

--- a/packages/core/utils/src/errors.ts
+++ b/packages/core/utils/src/errors.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
-import yup from 'yup';
+import type yup from 'yup';
 import { HttpError } from 'http-errors';
 import { formatYupErrors } from './format-yup-error';
 

--- a/packages/core/utils/src/file.ts
+++ b/packages/core/utils/src/file.ts
@@ -1,7 +1,8 @@
 /**
  * Utils file containing file treatment utils
  */
-import { Readable, Writable, WritableOptions } from 'node:stream';
+import type { Readable, WritableOptions } from 'node:stream';
+import { Writable } from 'node:stream';
 
 const kbytesToBytes = (kbytes: number) => kbytes * 1000;
 const bytesToKbytes = (bytes: number) => Math.round((bytes / 1000) * 100) / 100;

--- a/packages/core/utils/src/format-yup-error.ts
+++ b/packages/core/utils/src/format-yup-error.ts
@@ -1,5 +1,5 @@
 import { isEmpty, toPath } from 'lodash/fp';
-import { ValidationError } from 'yup';
+import type { ValidationError } from 'yup';
 
 const formatYupInnerError = (yupError: ValidationError) => ({
   path: toPath(yupError.path),

--- a/packages/core/utils/src/provider-factory.ts
+++ b/packages/core/utils/src/provider-factory.ts
@@ -1,9 +1,10 @@
 import { cloneDeep } from 'lodash/fp';
+import type {
+  AsyncSeriesHook,
+  AsyncParallelHook } from './hooks';
 import {
   createAsyncSeriesHook,
-  createAsyncParallelHook,
-  AsyncSeriesHook,
-  AsyncParallelHook,
+  createAsyncParallelHook
 } from './hooks';
 
 export interface ProviderHooksMap {

--- a/packages/core/utils/src/provider-factory.ts
+++ b/packages/core/utils/src/provider-factory.ts
@@ -1,11 +1,6 @@
 import { cloneDeep } from 'lodash/fp';
-import type {
-  AsyncSeriesHook,
-  AsyncParallelHook } from './hooks';
-import {
-  createAsyncSeriesHook,
-  createAsyncParallelHook
-} from './hooks';
+import type { AsyncSeriesHook, AsyncParallelHook } from './hooks';
+import { createAsyncSeriesHook, createAsyncParallelHook } from './hooks';
 
 export interface ProviderHooksMap {
   willRegister: AsyncSeriesHook;

--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -1,4 +1,4 @@
-import { CurriedFunction1 } from 'lodash';
+import type { CurriedFunction1 } from 'lodash';
 import { isArray, cloneDeep, omit } from 'lodash/fp';
 
 import { getNonWritableAttributes } from '../content-types';

--- a/packages/core/utils/src/traverse/factory.ts
+++ b/packages/core/utils/src/traverse/factory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-loop-func */
 import { isNil, pick } from 'lodash/fp';
-import {
+import type {
   AnyAttribute,
   Attribute,
   ComponentAttribute,

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -15,7 +15,7 @@ import {
 } from 'lodash/fp';
 
 import traverseFactory from './factory';
-import { Attribute } from '../types';
+import type { Attribute } from '../types';
 import { isMorphToRelationalAttribute } from '../content-types';
 
 const isKeyword = (keyword: string) => {

--- a/packages/core/utils/src/validate/index.ts
+++ b/packages/core/utils/src/validate/index.ts
@@ -1,4 +1,4 @@
-import { CurriedFunction1 } from 'lodash';
+import type { CurriedFunction1 } from 'lodash';
 import { isArray, isObject } from 'lodash/fp';
 
 import { getNonWritableAttributes } from '../content-types';
@@ -11,7 +11,7 @@ import traverseEntity from '../traverse-entity';
 
 import { traverseQueryFilters, traverseQuerySort } from '../traverse';
 
-import { Model, Data } from '../types';
+import type { Model, Data } from '../types';
 
 export interface Options {
   auth?: unknown;

--- a/packages/generators/app/src/create-project.ts
+++ b/packages/generators/app/src/create-project.ts
@@ -17,7 +17,8 @@ import adminTsconfig from './resources/json/ts/tsconfig-admin.json';
 import serverTsconfig from './resources/json/ts/tsconfig-server.json';
 import { createDatabaseConfig, generateDbEnvariables } from './resources/templates/database';
 import createEnvFile from './resources/templates/env';
-import { Configuration, Scope, isStderrError } from './types';
+import type { Configuration, Scope } from './types';
+import { isStderrError } from './types';
 
 export default async function createProject(
   scope: Scope,

--- a/packages/generators/app/src/resources/json/common/package.json.ts
+++ b/packages/generators/app/src/resources/json/common/package.json.ts
@@ -1,4 +1,4 @@
-import { Scope } from '../../../types';
+import type { Scope } from '../../../types';
 import engines from './engines';
 
 type OptsScope = Pick<

--- a/packages/generators/app/src/utils/usage.ts
+++ b/packages/generators/app/src/utils/usage.ts
@@ -2,7 +2,8 @@ import os from 'os';
 import _ from 'lodash';
 import fetch from 'node-fetch';
 import sentry, { Severity } from '@sentry/node';
-import { Scope, StderrError, isStderrError } from '../types';
+import type { Scope, StderrError } from '../types';
+import { isStderrError } from '../types';
 
 type TrackError = Error | string | StderrError;
 

--- a/packages/generators/generators/src/plopfile.ts
+++ b/packages/generators/generators/src/plopfile.ts
@@ -1,5 +1,5 @@
 import pluralize from 'pluralize';
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 
 import generateApi from './plops/api';
 import generateController from './plops/controller';

--- a/packages/generators/generators/src/plops/api.ts
+++ b/packages/generators/generators/src/plops/api.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import fs from 'fs-extra';
 import tsUtils from '@strapi/typescript-utils';
 

--- a/packages/generators/generators/src/plops/content-type.ts
+++ b/packages/generators/generators/src/plops/content-type.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { NodePlopAPI, ActionType } from 'plop';
+import type { NodePlopAPI, ActionType } from 'plop';
 import slugify from '@sindresorhus/slugify';
 import fs from 'fs-extra';
 import * as utils from '@strapi/utils';

--- a/packages/generators/generators/src/plops/controller.ts
+++ b/packages/generators/generators/src/plops/controller.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import tsUtils from '@strapi/typescript-utils';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';

--- a/packages/generators/generators/src/plops/middleware.ts
+++ b/packages/generators/generators/src/plops/middleware.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import tsUtils from '@strapi/typescript-utils';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';

--- a/packages/generators/generators/src/plops/migration.ts
+++ b/packages/generators/generators/src/plops/migration.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import tsUtils from '@strapi/typescript-utils';
 import validateFileNameInput from './utils/validate-file-name-input';
 import getFormattedDate from './utils/get-formatted-date';

--- a/packages/generators/generators/src/plops/plugin.ts
+++ b/packages/generators/generators/src/plops/plugin.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import chalk from 'chalk';
 import tsUtils from '@strapi/typescript-utils';
 import * as utils from '@strapi/utils';

--- a/packages/generators/generators/src/plops/policy.ts
+++ b/packages/generators/generators/src/plops/policy.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import tsUtils from '@strapi/typescript-utils';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';

--- a/packages/generators/generators/src/plops/service.ts
+++ b/packages/generators/generators/src/plops/service.ts
@@ -1,4 +1,4 @@
-import { NodePlopAPI } from 'plop';
+import type { NodePlopAPI } from 'plop';
 import tsUtils from '@strapi/typescript-utils';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';

--- a/packages/plugins/graphql/server/src/services/content-api/index.ts
+++ b/packages/plugins/graphql/server/src/services/content-api/index.ts
@@ -14,7 +14,7 @@ import {
   registerPolymorphicContentType,
   contentType,
 } from './register-functions';
-import { TypeRegistry } from '../type-registry';
+import type { TypeRegistry } from '../type-registry';
 
 const {
   registerEnumsDefinition,

--- a/packages/plugins/graphql/server/src/services/content-api/policy.ts
+++ b/packages/plugins/graphql/server/src/services/content-api/policy.ts
@@ -1,5 +1,5 @@
 import { propOr } from 'lodash/fp';
-import { GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql';
+import type { GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql';
 import { policy as policyUtils, errors } from '@strapi/utils';
 import type { Strapi } from '@strapi/types';
 

--- a/packages/plugins/graphql/server/src/services/content-api/wrap-resolvers.ts
+++ b/packages/plugins/graphql/server/src/services/content-api/wrap-resolvers.ts
@@ -1,11 +1,6 @@
 import { get, getOr, isFunction, first, isNil } from 'lodash/fp';
-import type {
-  GraphQLResolveInfo,
-  GraphQLSchema,
-  GraphQLFieldResolver } from 'graphql';
-import {
-  GraphQLObjectType
-} from 'graphql';
+import type { GraphQLResolveInfo, GraphQLSchema, GraphQLFieldResolver } from 'graphql';
+import { GraphQLObjectType } from 'graphql';
 import { errors } from '@strapi/utils';
 import type { Strapi, Common } from '@strapi/types';
 

--- a/packages/plugins/graphql/server/src/services/content-api/wrap-resolvers.ts
+++ b/packages/plugins/graphql/server/src/services/content-api/wrap-resolvers.ts
@@ -1,9 +1,10 @@
 import { get, getOr, isFunction, first, isNil } from 'lodash/fp';
-import {
-  GraphQLObjectType,
+import type {
   GraphQLResolveInfo,
   GraphQLSchema,
-  GraphQLFieldResolver,
+  GraphQLFieldResolver } from 'graphql';
+import {
+  GraphQLObjectType
 } from 'graphql';
 import { errors } from '@strapi/utils';
 import type { Strapi, Common } from '@strapi/types';

--- a/packages/plugins/graphql/server/src/services/internals/args/publication-state.ts
+++ b/packages/plugins/graphql/server/src/services/internals/args/publication-state.ts
@@ -1,5 +1,5 @@
 import { arg } from 'nexus';
-import { Context } from '../../types';
+import type { Context } from '../../types';
 
 export default ({ strapi }: Context) => {
   const { PUBLICATION_STATE_TYPE_NAME } = strapi.plugin('graphql').service('constants');

--- a/packages/providers/email-mailgun/src/__tests__/convert-provider-options.test.ts
+++ b/packages/providers/email-mailgun/src/__tests__/convert-provider-options.test.ts
@@ -1,6 +1,6 @@
 import formData from 'form-data';
 import Mailgun from 'mailgun.js';
-import Options from 'mailgun.js/interfaces/Options';
+import type Options from 'mailgun.js/interfaces/Options';
 import provider from '../index';
 
 describe('@strapi/provider-email-mailgun', () => {

--- a/packages/providers/email-mailgun/src/index.ts
+++ b/packages/providers/email-mailgun/src/index.ts
@@ -1,6 +1,6 @@
 import formData from 'form-data';
 import Mailgun from 'mailgun.js';
-import Options from 'mailgun.js/interfaces/Options';
+import type Options from 'mailgun.js/interfaces/Options';
 
 interface Settings {
   defaultFrom: string;

--- a/packages/providers/email-nodemailer/src/index.ts
+++ b/packages/providers/email-nodemailer/src/index.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import nodemailer, { SendMailOptions } from 'nodemailer';
+import type { SendMailOptions } from 'nodemailer';
+import nodemailer from 'nodemailer';
 
 interface Settings {
   defaultFrom: string;

--- a/packages/providers/email-sendgrid/src/index.ts
+++ b/packages/providers/email-sendgrid/src/index.ts
@@ -1,4 +1,5 @@
-import sendgrid, { MailDataRequired } from '@sendgrid/mail';
+import type { MailDataRequired } from '@sendgrid/mail';
+import sendgrid from '@sendgrid/mail';
 
 interface Settings {
   defaultFrom: string;

--- a/packages/providers/email-sendmail/src/index.ts
+++ b/packages/providers/email-sendmail/src/index.ts
@@ -1,4 +1,5 @@
-import sendmailFactory, { Options, MailInput } from 'sendmail';
+import type { Options, MailInput } from 'sendmail';
+import sendmailFactory from 'sendmail';
 
 interface Settings {
   defaultFrom: string;

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -1,4 +1,5 @@
-import awsProvider, { File } from '../index';
+import type { File } from '../index';
+import awsProvider from '../index';
 
 jest.mock('../utils', () => ({
   ...jest.requireActual('../utils'),

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -5,7 +5,8 @@ import type {
   PutObjectCommandInput,
   CompleteMultipartUploadCommandOutput,
   AbortMultipartUploadCommandOutput,
-  S3ClientConfig } from '@aws-sdk/client-s3';
+  S3ClientConfig,
+} from '@aws-sdk/client-s3';
 import {
   S3Client,
   GetObjectCommand,

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -1,14 +1,15 @@
 import type { ReadStream } from 'node:fs';
 import { getOr } from 'lodash/fp';
-import {
-  S3Client,
-  GetObjectCommand,
-  DeleteObjectCommand,
+import type {
   DeleteObjectCommandOutput,
   PutObjectCommandInput,
   CompleteMultipartUploadCommandOutput,
   AbortMultipartUploadCommandOutput,
-  S3ClientConfig,
+  S3ClientConfig } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  GetObjectCommand,
+  DeleteObjectCommand,
   ObjectCannedACL,
 } from '@aws-sdk/client-s3';
 import type { AwsCredentialIdentity } from '@aws-sdk/types';

--- a/packages/providers/upload-cloudinary/src/index.ts
+++ b/packages/providers/upload-cloudinary/src/index.ts
@@ -1,5 +1,6 @@
 import type { ReadStream } from 'node:fs';
-import { v2 as cloudinary, ConfigOptions, UploadApiOptions } from 'cloudinary';
+import type { ConfigOptions, UploadApiOptions } from 'cloudinary';
+import { v2 as cloudinary } from 'cloudinary';
 import intoStream from 'into-stream';
 import * as utils from '@strapi/utils';
 

--- a/packages/providers/upload-local/src/index.ts
+++ b/packages/providers/upload-local/src/index.ts
@@ -1,5 +1,6 @@
 import { pipeline } from 'stream';
-import fs, { ReadStream } from 'fs';
+import type { ReadStream } from 'fs';
+import fs from 'fs';
 import path from 'path';
 import fse from 'fs-extra';
 import * as utils from '@strapi/utils';

--- a/packages/utils/logger/src/configs/default-configuration.ts
+++ b/packages/utils/logger/src/configs/default-configuration.ts
@@ -1,4 +1,5 @@
-import { transports, LoggerOptions } from 'winston';
+import type { LoggerOptions } from 'winston';
+import { transports } from 'winston';
 import { LEVEL_LABEL, LEVELS } from '../constants';
 import { prettyPrint } from '../formats';
 

--- a/packages/utils/logger/src/configs/output-file-configuration.ts
+++ b/packages/utils/logger/src/configs/output-file-configuration.ts
@@ -1,4 +1,5 @@
-import { transports, LoggerOptions } from 'winston';
+import type { LoggerOptions } from 'winston';
+import { transports } from 'winston';
 
 import { LEVEL_LABEL, LEVELS } from '../constants';
 import { prettyPrint, excludeColors } from '../formats';

--- a/packages/utils/logger/src/formats/log-errors.ts
+++ b/packages/utils/logger/src/formats/log-errors.ts
@@ -1,4 +1,5 @@
-import { format, Logform } from 'winston';
+import type { Logform } from 'winston';
+import { format } from 'winston';
 
 const logErrors: Logform.FormatWrap = format((info) => {
   if (info instanceof Error) {

--- a/packages/utils/logger/src/formats/pretty-print.ts
+++ b/packages/utils/logger/src/formats/pretty-print.ts
@@ -1,4 +1,5 @@
-import { format, Logform } from 'winston';
+import type { Logform } from 'winston';
+import { format } from 'winston';
 import logErrors from './log-errors';
 
 const defaultTimestampFormat = 'YYYY-MM-DD HH:mm:ss.SSS';

--- a/packages/utils/pack-up/src/__tests__/node.test.ts
+++ b/packages/utils/pack-up/src/__tests__/node.test.ts
@@ -3,7 +3,11 @@ import { createWorkspace } from '../../tests/workspaces';
 import { init } from '../node/init';
 import { defaultTemplate } from '../node/templates/internal/default';
 
-import type { Template, TemplateOrTemplateResolver, TemplateResolver } from '../node/templates/types';
+import type {
+  Template,
+  TemplateOrTemplateResolver,
+  TemplateResolver,
+} from '../node/templates/types';
 
 const loggerMock = {
   debug: jest.fn(),

--- a/packages/utils/pack-up/src/__tests__/node.test.ts
+++ b/packages/utils/pack-up/src/__tests__/node.test.ts
@@ -2,7 +2,8 @@ import { stripColor } from '../../tests/console';
 import { createWorkspace } from '../../tests/workspaces';
 import { init } from '../node/init';
 import { defaultTemplate } from '../node/templates/internal/default';
-import { Template, TemplateOrTemplateResolver, TemplateResolver } from '../node/templates/types';
+
+import type { Template, TemplateOrTemplateResolver, TemplateResolver } from '../node/templates/types';
 
 const loggerMock = {
   debug: jest.fn(),

--- a/packages/utils/pack-up/src/cli/commands/build.ts
+++ b/packages/utils/pack-up/src/cli/commands/build.ts
@@ -1,5 +1,7 @@
-import { build as nodeBuild, BuildCLIOptions } from '../../node/build';
+import { build as nodeBuild } from '../../node/build';
 import { handleError } from '../errors';
+
+import type { BuildCLIOptions } from '../../node/build';
 
 export const build = async (options: BuildCLIOptions) => {
   try {

--- a/packages/utils/pack-up/src/cli/commands/check.ts
+++ b/packages/utils/pack-up/src/cli/commands/check.ts
@@ -1,5 +1,7 @@
-import { CheckOptions, check as nodeCheck } from '../../node/check';
+import { check as nodeCheck } from '../../node/check';
 import { handleError } from '../errors';
+
+import type { CheckOptions } from '../../node/check';
 
 export const check = async (options: CheckOptions) => {
   try {

--- a/packages/utils/pack-up/src/cli/commands/init.ts
+++ b/packages/utils/pack-up/src/cli/commands/init.ts
@@ -1,5 +1,7 @@
-import { InitOptions, init as nodeInit } from '../../node/init';
+import { init as nodeInit } from '../../node/init';
 import { handleError } from '../errors';
+
+import type { InitOptions } from '../../node/init';
 
 export const init = async (options: InitOptions) => {
   try {

--- a/packages/utils/pack-up/src/cli/commands/watch.ts
+++ b/packages/utils/pack-up/src/cli/commands/watch.ts
@@ -1,5 +1,7 @@
-import { WatchCLIOptions, watch as nodeWatch } from '../../node/watch';
+import { watch as nodeWatch } from '../../node/watch';
 import { handleError } from '../errors';
+
+import type { WatchCLIOptions } from '../../node/watch';
 
 export const watch = async (options: WatchCLIOptions) => {
   try {

--- a/packages/utils/pack-up/src/node/build.ts
+++ b/packages/utils/pack-up/src/node/build.ts
@@ -2,7 +2,6 @@ import fs from 'fs/promises';
 import ora from 'ora';
 import os from 'os';
 
-import { CommonCLIOptions } from '../types';
 
 import { loadConfig, type Config } from './core/config';
 import { isError } from './core/errors';
@@ -10,8 +9,12 @@ import { getExportExtensionMap, validateExportsOrdering } from './core/exports';
 import { createLogger } from './core/logger';
 import { loadPkg, validatePkg } from './core/pkg';
 import { createBuildContext } from './createBuildContext';
-import { BuildTask, createBuildTasks } from './createTasks';
-import { TaskHandler, taskHandlers } from './tasks';
+import { createBuildTasks } from './createTasks';
+import { taskHandlers } from './tasks';
+
+import type { BuildTask } from './createTasks';
+import type { TaskHandler } from './tasks';
+import type { CommonCLIOptions } from '../types';
 
 interface BuildCLIOptions extends CommonCLIOptions {
   minify?: boolean;

--- a/packages/utils/pack-up/src/node/build.ts
+++ b/packages/utils/pack-up/src/node/build.ts
@@ -2,7 +2,6 @@ import fs from 'fs/promises';
 import ora from 'ora';
 import os from 'os';
 
-
 import { loadConfig, type Config } from './core/config';
 import { isError } from './core/errors';
 import { getExportExtensionMap, validateExportsOrdering } from './core/exports';

--- a/packages/utils/pack-up/src/node/check.ts
+++ b/packages/utils/pack-up/src/node/check.ts
@@ -1,18 +1,21 @@
 import chalk from 'chalk';
-import esbuild, { BuildFailure, Format, Message } from 'esbuild';
+import esbuild from 'esbuild';
 import ora from 'ora';
 import os from 'os';
 import { resolve } from 'path';
 
-import { CommonCLIOptions } from '../types';
 
 import { loadConfig } from './core/config';
 import { isError } from './core/errors';
 import { getExportExtensionMap, validateExportsOrdering } from './core/exports';
 import { pathExists } from './core/files';
-import { Logger, createLogger } from './core/logger';
+import { createLogger } from './core/logger';
 import { loadPkg, validatePkg } from './core/pkg';
 import { createBuildContext } from './createBuildContext';
+
+import type { Logger } from './core/logger';
+import type { CommonCLIOptions } from '../types';
+import type { BuildFailure, Format, Message } from 'esbuild';
 
 export interface CheckOptions extends CommonCLIOptions {
   cwd?: string;

--- a/packages/utils/pack-up/src/node/check.ts
+++ b/packages/utils/pack-up/src/node/check.ts
@@ -4,7 +4,6 @@ import ora from 'ora';
 import os from 'os';
 import { resolve } from 'path';
 
-
 import { loadConfig } from './core/config';
 import { isError } from './core/errors';
 import { getExportExtensionMap, validateExportsOrdering } from './core/exports';

--- a/packages/utils/pack-up/src/node/core/__tests__/exports.test.ts
+++ b/packages/utils/pack-up/src/node/core/__tests__/exports.test.ts
@@ -1,5 +1,6 @@
 import { validateExportsOrdering, parseExports, getExportExtensionMap } from '../exports';
-import { PackageJson } from '../pkg';
+
+import type { PackageJson } from '../pkg';
 
 const loggerMock = {
   debug: jest.fn(),

--- a/packages/utils/pack-up/src/node/core/config.ts
+++ b/packages/utils/pack-up/src/node/core/config.ts
@@ -4,9 +4,8 @@ import os from 'os';
 import * as path from 'path';
 import pkgUp from 'pkg-up';
 
-import { Logger } from './logger';
-
 import type { Export } from './exports';
+import type { Logger } from './logger';
 import type { Runtime } from '../createBuildContext';
 import type { PluginOption } from 'vite';
 

--- a/packages/utils/pack-up/src/node/core/exports.ts
+++ b/packages/utils/pack-up/src/node/core/exports.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 
-import { Logger } from './logger';
-import { PackageJson } from './pkg';
+import type { Logger } from './logger';
+import type { PackageJson } from './pkg';
 
 /**
  * @description validate the `exports` property of the package.json against a set of rules.

--- a/packages/utils/pack-up/src/node/core/pkg.ts
+++ b/packages/utils/pack-up/src/node/core/pkg.ts
@@ -9,9 +9,9 @@ import os from 'os';
 import pkgUp from 'pkg-up';
 import * as yup from 'yup';
 
-import { Logger } from './logger';
-
 import type { Export } from './exports';
+import type { Logger } from './logger';
+
 
 const record = (value: unknown) =>
   yup

--- a/packages/utils/pack-up/src/node/core/pkg.ts
+++ b/packages/utils/pack-up/src/node/core/pkg.ts
@@ -12,7 +12,6 @@ import * as yup from 'yup';
 import type { Export } from './exports';
 import type { Logger } from './logger';
 
-
 const record = (value: unknown) =>
   yup
     .object(

--- a/packages/utils/pack-up/src/node/core/tsconfig.ts
+++ b/packages/utils/pack-up/src/node/core/tsconfig.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import nodePath from 'path';
 import ts from 'typescript';
 
-import { Logger } from './logger';
+import type { Logger } from './logger';
 
 /**
  * @description Load a tsconfig.json file and return the parsed config

--- a/packages/utils/pack-up/src/node/createBuildContext.ts
+++ b/packages/utils/pack-up/src/node/createBuildContext.ts
@@ -2,10 +2,11 @@ import browserslistToEsbuild from 'browserslist-to-esbuild';
 import path from 'path';
 
 import { resolveConfigProperty } from './core/config';
-import { parseExports, ExtMap, Export } from './core/exports';
+import { parseExports } from './core/exports';
 import { loadTsConfig } from './core/tsconfig';
 
 import type { Config } from './core/config';
+import type { ExtMap, Export } from './core/exports';
 import type { Logger } from './core/logger';
 import type { PackageJson } from './core/pkg';
 import type { ParsedCommandLine } from 'typescript';

--- a/packages/utils/pack-up/src/node/createTasks.ts
+++ b/packages/utils/pack-up/src/node/createTasks.ts
@@ -1,14 +1,14 @@
 import path from 'path';
 
-import { DtsWatchTask } from './tasks/dts/watch';
-import { ViteBaseTask, ViteTaskEntry } from './tasks/vite/types';
-import { ViteWatchTask } from './tasks/vite/watch';
 
 import type { Extensions } from './core/exports';
 import type { BuildContext, Runtime } from './createBuildContext';
 import type { DtsBuildTask } from './tasks/dts/build';
 import type { DtsBaseTask } from './tasks/dts/types';
+import type { DtsWatchTask } from './tasks/dts/watch';
 import type { ViteBuildTask } from './tasks/vite/build';
+import type { ViteBaseTask, ViteTaskEntry } from './tasks/vite/types';
+import type { ViteWatchTask } from './tasks/vite/watch';
 
 type BuildTask = DtsBuildTask | ViteBuildTask;
 type WatchTask = ViteWatchTask | DtsWatchTask;

--- a/packages/utils/pack-up/src/node/createTasks.ts
+++ b/packages/utils/pack-up/src/node/createTasks.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-
 import type { Extensions } from './core/exports';
 import type { BuildContext, Runtime } from './createBuildContext';
 import type { DtsBuildTask } from './tasks/dts/build';

--- a/packages/utils/pack-up/src/node/init.ts
+++ b/packages/utils/pack-up/src/node/init.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'path';
 
-
 import { isError } from './core/errors';
 import { ensurePackagePathIsViable } from './core/files';
 import { createLogger } from './core/logger';

--- a/packages/utils/pack-up/src/node/init.ts
+++ b/packages/utils/pack-up/src/node/init.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'path';
 
-import { CommonCLIOptions } from '../types';
 
 import { isError } from './core/errors';
 import { ensurePackagePathIsViable } from './core/files';
@@ -8,7 +7,9 @@ import { createLogger } from './core/logger';
 import { createPackageFromTemplate } from './templates/create';
 import { defaultTemplate } from './templates/internal/default';
 import { loadTemplate } from './templates/load';
-import { TemplateOrTemplateResolver } from './templates/types';
+
+import type { TemplateOrTemplateResolver } from './templates/types';
+import type { CommonCLIOptions } from '../types';
 
 export interface InitOptions extends CommonCLIOptions {
   cwd?: string;

--- a/packages/utils/pack-up/src/node/tasks/dts/build.ts
+++ b/packages/utils/pack-up/src/node/tasks/dts/build.ts
@@ -7,8 +7,8 @@ import { isError } from '../../core/errors';
 import { loadTsConfig } from '../../core/tsconfig';
 
 import { printDiagnostic } from './diagnostic';
-import { DtsBaseTask } from './types';
 
+import type { DtsBaseTask } from './types';
 import type { TaskHandler } from '../index';
 
 interface DtsBuildTask extends DtsBaseTask {

--- a/packages/utils/pack-up/src/node/tasks/dts/diagnostic.ts
+++ b/packages/utils/pack-up/src/node/tasks/dts/diagnostic.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import path from 'path';
 import ts from 'typescript';
 
-import { Logger } from '../../core/logger';
+import type { Logger } from '../../core/logger';
 
 const printDiagnostic = (
   diagnostic: ts.Diagnostic,

--- a/packages/utils/pack-up/src/node/tasks/dts/watch.ts
+++ b/packages/utils/pack-up/src/node/tasks/dts/watch.ts
@@ -7,8 +7,8 @@ import { isError } from '../../core/errors';
 import { loadTsConfig } from '../../core/tsconfig';
 
 import { printDiagnostic } from './diagnostic';
-import { DtsBaseTask } from './types';
 
+import type { DtsBaseTask } from './types';
 import type { TaskHandler } from '../index';
 
 interface DtsWatchTask extends DtsBaseTask {

--- a/packages/utils/pack-up/src/node/tasks/index.ts
+++ b/packages/utils/pack-up/src/node/tasks/index.ts
@@ -1,13 +1,17 @@
-import ts from 'typescript';
 
-import { BuildContext } from '../createBuildContext';
 
-import { dtsBuildTask, DtsBuildTask } from './dts/build';
-import { dtsWatchTask, DtsWatchTask } from './dts/watch';
-import { viteBuildTask, ViteBuildTask } from './vite/build';
-import { RollupWatcherEvent, viteWatchTask, ViteWatchTask } from './vite/watch';
+import { dtsBuildTask } from './dts/build';
+import { dtsWatchTask } from './dts/watch';
+import { viteBuildTask } from './vite/build';
+import { viteWatchTask } from './vite/watch';
 
+import type { DtsBuildTask } from './dts/build';
+import type { DtsWatchTask } from './dts/watch';
+import type { ViteBuildTask } from './vite/build';
+import type { RollupWatcherEvent, ViteWatchTask } from './vite/watch';
+import type { BuildContext } from '../createBuildContext';
 import type { Observable } from 'rxjs';
+import type ts from 'typescript';
 
 interface TaskHandler<Task, Result = void> {
   print(ctx: BuildContext, task: Task): void;

--- a/packages/utils/pack-up/src/node/tasks/index.ts
+++ b/packages/utils/pack-up/src/node/tasks/index.ts
@@ -1,5 +1,3 @@
-
-
 import { dtsBuildTask } from './dts/build';
 import { dtsWatchTask } from './dts/watch';
 import { viteBuildTask } from './vite/build';

--- a/packages/utils/pack-up/src/node/tasks/vite/build.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/build.ts
@@ -6,8 +6,8 @@ import { Observable } from 'rxjs';
 import { isError } from '../../core/errors';
 
 import { resolveViteConfig } from './config';
-import { ViteBaseTask } from './types';
 
+import type { ViteBaseTask } from './types';
 import type { TaskHandler } from '../index';
 
 interface ViteBuildTask extends ViteBaseTask {

--- a/packages/utils/pack-up/src/node/tasks/vite/types.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/types.ts
@@ -1,5 +1,5 @@
-import { Extensions } from '../../core/exports';
-import { Targets } from '../../createBuildContext';
+import type { Extensions } from '../../core/exports';
+import type { Targets } from '../../createBuildContext';
 
 interface ViteTaskEntry {
   path: string;

--- a/packages/utils/pack-up/src/node/tasks/vite/watch.ts
+++ b/packages/utils/pack-up/src/node/tasks/vite/watch.ts
@@ -6,8 +6,8 @@ import { Observable } from 'rxjs';
 import { isError } from '../../core/errors';
 
 import { resolveViteConfig } from './config';
-import { ViteBaseTask } from './types';
 
+import type { ViteBaseTask } from './types';
 import type { TaskHandler } from '../index';
 
 export type InputOption = string | string[] | { [entryAlias: string]: string };

--- a/packages/utils/pack-up/src/node/templates/create.ts
+++ b/packages/utils/pack-up/src/node/templates/create.ts
@@ -7,7 +7,12 @@ import prompts from 'prompts';
 import { isError } from '../core/errors';
 import { parseGlobalGitConfig } from '../core/git';
 
-import type { Template, TemplateFeature, TemplateOption, TemplateOrTemplateResolver } from './types';
+import type {
+  Template,
+  TemplateFeature,
+  TemplateOption,
+  TemplateOrTemplateResolver,
+} from './types';
 import type { Logger } from '../core/logger';
 import type { Config as PrettierConfig } from 'prettier';
 

--- a/packages/utils/pack-up/src/node/templates/create.ts
+++ b/packages/utils/pack-up/src/node/templates/create.ts
@@ -1,14 +1,15 @@
 import { mkdir, writeFile } from 'fs/promises';
 import os from 'os';
 import { relative, resolve, dirname } from 'path';
-import prettier, { Config as PrettierConfig } from 'prettier';
+import prettier from 'prettier';
 import prompts from 'prompts';
 
 import { isError } from '../core/errors';
 import { parseGlobalGitConfig } from '../core/git';
-import { Logger } from '../core/logger';
 
-import { Template, TemplateFeature, TemplateOption, TemplateOrTemplateResolver } from './types';
+import type { Template, TemplateFeature, TemplateOption, TemplateOrTemplateResolver } from './types';
+import type { Logger } from '../core/logger';
+import type { Config as PrettierConfig } from 'prettier';
 
 interface CreatePackageFromTemplateOpts {
   logger: Logger;

--- a/packages/utils/pack-up/src/node/templates/internal/default.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/default.ts
@@ -5,7 +5,6 @@ import { outdent } from 'outdent';
 import { isError } from '../../core/errors';
 import { definePackageFeature, definePackageOption, defineTemplate } from '../create';
 
-
 import { editorConfigFile } from './files/editorConfig';
 import { gitIgnoreFile } from './files/gitIgnore';
 import { prettierFile, prettierIgnoreFile } from './files/prettier';

--- a/packages/utils/pack-up/src/node/templates/internal/default.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/default.ts
@@ -3,13 +3,15 @@ import gitUrlParse from 'git-url-parse';
 import { outdent } from 'outdent';
 
 import { isError } from '../../core/errors';
-import { PackageJson } from '../../core/pkg';
 import { definePackageFeature, definePackageOption, defineTemplate } from '../create';
-import { TemplateFile } from '../types';
+
 
 import { editorConfigFile } from './files/editorConfig';
 import { gitIgnoreFile } from './files/gitIgnore';
 import { prettierFile, prettierIgnoreFile } from './files/prettier';
+
+import type { PackageJson } from '../../core/pkg';
+import type { TemplateFile } from '../types';
 
 const PACKAGE_NAME_REGEXP = /^(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)\/)?[a-z0-9-~][a-z0-9-._~]*$/i;
 

--- a/packages/utils/pack-up/src/node/templates/internal/files/editorConfig.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/files/editorConfig.ts
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent';
 
-import { TemplateFile } from '../../types';
+import type { TemplateFile } from '../../types';
 
 const editorConfigFile: TemplateFile = {
   name: '.editorconfig',

--- a/packages/utils/pack-up/src/node/templates/internal/files/eslint.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/files/eslint.ts
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent';
 
-import { TemplateFile } from '../../types';
+import type { TemplateFile } from '../../types';
 
 const eslintIgnoreFile: TemplateFile = {
   name: '.eslintignore',

--- a/packages/utils/pack-up/src/node/templates/internal/files/gitIgnore.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/files/gitIgnore.ts
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent';
 
-import { TemplateFile } from '../../types';
+import type { TemplateFile } from '../../types';
 
 const gitIgnoreFile: TemplateFile = {
   name: '.gitignore',

--- a/packages/utils/pack-up/src/node/templates/internal/files/prettier.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/files/prettier.ts
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent';
 
-import { TemplateFile } from '../../types';
+import type { TemplateFile } from '../../types';
 
 const prettierFile: TemplateFile = {
   name: '.prettierrc',

--- a/packages/utils/pack-up/src/node/templates/internal/files/typescript.ts
+++ b/packages/utils/pack-up/src/node/templates/internal/files/typescript.ts
@@ -1,6 +1,6 @@
 import { outdent } from 'outdent';
 
-import { TemplateFile } from '../../types';
+import type { TemplateFile } from '../../types';
 
 const tsconfigFile: TemplateFile = {
   name: 'tsconfig.json',

--- a/packages/utils/pack-up/src/node/templates/load.ts
+++ b/packages/utils/pack-up/src/node/templates/load.ts
@@ -5,7 +5,6 @@ import { resolve } from 'path';
 import type { TemplateOrTemplateResolver } from './types';
 import type { Logger } from '../core/logger';
 
-
 /**
  * @internal
  *

--- a/packages/utils/pack-up/src/node/templates/load.ts
+++ b/packages/utils/pack-up/src/node/templates/load.ts
@@ -2,9 +2,9 @@ import { register } from 'esbuild-register/dist/node';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 
-import { Logger } from '../core/logger';
+import type { TemplateOrTemplateResolver } from './types';
+import type { Logger } from '../core/logger';
 
-import { TemplateOrTemplateResolver } from './types';
 
 /**
  * @internal

--- a/packages/utils/pack-up/src/node/templates/types.ts
+++ b/packages/utils/pack-up/src/node/templates/types.ts
@@ -1,7 +1,7 @@
-import { PromptObject } from 'prompts';
 
-import { GitConfig } from '../core/git';
-import { Logger } from '../core/logger';
+import type { GitConfig } from '../core/git';
+import type { Logger } from '../core/logger';
+import type { PromptObject } from 'prompts';
 
 interface TemplateFeature<T extends string = string> extends Pick<PromptObject<T>, 'initial'> {
   /**

--- a/packages/utils/pack-up/src/node/templates/types.ts
+++ b/packages/utils/pack-up/src/node/templates/types.ts
@@ -1,4 +1,3 @@
-
 import type { GitConfig } from '../core/git';
 import type { Logger } from '../core/logger';
 import type { PromptObject } from 'prompts';

--- a/packages/utils/pack-up/src/node/watch.ts
+++ b/packages/utils/pack-up/src/node/watch.ts
@@ -2,17 +2,21 @@ import chokidar from 'chokidar';
 import path from 'path';
 import { Observable, distinctUntilChanged, scan, startWith, switchMap } from 'rxjs';
 
-import { CommonCLIOptions } from '../types';
 
-import { CONFIG_FILE_NAMES, Config, loadConfig } from './core/config';
+import { CONFIG_FILE_NAMES, loadConfig } from './core/config';
 import { getExportExtensionMap, validateExportsOrdering } from './core/exports';
 import { createLogger } from './core/logger';
 import { loadPkg, validatePkg } from './core/pkg';
 import { createBuildContext } from './createBuildContext';
-import { WatchTask, createWatchTasks } from './createTasks';
-import { TaskHandler, taskHandlers } from './tasks';
+import { createWatchTasks } from './createTasks';
+import { taskHandlers } from './tasks';
 
-interface WatchCLIOptions extends CommonCLIOptions {}
+import type { Config } from './core/config';
+import type { WatchTask } from './createTasks';
+import type { TaskHandler } from './tasks';
+import type { CommonCLIOptions } from '../types';
+
+type WatchCLIOptions = CommonCLIOptions;
 
 interface WatchOptionsWithoutConfig extends WatchCLIOptions {
   configFile?: true;

--- a/packages/utils/pack-up/src/node/watch.ts
+++ b/packages/utils/pack-up/src/node/watch.ts
@@ -2,7 +2,6 @@ import chokidar from 'chokidar';
 import path from 'path';
 import { Observable, distinctUntilChanged, scan, startWith, switchMap } from 'rxjs';
 
-
 import { CONFIG_FILE_NAMES, loadConfig } from './core/config';
 import { getExportExtensionMap, validateExportsOrdering } from './core/exports';
 import { createLogger } from './core/logger';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8064,9 +8064,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/eslint-config@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@strapi/eslint-config@npm:0.2.0"
+"@strapi/eslint-config@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@strapi/eslint-config@npm:0.2.1"
   dependencies:
     "@babel/eslint-parser": "npm:^7.19.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
@@ -8091,7 +8091,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: e0c5d3ade2d5c4c46533535784d964bad53023ffacab7c4692ea876b64e72aeb54469926a0c88d64399aaeb41c18fed9133698fac606712bc3376c836b8e813a
+  checksum: 753438ee07d25ea9bad11f1c6d533676110c067d1583dfe3690972736806316c52d0c09f0ebdcb46757f8c85f621b96d56a485cff3053eb7a1c8afb4e9ddb0da
   languageName: node
   linkType: hard
 
@@ -28715,7 +28715,7 @@ __metadata:
     "@babel/preset-react": "npm:7.18.6"
     "@playwright/test": "npm:1.38.1"
     "@strapi/admin-test-utils": "workspace:*"
-    "@strapi/eslint-config": "npm:0.2.0"
+    "@strapi/eslint-config": "npm:0.2.1"
     "@swc/cli": "npm:0.1.62"
     "@swc/core": "npm:1.3.58"
     "@swc/helpers": "npm:0.5.1"


### PR DESCRIPTION
### What does it do?

- bumps the eslint version so it gets the changes from this PR: https://github.com/strapi/eslint-config/pull/7
- applies eslint autofix so that import type and export type are used wherever possible

### Why is it needed?

See this post https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/

Now that this is handled by ESLint it shouldn't come up in PR reviews

### How to test it?

it only affects the typescript layer, so if the CI builds we should be good
