### PR TITLE
Chore: Revert @koa/cors upgrade to 5.0.0 due to breaking cors middleware

### DIFF
--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -111,7 +111,7 @@
     "watch": "pack-up watch"
   },
   "dependencies": {
-    "@koa/cors": "5.0.0",
+    "@koa/cors": "3.4.3",
     "@koa/router": "10.1.1",
     "@strapi/admin": "4.22.0",
     "@strapi/content-releases": "4.22.0",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@casl/ability": "6.5.0",
-    "@koa/cors": "5.0.0",
+    "@koa/cors": "3.4.3",
     "@koa/router": "10.1.1",
     "@strapi/database": "4.22.0",
     "@strapi/logger": "4.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4136,16 +4136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koa/cors@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@koa/cors@npm:5.0.0"
-  dependencies:
-    vary: "npm:^1.1.2"
-  checksum: 3a0e32fbc422a5f9a41540ce3b7499d46073ddb0e4e851394a74bac5ecd0eaa1f24a8f189b7bd6a50c5863788ae6945c52d990edf99fdd2151a4404f266fe2e7
-  languageName: node
-  linkType: hard
-
-"@koa/cors@npm:^3.1.0":
+"@koa/cors@npm:3.4.3, @koa/cors@npm:^3.1.0":
   version: 3.4.3
   resolution: "@koa/cors@npm:3.4.3"
   dependencies:
@@ -8776,7 +8767,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/strapi@workspace:packages/core/strapi"
   dependencies:
-    "@koa/cors": "npm:5.0.0"
+    "@koa/cors": "npm:3.4.3"
     "@koa/router": "npm:10.1.1"
     "@strapi/admin": "npm:4.22.0"
     "@strapi/content-releases": "npm:4.22.0"
@@ -8880,7 +8871,7 @@ __metadata:
   resolution: "@strapi/types@workspace:packages/core/types"
   dependencies:
     "@casl/ability": "npm:6.5.0"
-    "@koa/cors": "npm:5.0.0"
+    "@koa/cors": "npm:3.4.3"
     "@koa/router": "npm:10.1.1"
     "@strapi/database": "npm:4.22.0"
     "@strapi/logger": "npm:4.22.0"


### PR DESCRIPTION
### What does it do?

Reverts the upgrade made in https://github.com/strapi/strapi/pull/19921 due to https://github.com/strapi/strapi/issues/20033

### Why is it needed?

CORs broken in 4.22.0 due to the @koa/cors upgrade

### How to test it?

Reconfigure Strapi CORs middleware with a custom origin and ensure you can access the admin panel and fetch requests from external API

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/20033
