### PR TITLE
enhancement: log when server restarts

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -402,7 +402,7 @@ class Strapi extends Container implements Core.Strapi {
     const isInitialized = await utils.isInitialized(this);
 
     this.startupLogger.logStartupMessage({ isInitialized });
-
+    this.log.info('Strapi server started successfully');
     this.sendStartupTelemetry();
     this.openAdmin({ isInitialized });
   }

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -406,7 +406,7 @@ class Strapi extends Container implements Core.Strapi {
 
     this.startupLogger.logStartupMessage({ isInitialized });
 
-    this.log.info('Strapi server started successfully');
+    this.log.info('Strapi started successfully');
     this.sendStartupTelemetry();
     this.openAdmin({ isInitialized });
   }

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -343,6 +343,7 @@ class Strapi extends Container implements Core.Strapi {
   }
 
   async destroy() {
+    this.log.info('Shutting down Strapi');
     await this.server.destroy();
     await this.runLifecyclesFunctions(utils.LIFECYCLES.DESTROY);
 
@@ -357,6 +358,8 @@ class Strapi extends Container implements Core.Strapi {
 
     // @ts-expect-error: Allow clean delete of global.strapi to allow re-instanciation
     delete global.strapi;
+
+    this.log.info('Strapi has been shut down');
   }
 
   sendStartupTelemetry() {
@@ -402,6 +405,7 @@ class Strapi extends Container implements Core.Strapi {
     const isInitialized = await utils.isInitialized(this);
 
     this.startupLogger.logStartupMessage({ isInitialized });
+
     this.log.info('Strapi server started successfully');
     this.sendStartupTelemetry();
     this.openAdmin({ isInitialized });

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -252,7 +252,6 @@ const develop = async ({
 
     const restart = async () => {
       if (strapiInstance.reload.isWatching && !strapiInstance.reload.isReloading) {
-        strapiInstance.log.info('Restarting Strapi server');
         strapiInstance.reload.isReloading = true;
         strapiInstance.reload();
       }
@@ -315,7 +314,6 @@ const develop = async ({
             'child process has the kill message, destroying the strapi instance and sending the killed process message'
           );
           await watcher.close();
-
           await strapiInstance.destroy();
 
           if (bundleWatcher) {

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -275,6 +275,11 @@ const develop = async ({
           '**/plugins.json',
           '**/build',
           '**/build/**',
+          '**/log',
+          '**/log/**',
+          '**/logs',
+          '**/logs/**',
+          '**/*.log',
           '**/index.html',
           '**/public',
           '**/public/**',
@@ -286,6 +291,7 @@ const develop = async ({
           '**/*.d.ts',
           '**/.yalc/**',
           '**/yalc.lock',
+          // TODO v6: watch only src folder by default, and flip this to watchIncludeFiles
           ...strapiInstance.config.get('admin.watchIgnoreFiles', []),
         ],
       })

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -314,6 +314,7 @@ const develop = async ({
             'child process has the kill message, destroying the strapi instance and sending the killed process message'
           );
           await watcher.close();
+
           await strapiInstance.destroy();
 
           if (bundleWatcher) {

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -252,6 +252,7 @@ const develop = async ({
 
     const restart = async () => {
       if (strapiInstance.reload.isWatching && !strapiInstance.reload.isReloading) {
+        strapiInstance.log.info('Restarting Strapi server');
         strapiInstance.reload.isReloading = true;
         strapiInstance.reload();
       }


### PR DESCRIPTION
### What does it do?

- Logs when the server shuts down and starts up
- adds more exceptions for log files to the develop watcher

### Why is it needed?

In general, even though we visually have the startupLogger(), it's important to have this in log files so we can track when these quite important events actually happen

In `develop`in particular, we log when files change, but not when the restart is triggered. That means we get multiple notifications for files changing but have no idea when the restart actually happens or completes. We need to see the actual events happening to know when they've started/completed.

### How to test it?

use `yarn develop` and touch multiple files, then rm them all at once. You'll see that you still get multiple logs about the files changing, and then afterwards you get the singular log about server stopping/starting

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
