### PR TITLE
fix: invalidate document after history version is restored

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -66,7 +66,11 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
 
   const handleRestore = async () => {
     const response = await restoreVersion({
-      params: { versionId: version.id },
+      params: {
+        versionId: version.id,
+        documentId: version.relatedDocumentId,
+        contentType: version.contentType,
+      },
       body: { contentType: version.contentType },
     });
 

--- a/packages/core/content-manager/admin/src/history/services/historyVersion.ts
+++ b/packages/core/content-manager/admin/src/history/services/historyVersion.ts
@@ -30,7 +30,12 @@ const historyVersionsApi = contentManagerApi.injectEndpoints({
             data: body,
           };
         },
-        invalidatesTags: ['HistoryVersion'],
+        invalidatesTags: (_res, _error, { params }) => {
+          return [
+            'HistoryVersion',
+            { type: 'Document', id: `${params.contentType}_${params.documentId}` },
+          ];
+        },
       }
     ),
   }),

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -82,6 +82,8 @@ export declare namespace RestoreHistoryVersion {
   export interface Request {
     params: {
       versionId: Data.ID;
+      documentId: Data.ID;
+      contentType: UID.ContentType;
     };
     body: {
       contentType: UID.ContentType;


### PR DESCRIPTION
### What does it do?

Invalidates the relevant document after restoring a history version

### Why is it needed?

After restoring content, we were redirected to the edit view page, but we didn't see the changes until we refreshed the page

### How to test it?

Restore an old history version, as soon as you're redirected to the edit view you should see the content from that restored version.

### Related issue(s)/PR(s)

builds on top of #20106