### PR TITLE
chore(history): simplify the meta object

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
@@ -56,6 +56,12 @@ describe('VersionHeader', () => {
       data: {
         title: 'Test Title',
       },
+      meta: {
+        unknownAttributes: {
+          added: {},
+          removed: {},
+        },
+      },
     };
 
     it('should display the correct title and subtitle for a non-localized entry', () => {
@@ -129,6 +135,12 @@ describe('VersionHeader', () => {
       locale: null,
       data: {
         title: 'Test Title',
+      },
+      meta: {
+        unknownAttributes: {
+          added: {},
+          removed: {},
+        },
       },
     };
 

--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -1,4 +1,4 @@
-import type { UID } from '@strapi/types';
+import type { Struct, UID } from '@strapi/types';
 import { scheduleJob } from 'node-schedule';
 import { HISTORY_VERSION_UID } from '../../constants';
 import { createHistoryService } from '../history';
@@ -188,7 +188,7 @@ describe('history-version service', () => {
           title: {
             type: 'string',
           },
-        },
+        } as Struct.SchemaAttributes,
         status: 'draft' as const,
       };
 
@@ -216,7 +216,7 @@ describe('history-version service', () => {
           title: {
             type: 'string',
           },
-        },
+        } as Struct.SchemaAttributes,
         status: null,
       };
 

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -175,15 +175,14 @@ const createHistoryService = ({ strapi }: { strapi: Core.LoadedStrapi }) => {
       ]);
 
       const versionsWithMeta = results.map((version) => {
-        const { added, removed } = getSchemaAttributesDiff(
-          version.schema,
-          strapi.getModel(params.contentType).attributes
-        );
-        const hasSchemaDiff = Object.keys(added).length > 0 || Object.keys(removed).length > 0;
-
         return {
           ...version,
-          ...(hasSchemaDiff ? { meta: { unknownAttributes: { added, removed } } } : {}),
+          meta: {
+            unknownAttributes: getSchemaAttributesDiff(
+              version.schema,
+              strapi.getModel(params.contentType).attributes
+            ),
+          },
         };
       });
 

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -1,4 +1,4 @@
-import type { Data, UID } from '@strapi/types';
+import type { Data, Struct, UID } from '@strapi/types';
 import { type errors } from '@strapi/utils';
 
 /**
@@ -12,7 +12,7 @@ export interface CreateHistoryVersion {
   locale: string | null;
   status: 'draft' | 'published' | 'modified' | null;
   data: Record<string, unknown>;
-  schema: Record<string, unknown>;
+  schema: Struct.SchemaAttributes;
 }
 
 interface Locale {
@@ -31,10 +31,10 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
-  meta?: {
-    unknownAttributes?: {
-      added: Record<string, unknown>;
-      removed: Record<string, unknown>;
+  meta: {
+    unknownAttributes: {
+      added: Struct.SchemaAttributes;
+      removed: Struct.SchemaAttributes;
     };
   };
 }


### PR DESCRIPTION
### What does it do?

- Make the `meta.unknownAttributes` constant in the response
- Use the strapi type for schema attributes

### Why is it needed?

- To simplify and have a more predictable response object

### How to test it?

- Everything should work the same. You should always be able to access `versions.meta.unknownAttributes.added | .removed`

