### PR TITLE
fix: updated at value when enabling DP

### DIFF
--- a/packages/core/core/src/migrations/draft-publish.ts
+++ b/packages/core/core/src/migrations/draft-publish.ts
@@ -68,11 +68,8 @@ const enableDraftAndPublish = async ({ oldContentTypes, contentTypes }: Input) =
                   return qb.raw('NULL as published_at');
                 }
 
-                // TODO: Find a way to insert a date using the correct format
-                //           Before: 1710240975246
-                // With qb.fn.now(): 2021-10-24 09:52:46
                 if (att === 'updated_at') {
-                  return qb.raw(`?? as updated_at`, [qb.fn.now()]);
+                  return qb.raw(`? as updated_at`, [new Date()]);
                 }
 
                 return att;


### PR DESCRIPTION
### What does it do?

Set the updated at value using new Date when enabling DP on a content type
