### PR TITLE
chore: remove locale when disabling i18n

### DIFF
--- a/packages/plugins/i18n/server/src/migrations/__tests__/content-type.test.ts
+++ b/packages/plugins/i18n/server/src/migrations/__tests__/content-type.test.ts
@@ -4,12 +4,10 @@ import contentTypesServiceFactory from '../../services/content-types';
 
 const ctService = contentTypesServiceFactory();
 
-const createQueryBuilderMock = () => {
+const createDBQueryMock = () => {
   const obj = {
-    delete: jest.fn(() => obj),
-    update: jest.fn(() => obj),
-    where: jest.fn(() => obj),
-    execute() {},
+    deleteMany: jest.fn(() => obj),
+    updateMany: jest.fn(() => obj),
   } as any;
 
   return jest.fn(() => obj);
@@ -35,7 +33,7 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
   describe('enable localization on a CT', () => {
     describe('Should not migrate', () => {
       test('non i18n => non i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = {};
         const definition = {};
@@ -45,11 +43,11 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           contentTypes: { test: definition },
         });
 
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
 
       test('i18n => non i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = { pluginOptions: { i18n: { localized: true } } };
         const definition = {};
@@ -59,11 +57,11 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           contentTypes: { test: definition },
         });
 
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
 
       test('i18n => i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = { pluginOptions: { i18n: { localized: true } } };
         const definition = { pluginOptions: { i18n: { localized: true } } };
@@ -73,13 +71,13 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           contentTypes: { test: definition },
         });
 
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
     });
 
     describe('Should migrate', () => {
       test('non i18n => i18n ', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = {};
         const definition = { pluginOptions: { i18n: { localized: true } } };
@@ -90,7 +88,7 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
         });
 
         expect(strapi.plugins.i18n.services.locales.getDefaultLocale).toHaveBeenCalled();
-        expect(strapi.db.queryBuilder).toHaveBeenCalled();
+        expect(strapi.db.query).toHaveBeenCalled();
       });
     });
   });
@@ -98,7 +96,7 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
   describe('disable localization on a CT', () => {
     describe('Should not migrate', () => {
       test('non i18n => non i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = {};
         const definition = {};
@@ -107,11 +105,11 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           oldContentTypes: { test: previousDefinition },
           contentTypes: { test: definition },
         });
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
 
       test('non i18n => i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = {};
         const definition = { pluginOptions: { i18n: { localized: true } } };
@@ -120,11 +118,11 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           oldContentTypes: { test: previousDefinition },
           contentTypes: { test: definition },
         });
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
 
       test('i18n => i18n', async () => {
-        strapi.db.queryBuilder = createQueryBuilderMock();
+        strapi.db.query = createDBQueryMock();
 
         const previousDefinition = { pluginOptions: { i18n: { localized: true } } };
         const definition = { pluginOptions: { i18n: { localized: true } } };
@@ -133,7 +131,7 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
           oldContentTypes: { test: previousDefinition },
           contentTypes: { test: definition },
         });
-        expect(strapi.db.queryBuilder).not.toHaveBeenCalled();
+        expect(strapi.db.query).not.toHaveBeenCalled();
       });
     });
 
@@ -150,7 +148,7 @@ describe('i18n - Migration - enable/disable localization on a CT', () => {
         });
 
         expect(strapi.plugins.i18n.services.locales.getDefaultLocale).toHaveBeenCalled();
-        expect(strapi.db.queryBuilder).toHaveBeenCalled();
+        expect(strapi.db.query).toHaveBeenCalled();
       });
     });
   });

--- a/packages/plugins/i18n/server/src/migrations/content-type/disable/index.ts
+++ b/packages/plugins/i18n/server/src/migrations/content-type/disable/index.ts
@@ -22,11 +22,20 @@ export default async ({ oldContentTypes, contentTypes }: any) => {
     if (isLocalizedContentType(oldContentType) && !isLocalizedContentType(contentType)) {
       const defaultLocale = (await getDefaultLocale()) || DEFAULT_LOCALE.code;
 
-      await strapi.db
-        .queryBuilder(uid)
-        .delete()
-        .where({ locale: { $ne: defaultLocale } })
-        .execute();
+      await Promise.all([
+        // Delete all entities that are not in the default locale
+        strapi.db
+          .queryBuilder(uid)
+          .delete()
+          .where({ locale: { $ne: defaultLocale } })
+          .execute(),
+        // Set locale to null for the rest
+        strapi.db
+          .queryBuilder(uid)
+          .update({ locale: null })
+          .where({ locale: { $eq: defaultLocale } })
+          .execute(),
+      ]);
     }
   }
 };

--- a/packages/plugins/i18n/server/src/migrations/content-type/disable/index.ts
+++ b/packages/plugins/i18n/server/src/migrations/content-type/disable/index.ts
@@ -24,17 +24,14 @@ export default async ({ oldContentTypes, contentTypes }: any) => {
 
       await Promise.all([
         // Delete all entities that are not in the default locale
-        strapi.db
-          .queryBuilder(uid)
-          .delete()
-          .where({ locale: { $ne: defaultLocale } })
-          .execute(),
+        strapi.db.query(uid).deleteMany({
+          where: { locale: { $ne: defaultLocale } },
+        }),
         // Set locale to null for the rest
-        strapi.db
-          .queryBuilder(uid)
-          .update({ locale: null })
-          .where({ locale: { $eq: defaultLocale } })
-          .execute(),
+        strapi.db.query(uid).updateMany({
+          where: { locale: { $eq: defaultLocale } },
+          data: { locale: null },
+        }),
       ]);
     }
   }

--- a/packages/plugins/i18n/server/src/migrations/content-type/enable/index.ts
+++ b/packages/plugins/i18n/server/src/migrations/content-type/enable/index.ts
@@ -21,11 +21,10 @@ export default async ({ oldContentTypes, contentTypes }: any) => {
     if (!isLocalizedContentType(oldContentType) && isLocalizedContentType(contentType)) {
       const defaultLocale = (await getDefaultLocale()) || DEFAULT_LOCALE.code;
 
-      await strapi.db
-        .queryBuilder(uid)
-        .update({ locale: defaultLocale })
-        .where({ locale: null })
-        .execute();
+      await strapi.db.query(uid).updateMany({
+        where: { locale: null },
+        data: { locale: defaultLocale },
+      });
     }
   }
 };


### PR DESCRIPTION
### What does it do?

Locales other than the default one were deleted when disabling i18n, but the left default locale was not set to null.

