### PR TITLE
Improve DocumentService types for D&P

### DIFF
--- a/packages/core/types/src/modules/documents/service-instance.ts
+++ b/packages/core/types/src/modules/documents/service-instance.ts
@@ -4,73 +4,69 @@ import type { IsDraftAndPublishEnabled } from './draft-and-publish';
 import type * as Params from './params/document-engine';
 import type * as Result from './result/document-engine';
 
-export type ServiceInstance<TContentTypeUID extends UID.ContentType = UID.ContentType> = {
-  findMany: <TParams extends Params.FindMany<TContentTypeUID>>(
-    params?: TParams
-  ) => Result.FindMany<TContentTypeUID, TParams>;
+export type ServiceInstance<TContentTypeUID extends UID.ContentType = UID.ContentType> =
+  Utils.Intersect<
+    [
+      // Base methods (findMany, create, update, etc...)
+      BaseServiceInstance,
+      // Publication methods are only enabled if D&P is enabled for the content type
+      Utils.If<IsDraftAndPublishEnabled<TContentTypeUID>, DraftAndPublishMethods, unknown>
+    ]
+  >;
 
-  findFirst: <TParams extends Params.FindFirst<TContentTypeUID>>(
+type BaseServiceInstance<TContentTypeUID extends UID.ContentType = UID.ContentType> = {
+  findMany<TParams extends Params.FindMany<TContentTypeUID>>(
     params?: TParams
-  ) => Result.FindFirst<TContentTypeUID, TParams>;
+  ): Result.FindMany<TContentTypeUID, TParams>;
 
-  findOne: <TParams extends Params.FindOne<TContentTypeUID>>(
+  findFirst<TParams extends Params.FindFirst<TContentTypeUID>>(
+    params?: TParams
+  ): Result.FindFirst<TContentTypeUID, TParams>;
+
+  findOne<TParams extends Params.FindOne<TContentTypeUID>>(
     id: ID,
     params?: TParams
-  ) => Result.FindOne<TContentTypeUID, TParams>;
+  ): Result.FindOne<TContentTypeUID, TParams>;
 
-  delete: <TParams extends Params.Delete<TContentTypeUID>>(
+  delete<TParams extends Params.Delete<TContentTypeUID>>(
     documentId: ID,
     params?: TParams
-  ) => Result.Delete;
+  ): Result.Delete;
 
-  create: <TParams extends Params.Create<TContentTypeUID>>(
+  create<TParams extends Params.Create<TContentTypeUID>>(
     params: TParams
-  ) => Result.Create<TContentTypeUID, TParams>;
+  ): Result.Create<TContentTypeUID, TParams>;
 
   /**
    * @internal
    * Exposed for use within the Strapi Admin Panel
    */
-  clone: <TParams extends Params.Clone<TContentTypeUID>>(
+  clone<TParams extends Params.Clone<TContentTypeUID>>(
     documentId: ID,
     params: TParams
-  ) => Result.Clone<TContentTypeUID, TParams>;
+  ): Result.Clone<TContentTypeUID, TParams>;
 
-  update: <TParams extends Params.Update<TContentTypeUID>>(
+  update<TParams extends Params.Update<TContentTypeUID>>(
     documentId: ID,
     params: TParams
-  ) => Result.Update<TContentTypeUID, TParams>;
+  ): Result.Update<TContentTypeUID, TParams>;
 
-  count: <TParams extends Params.Count<TContentTypeUID>>(params?: TParams) => Result.Count;
+  count<TParams extends Params.Count<TContentTypeUID>>(params?: TParams): Result.Count;
+};
 
-  // Publication methods are only enabled if D&P is enabled for the content type
-  publish: Utils.If<
-    // If draft and publish is enabled for the content type
-    IsDraftAndPublishEnabled<TContentTypeUID>,
-    // Then, publish method is enabled
-    <TParams extends Params.Publish<TContentTypeUID>>(
-      documentId: ID,
-      params?: TParams
-    ) => Result.Publish<TContentTypeUID, TParams>,
-    // Otherwise, disable it
-    undefined
-  >;
+type DraftAndPublishMethods<TContentTypeUID extends UID.ContentType = UID.ContentType> = {
+  publish<TParams extends Params.Publish<TContentTypeUID>>(
+    documentId: ID,
+    params?: TParams
+  ): Result.Publish<TContentTypeUID, TParams>;
 
-  unpublish: Utils.If<
-    IsDraftAndPublishEnabled<TContentTypeUID>,
-    <TParams extends Params.Unpublish<TContentTypeUID>>(
-      documentId: ID,
-      params?: TParams
-    ) => Result.Unpublish<TContentTypeUID, TParams>,
-    undefined
-  >;
+  unpublish<TParams extends Params.Unpublish<TContentTypeUID>>(
+    documentId: ID,
+    params?: TParams
+  ): Result.Unpublish<TContentTypeUID, TParams>;
 
-  discardDraft: Utils.If<
-    IsDraftAndPublishEnabled<TContentTypeUID>,
-    <TParams extends Params.DiscardDraft<TContentTypeUID>>(
-      documentId: ID,
-      params?: TParams
-    ) => Result.DiscardDraft<TContentTypeUID, TParams>,
-    undefined
-  >;
+  discardDraft<TParams extends Params.DiscardDraft<TContentTypeUID>>(
+    documentId: ID,
+    params?: TParams
+  ): Result.DiscardDraft<TContentTypeUID, TParams>;
 };


### PR DESCRIPTION
### What does it do?

Only add the publication methods (publish, unpublish, discardDraft) when D&P is enabled on the content type

### Why is it needed?

Currently, publication methods are always visible in the type hints, and are only set to undefined -not removed- when D&P is disabled.

### How to test it?

With D&P enabled
![image](https://github.com/strapi/strapi/assets/25851739/90676952-52c9-4e5f-ba88-22e15cc026e4)

With D&P disabled
![image](https://github.com/strapi/strapi/assets/25851739/e9af66a5-c605-4d9d-b8e3-8196835b5970)

With types not generated
![image](https://github.com/strapi/strapi/assets/25851739/b54fe526-96f7-44f1-a19b-0b391ccd4ed5)

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
