### PR TITLE
Chore: Upgrade mysql2 from 3.6.0 to 3.9.4

### DIFF
--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -27,7 +27,7 @@
     "better-sqlite3": "8.6.0",
     "lodash": "4.17.21",
     "mysql": "2.18.1",
-    "mysql2": "3.6.0",
+    "mysql2": "3.9.4",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",
     "react": "^18.2.0",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -19,7 +19,7 @@
     "@strapi/strapi": "4.23.0",
     "lodash": "4.17.21",
     "mysql": "2.18.1",
-    "mysql2": "3.6.0",
+    "mysql2": "3.9.4",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",
     "react": "^18.2.0",

--- a/packages/generators/app/src/utils/db-client-dependencies.ts
+++ b/packages/generators/app/src/utils/db-client-dependencies.ts
@@ -2,7 +2,7 @@ import type { ClientName } from '../types';
 
 const sqlClientModule = {
   mysql: { mysql: '2.18.1' },
-  mysql2: { mysql2: '3.6.0' },
+  mysql2: { mysql2: '3.9.4' },
   postgres: { pg: '8.8.0' },
   sqlite: { 'better-sqlite3': '8.6.0' },
   'sqlite-legacy': { sqlite3: '5.1.2' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18018,7 +18018,7 @@ __metadata:
     better-sqlite3: "npm:8.6.0"
     lodash: "npm:4.17.21"
     mysql: "npm:2.18.1"
-    mysql2: "npm:3.6.0"
+    mysql2: "npm:3.9.4"
     passport-google-oauth2: "npm:0.2.0"
     pg: "npm:8.11.1"
     react: "npm:^18.2.0"
@@ -21231,7 +21231,7 @@ __metadata:
     "@strapi/strapi": "npm:4.23.0"
     lodash: "npm:4.17.21"
     mysql: "npm:2.18.1"
-    mysql2: "npm:3.6.0"
+    mysql2: "npm:3.9.4"
     passport-google-oauth2: "npm:0.2.0"
     pg: "npm:8.11.1"
     react: "npm:^18.2.0"
@@ -23481,9 +23481,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mysql2@npm:3.6.0":
-  version: 3.6.0
-  resolution: "mysql2@npm:3.6.0"
+"mysql2@npm:3.9.4":
+  version: 3.9.4
+  resolution: "mysql2@npm:3.9.4"
   dependencies:
     denque: "npm:^2.1.0"
     generate-function: "npm:^2.3.1"
@@ -23493,7 +23493,7 @@ __metadata:
     named-placeholders: "npm:^1.1.3"
     seq-queue: "npm:^0.0.5"
     sqlstring: "npm:^2.3.2"
-  checksum: 48a6b138288debe6205f51a993ad33de44641a6ed07f94eafb1ea5f7e75fb31bfc5532e5ddf5a664898f4d26d6cf3e490de7d1d343bc4824b4e08ace0bf2b508
+  checksum: 8b706a507e331f28d19e84b55a0035d79ecdc1522405815adef664b3ec1d8b5006046c183ad8ab140cc50c9506d52a5fd49ab712bc98174027ee085665509c62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Upgrades the MySQL2 package from 3.6.0 to 3.9.4
Changelog: https://github.com/sidorares/node-mysql2/blob/master/Changelog.md

### Why is it needed?

Related to 3 dependabot alerts to a vuln we aren't directly susceptible too however some users may hit it if they use direct queries.
Related PRs for the vuln: 

- https://github.com/sidorares/node-mysql2/pull/2572
- https://github.com/sidorares/node-mysql2/pull/2424

### How to test it?

Test against clients accepting the mysql2 package (MySQL 8+ and MariaDB 10.5+

### Related issue(s)/PR(s)

N/A
