### PR TITLE
fix: add render prop to use VersionInputRenderer

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -323,7 +323,16 @@ const VersionInputRenderer = ({
     case 'blocks':
       return <BlocksInput {...props} hint={hint} type={props.type} disabled={fieldIsDisabled} />;
     case 'component':
-      return <ComponentInput {...props} hint={hint} disabled={fieldIsDisabled} />;
+      return (
+        <ComponentInput
+          {...props}
+          hint={hint}
+          disabled={fieldIsDisabled}
+          customInputRenderer={(props) => (
+            <VersionInputRenderer {...props} shouldIgnoreRBAC={true} />
+          )}
+        />
+      );
     case 'dynamiczone':
       return <DynamicZone {...props} hint={hint} disabled={fieldIsDisabled} />;
     case 'relation':

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -328,9 +328,7 @@ const VersionInputRenderer = ({
           {...props}
           hint={hint}
           disabled={fieldIsDisabled}
-          customInputRenderer={(props) => (
-            <VersionInputRenderer {...props} shouldIgnoreRBAC={true} />
-          )}
+          renderInput={(props) => <VersionInputRenderer {...props} shouldIgnoreRBAC={true} />}
         />
       );
     case 'dynamiczone':

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
@@ -20,7 +20,7 @@ interface ComponentInputProps
   extends Omit<Extract<EditFieldLayout, { type: 'component' }>, 'size' | 'hint'>,
     Pick<InputProps, 'hint'> {
   labelAction?: React.ReactNode;
-  customInputRenderer?: (props: InputRendererProps) => React.ReactNode;
+  renderInput?: (props: InputRendererProps) => React.ReactNode;
 }
 
 const ComponentInput = ({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
@@ -10,6 +10,7 @@ import { EditFieldLayout } from '../../../../../hooks/useDocumentLayout';
 import { getTranslation } from '../../../../../utils/translations';
 import { transformDocument } from '../../../utils/data';
 import { createDefaultForm } from '../../../utils/forms';
+import { InputRendererProps } from '../../InputRenderer';
 
 import { Initializer } from './Initializer';
 import { NonRepeatableComponent } from './NonRepeatable';
@@ -19,6 +20,7 @@ interface ComponentInputProps
   extends Omit<Extract<EditFieldLayout, { type: 'component' }>, 'size' | 'hint'>,
     Pick<InputProps, 'hint'> {
   labelAction?: React.ReactNode;
+  customInputRenderer?: (props: InputRendererProps) => React.ReactNode;
 }
 
 const ComponentInput = ({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
@@ -9,7 +9,11 @@ import type { ComponentInputProps } from './Input';
 
 interface NonRepeatableComponentProps extends Omit<ComponentInputProps, 'required' | 'label'> {}
 
-const NonRepeatableComponent = ({ attribute, name }: NonRepeatableComponentProps) => {
+const NonRepeatableComponent = ({
+  attribute,
+  name,
+  customInputRenderer,
+}: NonRepeatableComponentProps) => {
   const {
     edit: { components },
   } = useDocLayout();
@@ -47,7 +51,11 @@ const NonRepeatableComponent = ({ attribute, name }: NonRepeatableComponentProps
 
                   return (
                     <GridItem col={size} key={completeFieldName} s={12} xs={12}>
-                      <InputRenderer {...field} name={completeFieldName} />
+                      {customInputRenderer ? (
+                        customInputRenderer({ ...field, name: completeFieldName })
+                      ) : (
+                        <InputRenderer {...field} name={completeFieldName} />
+                      )}
                     </GridItem>
                   );
                 })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
@@ -12,7 +12,7 @@ interface NonRepeatableComponentProps extends Omit<ComponentInputProps, 'require
 const NonRepeatableComponent = ({
   attribute,
   name,
-  customInputRenderer,
+  renderInput = InputRenderer,
 }: NonRepeatableComponentProps) => {
   const {
     edit: { components },
@@ -51,11 +51,7 @@ const NonRepeatableComponent = ({
 
                   return (
                     <GridItem col={size} key={completeFieldName} s={12} xs={12}>
-                      {customInputRenderer ? (
-                        customInputRenderer({ ...field, name: completeFieldName })
-                      ) : (
-                        <InputRenderer {...field} name={completeFieldName} />
-                      )}
+                      {renderInput({ ...field, name: completeFieldName })}
                     </GridItem>
                   );
                 })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -49,6 +49,7 @@ const RepeatableComponent = ({
   disabled,
   name,
   mainField,
+  customInputRenderer,
 }: RepeatableComponentProps) => {
   const { toggleNotification } = useNotification();
   const { formatMessage } = useIntl();
@@ -226,6 +227,7 @@ const RepeatableComponent = ({
                   index={index}
                   isOpen={collapseToOpen === key}
                   mainField={mainField}
+                  customInputRenderer={customInputRenderer}
                   onMoveItem={handleMoveComponentField}
                   onClickToggle={handleToggle(key)}
                   onDeleteComponent={() => {
@@ -377,7 +379,7 @@ const ActionsFlex = styled(Flex)<{ expanded?: boolean }>`
 
 interface ComponentProps
   extends Pick<UseDragAndDropOptions, 'onGrabItem' | 'onDropItem' | 'onCancel' | 'onMoveItem'>,
-    Pick<RepeatableComponentProps, 'mainField'> {
+    Pick<RepeatableComponentProps, 'mainField' | 'customInputRenderer'> {
   attribute: Schema.Attribute.Component<`${string}.${string}`, boolean>;
   disabled?: boolean;
   index: number;
@@ -401,6 +403,7 @@ const Component = ({
   onClickToggle,
   onDeleteComponent,
   toggleCollapses,
+  customInputRenderer,
   ...dragProps
 }: ComponentProps) => {
   const { formatMessage } = useIntl();
@@ -511,7 +514,11 @@ const Component = ({
 
                       return (
                         <GridItem col={size} key={completeFieldName} s={12} xs={12}>
-                          <InputRenderer {...field} name={completeFieldName} />
+                          {customInputRenderer ? (
+                            customInputRenderer({ ...field, name: completeFieldName })
+                          ) : (
+                            <InputRenderer {...field} name={completeFieldName} />
+                          )}
                         </GridItem>
                       );
                     })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -49,7 +49,7 @@ const RepeatableComponent = ({
   disabled,
   name,
   mainField,
-  customInputRenderer,
+  renderInput,
 }: RepeatableComponentProps) => {
   const { toggleNotification } = useNotification();
   const { formatMessage } = useIntl();
@@ -227,7 +227,7 @@ const RepeatableComponent = ({
                   index={index}
                   isOpen={collapseToOpen === key}
                   mainField={mainField}
-                  customInputRenderer={customInputRenderer}
+                  renderInput={renderInput}
                   onMoveItem={handleMoveComponentField}
                   onClickToggle={handleToggle(key)}
                   onDeleteComponent={() => {
@@ -379,7 +379,7 @@ const ActionsFlex = styled(Flex)<{ expanded?: boolean }>`
 
 interface ComponentProps
   extends Pick<UseDragAndDropOptions, 'onGrabItem' | 'onDropItem' | 'onCancel' | 'onMoveItem'>,
-    Pick<RepeatableComponentProps, 'mainField' | 'customInputRenderer'> {
+    Pick<RepeatableComponentProps, 'mainField' | 'renderInput'> {
   attribute: Schema.Attribute.Component<`${string}.${string}`, boolean>;
   disabled?: boolean;
   index: number;
@@ -403,7 +403,7 @@ const Component = ({
   onClickToggle,
   onDeleteComponent,
   toggleCollapses,
-  customInputRenderer,
+  renderInput = InputRenderer,
   ...dragProps
 }: ComponentProps) => {
   const { formatMessage } = useIntl();
@@ -514,11 +514,7 @@ const Component = ({
 
                       return (
                         <GridItem col={size} key={completeFieldName} s={12} xs={12}>
-                          {customInputRenderer ? (
-                            customInputRenderer({ ...field, name: completeFieldName })
-                          ) : (
-                            <InputRenderer {...field} name={completeFieldName} />
-                          )}
+                          {renderInput({ ...field, name: completeFieldName })}
                         </GridItem>
                       );
                     })}


### PR DESCRIPTION
### What does it do?

- Add `customInputRenderer` render prop to component inputs so they can provide their own renderer

### Why is it needed?

Unknown fields for history version need to ignore RBAC. This is handled in the `VersionInputRenderer` which we use to replace the EditView's `InputRenderer`. Components however also call this InputRenderer and we need to replace it with `VersionInputRenderer` at the level as well.

This solution seemed the most flexible with least amount of change, but happy to discuss alternatives.

### How to test it?
Currently on v5/main components that have been renamed or deleted show No permissions:

![Screenshot 2024-04-17 at 14 56 06](https://github.com/strapi/strapi/assets/26598053/91568513-2d34-4c70-be63-68ef69c3043b)

- Using a content type that has both repeatable and non-repeatable components, add some values to each component, then save to create a history version
- Rename or delete these component fields
- Save the document again to create another history version
- On the history page, go to the previous version where the fields existed 
- In the unknown fields section you should see the components and the values they had at that time in history

