### PR TITLE
chore: inverse control of contentAPI sanitize & validate

### DIFF
--- a/packages/core/core/src/core-api/controller/index.ts
+++ b/packages/core/core/src/core-api/controller/index.ts
@@ -1,6 +1,6 @@
 import { prop } from 'lodash/fp';
 import type Koa from 'koa';
-import { contentTypes as contentTypeUtils, sanitize, validate } from '@strapi/utils';
+import { contentTypes as contentTypeUtils } from '@strapi/utils';
 import type { Core, Struct } from '@strapi/types';
 
 import { transformResponse } from './transform';
@@ -38,31 +38,31 @@ function createController({
     async sanitizeOutput(data, ctx) {
       const auth = getAuthFromKoaContext(ctx);
 
-      return sanitize.contentAPI.output(data, contentType, { auth });
+      return strapi.contentAPI.sanitize.output(data, contentType, { auth });
     },
 
     async sanitizeInput(data, ctx) {
       const auth = getAuthFromKoaContext(ctx);
 
-      return sanitize.contentAPI.input(data, contentType, { auth });
+      return strapi.contentAPI.sanitize.input(data, contentType, { auth });
     },
 
     async sanitizeQuery(ctx) {
       const auth = getAuthFromKoaContext(ctx);
 
-      return sanitize.contentAPI.query(ctx.query, contentType, { auth });
+      return strapi.contentAPI.sanitize.query(ctx.query, contentType, { auth });
     },
 
     async validateQuery(ctx) {
       const auth = getAuthFromKoaContext(ctx);
 
-      return validate.contentAPI.query(ctx.query, contentType, { auth });
+      return strapi.contentAPI.validate.query(ctx.query, contentType, { auth });
     },
 
     async validateInput(data, ctx) {
       const auth = getAuthFromKoaContext(ctx);
 
-      return validate.contentAPI.input(data, contentType, { auth });
+      return strapi.contentAPI.validate.input(data, contentType, { auth });
     },
   };
 

--- a/packages/core/core/src/services/__tests__/content-api-permissions.test.ts
+++ b/packages/core/core/src/services/__tests__/content-api-permissions.test.ts
@@ -1,15 +1,27 @@
 import createContentAPI from '../content-api';
-import type { Utils } from '../..';
+
+const strapiMock = {
+  sanitizers: {
+    get() {
+      return [];
+    },
+  },
+  validators: {
+    get() {
+      return [];
+    },
+  },
+};
 
 describe('Content API - Permissions', () => {
-  const bindToContentAPI = (action: Utils.Function.Any) => {
+  const bindToContentAPI = (action: any) => {
     Object.assign(action, { [Symbol.for('__type__')]: ['content-api'] });
     return action;
   };
 
   describe('Get Actions Map', () => {
     test('When no API are defined, it should return an empty object', () => {
-      global.strapi = {} as any;
+      global.strapi = strapiMock as any;
 
       const contentAPI = createContentAPI(global.strapi);
       const actionsMap = contentAPI.permissions.getActionsMap();
@@ -19,6 +31,7 @@ describe('Content API - Permissions', () => {
 
     test('When no controller are defined for an API, it should ignore the API', () => {
       global.strapi = {
+        ...strapiMock,
         api: {
           foo: {},
           bar: {},
@@ -36,6 +49,7 @@ describe('Content API - Permissions', () => {
       Object.assign(actionC, { [Symbol.for('__type__')]: ['admin-api'] });
 
       global.strapi = {
+        ...strapiMock,
         api: {
           foo: {
             controllers: {
@@ -59,6 +73,7 @@ describe('Content API - Permissions', () => {
 
     test('Creates and populate a map of actions from APIs and plugins', () => {
       global.strapi = {
+        ...strapiMock,
         api: {
           foo: {
             controllers: {
@@ -130,6 +145,7 @@ describe('Content API - Permissions', () => {
   describe('Register Actions', () => {
     beforeEach(() => {
       global.strapi = {
+        ...strapiMock,
         api: {
           foo: {
             controllers: {
@@ -234,6 +250,7 @@ describe('Content API - Permissions', () => {
   describe('Engine', () => {
     test('Engine warns when registering an unknown action', async () => {
       global.strapi = {
+        ...strapiMock,
         log: {
           debug: jest.fn(),
         },
@@ -251,6 +268,7 @@ describe('Content API - Permissions', () => {
 
     test('Engine filter out invalid action when generating an ability', async () => {
       global.strapi = {
+        ...strapiMock,
         log: {
           debug: jest.fn(),
         },

--- a/packages/core/core/src/services/content-api/index.ts
+++ b/packages/core/core/src/services/content-api/index.ts
@@ -1,5 +1,8 @@
 import _ from 'lodash';
+import { sanitize, validate } from '@strapi/utils';
+
 import type { Core } from '@strapi/types';
+
 import instantiatePermissionsUtilities from './permissions';
 
 const transformRoutePrefixFor = (pluginName: string) => (route: Core.Route) => {
@@ -66,9 +69,30 @@ const createContentAPI = (strapi: Core.Strapi) => {
     return routesMap;
   };
 
+  const sanitizer = sanitize.createAPISanitizers({
+    // NOTE: use lazy access to allow registration of sanitizers after the creation of the container
+    get sanitizers() {
+      return {
+        input: strapi.sanitizers.get('content-api.input'),
+        output: strapi.sanitizers.get('content-api.output'),
+      };
+    },
+  });
+
+  const validator = validate.createAPIValidators({
+    // NOTE: use lazy access to allow registration of validators after the creation of the container
+    get validators() {
+      return {
+        input: strapi.validators.get('content-api.input'),
+      };
+    },
+  });
+
   return {
     permissions: instantiatePermissionsUtilities(strapi),
     getRoutesMap,
+    sanitize: sanitizer,
+    validate: validator,
   };
 };
 

--- a/packages/core/types/src/modules/content-api.ts
+++ b/packages/core/types/src/modules/content-api.ts
@@ -1,5 +1,5 @@
 import permissions from '@strapi/permissions';
-import { providerFactory } from '@strapi/utils';
+import { providerFactory, sanitize, validate } from '@strapi/utils';
 
 import type { Route } from '../core';
 
@@ -34,4 +34,6 @@ export interface PermissionUtilities {
 export interface ContentApi {
   permissions: PermissionUtilities;
   getRoutesMap: () => Promise<Record<string, Route[]>>;
+  sanitize: sanitize.APISanitiers;
+  validate: validate.APIValidators;
 }

--- a/packages/core/types/src/modules/sanitizers.ts
+++ b/packages/core/types/src/modules/sanitizers.ts
@@ -1,8 +1,8 @@
-type Sanitizer = (value: unknown) => unknown;
+import type { sanitize } from '@strapi/utils';
 
 export interface SanitizersRegistry {
-  get(path: string): Sanitizer[];
-  add(path: string, sanitizer: Sanitizer): this;
-  set(path: string, value?: Sanitizer[]): this;
+  get(path: string): sanitize.Sanitizer[];
+  add(path: string, sanitizer: sanitize.Sanitizer): this;
+  set(path: string, value?: sanitize.Sanitizer[]): this;
   has(path: string): boolean;
 }

--- a/packages/core/types/src/modules/validators.ts
+++ b/packages/core/types/src/modules/validators.ts
@@ -1,8 +1,8 @@
-type Validator = unknown;
+import type { validate } from '@strapi/utils';
 
 export interface ValidatorsRegistry {
-  get(path: string): Validator[];
-  add(path: string, validator: Validator): this;
-  set(path: string, value?: Validator[]): this;
+  get(path: string): validate.Validator[];
+  add(path: string, validator: validate.Validator): this;
+  set(path: string, value?: validate.Validator[]): this;
   has(path: string): boolean;
 }

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -2,158 +2,160 @@ import _ from 'lodash';
 import utils from '@strapi/utils';
 
 import type { Context } from 'koa';
+import type { Core } from '@strapi/types';
 
 import { getService } from '../utils';
 import { FILE_MODEL_UID } from '../constants';
 import { validateUploadBody } from './validation/content-api/upload';
 import { FileInfo } from '../types';
 
-const { sanitize, validate } = utils;
 const { ValidationError } = utils.errors;
 
-const sanitizeOutput = async (data: unknown | unknown[], ctx: Context) => {
-  const schema = strapi.getModel(FILE_MODEL_UID);
-  const { auth } = ctx.state;
+export default ({ strapi }: { strapi: Core.Strapi }) => {
+  const sanitizeOutput = async (data: unknown | unknown[], ctx: Context) => {
+    const schema = strapi.getModel(FILE_MODEL_UID);
+    const { auth } = ctx.state;
 
-  return sanitize.contentAPI.output(data, schema, { auth });
-};
+    return strapi.contentAPI.sanitize.output(data, schema, { auth });
+  };
 
-const validateQuery = async (data: Record<string, unknown>, ctx: Context) => {
-  const schema = strapi.getModel(FILE_MODEL_UID);
-  const { auth } = ctx.state;
+  const validateQuery = async (data: Record<string, unknown>, ctx: Context) => {
+    const schema = strapi.getModel(FILE_MODEL_UID);
+    const { auth } = ctx.state;
 
-  return validate.contentAPI.query(data, schema, { auth });
-};
+    return strapi.contentAPI.validate.query(data, schema, { auth });
+  };
 
-const sanitizeQuery = async (data: Record<string, unknown>, ctx: Context) => {
-  const schema = strapi.getModel(FILE_MODEL_UID);
-  const { auth } = ctx.state;
+  const sanitizeQuery = async (data: Record<string, unknown>, ctx: Context) => {
+    const schema = strapi.getModel(FILE_MODEL_UID);
+    const { auth } = ctx.state;
 
-  return sanitize.contentAPI.query(data, schema, { auth });
-};
+    return strapi.contentAPI.sanitize.query(data, schema, { auth });
+  };
 
-export default {
-  async find(ctx: Context) {
-    await validateQuery(ctx.query, ctx);
-    const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
+  return {
+    async find(ctx: Context) {
+      await validateQuery(ctx.query, ctx);
+      const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
 
-    const files = await getService('upload').findMany(sanitizedQuery);
+      const files = await getService('upload').findMany(sanitizedQuery);
 
-    ctx.body = await sanitizeOutput(files, ctx);
-  },
+      ctx.body = await sanitizeOutput(files, ctx);
+    },
 
-  async findOne(ctx: Context) {
-    const {
-      params: { id },
-    } = ctx;
+    async findOne(ctx: Context) {
+      const {
+        params: { id },
+      } = ctx;
 
-    await validateQuery(ctx.query, ctx);
-    const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
+      await validateQuery(ctx.query, ctx);
+      const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
 
-    const file = await getService('upload').findOne(id, sanitizedQuery.populate!);
+      const file = await getService('upload').findOne(id, sanitizedQuery.populate!);
 
-    if (!file) {
-      return ctx.notFound('file.notFound');
-    }
-
-    ctx.body = await sanitizeOutput(file, ctx);
-  },
-
-  async destroy(ctx: Context) {
-    const {
-      params: { id },
-    } = ctx;
-
-    const file = await getService('upload').findOne(id);
-
-    if (!file) {
-      return ctx.notFound('file.notFound');
-    }
-
-    await getService('upload').remove(file);
-
-    ctx.body = await sanitizeOutput(file, ctx);
-  },
-
-  async updateFileInfo(ctx: Context) {
-    const {
-      query: { id },
-      request: { body },
-    } = ctx;
-    const data = await validateUploadBody(body);
-
-    if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
-      throw new ValidationError('File id is required and must be a single value');
-    }
-
-    const result = await getService('upload').updateFileInfo(id, data.fileInfo as any);
-
-    ctx.body = await sanitizeOutput(result, ctx);
-  },
-
-  async replaceFile(ctx: Context) {
-    const {
-      query: { id },
-      request: { body, files: { files } = {} },
-    } = ctx;
-
-    // cannot replace with more than one file
-    if (Array.isArray(files)) {
-      throw new ValidationError('Cannot replace a file with multiple ones');
-    }
-
-    if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
-      throw new ValidationError('File id is required and must be a single value');
-    }
-
-    const data = (await validateUploadBody(body)) as { fileInfo: FileInfo };
-
-    const replacedFiles = await getService('upload').replace(id, { data, file: files });
-
-    ctx.body = await sanitizeOutput(replacedFiles, ctx);
-  },
-
-  async uploadFiles(ctx: Context) {
-    const {
-      request: { body, files: { files } = {} },
-    } = ctx;
-
-    const data: any = await validateUploadBody(body, Array.isArray(files));
-
-    const apiUploadFolderService = getService('api-upload-folder');
-
-    const apiUploadFolder = await apiUploadFolderService.getAPIUploadFolder();
-
-    if (Array.isArray(files)) {
-      data.fileInfo = data.fileInfo || [];
-      data.fileInfo = files.map((_f, i) => ({ ...data.fileInfo[i], folder: apiUploadFolder.id }));
-    } else {
-      data.fileInfo = { ...data.fileInfo, folder: apiUploadFolder.id };
-    }
-
-    const uploadedFiles = await getService('upload').upload({
-      data,
-      files,
-    });
-
-    ctx.body = await sanitizeOutput(uploadedFiles as any, ctx);
-  },
-
-  // TODO: split into multiple endpoints
-  async upload(ctx: Context) {
-    const {
-      query: { id },
-      request: { files: { files } = {} },
-    } = ctx;
-
-    if (_.isEmpty(files) || (!Array.isArray(files) && files.size === 0)) {
-      if (id) {
-        return this.updateFileInfo(ctx);
+      if (!file) {
+        return ctx.notFound('file.notFound');
       }
 
-      throw new ValidationError('Files are empty');
-    }
+      ctx.body = await sanitizeOutput(file, ctx);
+    },
 
-    await (id ? this.replaceFile : this.uploadFiles)(ctx);
-  },
+    async destroy(ctx: Context) {
+      const {
+        params: { id },
+      } = ctx;
+
+      const file = await getService('upload').findOne(id);
+
+      if (!file) {
+        return ctx.notFound('file.notFound');
+      }
+
+      await getService('upload').remove(file);
+
+      ctx.body = await sanitizeOutput(file, ctx);
+    },
+
+    async updateFileInfo(ctx: Context) {
+      const {
+        query: { id },
+        request: { body },
+      } = ctx;
+      const data = await validateUploadBody(body);
+
+      if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
+        throw new ValidationError('File id is required and must be a single value');
+      }
+
+      const result = await getService('upload').updateFileInfo(id, data.fileInfo as any);
+
+      ctx.body = await sanitizeOutput(result, ctx);
+    },
+
+    async replaceFile(ctx: Context) {
+      const {
+        query: { id },
+        request: { body, files: { files } = {} },
+      } = ctx;
+
+      // cannot replace with more than one file
+      if (Array.isArray(files)) {
+        throw new ValidationError('Cannot replace a file with multiple ones');
+      }
+
+      if (!id || (typeof id !== 'string' && typeof id !== 'number')) {
+        throw new ValidationError('File id is required and must be a single value');
+      }
+
+      const data = (await validateUploadBody(body)) as { fileInfo: FileInfo };
+
+      const replacedFiles = await getService('upload').replace(id, { data, file: files });
+
+      ctx.body = await sanitizeOutput(replacedFiles, ctx);
+    },
+
+    async uploadFiles(ctx: Context) {
+      const {
+        request: { body, files: { files } = {} },
+      } = ctx;
+
+      const data: any = await validateUploadBody(body, Array.isArray(files));
+
+      const apiUploadFolderService = getService('api-upload-folder');
+
+      const apiUploadFolder = await apiUploadFolderService.getAPIUploadFolder();
+
+      if (Array.isArray(files)) {
+        data.fileInfo = data.fileInfo || [];
+        data.fileInfo = files.map((_f, i) => ({ ...data.fileInfo[i], folder: apiUploadFolder.id }));
+      } else {
+        data.fileInfo = { ...data.fileInfo, folder: apiUploadFolder.id };
+      }
+
+      const uploadedFiles = await getService('upload').upload({
+        data,
+        files,
+      });
+
+      ctx.body = await sanitizeOutput(uploadedFiles as any, ctx);
+    },
+
+    // TODO: split into multiple endpoints
+    async upload(ctx: Context) {
+      const {
+        query: { id },
+        request: { files: { files } = {} },
+      } = ctx;
+
+      if (_.isEmpty(files) || (!Array.isArray(files) && files.size === 0)) {
+        if (id) {
+          return this.updateFileInfo(ctx);
+        }
+
+        throw new ValidationError('Files are empty');
+      }
+
+      await (id ? this.replaceFile : this.uploadFiles)(ctx);
+    },
+  };
 };

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -2,8 +2,6 @@ export { default as parseType } from './parse-type';
 export { default as env } from './env-helper';
 export { default as setCreatorFields } from './set-creator-fields';
 export { default as providerFactory } from './provider-factory';
-export { default as sanitize } from './sanitize';
-export { default as validate } from './validate';
 export { default as traverseEntity } from './traverse-entity';
 export { default as convertQueryParams } from './convert-query-params';
 export { default as importDefault } from './import-default';
@@ -12,6 +10,8 @@ export { default as machineID } from './machine-id';
 export { validateYupSchema, validateYupSchemaSync } from './validators';
 export { isOperator, isOperatorOfType } from './operators';
 
+export * as sanitize from './sanitize';
+export * as validate from './validate';
 export * as pagination from './pagination';
 export * as packageManager from './package-manager';
 export * as traverse from './traverse';

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -61,6 +61,7 @@ const visitDynamicZoneEntry = async (visitor: Visitor, path: Path, entry: Data) 
 
   return traverseEntity(visitor, traverseOptions, entry);
 };
+
 const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity: Data) => {
   const { path = { raw: null, attribute: null }, schema } = options;
 

--- a/packages/core/utils/src/validate/index.ts
+++ b/packages/core/utils/src/validate/index.ts
@@ -19,14 +19,18 @@ export interface Options {
   auth?: unknown;
 }
 
-interface Validator {
+export interface Validator {
   (schema: Model): CurriedFunction1<Data, Promise<Data>>;
 }
 export interface ValidateFunc {
   (data: unknown, schema: Model, options?: Options): Promise<void>;
 }
 
-const createContentAPIValidators = () => {
+export interface Validators {
+  input?: Validator[];
+}
+
+const createAPIValidators = (opts?: { validators: Validators }) => {
   const validateInput: ValidateFunc = async (data: unknown, schema: Model, { auth } = {}) => {
     if (!schema) {
       throw new Error('Missing schema in validateInput');
@@ -61,9 +65,7 @@ const createContentAPIValidators = () => {
     }
 
     // Apply validators from registry if exists
-    strapi.validators
-      .get('content-api.input')
-      .forEach((validator: Validator) => transforms.push(validator(schema)));
+    opts?.validators?.input?.forEach((validator: Validator) => transforms.push(validator(schema)));
 
     await pipeAsync(...transforms)(data as Data);
   };
@@ -159,10 +161,6 @@ const createContentAPIValidators = () => {
   };
 };
 
-const contentAPI = createContentAPIValidators();
+export { createAPIValidators, validators, visitors };
 
-export default {
-  contentAPI,
-  validators,
-  visitors,
-};
+export type APIValidators = ReturnType<typeof createAPIValidators>;

--- a/packages/plugins/graphql/server/src/services/builders/mutations/collection-type.ts
+++ b/packages/plugins/graphql/server/src/services/builders/mutations/collection-type.ts
@@ -1,5 +1,4 @@
 import { extendType, nonNull, idArg } from 'nexus';
-import { sanitize } from '@strapi/utils';
 import type * as Nexus from 'nexus';
 import type { Struct } from '@strapi/types';
 import type { Context } from '../../types';
@@ -46,7 +45,7 @@ export default ({ strapi }: Context) => {
         const { auth } = context.state;
 
         // Sanitize input data
-        const sanitizedInputData = await sanitize.contentAPI.input(args.data, contentType, {
+        const sanitizedInputData = await strapi.contentAPI.sanitize.input(args.data, contentType, {
           auth,
         });
 
@@ -88,7 +87,7 @@ export default ({ strapi }: Context) => {
         const { data, documentId, ...restParams } = args;
 
         // Sanitize input data
-        const sanitizedInputData = await sanitize.contentAPI.input(data, contentType, {
+        const sanitizedInputData = await strapi.contentAPI.sanitize.input(data, contentType, {
           auth,
         });
 

--- a/packages/plugins/graphql/server/src/services/builders/mutations/single-type.ts
+++ b/packages/plugins/graphql/server/src/services/builders/mutations/single-type.ts
@@ -1,5 +1,5 @@
 import { extendType, nonNull } from 'nexus';
-import { sanitize, errors } from '@strapi/utils';
+import { errors } from '@strapi/utils';
 import type * as Nexus from 'nexus';
 import type { Struct } from '@strapi/types';
 import type { Context } from '../../types';
@@ -47,7 +47,7 @@ export default ({ strapi }: Context) => {
         const { auth } = context.state;
 
         // Sanitize input data
-        const sanitizedInputData = await sanitize.contentAPI.input(args.data, contentType, {
+        const sanitizedInputData = await strapi.contentAPI.sanitize.input(args.data, contentType, {
           auth,
         });
 

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -1,5 +1,5 @@
 import { get } from 'lodash/fp';
-import { sanitize, validate, async, errors } from '@strapi/utils';
+import { async, errors } from '@strapi/utils';
 import type { Internal } from '@strapi/types';
 
 import type { Context } from '../../types';
@@ -46,13 +46,17 @@ export default ({ strapi }: Context) => {
           usePagination: true,
         });
 
-        await validate.contentAPI.query(transformedArgs, targetContentType, {
+        await strapi.contentAPI.validate.query(transformedArgs, targetContentType, {
           auth,
         });
 
-        const sanitizedQuery = await sanitize.contentAPI.query(transformedArgs, targetContentType, {
-          auth,
-        });
+        const sanitizedQuery = await strapi.contentAPI.sanitize.query(
+          transformedArgs,
+          targetContentType,
+          {
+            auth,
+          }
+        );
 
         const data = await strapi.db
           ?.query(contentTypeUID)
@@ -70,7 +74,7 @@ export default ({ strapi }: Context) => {
           // Helpers used for the data cleanup
           const wrapData = (dataToWrap: any) => ({ [attributeName]: dataToWrap });
           const sanitizeData = (dataToSanitize: any) => {
-            return sanitize.contentAPI.output(dataToSanitize, contentType, { auth });
+            return strapi.contentAPI.sanitize.output(dataToSanitize, contentType, { auth });
           };
           const unwrapData = get(attributeName);
 

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/component.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/component.ts
@@ -1,4 +1,3 @@
-import { sanitize, validate } from '@strapi/utils';
 import type { Internal, Schema } from '@strapi/types';
 
 import type { Context } from '../../types';
@@ -23,11 +22,11 @@ export default ({ strapi }: Context) => ({
       const component = strapi.getModel(componentName);
 
       const transformedArgs = transformArgs(args, { contentType: component, usePagination: true });
-      await validate.contentAPI.query(transformedArgs, component, {
+      await strapi.contentAPI.validate.query(transformedArgs, component, {
         auth: ctx?.state?.auth,
       });
 
-      const sanitizedQuery = await sanitize.contentAPI.query(transformedArgs, component, {
+      const sanitizedQuery = await strapi.contentAPI.sanitize.query(transformedArgs, component, {
         auth: ctx?.state?.auth,
       });
 

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
@@ -1,4 +1,3 @@
-import { sanitize, validate } from '@strapi/utils';
 import type { Context } from '../../types';
 
 export default ({ strapi }: Context) => ({
@@ -8,11 +7,11 @@ export default ({ strapi }: Context) => ({
     const safeLimit = Math.max(limit, 1);
     const contentType = strapi.getModel(resourceUID);
 
-    await validate.contentAPI.query(args, contentType, {
+    await strapi.contentAPI.validate.query(args, contentType, {
       auth: ctx?.state?.auth,
     });
 
-    const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
+    const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
       auth: ctx?.state?.auth,
     });
 

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
@@ -1,5 +1,4 @@
 import { omit } from 'lodash/fp';
-import { sanitize, validate } from '@strapi/utils';
 import type { Schema } from '@strapi/types';
 import type { Context } from '../../types';
 
@@ -9,11 +8,11 @@ export default ({ strapi }: Context) => ({
 
     return {
       async findMany(parent: any, args: any, ctx: any) {
-        await validate.contentAPI.query(args, contentType, {
+        await strapi.contentAPI.validate.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
 
-        const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
+        const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
 
@@ -21,11 +20,11 @@ export default ({ strapi }: Context) => ({
       },
 
       async findFirst(parent: any, args: any, ctx: any) {
-        await validate.contentAPI.query(args, contentType, {
+        await strapi.contentAPI.validate.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
 
-        const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
+        const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
 
@@ -33,10 +32,10 @@ export default ({ strapi }: Context) => ({
       },
 
       async findOne(parent: any, args: any, ctx: any) {
-        await validate.contentAPI.query(args, contentType, {
+        await strapi.contentAPI.validate.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
-        const sanitizedQuery = await sanitize.contentAPI.query(args, contentType, {
+        const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
 

--- a/packages/plugins/i18n/server/src/controllers/__tests__/locales.test.ts
+++ b/packages/plugins/i18n/server/src/controllers/__tests__/locales.test.ts
@@ -1,14 +1,12 @@
-import { errors } from '@strapi/utils';
+import { errors, sanitize } from '@strapi/utils';
 import controller from '../locales';
 import localeModel from '../../content-types/locale';
 
 const { ApplicationError } = errors;
 
-const sanitizers = {
-  get() {
-    return [];
-  },
-} as any;
+const contentAPI = {
+  sanitize: sanitize.createAPISanitizers(),
+};
 
 describe('Locales', () => {
   describe('listLocales', () => {
@@ -30,7 +28,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {};
@@ -68,7 +66,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {
@@ -107,7 +105,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {
@@ -145,7 +143,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {
@@ -193,7 +191,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {
@@ -235,7 +233,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = {
@@ -284,7 +282,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = { params: { id: 1 } };
@@ -318,7 +316,7 @@ describe('Locales', () => {
             },
           },
         },
-        sanitizers,
+        contentAPI,
       } as any;
 
       const ctx: any = { params: { id: 1 } };

--- a/packages/plugins/i18n/server/src/controllers/locales.ts
+++ b/packages/plugins/i18n/server/src/controllers/locales.ts
@@ -5,13 +5,13 @@ import { getService } from '../utils';
 import { validateCreateLocaleInput, validateUpdateLocaleInput } from '../validation/locales';
 import { formatLocale } from '../domain/locale';
 
-const { setCreatorFields, sanitize } = utils;
+const { setCreatorFields } = utils;
 const { ApplicationError } = utils.errors;
 
 const sanitizeLocale = (locale: any) => {
   const model = strapi.getModel('plugin::i18n.locale');
 
-  return sanitize.contentAPI.output(locale, model);
+  return strapi.contentAPI.sanitize.output(locale, model);
 };
 
 const controller: Core.Controller = {

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -22,14 +22,13 @@ const {
   validateChangePasswordBody,
 } = require('./validation/auth');
 
-const { sanitize } = utils;
 const { ApplicationError, ValidationError, ForbiddenError } = utils.errors;
 
 const sanitizeUser = (user, ctx) => {
   const { auth } = ctx.state;
   const userSchema = strapi.getModel('plugin::users-permissions.user');
 
-  return sanitize.contentAPI.output(user, userSchema, { auth });
+  return strapi.contentAPI.sanitize.output(user, userSchema, { auth });
 };
 
 module.exports = {

--- a/packages/plugins/users-permissions/server/controllers/user.js
+++ b/packages/plugins/users-permissions/server/controllers/user.js
@@ -11,28 +11,27 @@ const utils = require('@strapi/utils');
 const { getService } = require('../utils');
 const { validateCreateUserBody, validateUpdateUserBody } = require('./validation/user');
 
-const { sanitize, validate } = utils;
 const { ApplicationError, ValidationError, NotFoundError } = utils.errors;
 
 const sanitizeOutput = async (user, ctx) => {
   const schema = strapi.getModel('plugin::users-permissions.user');
   const { auth } = ctx.state;
 
-  return sanitize.contentAPI.output(user, schema, { auth });
+  return strapi.contentAPI.sanitize.output(user, schema, { auth });
 };
 
 const validateQuery = async (query, ctx) => {
   const schema = strapi.getModel('plugin::users-permissions.user');
   const { auth } = ctx.state;
 
-  return validate.contentAPI.query(query, schema, { auth });
+  return strapi.contentAPI.validate.query(query, schema, { auth });
 };
 
 const sanitizeQuery = async (query, ctx) => {
   const schema = strapi.getModel('plugin::users-permissions.user');
   const { auth } = ctx.state;
 
-  return sanitize.contentAPI.query(query, schema, { auth });
+  return strapi.contentAPI.sanitize.query(query, schema, { auth });
 };
 
 module.exports = {

--- a/packages/plugins/users-permissions/server/controllers/validation/__tests__/auth.test.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/__tests__/auth.test.js
@@ -4,6 +4,11 @@ const errors = require('@strapi/utils');
 const auth = require('../../auth');
 
 const mockStrapi = {
+  contentAPI: {
+    sanitize: {
+      output: jest.fn((input) => input),
+    },
+  },
   store: jest.fn(() => {
     return {
       get: jest.fn(() => {

--- a/packages/utils/api-tests/builder/index.js
+++ b/packages/utils/api-tests/builder/index.js
@@ -34,7 +34,7 @@ const createTestBuilder = (options = {}) => {
       const model = strapi.getModel(modelsUtils.toContentTypeUID(modelName));
       const fixtures = this.fixturesFor(modelName);
 
-      return sanitize.contentAPI.output(fixtures, model);
+      return strapi.contentAPI.sanitize.output(fixtures, model);
     },
 
     fixturesFor(modelName) {


### PR DESCRIPTION
### What does it do?

Make utils generic & initialize API sanitization & validation inside the strapi app & expose with the strapi.contentAPI service

### Why is it needed?

To remove the dependency on strapi/core from the utils to type things & prevent circular dependencies
