### PR TITLE
fix: relations lazy loading

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -280,8 +280,8 @@ export default {
           ordering: 'desc',
         } as any,
         {
-          page: ctx.request.query.page,
-          pageSize: ctx.request.query.pageSize,
+          page: 1,
+          pageSize: ids.length,
         }
       );
 


### PR DESCRIPTION
### What does it do?
Copy of another pr that was approved
