### PR TITLE
chore: add watch script for all projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build": "nx run-many --target=build --nx-ignore-cycles",
     "build:size": "cd examples/getstarted && yarn build",
     "build:ts": "nx run-many --target=build:ts --nx-ignore-cycles",
+    "build:watch": "nx watch --all --nx-ignore-cycles  --includeDependentProjects=false -- nx run \\$NX_PROJECT_NAME:build --nx-ignore-cycles",
     "clean": "nx run-many --target=clean --nx-ignore-cycles",
     "doc:api": "node scripts/open-api/serve.js",
     "format": "yarn format:code && yarn format:other",
@@ -68,8 +69,7 @@
     "test:ts:packages": "nx run-many --target=test:ts --nx-ignore-cycles",
     "test:unit": "jest --config jest.config.js",
     "test:unit:all": "nx run-many --target=test:unit --nx-ignore-cycles",
-    "test:unit:watch": "run test:unit --watch",
-    "watch": "nx run-many --target=watch --nx-ignore-cycles"
+    "test:unit:watch": "run test:unit --watch"
   },
   "resolutions": {
     "@strapi/design-system": "1.17.0-typescript.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "nx run-many --target=build --nx-ignore-cycles",
     "build:size": "cd examples/getstarted && yarn build",
     "build:ts": "nx run-many --target=build:ts --nx-ignore-cycles",
-    "build:watch": "nx watch --all --nx-ignore-cycles  --includeDependentProjects=false -- nx run \\$NX_PROJECT_NAME:build --nx-ignore-cycles",
+    "build:watch": "nx watch --all --nx-ignore-cycles -- nx run \\$NX_PROJECT_NAME:build --nx-ignore-cycles",
     "clean": "nx run-many --target=clean --nx-ignore-cycles",
     "doc:api": "node scripts/open-api/serve.js",
     "format": "yarn format:code && yarn format:other",


### PR DESCRIPTION
### What does it do?

- removes `watch` script because it wasn't useful (only ran 3 random watch scripts in parallel with the rest pending)
- adds `build:watch` script that uses `nx watch --all`

Note that this still is not great for us because nx tries to be smart and rebuilds every project it depends on, but since we have circular dependencies, it causes the entire chain to be rebuilt every time. So, it's only a small improvement, but once we fix our circular deps this should be a good way to watch the entire monorepo for changes.

### Why is it needed?

watch was broken, and sometimes it's nice to watch many different projects especially when working on changes in multiple projects at once

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

DX-1359
