### PR TITLE
fix: make ctb refetch data after save or update

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/DataManagerProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/DataManagerProvider.tsx
@@ -42,6 +42,7 @@ import {
   REMOVE_FIELD_FROM_DISPLAYED_COMPONENT,
   SET_MODIFIED_DATA,
   UPDATE_SCHEMA,
+  UPDATE_INITIAL_STATE,
 } from './constants';
 import { makeSelectDataManagerProvider } from './selectors';
 import { formatMainDataType, getComponentsToPost, sortContentType } from './utils/cleanData';
@@ -552,7 +553,7 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       await serverRestartWatcher(true);
 
       // Unlock the app
-      await unlockAppWithAutoreload?.();
+      unlockAppWithAutoreload?.();
 
       if (
         isCreating &&
@@ -575,6 +576,10 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       } else {
         trackUsage('didSaveComponent');
       }
+
+      // refetch and update initial state after the data has been saved
+      await getDataRef.current();
+      dispatch({ type: UPDATE_INITIAL_STATE });
 
       // Update the app's permissions
       await updatePermissions();

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/constants.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/constants.ts
@@ -21,3 +21,4 @@ export const REMOVE_COMPONENT_FROM_DYNAMIC_ZONE =
 export const REMOVE_FIELD = 'ContentTypeBuilder/DataManagerProvider/REMOVE_FIELD';
 export const SET_MODIFIED_DATA = 'ContentTypeBuilder/DataManagerProvider/SET_MODIFIED_DATA';
 export const UPDATE_SCHEMA = 'ContentTypeBuilder/DataManagerProvider/UPDATE_SCHEMA';
+export const UPDATE_INITIAL_STATE = 'ContentTypeBuilder/DataManagerProvider/UPDATE_INITIAL_STATE';

--- a/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManagerProvider/reducer.ts
@@ -545,6 +545,11 @@ const reducer = (state = initialState, action: Action) =>
 
         break;
       }
+      case actions.UPDATE_INITIAL_STATE: {
+        draftState.initialData = draftState.modifiedData;
+
+        break;
+      }
       case actions.DELETE_NOT_SAVED_TYPE: {
         // Doing so will also reset the modified and the initial data
         draftState.contentTypes = state.initialContentTypes;

--- a/packages/core/content-type-builder/admin/src/contexts/DataManagerContext.ts
+++ b/packages/core/content-type-builder/admin/src/contexts/DataManagerContext.ts
@@ -41,7 +41,7 @@ export interface DataManagerContextValue {
   removeComponentFromDynamicZone: (dzName: string, componentToRemoveIndex: number) => void;
   setModifiedData: () => void;
   sortedContentTypesList: any[]; // Define the actual type
-  submitData: (additionalContentTypeData?: Record<string, any>) => void;
+  submitData: (additionalContentTypeData?: Record<string, any>) => Promise<void>;
   updateSchema: (data: Record<string, any>, schemaType: SchemaType, componentUID: UID.Any) => void;
   components: Record<UID.Component, Component>;
   componentsGroupedByCategory: Record<string, Component[]>;

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -139,7 +139,7 @@ const ListView = () => {
               )}
               <Button
                 startIcon={<Check />}
-                onClick={() => submitData()}
+                onClick={async () => await submitData()}
                 type="submit"
                 disabled={isEqual(modifiedData, initialData)}
               >


### PR DESCRIPTION
### What does it do?

- CTB refetches after save

### Why is it needed?

- After saving components or contenttypes in the ctb, state is not refreshing unless the page is reloaded manually

### How to test it?

- create or update a contentType it should work properly

### Related issue(s)/PR(s)

duplicate of #19811 for V5 beta
