### PR TITLE
feat(content-releases): new create many release actions endpoint

### DIFF
--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -1,8 +1,10 @@
+import { errors } from '@strapi/utils';
 import releaseActionController from '../release-action';
 
 const mockSanitizedQueryRead = jest.fn().mockResolvedValue({});
 const mockFindActions = jest.fn().mockResolvedValue({ results: [], pagination: {} });
 const mockSanitizeOutput = jest.fn((entry: { id: number; name: string }) => ({ id: entry.id }));
+const mockCreateAction = jest.fn();
 
 jest.mock('../../utils', () => ({
   getService: jest.fn(() => ({
@@ -18,6 +20,7 @@ jest.mock('../../utils', () => ({
         displayName: 'contentTypeB',
       },
     })),
+    createAction: mockCreateAction,
   })),
   getPermissionsChecker: jest.fn(() => ({
     sanitizedQuery: {
@@ -89,6 +92,85 @@ describe('Release Action controller', () => {
 
       // @ts-expect-error Ignore missing properties
       expect(() => releaseActionController.create(ctx)).rejects.toThrow('type is a required field');
+    });
+  });
+
+  describe('createMany', () => {
+    beforeEach(() => {
+      global.strapi = {
+        db: {
+          transaction: jest.fn((cb) => cb()),
+        },
+      };
+
+      jest.clearAllMocks();
+    });
+
+    it('creates multiple release actions', async () => {
+      mockCreateAction.mockResolvedValue({ id: 1 });
+
+      const ctx: any = {
+        params: {
+          releaseId: 1,
+        },
+        request: {
+          body: [
+            {
+              entry: {
+                id: 1,
+                contentType: 'api::contentTypeA.contentTypeA',
+              },
+              type: 'publish',
+            },
+            {
+              entry: {
+                id: 2,
+                contentType: 'api::contentTypeB.contentTypeB',
+              },
+              type: 'unpublish',
+            },
+          ],
+        },
+      };
+
+      await releaseActionController.createMany(ctx);
+
+      expect(mockCreateAction).toHaveBeenCalledTimes(2);
+      expect(ctx.body.data).toHaveLength(2);
+      expect(ctx.body.meta.totalEntries).toBe(2);
+      expect(ctx.body.meta.entriesAlreadyInRelease).toBe(0);
+    });
+
+    it('should count already added entries and dont throw an error', async () => {
+      mockCreateAction.mockRejectedValue(
+        new errors.ValidationError(
+          'Entry with id 1 and contentType api::contentTypeA.contentTypeA already exists in release with id 1'
+        )
+      );
+
+      const ctx: any = {
+        params: {
+          releaseId: 1,
+        },
+        request: {
+          body: [
+            {
+              entry: {
+                id: 1,
+                contentType: 'api::contentTypeA.contentTypeA',
+              },
+              type: 'publish',
+            },
+          ],
+        },
+      };
+
+      await releaseActionController.createMany(ctx);
+
+      expect(mockCreateAction).toHaveBeenCalledTimes(1);
+      expect(ctx.body.data).toHaveLength(0);
+      expect(ctx.body.meta.totalEntries).toBe(1);
+      expect(ctx.body.meta.entriesAlreadyInRelease).toBe(1);
     });
   });
 

--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -1,4 +1,4 @@
-import { errors } from '@strapi/utils';
+import { AlreadyOnReleaseError } from '../../services/validation';
 import releaseActionController from '../release-action';
 
 const mockSanitizedQueryRead = jest.fn().mockResolvedValue({});
@@ -143,7 +143,7 @@ describe('Release Action controller', () => {
 
     it('should count already added entries and dont throw an error', async () => {
       mockCreateAction.mockRejectedValue(
-        new errors.ValidationError(
+        new AlreadyOnReleaseError(
           'Entry with id 1 and contentType api::contentTypeA.contentTypeA already exists in release with id 1'
         )
       );

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../shared/contracts/release-actions';
 import { getService } from '../utils';
 import { RELEASE_ACTION_MODEL_UID } from '../constants';
+import { AlreadyOnReleaseError } from '../services/validation';
 
 const releaseActionController = {
   async create(ctx: Koa.Context) {
@@ -48,11 +49,8 @@ const releaseActionController = {
 
             return action;
           } catch (error) {
-            if (
-              error instanceof errors.ValidationError &&
-              error.message ===
-                `Entry with id ${releaseActionArgs.entry.id} and contentType ${releaseActionArgs.entry.contentType} already exists in release with id ${releaseId}`
-            ) {
+            // If the entry is already in the release, we don't want to throw an error, so we catch and ignore it
+            if (error instanceof AlreadyOnReleaseError) {
               return null;
             }
 

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -1,6 +1,6 @@
 import type Koa from 'koa';
 
-import { mapAsync, errors } from '@strapi/utils';
+import { mapAsync } from '@strapi/utils';
 import {
   validateReleaseAction,
   validateReleaseActionUpdateSchema,

--- a/packages/core/content-releases/server/src/routes/release-action.ts
+++ b/packages/core/content-releases/server/src/routes/release-action.ts
@@ -18,6 +18,22 @@ export default {
       },
     },
     {
+      method: 'POST',
+      path: '/:releaseId/actions/bulk',
+      handler: 'release-action.createMany',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::content-releases.create-action'],
+            },
+          },
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/:releaseId/actions',
       handler: 'release-action.findMany',

--- a/packages/core/content-releases/server/src/services/validation.ts
+++ b/packages/core/content-releases/server/src/services/validation.ts
@@ -5,6 +5,13 @@ import type { Release, CreateRelease, UpdateRelease } from '../../../shared/cont
 import type { CreateReleaseAction } from '../../../shared/contracts/release-actions';
 import { RELEASE_MODEL_UID } from '../constants';
 
+export class AlreadyOnReleaseError extends errors.ApplicationError<'AlreadyOnReleaseError'> {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AlreadyOnReleaseError';
+  }
+}
+
 const createReleaseValidationService = ({ strapi }: { strapi: LoadedStrapi }) => ({
   async validateUniqueEntry(
     releaseId: CreateReleaseAction.Request['params']['releaseId'],
@@ -29,7 +36,7 @@ const createReleaseValidationService = ({ strapi }: { strapi: LoadedStrapi }) =>
     );
 
     if (isEntryInRelease) {
-      throw new errors.ValidationError(
+      throw new AlreadyOnReleaseError(
         `Entry with id ${releaseActionArgs.entry.id} and contentType ${releaseActionArgs.entry.contentType} already exists in release with id ${releaseId}`
       );
     }

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -60,6 +60,34 @@ export declare namespace CreateReleaseAction {
 }
 
 /**
+ * POST /content-releases/:releaseId/actions/bulk - Create multiple release actions
+ */
+export declare namespace CreateManyReleaseActions {
+  export interface Request {
+    params: {
+      releaseId: Release['id'];
+    };
+    body: Array<{
+      type: ReleaseAction['type'];
+      entry: {
+        id: ReleaseActionEntry['id'];
+        locale?: ReleaseActionEntry['locale'];
+        contentType: Common.UID.ContentType;
+      };
+    }>;
+  }
+
+  export interface Response {
+    data: Array<ReleaseAction>;
+    meta: {
+      totalEntries: number;
+      entriesAlreadyInRelease: number;
+    };
+    error?: errors.ApplicationError | errors.ValidationError | errors.NotFoundError;
+  }
+}
+
+/**
  * GET /content-releases/:id/actions - Get all release actions
  */
 


### PR DESCRIPTION
### What does it do?

Add a new endpoint & controller to add multiple entries to a release. This endpoint should not fail if there is one entry already on the release.

### How to test it?

You need to run the project with a valid EE license and you can try to make different calls to the POST `/content-releases/:releaseId/actions/bulk` endpoint.

To know the form of the request to do please check the type associated: 
```ts
/**
 * POST /content-releases/:releaseId/actions/bulk - Create multiple release actions
 */
export declare namespace CreateManyReleaseActions {
  export interface Request {
    params: {
      releaseId: Release['id'];
    };
    body: Array<{
      type: ReleaseAction['type'];
      entry: {
        id: ReleaseActionEntry['id'];
        locale?: ReleaseActionEntry['locale'];
        contentType: Common.UID.ContentType;
      };
    }>;
  }

  export interface Response {
    data: Array<ReleaseAction>;
    meta: {
      totalEntries: number;
      entriesAlreadyInRelease: number;
    };
    error?: errors.ApplicationError | errors.ValidationError | errors.NotFoundError;
  }
}
```
