### PR TITLE
chore(deps): fix peer-deps to be 5 upwards

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -176,7 +176,7 @@
     "vite-plugin-dts": "3.7.3"
   },
   "peerDependencies": {
-    "@strapi/data-transfer": "^4.16.0",
+    "@strapi/data-transfer": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -94,7 +94,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/admin": "^4.19.0",
+    "@strapi/admin": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -54,7 +54,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.4.0",
+    "@strapi/strapi": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "6.21.1",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -70,7 +70,7 @@
     "typescript": "5.3.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.4.0",
+    "@strapi/strapi": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7080,7 +7080,7 @@ __metadata:
     vite-plugin-dts: "npm:3.7.3"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/data-transfer": ^4.16.0
+    "@strapi/data-transfer": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7455,7 +7455,7 @@ __metadata:
     tsconfig: "npm:5.0.0-beta.0"
     typescript: "npm:5.2.2"
   peerDependencies:
-    "@strapi/strapi": ^4.4.0
+    "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: 6.21.1
@@ -7481,7 +7481,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     typescript: "npm:5.3.2"
   peerDependencies:
-    "@strapi/strapi": ^4.4.0
+    "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7785,7 +7785,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^4.19.0
+    "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* ensures all the peer deps for the strapi packages is `^5.0.0`

### Why is it needed?

* afaik this should pass peer-dep checks when the versions are `beta` or `alpha`, but the documentation wasn't clear. Either way, they definitely should be min 5.

### Issues

* resolves #19903 
