### PR TITLE
feat: make relation status handling smarter

### DIFF
--- a/packages/core/core/src/services/document-service/transform/relations/utils/dp.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/utils/dp.ts
@@ -26,21 +26,35 @@ export const getRelationTargetStatus = (
     return ['published'];
   }
 
-  // priority:
-  // DP Enabled 'relation status' -> 'source status' -> 'draft'
-  // DP Disabled 'relation status' -> 'draft' and 'published'
-  if (relation.status) {
-    return [relation.status];
+  /**
+   * If both source and target have DP enabled,
+   * connect it to the same status as the source status
+   */
+  if (sourceHasDP && !isNil(opts.sourceStatus)) {
+    return [opts.sourceStatus];
   }
 
-  // Connect to both draft and published versions if dp is disabled and relation does not specify a status
+  /**
+   * Use the status from the relation if it's set
+   */
+  if (relation.status) {
+    switch (relation.status) {
+      case 'published':
+        return ['published'];
+      default:
+        // Default to draft if it's an invalid status (e.g. modified)
+        return ['draft'];
+    }
+  }
+
+  /**
+   * If DP is disabled and relation does not specify any status
+   * Connect to both draft and published versions
+   */
   if (!sourceHasDP) {
     return ['draft', 'published'];
   }
 
-  if (!isNil(opts.sourceStatus)) {
-    return [opts.sourceStatus];
-  }
-
+  // Default to draft as a fallback
   return ['draft'];
 };


### PR DESCRIPTION
### What does it do?

Make relation connecting status handling a bit smarter on the backend side.

Frontend sends status like "Modified" or "Published" when in reality the relation needs to be conected to the "Draft" state.  Before this PR, if you tried to connect a relation in a "Modified" state in the CM, you would see an error like:

![image](https://github.com/strapi/strapi/assets/20578351/1132b27b-5571-4269-ab76-3039adb25828)


This work assumes:

- If source and target content types of a relation have DP enabled
-  Then the relation target must match the source status (draft->draft, published->published)

That way, regardless of the sent status, this will always connect the relation to the correct status


