### PR TITLE
fix: sanitize history versions data field

### DIFF
--- a/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
@@ -155,7 +155,7 @@ export default ({ action, ability, model }: any) => {
       traverseEntity(omitHiddenFields, ctx),
       // Remove not allowed fields (RBAC)
       traverseEntity(removeDisallowedFields(permittedFields), ctx),
-      // Remove roles from createdBy & updateBy fields
+      // Remove roles from createdBy & updatedBy fields
       omitCreatorRoles
     );
   };

--- a/packages/core/content-manager/server/src/history/controllers/history-version.ts
+++ b/packages/core/content-manager/server/src/history/controllers/history-version.ts
@@ -68,7 +68,15 @@ const createHistoryVersionController = ({ strapi }: { strapi: Core.Strapi }) => 
         ...getValidPagination({ page: params.page, pageSize: params.pageSize }),
       });
 
-      return { data: results, meta: { pagination } };
+      return {
+        data: await Promise.all(
+          results.map(async (result) => ({
+            ...result,
+            data: await permissionChecker.sanitizeOutput(result.data),
+          }))
+        ),
+        meta: { pagination },
+      };
     },
 
     async restoreVersion(ctx) {

--- a/packages/core/content-manager/shared/contracts/history-versions.ts
+++ b/packages/core/content-manager/shared/contracts/history-versions.ts
@@ -16,7 +16,7 @@ export interface CreateHistoryVersion {
   componentsSchemas: Record<`${string}.${string}`, Struct.SchemaAttributes>;
 }
 
-interface Locale {
+export interface Locale {
   name: string;
   code: string;
 }


### PR DESCRIPTION
### What does it do?

Sanitizes the data field in the history version controller

### Why is it needed?

Passwords, even in their hashed version, should not be in the data object. This change aligns history with the behavior of the edit view

### How to test it?

Go to the history page on a content type that has a password field. You shouldn't see any data for that password in the history page. Nothing else should change
