### PR TITLE
fix(cm): send status & locale with disconnect array

### DIFF
--- a/api-tests/core/content-manager/find-relations.test.api.js
+++ b/api-tests/core/content-manager/find-relations.test.api.js
@@ -233,18 +233,14 @@ describe('Find Relations', () => {
 
     // Create draft products
     const [skate, chair, candle, table, porte, fenetre] = await Promise.all([
-      strapi.documents(productUid).create({ data: { name: 'Skate' }, status: 'published' }),
-      strapi.documents(productUid).create({ data: { name: 'Chair' }, status: 'published' }),
-      strapi.documents(productUid).create({ data: { name: 'Candle' }, status: 'published' }),
-      strapi.documents(productUid).create({ data: { name: 'Table' }, status: 'published' }),
+      strapi.documents(productUid).create({ data: { name: 'Skate' } }),
+      strapi.documents(productUid).create({ data: { name: 'Chair' } }),
+      strapi.documents(productUid).create({ data: { name: 'Candle' } }),
+      strapi.documents(productUid).create({ data: { name: 'Table' } }),
       // We create products in French in order to test that we can cant find
       // available relations in a different locale
-      strapi
-        .documents(productUid)
-        .create({ data: { name: 'Porte' }, locale: extraLocale, status: 'published' }),
-      strapi
-        .documents(productUid)
-        .create({ data: { name: 'Fenetre' }, locale: extraLocale, status: 'published' }),
+      strapi.documents(productUid).create({ data: { name: 'Porte' }, locale: extraLocale }),
+      strapi.documents(productUid).create({ data: { name: 'Fenetre' }, locale: extraLocale }),
     ]);
     data[productUid].draft.push(skate, chair, candle, table, porte, fenetre);
 
@@ -663,7 +659,7 @@ describe('Find Relations', () => {
               }))
           );
 
-          const idsToOmit = [documentsInThisLocale[1]?.documentId].filter(Boolean);
+          const idsToOmit = [documentsInThisLocale[1]?.id].filter(Boolean);
           const omitIdsRes = await rq({
             method: 'GET',
             url: `/content-manager/relations/${modelUID}/${fieldName}`,
@@ -675,8 +671,7 @@ describe('Find Relations', () => {
           });
 
           expect(omitIdsRes.body.results).toHaveLength(
-            documentsInThisLocale.filter((document) => !idsToOmit.includes(document.documentId))
-              .length
+            documentsInThisLocale.filter((document) => !idsToOmit.includes(document.id)).length
           );
         });
       });
