### PR TITLE
fix: show name of relations when lazy loading them

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -280,8 +280,8 @@ export default {
           ordering: 'desc',
         } as any,
         {
-          page: ctx.request.query.page,
-          pageSize: ctx.request.query.pageSize,
+          page: 1,
+          pageSize: ids.length,
         }
       );
 


### PR DESCRIPTION
### What does it do?

Display main field of relation instead of it's id when lazy loading them.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/19625
