### PR TITLE
enhancement: add relation data to history versions response

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
@@ -52,6 +52,7 @@ describe('VersionHeader', () => {
       createdAt: '2022-01-01T00:00:00Z',
       status: 'draft' as const,
       schema: {},
+      componentsSchemas: {},
       locale: null,
       data: {
         title: 'Test Title',
@@ -132,6 +133,7 @@ describe('VersionHeader', () => {
       createdAt: '2022-01-01T00:00:00Z',
       status: 'draft' as const,
       schema: {},
+      componentsSchemas: {},
       locale: null,
       data: {
         title: 'Test Title',

--- a/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/history.test.ts
@@ -1,4 +1,4 @@
-import type { Struct, UID } from '@strapi/types';
+import type { UID } from '@strapi/types';
 import { scheduleJob } from 'node-schedule';
 import { HISTORY_VERSION_UID } from '../../constants';
 import { createHistoryService } from '../history';
@@ -23,7 +23,7 @@ const mockGetRequestContext = jest.fn(() => {
     },
   };
 });
-
+const mockFindOne = jest.fn();
 const mockStrapi = {
   plugins: {
     'content-manager': {
@@ -35,7 +35,6 @@ const mockStrapi = {
     i18n: {
       service: jest.fn(() => ({
         getDefaultLocale: jest.fn().mockReturnValue('en'),
-        find: jest.fn(),
       })),
     },
   },
@@ -65,7 +64,7 @@ const mockStrapi = {
     },
   },
   documents: jest.fn(() => ({
-    findOne: jest.fn(),
+    findOne: mockFindOne,
   })),
   config: {
     get: () => undefined,
@@ -73,12 +72,41 @@ const mockStrapi = {
   requestContext: {
     get: mockGetRequestContext,
   },
-  contentType(uid: UID.ContentType) {
+  getModel(uid: UID.Schema) {
     if (uid === 'api::article.article') {
       return {
         attributes: {
           title: {
             type: 'string',
+          },
+          relation: {
+            type: 'relation',
+            target: 'api::category.category',
+          },
+          component: {
+            type: 'component',
+            component: 'some.component',
+          },
+          media: {
+            type: 'media',
+          },
+        },
+      };
+    }
+
+    if (uid === 'some.component') {
+      return {
+        attributes: {
+          title: {
+            type: 'string',
+          },
+          relation: {
+            type: 'relation',
+            target: 'api::restaurant.restaurant',
+          },
+          medias: {
+            type: 'media',
+            multiple: true,
           },
         },
       };
@@ -96,140 +124,192 @@ describe('history-version service', () => {
     jest.useRealTimers();
   });
 
-  describe('boostrap', () => {
-    it('inits service only once', () => {
-      historyService.bootstrap();
-      historyService.bootstrap();
-      // @ts-expect-error - ignore
-      expect(mockStrapi.documents.use).toHaveBeenCalledTimes(1);
-    });
+  it('inits service only once', () => {
+    historyService.bootstrap();
+    historyService.bootstrap();
+    // @ts-expect-error - ignore
+    expect(mockStrapi.documents.use).toHaveBeenCalledTimes(1);
+  });
 
-    it('saves relevant document actions in history', async () => {
-      const context = {
-        action: 'create',
-        contentType: {
-          uid: 'api::article.article',
+  it('saves relevant document actions in history', async () => {
+    const context = {
+      action: 'create',
+      contentType: {
+        uid: 'api::article.article',
+      },
+      args: [
+        {
+          locale: 'fr',
         },
-        args: [
-          {
-            locale: 'fr',
+      ],
+    };
+
+    const next = jest.fn((context) => ({ ...context, documentId: 'document-id' }));
+    await historyService.bootstrap();
+    // @ts-expect-error - ignore
+    const historyMiddlewareFunction = mockStrapi.documents.use.mock.calls[0][0];
+
+    // Check that we don't break the middleware chain
+    await historyMiddlewareFunction(context, next);
+    expect(next).toHaveBeenCalled();
+
+    // Ensure we're only storing the data we need in the database
+    expect(mockFindOne).toHaveBeenLastCalledWith('document-id', {
+      locale: 'fr',
+      populate: {
+        component: {
+          populate: {
+            relation: {
+              fields: ['documentId', 'locale', 'publishedAt'],
+            },
+            medias: {
+              fields: ['id'],
+            },
           },
-        ],
-      };
-
-      const next = jest.fn((context) => ({ ...context, documentId: 'document-id' }));
-      await historyService.bootstrap();
-      // @ts-expect-error - ignore
-      const historyMiddlewareFunction = mockStrapi.documents.use.mock.calls[0][0];
-
-      // Check that we don't break the middleware chain
-      await historyMiddlewareFunction(context, next);
-      expect(next).toHaveBeenCalled();
-
-      // Create and update actions should be saved in history
-      expect(createMock).toHaveBeenCalled();
-      context.action = 'update';
-      await historyMiddlewareFunction(context, next);
-      expect(createMock).toHaveBeenCalledTimes(2);
-
-      // Publish and unpublish actions should be saved in history
-      createMock.mockClear();
-      await historyMiddlewareFunction(context, next);
-      context.action = 'unpublish';
-      await historyMiddlewareFunction(context, next);
-      expect(createMock).toHaveBeenCalledTimes(2);
-
-      // Other actions should be ignored
-      createMock.mockClear();
-      context.action = 'findOne';
-      await historyMiddlewareFunction(context, next);
-      context.action = 'delete';
-      await historyMiddlewareFunction(context, next);
-      expect(createMock).toHaveBeenCalledTimes(0);
-
-      // Non-api content types should be ignored
-      createMock.mockClear();
-      context.contentType.uid = 'plugin::upload.file';
-      context.action = 'create';
-      await historyMiddlewareFunction(context, next);
-      expect(createMock).toHaveBeenCalledTimes(0);
-
-      // Don't break middleware chain even if we don't save the action in history
-      next.mockClear();
-      await historyMiddlewareFunction(context, next);
-      expect(next).toHaveBeenCalled();
+        },
+        relation: {
+          fields: ['documentId', 'locale', 'publishedAt'],
+        },
+        media: {
+          fields: ['id'],
+        },
+      },
     });
 
-    it('should create a cron job that runs once a day', async () => {
-      // @ts-expect-error - this is a mock
-      const mockScheduleJob = scheduleJob.mockImplementationOnce(
-        jest.fn((rule, callback) => callback())
-      );
+    // Create and update actions should be saved in history
+    const createPayload = createMock.mock.calls.at(-1)[0].data;
+    expect(createPayload.schema).toEqual({
+      title: {
+        type: 'string',
+      },
+      relation: {
+        type: 'relation',
+        target: 'api::category.category',
+      },
+      component: {
+        type: 'component',
+        component: 'some.component',
+      },
+      media: {
+        type: 'media',
+      },
+    });
+    expect(createPayload.componentsSchemas).toEqual({
+      'some.component': {
+        title: {
+          type: 'string',
+        },
+        relation: {
+          type: 'relation',
+          target: 'api::restaurant.restaurant',
+        },
+        medias: {
+          type: 'media',
+          multiple: true,
+        },
+      },
+    });
+    context.action = 'update';
+    await historyMiddlewareFunction(context, next);
+    expect(createMock).toHaveBeenCalledTimes(2);
 
-      await historyService.bootstrap();
+    // Publish and unpublish actions should be saved in history
+    createMock.mockClear();
+    await historyMiddlewareFunction(context, next);
+    context.action = 'unpublish';
+    await historyMiddlewareFunction(context, next);
+    expect(createMock).toHaveBeenCalledTimes(2);
 
-      expect(mockScheduleJob).toHaveBeenCalledTimes(1);
-      expect(mockScheduleJob).toHaveBeenCalledWith('0 0 * * *', expect.any(Function));
+    // Other actions should be ignored
+    createMock.mockClear();
+    context.action = 'findOne';
+    await historyMiddlewareFunction(context, next);
+    context.action = 'delete';
+    await historyMiddlewareFunction(context, next);
+    expect(createMock).toHaveBeenCalledTimes(0);
+
+    // Non-api content types should be ignored
+    createMock.mockClear();
+    context.contentType.uid = 'plugin::upload.file';
+    context.action = 'create';
+    await historyMiddlewareFunction(context, next);
+    expect(createMock).toHaveBeenCalledTimes(0);
+
+    // Don't break middleware chain even if we don't save the action in history
+    next.mockClear();
+    await historyMiddlewareFunction(context, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('creates a history version with the author', async () => {
+    jest.useFakeTimers().setSystemTime(fakeDate);
+
+    const historyVersionData = {
+      contentType: 'api::article.article' as UID.ContentType,
+      data: {
+        title: 'My article',
+      },
+      locale: 'en',
+      relatedDocumentId: 'randomid',
+      schema: {
+        title: {
+          type: 'string' as const,
+        },
+      },
+      componentsSchemas: {},
+      status: 'draft' as const,
+    };
+
+    await historyService.createVersion(historyVersionData);
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        ...historyVersionData,
+        createdBy: userId,
+        createdAt: fakeDate,
+      },
     });
   });
 
-  describe('createVersion', () => {
-    it('creates a history version with the author', async () => {
-      jest.useFakeTimers().setSystemTime(fakeDate);
+  it('creates a history version without any author', async () => {
+    jest.useFakeTimers().setSystemTime(fakeDate);
 
-      const historyVersionData = {
-        contentType: 'api::article.article' as UID.ContentType,
-        data: {
-          title: 'My article',
+    const historyVersionData = {
+      contentType: 'api::article.article' as UID.ContentType,
+      data: {
+        title: 'My article',
+      },
+      locale: 'en',
+      relatedDocumentId: 'randomid',
+      componentsSchemas: {},
+      schema: {
+        title: {
+          type: 'string' as const,
         },
-        locale: 'en',
-        relatedDocumentId: 'randomid',
-        schema: {
-          title: {
-            type: 'string',
-          },
-        } as Struct.SchemaAttributes,
-        status: 'draft' as const,
-      };
+      },
+      status: null,
+    };
 
-      await historyService.createVersion(historyVersionData);
-      expect(createMock).toHaveBeenCalledWith({
-        data: {
-          ...historyVersionData,
-          createdBy: userId,
-          createdAt: fakeDate,
-        },
-      });
+    mockGetRequestContext.mockReturnValueOnce(null as any);
+
+    await historyService.createVersion(historyVersionData);
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        ...historyVersionData,
+        createdBy: undefined,
+        createdAt: fakeDate,
+      },
     });
+  });
 
-    it('creates a history version without any author', async () => {
-      jest.useFakeTimers().setSystemTime(fakeDate);
+  it('should create a cron job that runs once a day', async () => {
+    // @ts-expect-error - this is a mock
+    const mockScheduleJob = scheduleJob.mockImplementationOnce(
+      jest.fn((rule, callback) => callback())
+    );
 
-      const historyVersionData = {
-        contentType: 'api::article.article' as UID.ContentType,
-        data: {
-          title: 'My article',
-        },
-        locale: 'en',
-        relatedDocumentId: 'randomid',
-        schema: {
-          title: {
-            type: 'string',
-          },
-        } as Struct.SchemaAttributes,
-        status: null,
-      };
+    await historyService.bootstrap();
 
-      mockGetRequestContext.mockReturnValueOnce(null as any);
-
-      await historyService.createVersion(historyVersionData);
-      expect(createMock).toHaveBeenCalledWith({
-        data: {
-          ...historyVersionData,
-          createdBy: undefined,
-          createdAt: fakeDate,
-        },
-      });
-    });
+    expect(mockScheduleJob).toHaveBeenCalledTimes(1);
+    expect(mockScheduleJob).toHaveBeenCalledWith('0 0 * * *', expect.any(Function));
   });
 });

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -1,4 +1,4 @@
-import type { Core, Modules, UID, Data, Struct } from '@strapi/types';
+import type { Core, Modules, UID, Data, Schema } from '@strapi/types';
 import { contentTypes } from '@strapi/utils';
 import { omit, pick } from 'lodash/fp';
 
@@ -280,7 +280,7 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
        */
       const buildRelationReponse = async (
         values: EntryToPopulate[],
-        attributeSchema: Struct.SchemaAttributes[keyof Struct.SchemaAttributes]
+        attributeSchema: Schema.Attribute.AnyAttribute
       ): Promise<{ results: any[]; meta: { missingCount: number } }> => {
         return (
           values
@@ -311,6 +311,7 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
                       .documents(attributeSchema.target)
                       .findOne(entry.documentId, { locale: entry.locale || undefined });
                   }
+                  // For media assets, only the id is available, double check that we have it
                 } else if ('id' in entry) {
                   relatedEntry = await strapi.db
                     .query('plugin::upload.file')

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -10,6 +10,7 @@ import {
   CreateHistoryVersion,
   HistoryVersionDataResponse,
 } from '../../../../shared/contracts/history-versions';
+import { getSchemaAttributesDiff } from './utils';
 
 // Needed because the query engine doesn't return any types yet
 type HistoryVersionQueryResult = Omit<HistoryVersionDataResponse, 'locale'> &
@@ -375,6 +376,12 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
           return {
             ...result,
             data: await populateEntryRelations(result),
+            meta: {
+              unknownAttributes: getSchemaAttributesDiff(
+                result.schema,
+                strapi.getModel(params.contentType).attributes
+              ),
+            },
             locale: result.locale ? localeDictionary[result.locale] : null,
             createdBy: result.createdBy
               ? pick(['id', 'firstname', 'lastname', 'username', 'email'], result.createdBy)

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -1,11 +1,19 @@
-import type { Core, Modules } from '@strapi/types';
+import type { Core, Modules, UID, Data, Struct } from '@strapi/types';
+import { contentTypes } from '@strapi/utils';
 import { omit, pick } from 'lodash/fp';
 
 import { scheduleJob } from 'node-schedule';
 
 import { FIELDS_TO_IGNORE, HISTORY_VERSION_UID } from '../constants';
 import type { HistoryVersions } from '../../../../shared/contracts';
-import { getSchemaAttributesDiff } from './utils';
+import {
+  CreateHistoryVersion,
+  HistoryVersionDataResponse,
+} from '../../../../shared/contracts/history-versions';
+
+// Needed because the query engine doesn't return any types yet
+type HistoryVersionQueryResult = Omit<HistoryVersionDataResponse, 'locale'> &
+  Pick<CreateHistoryVersion, 'locale'>;
 
 const DEFAULT_RETENTION_DAYS = 90;
 
@@ -63,6 +71,56 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
     return documentMetadataService.getStatus(document, meta.availableStatus);
   };
 
+  /**
+   * Creates a populate object that looks for all the relations that need
+   * to be saved in history, and populates only the fields needed to later retrieve the content.
+   */
+  const getDeepPopulate = (uid: UID.Schema) => {
+    const model = strapi.getModel(uid);
+    const attributes = Object.entries(model.attributes);
+
+    return attributes.reduce((acc: any, [attributeName, attribute]) => {
+      switch (attribute.type) {
+        case 'relation': {
+          const isVisible = contentTypes.isVisibleAttribute(model, attributeName);
+          if (isVisible) {
+            acc[attributeName] = { fields: ['documentId', 'locale', 'publishedAt'] };
+          }
+          break;
+        }
+
+        case 'media': {
+          acc[attributeName] = { fields: ['id'] };
+          break;
+        }
+
+        case 'component': {
+          const populate = getDeepPopulate(attribute.component);
+          acc[attributeName] = { populate };
+          break;
+        }
+
+        case 'dynamiczone': {
+          // Use fragments to populate the dynamic zone components
+          const populatedComponents = (attribute.components || []).reduce(
+            (acc: any, componentUID: UID.Component) => {
+              acc[componentUID] = { populate: getDeepPopulate(componentUID) };
+              return acc;
+            },
+            {}
+          );
+
+          acc[attributeName] = { on: populatedComponents };
+          break;
+        }
+        default:
+          break;
+      }
+
+      return acc;
+    }, {});
+  };
+
   return {
     async bootstrap() {
       // Prevent initializing the service twice
@@ -106,8 +164,33 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
           .documents(contentTypeUid)
           .findOne(documentContext.documentId, {
             locale,
+            populate: getDeepPopulate(contentTypeUid),
           });
+
         const status = await getVersionStatus(contentTypeUid, document);
+
+        /**
+         * Store schema of both the fields and the fields of the attributes, as it will let us know
+         * if changes were made in the CTB since a history version was created,
+         * and therefore which fields can be restored and which cannot.
+         */
+        const attributesSchema = strapi.getModel(contentTypeUid).attributes;
+        const componentsSchemas: CreateHistoryVersion['componentsSchemas'] = Object.keys(
+          attributesSchema
+        ).reduce((currentComponentSchemas, key) => {
+          const fieldSchema = attributesSchema[key];
+
+          if (fieldSchema.type === 'component') {
+            const componentSchema = strapi.getModel(fieldSchema.component).attributes;
+            return {
+              ...currentComponentSchemas,
+              [fieldSchema.component]: componentSchema,
+            };
+          }
+
+          // Ignore anything that's not a component
+          return currentComponentSchemas;
+        }, {});
 
         // Prevent creating a history version for an action that wasn't actually executed
         await strapi.db.transaction(async ({ onCommit }) => {
@@ -115,7 +198,8 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
             this.createVersion({
               contentType: contentTypeUid,
               data: omit(FIELDS_TO_IGNORE, document),
-              schema: omit(FIELDS_TO_IGNORE, strapi.contentType(contentTypeUid).attributes),
+              schema: omit(FIELDS_TO_IGNORE, attributesSchema),
+              componentsSchemas,
               relatedDocumentId: documentContext.documentId,
               locale,
               status,
@@ -160,7 +244,10 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
       });
     },
 
-    async findVersionsPage(params: HistoryVersions.GetHistoryVersions.Request['query']) {
+    async findVersionsPage(params: HistoryVersions.GetHistoryVersions.Request['query']): Promise<{
+      results: HistoryVersions.HistoryVersionDataResponse[];
+      pagination: HistoryVersions.Pagination;
+    }> {
       const [{ results, pagination }, localeDictionary] = await Promise.all([
         query.findPage({
           ...params,
@@ -177,25 +264,124 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
         getLocaleDictionary(),
       ]);
 
-      const versionsWithMeta = results.map((version) => {
-        return {
-          ...version,
-          meta: {
-            unknownAttributes: getSchemaAttributesDiff(
-              version.schema,
-              strapi.getModel(params.contentType).attributes
-            ),
-          },
-        };
-      });
+      type EntryToPopulate =
+        | {
+            documentId: string;
+            locale: string | null;
+          }
+        | { id: Data.ID }
+        | null;
 
-      const sanitizedResults = versionsWithMeta.map((result) => ({
-        ...result,
-        locale: result.locale ? localeDictionary[result.locale] : null,
-        createdBy: result.createdBy
-          ? pick(['id', 'firstname', 'lastname', 'username', 'email'], result.createdBy)
-          : null,
-      }));
+      /**
+       * Get an object with two keys:
+       * - results: an array with the current values of the relations
+       * - meta: an object with the count of missing relations
+       */
+      const buildRelationReponse = async (
+        values: EntryToPopulate[],
+        attributeSchema: Struct.SchemaAttributes[keyof Struct.SchemaAttributes]
+      ): Promise<{ results: any[]; meta: { missingCount: number } }> => {
+        return (
+          values
+            // Until we implement proper pagination, limit relations to an arbitrary amount
+            .slice(0, 25)
+            .reduce(
+              async (currentRelationDataPromise, entry) => {
+                const currentRelationData = await currentRelationDataPromise;
+
+                // Entry can be null if it's a toOne relation
+                if (!entry) {
+                  return currentRelationData;
+                }
+
+                const isNormalRelation =
+                  attributeSchema.type === 'relation' &&
+                  attributeSchema.relation !== 'morphToOne' &&
+                  attributeSchema.relation !== 'morphToMany';
+
+                /**
+                 * Adapt the query depending on if the attribute is a media
+                 * or a normal relation. The extra checks are only for type narrowing
+                 */
+                let relatedEntry;
+                if (isNormalRelation) {
+                  if ('documentId' in entry) {
+                    relatedEntry = await strapi
+                      .documents(attributeSchema.target)
+                      .findOne(entry.documentId, { locale: entry.locale || undefined });
+                  }
+                } else if ('id' in entry) {
+                  relatedEntry = await strapi.db
+                    .query('plugin::upload.file')
+                    .findOne({ where: { id: entry.id } });
+                }
+
+                if (relatedEntry) {
+                  currentRelationData.results.push({
+                    ...relatedEntry,
+                    ...(isNormalRelation
+                      ? {
+                          status: await getVersionStatus(attributeSchema.target, relatedEntry),
+                        }
+                      : {}),
+                  });
+                } else {
+                  // The related content has been deleted
+                  currentRelationData.meta.missingCount += 1;
+                }
+
+                return currentRelationData;
+              },
+              Promise.resolve({
+                results: [] as any[],
+                meta: { missingCount: 0 },
+              })
+            )
+        );
+      };
+
+      const populateEntryRelations = async (
+        entry: HistoryVersionQueryResult
+      ): Promise<CreateHistoryVersion['data']> => {
+        const entryWithRelations = await Object.entries(entry.schema).reduce(
+          async (currentDataWithRelations, [attributeKey, attributeSchema]) => {
+            // TODO: handle relations that are inside components
+            if (['relation', 'media'].includes(attributeSchema.type)) {
+              const attributeValue = entry.data[attributeKey];
+              const relationResponse = await buildRelationReponse(
+                (Array.isArray(attributeValue)
+                  ? attributeValue
+                  : [attributeValue]) as EntryToPopulate[],
+                attributeSchema
+              );
+
+              return {
+                ...(await currentDataWithRelations),
+                [attributeKey]: relationResponse,
+              };
+            }
+
+            // Not a media or relation, nothing to change
+            return currentDataWithRelations;
+          },
+          Promise.resolve(entry.data)
+        );
+
+        return entryWithRelations;
+      };
+
+      const sanitizedResults = await Promise.all(
+        (results as HistoryVersionQueryResult[]).map(async (result) => {
+          return {
+            ...result,
+            data: await populateEntryRelations(result),
+            locale: result.locale ? localeDictionary[result.locale] : null,
+            createdBy: result.createdBy
+              ? pick(['id', 'firstname', 'lastname', 'username', 'email'], result.createdBy)
+              : undefined,
+          };
+        })
+      );
 
       return {
         results: sanitizedResults,

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -1,4 +1,4 @@
-import type { Data, Struct, UID } from '@strapi/types';
+import type { Data, Schema, Struct, UID } from '@strapi/types';
 import { type errors } from '@strapi/utils';
 
 /**
@@ -12,7 +12,8 @@ export interface CreateHistoryVersion {
   locale: string | null;
   status: 'draft' | 'published' | 'modified' | null;
   data: Record<string, unknown>;
-  schema: Struct.SchemaAttributes;
+  schema: Schema.Attributes;
+  componentsSchemas: Record<`${string}.${string}`, Schema.Attributes>;
 }
 
 interface Locale {
@@ -31,12 +32,6 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
-  meta: {
-    unknownAttributes: {
-      added: Struct.SchemaAttributes;
-      removed: Struct.SchemaAttributes;
-    };
-  };
 }
 
 // Export to prevent the TS "cannot be named" error in the history service

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -12,8 +12,8 @@ export interface CreateHistoryVersion {
   locale: string | null;
   status: 'draft' | 'published' | 'modified' | null;
   data: Record<string, unknown>;
-  schema: Schema.Attributes;
-  componentsSchemas: Record<`${string}.${string}`, Schema.Attributes>;
+  schema: Struct.SchemaAttributes;
+  componentsSchemas: Record<`${string}.${string}`, Struct.SchemaAttributes>;
 }
 
 interface Locale {

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -32,6 +32,12 @@ export interface HistoryVersionDataResponse extends Omit<CreateHistoryVersion, '
     email: string;
   };
   locale: Locale | null;
+  meta: {
+    unknownAttributes: {
+      added: Struct.SchemaAttributes;
+      removed: Struct.SchemaAttributes;
+    };
+  };
 }
 
 // Export to prevent the TS "cannot be named" error in the history service


### PR DESCRIPTION
**_ℹ️  This PR replaces #19786, as the git history became too much of a mess on that one_**

### What does it do?

- Saves only the ID in the data key when history versions are related
- On retrieval, for each relation and media, populate an object with results and missingCount
- This PR starts messing around with the frontend too (relation input in history), but it's mostly pseudocode to make sure the approach works. The actual implementation is a separate ticket.

### Why is it needed?

We need to display relations in history. And showing that some relations were deleted requires special handling.

### How to test it?

🚨 Because of the data structure change, your app may crash with pre-existing history versions 🚨

Create history versions with some relations. View history, you should see the data. Go delete the related content, you should see that too in the history frontend.