### PR TITLE
Commit after git init

### DIFF
--- a/packages/generators/app/src/utils/git.ts
+++ b/packages/generators/app/src/utils/git.ts
@@ -26,6 +26,8 @@ export default async function tryGitInit(rootDir: string) {
     }
 
     await execa('git', ['init'], { stdio: 'ignore', cwd: rootDir });
+    await execa('git', ['add', '-A'], { stdio: 'ignore', cwd: rootDir });
+    await execa('git', ['commit', '-m', '"Initial commit from Create Strapi Project"'], { stdio: 'ignore', cwd: rootDir });
 
     return true;
   } catch (_) {

--- a/packages/generators/app/src/utils/git.ts
+++ b/packages/generators/app/src/utils/git.ts
@@ -27,7 +27,10 @@ export default async function tryGitInit(rootDir: string) {
 
     await execa('git', ['init'], { stdio: 'ignore', cwd: rootDir });
     await execa('git', ['add', '-A'], { stdio: 'ignore', cwd: rootDir });
-    await execa('git', ['commit', '-m', '"Initial commit from Create Strapi Project"'], { stdio: 'ignore', cwd: rootDir });
+    await execa('git', ['commit', '-m', '"Initial commit from Create Strapi Project"'], {
+      stdio: 'ignore',
+      cwd: rootDir,
+    });
 
     return true;
   } catch (_) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It launches the initial commit after the already triggered git init.

### Why is it needed?

It avoids users having to do this manually. Also, it allows them to better understand that new files are created every time they create a content type or a component.

### How to test it?

 - Clone this repository.
  - In `test/helpers/test-app.js`, replace `rootPath: path.resolve(appName),` with `rootPath: path.resolve('..', appName),` so the new project will be created outside of the `strapi` folder (which already has Git initiated).
 - Run `yarn`.
 - Run `yarn setup`.
 - Run `yarn test:generate-app sqlite`.

### Related issue(s)/PR(s)

It is an iteration of #16277
