### PR TITLE
fix(admin): if were in EE mode wait for the EE routes to be loaded before rendering

### DIFF
--- a/packages/core/admin/admin/src/App.tsx
+++ b/packages/core/admin/admin/src/App.tsx
@@ -137,7 +137,13 @@ export const App = ({ authLogo, menuLogo, showReleaseNotification, showTutorials
     [uuid, telemetryPropertiesQuery.data]
   );
 
-  if (initQuery.isLoading) {
+  /**
+   * `routes` will only be an array if EE mode is activated,
+   * therefore we need to ensure the lazy loading of EE routes
+   * has been complete otherwise the SSO repsonse URL will not be
+   * caught by the component and you won't be able to login with it.
+   */
+  if (initQuery.isLoading || (Array.isArray(routes) && routes.length === 0)) {
     return <LoadingIndicatorPage />;
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* if we're in EE the `routes` variable will be an `array` not `null`, if that's the case we wait for the routes to be loaded (which is not feature specific) before trying to re-render the app after being redirected from `admin/connect/PROVIDER` to `admin/login/success` because the component would not be ready to handle it & therefore the redirect will never complete

### Why is it needed?

* You can't login with SSO at the moment

### How to test it?

Experimental: `0.0.0-experimental.ccba4ea6043b6bab83888f85cc9a3f07f61dc262`

* Follow steps here https://docs.strapi.io/dev-docs/configurations/sso (I used Github, it was v easy)
* login with SSO
* be redirected to the homepage!

### Related issue(s)/PR(s)

* resolves #20219
* resolves DX-1392
