### PR TITLE
Removed .only modifier on a PrivateRoute test

### DIFF
--- a/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
@@ -44,7 +44,7 @@ describe('PrivateRoute', () => {
     expect(await screen.findByText('You are authenticated'));
   });
 
-  it.only('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
+  it('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
     let testLocation: Location = null!;
     let testHistory: History = null!;
 


### PR DESCRIPTION
The .only modifier was preventing the test "Authenticated users should be able to access protected routes" from running