### PR TITLE
feat: handle db errors on document service

### DIFF
--- a/api-tests/core/strapi/api/relations.test.api.js
+++ b/api-tests/core/strapi/api/relations.test.api.js
@@ -848,7 +848,7 @@ describe('Relations', () => {
       expect(updatedShop.data).toMatchObject(expectedShop);
     });
 
-    test.skip('Update relations using the same id multiple times', async () => {
+    test('Update relations using the same id multiple times', async () => {
       const shop = await createShop({
         anyToManyRel: [
           { documentId: id1, position: { end: true } },
@@ -867,7 +867,7 @@ describe('Relations', () => {
       expect(updatedShop.error).toMatchObject({ status: 400, name: 'ValidationError' });
     });
 
-    test.skip('Update relations with invalid connect array in strict mode', async () => {
+    test('Update relations with invalid connect array in strict mode', async () => {
       const shop = await createShop({
         anyToManyRel: [],
       });

--- a/packages/core/core/src/services/document-service/__tests__/middlewares.test.ts
+++ b/packages/core/core/src/services/document-service/__tests__/middlewares.test.ts
@@ -1,4 +1,4 @@
-import { createMiddlewareManager } from '../middlewares';
+import { createMiddlewareManager } from '../middlewares/middleware-manager';
 
 describe('middlewares', () => {
   describe('wrapObject', () => {

--- a/packages/core/core/src/services/document-service/index.ts
+++ b/packages/core/core/src/services/document-service/index.ts
@@ -1,7 +1,8 @@
 import { Strapi, Documents } from '@strapi/types';
 
-import { createMiddlewareManager } from './middlewares';
+import { createMiddlewareManager } from './middlewares/middleware-manager';
 import { createContentTypeRepository } from './repository';
+import { databaseErrorsMiddleware } from './middlewares/errors';
 
 /**
  * Repository to :
@@ -23,6 +24,8 @@ import { createContentTypeRepository } from './repository';
 export const createDocumentService = (strapi: Strapi): Documents.Service => {
   const repositories = new Map<string, Documents.ServiceInstance>();
   const middlewares = createMiddlewareManager();
+
+  middlewares.use(databaseErrorsMiddleware);
 
   const factory = function factory(uid) {
     if (repositories.has(uid)) {

--- a/packages/core/core/src/services/document-service/index.ts
+++ b/packages/core/core/src/services/document-service/index.ts
@@ -1,8 +1,7 @@
 import { Strapi, Documents } from '@strapi/types';
 
-import { createMiddlewareManager } from './middlewares/middleware-manager';
+import { createMiddlewareManager, databaseErrorsMiddleware } from './middlewares';
 import { createContentTypeRepository } from './repository';
-import { databaseErrorsMiddleware } from './middlewares/errors';
 
 /**
  * Repository to :

--- a/packages/core/core/src/services/document-service/middlewares/errors.ts
+++ b/packages/core/core/src/services/document-service/middlewares/errors.ts
@@ -1,0 +1,29 @@
+import { errors as databaseErrors } from '@strapi/database';
+import { errors } from '@strapi/utils';
+
+import type { Middleware } from './middleware-manager';
+
+const databaseErrorsToTransform = [
+  databaseErrors.InvalidTimeError,
+  databaseErrors.InvalidDateTimeError,
+  databaseErrors.InvalidDateError,
+  databaseErrors.InvalidRelationError,
+];
+
+/**
+ * Handle database errors
+ */
+export const databaseErrorsMiddleware: Middleware = async (ctx, next) => {
+  try {
+    return await next();
+  } catch (error) {
+    if (databaseErrorsToTransform.some((errorToTransform) => error instanceof errorToTransform)) {
+      if (error instanceof Error) {
+        throw new errors.ValidationError(error.message);
+      }
+
+      throw error;
+    }
+    throw error;
+  }
+};

--- a/packages/core/core/src/services/document-service/middlewares/index.ts
+++ b/packages/core/core/src/services/document-service/middlewares/index.ts
@@ -1,0 +1,2 @@
+export { databaseErrorsMiddleware } from './errors';
+export { createMiddlewareManager } from './middleware-manager';

--- a/packages/core/core/src/services/document-service/middlewares/middleware-manager.ts
+++ b/packages/core/core/src/services/document-service/middlewares/middleware-manager.ts
@@ -1,10 +1,10 @@
-type Middleware = (ctx: any, next: () => Promise<void>) => Promise<void>;
+export type Middleware = (ctx: any, next: () => Promise<void>) => Promise<void>;
 
 export const createMiddlewareManager = () => {
   const middlewares: Middleware[] = [];
 
   const manager = {
-    use(middleware: any) {
+    use(middleware: Middleware) {
       middlewares.push(middleware);
 
       return () => middlewares.splice(middlewares.indexOf(middleware), 1);


### PR DESCRIPTION
### What does it do?

We were not handling database errors on the document service, so any thrown error on DB resulted in a 500 status error on the APIs.
