### PR TITLE
chore: mark doc service as beta

### DIFF
--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -112,7 +112,7 @@ export interface Strapi extends Container {
    */
   entityService?: EntityService.EntityService;
   /**
-   * @description Documents API might change in the future.
+   * @description interact with documents within Strapi, this API is currently in beta and is subject to change in the future
    * @beta
    */
   documents?: Documents.Service;

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -111,6 +111,10 @@ export interface Strapi extends Container {
    * @deprecated will be removed in the next major
    */
   entityService?: EntityService.EntityService;
+  /**
+   * @description Documents API might change in the future.
+   * @beta
+   */
   documents?: Documents.Service;
   telemetry: TelemetryService;
   requestContext: RequestContext;


### PR DESCRIPTION
### What does it do?

Mark strapi.documents as a beta api
![image](https://github.com/strapi/strapi/assets/20578351/2aa19a30-18b6-4eb1-8a0d-0c354eb58a27)



