### PR TITLE
feat: count cm relations

### DIFF
--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -29,28 +29,13 @@ const emitEvent = async (uid: Common.UID.ContentType, event: string, document: D
 };
 
 const documentManager = ({ strapi }: { strapi: Strapi }) => {
-  const mapDocument = (uid: Common.UID.CollectionType, document: any): any => {
-    if (!document) return document;
-
-    if (Array.isArray(document)) {
-      return document.map((doc: Document) => mapDocument(uid, doc));
-    }
-
-    // document.id = document.documentId;
-
-    return document;
-  };
-
   return {
     async findOne(
       id: string,
       uid: Common.UID.CollectionType,
       opts: DocServiceParams<'findOne'>[1] = {}
     ) {
-      return strapi
-        .documents(uid)
-        .findOne(id, opts)
-        .then((doc) => mapDocument(uid, doc));
+      return strapi.documents(uid).findOne(id, opts);
     },
 
     /**
@@ -82,10 +67,7 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
 
     async findMany(opts: DocServiceParams<'findMany'>[0], uid: Common.UID.CollectionType) {
       const params = { ...opts, populate: getDeepPopulate(uid) } as typeof opts;
-      return strapi
-        .documents(uid)
-        .findMany(params)
-        .then((doc) => mapDocument(uid, doc));
+      return strapi.documents(uid).findMany(params);
     },
 
     async findPage(opts: DocServiceParams<'findMany'>[0], uid: Common.UID.CollectionType) {
@@ -99,7 +81,7 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       ]);
 
       return {
-        results: mapDocument(uid, documents),
+        results: documents,
         pagination: {
           page,
           pageSize,
@@ -113,13 +95,7 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = opts.populate ?? (await buildDeepPopulate(uid));
       const params = { ...opts, status: 'draft' as const, populate };
 
-      const document = await strapi.documents(uid).create(params);
-
-      // if (isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(document, uid);
-      // }
-
-      return mapDocument(uid, document);
+      return strapi.documents(uid).create(params);
     },
 
     async update(
@@ -131,13 +107,7 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = opts.populate ?? (await buildDeepPopulate(uid));
       const params = { ...opts, data: publishData, populate, status: 'draft' };
 
-      const updatedDocument = await strapi.documents(uid).update(id, params);
-
-      // if (isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(updatedDocument, uid);
-      // }
-
-      return mapDocument(uid, updatedDocument);
+      return strapi.documents(uid).update(id, params);
     },
 
     async clone(
@@ -154,15 +124,10 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
         populate,
       };
 
-      const result = await strapi.documents(uid).clone(id, params);
-
-      const clonedEntity = result?.versions.at(0);
-      // If relations were populated, relations count will be returned instead of the array of relations.
-      // if (clonedEntity && isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(clonedEntity, uid);
-      // }
-
-      return mapDocument(uid, clonedEntity);
+      return strapi
+        .documents(uid)
+        .clone(id, params)
+        .then((result) => result?.versions.at(0));
     },
 
     /**
@@ -188,12 +153,6 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = await buildDeepPopulate(uid);
 
       await strapi.documents(uid).delete(id, { ...opts, populate });
-
-      // If relations were populated, relations count will be returned instead of the array of relations.
-      // if (deletedDocument && isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(deletedEntity, uid);
-      // }
-
       return {};
     },
 
@@ -216,17 +175,10 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = await buildDeepPopulate(uid);
       const params = { ...opts, populate };
 
-      const { versions: publishedDocuments } = await strapi.documents(uid).publish(id, params);
-
-      // TODO: What if we publish many versions at once?
-      const publishedDocument = publishedDocuments.at(0);
-
-      // If relations were populated, relations count will be returned instead of the array of relations.
-      // if (publishedDocument && isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(publishedDocument, uid);
-      // }
-
-      return mapDocument(uid, publishedDocument);
+      return strapi
+        .documents(uid)
+        .publish(id, params)
+        .then((result) => result?.versions.at(0));
     },
 
     async publishMany(entities: Document[], uid: Common.UID.ContentType) {
@@ -318,14 +270,10 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = await buildDeepPopulate(uid);
       const params = { ...opts, populate };
 
-      await strapi.documents(uid).unpublish(id, params);
-
-      // If relations were populated, relations count will be returned instead of the array of relations.
-      // if (unpublishedDocument && isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(mappedEntity, uid);
-      // }
-
-      return {};
+      return strapi
+        .documents(uid)
+        .unpublish(id, params)
+        .then((result) => result?.versions.at(0));
     },
 
     async discardDraft(
@@ -336,17 +284,10 @@ const documentManager = ({ strapi }: { strapi: Strapi }) => {
       const populate = await buildDeepPopulate(uid);
       const params = { ...opts, populate };
 
-      const { versions: discardedDocuments } = await strapi.documents(uid).discardDraft(id, params);
-
-      // We only discard one document at a time
-      const discardedDocument = discardedDocuments.at(0);
-
-      // If relations were populated, relations count will be returned instead of the array of relations.
-      // if (discardedDocument && isWebhooksPopulateRelationsEnabled()) {
-      //   return getDeepRelationsCount(discardedDocument, uid);
-      // }
-
-      return mapDocument(uid, discardedDocument);
+      return strapi
+        .documents(uid)
+        .discardDraft(id, params)
+        .then((result) => result?.versions.at(0));
     },
 
     async countDraftRelations(id: string, uid: Common.UID.ContentType, locale: string) {

--- a/packages/core/content-manager/server/src/services/populate-builder.ts
+++ b/packages/core/content-manager/server/src/services/populate-builder.ts
@@ -31,19 +31,7 @@ const populateBuilder = (uid: Common.UID.Schema) => {
       getInitialPopulate = async () => getQueryPopulate(uid, query);
       return builder;
     },
-    /**
-     * Populate relations as count if condition is true.
-     * @param condition
-     * @param [options]
-     * @param [options.toMany] - Populate XtoMany relations as count if true.
-     * @param [options.toOne] - Populate XtoOne relations as count if true.
-     */
-    countRelationsIf(condition: boolean, { toMany, toOne } = { toMany: true, toOne: true }) {
-      if (condition) {
-        return this.countRelations({ toMany, toOne });
-      }
-      return builder;
-    },
+
     /**
      * Populate relations as count.
      * @param [options]
@@ -59,6 +47,7 @@ const populateBuilder = (uid: Common.UID.Schema) => {
       }
       return builder;
     },
+
     /**
      * Populate relations deeply, up to a certain level.
      * @param [level=Infinity] - Max level of nested populate.
@@ -67,6 +56,7 @@ const populateBuilder = (uid: Common.UID.Schema) => {
       deepPopulateOptions.maxLevel = level;
       return builder;
     },
+
     /**
      * Construct the populate object based on the builder options.
      * @returns Populate object

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -270,35 +270,8 @@ const getQueryPopulate = async (uid: Common.UID.Schema, query: object): Promise<
   return populateQuery;
 };
 
-/**
- * When config admin.webhooks.populateRelations is set to true,
- * populated relations will be passed to any webhook event.
- * The document response will not have the populated relations though.
- * For performance reasons, it is recommended to set it to false,
- *
- * See docs: https://docs.strapi.io/dev-docs/configurations/server
- *
- * TODO V5: Set to false by default.
- * TODO V5: Make webhooks always send the same entity data.
- */
-const isWebhooksPopulateRelationsEnabled = () => {
-  return strapi.config.get('server.webhooks.populateRelations', true);
-};
-
 const buildDeepPopulate = (uid: Common.UID.CollectionType) => {
-  // User can configure to populate relations, so downstream services can use them.
-  // They will be transformed into counts later if this is set to true.
-
-  return getService('populate-builder')(uid)
-    .populateDeep(Infinity)
-    .countRelationsIf(!isWebhooksPopulateRelationsEnabled())
-    .build();
+  return getService('populate-builder')(uid).populateDeep(Infinity).countRelations().build();
 };
 
-export {
-  getDeepPopulate,
-  getDeepPopulateDraftCount,
-  getQueryPopulate,
-  isWebhooksPopulateRelationsEnabled,
-  buildDeepPopulate,
-};
+export { getDeepPopulate, getDeepPopulateDraftCount, getQueryPopulate, buildDeepPopulate };

--- a/packages/core/types/src/types/core/config/server.ts
+++ b/packages/core/types/src/types/core/config/server.ts
@@ -11,10 +11,6 @@ export interface DirsProp {
   public?: string;
 }
 
-export interface WebhooksProp {
-  populateRelations?: boolean;
-}
-
 export interface LoggerProp {
   updates?: {
     enabled?: boolean;
@@ -48,7 +44,6 @@ export interface Server {
   globalProxy?: string;
   cron?: CronProp;
   dirs?: DirsProp;
-  webhooks?: WebhooksProp;
   logger?: LoggerProp;
   transfer?: TransferProp;
   admin?: AdminProp;

--- a/packages/generators/app/src/resources/files/ts/config/server.ts
+++ b/packages/generators/app/src/resources/files/ts/config/server.ts
@@ -4,7 +4,4 @@ export default ({ env }) => ({
   app: {
     keys: env.array('APP_KEYS'),
   },
-  webhooks: {
-    populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),
-  },
 });


### PR DESCRIPTION
### What does it do?
CM api returns count of relations (was returning populated relations). Also I am removing the following:

In order to always send populated relations to webhooks, we were using a complicated logic to populate relations on the backend and then return the count.

Not only that , we provided a config `webhooks.populateRelations` to disable this behaviour and improve performance. 
I am removing that in v5 because:

- I will refactor webhooks so they always send populated relations no matter what.
- Probably nobody knows about this
- It adds a lot of complexity
