### PR TITLE
fix: reload ctb after save

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/DataManagerProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/DataManagerProvider.tsx
@@ -43,6 +43,7 @@ import {
   REMOVE_FIELD_FROM_DISPLAYED_COMPONENT,
   SET_MODIFIED_DATA,
   UPDATE_SCHEMA,
+  UPDATE_INITIAL_STATE,
 } from './constants';
 import { makeSelectDataManagerProvider } from './selectors';
 import { formatMainDataType, getComponentsToPost, sortContentType } from './utils/cleanData';
@@ -555,7 +556,7 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       await serverRestartWatcher(true);
 
       // Unlock the app
-      await unlockAppWithAutoreload?.();
+      unlockAppWithAutoreload?.();
 
       if (
         isCreating &&
@@ -578,6 +579,10 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       } else {
         trackUsage('didSaveComponent');
       }
+
+      // refetch and update initial state after the data has been saved
+      await getDataRef.current();
+      dispatch({ type: UPDATE_INITIAL_STATE });
 
       // Update the app's permissions
       await updatePermissions();

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/constants.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/constants.ts
@@ -21,3 +21,4 @@ export const REMOVE_COMPONENT_FROM_DYNAMIC_ZONE =
 export const REMOVE_FIELD = 'ContentTypeBuilder/DataManagerProvider/REMOVE_FIELD';
 export const SET_MODIFIED_DATA = 'ContentTypeBuilder/DataManagerProvider/SET_MODIFIED_DATA';
 export const UPDATE_SCHEMA = 'ContentTypeBuilder/DataManagerProvider/UPDATE_SCHEMA';
+export const UPDATE_INITIAL_STATE = 'ContentTypeBuilder/DataManagerProvider/UPDATE_INITIAL_STATE';

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.ts
@@ -542,6 +542,10 @@ const reducer = (state = initialState, action: Action) =>
         draftState.contentTypes = action.contentTypes;
         draftState.reservedNames = action.reservedNames;
         draftState.isLoading = false;
+        break;
+      }
+      case actions.UPDATE_INITIAL_STATE: {
+        draftState.initialData = draftState.modifiedData;
 
         break;
       }

--- a/packages/core/content-type-builder/admin/src/contexts/DataManagerContext.ts
+++ b/packages/core/content-type-builder/admin/src/contexts/DataManagerContext.ts
@@ -41,7 +41,7 @@ export interface DataManagerContextValue {
   removeComponentFromDynamicZone: (dzName: string, componentToRemoveIndex: number) => void;
   setModifiedData: () => void;
   sortedContentTypesList: any[]; // Define the actual type
-  submitData: (additionalContentTypeData?: Record<string, any>) => void;
+  submitData: (additionalContentTypeData?: Record<string, any>) => Promise<void>;
   updateSchema: (data: Record<string, any>, schemaType: SchemaType, componentUID: UID.Any) => void;
   components: Record<UID.Component, Component>;
   componentsGroupedByCategory: Record<string, Component[]>;

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -6,7 +6,7 @@ import has from 'lodash/has';
 import isEqual from 'lodash/isEqual';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
-import { Prompt, useRouteMatch, useHistory } from 'react-router-dom';
+import { Prompt, useRouteMatch } from 'react-router-dom';
 
 import { List } from '../../components/List';
 import { ListRow } from '../../components/ListRow';
@@ -20,7 +20,6 @@ import { LinkToCMSettingsView } from './LinkToCMSettingsView';
 /* eslint-disable indent */
 
 const ListView = () => {
-  const history = useHistory();
   const { initialData, modifiedData, isInDevelopmentMode, isInContentTypeView, submitData } =
     useDataManager();
   const { formatMessage } = useIntl();
@@ -49,10 +48,6 @@ const ListView = () => {
   const hasModelBeenModified = !isEqual(modifiedData, initialData);
 
   const forTarget = isInContentTypeView ? 'contentType' : 'component';
-
-  const handleReload = () => {
-    history.go(0); // Reloads the current page
-  };
 
   const handleClickAddComponentToDZ = (dynamicZoneTarget?: string) => {
     onOpenModalAddComponentsToDZ({ dynamicZoneTarget, targetUid });
@@ -147,10 +142,7 @@ const ListView = () => {
               )}
               <Button
                 startIcon={<Check />}
-                onClick={async () => {
-                  await submitData();
-                  handleReload();
-                }}
+                onClick={async () => await submitData()}
                 type="submit"
                 disabled={isEqual(modifiedData, initialData)}
               >

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -6,7 +6,7 @@ import has from 'lodash/has';
 import isEqual from 'lodash/isEqual';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
-import { Prompt, useRouteMatch } from 'react-router-dom';
+import { Prompt, useRouteMatch, useHistory } from 'react-router-dom';
 
 import { List } from '../../components/List';
 import { ListRow } from '../../components/ListRow';
@@ -20,6 +20,7 @@ import { LinkToCMSettingsView } from './LinkToCMSettingsView';
 /* eslint-disable indent */
 
 const ListView = () => {
+  const history = useHistory();
   const { initialData, modifiedData, isInDevelopmentMode, isInContentTypeView, submitData } =
     useDataManager();
   const { formatMessage } = useIntl();
@@ -48,6 +49,10 @@ const ListView = () => {
   const hasModelBeenModified = !isEqual(modifiedData, initialData);
 
   const forTarget = isInContentTypeView ? 'contentType' : 'component';
+
+  const handleReload = () => {
+    history.go(0); // Reloads the current page
+  };
 
   const handleClickAddComponentToDZ = (dynamicZoneTarget?: string) => {
     onOpenModalAddComponentsToDZ({ dynamicZoneTarget, targetUid });
@@ -142,7 +147,10 @@ const ListView = () => {
               )}
               <Button
                 startIcon={<Check />}
-                onClick={() => submitData()}
+                onClick={async () => {
+                  await submitData();
+                  handleReload();
+                }}
                 type="submit"
                 disabled={isEqual(modifiedData, initialData)}
               >


### PR DESCRIPTION
### What does it do?

- forces ctb to reload after save

### Why is it needed?

- After saving components in the ctb, state is not refreshing unless the page is reloaded manually

### How to test it?

- create or update a contentType it should work properly

### Related issue(s)/PR(s)

fix #19378 
