### PR TITLE
add exports for convenient extending of the plugin features

### DIFF
--- a/packages/core/upload/server/src/services/image-manipulation.ts
+++ b/packages/core/upload/server/src/services/image-manipulation.ts
@@ -259,8 +259,13 @@ export default {
   isOptimizableImage,
   isResizableImage,
   isImage,
+  breakpointSmallerThan,
+  getBreakpoints,
   getDimensions,
+  getService,
+  generateBreakpoint,
   generateResponsiveFormats,
   generateThumbnail,
   optimize,
+  resizeFileTo,
 };


### PR DESCRIPTION
Hello strapi contributors,

Thank you for the project!

Please review my idea. It is small and safe change, but it is very important because it opens many ways to customize default behavior of the plugin. 

Thanks.

### What does it do?

added additional exports to upload plugin

### Why is it needed?

exporting of these functions give us an opportunity to reuse they when we want to extend, change or disable part of functionality of the original upload plugin. so we don't have to create a new upload module to change something in behavior of the original plugin, because it is very well, but sometimes we need to have this option.

for example: I would like to change generateBreakpoint algorithm and reuse it after in my own generateResponsiveFormats call which I can override when I extend the plugin or if I would like to extend default behavior of generateResponsiveFormats adding some additional actions.

### How to test it?

extend upload plugin with extending and overriding these functions

### Related issue(s)/PR(s)

no
