### PR TITLE
[v5] fix: move NotFoundPage into authenticated admin panel routes

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -725,11 +725,11 @@ class StrapiApp {
                   ),
                 })),
                 ...getBaseEERoutes(),
+                {
+                  path: '*',
+                  element: <NotFoundPage />,
+                },
               ],
-            },
-            {
-              path: '*',
-              element: <NotFoundPage />,
             },
           ],
         },


### PR DESCRIPTION
### What does it do?

Moves the v5 NotFoundPAge into the AuthenticatedLayout of the Admin panel.

### Why is it needed?

_Environment: development
OS: darwin-arm64
Strapi Version: 5.0.0-beta.1
Node/Yarn Version: yarn/1.22.19 npm/? node/v18.18.0 darwin arm64
Edition: Community
Database: sqlite_


Fixes (see screenrecording):
1. Showing the not-found page in full browser width, so missing the left menu.
2. Not redirecting an unauthenticated user to login for a not-found route.

https://github.com/strapi/strapi/assets/31662805/e14b9cb7-09a9-4e32-a864-be800f7e5992

### How to test it?

1. Login and navigate to /admin/not-existing-route
2. The page should show the `LeftMenu` and `NotFoundPage`

3. Logout and navigate to /admin/not-existing-route
4. User should be redirected to /auth/login

#### Fixed screenrecording:

https://github.com/strapi/strapi/assets/31662805/4c745e84-1eef-44d7-b138-65e2f7588e94
