### PR TITLE
add export {} declaration at the end of the generated typescript files

### DIFF
--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -47,6 +47,10 @@ const generateComponentsDefinitions = async (options = {}) => {
 
     // Global
     generateSharedExtensionDefinition('Components', componentsDefinitions),
+
+    // export {}
+    factory.createIdentifier('\n'),
+    factory.createExportDeclaration([], false, factory.createNamedExports([])),
   ];
 
   const output = emitDefinitions(allDefinitions);

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -47,6 +47,10 @@ const generateContentTypesDefinitions = async (options = {}) => {
 
     // Global
     generateSharedExtensionDefinition('ContentTypes', contentTypesDefinitions),
+
+    // export {}
+    factory.createIdentifier('\n'),
+    factory.createExportDeclaration([], false, factory.createNamedExports([])),
   ];
 
   const output = emitDefinitions(allDefinitions);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This changes how the `.d.ts` files are generated in `types/generated` to prevent an issue where if you have no components or no content-types then it's mistaken as an [Ambient Module](https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules) declaration. An empty export declaration is sufficient to make the file always be a module.

### Why is it needed?

Without this all the types declared in `@strapi/types` (and `@strapi/strapi`, since they are used by it) aren't available unless you create both a component and a content-type. This doesn't happen when after you create components or content-types because an import statement is added outside the `declare module` block, so the file becomes a module and the issue goes away.

### How to test it?

In a fresh ts project, after you started the development server or generated the typescript declaration, then attempt to `import { Strapi } from "@strapi/strapi"` in any .ts file. With this fix it should work just fine, without it you will be met with a `Module '"@strapi/strapi"' has no exported member 'Strapi'.` error.

### Related issue(s)/PR(s)

I haven't found any issues or PRs mentioning this issue.