### PR TITLE
chore: remove strapi global from traversal utils

### DIFF
--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -20,7 +20,15 @@ const omitIdField = omit('id');
 
 const emitEvent = async (uid: UID.ContentType, event: string, document: Document) => {
   const modelDef = strapi.getModel(uid);
-  const sanitizedDocument = await sanitize.sanitizers.defaultSanitizeOutput(modelDef, document);
+  const sanitizedDocument = await sanitize.sanitizers.defaultSanitizeOutput(
+    {
+      schema: modelDef,
+      getModel(uid) {
+        return strapi.getModel(uid as UID.Schema);
+      },
+    },
+    document
+  );
 
   strapi.eventHub.emit(event, {
     model: modelDef.modelName,

--- a/packages/core/content-manager/server/src/services/utils/configuration/__tests__/settings.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/__tests__/settings.test.ts
@@ -21,6 +21,10 @@ jest.mock('../settings', () => {
 });
 
 describe('Configuration settings service', () => {
+  global.strapi = {
+    getModel() {},
+  } as any;
+
   describe('createDefaultSettings', () => {
     test('Consistent defaults', async () => {
       const schema = {

--- a/packages/core/content-manager/server/src/services/utils/configuration/settings.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/settings.ts
@@ -35,7 +35,7 @@ async function isValidDefaultSort(schema: any, value: any) {
 
   const sanitizedValue = await traverse.traverseQuerySort(
     omitNonSortableAttributes,
-    { schema },
+    { schema, getModel: strapi.getModel.bind(strapi) },
     parsedValue
   );
 

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -263,7 +263,7 @@ const getQueryPopulate = async (uid: UID.Schema, query: object): Promise<Populat
         populateQuery = set(populatePath, {}, populateQuery);
       }
     },
-    { schema: strapi.getModel(uid) },
+    { schema: strapi.getModel(uid), getModel: strapi.getModel.bind(strapi) },
     query
   );
 

--- a/packages/core/core/src/services/content-api/index.ts
+++ b/packages/core/core/src/services/content-api/index.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { sanitize, validate } from '@strapi/utils';
 
-import type { Core } from '@strapi/types';
+import type { Core, UID } from '@strapi/types';
 
 import instantiatePermissionsUtilities from './permissions';
 
@@ -70,6 +70,9 @@ const createContentAPI = (strapi: Core.Strapi) => {
   };
 
   const sanitizer = sanitize.createAPISanitizers({
+    getModel(uid: string) {
+      return strapi.getModel(uid as UID.Schema);
+    },
     // NOTE: use lazy access to allow registration of sanitizers after the creation of the container
     get sanitizers() {
       return {
@@ -80,6 +83,9 @@ const createContentAPI = (strapi: Core.Strapi) => {
   });
 
   const validator = validate.createAPIValidators({
+    getModel(uid: string) {
+      return strapi.getModel(uid as UID.Schema);
+    },
     // NOTE: use lazy access to allow registration of validators after the creation of the container
     get validators() {
       return {

--- a/packages/core/core/src/services/document-service/transform/populate.ts
+++ b/packages/core/core/src/services/document-service/transform/populate.ts
@@ -22,7 +22,7 @@ export const transformPopulate = async (data: Data, opts: { uid: UID.Schema }) =
 
       set(key, value);
     },
-    { schema: strapi.getModel(opts.uid) },
+    { schema: strapi.getModel(opts.uid), getModel: strapi.getModel.bind(strapi) },
     data
   );
 };

--- a/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts
@@ -120,7 +120,7 @@ const extractDataIds = (
         });
       }
     },
-    { schema: strapi.getModel(opts.uid) },
+    { schema: strapi.getModel(opts.uid), getModel: strapi.getModel.bind(strapi) },
     data
   );
 };

--- a/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/transform/data-ids.ts
@@ -229,7 +229,7 @@ const transformDataIdsVisitor = (
         set(key, newRelation as any);
       }
     },
-    { schema: strapi.getModel(opts.uid) },
+    { schema: strapi.getModel(opts.uid), getModel: strapi.getModel.bind(strapi) },
     data
   );
 };

--- a/packages/core/upload/server/src/services/extensions/content-manager/entity-manager.ts
+++ b/packages/core/upload/server/src/services/extensions/content-manager/entity-manager.ts
@@ -63,8 +63,12 @@ const signEntityMediaVisitor: SignEntityMediaVisitor = async (
  */
 const signEntityMedia = async (entity: any, uid: UID.Schema) => {
   const model = strapi.getModel(uid);
-  // @ts-expect-error - FIXME: fix traverseEntity types
-  return traverseEntity(signEntityMediaVisitor, { schema: model }, entity);
+  return traverseEntity(
+    // @ts-expect-error - FIXME: fix traverseEntity types
+    signEntityMediaVisitor,
+    { schema: model, getModel: strapi.getModel.bind(strapi) },
+    entity
+  );
 };
 
 const addSignedFileUrlsToAdmin = async () => {

--- a/packages/core/upload/server/src/services/extensions/utils.ts
+++ b/packages/core/upload/server/src/services/extensions/utils.ts
@@ -64,8 +64,12 @@ const signEntityMediaVisitor: SignEntityMediaVisitor = async (
  */
 const signEntityMedia = async (entity: any, uid: UID.Schema) => {
   const model = strapi.getModel(uid);
-  // @ts-expect-error - FIXME: fix traverseEntity using wrong types
-  return traverseEntity(signEntityMediaVisitor, { schema: model }, entity);
+  return traverseEntity(
+    // @ts-expect-error - FIXME: fix traverseEntity using wrong types
+    signEntityMediaVisitor,
+    { schema: model, getModel: strapi.getModel.bind(strapi) },
+    entity
+  );
 };
 
 export { signEntityMedia };

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -14,7 +14,7 @@ import {
   convertQueryParams,
 } from '@strapi/utils';
 
-import type { Core } from '@strapi/types';
+import type { Core, UID } from '@strapi/types';
 
 import { FILE_MODEL_UID, ALLOWED_WEBHOOK_EVENTS } from '../constants';
 import { getService } from '../utils';
@@ -84,7 +84,15 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
   async function emitEvent(event: string, data: Record<string, any>) {
     const modelDef = strapi.getModel(FILE_MODEL_UID);
-    const sanitizedData = await sanitize.sanitizers.defaultSanitizeOutput(modelDef, data);
+    const sanitizedData = await sanitize.sanitizers.defaultSanitizeOutput(
+      {
+        schema: modelDef,
+        getModel(uid: string) {
+          return strapi.getModel(uid as UID.Schema);
+        },
+      },
+      data
+    );
 
     strapi.eventHub.emit(event, { media: sanitizedData });
   }

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -1,6 +1,10 @@
 import { traverseQueryPopulate } from '../traverse';
 
 describe('traverseQueryPopulate', () => {
+  global.strapi = {
+    getModel() {},
+  } as any;
+
   test('should not modify wildcard', async () => {
     const strapi = {
       getModel: jest.fn((uid) => {
@@ -45,6 +49,7 @@ describe('traverseQueryPopulate', () => {
           },
         },
       },
+      getModel() {},
     })('*');
 
     expect(query).toEqual('*');
@@ -94,6 +99,7 @@ describe('traverseQueryPopulate', () => {
           },
         },
       },
+      getModel() {},
     })('address');
 
     expect(query).toEqual('address');

--- a/packages/core/utils/src/sanitize/sanitizers.ts
+++ b/packages/core/utils/src/sanitize/sanitizers.ts
@@ -22,178 +22,171 @@ import { isOperator } from '../operators';
 
 import type { Model, Data } from '../types';
 
+interface Context {
+  schema: Model;
+  getModel: (model: string) => Model;
+}
+
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE } = constants;
 
-const sanitizePasswords = (schema: Model) => async (entity: Data) => {
-  if (!schema) {
+const sanitizePasswords = (ctx: Context) => async (entity: Data) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in sanitizePasswords');
   }
-  return traverseEntity(removePassword, { schema }, entity);
+
+  return traverseEntity(removePassword, ctx, entity);
 };
 
-const defaultSanitizeOutput = async (schema: Model, entity: Data) => {
-  if (!schema) {
+const defaultSanitizeOutput = async (ctx: Context, entity: Data) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in defaultSanitizeOutput');
   }
+
   return traverseEntity(
     (...args) => {
       removePassword(...args);
       removePrivate(...args);
     },
-    { schema },
+    ctx,
     entity
   );
 };
 
-const defaultSanitizeFilters = curry((schema: Model, filters: unknown) => {
-  if (!schema) {
+const defaultSanitizeFilters = curry((ctx: Context, filters: unknown) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in defaultSanitizeFilters');
   }
+
   return pipeAsync(
     // Remove keys that are not attributes or valid operators
-    traverseQueryFilters(
-      ({ key, attribute }, { remove }) => {
-        const isAttribute = !!attribute;
+    traverseQueryFilters(({ key, attribute }, { remove }) => {
+      const isAttribute = !!attribute;
 
-        // ID is not an attribute per se, so we need to make
-        // an extra check to ensure we're not checking it
-        if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
-          return;
-        }
+      // ID is not an attribute per se, so we need to make
+      // an extra check to ensure we're not checking it
+      if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
+        return;
+      }
 
-        if (!isAttribute && !isOperator(key)) {
-          remove(key);
-        }
-      },
-      { schema }
-    ),
+      if (!isAttribute && !isOperator(key)) {
+        remove(key);
+      }
+    }, ctx),
     // Remove dynamic zones from filters
-    traverseQueryFilters(removeDynamicZones, { schema }),
+    traverseQueryFilters(removeDynamicZones, ctx),
     // Remove morpTo relations from filters
-    traverseQueryFilters(removeMorphToRelations, { schema }),
+    traverseQueryFilters(removeMorphToRelations, ctx),
     // Remove passwords from filters
-    traverseQueryFilters(removePassword, { schema }),
+    traverseQueryFilters(removePassword, ctx),
     // Remove private from filters
-    traverseQueryFilters(removePrivate, { schema }),
+    traverseQueryFilters(removePrivate, ctx),
     // Remove empty objects
-    traverseQueryFilters(
-      ({ key, value }, { remove }) => {
-        if (isObject(value) && isEmpty(value)) {
-          remove(key);
-        }
-      },
-      { schema }
-    )
+    traverseQueryFilters(({ key, value }, { remove }) => {
+      if (isObject(value) && isEmpty(value)) {
+        remove(key);
+      }
+    }, ctx)
   )(filters);
 });
 
-const defaultSanitizeSort = curry((schema: Model, sort: unknown) => {
-  if (!schema) {
+const defaultSanitizeSort = curry((ctx: Context, sort: unknown) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in defaultSanitizeSort');
   }
+
   return pipeAsync(
     // Remove non attribute keys
-    traverseQuerySort(
-      ({ key, attribute }, { remove }) => {
-        // ID is not an attribute per se, so we need to make
-        // an extra check to ensure we're not checking it
-        if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
-          return;
-        }
+    traverseQuerySort(({ key, attribute }, { remove }) => {
+      // ID is not an attribute per se, so we need to make
+      // an extra check to ensure we're not checking it
+      if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
+        return;
+      }
 
-        if (!attribute) {
-          remove(key);
-        }
-      },
-      { schema }
-    ),
+      if (!attribute) {
+        remove(key);
+      }
+    }, ctx),
     // Remove dynamic zones from sort
-    traverseQuerySort(removeDynamicZones, { schema }),
+    traverseQuerySort(removeDynamicZones, ctx),
     // Remove morpTo relations from sort
-    traverseQuerySort(removeMorphToRelations, { schema }),
+    traverseQuerySort(removeMorphToRelations, ctx),
     // Remove private from sort
-    traverseQuerySort(removePrivate, { schema }),
+    traverseQuerySort(removePrivate, ctx),
     // Remove passwords from filters
-    traverseQuerySort(removePassword, { schema }),
+    traverseQuerySort(removePassword, ctx),
     // Remove keys for empty non-scalar values
-    traverseQuerySort(
-      ({ key, attribute, value }, { remove }) => {
-        // ID is not an attribute per se, so we need to make
-        // an extra check to ensure we're not removing it
-        if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
-          return;
-        }
+    traverseQuerySort(({ key, attribute, value }, { remove }) => {
+      // ID is not an attribute per se, so we need to make
+      // an extra check to ensure we're not removing it
+      if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
+        return;
+      }
 
-        if (!isScalarAttribute(attribute) && isEmpty(value)) {
-          remove(key);
-        }
-      },
-      { schema }
-    )
+      if (!isScalarAttribute(attribute) && isEmpty(value)) {
+        remove(key);
+      }
+    }, ctx)
   )(sort);
 });
 
-const defaultSanitizeFields = curry((schema: Model, fields: unknown) => {
-  if (!schema) {
+const defaultSanitizeFields = curry((ctx: Context, fields: unknown) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in defaultSanitizeFields');
   }
+
   return pipeAsync(
     // Only keep scalar attributes
-    traverseQueryFields(
-      ({ key, attribute }, { remove }) => {
-        // ID is not an attribute per se, so we need to make
-        // an extra check to ensure we're not checking it
-        if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
-          return;
-        }
+    traverseQueryFields(({ key, attribute }, { remove }) => {
+      // ID is not an attribute per se, so we need to make
+      // an extra check to ensure we're not checking it
+      if ([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE].includes(key)) {
+        return;
+      }
 
-        if (isNil(attribute) || !isScalarAttribute(attribute)) {
-          remove(key);
-        }
-      },
-      { schema }
-    ),
+      if (isNil(attribute) || !isScalarAttribute(attribute)) {
+        remove(key);
+      }
+    }, ctx),
     // Remove private fields
-    traverseQueryFields(removePrivate, { schema }),
+    traverseQueryFields(removePrivate, ctx),
     // Remove password fields
-    traverseQueryFields(removePassword, { schema }),
+    traverseQueryFields(removePassword, ctx),
     // Remove nil values from fields array
     (value) => (isArray(value) ? value.filter((field) => !isNil(field)) : value)
   )(fields);
 });
 
-const defaultSanitizePopulate = curry((schema: Model, populate: unknown) => {
-  if (!schema) {
+const defaultSanitizePopulate = curry((ctx: Context, populate: unknown) => {
+  if (!ctx.schema) {
     throw new Error('Missing schema in defaultSanitizePopulate');
   }
+
   return pipeAsync(
-    traverseQueryPopulate(expandWildcardPopulate, { schema }),
-    traverseQueryPopulate(
-      async ({ key, value, schema, attribute }, { set }) => {
-        if (attribute) {
-          return;
-        }
+    traverseQueryPopulate(expandWildcardPopulate, ctx),
+    traverseQueryPopulate(async ({ key, value, schema, attribute, getModel }, { set }) => {
+      if (attribute) {
+        return;
+      }
 
-        if (key === 'sort') {
-          set(key, await defaultSanitizeSort(schema, value));
-        }
+      if (key === 'sort') {
+        set(key, await defaultSanitizeSort({ schema, getModel }, value));
+      }
 
-        if (key === 'filters') {
-          set(key, await defaultSanitizeFilters(schema, value));
-        }
+      if (key === 'filters') {
+        set(key, await defaultSanitizeFilters({ schema, getModel }, value));
+      }
 
-        if (key === 'fields') {
-          set(key, await defaultSanitizeFields(schema, value));
-        }
+      if (key === 'fields') {
+        set(key, await defaultSanitizeFields({ schema, getModel }, value));
+      }
 
-        if (key === 'populate') {
-          set(key, await defaultSanitizePopulate(schema, value));
-        }
-      },
-      { schema }
-    ),
+      if (key === 'populate') {
+        set(key, await defaultSanitizePopulate({ schema, getModel }, value));
+      }
+    }, ctx),
     // Remove private fields
-    traverseQueryPopulate(removePrivate, { schema })
+    traverseQueryPopulate(removePrivate, ctx)
   )(populate);
 });
 

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -1,4 +1,5 @@
 import { clone, isObject, isArray, isNil, curry } from 'lodash/fp';
+
 import type { AnyAttribute, Model, Data } from './types';
 import { isRelationalAttribute, isMediaAttribute } from './content-types';
 
@@ -11,6 +12,7 @@ export interface VisitorOptions {
   value: Data[keyof Data];
   attribute: AnyAttribute;
   path: Path;
+  getModel(uid: string): Model;
 }
 
 export type Visitor = (visitorOptions: VisitorOptions, visitorUtils: VisitorUtils) => void;
@@ -23,47 +25,48 @@ export interface Path {
 export interface TraverseOptions {
   path?: Path;
   schema: Model;
+  getModel(uid: string): Model;
 }
 
-const traverseMorphRelationTarget = async (visitor: Visitor, path: Path, entry: Data) => {
-  const targetSchema = strapi.getModel(entry.__type);
+const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity: Data) => {
+  const { path = { raw: null, attribute: null }, schema, getModel } = options;
 
-  const traverseOptions = { schema: targetSchema, path };
+  const traverseMorphRelationTarget = async (visitor: Visitor, path: Path, entry: Data) => {
+    const targetSchema = getModel(entry.__type!);
 
-  return traverseEntity(visitor, traverseOptions, entry);
-};
-
-const traverseRelationTarget =
-  (schema: Model) => async (visitor: Visitor, path: Path, entry: Data) => {
-    const traverseOptions = { schema, path };
+    const traverseOptions = { schema: targetSchema, path, getModel };
 
     return traverseEntity(visitor, traverseOptions, entry);
   };
 
-const traverseMediaTarget = async (visitor: Visitor, path: Path, entry: Data) => {
-  const targetSchemaUID = 'plugin::upload.file';
-  const targetSchema = strapi.getModel(targetSchemaUID);
+  const traverseRelationTarget =
+    (schema: Model) => async (visitor: Visitor, path: Path, entry: Data) => {
+      const traverseOptions = { schema, path, getModel };
 
-  const traverseOptions = { schema: targetSchema, path };
+      return traverseEntity(visitor, traverseOptions, entry);
+    };
 
-  return traverseEntity(visitor, traverseOptions, entry);
-};
+  const traverseMediaTarget = async (visitor: Visitor, path: Path, entry: Data) => {
+    const targetSchemaUID = 'plugin::upload.file';
+    const targetSchema = getModel(targetSchemaUID);
 
-const traverseComponent = async (visitor: Visitor, path: Path, schema: Model, entry: Data) => {
-  const traverseOptions = { schema, path };
+    const traverseOptions = { schema: targetSchema, path, getModel };
 
-  return traverseEntity(visitor, traverseOptions, entry);
-};
+    return traverseEntity(visitor, traverseOptions, entry);
+  };
 
-const visitDynamicZoneEntry = async (visitor: Visitor, path: Path, entry: Data) => {
-  const targetSchema = strapi.getModel(entry.__component);
-  const traverseOptions = { schema: targetSchema, path };
+  const traverseComponent = async (visitor: Visitor, path: Path, schema: Model, entry: Data) => {
+    const traverseOptions = { schema, path, getModel };
 
-  return traverseEntity(visitor, traverseOptions, entry);
-};
+    return traverseEntity(visitor, traverseOptions, entry);
+  };
 
-const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity: Data) => {
-  const { path = { raw: null, attribute: null }, schema } = options;
+  const visitDynamicZoneEntry = async (visitor: Visitor, path: Path, entry: Data) => {
+    const targetSchema = getModel(entry.__component!);
+    const traverseOptions = { schema: targetSchema, path, getModel };
+
+    return traverseEntity(visitor, traverseOptions, entry);
+  };
 
   // End recursion
   if (!isObject(entity) || isNil(schema)) {
@@ -102,6 +105,7 @@ const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity
       value: copy[key],
       attribute,
       path: newPath,
+      getModel,
     };
 
     await visitor(visitorOptions, visitorUtils);
@@ -119,7 +123,7 @@ const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity
 
       const method = isMorphRelation
         ? traverseMorphRelationTarget
-        : traverseRelationTarget(strapi.getModel(attribute.target));
+        : traverseRelationTarget(getModel(attribute.target!));
 
       if (isArray(value)) {
         const res = new Array(value.length);
@@ -150,7 +154,7 @@ const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity
     }
 
     if (attribute.type === 'component') {
-      const targetSchema = strapi.getModel(attribute.component);
+      const targetSchema = getModel(attribute.component);
 
       if (isArray(value)) {
         const res: Data[] = new Array(value.length);

--- a/packages/core/utils/src/traverse/index.ts
+++ b/packages/core/utils/src/traverse/index.ts
@@ -1,4 +1,3 @@
-export { default as factory } from './factory';
 export { default as traverseQueryFilters } from './query-filters';
 export { default as traverseQuerySort } from './query-sort';
 export { default as traverseQueryPopulate } from './query-populate';

--- a/packages/core/utils/src/traverse/query-filters.ts
+++ b/packages/core/utils/src/traverse/query-filters.ts
@@ -55,12 +55,12 @@ const filters = traverseFactory()
   // Recursion on operators (non attributes)
   .on(
     ({ attribute }) => isNil(attribute),
-    async ({ key, visitor, path, value, schema }, { set, recurse }) => {
-      set(key, await recurse(visitor, { schema, path }, value));
+    async ({ key, visitor, path, value, schema, getModel }, { set, recurse }) => {
+      set(key, await recurse(visitor, { schema, path, getModel }, value));
     }
   )
   // Handle relation recursion
-  .onRelation(async ({ key, attribute, visitor, path, value }, { set, recurse }) => {
+  .onRelation(async ({ key, attribute, visitor, path, value, getModel }, { set, recurse }) => {
     const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
 
     if (isMorphRelation) {
@@ -68,25 +68,25 @@ const filters = traverseFactory()
     }
 
     const targetSchemaUID = attribute.target;
-    const targetSchema = strapi.getModel(targetSchemaUID);
+    const targetSchema = getModel(targetSchemaUID!);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   })
-  .onComponent(async ({ key, attribute, visitor, path, value }, { set, recurse }) => {
-    const targetSchema = strapi.getModel(attribute.component);
+  .onComponent(async ({ key, attribute, visitor, path, value, getModel }, { set, recurse }) => {
+    const targetSchema = getModel(attribute.component);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   })
   // Handle media recursion
-  .onMedia(async ({ key, visitor, path, value }, { set, recurse }) => {
+  .onMedia(async ({ key, visitor, path, value, getModel }, { set, recurse }) => {
     const targetSchemaUID = 'plugin::upload.file';
-    const targetSchema = strapi.getModel(targetSchemaUID);
+    const targetSchema = getModel(targetSchemaUID);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   });

--- a/packages/core/utils/src/traverse/query-sort.ts
+++ b/packages/core/utils/src/traverse/query-sort.ts
@@ -135,7 +135,7 @@ const sort = traverseFactory()
     },
   }))
   // Handle deep sort on relation
-  .onRelation(async ({ key, value, attribute, visitor, path }, { set, recurse }) => {
+  .onRelation(async ({ key, value, attribute, visitor, path, getModel }, { set, recurse }) => {
     const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
 
     if (isMorphRelation) {
@@ -143,26 +143,26 @@ const sort = traverseFactory()
     }
 
     const targetSchemaUID = attribute.target;
-    const targetSchema = strapi.getModel(targetSchemaUID);
+    const targetSchema = getModel(targetSchemaUID!);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   })
   // Handle deep sort on media
-  .onMedia(async ({ key, path, visitor, value }, { recurse, set }) => {
+  .onMedia(async ({ key, path, visitor, value, getModel }, { recurse, set }) => {
     const targetSchemaUID = 'plugin::upload.file';
-    const targetSchema = strapi.getModel(targetSchemaUID);
+    const targetSchema = getModel(targetSchemaUID);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   })
   // Handle deep sort on components
-  .onComponent(async ({ key, value, visitor, path, attribute }, { recurse, set }) => {
-    const targetSchema = strapi.getModel(attribute.component);
+  .onComponent(async ({ key, value, visitor, path, attribute, getModel }, { recurse, set }) => {
+    const targetSchema = getModel(attribute.component);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path }, value);
+    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
 
     set(key, newValue);
   });

--- a/packages/core/utils/src/types.ts
+++ b/packages/core/utils/src/types.ts
@@ -5,6 +5,8 @@ type ID = number | string;
 
 export type Data = {
   id?: ID;
+  __component?: string;
+  __type?: string;
   [key: string]: string | number | ID | boolean | null | undefined | Date | Data | Data[];
 };
 

--- a/packages/plugins/i18n/server/src/controllers/__tests__/locales.test.ts
+++ b/packages/plugins/i18n/server/src/controllers/__tests__/locales.test.ts
@@ -5,7 +5,9 @@ import localeModel from '../../content-types/locale';
 const { ApplicationError } = errors;
 
 const contentAPI = {
-  sanitize: sanitize.createAPISanitizers(),
+  sanitize: sanitize.createAPISanitizers({
+    getModel: jest.fn(() => {}),
+  } as any),
 };
 
 describe('Locales', () => {

--- a/packages/plugins/users-permissions/server/utils/sanitize/sanitizers.js
+++ b/packages/plugins/users-permissions/server/utils/sanitize/sanitizers.js
@@ -6,7 +6,11 @@ const { traverseEntity, async } = require('@strapi/utils');
 const { removeUserRelationFromRoleEntities } = require('./visitors');
 
 const sanitizeUserRelationFromRoleEntities = curry((schema, entity) => {
-  return traverseEntity(removeUserRelationFromRoleEntities, { schema }, entity);
+  return traverseEntity(
+    removeUserRelationFromRoleEntities,
+    { schema, getModel: strapi.getModel.bind(strapi) },
+    entity
+  );
 });
 
 const defaultSanitizeOutput = curry((schema, entity) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Removes strapi global from traversal utils
- Next iteration will make the traversal more generic and move the non generic logic in a dedicated place with the right context

### Why is it needed?

To make the utils agnostic

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
