### PR TITLE
fix: document service find many pagination

### DIFF
--- a/packages/core/database/src/entity-manager/entity-repository.ts
+++ b/packages/core/database/src/entity-manager/entity-repository.ts
@@ -1,4 +1,4 @@
-import { isString } from 'lodash/fp';
+import { isString, isNil } from 'lodash/fp';
 import type { Database } from '..';
 import type { Repository, Params } from './types';
 
@@ -20,6 +20,17 @@ type ParamsWithLimits = Omit<Params, 'page' | 'pageSize'> & {
 const withOffsetLimit = (
   params: Params
 ): [ParamsWithLimits, { page: number; pageSize: number }] => {
+  // If params already include limit and offset, return them as is
+  if (!isNil(params.limit) && !isNil(params.offset)) {
+    return [
+      params as ParamsWithLimits,
+      {
+        page: Math.floor(params.offset / params.limit) + 1,
+        pageSize: params.limit,
+      },
+    ];
+  }
+
   const { page, pageSize, ...rest } = withDefaultPagination(params);
 
   const offset = Math.max(page - 1, 0) * pageSize;

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -247,7 +247,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     return limitAsANumber;
   };
 
-  const convertPaginationToOffsetLimit = (
+  const convertPageQueryToOffsetLimit = (
     page: unknown,
     pageSize?: unknown
   ): {
@@ -479,7 +479,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     validatePaginationParams(page, pageSize, start, limit);
 
     if (!isNil(page) || !isNil(pageSize)) {
-      const { offset, limit } = convertPaginationToOffsetLimit(page, pageSize);
+      const { offset, limit } = convertPageQueryToOffsetLimit(page, pageSize);
       query.offset = offset;
       query.limit = limit;
     }
@@ -668,7 +668,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     validatePaginationParams(page, pageSize, start, limit);
 
     if (!isNil(page) || !isNil(pageSize)) {
-      const { offset, limit } = convertPaginationToOffsetLimit(page, pageSize);
+      const { offset, limit } = convertPageQueryToOffsetLimit(page, pageSize);
       query.offset = offset;
       query.limit = limit;
     }


### PR DESCRIPTION
### What does it do?

We allowed page & pageSize parameters on find Many, but those params were not properly converted to the offset & limit database params.

This PR proposes a fix, which always converts pagination params to offset and limit, so both page & pagesize, and start & limit works on the `findMany` method, or any other that accepts pagination.

### How to test
Go to the List View of the CMS, and the pages should load correctlly, 10 entities at a time

Closes https://github.com/strapi/strapi/issues/20005