### PR TITLE
fix(content-releases): fix cache issues

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -193,10 +193,9 @@ const EditReleaseItem = ({ releaseId }: EditReleaseItemProps) => {
   return (
     <StyledMenuItem>
       <Link
-        as={NavLink}
-        // @ts-expect-error TODO: This component from DS is not using types from NavLink
-        to={`/plugins/content-releases/${releaseId}`}
+        href={`/admin/plugins/content-releases/${releaseId}`}
         startIcon={<Icon as={Pencil} width={3} height={3} />}
+        isExternal={false}
       >
         <Typography variant="omega">
           {formatMessage({

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -265,7 +265,12 @@ export const ReleaseDetailsLayout = ({
   };
 
   const handleRefresh = () => {
-    dispatch(releaseApi.util.invalidateTags([{ type: 'ReleaseAction', id: 'LIST' }]));
+    dispatch(
+      releaseApi.util.invalidateTags([
+        { type: 'ReleaseAction', id: 'LIST' },
+        { type: 'Release', id: releaseId },
+      ])
+    );
   };
 
   const getCreatedByUser = () => {

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -234,8 +234,9 @@ const releaseApi = createApi({
             method: 'DELETE',
           };
         },
-        invalidatesTags: [
+        invalidatesTags: (result, error, arg) => [
           { type: 'Release', id: 'LIST' },
+          { type: 'Release', id: arg.params.releaseId },
           { type: 'ReleaseAction', id: 'LIST' },
         ],
       }),


### PR DESCRIPTION
### What does it do?

Fix multiple problems related to how we invalidate the cache on releases page.

### How to test it?

Test all the cases:
1. When deleting an entry from a release the release status should be updated
2. If you go from the Edit View to the Release Details page the status should be the most updated and not one on the cache.
