### PR TITLE
fix(content-releases): fix creation of utc time based when sending to back

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -62,9 +62,8 @@ export const ReleaseModal = ({
   const getScheduledTimestamp = (values: FormValues) => {
     const { date, time, timezone } = values;
     if (!date || !time || !timezone) return null;
-    const formattedDate = parse(time, 'HH:mm', new Date(date));
     const timezoneWithoutOffset = timezone.split('&')[1];
-    return zonedTimeToUtc(formattedDate, timezoneWithoutOffset);
+    return zonedTimeToUtc(`${date} ${time}`, timezoneWithoutOffset);
   };
 
   /**

--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -28,7 +28,7 @@ import { getTimezoneOffset } from '../utils/time';
 
 export interface FormValues {
   name: string;
-  date: Date | null;
+  date: string | null;
   time: string;
   timezone: string | null;
   isScheduled?: boolean;

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -878,7 +878,7 @@ const ReleaseDetailsPage = () => {
   const scheduledAt =
     releaseData?.scheduledAt && timezone ? utcToZonedTime(releaseData.scheduledAt, timezone) : null;
   // Just get the date and time to display without considering updated timezone time
-  const date = scheduledAt ? new Date(format(scheduledAt, 'yyyy-MM-dd')) : null;
+  const date = scheduledAt ? format(scheduledAt, 'yyyy-MM-dd') : null;
   const time = scheduledAt ? format(scheduledAt, 'HH:mm') : '';
 
   const handleEditRelease = async (values: FormValues) => {


### PR DESCRIPTION
### Current error

On frontend, when we are creating the "UTC0" timestamp to send to the backend we have an error generating the UTC time.

Before we were doing this logic:
```
const formattedDate = parse(time, 'HH:mm', new Date(date));
```
when executing `new Date(date)`, if timezone is not defined on `date`, the constructor would assume that we are sending a date in UTC, and considering this is executed on client this would change the date to the system timezone (the one from the user executing this). 

So, what's the problem? If you are in a timezone with a positive offset you don't see any problem because:
- If you are in `Europe/Madrid` (UTC+01). Then `new Date('2024-03-21')` is translated to "2024-03-21 01:00:00 UTC+01" (We still have the same day, then we replace the time and everything is fine)

But, if you are in a timezone with a negative offset:
- If you are in `America/Caracas` (UTC-04). Then `new Date(2024-03-21')` is translated to "2024-03-20 20:00:00 UTC-04" (The day is wrong)

This makes the date we are sending to backend to be wrong.

### Solution

All this logic using `parse` is not really needed, and looking to the date-fns-tz docs, the example to use `zonedTimeToUtc` is exactly [our use case](https://github.com/marnusw/date-fns-tz?tab=readme-ov-file#zonedtimetoutc), so I changed to that