### PR TITLE
fix(i18n): remove strapi dep to fix circular deps

### DIFF
--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -68,7 +68,6 @@
     "@strapi/admin-test-utils": "5.0.0-beta.1",
     "@strapi/pack-up": "5.0.0-beta.1",
     "@strapi/plugin-content-manager": "5.0.0-beta.1",
-    "@strapi/strapi": "5.0.0-beta.1",
     "@strapi/types": "5.0.0-beta.1",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7849,7 +7849,6 @@ __metadata:
     "@strapi/icons": "npm:1.16.0"
     "@strapi/pack-up": "npm:5.0.0-beta.1"
     "@strapi/plugin-content-manager": "npm:5.0.0-beta.1"
-    "@strapi/strapi": "npm:5.0.0-beta.1"
     "@strapi/types": "npm:5.0.0-beta.1"
     "@strapi/utils": "npm:5.0.0-beta.1"
     "@testing-library/react": "npm:14.0.0"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* removes the `@strapi/strapi` dependency from `i18n`

### Why is it needed?

* it was creating a circular dep and it's not required
