### PR TITLE
fix: reserve attribute name 'locale' in CTB

### DIFF
--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -22,8 +22,7 @@ export const getReservedNames = () => {
       'published_at',
       'created_by_id',
       'updated_by_id',
-
-      // TODO v5: restricting 'locale' would be a breaking change in v4 but we will need it if this is not resolved: https://github.com/strapi/strapi/issues/10181
+      'locale', // conflicts with internal locale field
 
       // not actually breaking but we'll leave it to avoid confusion
       'created_by',


### PR DESCRIPTION
### What does it do?

Restricts the attribute name 'locale' since we use it internally

### Why is it needed?

if a user creates an attribute called 'locale' it causes weird / breaking issues in Strapi

### How to test it?

Try to create an attribute called 'locale' and see that you get an error that it would conflict with existing functionality

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
