### PR TITLE
ci: use only mysql 8 in workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -339,46 +339,6 @@ jobs:
           dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
           jestOptions: '--shard=${{ matrix.shard }}'
 
-  api_ce_mysql_5:
-    if: needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
-    needs: [changes, build, typescript, unit_back, unit_front]
-    name: '[CE] API Integration (mysql:5, client: ${{ matrix.db_client }} , node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    strategy:
-      matrix:
-        node: [18, 20]
-        db_client: ['mysql', 'mysql2']
-        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
-    services:
-      mysql:
-        image: bitnami/mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: strapi
-          MYSQL_USER: strapi
-          MYSQL_PASSWORD: strapi
-          MYSQL_DATABASE: strapi_test
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 3306:3306
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-      - name: Monorepo install
-        uses: ./.github/actions/yarn-nm-install
-      - name: Monorepo build
-        uses: ./.github/actions/run-build
-      - uses: ./.github/actions/run-api-tests
-        with:
-          dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
-          jestOptions: '--shard=${{ matrix.shard }}'
-
   api_ce_sqlite:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,9 +14,8 @@ services:
       - '5432:5432'
 
   mysql:
-    image: mysql:5
+    image: mysql:8
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: strapi
       MYSQL_USER: strapi

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,9 +14,8 @@ services:
       - '5432:5432'
 
   mysql:
-    image: mysql
+    image: mysql:8
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: strapi_test
       MYSQL_USER: strapi


### PR DESCRIPTION
### What does it do?

removes mysql 5 and uses mysql 8

### Why is it needed?

Strapi 5 drops support mysql 5 so we don't need to test it. Most of it had been removed already but there were still these few things remaining.

### How to test it?

github CI should still work

### Related issue(s)/PR(s)
