### PR TITLE
[codemod] Set react-router-dom version in the Project package.json

### DIFF
--- a/packages/utils/upgrade/resources/codemods/5.0.0/dependency-upgrade-react-router-dom.json.ts
+++ b/packages/utils/upgrade/resources/codemods/5.0.0/dependency-upgrade-react-router-dom.json.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import semver from 'semver';
+
+import type { modules } from '../../../dist';
+
+const REACT_ROUTER_DEP_NAME = 'react-router-dom';
+const REACT_ROUTER_DEP_PATH = `dependencies.${REACT_ROUTER_DEP_NAME}`;
+
+const DEP_NEW_VERSION_RANGE = '^6.0.0';
+
+/**
+ * Specifically targets the root package.json and updates the react-router-dom dependency version.
+ *
+ * We first check if the react-router-dom dependency is listed in the package.json. If the dependency is
+ * found, we verify its version.
+ *
+ * If the detected version does not satisfy the new version range, we replace it with the new one.
+ *
+ * Conversely, if no react-router-dom dependency is listed, we add it with the new version range.
+ */
+const transform: modules.runner.json.JSONTransform = (file, params) => {
+  const { cwd, json } = params;
+
+  const rootPackageJsonPath = path.join(cwd, 'package.json');
+
+  if (file.path !== rootPackageJsonPath) {
+    return file.json;
+  }
+
+  const j = json(file.json);
+
+  if (j.has(REACT_ROUTER_DEP_PATH)) {
+    const currentVersion = j.get(REACT_ROUTER_DEP_PATH);
+
+    // If the current version is not a string, then something is wrong, abort
+    if (typeof currentVersion !== 'string') {
+      return j.root();
+    }
+
+    const currentSatisfiesNew = semver.satisfies(currentVersion, DEP_NEW_VERSION_RANGE);
+
+    // if the current version satisfies the new range, keep it as is and abort
+    if (currentSatisfiesNew) {
+      return j.root();
+    }
+
+    // else, update the version with the new one
+    j.set(REACT_ROUTER_DEP_PATH, DEP_NEW_VERSION_RANGE);
+  }
+
+  // If the dependency is not listed yet, add it
+  else {
+    j.set(REACT_ROUTER_DEP_PATH, DEP_NEW_VERSION_RANGE);
+  }
+
+  return j.root();
+};
+
+export default transform;


### PR DESCRIPTION
### What does it do?

Add a new code mod that updates the react-router-dom version in the package.json dependencies of a Strapi project.

- if the dependency doesn't exist, add it
- if the dependency exists but isn't valid, ignore
- if the dependency exists but already satisfies the new range, ignore
- if the dependency exists and does not satisfy the new range, update it with `^6.0.0`

Note: Should we manually ignore plugins? People should be responsible enough to know not to run this codemod on plugin, but... what do you think?

Note: Currently the codemod is named "dependency upgrade react router dom". If you've better suggestion, feel free to speak up :slightly_smiling_face: 

### Why is it needed?

v5 uses a newer version of react-router-dom that’s not compatible with v4 one.

New apps are generated using ^6.0.0.

### How to test it?

- Got to getstarted
- Run `../../packages/utils/upgrade/bin/upgrade.js codemods`, then only select `dependency upgrade react router dom`
- You can play with the react-router-dom version in the package.json and try again. It should work according to the description above

