### PR TITLE
fix(content-releases): change createMany releases actions api

### DIFF
--- a/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/controllers/__tests__/release-action.test.ts
@@ -114,22 +114,12 @@ describe('Release Action controller', () => {
           releaseId: 1,
         },
         request: {
-          body: [
-            {
-              entry: {
-                id: 1,
-                contentType: 'api::contentTypeA.contentTypeA',
-              },
-              type: 'publish',
-            },
-            {
-              entry: {
-                id: 2,
-                contentType: 'api::contentTypeB.contentTypeB',
-              },
-              type: 'unpublish',
-            },
-          ],
+          body: {
+            locale: 'en',
+            type: 'publish',
+            contentType: 'api::contentTypeA.contentTypeA',
+            entries: [1, 2],
+          },
         },
       };
 
@@ -153,15 +143,12 @@ describe('Release Action controller', () => {
           releaseId: 1,
         },
         request: {
-          body: [
-            {
-              entry: {
-                id: 1,
-                contentType: 'api::contentTypeA.contentTypeA',
-              },
-              type: 'publish',
-            },
-          ],
+          body: {
+            locale: 'en',
+            type: 'publish',
+            contentType: 'api::contentTypeA.contentTypeA',
+            entries: [1],
+          },
         },
       };
 

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -35,19 +35,20 @@ const releaseActionController = {
     const releaseId: CreateManyReleaseActions.Request['params']['releaseId'] = ctx.params.releaseId;
     const releaseActionsArgs: CreateManyReleaseActions.Request['body'] = ctx.request.body;
 
-    await Promise.all(
-      releaseActionsArgs.map((releaseActionArgs) => validateReleaseAction(releaseActionArgs))
-    );
+    const { contentType, locale, type, entries } = releaseActionsArgs;
 
     const releaseService = getService('release', { strapi });
 
     const releaseActions = await strapi.db.transaction(async () => {
       const releaseActions = await Promise.all(
-        releaseActionsArgs.map(async (releaseActionArgs) => {
+        entries.map(async (id) => {
           try {
-            const action = await releaseService.createAction(releaseId, releaseActionArgs);
+            const releaseAction = await releaseService.createAction(releaseId, {
+              type,
+              entry: { id, contentType, locale },
+            });
 
-            return action;
+            return releaseAction;
           } catch (error) {
             // If the entry is already in the release, we don't want to throw an error, so we catch and ignore it
             if (error instanceof AlreadyOnReleaseError) {

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -67,14 +67,12 @@ export declare namespace CreateManyReleaseActions {
     params: {
       releaseId: Release['id'];
     };
-    body: Array<{
+    body: {
       type: ReleaseAction['type'];
-      entry: {
-        id: ReleaseActionEntry['id'];
-        locale?: ReleaseActionEntry['locale'];
-        contentType: Common.UID.ContentType;
-      };
-    }>;
+      locale: ReleaseActionEntry['locale'];
+      contentType: Common.UID.ContentType;
+      entries: Array<ReleaseActionEntry['id']>;
+    };
   }
 
   export interface Response {


### PR DESCRIPTION
### What does it do?

Changes the createMany releases actions API to be more easily used from the frontend.

### How to test it?

The endpoint to call is POST: `/content-releases/:releaseId/actions/bulk`, and the request should be like this: 
```
{
    params: {
      releaseId: Release['id'];
    };
    body: {
      type: ReleaseAction['type'];
      locale: ReleaseActionEntry['locale'];
      contentType: Common.UID.ContentType;
      entries: Array<ReleaseActionEntry['id']>;
    };
  }
```
If one entry is already on the release we don't throw an error, instead we return a meta object with that information:
```
{
  totalEntries: number // Total entries that user tried to add to the release
  entriesAlreadyInRelease: number // Total entries that were not added because they were already on the release
}
```