@@ -727,7 +722,7 @@ describe('Find Relations', () => {
 
         expect(res.body.results).toMatchObject(availableDocuments);
 
-        const idsToOmit = [availableDocuments[1]?.documentId].filter(Boolean);
+        const idsToOmit = [availableDocuments[1]?.id].filter(Boolean);
         const omitIdsRes = await rq({
           method: 'GET',
           url: `/content-manager/relations/${modelUID}/${fieldName}`,
@@ -739,7 +734,7 @@ describe('Find Relations', () => {
         });
 
         expect(omitIdsRes.body.results).toHaveLength(
-          availableDocuments.filter((document) => !idsToOmit.includes(document.documentId)).length
+          availableDocuments.filter((document) => !idsToOmit.includes(document.id)).length
         );
       });
 

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/DocumentActions.tsx
@@ -621,6 +621,7 @@ const UpdateAction: DocumentActionComponent = ({
   const document = useForm('UpdateAction', ({ values }) => values);
   const validate = useForm('UpdateAction', (state) => state.validate);
   const setErrors = useForm('UpdateAction', (state) => state.setErrors);
+  const resetForm = useForm('PublishAction', ({ resetForm }) => resetForm);
 
   return {
     /**
@@ -701,6 +702,8 @@ const UpdateAction: DocumentActionComponent = ({
             res.error.name === 'ValidationError'
           ) {
             setErrors(formatValidationErrors(res.error));
+          } else {
+            resetForm();
           }
         } else {
           const res = await create(

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -77,7 +77,7 @@ interface RelationsFieldProps
 
 interface RelationsFormValue {
   connect?: Relation[];
-  disconnect?: Pick<RelationResult, 'documentId'>[];
+  disconnect?: Pick<Relation, 'id'>[];
 }
 
 /**
@@ -223,7 +223,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
          */
         __temp_key__: generateNKeysBetween(lastItemInList?.__temp_key__ ?? null, null, 1)[0],
         // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
-        [props.mainField?.name ?? 'id']: relation[props.mainField?.name ?? 'id'],
+        [props.mainField?.name ?? 'documentId']: relation[props.mainField?.name ?? 'documentId'],
         label: getRelationLabel(relation, props.mainField),
         // @ts-expect-error – targetModel does exist on the attribute, but it's not typed.
         href: `../${COLLECTION_TYPES}/${props.attribute.targetModel}/${relation.documentId}`,
@@ -314,7 +314,7 @@ const removeConnected =
     return relations.filter((relation) => {
       const connectedRelations = field?.connect ?? [];
 
-      return connectedRelations.findIndex((rel) => rel.documentId === relation.documentId) === -1;
+      return connectedRelations.findIndex((rel) => rel.id === relation.id) === -1;
     });
   };
 
@@ -327,9 +327,7 @@ const removeDisconnected =
     relations.filter((relation) => {
       const disconnectedRelations = field?.disconnect ?? [];
 
-      return (
-        disconnectedRelations.findIndex((rel) => rel.documentId === relation.documentId) === -1
-      );
+      return disconnectedRelations.findIndex((rel) => rel.id === relation.id) === -1;
     });
 
 /**
@@ -342,8 +340,8 @@ const addLabelAndHref =
     relations.map((relation) => {
       return {
         ...relation,
-        // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
-        [mainField?.name ?? 'id']: relation[mainField?.name ?? 'id'],
+        // Fallback to `id` if there is no `mainField` value, which will overwrite the above `documentId` property with the exact same data.
+        [mainField?.name ?? 'documentId']: relation[mainField?.name ?? 'documentId'],
         label: getRelationLabel(relation, mainField),
         href: `${href}/${relation.documentId}`,
       };
@@ -414,8 +412,8 @@ const RelationsInput = ({
         ...buildValidParams(query),
         id: id ?? '',
         pageSize: 10,
-        idsToInclude: field.value?.disconnect?.map((rel) => rel.documentId) ?? [],
-        idsToOmit: field.value?.connect?.map((rel) => rel.documentId) ?? [],
+        idsToInclude: field.value?.disconnect?.map((rel) => rel.id.toString()) ?? [],
+        idsToOmit: field.value?.connect?.map((rel) => rel.id.toString()) ?? [],
         ...searchParams,
       },
     });
@@ -740,8 +738,7 @@ const RelationsList = ({
        * from the connect array
        */
       const indexOfRelationInConnectArray = field.value.connect.findIndex(
-        (rel: NonNullable<RelationsFormValue['connect']>[number]) =>
-          rel.documentId === relation.documentId
+        (rel: NonNullable<RelationsFormValue['connect']>[number]) => rel.id === relation.id
       );
 
       if (indexOfRelationInConnectArray >= 0) {
@@ -750,7 +747,7 @@ const RelationsList = ({
       }
     }
 
-    addFieldRow(`${name}.disconnect`, { documentId: relation.documentId });
+    addFieldRow(`${name}.disconnect`, { id: relation.id });
   };
 
   /**

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -218,6 +218,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
 
       const item = {
         id: relation.id,
+        status: relation.status,
         /**
          * If there's a last item, that's the first key we use to generate out next one.
          */

--- a/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/EditView/components/FormInputs/Relations.tsx
@@ -217,7 +217,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       const [lastItemInList] = relations.slice(-1);
 
       const item = {
-        ...relation,
+        id: relation.id,
         /**
          * If there's a last item, that's the first key we use to generate out next one.
          */
@@ -441,7 +441,7 @@ const RelationsInput = ({
       return;
     }
 
-    const relation = options.find((opt) => opt.documentId === relationId);
+    const relation = options.find((opt) => opt.id.toString() === relationId);
 
     if (!relation) {
       // This is very unlikely to happen, but it ensures we don't have any data for.
@@ -528,7 +528,7 @@ const RelationsInput = ({
         const textValue = getRelationLabel(opt, mainField);
 
         return (
-          <ComboboxOption key={opt.documentId} value={opt.documentId} textValue={textValue}>
+          <ComboboxOption key={opt.id} value={opt.id.toString()} textValue={textValue}>
             <Flex gap={2} justifyContent="space-between">
               <Typography ellipsis>{textValue}</Typography>
               {opt.status ? <DocumentStatus status={opt.status} /> : null}

--- a/packages/core/admin/admin/src/content-manager/services/api.ts
+++ b/packages/core/admin/admin/src/content-manager/services/api.ts
@@ -12,6 +12,7 @@ const contentManagerApi = createApi({
     'Document',
     'InitialData',
     'HistoryVersion',
+    'Relations',
   ],
   endpoints: () => ({}),
 });

--- a/packages/core/admin/admin/src/content-manager/services/documents.ts
+++ b/packages/core/admin/admin/src/content-manager/services/documents.ts
@@ -59,7 +59,13 @@ const documentApi = contentManagerApi.injectEndpoints({
           params,
         },
       }),
-      invalidatesTags: (_result, _error, { model }) => [{ type: 'Document', id: `${model}_LIST` }],
+      invalidatesTags: (result, _error, { model }) => [
+        { type: 'Document', id: `${model}_LIST` },
+        {
+          type: 'Relations',
+          id: `${model}_${result?.data.documentId}`,
+        },
+      ],
     }),
     deleteDocument: builder.mutation<
       Contracts.CollectionTypes.Delete.Response,
@@ -121,6 +127,10 @@ const documentApi = contentManagerApi.injectEndpoints({
             id: collectionType !== SINGLE_TYPES ? `${model}_${documentId}` : model,
           },
           { type: 'Document', id: `${model}_LIST` },
+          {
+            type: 'Relations',
+            id: `${model}_${documentId}`,
+          },
         ];
       },
     }),
@@ -268,6 +278,10 @@ const documentApi = contentManagerApi.injectEndpoints({
             id: collectionType !== SINGLE_TYPES ? `${model}_${documentId}` : model,
           },
           { type: 'Document', id: `${model}_LIST` },
+          {
+            type: 'Relations',
+            id: `${model}_${documentId}`,
+          },
         ];
       },
     }),
