### PR TITLE
chore: ignore nx cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,17 +101,13 @@ test-apps
 coverage
 
 ############################
-# Documentation
-############################
-
-dist
-
-############################
 # Builds
 ############################
 
 packages/generators/app/files/public/
 schema.graphql
+dist
+.nx
 
 ############################
 # Example app


### PR DESCRIPTION
### What does it do?

ignores the `.nx` folder

### Why is it needed?

doing a build currently shows the nx cache as new files in git

### How to test it?

build and you shouldn't see .nx folders in git status

### Related issue(s)/PR(s)

