### PR TITLE
feat: ignore relations that do not target content types

### DIFF
--- a/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
@@ -6,6 +6,7 @@ import { ShortHand, LongHand, LongHandDocument } from '../utils/types';
 import { isShortHand, isLongHand } from '../utils/data';
 import { getRelationTargetLocale } from '../utils/i18n';
 import { getRelationTargetStatus } from '../utils/dp';
+import { isContentType } from '../utils/content-types';
 
 /**
  *  Get relation ids from primitive representation (id, id[], {id}, {id}[])
@@ -94,7 +95,7 @@ const extractDataIds = (
 
         // TODO: Handle morph relations (they have multiple targets)
         const target = attribute.target;
-        if (!target) return;
+        if (!target || !isContentType(target)) return;
 
         // If not connecting to any version on disabled d&p, we should connect to both draft and published relations at the same time
         extractedIds.forEach((relation) => {

--- a/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
@@ -8,6 +8,7 @@ import { isShortHand, isLongHand } from '../utils/data';
 import { IdMap } from '../../id-map';
 import { getRelationTargetLocale } from '../utils/i18n';
 import { getRelationTargetStatus } from '../utils/dp';
+import { isContentType } from '../utils/content-types';
 
 const isNumeric = (value: any): value is number => {
   if (Array.isArray(value)) return false; // Handle [1, 'docId'] case
@@ -155,14 +156,6 @@ const transformRelationIdsVisitor = <T extends Attribute.RelationKind.Any>(
   return relation;
 };
 
-const EXCLUDED_FIELDS = [
-  'createdBy',
-  'updatedBy',
-  'localizations',
-  'strapi_stage',
-  'strapi_assignee',
-];
-
 const transformDataIdsVisitor = (
   idMap: IdMap,
   data: Record<string, any>,
@@ -178,10 +171,9 @@ const transformDataIdsVisitor = (
       // Find relational attributes, and return the document ids
       if (attribute.type === 'relation') {
         const target = attribute.target as Common.UID.Schema | undefined;
+        // If uid doesn't target a content type, ignore any transformation
         // TODO: Handle polymorphic relations
-        if (!target) return;
-        // TODO: V5 remove excluded fields and use { id: } syntax for those relations
-        if (EXCLUDED_FIELDS.includes(key)) return;
+        if (!target || !isContentType(target)) return;
 
         const getIds = (
           documentId: ID,

--- a/packages/core/core/src/services/document-service/transform/relations/utils/content-types.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/utils/content-types.ts
@@ -1,0 +1,9 @@
+import { Common } from '@strapi/types';
+
+/**
+ * Check if the UID is from a content type
+ */
+export const isContentType = (uid: string): boolean => {
+  const contentType = strapi.contentType(uid as Common.UID.ContentType);
+  return !!contentType;
+};


### PR DESCRIPTION
### What does it do?

Ignore relation transformations if the targeted uid is not a content type.
This might not be an issue atm anywhere, but just in case 
