### PR TITLE
enhancement: remove `then` as reserved word

### DIFF
--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -7,7 +7,6 @@ export const getReservedNames = () => {
       'date-time',
       'time',
       'upload',
-      'then', // https://github.com/strapi/strapi/issues/15557
       'rest', // https://github.com/strapi/strapi/issues/13643
       'document',
     ],


### PR DESCRIPTION
### What does it do?

Allows the use of the content type name "then" by not including model names as root property names returned by promises.

* I do not know if we want to merge this*, because it could potentially lead to very difficult to debug issues in the future if someone attempts to return a list of content type names in a promise somewhere else in the code. But currently everything works fine.

Calling this an enhancement, because it literally only happens with the `then` keyword and we've blocked that already in the CTB. Although it's kind of a fix, because we only restrict `then` in the CTB and someone adding it to their schema directly is still unable to start up Strapi.

### Why is it needed?

Node Promises interprets any object with a `then` property to be a promise. When we were loading dynamic content type names into 

### How to test it?

Create a content type named "then" and everything should work.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/15557