### PR TITLE
fix: fix cm metadata when dp is disabled

### DIFF
--- a/api-tests/core/content-manager/find-relations.test.api.js
+++ b/api-tests/core/content-manager/find-relations.test.api.js
@@ -233,14 +233,18 @@ describe('Find Relations', () => {
 
     // Create draft products
     const [skate, chair, candle, table, porte, fenetre] = await Promise.all([
-      strapi.documents(productUid).create({ data: { name: 'Skate' } }),
-      strapi.documents(productUid).create({ data: { name: 'Chair' } }),
-      strapi.documents(productUid).create({ data: { name: 'Candle' } }),
-      strapi.documents(productUid).create({ data: { name: 'Table' } }),
+      strapi.documents(productUid).create({ data: { name: 'Skate' }, status: 'published' }),
+      strapi.documents(productUid).create({ data: { name: 'Chair' }, status: 'published' }),
+      strapi.documents(productUid).create({ data: { name: 'Candle' }, status: 'published' }),
+      strapi.documents(productUid).create({ data: { name: 'Table' }, status: 'published' }),
       // We create products in French in order to test that we can cant find
-      // aviailable relations in a different locale
-      strapi.documents(productUid).create({ data: { name: 'Porte' }, locale: extraLocale }),
-      strapi.documents(productUid).create({ data: { name: 'Fenetre' }, locale: extraLocale }),
+      // available relations in a different locale
+      strapi
+        .documents(productUid)
+        .create({ data: { name: 'Porte' }, locale: extraLocale, status: 'published' }),
+      strapi
+        .documents(productUid)
+        .create({ data: { name: 'Fenetre' }, locale: extraLocale, status: 'published' }),
     ]);
     data[productUid].draft.push(skate, chair, candle, table, porte, fenetre);
 
@@ -336,6 +340,11 @@ describe('Find Relations', () => {
         modelUID: compoUid,
         id: data[shopUid].draft[0].myCompo.id,
         idEmptyShop: data[shopUid].draft[1].myCompo.id,
+      },
+      publishedComponent: {
+        modelUID: compoUid,
+        id: data[shopUid].published[0].myCompo.id,
+        idEmptyShop: undefined,
       },
       entity: {
         // If the source of the relation is a content type, we use the documentId
@@ -825,7 +834,9 @@ describe('Find Relations', () => {
       });
 
       test('Can query by status for existing relations', async () => {
-        const { id, modelUID } = isComponent ? data.testData.component : data.testData.entity;
+        const { id, modelUID } = isComponent
+          ? data.testData.publishedComponent
+          : data.testData.entity;
 
         const res = await rq({
           method: 'GET',

--- a/api-tests/plugins/i18n/content-manager/find-available-relations.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/find-available-relations.test.api.js
@@ -24,6 +24,7 @@ const productModel = {
       type: 'string',
     },
   },
+  draftAndPublish: false,
   displayName: 'Product',
   singularName: 'product',
   pluralName: 'products',
@@ -48,6 +49,7 @@ const shopModel = {
       targetAttribute: 'shops',
     },
   },
+  draftAndPublish: false,
   displayName: 'Shop',
   singularName: 'shop',
   pluralName: 'shops',
@@ -57,6 +59,10 @@ const shops = [
   {
     name: 'market',
     locale: 'en',
+  },
+  {
+    name: 'mercato',
+    locale: 'it',
   },
 ];
 
@@ -119,7 +125,6 @@ describe('i18n - Find available relations', () => {
 
     const expectedObj = {
       ...pick(['id', 'name', 'publishedAt', 'documentId', 'locale', 'updatedAt'], data.products[1]),
-      status: 'published',
     };
     expect(res.body.results).toHaveLength(1);
     expect(res.body.results[0]).toStrictEqual(expectedObj);
@@ -134,7 +139,6 @@ describe('i18n - Find available relations', () => {
 
     const expectedObj = {
       ...pick(['id', 'name', 'publishedAt', 'documentId', 'locale', 'updatedAt'], data.products[0]),
-      status: 'published',
     };
     expect(res.body.results).toHaveLength(1);
     expect(res.body.results[0]).toStrictEqual(expectedObj);

--- a/api-tests/plugins/i18n/content-manager/find-existing-relations.test.api.js
+++ b/api-tests/plugins/i18n/content-manager/find-existing-relations.test.api.js
@@ -24,6 +24,7 @@ const productModel = {
       type: 'string',
     },
   },
+  draftAndPublish: false,
   displayName: 'Product',
   singularName: 'product',
   pluralName: 'products',
@@ -48,6 +49,7 @@ const shopModel = {
       targetAttribute: 'shops',
     },
   },
+  draftAndPublish: false,
   displayName: 'Shop',
   singularName: 'shop',
   pluralName: 'shops',
@@ -130,7 +132,6 @@ describe('i18n - Find existing relations', () => {
       locale,
       publishedAt,
       updatedAt,
-      status: 'published',
     };
 
     expect(res.body.results).toHaveLength(1);
@@ -155,7 +156,6 @@ describe('i18n - Find existing relations', () => {
       locale,
       publishedAt,
       updatedAt,
-      status: 'published',
     };
 
     expect(res.body.results).toHaveLength(1);

--- a/examples/getstarted/src/index.js
+++ b/examples/getstarted/src/index.js
@@ -16,7 +16,16 @@ module.exports = {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap({ strapi }) {},
+  async bootstrap({ strapi }) {
+    // const data = new Array(50).fill(0).map((_, i) => ({
+    //   name: `cat-${i}`,
+    //   locale: 'en',
+    //   publishedAt: null,
+    // }));
+    // await strapi.db.query('api::category.category').createMany({
+    //   data,
+    // });
+  },
 
   /**
    * An asynchronous destroy function that runs before

--- a/examples/getstarted/src/index.js
+++ b/examples/getstarted/src/index.js
@@ -16,16 +16,7 @@ module.exports = {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  async bootstrap({ strapi }) {
-    // const data = new Array(50).fill(0).map((_, i) => ({
-    //   name: `cat-${i}`,
-    //   locale: 'en',
-    //   publishedAt: null,
-    // }));
-    // await strapi.db.query('api::category.category').createMany({
-    //   data,
-    // });
-  },
+  async bootstrap({ strapi }) {},
 
   /**
    * An asynchronous destroy function that runs before

--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -560,7 +560,6 @@ const reducer = <TFormValues extends FormValues = FormValues>(
          */
         const currentField = [...(getIn(state.values, field, []) as Array<any>)];
         const currentRow = currentField[fromIndex];
-        const newIndex = action.payload.toIndex;
 
         const startKey =
           fromIndex > toIndex
@@ -573,7 +572,7 @@ const reducer = <TFormValues extends FormValues = FormValues>(
         const [newKey] = generateNKeysBetween(startKey, endKey, 1);
 
         currentField.splice(fromIndex, 1);
-        currentField.splice(newIndex, 0, { ...currentRow, __temp_key__: newKey });
+        currentField.splice(toIndex, 0, { ...currentRow, __temp_key__: newKey });
 
         draft.values = setIn(state.values, field, currentField);
 

--- a/packages/core/admin/admin/src/content-manager/pages/ComponentConfigurationPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ComponentConfigurationPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { useAPIErrorHandler, useNotification } from '@strapi/helper-plugin';
+import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
 
 import { Page } from '../../components/PageHelpers';
@@ -199,12 +200,15 @@ const ComponentConfigurationPage = () => {
   }
 
   return (
-    <ConfigurationForm
-      onSubmit={handleSubmit}
-      attributes={schema.attributes}
-      fieldSizes={fieldSizes}
-      layout={editLayout}
-    />
+    <>
+      <Helmet title={`Configure ${editLayout.settings.displayName} Edit View | Strapi`} />
+      <ConfigurationForm
+        onSubmit={handleSubmit}
+        attributes={schema.attributes}
+        fieldSizes={fieldSizes}
+        layout={editLayout}
+      />
+    </>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditConfigurationPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditConfigurationPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { useAPIErrorHandler, useNotification, useTracking } from '@strapi/helper-plugin';
+import { Helmet } from 'react-helmet';
 
 import { Page } from '../../components/PageHelpers';
 import { useTypedSelector } from '../../core/store/hooks';
@@ -138,12 +139,15 @@ const EditConfigurationPage = () => {
   }
 
   return (
-    <ConfigurationForm
-      onSubmit={handleSubmit}
-      attributes={schema.attributes}
-      fieldSizes={fieldSizes}
-      layout={edit}
-    />
+    <>
+      <Helmet title={`Configure ${edit.settings.displayName} Edit View | Strapi`} />
+      <ConfigurationForm
+        onSubmit={handleSubmit}
+        attributes={schema.attributes}
+        fieldSizes={fieldSizes}
+        layout={edit}
+      />
+    </>
   );
 };
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -220,7 +220,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
          */
         __temp_key__: generateNKeysBetween(lastItemInList?.__temp_key__ ?? null, null, 1)[0],
         // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
-        [props.mainField ?? 'id']: relation[props.mainField ?? 'id'],
+        [props.mainField?.name ?? 'id']: relation[props.mainField?.name ?? 'id'],
         label: getRelationLabel(relation, props.mainField),
         // @ts-expect-error – targetModel does exist on the attribute, but it's not typed.
         href: `../${COLLECTION_TYPES}/${props.attribute.targetModel}/${relation.documentId}`,
@@ -340,7 +340,7 @@ const addLabelAndHref =
       return {
         ...relation,
         // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
-        [mainField ?? 'id']: relation[mainField ?? 'id'],
+        [mainField?.name ?? 'id']: relation[mainField?.name ?? 'id'],
         label: getRelationLabel(relation, mainField),
         href: `${href}/${relation.documentId}`,
       };

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -463,7 +463,7 @@ const RelationsInput = ({
      * You need to give this relation a correct _temp_key_ but
      * this component doesn't know about those ones, you can't rely
      * on the connect array because that doesn't hold items that haven't
-     * moved. So use a callback to fill in theg gaps when connecting.
+     * moved. So use a callback to fill in the gaps when connecting.
      *
      */
     onChange(relation);
@@ -646,7 +646,7 @@ const RelationsList = ({
     newData.splice(newIndex, 0, { ...currentRow, __temp_key__: newKey });
 
     /**
-     * Now we diff against the server to understand what's difference so we
+     * Now we diff against the server to understand what's different so we
      * can keep the connect array nice and tidy. It also needs reversing because
      * we reverse the relations from the server in the first place.
      */

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -16,7 +16,7 @@ import {
 import { Link } from '@strapi/design-system/v2';
 import { useFocusInputField, useNotification, useQueryParams } from '@strapi/helper-plugin';
 import { Cross, Drag, Refresh } from '@strapi/icons';
-import { Contracts } from '@strapi/plugin-content-manager/_internal/shared';
+import { generateNKeysBetween } from 'fractional-indexing';
 import pipe from 'lodash/fp/pipe';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
@@ -24,17 +24,21 @@ import { NavLink } from 'react-router-dom';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import styled from 'styled-components';
 
-import { RelationResult } from '../../../../../../../../content-manager/dist/shared/contracts/relations';
 import { type InputProps, useField, useForm } from '../../../../../components/Form';
 import { COLLECTION_TYPES } from '../../../../constants/collections';
 import { ItemTypes } from '../../../../constants/dragAndDrop';
 import { useDoc } from '../../../../hooks/useDocument';
+import { type EditFieldLayout } from '../../../../hooks/useDocumentLayout';
 import {
   DROP_SENSITIVITY,
   UseDragAndDropOptions,
   useDragAndDrop,
 } from '../../../../hooks/useDragAndDrop';
-import { useGetRelationsQuery, useLazySearchRelationsQuery } from '../../../../services/relations';
+import {
+  useGetRelationsQuery,
+  useLazySearchRelationsQuery,
+  RelationResult,
+} from '../../../../services/relations';
 import { buildValidParams } from '../../../../utils/api';
 import { getRelationLabel } from '../../../../utils/relations';
 import { getTranslation } from '../../../../utils/translations';
@@ -42,7 +46,6 @@ import { DocumentStatus } from '../DocumentStatus';
 
 import { useComponent } from './ComponentContext';
 
-import type { EditFieldLayout } from '../../../../hooks/useDocumentLayout';
 import type { Attribute } from '@strapi/types';
 
 /* -------------------------------------------------------------------------------------------------
@@ -51,10 +54,18 @@ import type { Attribute } from '@strapi/types';
 const RELATIONS_TO_DISPLAY = 5;
 const ONE_WAY_RELATIONS = ['oneWay', 'oneToOne', 'manyToOne', 'oneToManyMorph', 'oneToOneMorph'];
 
-interface Relation extends Contracts.Relations.RelationResult {
+type RelationPosition =
+  | (Pick<RelationResult, 'status' | 'locale'> & {
+      before: string;
+      end?: never;
+    })
+  | { end: boolean; before?: never; status?: never; locale?: never };
+
+interface Relation extends Pick<RelationResult, 'documentId' | 'id' | 'locale' | 'status'> {
   href: string;
   label: string;
-  [key: string]: any;
+  position?: RelationPosition;
+  __temp_key__: string;
 }
 
 interface RelationsFieldProps
@@ -62,8 +73,8 @@ interface RelationsFieldProps
     Pick<InputProps, 'hint'> {}
 
 interface RelationsFormValue {
-  connect?: Contracts.Relations.RelationResult[];
-  disconnect?: Contracts.Relations.RelationResult[];
+  connect?: Relation[];
+  disconnect?: Pick<RelationResult, 'documentId'>[];
 }
 
 /**
@@ -140,17 +151,29 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       setCurrentPage((prev) => prev + 1);
     };
 
-    const field = useField<RelationsFormValue>(props.name);
+    const field = useField(props.name);
 
     const isFetchingMoreRelations = isLoading || isFetching;
 
     const realServerRelationsCount =
       'pagination' in data && data.pagination ? data.pagination.total : 0;
-    const relationsConnected = field.value?.connect?.length ?? 0;
+    /**
+     * Items that are already connected, but reordered would be in
+     * this list, so to get an accurate figure, we remove them.
+     */
+    const relationsConnected =
+      (field.value?.connect ?? []).filter(
+        (rel: Relation) => data.results.findIndex((relation) => relation.id === rel.id) === -1
+      ).length ?? 0;
     const relationsDisconnected = field.value?.disconnect?.length ?? 0;
 
     const relationsCount = realServerRelationsCount + relationsConnected - relationsDisconnected;
 
+    /**
+     * This is it, the source of truth for reordering in conjunction with partial loading & updating
+     * of relations. Relations on load are given __temp_key__ when fetched, because we don't want to
+     * create brand new keys everytime the data updates, just keep adding them onto the newly loaded ones.
+     */
     const relations = React.useMemo(() => {
       const ctx = {
         field: field.value,
@@ -159,9 +182,26 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         mainField: props.mainField,
       };
 
-      const transformations = pipe(removeDisconnected(ctx), addLabelAndHref(ctx));
+      /**
+       * Tidy up our data.
+       */
+      const transformations = pipe(
+        removeConnected(ctx),
+        removeDisconnected(ctx),
+        addLabelAndHref(ctx)
+      );
 
-      return transformations([...data.results, ...(field.value?.connect ?? [])]);
+      const transformedRels = transformations([...data.results]);
+
+      /**
+       * THIS IS CRUCIAL. If you don't sort by the __temp_key__ which comes from fractional indexing
+       * then the list will be in the wrong order.
+       */
+      return [...transformedRels, ...(field.value?.connect ?? [])].sort((a, b) => {
+        if (a.__temp_key__ < b.__temp_key__) return -1;
+        if (a.__temp_key__ > b.__temp_key__) return 1;
+        return 0;
+      });
     }, [
       data.results,
       field.value,
@@ -169,6 +209,29 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       props.attribute.targetModel,
       props.mainField,
     ]);
+
+    const handleConnect: RelationsInputProps['onChange'] = (relation) => {
+      const [lastItemInList] = relations.slice(-1);
+
+      const item = {
+        ...relation,
+        /**
+         * If there's a last item, that's the first key we use to generate out next one.
+         */
+        __temp_key__: generateNKeysBetween(lastItemInList?.__temp_key__ ?? null, null, 1)[0],
+        // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
+        [props.mainField ?? 'id']: relation[props.mainField ?? 'id'],
+        label: getRelationLabel(relation, props.mainField),
+        // @ts-expect-error – targetModel does exist on the attribute, but it's not typed.
+        href: `../${COLLECTION_TYPES}/${props.attribute.targetModel}/${relation.documentId}`,
+      };
+
+      if (ONE_WAY_RELATIONS.includes(props.attribute.relation)) {
+        field.onChange(props.name, { connect: [item] });
+      } else {
+        field.onChange(`${props.name}.connect`, [...(field.value?.connect ?? []), item]);
+      }
+    };
 
     return (
       <Flex
@@ -185,6 +248,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
             id={id}
             label={`${label} ${relationsCount > 0 ? `(${relationsCount})` : ''}`}
             model={model}
+            onChange={handleConnect}
             {...props}
           />
           {'pagination' in data &&
@@ -207,6 +271,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         </StyledFlex>
         <RelationsList
           data={relations}
+          serverData={data.results}
           disabled={isDisabled}
           name={props.name}
           isLoading={isFetchingMoreRelations}
@@ -237,6 +302,20 @@ interface TransformationContext extends Pick<RelationsFieldProps, 'mainField'> {
 }
 
 /**
+ * If it's in the connected array, it can get out of our data array,
+ * we'll be putting it back in later and sorting it anyway.
+ */
+const removeConnected =
+  ({ field }: TransformationContext) =>
+  (relations: RelationResult[]) => {
+    return relations.filter((relation) => {
+      const connectedRelations = field?.connect ?? [];
+
+      return connectedRelations.findIndex((rel) => rel.documentId === relation.documentId) === -1;
+    });
+  };
+
+/**
  * @description Removes relations that are in the `disconnect` array of the field
  */
 const removeDisconnected =
@@ -260,6 +339,8 @@ const addLabelAndHref =
     relations.map((relation) => {
       return {
         ...relation,
+        // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
+        [mainField ?? 'id']: relation[mainField ?? 'id'],
         label: getRelationLabel(relation, mainField),
         href: `${href}/${relation.documentId}`,
       };
@@ -272,6 +353,11 @@ const addLabelAndHref =
 interface RelationsInputProps extends Omit<RelationsFieldProps, 'type'> {
   id?: string;
   model: string;
+  onChange: (
+    relation: Pick<RelationResult, 'documentId' | 'id' | 'locale' | 'status'> & {
+      [key: string]: any;
+    }
+  ) => void;
 }
 
 /**
@@ -288,7 +374,7 @@ const RelationsInput = ({
   mainField,
   placeholder,
   required,
-  attribute,
+  onChange,
 }: RelationsInputProps) => {
   const [textValue, setTextValue] = React.useState<string | undefined>('');
   const [searchParams, setSearchParams] = React.useState({
@@ -301,7 +387,6 @@ const RelationsInput = ({
   const { formatMessage } = useIntl();
   const fieldRef = useFocusInputField(name);
   const field = useField<RelationsFormValue>(name);
-  const addFieldRow = useForm('RelationInput', (state) => state.addFieldRow);
 
   const [searchForTrigger, { data, isLoading }] = useLazySearchRelationsQuery();
 
@@ -350,8 +435,6 @@ const RelationsInput = ({
 
   const options = data?.results ?? [];
 
-  const isSingleRelation = ONE_WAY_RELATIONS.includes(attribute.relation);
-
   const handleChange = (relationId?: string) => {
     if (!relationId) {
       return;
@@ -376,11 +459,14 @@ const RelationsInput = ({
       return;
     }
 
-    if (isSingleRelation) {
-      field.onChange(name, { connect: [relation] });
-    } else {
-      addFieldRow(`${name}.connect`, relation);
-    }
+    /**
+     * You need to give this relation a correct _temp_key_ but
+     * this component doesn't know about those ones, you can't rely
+     * on the connect array because that doesn't hold items that haven't
+     * moved. So use a callback to fill in theg gaps when connecting.
+     *
+     */
+    onChange(relation);
   };
 
   const handleLoadMore = () => {
@@ -463,16 +549,27 @@ interface RelationsListProps extends Pick<RelationsFieldProps, 'disabled' | 'nam
   data: Relation[];
   isLoading?: boolean;
   relationType: Attribute.Relation['relation'];
+  /**
+   * The existing relations connected on the server. We need these to diff against.
+   */
+  serverData: RelationResult[];
 }
 
-const RelationsList = ({ data, disabled, name, isLoading, relationType }: RelationsListProps) => {
+const RelationsList = ({
+  data,
+  serverData,
+  disabled,
+  name,
+  isLoading,
+  relationType,
+}: RelationsListProps) => {
   const ariaDescriptionId = React.useId();
   const { formatMessage } = useIntl();
   const listRef = React.useRef<FixedSizeList>(null);
   const outerListRef = React.useRef<HTMLUListElement>(null);
   const [overflow, setOverflow] = React.useState<'top' | 'bottom' | 'top-bottom'>();
   const [liveText, setLiveText] = React.useState('');
-  const field = useField<RelationsFormValue>(name);
+  const field = useField(name);
   const removeFieldRow = useForm('RelationsList', (state) => state.removeFieldRow);
   const addFieldRow = useForm('RelationsList', (state) => state.addFieldRow);
 
@@ -512,7 +609,7 @@ const RelationsList = ({ data, disabled, name, isLoading, relationType }: Relati
 
   const getItemPos = (index: number) => `${index + 1} of ${data.length}`;
 
-  const handleMoveItem: UseDragAndDropOptions['onMoveItem'] = (oldIndex, newIndex) => {
+  const handleMoveItem: UseDragAndDropOptions['onMoveItem'] = (newIndex, oldIndex) => {
     const item = data[oldIndex];
 
     setLiveText(
@@ -527,6 +624,59 @@ const RelationsList = ({ data, disabled, name, isLoading, relationType }: Relati
         }
       )
     );
+
+    /**
+     * Splicing mutates the array, so we need to create a new array
+     */
+    const newData = [...data];
+    const currentRow = data[oldIndex];
+
+    const startKey =
+      oldIndex > newIndex ? newData[newIndex - 1]?.__temp_key__ : newData[newIndex]?.__temp_key__;
+    const endKey =
+      oldIndex > newIndex ? newData[newIndex]?.__temp_key__ : newData[newIndex + 1]?.__temp_key__;
+
+    /**
+     * We're moving the relation between two other relations, so
+     * we need to generate a new key that keeps the order
+     */
+    const [newKey] = generateNKeysBetween(startKey, endKey, 1);
+
+    newData.splice(oldIndex, 1);
+    newData.splice(newIndex, 0, { ...currentRow, __temp_key__: newKey });
+
+    /**
+     * Now we diff against the server to understand what's difference so we
+     * can keep the connect array nice and tidy. It also needs reversing because
+     * we reverse the relations from the server in the first place.
+     */
+    const connectedRelations = newData
+      .reduce<Relation[]>((acc, relation, currentIndex, array) => {
+        const relationOnServer = serverData.find(
+          (oldRelation) => oldRelation.documentId === relation.documentId
+        );
+
+        const relationInFront = array[currentIndex + 1];
+
+        if (!relationOnServer || relationOnServer.__temp_key__ !== relation.__temp_key__) {
+          const position = relationInFront
+            ? {
+                before: relationInFront.documentId,
+                locale: relationInFront.locale,
+                status: relationInFront.status,
+              }
+            : { end: true };
+
+          const relationWithPosition: Relation = { ...relation, position };
+
+          return [...acc, relationWithPosition];
+        }
+
+        return acc;
+      }, [])
+      .toReversed();
+
+    field.onChange(`${name}.connect`, connectedRelations);
   };
 
   const handleGrabItem: UseDragAndDropOptions['onGrabItem'] = (index) => {
@@ -547,7 +697,7 @@ const RelationsList = ({ data, disabled, name, isLoading, relationType }: Relati
   };
 
   const handleDropItem: UseDragAndDropOptions['onDropItem'] = (index) => {
-    const item = data[index];
+    const { href: _href, label, ...item } = data[index];
 
     setLiveText(
       formatMessage(
@@ -556,7 +706,7 @@ const RelationsList = ({ data, disabled, name, isLoading, relationType }: Relati
           defaultMessage: `{item}, dropped. Final position in list: {position}.`,
         },
         {
-          item: item.label ?? item.documentId,
+          item: label ?? item.documentId,
           position: getItemPos(index),
         }
       )
@@ -587,7 +737,8 @@ const RelationsList = ({ data, disabled, name, isLoading, relationType }: Relati
        * from the connect array
        */
       const indexOfRelationInConnectArray = field.value.connect.findIndex(
-        (rel) => rel.documentId === relation.documentId
+        (rel: NonNullable<RelationsFormValue['connect']>[number]) =>
+          rel.documentId === relation.documentId
       );
 
       if (indexOfRelationInConnectArray >= 0) {
@@ -736,7 +887,7 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
       onDropItem: handleDropItem,
       onGrabItem: handleGrabItem,
       onCancel: handleCancel,
-      dropSensitivity: DROP_SENSITIVITY.IMMEDIATE,
+      dropSensitivity: DROP_SENSITIVITY.REGULAR,
     });
 
   const composedRefs = useComposedRefs<HTMLDivElement>(relationRef, dragRef);

--- a/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/ListConfigurationPage.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListConfiguration/ListConfigurationPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ContentLayout, Divider, Flex, Layout, Main } from '@strapi/design-system';
 import { useAPIErrorHandler, useNotification, useTracking } from '@strapi/helper-plugin';
+import { Helmet } from 'react-helmet';
 import { useIntl } from 'react-intl';
 import { Navigate } from 'react-router-dom';
 
@@ -118,6 +119,7 @@ const ListConfiguration = () => {
 
   return (
     <Layout>
+      <Helmet title={`Configure ${list.settings.displayName} List View | Strapi`} />
       <Main>
         <Form initialValues={initialValues} onSubmit={handleSubmit} method="PUT">
           <Header

--- a/packages/core/admin/admin/src/content-manager/services/relations.ts
+++ b/packages/core/admin/admin/src/content-manager/services/relations.ts
@@ -170,7 +170,7 @@ const relationsApi = contentManagerApi.injectEndpoints({
 
 /**
  * @internal
- * @description Adds a `__temp_key__` to each component and dynamiczone item. This gives us
+ * @description Adds a `__temp_key__` to each relation item. This gives us
  * a stable identifier regardless of it's ids etc. that we can then use for drag and drop.
  */
 const prepareTempKeys = (

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -794,7 +794,7 @@
   "content-manager.containers.list-settings.modal-form.label": "Edit {fieldName}",
   "content-manager.containers.list-settings.modal-form.error": "An error occurred while trying to open the form.",
   "content-manager.containers.edit-settings.modal-form.error": "An error occurred while trying to open the form.",
-  "content-manager.containers.edit-settings.modal-form.label": "Edit {fieldName}",
+  "content-manager.containers.edit-settings.modal-form.label": "Label",
   "content-manager.containers.edit-settings.modal-form.description": "Description",
   "content-manager.containers.edit-settings.modal-form.placeholder": "Placeholder",
   "content-manager.containers.edit-settings.modal-form.mainField": "Entry title",

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -73,7 +73,11 @@ export default ({ strapi }: { strapi: Strapi }) => ({
   /**
    * Returns available locales of a document for the current status
    */
-  getAvailableLocales(version: DocumentVersion, allVersions: DocumentVersion[]) {
+  getAvailableLocales(
+    uid: Common.UID.ContentType,
+    version: DocumentVersion,
+    allVersions: DocumentVersion[]
+  ) {
     // Group all versions by locale
     const versionsByLocale = groupBy('locale', allVersions);
 
@@ -81,17 +85,27 @@ export default ({ strapi }: { strapi: Strapi }) => ({
     delete versionsByLocale[version.locale];
 
     // For each locale, get the ones with the same status
-    return Object.values(versionsByLocale).map((localeVersions: DocumentVersion[]) => {
-      const draftVersion = localeVersions.find((v) => v.publishedAt === null);
-      const otherVersions = localeVersions.filter((v) => v.id !== draftVersion?.id);
+    return (
+      Object.values(versionsByLocale)
+        .map((localeVersions: DocumentVersion[]) => {
+          // There will not be a draft and a version counterpart if the content type does not have draft and publish
+          if (!contentTypes.hasDraftAndPublish(strapi.getModel(uid))) {
+            return pick(AVAILABLE_LOCALES_FIELDS, localeVersions[0]);
+          }
 
-      if (!draftVersion) return;
+          const draftVersion = localeVersions.find((v) => v.publishedAt === null);
+          const otherVersions = localeVersions.filter((v) => v.id !== draftVersion?.id);
 
-      return {
-        ...pick(AVAILABLE_LOCALES_FIELDS, draftVersion),
-        status: this.getStatus(draftVersion, otherVersions as any),
-      };
-    });
+          if (!draftVersion) return;
+
+          return {
+            ...pick(AVAILABLE_LOCALES_FIELDS, draftVersion),
+            status: this.getStatus(draftVersion, otherVersions as any),
+          };
+        })
+        // Filter just in case there is a document with no drafts
+        .filter(Boolean)
+    );
   },
 
   /**
@@ -186,7 +200,7 @@ export default ({ strapi }: { strapi: Strapi }) => ({
     });
 
     const availableLocalesResult = availableLocales
-      ? this.getAvailableLocales(version, versions)
+      ? this.getAvailableLocales(uid, version, versions)
       : [];
 
     const availableStatusResult = availableStatus

--- a/packages/core/content-manager/shared/contracts/relations.ts
+++ b/packages/core/content-manager/shared/contracts/relations.ts
@@ -8,7 +8,7 @@ export interface RelationResult {
   id: number;
   status: Documents.Params.PublicationStatus.Kind;
   locale?: Documents.Params.Locale;
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 export interface Pagination {


### PR DESCRIPTION
### What does it do?

CM broke when loading an entry with enabled I18n but disabled DP
