### PR TITLE
test: change default test log level to warn

### DIFF
--- a/packages/utils/api-tests/strapi.js
+++ b/packages/utils/api-tests/strapi.js
@@ -17,7 +17,7 @@ const superAdminLoginInfo = _.pick(superAdminCredentials, ['email', 'password'])
 
 const createStrapiInstance = async ({
   ensureSuperAdmin = true,
-  logLevel = 'info',
+  logLevel = 'warn',
   bypassAuth = true,
   bootstrap,
 } = {}) => {


### PR DESCRIPTION
### What does it do?

Changes the default log level for createStrapiInstance to 'warn'

### Why is it needed?

Now that we're adding more logging, they are appearing in our API tests and polluting the test logs. Our tests should be mocking their own logger, but that would be a huge refactoring, and this works for now.

### What we actually need to do in the future

Our test utility for creating an instance should do something like automatically mock the logger, and people writing tests should be made aware of that and how to access those mocks directly instead of mocking console methods.

### How to test it

As long as the API tests pass without showing a bunch of info logs with every test, it should be fine. Currently running them, and expecting some of them to fail if they're `expect`ing the output of certain logs that won't appear now.

Update: tests pass! Yay!