### PR TITLE
feat(admin): create internal history for universal back button

### DIFF
--- a/.github/workflows/contributor-doc.yml
+++ b/.github/workflows/contributor-doc.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'develop'
-    paths:
-      - 'docs/**'
 
   workflow_dispatch:
 

--- a/packages/core/admin/admin/src/components/Providers.tsx
+++ b/packages/core/admin/admin/src/components/Providers.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 
 import { AuthProvider } from '../features/Auth';
+import { HistoryProvider } from '../features/BackButton';
 
 import { GuidedTourProvider } from './GuidedTour/Provider';
 import { LanguageProvider, LanguageProviderProps } from './LanguageProvider';
@@ -69,36 +70,38 @@ const Providers = ({
 }: ProvidersProps) => {
   return (
     <Provider store={store}>
-      <AuthProvider>
-        <LanguageProvider messages={messages}>
-          <Theme themes={themes}>
-            <QueryClientProvider client={queryClient}>
-              <StrapiAppProvider
-                getPlugin={getPlugin}
-                getAdminInjectedComponents={getAdminInjectedComponents}
-                menu={menu}
-                plugins={plugins}
-                runHookParallel={runHookParallel}
-                runHookWaterfall={runHookWaterfall}
-                runHookSeries={runHookSeries}
-                settings={settings}
-              >
-                <LibraryProvider components={components} fields={fields}>
-                  <CustomFieldsProvider customFields={customFields}>
-                    <AutoReloadOverlayBlockerProvider>
-                      <OverlayBlockerProvider>
-                        <GuidedTourProvider>
-                          <NotificationsProvider>{children}</NotificationsProvider>
-                        </GuidedTourProvider>
-                      </OverlayBlockerProvider>
-                    </AutoReloadOverlayBlockerProvider>
-                  </CustomFieldsProvider>
-                </LibraryProvider>
-              </StrapiAppProvider>
-            </QueryClientProvider>
-          </Theme>
-        </LanguageProvider>
-      </AuthProvider>
+      <HistoryProvider>
+        <AuthProvider>
+          <LanguageProvider messages={messages}>
+            <Theme themes={themes}>
+              <QueryClientProvider client={queryClient}>
+                <StrapiAppProvider
+                  getPlugin={getPlugin}
+                  getAdminInjectedComponents={getAdminInjectedComponents}
+                  menu={menu}
+                  plugins={plugins}
+                  runHookParallel={runHookParallel}
+                  runHookWaterfall={runHookWaterfall}
+                  runHookSeries={runHookSeries}
+                  settings={settings}
+                >
+                  <LibraryProvider components={components} fields={fields}>
+                    <CustomFieldsProvider customFields={customFields}>
+                      <AutoReloadOverlayBlockerProvider>
+                        <OverlayBlockerProvider>
+                          <GuidedTourProvider>
+                            <NotificationsProvider>{children}</NotificationsProvider>
+                          </GuidedTourProvider>
+                        </OverlayBlockerProvider>
+                      </AutoReloadOverlayBlockerProvider>
+                    </CustomFieldsProvider>
+                  </LibraryProvider>
+                </StrapiAppProvider>
+              </QueryClientProvider>
+            </Theme>
+          </LanguageProvider>
+        </AuthProvider>
+      </HistoryProvider>
     </Provider>
   );
 };

--- a/packages/core/admin/admin/src/content-manager/components/ConfigurationForm/Form.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ConfigurationForm/Form.tsx
@@ -12,15 +12,13 @@ import {
   Main,
   Typography,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
-import { ArrowLeft } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import pipe from 'lodash/fp/pipe';
 import { useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
 
 import { Form, FormProps, useForm } from '../../../components/Form';
 import { InputRenderer } from '../../../components/FormInputs/Renderer';
+import { BackButton } from '../../../features/BackButton';
 import { capitalise } from '../../../utils/strings';
 import { ATTRIBUTE_TYPES_THAT_CANNOT_BE_MAIN_FIELD } from '../../constants/attributes';
 import { getTranslation } from '../../utils/translations';
@@ -298,15 +296,7 @@ const Header = ({ name }: HeaderProps) => {
         id: getTranslation('components.SettingsViewWrapper.pluginHeader.description.edit-settings'),
         defaultMessage: 'Customize how the edit view will look like.',
       })}
