### PR TITLE
fix: prevent empty body when cloning

### DIFF
--- a/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
+++ b/packages/plugins/i18n/server/src/controllers/validate-locale-creation.ts
@@ -9,15 +9,15 @@ const { ApplicationError } = errors;
 const validateLocaleCreation: Core.MiddlewareHandler = async (ctx, next) => {
   const { model } = ctx.params;
   const { query } = ctx.request;
+
+  // Prevent empty body
+  if (!ctx.request.body) {
+    ctx.request.body = {};
+  }
+
   const body = ctx.request.body as any;
 
-  const {
-    getValidLocale,
-
-    isLocalizedContentType,
-
-    // fillNonLocalizedAttributes,
-  } = getService('content-types');
+  const { getValidLocale, isLocalizedContentType } = getService('content-types');
 
   const modelDef = strapi.getModel(model) as Struct.ContentTypeSchema;
 
@@ -52,9 +52,6 @@ const validateLocaleCreation: Core.MiddlewareHandler = async (ctx, next) => {
       return next();
     }
   }
-
-  // TODO V5 - non localized attributes
-  // fillNonLocalizedAttributes(body, relatedEntity, { model });
 
   return next();
 };


### PR DESCRIPTION
### What does it do?

An i18n middleware was faliling when trying to clone a document.

The clone request had an empty body, which was an unexpected edge case.

Fixes 
![image](https://github.com/strapi/strapi/assets/20578351/3ab89db3-0a5d-446e-ab01-c4e8d205d1ca)

Also, the content manager does not send any locale when duplicating an entry, I will create another ticket for that.