### PR TITLE
[v5] fix(admin): remove double modal toggle for on delete RBAC role

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -81,7 +81,6 @@ const ListPage = () => {
         });
       }
     }
-    handleToggleModal();
   };
 
   const handleNewRoleClick = () => navigate('new');


### PR DESCRIPTION
### What does it do?

Removes the double modal toggle for the delete confirmation for RBAC roles in the admin panel.

### Why is it needed?

The modal is toggled off and back on, because ConfirmDialog executes onClose after onConfirm has been successful. See code reference below:

https://github.com/strapi/strapi/blob/971168147bacca33746fef2a1c66c1f17603eed6/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx#L265-L269

https://github.com/strapi/strapi/blob/971168147bacca33746fef2a1c66c1f17603eed6/packages/core/admin/admin/src/components/ConfirmDialog.tsx#L84-L85

### How to test it?

1. npx create-strapi-app@beta strapi-v5-delete-role --quickstart
2. Create super admin
3. Go to Settings > ADMINISTRATION PANEL > Roles
4. Delete role Editor

### Related issue(s)/PR(s)

fixes: #19962