### PR TITLE
fix: u&p service hashes passwords

### DIFF
--- a/tests/api/plugins/users-permissions/content-api/auth.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/auth.test.api.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const bcrypt = require('bcryptjs');
+
 const { createStrapiInstance } = require('api-tests/strapi');
 const { createRequest } = require('api-tests/request');
 const { createAuthenticatedUser } = require('../utils');
@@ -20,7 +22,7 @@ const internals = {
 
 const data = {};
 
-describe.skip('Auth API', () => {
+describe('Auth API', () => {
   beforeAll(async () => {
     strapi = await createStrapiInstance({ bypassAuth: false });
 
@@ -111,6 +113,15 @@ describe.skip('Auth API', () => {
         },
       });
 
+      // check that password was hashed
+      const user = await strapi.db.query('plugin::users-permissions.user').findOne({
+        where: {
+          email: internals.user.email.toLowerCase(),
+        },
+      });
+      expect(bcrypt.compareSync(internals.newPassword, user.password)).toBe(true);
+
+      // check results
       expect(res.statusCode).toBe(200);
       expect(res.body).toMatchObject({
         jwt: expect.any(String),

--- a/tests/api/plugins/users-permissions/content-api/users-api.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/users-api.test.api.js
@@ -2,6 +2,7 @@
 
 // Test a simple default API with no relations
 
+const bcrypt = require('bcryptjs');
 const { createStrapiInstance } = require('api-tests/strapi');
 const { createContentAPIRequest } = require('api-tests/request');
 
@@ -72,6 +73,15 @@ describe('Users API', () => {
       url: '/users',
       body: user,
     });
+
+    // check that password was hashed
+    const userDb = await strapi.db.query('plugin::users-permissions.user').findOne({
+      where: {
+        email: user.email,
+      },
+    });
+
+    expect(bcrypt.compareSync(user.newPassword, userDb.password)).toBe(true);
 
     expect(res.statusCode).toBe(201);
     expect(res.body).toMatchObject({


### PR DESCRIPTION
### What does it do?

The u&p service lost its password hashing during the deprecation migration of entity service. This adds it back.

We may actually want to switch to use document service universally here, in case there's any other logic we're missing.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
