### PR TITLE
fix(releases): On edit release error dont close modal 

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseModal.tsx
@@ -16,7 +16,7 @@ import {
   Combobox,
   ComboboxOption,
 } from '@strapi/design-system';
-import { formatISO, parse } from 'date-fns';
+import { formatISO } from 'date-fns';
 import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import { Formik, Form, useFormikContext } from 'formik';
 import { useIntl } from 'react-intl';

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -898,6 +898,7 @@ const ReleaseDetailsPage = () => {
           defaultMessage: 'Release updated.',
         }),
       });
+      toggleEditReleaseModal();
     } else if (isAxiosError(response.error)) {
       // When the response returns an object with 'error', handle axios error
       toggleNotification({
@@ -911,8 +912,6 @@ const ReleaseDetailsPage = () => {
         message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
-
-    toggleEditReleaseModal();
   };
 
   const handleDeleteRelease = async () => {


### PR DESCRIPTION

### What does it do?

On edit release error, don't close modal and user should be able to edit details. 
Previously it used to close irrespective of the status
 
### How to test it?
On editing release, if error appears it should not close the modal.