### PR TITLE
fix(admin): force an absolute URL if the BACKEND_URL is relative

### DIFF
--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -3,6 +3,7 @@ import { getFetchClient } from '@strapi/helper-plugin';
 import { createRoot } from 'react-dom/client';
 
 import { StrapiApp, StrapiAppConstructorArgs } from './StrapiApp';
+import { createAbsoluteUrl } from './utils/urls';
 
 import type { FeaturesService } from '@strapi/types';
 
@@ -27,7 +28,7 @@ const renderAdmin = async (
      *
      * To ensure that the backendURL is always set, we use the window.location.origin as a fallback.
      */
-    backendURL: process.env.STRAPI_ADMIN_BACKEND_URL || window.location.origin,
+    backendURL: createAbsoluteUrl(process.env.STRAPI_ADMIN_BACKEND_URL),
     isEE: false,
     telemetryDisabled: process.env.STRAPI_TELEMETRY_DISABLED === 'true' ? true : false,
     future: {

--- a/packages/core/admin/admin/src/utils/tests/urls.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/urls.test.ts
@@ -1,0 +1,21 @@
+import { createAbsoluteUrl } from '../urls';
+
+describe('urls', () => {
+  describe('createAbsoluteUrl', () => {
+    it('should return the url if it is an absolute URL', () => {
+      expect(createAbsoluteUrl('https://example.com')).toMatchInlineSnapshot(
+        `"https://example.com"`
+      );
+    });
+
+    it('should return the window.location.origin if the url is not provided', () => {
+      expect(createAbsoluteUrl()).toMatchInlineSnapshot(`"http://localhost:1337"`);
+    });
+
+    it('should return the window.location.origin prefixed to the provided url if the url is relative', () => {
+      expect(createAbsoluteUrl('/example')).toMatchInlineSnapshot(
+        `"http://localhost:1337/example"`
+      );
+    });
+  });
+});

--- a/packages/core/admin/admin/src/utils/tests/urls.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/urls.test.ts
@@ -17,5 +17,9 @@ describe('urls', () => {
         `"http://localhost:1337/example"`
       );
     });
+
+    it('should handle protocol relative URLs', () => {
+      expect(createAbsoluteUrl('//example.com')).toMatchInlineSnapshot(`"http://example.com/"`);
+    });
   });
 });

--- a/packages/core/admin/admin/src/utils/urls.ts
+++ b/packages/core/admin/admin/src/utils/urls.ts
@@ -1,0 +1,17 @@
+/**
+ * @description Creates an absolute URL, if there is no URL or it
+ * is relative, we use the `window.location.origin` as a fallback.
+ * IF it's an absolute URL, we return it as is.
+ */
+const createAbsoluteUrl = (url?: string): string => {
+  if (!url) {
+    return window.location.origin;
+  }
+  if (url.startsWith('/')) {
+    return new URL(url, window.location.origin).toString();
+  } else {
+    return url;
+  }
+};
+
+export { createAbsoluteUrl };

--- a/packages/core/admin/admin/src/utils/urls.ts
+++ b/packages/core/admin/admin/src/utils/urls.ts
@@ -8,6 +8,10 @@ const createAbsoluteUrl = (url?: string): string => {
     return window.location.origin;
   }
   if (url.startsWith('/')) {
+    /**
+     * This will also manage protocol relative URLs which is fine because
+     * as we can see from the test, we still get the expected result.
+     */
     return new URL(url, window.location.origin).toString();
   } else {
     return url;


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* enforces the `BACKEND_URL` to always be an absolute URL falling back to use `window.location.origin` in cases where it's relative or for some reason does not exist.

### Why is it needed?

* the `url` property of the `server` config file can be relative and this currently breaks the `appendSearchParams` helper. Realistically, we always want it to be absolute.

### Related issue(s)/PR(s)

* resolves #18175
* resolves DX-1312
