### PR TITLE
Force sql_require_primary_key inside a transaction so it errors in that statement instead of next statement in that session

### DIFF
--- a/packages/core/database/src/dialects/mysql/index.ts
+++ b/packages/core/database/src/dialects/mysql/index.ts
@@ -67,14 +67,14 @@ export default class MysqlDialect extends Dialect {
   async startSchemaUpdate() {
     try {
       await this.db.connection.raw(`set foreign_key_checks = 0;`);
-      await this.db.connection.raw(`set session sql_require_primary_key = 0;`);
+      await this.db.connection.raw(`begin; set session sql_require_primary_key = 0; commit;`);
     } catch (err) {
       // Ignore error due to lack of session permissions
     }
   }
 
   async endSchemaUpdate() {
-    await this.db.connection.raw(`set foreign_key_checks = 1;`);
+    await this.db.connection.raw(`begin; set foreign_key_checks = 1; commit;`);
   }
 
   supportsUnsigned() {


### PR DESCRIPTION
### What does it do?

Describe the technical changes you did.

### Why is it needed?

We use proxysql to support multiple backend mysql 8 servers, and have pretty granular controls on what statements can be done by which accounts.

The current implementation is throwing `ER_SPECIFIC_ACCESS_DENIED_ERROR: Access denied; you need (at least one of) the SUPER, SYSTEM_VARIABLES_ADMIN or SESSION_VARIABLES_ADMIN privilege(s) for this operation` on startup, but on random confusing statements.

### How to test it?

TODO: Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/16954
https://github.com/strapi/strapi/pull/12553#issuecomment-1043502932
https://github.com/strapi/strapi/blob/fc231041206e6f3999b094160cfa05db2892ad54/packages/core/database/src/dialects/mysql/index.ts#L57-L78
