### PR TITLE
feat: register internal migrations dynamically

### DIFF
--- a/packages/core/database/src/migrations/common.ts
+++ b/packages/core/database/src/migrations/common.ts
@@ -16,7 +16,7 @@ export interface InternalMigrationProvider {
   down(): Promise<void>;
 }
 export interface MigrationProvider {
-  internal: InternalMigrationProvider;
+  providers: { internal: InternalMigrationProvider };
   shouldRun(): Promise<boolean>;
   up(): Promise<void>;
   down(): Promise<void>;

--- a/packages/core/database/src/migrations/common.ts
+++ b/packages/core/database/src/migrations/common.ts
@@ -3,7 +3,20 @@ import type { Knex } from 'knex';
 
 import type { Database } from '..';
 
+export interface UserMigrationProvider {
+  shouldRun(): Promise<boolean>;
+  up(): Promise<void>;
+  down(): Promise<void>;
+}
+
+export interface InternalMigrationProvider {
+  register(migration: Migration): void;
+  shouldRun(): Promise<boolean>;
+  up(): Promise<void>;
+  down(): Promise<void>;
+}
 export interface MigrationProvider {
+  internal: InternalMigrationProvider;
   shouldRun(): Promise<boolean>;
   up(): Promise<void>;
   down(): Promise<void>;

--- a/packages/core/database/src/migrations/index.ts
+++ b/packages/core/database/src/migrations/index.ts
@@ -12,7 +12,9 @@ export const createMigrationsProvider = (db: Database): MigrationProvider => {
   const providers = [userProvider, internalProvider];
 
   return {
-    internal: internalProvider,
+    providers: {
+      internal: internalProvider,
+    },
     async shouldRun() {
       const shouldRunResponses = await Promise.all(
         providers.map((provider) => provider.shouldRun())

--- a/packages/core/database/src/migrations/index.ts
+++ b/packages/core/database/src/migrations/index.ts
@@ -7,9 +7,12 @@ import type { Database } from '..';
 export type { MigrationProvider };
 
 export const createMigrationsProvider = (db: Database): MigrationProvider => {
-  const providers = [createUserMigrationProvider(db), createInternalMigrationProvider(db)];
+  const userProvider = createUserMigrationProvider(db);
+  const internalProvider = createInternalMigrationProvider(db);
+  const providers = [userProvider, internalProvider];
 
   return {
+    internal: internalProvider,
     async shouldRun() {
       const shouldRunResponses = await Promise.all(
         providers.map((provider) => provider.shouldRun())

--- a/packages/core/database/src/migrations/internal.ts
+++ b/packages/core/database/src/migrations/internal.ts
@@ -4,26 +4,36 @@ import { wrapTransaction } from './common';
 import { internalMigrations } from './internal-migrations';
 import { createStorage } from './storage';
 
-import type { MigrationProvider } from './common';
+import type { InternalMigrationProvider, Migration } from './common';
 import type { Database } from '..';
 
-export const createInternalMigrationProvider = (db: Database): MigrationProvider => {
+export const createInternalMigrationProvider = (db: Database): InternalMigrationProvider => {
   const context = { db };
+  const migrations: Migration[] = [...internalMigrations];
 
-  const umzugProvider = new Umzug({
-    storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
-    logger: console,
-    context,
-    migrations: internalMigrations.map((migration) => {
-      return {
-        name: migration.name,
-        up: wrapTransaction(context.db)(migration.up),
-        down: wrapTransaction(context.db)(migration.down),
-      };
-    }),
-  });
+  const createProvider = () => {
+    return new Umzug({
+      storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
+      logger: console,
+      context,
+      migrations: migrations.map((migration) => {
+        return {
+          name: migration.name,
+          up: wrapTransaction(context.db)(migration.up),
+          down: wrapTransaction(context.db)(migration.down),
+        };
+      }),
+    });
+  };
+
+  let umzugProvider = createProvider();
 
   return {
+    async register(migration: Migration) {
+      migrations.push(migration);
+      // Recreate the umzug provider to include the new migration
+      umzugProvider = createProvider();
+    },
     async shouldRun() {
       const pendingMigrations = await umzugProvider.pending();
       return pendingMigrations.length > 0;

--- a/packages/core/database/src/migrations/internal.ts
+++ b/packages/core/database/src/migrations/internal.ts
@@ -10,44 +10,34 @@ import type { Database } from '..';
 export const createInternalMigrationProvider = (db: Database): InternalMigrationProvider => {
   const context = { db };
   const migrations: Migration[] = [...internalMigrations];
-  let umzug: Umzug;
 
-  const getUmzug = () => {
-    if (umzug) {
-      return umzug;
-    }
-
-    return new Umzug({
-      storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
-      logger: console,
-      context,
-      migrations: migrations.map((migration) => {
+  const umzugProvider = new Umzug({
+    storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
+    logger: console,
+    context,
+    migrations: () =>
+      migrations.map((migration) => {
         return {
           name: migration.name,
           up: wrapTransaction(context.db)(migration.up),
           down: wrapTransaction(context.db)(migration.down),
         };
       }),
-    });
-  };
+  });
 
   return {
     async register(migration: Migration) {
-      if (umzug !== undefined) {
-        throw new Error('Cannot register new migrations after the provider has been created');
-      }
-
       migrations.push(migration);
     },
     async shouldRun() {
-      const pendingMigrations = await getUmzug().pending();
+      const pendingMigrations = await umzugProvider.pending();
       return pendingMigrations.length > 0;
     },
     async up() {
-      await getUmzug().up();
+      await umzugProvider.up();
     },
     async down() {
-      await getUmzug().down();
+      await umzugProvider.down();
     },
   };
 };

--- a/packages/core/database/src/migrations/users.ts
+++ b/packages/core/database/src/migrations/users.ts
@@ -3,7 +3,7 @@ import { Umzug } from 'umzug';
 
 import { createStorage } from './storage';
 import { wrapTransaction } from './common';
-import type { MigrationProvider, MigrationResolver } from './common';
+import type { MigrationResolver, UserMigrationProvider } from './common';
 import type { Database } from '..';
 
 // TODO: check multiple commands in one sql statement
@@ -37,7 +37,7 @@ const migrationResolver: MigrationResolver = ({ name, path, context }) => {
   };
 };
 
-export const createUserMigrationProvider = (db: Database): MigrationProvider => {
+export const createUserMigrationProvider = (db: Database): UserMigrationProvider => {
   const dir = db.config.settings.migrations.dir;
 
   fse.ensureDirSync(dir);


### PR DESCRIPTION
### What does it do?

Allows to dynamically register internal migrations:

```ts
strapi.db.migrations.providers.internal.register({
  name: 'v5-train'
  up: () => {}
})
```

The order of the migrations will always be:
 
User migrations -> Db Internal migrations ->  Dynamically registered internal migrations

### Why is it needed?
https://github.com/strapi/strapi/pull/19813
It was required to use the document service in one of the db migrations.

