### PR TITLE
chore: init zod usage

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -144,7 +144,8 @@
     "styled-components": "5.3.11",
     "typescript": "5.3.2",
     "use-context-selector": "1.4.1",
-    "yup": "0.32.9"
+    "yup": "0.32.9",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@strapi/admin-test-utils": "5.0.0-beta.0",

--- a/packages/core/admin/server/src/validation/project-settings.ts
+++ b/packages/core/admin/server/src/validation/project-settings.ts
@@ -1,45 +1,45 @@
-import { yup, validateYupSchemaSync } from '@strapi/utils';
+import { z } from 'zod';
+import { validateZod } from '@strapi/utils';
 
 const MAX_IMAGE_WIDTH = 750;
 const MAX_IMAGE_HEIGHT = MAX_IMAGE_WIDTH;
 const MAX_IMAGE_FILE_SIZE = 1024 * 1024; // 1Mo
-const ALLOWED_IMAGE_FILE_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml'];
 
-const updateProjectSettings = yup
+const updateProjectSettings = z
   .object({
-    menuLogo: yup.string(),
-    authLogo: yup.string(),
+    menuLogo: z.string().nullish(),
+    authLogo: z.string().nullish(),
   })
-  .noUnknown();
+  .strict();
 
-const updateProjectSettingsLogo = yup.object({
-  name: yup.string(),
-  type: yup.string().oneOf(ALLOWED_IMAGE_FILE_TYPES),
-  size: yup.number().max(MAX_IMAGE_FILE_SIZE),
+const updateProjectSettingsLogo = z.object({
+  name: z.string().nullish(),
+  type: z.enum(['image/jpeg', 'image/png', 'image/svg+xml']),
+  size: z.number().max(MAX_IMAGE_FILE_SIZE).nullish(),
 });
 
-const updateProjectSettingsFiles = yup
+const updateProjectSettingsFiles = z
   .object({
-    menuLogo: updateProjectSettingsLogo,
-    authLogo: updateProjectSettingsLogo,
+    menuLogo: updateProjectSettingsLogo.nullish(),
+    authLogo: updateProjectSettingsLogo.nullish(),
   })
-  .noUnknown();
+  .strict();
 
-const logoDimensions = yup.object({
-  width: yup.number().max(MAX_IMAGE_WIDTH),
-  height: yup.number().max(MAX_IMAGE_HEIGHT),
+const logoDimensions = z.object({
+  width: z.number().max(MAX_IMAGE_WIDTH).nullish(),
+  height: z.number().max(MAX_IMAGE_HEIGHT).nullish(),
 });
 
-const updateProjectSettingsImagesDimensions = yup
+const updateProjectSettingsImagesDimensions = z
   .object({
-    menuLogo: logoDimensions,
-    authLogo: logoDimensions,
+    menuLogo: logoDimensions.nullish(),
+    authLogo: logoDimensions.nullish(),
   })
-  .noUnknown();
+  .strict();
 
-export const validateUpdateProjectSettings = validateYupSchemaSync(updateProjectSettings);
-export const validateUpdateProjectSettingsFiles = validateYupSchemaSync(updateProjectSettingsFiles);
-export const validateUpdateProjectSettingsImagesDimensions = validateYupSchemaSync(
+export const validateUpdateProjectSettings = validateZod(updateProjectSettings);
+export const validateUpdateProjectSettingsFiles = validateZod(updateProjectSettingsFiles);
+export const validateUpdateProjectSettingsImagesDimensions = validateZod(
   updateProjectSettingsImagesDimensions
 );
 

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -52,7 +52,8 @@
     "node-machine-id": "1.1.12",
     "p-map": "4.0.0",
     "preferred-pm": "3.1.2",
-    "yup": "0.32.9"
+    "yup": "0.32.9",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@strapi/pack-up": "5.0.0-beta.0",

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -24,5 +24,6 @@ export * as errors from './errors';
 export * as contentTypes from './content-types';
 export * as relations from './relations';
 export * as hooks from './hooks';
+export * from './zod';
 
 export * from './primitives';

--- a/packages/core/utils/src/zod.ts
+++ b/packages/core/utils/src/zod.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import { ValidationError } from './errors';
+
+export const validateZod =
+  <T extends z.ZodTypeAny>(schema: T) =>
+  (data: unknown): z.TypeOf<T> => {
+    try {
+      return schema.parse(data);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const { message, errors } = formatZodErrors(error);
+        throw new ValidationError(message, { errors });
+      }
+
+      throw error;
+    }
+  };
+
+const formatZodErrors = (zodError: z.ZodError) => ({
+  errors: zodError.errors.map((error) => {
+    return {
+      path: error.path,
+      message: error.message,
+      name: 'ValidationError',
+    };
+  }),
+  message: 'Validation error',
+});

--- a/packages/utils/eslint-config-custom/back/typescript.js
+++ b/packages/utils/eslint-config-custom/back/typescript.js
@@ -20,6 +20,7 @@ module.exports = {
     // to be solved in configuration
     'node/no-unsupported-features/es-syntax': 'off',
     'import/prefer-default-export': 'off',
+    'import/namespace': 'off',
     'node/no-missing-import': 'off',
     '@typescript-eslint/brace-style': 'off', // TODO: fix conflict with prettier/prettier in data-transfer/engine/index.ts
     // to be cleaned up throughout codebase (too many to fix at the moment)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7079,6 +7079,7 @@ __metadata:
     vite: "npm:5.1.6"
     vite-plugin-dts: "npm:3.7.3"
     yup: "npm:0.32.9"
+    zod: "npm:^3.22.4"
   peerDependencies:
     "@strapi/data-transfer": ^4.16.0
     react: ^17.0.0 || ^18.0.0
@@ -8177,6 +8178,7 @@ __metadata:
     preferred-pm: "npm:3.1.2"
     tsconfig: "npm:5.0.0-beta.0"
     yup: "npm:0.32.9"
+    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 
@@ -12112,10 +12114,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001541, caniuse-lite@npm:^1.0.30001565, caniuse-lite@npm:^1.0.30001587":
+"caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001587":
   version: 1.0.30001600
   resolution: "caniuse-lite@npm:1.0.30001600"
   checksum: 4c52f83ed71bc5f6e443bd17923460f1c77915adc2c2aa79ddaedceccc690b5917054b0c41b79e9138cbbd9abcdc0db9e224e79e3e734e581dfec06505f3a2b4
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001541":
+  version: 1.0.30001542
+  resolution: "caniuse-lite@npm:1.0.30001542"
+  checksum: 07b14b8341d7bf0ea386a5fa5b5edbee41d81dfc072d3d11db22dd1d7a929358f522b16fdf3cbd154c8a5cae84662578cf5c9e490e7d7606ee7d156ccf07c9fa
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001565":
+  version: 1.0.30001574
+  resolution: "caniuse-lite@npm:1.0.30001574"
+  checksum: 159ebd04d9bbef11bd08499f058f70bf795a55641929be5efadf0f6b17216d4b923506778e59bbb939246834304b753b2e88ff1e2430f6a5aef0a86971f98bd3
   languageName: node
   linkType: hard
 
@@ -30222,5 +30238,12 @@ __metadata:
   bin:
     z-schema: bin/z-schema
   checksum: 8ac2fa445f5a00e790d1f91a48aeff0ccfc340f84626771853e03f4d97cdc2f5f798cdb2e38418f7815ffc3aac3952c45caabcf077bf4f83fedf0cdef43b885b
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 73622ca36a916f785cf528fe612a884b3e0f183dbe6b33365a7d0fc92abdbedf7804c5e2bd8df0a278e1472106d46674281397a3dd800fa9031dc3429758c6ac
   languageName: node
   linkType: hard


### PR DESCRIPTION
### What does it do?

Introduce zod. use the same error formatting as yup so we can incrementally replace yup without breaking the response format.