### PR TITLE
fix(strapi): vite crashes because files can't be found

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -7,6 +7,7 @@ import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import { Helmet } from 'react-helmet';
+import { Provider } from 'react-redux';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { DefaultTheme } from 'styled-components';
 
@@ -15,6 +16,7 @@ import { getEERoutes as getSettingsEERoutes } from '../../ee/admin/src/pages/Set
 
 import { App } from './App';
 import Logo from './assets/images/logo-strapi-2022.svg';
+import { ErrorElement } from './components/ErrorElement';
 import {
   INJECTION_ZONES,
   InjectionZoneBlock,
@@ -23,8 +25,10 @@ import {
   InjectionZoneModule,
   InjectionZones,
 } from './components/InjectionZone';
+import { LanguageProvider } from './components/LanguageProvider';
 import { Page } from './components/PageHelpers';
 import { Providers } from './components/Providers';
+import { Theme } from './components/Theme';
 import { HOOKS } from './constants';
 import { routes as cmRoutes } from './content-manager/router';
 import { ContentManagerPlugin } from './core/apis/content-manager';
@@ -629,6 +633,15 @@ class StrapiApp {
       [
         {
           path: '/*',
+          errorElement: (
+            <Provider store={store}>
+              <LanguageProvider messages={this.configurations.translations}>
+                <Theme themes={this.configurations.themes}>
+                  <ErrorElement />
+                </Theme>
+              </LanguageProvider>
+            </Provider>
+          ),
           element: <Root strapi={this} localeNames={localeNames} store={store} />,
           children: [
             {

--- a/packages/core/admin/admin/src/components/ErrorElement.tsx
+++ b/packages/core/admin/admin/src/components/ErrorElement.tsx
@@ -1,0 +1,20 @@
+import { useRouteError } from 'react-router-dom';
+
+import { Page } from './PageHelpers';
+
+/**
+ * @description this stops the app from going white, and instead shows the error message.
+ * But it could be improved for sure.
+ */
+const ErrorElement = () => {
+  const error = useRouteError();
+
+  if (error instanceof Error) {
+    console.error(error);
+    return <Page.Error content={error.message} />;
+  }
+
+  throw error;
+};
+
+export { ErrorElement };

--- a/packages/core/admin/admin/src/components/ErrorElement.tsx
+++ b/packages/core/admin/admin/src/components/ErrorElement.tsx
@@ -1,6 +1,8 @@
+import { Alert, Flex, Icon, Main, Typography } from '@strapi/design-system';
+import { ExclamationMarkCircle } from '@strapi/icons';
+import { useIntl } from 'react-intl';
 import { useRouteError } from 'react-router-dom';
-
-import { Page } from './PageHelpers';
+import styled from 'styled-components';
 
 /**
  * @description this stops the app from going white, and instead shows the error message.
@@ -8,13 +10,73 @@ import { Page } from './PageHelpers';
  */
 const ErrorElement = () => {
   const error = useRouteError();
+  const { formatMessage } = useIntl();
+
+  const errorMsg =
+    process.env.NODE_ENV === 'development'
+      ? formatMessage({
+          id: 'app.error.development',
+          defaultMessage: 'This is likely a bug with Strapi. Please open an issue.',
+        })
+      : formatMessage({
+          id: 'app.error.production',
+          defaultMessage: 'Please contact your administrator.',
+        });
 
   if (error instanceof Error) {
     console.error(error);
-    return <Page.Error content={error.message} />;
+
+    return (
+      <Main height="100%">
+        <Flex alignItems="center" height="100%" justifyContent="center">
+          <Flex
+            gap={7}
+            padding={7}
+            direction="column"
+            width="35%"
+            shadow="tableShadow"
+            borderColor="neutral150"
+            background="neutral0"
+            hasRadius
+          >
+            <Flex direction="column" gap={2}>
+              <Icon as={ExclamationMarkCircle} width="32px" height="32px" color="danger600" />
+              <Typography fontSize={4} fontWeight="bold">
+                {formatMessage({
+                  id: 'app.error',
+                  defaultMessage: 'Your app crashed',
+                })}
+              </Typography>
+              <Typography variant="omega" textAlign="center">
+                {errorMsg}
+              </Typography>
+            </Flex>
+            {/* the Alert component needs to make its close button optional. */}
+            <StyledAlert
+              title={error.name !== 'Error' ? error.name : ''}
+              onClose={() => {}}
+              closeLabel=""
+              variant="danger"
+            >
+              <ErrorType>{error.message}</ErrorType>
+            </StyledAlert>
+          </Flex>
+        </Flex>
+      </Main>
+    );
   }
 
   throw error;
 };
+
+const StyledAlert = styled(Alert)`
+  & > button {
+    display: none;
+  }
+`;
+
+const ErrorType = styled(Typography)`
+  word-break: break-all;
+`;
 
 export { ErrorElement };

--- a/packages/core/core/src/middlewares/security.ts
+++ b/packages/core/core/src/middlewares/security.ts
@@ -71,12 +71,24 @@ export const security: Common.MiddlewareFactory<Config> =
       });
     }
 
-    if (ctx.method === 'GET' && ['/admin'].some((str) => ctx.path.startsWith(str))) {
+    /**
+     * These are for vite's watch mode so it can accurately
+     * connect to the HMR websocket & reconnect on failure
+     * or when the server restarts.
+     *
+     * It only applies in development, and only on GET requests
+     * that are part of the admin route.
+     */
+    if (
+      process.env.NODE_ENV === 'development' &&
+      ctx.method === 'GET' &&
+      ['/admin'].some((str) => ctx.path.startsWith(str))
+    ) {
       helmetConfig = merge(helmetConfig, {
         contentSecurityPolicy: {
           directives: {
             'script-src': ["'self'", "'unsafe-inline'"],
-            'connect-src': ["'self'", 'https:', 'ws:'],
+            'connect-src': ["'self'", 'http:', 'https:', 'ws:'],
           },
         },
       });

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -18,7 +18,7 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
 
   const { createServer } = await import('vite');
 
-  const vite = await createServer(config);
+  const vite = await createServer(finalConfig);
 
   ctx.strapi.server.app.use(async (ctx, next) => {
     const url = ctx.url;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* sets the security policy for admin routes with GET methods to only run in development mode and allow `http` as a `content-src`.
* Adds global error element incase of catastrophic failure.

### Why is it needed?

* Vite uses a websocket in watch-mode to get it's HMR updates, when we use the CTB we shut the server down and restart it, this disconnects the socket and the client cannot reconnect because it uses `http` to connect.
* Better UX

### How to test it?

* using this experimental version – `0.0.0-experimental.171e4d8ec72685e5302378f337dc9073c35a9100`
* run `yarn develop`
* go to CTB
* add a content-type so the server restarts
* the app should be navigable to all pages like the EditView which is dynamically fetched
* you can verify because there will not be a continuous error saying "Refused to connect...." *AFTER* the server has rebooted.

### Related issue(s)/PR(s)

* resolves CONTENT-2334
