### PR TITLE
chore: skip bulk actions test because they're not implemented in v5

### DIFF
--- a/e2e/tests/content-manager/listview.spec.ts
+++ b/e2e/tests/content-manager/listview.spec.ts
@@ -19,7 +19,7 @@ test.describe('List View', () => {
     await expect(page.getByRole('link', { name: /Create new entry/ }).first()).toBeVisible();
   });
 
-  test('A user should be able to perform bulk actions on entries', async ({ page }) => {
+  test.skip('A user should be able to perform bulk actions on entries', async ({ page }) => {
     await test.step('bulk unpublish', async () => {
       await page.getByRole('link', { name: 'Content Manager' }).click();
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* skip list-view e2e for bulk actions

### Why is it needed?

* we haven't implemented bulk actions in v5, so they will always fail!
