### PR TITLE
Disable schema sync in bootstrap

### DIFF
--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -591,7 +591,7 @@ class Strapi implements StrapiI {
       contentTypes: this.contentTypes,
     });
 
-    await this.db.schema.sync();
+    // await this.db.schema.sync();
 
     if (this.EE) {
       await ee.checkLicense({ strapi: this });


### PR DESCRIPTION
Forked strapi to disable schema sync, which is now handled by prisma