### PR TITLE
feat: support media deep filtering & relation shortcut filters

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -7,6 +7,7 @@ backend:
   - 'packages/{utils,generators,cli,providers}/**'
   - 'packages/core/*/{lib,bin,ee}/**'
   - 'tests/api/**'
+  - 'packages/core/database/**'
 frontend:
   - '.github/actions/yarn-nm-install/*.yml'
   - '.github/workflows/**'

--- a/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
+++ b/examples/getstarted/src/api/kitchensink/content-types/kitchensink/schema.json
@@ -134,6 +134,12 @@
       "type": "relation",
       "relation": "morphToMany"
     },
+    "morph_one": {
+      "type": "relation",
+      "relation": "morphOne",
+      "target": "api::tag.tag",
+      "morphBy": "taggable"
+    },
     "custom_field": {
       "type": "customField",
       "customField": "plugin::color-picker.color"

--- a/examples/getstarted/src/api/tag/content-types/tag/schema.json
+++ b/examples/getstarted/src/api/tag/content-types/tag/schema.json
@@ -38,6 +38,19 @@
       "relation": "oneToOne",
       "target": "api::kitchensink.kitchensink",
       "mappedBy": "one_to_one_tag"
+    },
+    "taggable": {
+      "type": "relation",
+      "relation": "morphToOne",
+      "morphColumn": {
+        "typeColumn": {
+          "name": "taggable_type"
+        },
+        "idColumn": {
+          "name": "taggable_id",
+          "referencedColumn": "id"
+        }
+      }
     }
   }
 }

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -209,13 +209,13 @@ const createManyToMany = (
  *  set info in the traget
  */
 const createMorphToOne = (attributeName: string, attribute: Relation.MorphToOne) => {
-  const idColumnName = 'target_id';
-  const typeColumnName = 'target_type';
+  // TODO: (breaking) support ${attributeName}_id and ${attributeName}_type as default column names
+  const idColumnName = `target_id`;
+  const typeColumnName = `target_type`;
 
   Object.assign(attribute, {
     owner: true,
-    morphColumn: {
-      // TODO: add referenced column
+    morphColumn: attribute.morphColumn ?? {
       typeColumn: {
         name: typeColumnName,
       },
@@ -225,8 +225,6 @@ const createMorphToOne = (attributeName: string, attribute: Relation.MorphToOne)
       },
     },
   });
-
-  // TODO: implement bidirectional
 };
 
 /**

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { isArray, castArray, keys, isPlainObject } from 'lodash/fp';
+import { isArray, castArray, isPlainObject } from 'lodash/fp';
 import type { Knex } from 'knex';
 
-import { isOperatorOfType } from '@strapi/utils';
+import { isOperator, isOperatorOfType } from '@strapi/utils';
 import * as types from '../../utils/types';
 import { createField } from '../../fields';
 import { createJoin } from './join';
@@ -11,6 +11,8 @@ import { isKnexQuery } from '../../utils/knex';
 
 import type { Ctx } from '../types';
 import type { Attribute } from '../../types';
+
+type WhereCtx = Ctx & { alias?: string; isGroupRoot?: boolean };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => isPlainObject(value);
 
@@ -72,7 +74,34 @@ const processNested = (where: unknown, ctx: WhereCtx) => {
   return processWhere(where, ctx);
 };
 
-type WhereCtx = Ctx & { alias?: string };
+const processRelationWhere = (where: unknown, ctx: WhereCtx) => {
+  const { qb, alias } = ctx;
+
+  const idAlias = qb.aliasColumn('id', alias);
+  if (!isRecord(where)) {
+    return { [idAlias]: where };
+  }
+
+  const keys = Object.keys(where);
+  const operatorKeys = keys.filter((key) => isOperator(key));
+
+  if (operatorKeys.length > 0 && operatorKeys.length !== keys.length) {
+    throw new Error(`Operator and non-operator keys cannot be mixed in a relation where clause`);
+  }
+
+  if (operatorKeys.length > 1) {
+    throw new Error(
+      `Only one operator key is allowed in a relation where clause found ${operatorKeys}`
+    );
+  }
+
+  if (operatorKeys.length === 1) {
+    const operator = operatorKeys[0];
+    return { [idAlias]: { [operator]: processNested(where[operator], ctx) } };
+  }
+
+  return processWhere(where, ctx);
+};
 
 /**
  * Process where parameter
@@ -100,8 +129,12 @@ function processWhere(
   for (const key of Object.keys(where)) {
     const value = where[key];
 
-    // if operator $and $or then loop over them
-    if (isOperatorOfType('group', key) && Array.isArray(value)) {
+    // if operator $and $or -> process recursively
+    if (isOperatorOfType('group', key)) {
+      if (!Array.isArray(value)) {
+        throw new Error(`Operator ${key} must be an array`);
+      }
+
       filters[key] = value.map((sub) => processNested(sub, ctx));
       continue;
     }
@@ -132,16 +165,12 @@ function processWhere(
         attribute,
       });
 
-      let nestedWhere = processNested(value, {
+      const nestedWhere = processRelationWhere(value, {
         db,
         qb,
         alias: subAlias,
         uid: attribute.target,
       });
-
-      if (!isRecord(nestedWhere) || isOperatorOfType('where', keys(nestedWhere)[0])) {
-        nestedWhere = { [qb.aliasColumn('id', subAlias)]: nestedWhere };
-      }
 
       // TODO: use a better merge logic (push to $and when collisions)
       Object.assign(filters, nestedWhere);

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -91,7 +91,7 @@ const processRelationWhere = (where: unknown, ctx: WhereCtx) => {
 
   if (operatorKeys.length > 1) {
     throw new Error(
-      `Only one operator key is allowed in a relation where clause found ${operatorKeys}`
+      `Only one operator key is allowed in a relation where clause, but found: ${operatorKeys}`
     );
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

> ⚠️  Needs testing & qa

### What does it do?

- Implements https://github.com/strapi/strapi/issues/12225 
- Add support for deep media (polymorphic) queries like `filters[media][name][$contains]=xxx`
- Support shortcut relational queries `filters[relation] = ${subQuery}` => will auto apply to the id

### Why is it needed?

- Improve DX

### How to test it?

- Follow the examples in the issue mentionned. 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
