### PR TITLE
chore: set default log level to 'http'

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -222,13 +222,13 @@ class Strapi extends Container implements StrapiI {
     this.eventHub = createEventHub();
     this.startupLogger = utils.createStartupLogger(this);
 
-    // We will continue to support 'logger' to prevent unnecessary deprecations but prioritize server.logger.config
-    // So we find: server.logger.config || logger || 'info'
-    const logLevel = this.config.get(
-      'server.logger.config',
-      this.config.get('logger', { level: 'info' })
-    );
-    this.log = createLogger(logLevel);
+    const logConfig = {
+      level: 'http', // Strapi defaults to level 'http'
+      ...this.config.get('logger'), // DEPRECATED
+      ...this.config.get('server.logger.config'),
+    };
+
+    this.log = createLogger(logConfig);
     this.cron = createCronService();
     this.telemetry = createTelemetry(this);
     this.requestContext = requestContext;


### PR DESCRIPTION
### What does it do?

sets the default server log level to 'http'

### Why is it needed?

'info' was too high and preventing admin requests from being seen

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
