### PR TITLE
chore: make default log level http

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -222,13 +222,13 @@ class Strapi extends Container implements StrapiI {
     this.eventHub = createEventHub();
     this.startupLogger = utils.createStartupLogger(this);
 
-    // We will continue to support 'logger' to prevent unnecessary deprecations but prioritize server.logger.config
-    // So we find: server.logger.config || logger || 'http'
-    const logLevel = this.config.get(
-      'server.logger.config',
-      this.config.get('logger', { level: 'http' })
-    );
-    this.log = createLogger(logLevel);
+    const logConfig = {
+      level: 'debug',
+      ...this.config.get('logger'), // DEPRECATED
+      ...this.config.get('server.logger.config'),
+    };
+
+    this.log = createLogger(logConfig);
     this.cron = createCronService();
     this.telemetry = createTelemetry(this);
     this.requestContext = requestContext;

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -223,7 +223,7 @@ class Strapi extends Container implements StrapiI {
     this.startupLogger = utils.createStartupLogger(this);
 
     const logConfig = {
-      level: 'debug',
+      level: 'http', // Strapi defaults to level 'http'
       ...this.config.get('logger'), // DEPRECATED
       ...this.config.get('server.logger.config'),
     };

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -223,10 +223,10 @@ class Strapi extends Container implements StrapiI {
     this.startupLogger = utils.createStartupLogger(this);
 
     // We will continue to support 'logger' to prevent unnecessary deprecations but prioritize server.logger.config
-    // So we find: server.logger.config || logger || 'info'
+    // So we find: server.logger.config || logger || 'http'
     const logLevel = this.config.get(
       'server.logger.config',
-      this.config.get('logger', { level: 'info' })
+      this.config.get('logger', { level: 'http' })
     );
     this.log = createLogger(logLevel);
     this.cron = createCronService();


### PR DESCRIPTION
### What does it do?

makes the strapi default log level 'http' instead of 'silly' (v4) or 'info' (previous v5)

### Why is it needed?

so that admin http requests appear in server logs

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
