### PR TITLE
chore(deps): install prettier@2 *just* for jest snapshots

### DIFF
--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -30,6 +30,7 @@ module.exports = {
   setupFiles: ['@strapi/admin-test-utils/setup'],
   setupFilesAfterEnv: ['@strapi/admin-test-utils/after-env'],
   testEnvironment: '@strapi/admin-test-utils/environment',
+  prettierPath: require.resolve('prettier-2'),
   transform: {
     '^.+\\.js(x)?$': [
       '@swc/jest',

--- a/jest-preset.unit.js
+++ b/jest-preset.unit.js
@@ -10,6 +10,7 @@ module.exports = {
     '__tests__/resources',
     'tests/resources',
   ],
+  prettierPath: require.resolve('prettier-2'),
   testMatch: ['**/__tests__/**/*.{js,ts,jsx,tsx}'],
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest'],

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "nx": "18.2.2",
     "plop": "2.7.6",
     "prettier": "3.2.5",
+    "prettier-2": "npm:prettier@^2",
     "qs": "6.11.1",
     "rimraf": "5.0.5",
     "semver": "7.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24084,6 +24084,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-2@npm:prettier@^2":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+  languageName: node
+  linkType: hard
+
 "prettier-linter-helpers@npm:^1.0.0":
   version: 1.0.0
   resolution: "prettier-linter-helpers@npm:1.0.0"
@@ -26862,6 +26871,7 @@ __metadata:
     nx: "npm:18.2.2"
     plop: "npm:2.7.6"
     prettier: "npm:3.2.5"
+    prettier-2: "npm:prettier@^2"
     qs: "npm:6.11.1"
     rimraf: "npm:5.0.5"
     semver: "npm:7.5.4"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* installs `prettier@2` to be used by `jest` until `jest@30` is released

### Why is it needed?

* you can't redo inline snapshots without it
