### PR TITLE
enhancement(ctb)!: reserve keywords needed for Strapi 5

### DIFF
--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -13,20 +13,30 @@ export const getReservedNames = () => {
     ],
     // attributes are compared with snake_case(name), so only snake_case is needed here and camelCase + UPPER_CASE matches will still be caught
     attributes: [
-      // TODO V5: these need to come from a centralized place so we don't break things accidentally in the future
+      // TODO: these need to come from a centralized place so we don't break things accidentally in the future
+
+      // ID fields
       'id',
       'documentId',
       'document_id',
+
+      // Creator fields
       'created_at',
       'updated_at',
       'published_at',
       'created_by_id',
       'updated_by_id',
-      'locale', // conflicts with internal locale field
-
-      // not actually breaking but we'll leave it to avoid confusion
+      // does not actually conflict because the fields are called *_by_id but we'll leave it to avoid confusion
       'created_by',
       'updated_by',
+
+      // Used for Strapi functionality
+      'entry_id',
+      'strapi',
+      'status',
+      'localizations',
+      'meta',
+      'locale',
     ],
   };
   // strapi.db.getReservedNames();

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -37,6 +37,10 @@ export const getReservedNames = () => {
       'localizations',
       'meta',
       'locale',
+      'stage',
+      'release',
+      'history',
+      'version',
     ],
   };
   // strapi.db.getReservedNames();

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -36,10 +36,9 @@ export const getReservedNames = () => {
       'localizations',
       'meta',
       'locale',
-      'stage',
-      'release',
-      'history',
-      'version',
+      // TODO: remove these in favor of restricting the strapi_ prefix
+      'strapi_stage',
+      'strapi_assignee',
     ],
   };
   // strapi.db.getReservedNames();

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -13,7 +13,7 @@ export const getReservedNames = () => {
     ],
     // attributes are compared with snake_case(name), so only snake_case is needed here and camelCase + UPPER_CASE matches will still be caught
     attributes: [
-      // TODO: these need to come from a centralized place so we don't break things accidentally in the future
+      // TODO: these need to come from a centralized place so we don't break things accidentally in the future and can share them outside the CTB, for example on Strapi bootstrap prior to schema db sync
 
       // ID fields
       'id',

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -16,7 +16,6 @@ export const getReservedNames = () => {
 
       // ID fields
       'id',
-      'documentId',
       'document_id',
 
       // Creator fields

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -31,12 +31,12 @@ export const getReservedNames = () => {
 
       // Used for Strapi functionality
       'entry_id',
-      'strapi',
       'status',
       'localizations',
       'meta',
       'locale',
       // TODO: remove these in favor of restricting the strapi_ prefix
+      'strapi',
       'strapi_stage',
       'strapi_assignee',
     ],

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -8,7 +8,6 @@ export const getReservedNames = () => {
       'time',
       'upload',
       'then', // https://github.com/strapi/strapi/issues/15557
-      'rest', // https://github.com/strapi/strapi/issues/13643
       'document',
     ],
     // attributes are compared with snake_case(name), so only snake_case is needed here and camelCase + UPPER_CASE matches will still be caught


### PR DESCRIPTION
### What does it do?

Adds reserved attribute names to the CTB validation

**Please comment your opinions on these**

Some of them are not currently strictly necessary and may be going "too far" and cause issues during v4->v5 migration, as well as annoyances that some common words are restricted.

Roadmap in a future PR:

- restrict entire prefix(es), most like `strapi` and/or `__`
- restrict the suffix `_`

### Why is it needed?

These attributes will conflict with internal Strapi attributes (or planned attributes in the future)

### How to test it?

Try to use one of these reserved words in the CTB and you will get an error

### Related issue(s)/PR(s)

DX-1267