-      navigationAction={
-        // @ts-expect-error – DS does not infer props from the `as` prop
-        <Link startIcon={<ArrowLeft />} as={NavLink} to="..">
-          {formatMessage({
-            id: 'global.back',
-            defaultMessage: 'Back',
-          })}
-        </Link>
-      }
+      navigationAction={<BackButton />}
       primaryAction={
         <Button disabled={!modified} loading={isSubmitting} type="submit">
           {formatMessage({ id: 'global.save', defaultMessage: 'Save' })}

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/Header.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
 import { Flex, Icon, SingleSelect, SingleSelectOption, Typography } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import { useNotification, useQueryParams, useStrapiApp } from '@strapi/helper-plugin';
-import { ArrowLeft, Cog, ExclamationMarkCircle, Pencil, Trash } from '@strapi/icons';
+import { Cog, ExclamationMarkCircle, Pencil, Trash } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useMatch, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -11,6 +10,7 @@ import styled from 'styled-components';
 import { DescriptionComponentRenderer } from '../../../../components/DescriptionComponentRenderer';
 import { useForm } from '../../../../components/Form';
 import { RelativeTime } from '../../../../components/RelativeTime';
+import { BackButton } from '../../../../features/BackButton';
 import {
   CREATED_AT_ATTRIBUTE_NAME,
   CREATED_BY_ATTRIBUTE_NAME,
@@ -57,13 +57,7 @@ const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: Heade
 
   return (
     <Flex direction="column" alignItems="flex-start" paddingTop={8} paddingBottom={4} gap={3}>
-      {/* TODO: implement back button behaviour, track issue - https://strapi-inc.atlassian.net/browse/CONTENT-2173 */}
-      <Link startIcon={<ArrowLeft />}>
-        {formatMessage({
-          id: 'global.back',
-          defaultMessage: 'Back',
-        })}
-      </Link>
+      <BackButton />
       <Flex
         width="100%"
         justifyContent="space-between"

--- a/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/components/Header.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/components/Header.tsx
@@ -1,11 +1,8 @@
 import { Button, HeaderLayout } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
-import { useQueryParams } from '@strapi/helper-plugin';
-import { ArrowLeft } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
 
 import { useForm } from '../../../../components/Form';
+import { BackButton } from '../../../../features/BackButton';
 import { capitalise } from '../../../../utils/strings';
 import { getTranslation } from '../../../utils/translations';
 
@@ -15,8 +12,7 @@ interface HeaderProps {
   model: string;
 }
 
-const Header = ({ collectionType, name, model }: HeaderProps) => {
-  const [{ rawQuery }] = useQueryParams();
+const Header = ({ name }: HeaderProps) => {
   const { formatMessage } = useIntl();
 
   const modified = useForm('Header', (state) => state.modified);
@@ -24,20 +20,7 @@ const Header = ({ collectionType, name, model }: HeaderProps) => {
 
   return (
     <HeaderLayout
-      navigationAction={
-        <Link
-          startIcon={<ArrowLeft />}
-          // @ts-expect-error invalid typings
-          to={{
-            pathname: `/content-manager/${collectionType}/${model}`,
-            search: rawQuery,
-          }}
-          id="go-back"
-          as={NavLink}
-        >
-          {formatMessage({ id: 'global.back', defaultMessage: 'Back' })}
-        </Link>
-      }
+      navigationAction={<BackButton />}
       primaryAction={
         <Button size="S" disabled={!modified} type="submit" loading={isSubmitting}>
           {formatMessage({ id: 'global.save', defaultMessage: 'Save' })}

--- a/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/tests/ListConfigurationPage.test.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/tests/ListConfigurationPage.test.tsx
@@ -67,22 +67,6 @@ describe('Configure the List View', () => {
     expect(screen.getByRole('button', { name: 'Add a field' })).toBeInTheDocument();
   });
 
-  it('should keep plugins query params when arriving on the page and going back', async () => {
-    const { getByRole, user, findByRole, getByText } = render({
-      initialEntries: [
-        '/content-manager/collection-types/api::address.address/configurations/list?plugins[i18n][locale]=fr',
-      ],
-    });
-
-    await findByRole('heading', { name: 'Configure the view - Address' });
-
-    expect(getByText('?plugins[i18n][locale]=fr')).toBeInTheDocument();
-
-    await user.click(getByRole('link', { name: 'Back' }));
-
-    expect(getByText('?plugins[i18n][locale]=fr')).toBeInTheDocument();
-  });
-
   it('should add field', async () => {
     const { getByRole, user, findByRole } = render();
 

--- a/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/ListViewPage.tsx
@@ -13,7 +13,6 @@ import {
   lightTheme,
   ButtonProps,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import {
   useFocusWhenNavigate,
   useQueryParams,
@@ -22,7 +21,7 @@ import {
   useAPIErrorHandler,
   useStrapiApp,
 } from '@strapi/helper-plugin';
-import { ArrowLeft, Plus } from '@strapi/icons';
+import { Plus } from '@strapi/icons';
 import isEqual from 'lodash/isEqual';
 import { stringify } from 'qs';
 import { Helmet } from 'react-helmet';
@@ -35,6 +34,7 @@ import { Page } from '../../../components/PageHelpers';
 import { Pagination } from '../../../components/Pagination';
 import { SearchInput } from '../../../components/SearchInput';
 import { HOOKS } from '../../../constants';
+import { BackButton } from '../../../features/BackButton';
 import { useEnterprise } from '../../../hooks/useEnterprise';
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { DocumentRBAC, useDocumentRBAC } from '../../features/DocumentRBAC';
@@ -301,17 +301,7 @@ const ListViewPage = () => {
           { number: pagination?.total }
         )}
         title={contentTypeTitle}
-        navigationAction={
-          /**
-           * TODO: sort out back link behaviour, part of https://strapi-inc.atlassian.net/browse/CONTENT-2173
-           */
-          <Link startIcon={<ArrowLeft />}>
-            {formatMessage({
-              id: 'global.back',
-              defaultMessage: 'Back',
-            })}
-          </Link>
-        }
+        navigationAction={<BackButton />}
       />
       <ActionLayout
         endActions={

--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -98,5 +98,15 @@ type Store = ReturnType<typeof configureStoreImpl> & {
 
 type RootState = ReturnType<Store['getState']>;
 
+type Dispatch = Store['dispatch'];
+
 export { configureStoreImpl as configureStore };
-export type { RootState, AppState, RBACState, Store, PreloadState, ContentManagerAppState };
+export type {
+  RootState,
+  Dispatch,
+  AppState,
+  RBACState,
+  Store,
+  PreloadState,
+  ContentManagerAppState,
+};

--- a/packages/core/admin/admin/src/core/store/middleware.ts
+++ b/packages/core/admin/admin/src/core/store/middleware.ts
@@ -1,0 +1,9 @@
+import { createListenerMiddleware, type TypedStartListening } from '@reduxjs/toolkit';
+
+import { RootState, Dispatch } from './configure';
+
+export const listenerMiddleware = createListenerMiddleware();
+
+export type AppStartListening = TypedStartListening<RootState, Dispatch>;
+
+export const startTypedListening = listenerMiddleware.startListening as AppStartListening;

--- a/packages/core/admin/admin/src/core/store/middleware.ts
+++ b/packages/core/admin/admin/src/core/store/middleware.ts
@@ -1,9 +1,0 @@
-import { createListenerMiddleware, type TypedStartListening } from '@reduxjs/toolkit';
-
-import { RootState, Dispatch } from './configure';
-
-export const listenerMiddleware = createListenerMiddleware();
-
-export type AppStartListening = TypedStartListening<RootState, Dispatch>;
-
-export const startTypedListening = listenerMiddleware.startListening as AppStartListening;

--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -216,6 +216,7 @@ const BackButton = React.forwardRef<HTMLAnchorElement, BackButtonProps>(({ disab
       to={history.at(-1)}
       onClick={handleClick}
       disabled={disabled || !canGoBack}
+      aria-disabled={disabled || !canGoBack}
       startIcon={<ArrowLeft />}
     >
       {formatMessage({

--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -1,0 +1,231 @@
+import * as React from 'react';
+
+import { Link, LinkProps } from '@strapi/design-system/v2';
+import { ArrowLeft } from '@strapi/icons';
+import produce from 'immer';
+import { useIntl } from 'react-intl';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+
+import { createContext } from '../components/Context';
+
+/* -------------------------------------------------------------------------------------------------
+ * HistoryProvider
+ * -----------------------------------------------------------------------------------------------*/
+interface HistoryState {
+  /**
+   * The history of the user's navigation within our application
+   * during their current session.
+   */
+  history: string[];
+  /**
+   * The index of the current location in the history array.
+   */
+  currentLocationIndex: number;
+  /**
+   * The current location of the user within our application.
+   */
+  currentLocation: string;
+  /**
+   * Whether the user can go back in the history.
+   */
+  canGoBack: boolean;
+}
+
+interface HistoryContextValue extends HistoryState {
+  /**
+   * @description Push a new state to the history. You can
+   * either pass a string or an object.
+   */
+  pushState: (
+    path:
+      | {
+          to: string;
+          search: string;
+        }
+      | string
+  ) => void;
+  /**
+   * @description Go back in the history. This calls `navigate(-1)` internally
+   * to keep the browser in sync with the application state.
+   */
+  goBack: () => void;
+}
+
+const [Provider, useHistory] = createContext<HistoryContextValue>('History', {
+  history: [],
+  currentLocationIndex: 0,
+  currentLocation: '',
+  canGoBack: false,
+  pushState: () => {
+    throw new Error('You must use the `HistoryProvider` to access the `pushState` function.');
+  },
+  goBack: () => {
+    throw new Error('You must use the `HistoryProvider` to access the `goBack` function.');
+  },
+});
+
+interface HistoryProviderProps {
+  children: React.ReactNode;
+}
+
+const HistoryProvider = ({ children }: HistoryProviderProps) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [state, dispatch] = React.useReducer(reducer, {
+    history: [],
+    currentLocationIndex: 0,
+    currentLocation: '',
+    canGoBack: false,
+  });
+
+  const isGoingBack = React.useRef(false);
+
+  const pushState: HistoryContextValue['pushState'] = React.useCallback((path) => {
+    dispatch({
+      type: 'PUSH_STATE',
+      payload: typeof path === 'string' ? { to: path, search: '' } : path,
+    });
+  }, []);
+
+  const goBack: HistoryContextValue['goBack'] = React.useCallback(() => {
+    /**
+     * Perform the browser back action
+     * dispatch the goBack action to keep redux in sync
+     * and set the ref to avoid an infinite loop and incorrect state pushing
+     */
+    navigate(-1);
+    dispatch({ type: 'GO_BACK' });
+    isGoingBack.current = true;
+  }, [navigate]);
+
+  /**
+   * This is a semi-listener pattern to keep the `canGoBack` state in sync.
+   */
+  const prevIndex = React.useRef(state.currentLocationIndex);
+  React.useEffect(() => {
+    if (state.currentLocationIndex !== prevIndex.current) {
+      dispatch({
+        type: 'SET_ABILITY_TO_NAVIGATE',
+        payload: state.currentLocationIndex > 1 && state.history.length > 1,
+      });
+      prevIndex.current = state.currentLocationIndex;
+    }
+  }, [prevIndex, state.currentLocationIndex, state.history.length]);
+
+  /**
+   * This effect is responsible for pushing the new state to the history
+   * when the user navigates to a new location assuming they're not going back.
+   */
+  React.useLayoutEffect(() => {
+    if (isGoingBack.current) {
+      isGoingBack.current = false;
+      return;
+    } else {
+      // this should only occur on link movements, not back/forward clicks
+      dispatch({
+        type: 'PUSH_STATE',
+        payload: { to: location.pathname, search: location.search },
+      });
+    }
+  }, [dispatch, location.pathname, location.search]);
+
+  return (
+    <Provider pushState={pushState} goBack={goBack} {...state}>
+      {children}
+    </Provider>
+  );
+};
+
+type HistoryActions =
+  | {
+      type: 'PUSH_STATE';
+      payload: {
+        to: string;
+        search: string;
+      };
+    }
+  | {
+      type: 'GO_BACK';
+    }
+  | {
+      type: 'SET_ABILITY_TO_NAVIGATE';
+      payload: boolean;
+    };
+
+const reducer = (state: HistoryState, action: HistoryActions) =>
+  produce(state, (draft) => {
+    switch (action.type) {
+      case 'PUSH_STATE': {
+        const path = `${action.payload.to}${action.payload.search}`;
+        if (state.currentLocationIndex === state.history.length) {
+          // add the new place
+          draft.history = [...state.history, path];
+        } else {
+          // delete all the history after the current place and then add the new place
+          draft.history = [...state.history.slice(0, state.currentLocationIndex), path];
+        }
+
+        draft.currentLocation = path;
+        draft.currentLocationIndex += 1;
+
+        break;
+      }
+      case 'GO_BACK': {
+        const newIndex = state.currentLocationIndex - 1;
+
+        draft.currentLocation = state.history[newIndex - 1];
+        draft.currentLocationIndex = newIndex;
+        break;
+      }
+      case 'SET_ABILITY_TO_NAVIGATE': {
+        draft.canGoBack = action.payload;
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+/* -------------------------------------------------------------------------------------------------
+ * BackButton
+ * -----------------------------------------------------------------------------------------------*/
+interface BackButtonProps extends Pick<LinkProps, 'disabled'> {}
+
+/**
+ * @beta
+ * @description The universal back button for the Strapi application. This uses the internal history
+ * context to navigate the user back to the previous location. It can be completely disabled in a
+ * specific user case.
+ */
+const BackButton = React.forwardRef<HTMLAnchorElement, BackButtonProps>(({ disabled }, ref) => {
+  const { formatMessage } = useIntl();
+
+  const canGoBack = useHistory('BackButton', (state) => state.canGoBack);
+  const goBack = useHistory('BackButton', (state) => state.goBack);
+  const history = useHistory('BackButton', (state) => state.history);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    goBack();
+  };
+
+  return (
+    <Link
+      ref={ref}
+      as={NavLink}
+      // @ts-expect-error – the DS does not infer the props from the `as` prop to the component.
+      to={history.at(-1)}
+      onClick={handleClick}
+      disabled={disabled || !canGoBack}
+      startIcon={<ArrowLeft />}
+    >
+      {formatMessage({
+        id: 'global.back',
+        defaultMessage: 'Back',
+      })}
+    </Link>
+  );
+});
+
+export { BackButton, HistoryProvider };
+export type { BackButtonProps, HistoryProviderProps, HistoryContextValue, HistoryState };

--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -105,7 +105,7 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
   React.useEffect(() => {
     if (state.currentLocationIndex !== prevIndex.current) {
       dispatch({
-        type: 'SET_ABILITY_TO_NAVIGATE',
+        type: 'SET_CAN_GO_BACK',
         payload: state.currentLocationIndex > 1 && state.history.length > 1,
       });
       prevIndex.current = state.currentLocationIndex;
@@ -147,7 +147,7 @@ type HistoryActions =
       type: 'GO_BACK';
     }
   | {
-      type: 'SET_ABILITY_TO_NAVIGATE';
+      type: 'SET_CAN_GO_BACK';
       payload: boolean;
     };
 
@@ -176,7 +176,7 @@ const reducer = (state: HistoryState, action: HistoryActions) =>
         draft.currentLocationIndex = newIndex;
         break;
       }
-      case 'SET_ABILITY_TO_NAVIGATE': {
+      case 'SET_CAN_GO_BACK': {
         draft.canGoBack = action.payload;
         break;
       }

--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -119,7 +119,6 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
   React.useLayoutEffect(() => {
     if (isGoingBack.current) {
       isGoingBack.current = false;
-      return;
     } else {
       // this should only occur on link movements, not back/forward clicks
       dispatch({

--- a/packages/core/admin/admin/src/features/tests/BackButton.test.tsx
+++ b/packages/core/admin/admin/src/features/tests/BackButton.test.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+
+import { render as renderRTL, screen, waitFor } from '@tests/utils';
+import { NavLink, useLocation } from 'react-router-dom';
+
+import { BackButton, HistoryProvider } from '../BackButton';
+
+const LocationDisplay = () => {
+  const location = useLocation();
+
+  return <span data-testId="location">{location.pathname}</span>;
+};
+
+const RandomNavLink = () => {
+  const location = useLocation();
+
+  const to = useMemo(() => Math.random().toString(), [location]);
+
+  return <NavLink to={to}>Navigate</NavLink>;
+};
+
+const render = () =>
+  renderRTL(<BackButton />, {
+    renderOptions: {
+      wrapper({ children }) {
+        return (
+          <HistoryProvider>
+            {children}
+            <RandomNavLink />
+            <LocationDisplay />
+          </HistoryProvider>
+        );
+      },
+    },
+  });
+
+describe('BackButton', () => {
+  it('should be disabled if there is no history', () => {
+    render();
+
+    expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should be enabled if there is history', async () => {
+    const { user } = render();
+
+    user.click(screen.getByRole('link', { name: 'Navigate' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute('aria-disabled', 'false')
+    );
+  });
+
+  it('should navigate us backwards when pressed', async () => {
+    const { user } = render();
+
+    user.click(screen.getByRole('link', { name: 'Navigate' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute('aria-disabled', 'false')
+    );
+
+    const location1 = screen.getByTestId('location').textContent ?? '';
+
+    user.click(screen.getByRole('link', { name: 'Navigate' }));
+
+    await waitFor(() => expect(screen.getByTestId('location')).not.toHaveTextContent(location1));
+
+    user.click(screen.getByRole('link', { name: 'Back' }));
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent(location1));
+
+    user.click(screen.getByRole('link', { name: 'Back' }));
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/'));
+  });
+});

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -12,6 +12,7 @@ export * from './components/FormInputs/Renderer';
 export * from './components/PageHelpers';
 export * from './components/Pagination';
 export * from './components/SearchInput';
+export { BackButton, type BackButtonProps } from './features/BackButton';
 
 /**
  * Hooks

--- a/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
 import { Button, Flex, HeaderLayout } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import { ConfirmDialog, useAPIErrorHandler, useNotification } from '@strapi/helper-plugin';
-import { ArrowLeft, Check, Refresh } from '@strapi/icons';
+import { Check, Refresh } from '@strapi/icons';
 import { MessageDescriptor, useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
 
+import { BackButton } from '../../../../features/BackButton';
 import { useRegenerateTokenMutation } from '../../../../services/api';
 
 import type { Entity } from '@strapi/types';
@@ -115,7 +114,6 @@ interface FormHeadProps<TToken extends Token | null> {
   canRegenerate: boolean;
   setToken: (token: TToken) => void;
   isSubmitting: boolean;
-  backUrl: string;
   regenerateUrl: string;
 }
 
@@ -126,7 +124,6 @@ export const FormHead = <TToken extends Token | null>({
   canEditInputs,
   canRegenerate,
   isSubmitting,
-  backUrl,
   regenerateUrl,
 }: FormHeadProps<TToken>) => {
   const { formatMessage } = useIntl();
@@ -172,17 +169,7 @@ export const FormHead = <TToken extends Token | null>({
           )
         )
       }
-      navigationAction={
-        <>
-          {/* @ts-expect-error polymorphic */}
-          <Link as={NavLink} startIcon={<ArrowLeft />} to={backUrl}>
-            {formatMessage({
-              id: 'global.back',
-              defaultMessage: 'Back',
-            })}
-          </Link>
-        </>
-      }
+      navigationAction={<BackButton />}
       ellipsis
     />
   );

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
@@ -357,7 +357,6 @@ export const EditView = () => {
             return (
               <Form>
                 <FormHead
-                  backUrl="/settings/api-tokens"
                   title={{
                     id: 'Settings.apiTokens.createPage.title',
                     defaultMessage: 'Create API Token',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
@@ -13,7 +13,6 @@ import {
   TextInput,
   Typography,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import {
   useNotification,
   useOverlayBlocker,
@@ -21,17 +20,17 @@ import {
   translatedErrors,
   useAPIErrorHandler,
 } from '@strapi/helper-plugin';
-import { ArrowLeft } from '@strapi/icons';
 import { format } from 'date-fns';
 import { Formik, Form, FormikHelpers } from 'formik';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
-import { NavLink, useNavigate, useMatch } from 'react-router-dom';
+import { useNavigate, useMatch } from 'react-router-dom';
 import styled from 'styled-components';
 import * as yup from 'yup';
 
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
+import { BackButton } from '../../../../features/BackButton';
 import {
   useCreateRoleMutation,
   useGetRolePermissionLayoutQuery,
@@ -235,15 +234,7 @@ const CreatePage = () => {
                   id: 'Settings.roles.create.description',
                   defaultMessage: 'Define the rights given to the role',
                 })}
-                navigationAction={
-                  // @ts-expect-error – the props from the component passed as `as` are not correctly inferred.
-                  <Link as={NavLink} startIcon={<ArrowLeft />} to="/settings/roles">
-                    {formatMessage({
-                      id: 'global.back',
-                      defaultMessage: 'Back',
-                    })}
-                  </Link>
-                }
+                navigationAction={<BackButton />}
               />
               <ContentLayout>
                 <Flex direction="column" alignItems="stretch" gap={6}>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { Box, Button, ContentLayout, Flex, HeaderLayout, Main } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import {
   useAPIErrorHandler,
   useNotification,
@@ -9,15 +8,15 @@ import {
   useTracking,
   translatedErrors,
 } from '@strapi/helper-plugin';
-import { ArrowLeft } from '@strapi/icons';
 import { Formik, FormikHelpers } from 'formik';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
-import { NavLink, Navigate, useMatch } from 'react-router-dom';
+import { Navigate, useMatch } from 'react-router-dom';
 import * as yup from 'yup';
 
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
+import { BackButton } from '../../../../features/BackButton';
 import { useAdminRoles } from '../../../../hooks/useAdminRoles';
 import {
   useGetRolePermissionLayoutQuery,
@@ -221,15 +220,7 @@ const EditPage = () => {
                 id: 'Settings.roles.create.description',
                 defaultMessage: 'Define the rights given to the role',
               })}
-              navigationAction={
-                // @ts-expect-error – the props from the component passed as `as` are not correctly inferred.
-                <Link as={NavLink} startIcon={<ArrowLeft />} to="/settings/roles">
-                  {formatMessage({
-                    id: 'global.back',
-                    defaultMessage: 'Back',
-                  })}
-                </Link>
-              }
+              navigationAction={<BackButton />}
             />
             <ContentLayout>
               <Flex direction="column" alignItems="stretch" gap={6}>

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
@@ -266,7 +266,6 @@ const EditView = () => {
           return (
             <Form>
               <FormHead
-                backUrl="/settings/transfer-tokens"
                 title={{
                   id: 'Settings.transferTokens.createPage.title',
                   defaultMessage: 'TokenCreate Transfer Token',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
@@ -11,7 +11,6 @@ import {
   Main,
   Typography,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import {
   translatedErrors,
   useAPIErrorHandler,
@@ -20,11 +19,11 @@ import {
   useOverlayBlocker,
   useRBAC,
 } from '@strapi/helper-plugin';
-import { ArrowLeft, Check } from '@strapi/icons';
+import { Check } from '@strapi/icons';
 import pick from 'lodash/pick';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
-import { NavLink, useMatch, useNavigate } from 'react-router-dom';
+import { useMatch, useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
 import { Update } from '../../../../../../shared/contracts/user';
@@ -32,6 +31,7 @@ import { Form, FormHelpers } from '../../../../components/Form';
 import { InputRenderer } from '../../../../components/FormInputs/Renderer';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
+import { BackButton } from '../../../../features/BackButton';
 import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { selectAdminPermissions } from '../../../../selectors';
 import { useAdminUsers, useUpdateUserMutation } from '../../../../services/users';
@@ -228,19 +228,7 @@ const EditPage = () => {
                       getFullName(initialData?.firstname ?? '', initialData.lastname),
                   }
                 )}
-                navigationAction={
-                  <Link
-                    as={NavLink}
-                    startIcon={<ArrowLeft />}
-                    // @ts-expect-error – as component props are not inferred correctly.
-                    to="/settings/users?pageSize=10&page=1&sort=firstname"
-                  >
-                    {formatMessage({
-                      id: 'global.back',
-                      defaultMessage: 'Back',
-                    })}
-                  </Link>
-                }
+                navigationAction={<BackButton />}
               />
               <ContentLayout>
                 {user?.registrationToken && (

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
@@ -10,15 +10,14 @@ import {
   HeaderLayout,
   TextInput,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
-import { ArrowLeft, Check, Play as Publish } from '@strapi/icons';
+import { Check, Play as Publish } from '@strapi/icons';
 import { Webhook } from '@strapi/types';
 import { Field, Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
 import { IntlShape, useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
 import * as yup from 'yup';
 
 import { TriggerWebhook } from '../../../../../../../shared/contracts/webhooks';
+import { BackButton } from '../../../../../features/BackButton';
 import { useEnterprise } from '../../../../../hooks/useEnterprise';
 
 import { EventTableCE } from './EventsTable';
@@ -140,15 +139,7 @@ const WebhookForm = ({
                 })
               : data?.name
           }
-          navigationAction={
-            // @ts-expect-error – as components props are not inferred correctly.
-            <Link as={NavLink} startIcon={<ArrowLeft />} to="/settings/webhooks">
-              {formatMessage({
-                id: 'global.back',
-                defaultMessage: 'Back',
-              })}
-            </Link>
-          }
+          navigationAction={<BackButton />}
         />
         <ContentLayout>
           <Flex direction="column" alignItems="stretch" gap={4}>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/CreatePage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/CreatePage.tsx
@@ -8,6 +8,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import { BackButton } from '../../../../../../../admin/src/features/BackButton';
 import { useAdminRoles } from '../../../../../../../admin/src/hooks/useAdminRoles';
 import { useContentTypes } from '../../../../../../../admin/src/hooks/useContentTypes';
 import { useInjectReducer } from '../../../../../../../admin/src/hooks/useInjectReducer';
@@ -237,7 +238,7 @@ export const ReviewWorkflowsCreatePage = () => {
       <FormikProvider value={formik}>
         <Form onSubmit={formik.handleSubmit}>
           <Layout.Header
-            navigationAction={<Layout.Back href="/settings/review-workflows" />}
+            navigationAction={<BackButton />}
             primaryAction={
               <Button
                 startIcon={<Check />}

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/EditPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/EditPage.tsx
@@ -8,6 +8,7 @@ import { useIntl } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
+import { BackButton } from '../../../../../../../admin/src/features/BackButton';
 import { useAdminRoles } from '../../../../../../../admin/src/hooks/useAdminRoles';
 import { useContentTypes } from '../../../../../../../admin/src/hooks/useContentTypes';
 import { useInjectReducer } from '../../../../../../../admin/src/hooks/useInjectReducer';
@@ -304,7 +305,7 @@ export const ReviewWorkflowsEditPage = () => {
       <FormikProvider value={formik}>
         <Form onSubmit={formik.handleSubmit}>
           <Layout.Header
-            navigationAction={<Layout.Back href="/settings/review-workflows" />}
+            navigationAction={<BackButton />}
             primaryAction={
               canUpdate && (
                 <Button

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/Layout.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ReviewWorkflows/components/Layout.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 
 import { ContentLayout, HeaderLayout, Layout, Main } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
-import { ArrowLeft } from '@strapi/icons';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
 
 import { DragLayer } from '../../../../../../../../admin/src/components/DragLayer';
 import { DRAG_DROP_TYPES } from '../constants';
@@ -31,23 +28,6 @@ const Root: React.FC<React.PropsWithChildren> = ({ children }) => {
         <ContentLayout>{children}</ContentLayout>
       </Main>
     </Layout>
-  );
-};
-
-type BackProps = {
-  href: string;
-};
-const Back: React.FC<BackProps> = ({ href }) => {
-  const { formatMessage } = useIntl();
-
-  return (
-    // @ts-expect-error – the `as` prop does not correctly infer the props of it's component
-    <Link as={NavLink} startIcon={<ArrowLeft />} to={href}>
-      {formatMessage({
-        id: 'global.back',
-        defaultMessage: 'Back',
-      })}
-    </Link>
   );
 };
 
@@ -80,4 +60,4 @@ const Header: React.FC<HeaderProps> = ({ title, subtitle, navigationAction, prim
   );
 };
 
-export { Back, DragLayerRendered, Header, Root };
+export { DragLayerRendered, Header, Root };

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
-import { Page, unstable_useDocument, Pagination } from '@strapi/admin/strapi-admin';
+import { Page, unstable_useDocument, Pagination, BackButton } from '@strapi/admin/strapi-admin';
 import {
   Button,
   ContentLayout,
   Flex,
   HeaderLayout,
   IconButton,
-  Link,
   Main,
   Tr,
   Td,
@@ -30,15 +29,7 @@ import {
   useRBAC,
   useTracking,
 } from '@strapi/helper-plugin';
-import {
-  ArrowLeft,
-  CheckCircle,
-  More,
-  Pencil,
-  Trash,
-  CrossCircle,
-  EmptyDocuments,
-} from '@strapi/icons';
+import { CheckCircle, More, Pencil, Trash, CrossCircle, EmptyDocuments } from '@strapi/icons';
 import format from 'date-fns/format';
 import { utcToZonedTime } from 'date-fns-tz';
 import { useIntl } from 'react-intl';
@@ -367,14 +358,7 @@ const ReleaseDetailsLayout = ({
             <Badge {...getBadgeProps(release.status)}>{release.status}</Badge>
           </Flex>
         }
-        navigationAction={
-          <Link startIcon={<ArrowLeft />} to="/plugins/content-releases">
-            {formatMessage({
-              id: 'global.back',
-              defaultMessage: 'Back',
-            })}
-          </Link>
-        }
+        navigationAction={<BackButton />}
         primaryAction={
           !release.releasedAt && (
             <Flex gap={2}>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -1,13 +1,13 @@
+import { BackButton } from '@strapi/admin/strapi-admin';
 import { Box, Button, ContentLayout, Flex, HeaderLayout } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import { useTracking } from '@strapi/helper-plugin';
-import { ArrowLeft, Check, Pencil, Plus } from '@strapi/icons';
+import { Check, Pencil, Plus } from '@strapi/icons';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isEqual from 'lodash/isEqual';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
-import { unstable_usePrompt as usePrompt, useMatch, NavLink } from 'react-router-dom';
+import { unstable_usePrompt as usePrompt, useMatch } from 'react-router-dom';
 
 import { List } from '../../components/List';
 import { ListRow } from '../../components/ListRow';
@@ -169,15 +169,7 @@ const ListView = () => {
           id: getTrad('listView.headerLayout.description'),
           defaultMessage: 'Build the data architecture of your content',
         })}
-        navigationAction={
-          // @ts-expect-error – the `as` prop does not correctly infer the props of it's component
-          <Link startIcon={<ArrowLeft />} as={NavLink} to="/plugins/content-type-builder/">
-            {formatMessage({
-              id: 'global.back',
-              defaultMessage: 'Back',
-            })}
-          </Link>
-        }
+        navigationAction={<BackButton />}
       />
       <ContentLayout>
         <Flex direction="column" alignItems="stretch" gap={4}>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/ListView.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/ListView.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
 .c4 {
   font-size: 0.875rem;
   line-height: 1.43;
-  color: #4945ff;
+  color: #666687;
 }
 
 .c8 {
@@ -690,6 +690,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   gap: 8px;
+  pointer-events: none;
   position: relative;
   outline: none;
 }
@@ -699,7 +700,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
 }
 
 .c2 svg path {
-  fill: #4945ff;
+  fill: #666687;
 }
 
 .c2:hover {
@@ -1055,8 +1056,10 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
         class="c1"
       >
         <a
-          class="c2"
-          href="/plugins/content-type-builder/"
+          aria-current="page"
+          class="c2 active"
+          disabled=""
+          href="/"
         >
           <svg
             fill="none"

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/ListView.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/__snapshots__/ListView.test.tsx.snap
@@ -1057,6 +1057,7 @@ exports[`<ListView /> renders and matches the snapshot 1`] = `
       >
         <a
           aria-current="page"
+          aria-disabled="true"
           class="c2 active"
           disabled=""
           href="/"

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
@@ -12,20 +12,19 @@ import {
   GridItem,
   Grid,
 } from '@strapi/design-system';
-import { Link } from '@strapi/design-system/v2';
 import {
   useOverlayBlocker,
   useAPIErrorHandler,
   useFetchClient,
   useNotification,
 } from '@strapi/helper-plugin';
-import { ArrowLeft, Check } from '@strapi/icons';
-import { Page } from '@strapi/strapi/admin';
+import { Check } from '@strapi/icons';
+import { Page, BackButton } from '@strapi/strapi/admin';
 import { Formik, Form } from 'formik';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
 import { useQuery, useMutation } from 'react-query';
-import { NavLink, useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router-dom';
 
 import UsersPermissions from '../../../components/UsersPermissions';
 import { PERMISSIONS } from '../../../constants';
@@ -128,14 +127,7 @@ export const EditPage = () => {
               }
               title={role.name}
               subtitle={role.description}
-              navigationAction={
-                <Link as={NavLink} startIcon={<ArrowLeft />} to="/settings/users-permissions/roles">
-                  {formatMessage({
-                    id: 'global.back',
-                    defaultMessage: 'Back',
-                  })}
-                </Link>
-              }
+              navigationAction={<BackButton />}
             />
             <ContentLayout>
               <Flex

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -28,7 +28,7 @@ import {
   useTracking,
 } from '@strapi/helper-plugin';
 import { Plus } from '@strapi/icons';
-import { Page, SearchInput } from '@strapi/strapi/admin';
+import { Page, SearchInput, BackButton } from '@strapi/strapi/admin';
 import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery } from 'react-query';
@@ -167,6 +167,7 @@ export const RolesListPage = () => {
               </LinkButton>
             </CheckPermissions>
           }
+          navigationAction={<BackButton />}
         />
 
         <ActionLayout


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* introduces a universal back-button that can / should be implemented on all pages, it records the internal app state so it won't cause the user to leave the application, instead it disables itself. It also works across the entire app without needing to know paths.

### Why is it needed?

* user-story from design

### Related issue(s)/PR(s)

* resolves CONTENT-2173