@@ -306,6 +320,10 @@ const documentApi = contentManagerApi.injectEndpoints({
           {
             type: 'Document',
             id: collectionType !== SINGLE_TYPES ? `${model}_${documentId}` : model,
+          },
+          {
+            type: 'Relations',
+            id: `${model}_${documentId}`,
           },
         ];
       },

--- a/packages/core/admin/admin/src/content-manager/services/relations.ts
+++ b/packages/core/admin/admin/src/content-manager/services/relations.ts
@@ -51,6 +51,8 @@ const relationsApi = contentManagerApi.injectEndpoints({
           model: queryArgs.model,
           id: queryArgs.id,
           targetField: queryArgs.targetField,
+          locale: queryArgs.params?.locale,
+          status: queryArgs.params?.status,
         };
       },
       merge: (currentCache, newItems) => {

--- a/packages/core/admin/admin/src/content-manager/services/relations.ts
+++ b/packages/core/admin/admin/src/content-manager/services/relations.ts
@@ -95,6 +95,9 @@ const relationsApi = contentManagerApi.injectEndpoints({
           return response;
         }
       },
+      providesTags: (result, error, args) => [
+        { type: 'Relations', id: `${args.model}_${args.id}` },
+      ],
     }),
     searchRelations: build.query<
       Contracts.Relations.FindAvailable.Response,

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -328,7 +328,7 @@ export default {
        * We don't want to include them in the available relations.
        */
       if ((idsToInclude?.length ?? 0) !== 0) {
-        where[`${alias}.document_id`].$notIn = idsToInclude;
+        where[`${alias}.id`].$notIn = idsToInclude;
       }
 
       const knexSubQuery = subQuery
@@ -354,7 +354,7 @@ export default {
     if (idsToOmit?.length > 0) {
       // If we have ids to omit, we should filter them out
       addFiltersClause(queryParams, {
-        documentId: { $notIn: uniq(idsToOmit) },
+        id: { $notIn: uniq(idsToOmit) },
       });
     }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* sends the full relation back on the disconnect array

### Why is it needed?

* I should have done it to begin with, but you can't disconnect a relation correctly without the dimensions

