### PR TITLE
feat(core): document service (un)publish multiple locales

### DIFF
--- a/packages/core/core/src/services/document-service/internationalization.ts
+++ b/packages/core/core/src/services/document-service/internationalization.ts
@@ -37,26 +37,15 @@ const localeToLookup: Transform = (contentType, params) => {
   }
 
   if (params.locale) {
-    return assoc(['lookup', 'locale'], params.locale, params);
-  }
+    if (typeof params.locale === 'string') {
+      if (params.locale === '*') {
+        return params;
+      }
 
-  return params;
-};
-
-/**
- * Add locale lookup query to the params
- */
-const multiLocaleToLookup: Transform = (contentType, params) => {
-  if (!strapi.plugin('i18n').service('content-types').isLocalizedContentType(contentType)) {
-    return params;
-  }
-
-  if (params.locale) {
-    if (params.locale === '*') {
-      return params;
+      return assoc(['lookup', 'locale'], params.locale, params);
     }
 
-    return assoc(['lookup', 'locale'], params.locale, params);
+    return assoc(['lookup', 'locale', '$in'], params.locale, params);
   }
 
   return params;
@@ -70,7 +59,7 @@ const localeToData: Transform = (contentType, params) => {
     return params;
   }
 
-  if (params.locale) {
+  if (params.locale && typeof params.locale === 'string') {
     return assoc(['data', 'locale'], params.locale, params);
   }
 
@@ -79,12 +68,10 @@ const localeToData: Transform = (contentType, params) => {
 
 const defaultLocaleCurry = curry(defaultLocale);
 const localeToLookupCurry = curry(localeToLookup);
-const multiLocaleToLookupCurry = curry(multiLocaleToLookup);
 const localeToDataCurry = curry(localeToData);
 
 export {
   defaultLocaleCurry as defaultLocale,
   localeToLookupCurry as localeToLookup,
   localeToDataCurry as localeToData,
-  multiLocaleToLookupCurry as multiLocaleToLookup,
 };

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -86,7 +86,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     const query = await async.pipe(
       omit('status'),
       i18n.defaultLocale(contentType),
-      i18n.multiLocaleToLookup(contentType),
+      i18n.localeToLookup(contentType),
       transformParamsToQuery(uid),
       (query) => assoc('where', { ...query.where, documentId }, query)
     )(params);
@@ -155,7 +155,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     const queryParams = await async.pipe(
       DP.filterDataPublishedAt,
       i18n.defaultLocale(contentType),
-      i18n.multiLocaleToLookup(contentType)
+      i18n.localeToLookup(contentType)
     )(params);
 
     // Get deep populate
@@ -267,7 +267,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
   async function publish(documentId: string, params = {} as any) {
     const queryParams = await async.pipe(
       i18n.defaultLocale(contentType),
-      i18n.multiLocaleToLookup(contentType)
+      i18n.localeToLookup(contentType)
     )(params);
 
     await deleteFn(documentId, {
@@ -311,7 +311,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
   async function unpublish(documentId: string, params = {} as any) {
     const queryParams = await async.pipe(
       i18n.defaultLocale(contentType),
-      i18n.multiLocaleToLookup(contentType)
+      i18n.localeToLookup(contentType)
     )(params);
 
     const { deletedEntries } = await deleteFn(documentId, {
@@ -325,7 +325,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
   async function discardDraft(documentId: string, params = {} as any) {
     const queryParams = await async.pipe(
       i18n.defaultLocale(contentType),
-      i18n.multiLocaleToLookup(contentType)
+      i18n.localeToLookup(contentType)
     )(params);
 
     await deleteFn(documentId, {

--- a/packages/core/types/src/modules/documents/params/index.ts
+++ b/packages/core/types/src/modules/documents/params/index.ts
@@ -43,7 +43,7 @@ export type Pick<TSchemaUID extends UID.Schema, TKind extends Kind> = MatchAllIn
     // Publication Status
     [HasMember<TKind, 'status'>, PublicationStatus.Param],
     // Locale
-    [HasMember<TKind, 'locale'>, { locale?: Locale }], // TODO: also allow arrays ?
+    [HasMember<TKind, 'locale'>, { locale?: Locale | Locale[] }],
     // Plugin
     [HasMember<TKind, 'plugin'>, GetPluginParams<TSchemaUID>],
     // Data

--- a/tests/api/core/strapi/document-service/unpublish.test.api.ts
+++ b/tests/api/core/strapi/document-service/unpublish.test.api.ts
@@ -56,5 +56,30 @@ describe('Document Service', () => {
         });
       })
     );
+
+    it(
+      'unpublish multiple locales of a document',
+      testInTransaction(async () => {
+        const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
+
+        // Publish first all locales
+        await strapi.documents(ARTICLE_UID).publish(articleDb.documentId, { locale: '*' });
+        const publishedArticlesBefore = await findPublishedArticlesDb(articleDb.documentId);
+
+        await strapi.documents(ARTICLE_UID).unpublish(articleDb.documentId, {
+          locale: ['en', 'it'],
+        });
+
+        const publishedArticlesAfter = await findPublishedArticlesDb(articleDb.documentId);
+
+        // Sanity check to validate there are multiple locales
+        expect(publishedArticlesBefore.length).toBeGreaterThan(1);
+        // Only the english locale should have been unpublished
+        expect(publishedArticlesAfter.length).toBe(publishedArticlesBefore.length - 2);
+        publishedArticlesAfter.forEach((article) => {
+          expect(['en', 'it']).not.toContain(article.locale);
+        });
+      })
+    );
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows arrays of locales to be passed to publish and unpublish in the document service

### Why is it needed?

So we can (un)publish multiple locales at once from the CM edit view

### How to test it?

Added API tests

### Related issue(s)/PR(s)

CONTENT-1903
DX-1335