### PR TITLE
Admin user last name null validation error #19633

### DIFF
--- a/packages/core/admin/server/src/content-types/User.ts
+++ b/packages/core/admin/server/src/content-types/User.ts
@@ -29,6 +29,8 @@ export default {
       minLength: 1,
       configurable: false,
       required: false,
+      nullable:true,
+
     },
     username: {
       type: 'string',


### PR DESCRIPTION
https://github.com/strapi/strapi/assets/67168239/9d223a48-6f1a-418e-a4b1-4f849d8a9482

**What does it do?**

The fix addresses an issue where attempting to save a user profile without entering a last name in the Strapi admin panel triggers a validation error. It ensures that the Last name field can be left empty without causing an error, aligning with its non-required status.

**Technical Changes**:

Updated the schema definition of the Last name field in the user model to allow null values.
Before the fix, the Last name field's schema did not support null values, causing the validation error.
After the fix, the Last name field's schema was modified to include the nullable: true property, enabling it to accept null values.

**Why is it needed**?

The issue arose due to the Last name field's schema not allowing null values, despite it being non-required. This led to a validation error when attempting to save a user profile without entering a last name. The fix ensures that users can save their profiles without providing a last name, addressing this inconvenience and aligning with the field's non-required status.

**How to test it**:

Environment: Access the Strapi admin panel.
Path to Verify Behavior:
Log in to the admin panel of your Strapi instance.
Navigate to settings and select the user submenu.
Choose an existing user profile to edit.
Leave the Last name field empty.
Attempt to save the changes.
Verify that the changes to the user profile, excluding the Last name field, are saved successfully without triggering any validation errors.

**Related Issue(s)/PR(s)**:
None
