### PR TITLE
Fix Duplicate Export in strapi/admin

### DIFF
--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -67,7 +67,6 @@ export type {
   HeaderActionDescription,
   HeaderActionProps,
 } from './core/apis/content-manager';
-export type { StrapiApp } from './StrapiApp';
 
 /**
  * Utils


### PR DESCRIPTION
### What does it do?

Remove a duplicate export for StrapiApp in strapi/admin

### Why is it needed?

test:ts:front is currently failing on v5/main

### How to test it?

`yarn run test:ts:front`

### Related issue(s)/PR(s)

Probably comes from https://github.com/strapi/strapi/pull/19860
