### PR TITLE
fix: content could be undefined

### DIFF
--- a/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/admin/admin/src/content-manager/pages/ListView/components/TableCells/CellContent.tsx
@@ -95,7 +95,7 @@ const hasContent = (
     // Repeatable fields show the ID as fallback, in case the mainField
     // doesn't have any content
     if (fieldSchema?.repeatable || !mainField) {
-      return content.length > 0;
+      return content && Array.isArray(content) && content.length > 0;
     }
 
     const value = content?.[mainField.name];
@@ -130,7 +130,7 @@ const hasContent = (
     return content?.count > 0;
   }
 
-  /* 
+  /*
       Biginteger fields need to be treated as strings, as `isNumber`
       doesn't deal with them.
   */


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

content can be undefined because of some timing issues. the Cell is rendered before the new data is loaded when navigating between content types in the CM list views. 

There is a depper issue to fix for v5 but it it's still valid to check the value is defined and is an array before accessing that length prop regardless

### Why is it needed?

Fix a bug

### How to test it?

Navigating in the CM between content-types with repeatable components displayed in the list view should not reproduce the error anymore

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/19660
