### PR TITLE
fix: only add better-sqlite3 package when needed

### DIFF
--- a/packages/utils/upgrade/resources/codemods/5.0.0/sqlite3-to-better-sqlite3.json.ts
+++ b/packages/utils/upgrade/resources/codemods/5.0.0/sqlite3-to-better-sqlite3.json.ts
@@ -17,16 +17,19 @@ const transform: modules.runner.json.JSONTransform = (file, params) => {
 
   const j = json(file.json);
 
+  let removed = false;
+
   const targetProperties = ['sqlite3', '@vscode/sqlite3'];
 
   targetProperties.forEach((targetProperty) => {
     const oldSqliteDependency = `dependencies.${targetProperty}`;
     if (j.has(oldSqliteDependency)) {
       j.remove(oldSqliteDependency);
+      removed = true;
     }
   });
 
-  if (!j.has('dependencies.better-sqlite3')) {
+  if (removed && !j.has('dependencies.better-sqlite3')) {
     // TODO check this version when releasing V5
     j.set('dependencies.better-sqlite3', '9.0.0');
   }


### PR DESCRIPTION
### What does it do?

fixes codemod to not add better-sqlite3 to all projects; only when a sqlite package was removed

### Why is it needed?

currently ugprade tool is adding better-sqlite3 to all strapi projects regardless of original packages used

### How to test it?

only projects that were previously using `sqlite3` will add `better-sqlite3`

projects such as those using mysql and postgres should not have anything added

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
