### PR TITLE
[Type System] Add a Default Param to Schema.Attributes 

### DIFF
--- a/packages/core/types/src/schema/index.ts
+++ b/packages/core/types/src/schema/index.ts
@@ -71,7 +71,9 @@ export type AttributeValueByName<
  *
  * @template TSchemaUID - The Schema's UID used to get its attributes
  */
-export type Attributes<TSchemaUID extends UID.Schema> = Schema<TSchemaUID>['attributes'];
+export type Attributes<TSchemaUID extends UID.Schema = UID.Schema> = {
+  [TUID in TSchemaUID]: Schema<TSchemaUID>['attributes'];
+}[TSchemaUID];
 
 /**
  * Union type of every attribute name within {@link TSchemaUID}'s attributes


### PR DESCRIPTION
### What does it do?

It's now possible to do `const foo: Schema.Attributes;`.

### Why is it needed?

It was previously annoying to type a structure representing the attributes of a schema (based on the schema registry).

Devs had to either use `Struct.SchemaAttributes` or `Record<string, Schema.Attribute.AnyAttribute>`


