### PR TITLE
fix: transfer issues with foreign keys

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/entities.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/strategies/restore/entities.ts
@@ -31,16 +31,16 @@ const createEntitiesWriteStream = (options: IEntitiesRestoreStreamOptions) => {
         const { create, getDeepPopulateComponentLikeQuery } = query(type);
         const contentType = strapi.getModel(type);
 
-        let cType:
-          | Schema.ContentType
-          | Schema.Component
-          | ((...opts: any[]) => Schema.ContentType | Schema.Component) = contentType;
-
         /**
          * Resolve the component UID of an entity's attribute based
          * on a given path (components & dynamic zones only)
          */
         const resolveType = (paths: string[]): Common.UID.Schema | undefined => {
+          let cType:
+            | Schema.ContentType
+            | Schema.Component
+            | ((...opts: any[]) => Schema.ContentType | Schema.Component) = contentType;
+
           let value: unknown = data;
 
           for (const path of paths) {


### PR DESCRIPTION
### What does it do?

Fix some transfer errors when we have two components within the same entity. 
Content type was not reset correctly for each component of an entity. 
It leads to some errors like : 
`warn: Skipping link products.cross-selling:1 -> api::product.product:3`

As the `cType` variable's scope was too high, we we're not getting the correct contentType (the one of the entity) on the second (and more) loop. 
So we cannot update the `entitiesMapper` correctly because the contentType is not correct. 
So finally, we were trying to push a link between a newID and an oldID which creates a foreign key issue (as ID has not been matched with a new one).

_Linked code :_
```js
left.ref = mapID(left.type, originalLeftRef) ?? originalLeftRef;
right.ref = mapID(right.type, originalRightRef) ?? originalRightRef;
```

### Why is it needed?

Solves issue on transfer (or simply import/export) where the data is not replicated correctly. 

### How to test it?

Test has been done through this repro repo : https://github.com/thollander/strapi-repro-18350. 

https://github.com/strapi/strapi/assets/23191482/1b5fd00f-da14-4195-8250-56397cd2fda5

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/18350 
