### PR TITLE
chore(deps): bump @koa/cors from 3.4.3 to 5.0.0

### DIFF
--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -111,7 +111,7 @@
     "watch": "pack-up watch"
   },
   "dependencies": {
-    "@koa/cors": "3.4.3",
+    "@koa/cors": "5.0.0",
     "@koa/router": "10.1.1",
     "@strapi/admin": "4.21.0",
     "@strapi/content-releases": "4.21.0",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@casl/ability": "6.5.0",
-    "@koa/cors": "3.4.3",
+    "@koa/cors": "5.0.0",
     "@koa/router": "10.1.1",
     "@strapi/database": "4.21.0",
     "@strapi/logger": "4.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4136,7 +4136,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koa/cors@npm:3.4.3, @koa/cors@npm:^3.1.0":
+"@koa/cors@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@koa/cors@npm:5.0.0"
+  dependencies:
+    vary: "npm:^1.1.2"
+  checksum: 3a0e32fbc422a5f9a41540ce3b7499d46073ddb0e4e851394a74bac5ecd0eaa1f24a8f189b7bd6a50c5863788ae6945c52d990edf99fdd2151a4404f266fe2e7
+  languageName: node
+  linkType: hard
+
+"@koa/cors@npm:^3.1.0":
   version: 3.4.3
   resolution: "@koa/cors@npm:3.4.3"
   dependencies:
@@ -8767,7 +8776,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/strapi@workspace:packages/core/strapi"
   dependencies:
-    "@koa/cors": "npm:3.4.3"
+    "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:10.1.1"
     "@strapi/admin": "npm:4.21.0"
     "@strapi/content-releases": "npm:4.21.0"
@@ -8871,7 +8880,7 @@ __metadata:
   resolution: "@strapi/types@workspace:packages/core/types"
   dependencies:
     "@casl/ability": "npm:6.5.0"
-    "@koa/cors": "npm:3.4.3"
+    "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:10.1.1"
     "@strapi/database": "npm:4.21.0"
     "@strapi/logger": "npm:4.21.0"


### PR DESCRIPTION

### What does it do?

Updates the @koa/cors version to 5.0.0

### Why is it needed?

fixes https://www.npmjs.com/advisories/1095223

### How to test it?

No testing needed as we were not vulnerable to any issues as we already implemented the "fix" like 4 years ago

### Related issue(s)/PR(s)

N/A
