### PR TITLE
feat(history): diff schemas to get unknown attributes

### DIFF
--- a/packages/core/content-manager/server/src/history/constants.ts
+++ b/packages/core/content-manager/server/src/history/constants.ts
@@ -1,1 +1,11 @@
 export const HISTORY_VERSION_UID = 'plugin::content-manager.history-version';
+export const FIELDS_TO_IGNORE = [
+  'createdAt',
+  'updatedAt',
+  'publishedAt',
+  'createdBy',
+  'updatedBy',
+  'locale',
+  'strapi_stage',
+  'strapi_assignee',
+];

--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -25,18 +25,6 @@ const mockGetRequestContext = jest.fn(() => {
 });
 
 const mockStrapi = {
-  getModel() {
-    return {
-      attributes: {
-        newField: {
-          type: 'string',
-        },
-        renamed: {
-          type: 'string',
-        },
-      },
-    };
-  },
   plugins: {
     'content-manager': {
       service: jest.fn(() => ({
@@ -58,20 +46,6 @@ const mockStrapi = {
       if (uid === HISTORY_VERSION_UID) {
         return {
           create: createMock,
-          findPage() {
-            return {
-              results: [
-                {
-                  contentType: 'api::article.article',
-                  schema: {
-                    title: {
-                      type: 'string',
-                    },
-                  },
-                },
-              ],
-            };
-          },
         };
       }
     },
@@ -254,28 +228,6 @@ describe('history-version service', () => {
           ...historyVersionData,
           createdBy: undefined,
           createdAt: fakeDate,
-        },
-      });
-    });
-  });
-
-  describe('findVersionPage', () => {
-    it('should contain a meta object with unknown attributes', async () => {
-      const { results } = await historyService.findVersionsPage({
-        contentType: 'api::article.article',
-        documentId: 'randomid',
-        locale: 'en',
-      });
-
-      expect(results[0].meta).toEqual({
-        unknownAttributes: {
-          added: {
-            newField: { type: 'string' },
-            renamed: { type: 'string' },
-          },
-          removed: {
-            title: { type: 'string' },
-          },
         },
       });
     });

--- a/packages/core/content-manager/server/src/history/services/__tests__/utils.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/utils.test.ts
@@ -1,0 +1,63 @@
+import { getSchemaAttributesDiff } from '../utils';
+
+describe('history-version service utils', () => {
+  describe('getSchemaAttributesDiff', () => {
+    it('should return a diff', () => {
+      const versionSchema = {
+        title: {
+          type: 'string',
+        },
+        someOtherField: {
+          type: 'string',
+        },
+      };
+      const contentTypeSchema = {
+        renamed: {
+          type: 'string',
+        },
+        newField: {
+          type: 'string',
+        },
+        someOtherField: {
+          type: 'string',
+        },
+      };
+
+      // @ts-expect-error ignore
+      const { added, removed } = getSchemaAttributesDiff(versionSchema, contentTypeSchema);
+
+      expect(added).toEqual({
+        renamed: {
+          type: 'string',
+        },
+        newField: {
+          type: 'string',
+        },
+      });
+      expect(removed).toEqual({
+        title: {
+          type: 'string',
+        },
+      });
+    });
+
+    it('should not return a diff', () => {
+      const versionSchema = {
+        title: {
+          type: 'string',
+        },
+      };
+      const contentTypeSchema = {
+        title: {
+          type: 'string',
+        },
+      };
+
+      // @ts-expect-error ignore
+      const { added, removed } = getSchemaAttributesDiff(versionSchema, contentTypeSchema);
+
+      expect(added).toEqual({});
+      expect(removed).toEqual({});
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -174,14 +174,15 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
       ]);
 
       const versionsWithMeta = results.map((version) => {
+        const { added, removed } = getSchemaAttributesDiff(
+          version.schema,
+          strapi.getModel(params.contentType).attributes
+        );
+        const hasSchemaDiff = Object.keys(added).length > 0 || Object.keys(removed).length > 0;
+
         return {
           ...version,
-          meta: {
-            unknownAttributes: getSchemaAttributesDiff(
-              version.schema,
-              strapi.getModel(params.contentType).attributes
-            ),
-          },
+          ...(hasSchemaDiff ? { meta: { unknownAttributes: { added, removed } } } : {}),
         };
       });
 

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -88,10 +88,10 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
       diffKeys: string[],
       source: CreateHistoryVersion['schema']
     ) => {
-      return diffKeys.reduce<CreateHistoryVersion['schema']>((previousAttributeObject, diffKey) => {
-        previousAttributeObject[diffKey] = source[diffKey];
+      return diffKeys.reduce<CreateHistoryVersion['schema']>((previousAttributesObject, diffKey) => {
+        previousAttributesObject[diffKey] = source[diffKey];
 
-        return previousAttributeObject;
+        return previousAttributesObject;
       }, {});
     };
 

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -164,10 +164,7 @@ const createHistoryService = ({ strapi }: { strapi: LoadedStrapi }) => {
             this.createVersion({
               contentType: contentTypeUid,
               data: omit(FIELDS_TO_IGNORE, document),
-              schema: omit(
-                FIELDS_TO_IGNORE,
-                strapi.contentType(contentTypeUid).attributes
-              ),
+              schema: omit(FIELDS_TO_IGNORE, strapi.contentType(contentTypeUid).attributes),
               relatedDocumentId: documentContext.documentId,
               locale,
               status,

--- a/packages/core/content-manager/server/src/history/services/utils.ts
+++ b/packages/core/content-manager/server/src/history/services/utils.ts
@@ -1,0 +1,44 @@
+import { difference, omit } from 'lodash/fp';
+import { Schema } from '@strapi/types';
+import { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
+import { FIELDS_TO_IGNORE } from '../constants';
+
+/**
+ * Get the difference between the version schema and the content type schema
+ * Returns the attributes with their original shape
+ */
+export const getSchemaAttributesDiff = (
+  versionSchemaAttributes: CreateHistoryVersion['schema'],
+  contentTypeSchemaAttributes: Schema.Attributes
+) => {
+  // Omit the same fields that were omitted when creating a history version
+  const sanitizedContentTypeSchemaAttributes = omit(
+    FIELDS_TO_IGNORE,
+    contentTypeSchemaAttributes
+  ) as CreateHistoryVersion['schema'];
+
+  const reduceDifferenceToAttributesObject = (
+    diffKeys: string[],
+    source: CreateHistoryVersion['schema']
+  ) => {
+    return diffKeys.reduce<CreateHistoryVersion['schema']>((previousAttributesObject, diffKey) => {
+      previousAttributesObject[diffKey] = source[diffKey];
+
+      return previousAttributesObject;
+    }, {});
+  };
+
+  const versionSchemaKeys = Object.keys(versionSchemaAttributes);
+  const contentTypeSchemaAttributesKeys = Object.keys(sanitizedContentTypeSchemaAttributes);
+  // The attribute is new if it's on the content type schema but not on the version schema
+  const uniqueToContentType = difference(contentTypeSchemaAttributesKeys, versionSchemaKeys);
+  const added = reduceDifferenceToAttributesObject(
+    uniqueToContentType,
+    sanitizedContentTypeSchemaAttributes
+  );
+  // The attribute was removed or renamed if it's on the version schema but not on the content type schema
+  const uniqueToVersion = difference(versionSchemaKeys, contentTypeSchemaAttributesKeys);
+  const removed = reduceDifferenceToAttributesObject(uniqueToVersion, versionSchemaAttributes);
+
+  return { added, removed };
+};

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -31,7 +31,7 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
-  meta?: {
+  meta: {
     unknownAttributes: {
       added: Record<string, unknown>;
       deleted: Record<string, unknown>;

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -31,6 +31,12 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
+  meta?: {
+    unknownAttributes: {
+      added: Record<string, unknown>;
+      deleted: Record<string, unknown>;
+    };
+  };
 }
 
 // Export to prevent the TS "cannot be named" error in the history service

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -31,10 +31,10 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
-  meta: {
-    unknownAttributes: {
+  meta?: {
+    unknownAttributes?: {
       added: Record<string, unknown>;
-      deleted: Record<string, unknown>;
+      removed: Record<string, unknown>;
     };
   };
 }


### PR DESCRIPTION
### What does it do?

- Add a meta object to `findVersionsPage` containing unknown attributes 
- Refactor tests into describes

### Why is it needed?

- So we can determine what can and cannot be restored

### How to test it?

- Go to a contentType schema and add an attribute like `newField`
- Make a request to findVersionsPage
- You should have a `meta.unknownAttributes` object with:
```
{
	added: {
	  newField: {type: 'string'}
	}
}
```
- Remove an attribute and you should have
```
{
	added: {
	  newField: {type: 'string'}
	},
	removed: {
	  fieldYouRemoved: {type: 'string'}
	},
}
``` 
- Rename an attribute and you should have
```
{
	added: {
	  newField: {type: 'string'}
      renamedField: {type: 'string'}
	},
	removed: {
	  fieldYouRemoved: {type: 'string'}
      fieldYouRenamed: : {type: 'string'}
	},
}
``` 

