### PR TITLE
Fix link add target _blank

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -134,6 +134,7 @@ const NpmPackageCard = ({
         <LinkButton
           size="S"
           href={npmPackageHref}
+          target="_blank"
           isExternal
           endIcon={<ExternalLink />}
           aria-label={formatMessage(


### PR DESCRIPTION
### What does it do?

Specify target blank attribute to make the link open in a new tab.

### Why is it needed?

The plugin information link was opening on the same tab as the administration panel. That makes the user have to open the admin panel in a new tab again.

### How to test it?
#### Before:
![Grabaciondepantalla2024-03-19alas21 01 52-ezgif com-video-to-gif-converter](https://github.com/strapi/strapi/assets/33104288/83fe3af1-5367-4399-998c-97fef15ff628)

#### After:
![Grabaciondepantalla2024-03-19alas21 31 38-ezgif com-video-to-gif-converter](https://github.com/strapi/strapi/assets/33104288/bb0abddb-eeb5-47d1-bb23-77727950def0)