### PR TITLE
fix: add session token in aws iam for s3

### DIFF
--- a/packages/providers/upload-aws-s3/src/utils.ts
+++ b/packages/providers/upload-aws-s3/src/utils.ts
@@ -8,6 +8,12 @@ interface BucketInfo {
   err?: string;
 }
 
+interface AWSCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
 export function isUrlFromBucket(fileUrl: string, bucketName: string, baseUrl = ''): boolean {
   const url = new URL(fileUrl);
 
@@ -109,10 +115,14 @@ export const extractCredentials = (options: InitOptions): AwsCredentialIdentity 
   }
   // V5
   if (options.s3Options?.credentials) {
-    return {
+    const credentials : AWSCredentials = {
       accessKeyId: options.s3Options.credentials.accessKeyId,
-      secretAccessKey: options.s3Options.credentials.secretAccessKey,
+      secretAccessKey: options.s3Options.credentials.secretAccessKey
     };
+    if(options.s3Options.credentials.sessionToken) {
+      credentials.sessionToken = options.s3Options.credentials.sessionToken;
+    }
+    return credentials;
   }
   return null;
 };


### PR DESCRIPTION
### What does it do?

It adds the session token in aws credentials to access S3 when using temporary credentials.

### Why is it needed?

In our local development environment, we use SSO to connect with AWS and use its services. For that purpose, to interact with AWS we use temporary credentials that we get from `@aws-sdk/credentials-provider` package using `fromSSO` function. These credentials must include session token for AWS to validate the access keys.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

<img width="796" alt="Screenshot 2024-04-02 at 2 58 21 PM" src="https://github.com/strapi/strapi/assets/45253701/8894c5a6-d52d-4c12-8a59-bc706e675b63">


### How to test it?

In S3 Plugin, pass only accessKeyId and secretAccessKey, it should work correctly and manage files in S3.
  In S3 Plugin, if we are using SSO and have session token then pass sessionToken along with access and secret key, it should work correctly.
In S3 Plugin, if we are using SSO and DO NOT sessionToken along with access and secret key, it should throw access denied error.

