### PR TITLE
fix: failed to dynamically load chunk

### DIFF
--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -20,23 +20,16 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
 
   const vite = await createServer(finalConfig);
 
-  ctx.strapi.server.app.use(async (ctx, next) => {
-    const url = ctx.url;
-
-    // Check if the URL points to a file that Vite can handle
-    const file = await vite.moduleGraph.getModuleByUrl(url);
-
-    if (file || url.startsWith('/@')) {
-      // If Vite can handle the file, pass the request to the Vite middleware
-      return new Promise((resolve, reject) => {
-        vite.middlewares(ctx.req, ctx.res, (err: unknown) => {
-          if (err) reject(err);
-          else resolve(next());
-        });
+  ctx.strapi.server.app.use((ctx, next) => {
+    return new Promise((resolve, reject) => {
+      vite.middlewares(ctx.req, ctx.res, (err: unknown) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(next());
+        }
       });
-    }
-
-    await next();
+    });
   });
 
   const serveAdmin: Common.MiddlewareHandler = async (koaCtx, next) => {


### PR DESCRIPTION
### What does it do?
We were manually checking if the requested url was from a bit chunk file. This is actually handled automatically by vite middlewares, and apparently doesn't have the "Failed to dynamically load..." error
