### PR TITLE
[codemod] Remove @strapi/plugin-i18n from the Project package.json

### DIFF
--- a/packages/utils/upgrade/resources/codemods/5.0.0/dependency-remove-strapi-plugin-i18n.json.ts
+++ b/packages/utils/upgrade/resources/codemods/5.0.0/dependency-remove-strapi-plugin-i18n.json.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+
+import type { modules } from '../../../dist';
+
+const STRAPI_I18N_DEP_NAME = '@strapi/plugin-i18n';
+const STRAPI_I18N_DEP_PATH = `dependencies.${STRAPI_I18N_DEP_NAME}`;
+
+/**
+ * Specifically targets the root package.json and removes the @strapi/plugin-i18n dependency.
+ *
+ * Why? The i18n plugin is now a hard dependency of @strapi/strapi and isn't needed in the package.json anymore.
+ */
+const transform: modules.runner.json.JSONTransform = (file, params) => {
+  const { cwd, json } = params;
+
+  const rootPackageJsonPath = path.join(cwd, 'package.json');
+
+  if (file.path !== rootPackageJsonPath) {
+    return file.json;
+  }
+
+  const j = json(file.json);
+
+  if (j.has(STRAPI_I18N_DEP_PATH)) {
+    j.remove(STRAPI_I18N_DEP_PATH);
+  }
+
+  return j.root();
+};
+
+export default transform;


### PR DESCRIPTION
### What does it do?

Add a new code mod that removes the `@strapi/plugin-i18n` package in the package.json dependencies of a Strapi project.

- if the dependency doesn't exist, ignore
- if the dependency exists, remove it

### Why is it needed?

v5 strapi/strapi has a hard dependency on i18n, making useless the need to have it in the project dependencies

### How to test it?

- Got to getstarted
- Run `../../packages/utils/upgrade/bin/upgrade.js codemods`, then only select `dependency remove strapi plugin i18n`
- You can play with the @strapi/plugin-i18n dep in the package.json and try again. It should work according to the description above

