### PR TITLE
test(e2e): close 'saved' notification box after confirming it exists

### DIFF
--- a/e2e/tests/admin/signup.spec.js
+++ b/e2e/tests/admin/signup.spec.js
@@ -96,7 +96,6 @@ test.describe('Sign Up', () => {
   }) => {
     await page.getByRole('button', { name: "Let's start" }).click();
 
-    await page.waitForURL('**/admin/');
     await expect(page).toHaveTitle('Homepage');
   });
 });

--- a/e2e/tests/content-manager/editview.spec.ts
+++ b/e2e/tests/content-manager/editview.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../scripts/dts-import';
 import { findAndClose } from '../../utils/shared';

--- a/e2e/tests/content-manager/editview.spec.ts
+++ b/e2e/tests/content-manager/editview.spec.ts
@@ -27,7 +27,11 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'Save' }).click();
 
+      // Check that the "saved" box appears
       await expect(page.getByText('Saved')).toBeVisible();
+
+      // close it, or it's still open for the next save click
+      await page.getByRole('button', { name: 'Close' }).click();
 
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 
@@ -64,7 +68,13 @@ test.describe('Edit View', () => {
 
       await expect(page.getByRole('button', { name: 'Save' })).not.toBeDisabled();
       await page.getByRole('button', { name: 'Save' }).click();
+
+      // Check that the "saved" box appears
       await expect(page.getByText('Saved')).toBeVisible();
+
+      // close it, or it's still open for the next save click
+      await page.getByRole('button', { name: 'Close' }).click();
+
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 
       await expect(page.getByRole('button', { name: 'Publish' })).not.toBeDisabled();
@@ -136,7 +146,11 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'Save' }).click();
 
+      // Check that the "saved" box appears
       await expect(page.getByText('Saved')).toBeVisible();
+
+      // close it, or it's still open for the next save click
+      await page.getByRole('button', { name: 'Close' }).click();
 
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 

--- a/e2e/tests/content-manager/editview.spec.ts
+++ b/e2e/tests/content-manager/editview.spec.ts
@@ -1,6 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../scripts/dts-import';
+import { findAndClose } from '../../utils/shared';
 
 test.describe('Edit View', () => {
   test.beforeEach(async ({ page }) => {
@@ -9,6 +10,9 @@ test.describe('Edit View', () => {
     await login({ page });
   });
 
+  /**
+   * TODO: we should split these tests into smaller ones.
+   */
   test.describe('Collection Type', () => {
     test('A user should be able to navigate to the EditView of the content manager to create, save, publish, unpublish & delete a new entry', async ({
       page,
@@ -27,11 +31,7 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'Save' }).click();
 
-      // Check that the "saved" box appears
-      await expect(page.getByText('Saved')).toBeVisible();
-
-      // close it, or it's still open for the next save click
-      await page.getByRole('button', { name: 'Close' }).click();
+      await findAndClose(page, 'Saved');
 
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 
@@ -69,11 +69,7 @@ test.describe('Edit View', () => {
       await expect(page.getByRole('button', { name: 'Save' })).not.toBeDisabled();
       await page.getByRole('button', { name: 'Save' }).click();
 
-      // Check that the "saved" box appears
-      await expect(page.getByText('Saved')).toBeVisible();
-
-      // close it, or it's still open for the next save click
-      await page.getByRole('button', { name: 'Close' }).click();
+      await findAndClose(page, 'Saved');
 
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 
@@ -146,11 +142,7 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'Save' }).click();
 
-      // Check that the "saved" box appears
-      await expect(page.getByText('Saved')).toBeVisible();
-
-      // close it, or it's still open for the next save click
-      await page.getByRole('button', { name: 'Close' }).click();
+      await findAndClose(page, 'Saved');
 
       await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
 

--- a/e2e/utils/shared.ts
+++ b/e2e/utils/shared.ts
@@ -23,3 +23,24 @@ export const navToHeader = async (page: Page, navItems: string[], headerText: st
   await expect(header).toBeVisible();
   return header;
 };
+
+/**
+ * Look for an element containing text, and then click a sibling button containing closeText
+ */
+export const findAndClose = async (
+  page: Page,
+  text: string,
+  toastRole: string = 'status',
+  closeText: string = 'Close'
+) => {
+  // Verify the popup text is visible.
+  await expect(page.locator(`:has-text("${text}")[role="status"]`)).toBeVisible();
+
+  // Find the 'Close' button that is a sibling of the element containing the specified text.
+  const closeBtn = await page.locator(
+    `:has-text("${text}")[role="status"] ~ button[aria-label="Close"]`
+  );
+
+  // Click the 'Close' button.
+  await closeBtn.click();
+};

--- a/e2e/utils/shared.ts
+++ b/e2e/utils/shared.ts
@@ -25,20 +25,20 @@ export const navToHeader = async (page: Page, navItems: string[], headerText: st
 };
 
 /**
- * Look for an element containing text, and then click a sibling button containing closeText
+ * Look for an element containing text, and then click a sibling close button
  */
 export const findAndClose = async (
   page: Page,
   text: string,
-  toastRole: string = 'status',
-  closeText: string = 'Close'
+  role: string = 'status',
+  closeLabel: string = 'Close'
 ) => {
   // Verify the popup text is visible.
-  await expect(page.locator(`:has-text("${text}")[role="status"]`)).toBeVisible();
+  await expect(page.locator(`:has-text("${text}")[role="${role}"]`)).toBeVisible();
 
   // Find the 'Close' button that is a sibling of the element containing the specified text.
   const closeBtn = await page.locator(
-    `:has-text("${text}")[role="status"] ~ button[aria-label="Close"]`
+    `:has-text("${text}")[role="${role}"] ~ button[aria-label="${closeLabel}"]`
   );
 
   // Click the 'Close' button.


### PR DESCRIPTION
### What does it do?

closes the "saved" notification box

### Why is it needed?

the tests run fast enough that multiple "saved" boxes appear at once, so the checks for finding one saved box fail because there are more than one

### How to test it?

e2e tests should pass

### Related issue(s)/PR(s)

DX-1295