### PR TITLE
Fix OpenAPI required fields

### DIFF
--- a/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
+++ b/packages/plugins/documentation/server/services/helpers/utils/clean-schema-attributes.js
@@ -3,6 +3,22 @@
 const _ = require('lodash');
 const getSchemaData = require('./get-schema-data');
 const pascalCase = require('./pascal-case');
+
+function extractRequiredProperties(attributes) {
+  const required = [];
+  for (const [key, value] of Object.entries(attributes)) {
+    //console.log('key', key, 'value', value);
+    if (value.required) {
+      required.push(key);
+    }
+    // if (value.type === 'component') {
+    //   console.log('HELLO', value.type, value.component)
+    //   extractRequiredProperties(strapi.components[value.component].attributes);
+    // }
+  };
+  return required.length > 0 ? required : undefined;
+}
+
 /**
  * @description - Converts types found on attributes to OpenAPI acceptable data types
  *
@@ -104,6 +120,7 @@ const cleanSchemaAttributes = (
               isRequest,
             }),
           },
+          required: extractRequiredProperties(componentAttributes),
         };
         const refComponentSchema = {
           $ref: `#/components/schemas/${pascalCase(attribute.component)}Component`,
@@ -137,6 +154,7 @@ const cleanSchemaAttributes = (
                 didAddStrapiComponentsToSchemas,
               }),
             },
+            required: extractRequiredProperties(componentAttributes),
           };
           const refComponentSchema = {
             $ref: `#/components/schemas/${pascalCase(component)}Component`,
@@ -171,6 +189,7 @@ const cleanSchemaAttributes = (
           break;
         }
 
+        //console.log({imageAttributes})
         attributesCopy[prop] = {
           type: 'object',
           properties: {
@@ -179,6 +198,8 @@ const cleanSchemaAttributes = (
               cleanSchemaAttributes(imageAttributes, { typeMap })
             ),
           },
+          // Does nothing
+          //required: extractRequiredProperties(imageAttributes),
         };
         break;
       }


### PR DESCRIPTION
WIP

The openapi.json file generated by Strapi is missing the required fields.

The fields in openapi.json are all nullable and they should not.

Related issues:
- https://forum.strapi.io/t/documentation-plugin-mark-as-required-field-in-response/17775
- https://forum.strapi.io/t/is-there-a-way-to-extract-typescript-types-to-be-used-in-a-separate-frontend/27673
- https://github.com/strapi/strapi/issues/15710 (https://github.com/strapi/strapi/pull/16440)
- https://github.com/strapi/strapi/issues/5538

Other related contents:
- https://strapi.io/blog/improve-your-frontend-experience-with-strapi-types-and-type-script
- https://github.com/mancku/strapi-plugin-schemas-to-ts