### PR TITLE
Refactor Link to v2

### DIFF
--- a/packages/plugins/cloud/admin/src/pages/HomePage.tsx
+++ b/packages/plugins/cloud/admin/src/pages/HomePage.tsx
@@ -4,7 +4,8 @@
  *
  */
 
-import { Box, GridLayout, Flex, Typography, Link } from '@strapi/design-system';
+import { Box, GridLayout, Flex, Typography } from '@strapi/design-system';
+import { Link } from '@strapi/design-system/v2';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 


### PR DESCRIPTION
### What does it do?

It replaces the imports of Link to use the v2 of the `@strapi/design-system`

### Why is it needed?

To use the latest version of the Link component.

### How to test it?

Check that the frontend tests are passing and that the Cloud HomePage still works as expected

### Related issue(s)/PR(s)
CONTENT-1485