### PR TITLE
fix: name validation

### DIFF
--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -85,11 +85,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     // eslint-disable-next-line no-control-regex
     return /[<>:"/\\|?*\u0000-\u001F]/g;
   }
-  
+
   function windowsReservedNameRegex() {
     return /^(con|prn|aux|nul|com\d|lpt\d)$/i;
   }
-  
+
   /**
    * Copied from https://github.com/sindresorhus/valid-filename package
    */
@@ -105,7 +105,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     }
     return true;
   }
-  
+
   async function emitEvent(event: string, data: Record<string, any>) {
     const modelDef = strapi.getModel(FILE_MODEL_UID);
     const sanitizedData = await sanitize.sanitizers.defaultSanitizeOutput(

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -81,6 +81,31 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     return tmpWorkingDirectory;
   };
 
+  function filenameReservedRegex() {
+    // eslint-disable-next-line no-control-regex
+    return /[<>:"/\\|?*\u0000-\u001F]/g;
+  }
+  
+  function windowsReservedNameRegex() {
+    return /^(con|prn|aux|nul|com\d|lpt\d)$/i;
+  }
+  
+  /**
+   * Copied from https://github.com/sindresorhus/valid-filename package
+   */
+  function isValidFilename(string: string) {
+    if (!string || string.length > 255) {
+      return false;
+    }
+    if (filenameReservedRegex().test(string) || windowsReservedNameRegex().test(string)) {
+      return false;
+    }
+    if (string === '.' || string === '..') {
+      return false;
+    }
+    return true;
+  }
+  
   async function emitEvent(event: string, data: Record<string, any>) {
     const modelDef = strapi.getModel(FILE_MODEL_UID);
     const sanitizedData = await sanitize.sanitizers.defaultSanitizeOutput(
@@ -109,12 +134,21 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
   ): Promise<Omit<UploadableFile, 'getStream'>> {
     const fileService = getService('file');
 
+    if (!isValidFilename(filename)) {
+      throw new ApplicationError('File name contains invalid characters');
+    }
+
     let ext = path.extname(filename);
     if (!ext) {
       ext = `.${extension(type)}`;
     }
     const usedName = (fileInfo.name || filename).normalize();
     const basename = path.basename(usedName, ext);
+
+    // Prevent null characters in file name
+    if (!isValidFilename(filename)) {
+      throw new ApplicationError('File name contains invalid characters');
+    }
 
     const entity: Omit<UploadableFile, 'getStream'> = {
       name: usedName,


### PR DESCRIPTION
### What does it do?

Adds the name validation that was accidentally lost during a merge conflict resolution from `develop -> v5/main`

### Why is it needed?

Tests are failing because some code was removed

### How to test it?

Tests should pass with upload file name validation

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
