### PR TITLE
fix(docs): fix comment that breaks docs build

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -568,6 +568,7 @@ namespace Filters {
        *    }
        *  }
        * }
+       * ```
        */
       $and?: Array<Record<string, Record<string, string | Record<string, string>>>>;
     };


### PR DESCRIPTION
### What does it do?

fixes a comment with a code example that breaks the docs build parser (in turn causing vercel deployment to fail)

### Why is it needed?

it was broken

### How to test it?

docs should build (albeit with a bunch of broken links we need to fix later)

### Related issue(s)/PR(s)
