### PR TITLE
chore: allow pre-releases in deps

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -176,7 +176,7 @@
     "vite-plugin-dts": "3.7.3"
   },
   "peerDependencies": {
-    "@strapi/data-transfer": "^5.0.0",
+    "@strapi/data-transfer": "^5.0.0 ||  ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -87,7 +87,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@strapi/admin": "^5.0.0",
+    "@strapi/admin": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -89,7 +89,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/admin": "^5.0.0",
+    "@strapi/admin": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -78,7 +78,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/admin": "^5.0.0",
+    "@strapi/admin": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "koa": "2.13.4",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -94,7 +94,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/admin": "^5.0.0",
+    "@strapi/admin": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -54,7 +54,7 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "6.21.1",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -70,7 +70,7 @@
     "typescript": "5.3.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -94,7 +94,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -83,7 +83,7 @@
     "typescript": "5.3.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -78,7 +78,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/admin": "^5.0.0",
+    "@strapi/admin": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -63,7 +63,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -79,7 +79,7 @@
     "styled-components": "5.3.11"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^5.0.0",
+    "@strapi/strapi": "^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7080,7 +7080,7 @@ __metadata:
     vite-plugin-dts: "npm:3.7.3"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/data-transfer": ^5.0.0
+    "@strapi/data-transfer": ^5.0.0 ||  ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7122,7 +7122,7 @@ __metadata:
     typescript: "npm:5.2.2"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^5.0.0
+    "@strapi/admin": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7455,7 +7455,7 @@ __metadata:
     tsconfig: "npm:5.0.0-beta.0"
     typescript: "npm:5.2.2"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: 6.21.1
@@ -7481,7 +7481,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     typescript: "npm:5.3.2"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7542,7 +7542,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^5.0.0
+    "@strapi/admin": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7593,7 +7593,7 @@ __metadata:
     yaml: "npm:1.10.2"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7628,7 +7628,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^5.0.0
+    "@strapi/admin": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     koa: 2.13.4
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -7673,7 +7673,7 @@ __metadata:
     tsconfig: "npm:5.0.0-beta.0"
     typescript: "npm:5.3.2"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7708,7 +7708,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^5.0.0
+    "@strapi/admin": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7730,7 +7730,7 @@ __metadata:
     react-router-dom: "npm:6.22.3"
     styled-components: "npm:5.3.11"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7785,7 +7785,7 @@ __metadata:
     styled-components: "npm:5.3.11"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/admin": ^5.0.0
+    "@strapi/admin": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
@@ -7827,7 +7827,7 @@ __metadata:
     url-join: "npm:4.0.1"
     yup: "npm:0.32.9"
   peerDependencies:
-    "@strapi/strapi": ^5.0.0
+    "@strapi/strapi": ^5.0.0 || ^5.0.0-beta || ^5.0.0-alpha || ^5.0.0-rc
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* allow pre-releases in peer-deps

### Why is it needed?

* users should be able to use `npm` and `pnpm`
