### PR TITLE
chore: moved cms components from DS to admin

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/ActionLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/ActionLayout.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import { Flex } from '@strapi/design-system';
+
+interface ActionLayoutProps {
+  endActions?: React.ReactNode;
+  startActions?: React.ReactNode;
+}
+
+const ActionLayout = ({ startActions, endActions }: ActionLayoutProps) => {
+  if (!startActions && !endActions) {
+    return null;
+  }
+
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItems="flex-start"
+      paddingBottom={4}
+      paddingLeft={10}
+      paddingRight={10}
+    >
+      <Flex gap={2} wrap="wrap">
+        {startActions}
+      </Flex>
+
+      <Flex gap={2} shrink={0} wrap="wrap">
+        {endActions}
+      </Flex>
+    </Flex>
+  );
+};
+
+export { ActionLayout, type ActionLayoutProps };

--- a/packages/core/admin/admin/src/components/Layouts/ContentLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/ContentLayout.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { Box } from '@strapi/design-system';
+
+interface ContentLayoutProps {
+  children: React.ReactNode;
+}
+
+const ContentLayout = ({ children }: ContentLayoutProps) => {
+  return (
+    <Box paddingLeft={10} paddingRight={10}>
+      {children}
+    </Box>
+  );
+};
+
+export { ContentLayout, type ContentLayoutProps };

--- a/packages/core/admin/admin/src/components/Layouts/GridLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/GridLayout.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { Box } from '@strapi/design-system';
+import styled from 'styled-components';
+
+interface GridColSize {
+  S: number;
+  M: number;
+}
+
+const GridColSize = {
+  S: 180,
+  M: 250,
+};
+
+type Size = keyof GridColSize;
+
+const StyledGrid = styled(Box)<{ $size: Size }>`
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(${({ $size }: { $size: Size }) => `${GridColSize[$size]}px`}, 1fr)
+  );
+  grid-gap: ${({ theme }) => theme.spaces[4]};
+`;
+
+interface GridLayoutProps {
+  size: Size;
+  children: React.ReactNode;
+}
+
+const GridLayout = ({ size, children }: GridLayoutProps) => {
+  return <StyledGrid $size={size}>{children}</StyledGrid>;
+};
+
+export { GridLayout };
+export type { GridColSize };

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+
+import { Box, Flex, Typography, TypographyProps, useCallbackRef } from '@strapi/design-system';
+
+/* -------------------------------------------------------------------------------------------------
+ * BaseHeaderLayout
+ * -----------------------------------------------------------------------------------------------*/
+
+interface BaseHeaderLayoutProps extends TypographyProps {
+  navigationAction?: React.ReactNode;
+  primaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode;
+  subtitle?: React.ReactNode;
+  sticky?: boolean;
+  width?: number;
+}
+
+const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>(
+  (
+    { navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props },
+    ref
+  ) => {
+    const isSubtitleString = typeof subtitle === 'string';
+
+    if (sticky) {
+      return (
+        <Box
+          paddingLeft={6}
+          paddingRight={6}
+          paddingTop={3}
+          paddingBottom={3}
+          position="fixed"
+          top={0}
+          right={0}
+          background="neutral0"
+          shadow="tableShadow"
+          width={`${width}rem`}
+          zIndex={1}
+          data-strapi-header-sticky
+        >
+          <Flex justifyContent="space-between">
+            <Flex>
+              {navigationAction && <Box paddingRight={3}>{navigationAction}</Box>}
+              <Box>
+                <Typography variant="beta" as="h1" {...props}>
+                  {title}
+                </Typography>
+                {isSubtitleString ? (
+                  <Typography variant="pi" textColor="neutral600">
+                    {subtitle}
+                  </Typography>
+                ) : (
+                  subtitle
+                )}
+              </Box>
+              {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
+            </Flex>
+            <Flex>{primaryAction ? <Box paddingLeft={2}>{primaryAction}</Box> : undefined}</Flex>
+          </Flex>
+        </Box>
+      );
+    }
+
+    return (
+      <Box
+        ref={ref}
+        paddingLeft={10}
+        paddingRight={10}
+        paddingBottom={8}
+        paddingTop={navigationAction ? 6 : 8}
+        background="neutral100"
+        data-strapi-header
+      >
+        {navigationAction ? <Box paddingBottom={2}>{navigationAction}</Box> : null}
+        <Flex justifyContent="space-between">
+          <Flex minWidth={0}>
+            <Typography as="h1" variant="alpha" {...props}>
+              {title}
+            </Typography>
+            {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
+          </Flex>
+          {primaryAction}
+        </Flex>
+        {isSubtitleString ? (
+          <Typography variant="epsilon" textColor="neutral600" as="p">
+            {subtitle}
+          </Typography>
+        ) : (
+          subtitle
+        )}
+      </Box>
+    );
+  }
+);
+
+/* -------------------------------------------------------------------------------------------------
+ * HeaderLayout
+ * -----------------------------------------------------------------------------------------------*/
+
+interface HeaderLayoutProps extends BaseHeaderLayoutProps {}
+
+const HeaderLayout = (props: HeaderLayoutProps) => {
+  const baseHeaderLayoutRef = React.useRef<HTMLDivElement>(null);
+  const [headerSize, setHeaderSize] = React.useState<DOMRect | null>(null);
+
+  const [containerRef, isVisible] = useElementOnScreen<HTMLDivElement>({
+    root: null,
+    rootMargin: '0px',
+    threshold: 0,
+  });
+
+  useResizeObserver(containerRef, () => {
+    if (containerRef.current) {
+      setHeaderSize(containerRef.current.getBoundingClientRect());
+    }
+  });
+
+  React.useEffect(() => {
+    if (baseHeaderLayoutRef.current) {
+      setHeaderSize(baseHeaderLayoutRef.current.getBoundingClientRect());
+    }
+  }, [baseHeaderLayoutRef]);
+
+  return (
+    <>
+      <div style={{ height: headerSize?.height }} ref={containerRef}>
+        {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} />}
+      </div>
+
+      {!isVisible && <BaseHeaderLayout {...props} sticky width={headerSize?.width} />}
+    </>
+  );
+};
+
+HeaderLayout.displayName = 'HeaderLayout';
+
+/**
+ * useElementOnScreen: hook that returns a ref to an element and a boolean indicating if the element is in the viewport.
+ */
+const useElementOnScreen = <TElement extends HTMLElement = HTMLElement>(
+  // eslint-disable-next-line
+  options?: IntersectionObserverInit
+): [containerRef: React.RefObject<TElement>, isVisible: boolean] => {
+  const containerRef = React.useRef<TElement>(null);
+
+  const [isVisible, setIsVisible] = React.useState<boolean>(true);
+
+  // eslint-disable-next-line
+  const callback: IntersectionObserverCallback = ([entry]) => {
+    setIsVisible(entry.isIntersecting);
+  };
+
+  React.useEffect(() => {
+    const containerEl = containerRef.current;
+    const observer = new IntersectionObserver(callback, options);
+
+    if (containerEl) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => {
+      if (containerEl) {
+        observer.disconnect();
+      }
+    };
+  }, [containerRef, options]);
+
+  return [containerRef, isVisible];
+};
+
+/**
+ * useResizeObserver: hook that observes the size of an element and calls a callback when it changes.
+ */
+const useResizeObserver = (
+  sources: React.RefObject<HTMLElement> | React.RefObject<HTMLElement>[],
+  // eslint-disable-next-line
+  onResize: ResizeObserverCallback
+) => {
+  const handleResize = useCallbackRef(onResize);
+
+  React.useLayoutEffect(() => {
+    const resizeObs = new ResizeObserver(handleResize);
+
+    if (Array.isArray(sources)) {
+      sources.forEach((source) => {
+        if (source.current) {
+          resizeObs.observe(source.current);
+        }
+      });
+    } else if (sources.current) {
+      resizeObs.observe(sources.current);
+    }
+
+    return () => {
+      resizeObs.disconnect();
+    };
+  }, [sources, handleResize]);
+};
+
+export type { HeaderLayoutProps, BaseHeaderLayoutProps };
+export { HeaderLayout, BaseHeaderLayout };

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -138,14 +138,12 @@ HeaderLayout.displayName = 'HeaderLayout';
  * useElementOnScreen: hook that returns a ref to an element and a boolean indicating if the element is in the viewport.
  */
 const useElementOnScreen = <TElement extends HTMLElement = HTMLElement>(
-  // eslint-disable-next-line
   options?: IntersectionObserverInit
 ): [containerRef: React.RefObject<TElement>, isVisible: boolean] => {
   const containerRef = React.useRef<TElement>(null);
 
   const [isVisible, setIsVisible] = React.useState<boolean>(true);
 
-  // eslint-disable-next-line
   const callback: IntersectionObserverCallback = ([entry]) => {
     setIsVisible(entry.isIntersecting);
   };
@@ -173,7 +171,6 @@ const useElementOnScreen = <TElement extends HTMLElement = HTMLElement>(
  */
 const useResizeObserver = (
   sources: React.RefObject<HTMLElement> | React.RefObject<HTMLElement>[],
-  // eslint-disable-next-line
   onResize: ResizeObserverCallback
 ) => {
   const handleResize = useCallbackRef(onResize);

--- a/packages/core/admin/admin/src/components/Layouts/Layout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/Layout.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { Box } from '@strapi/design-system';
+import styled from 'styled-components';
+
+import { ActionLayout } from './ActionLayout';
+import { ContentLayout } from './ContentLayout';
+import { GridLayout } from './GridLayout';
+import { HeaderLayout, BaseHeaderLayout } from './HeaderLayout';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  sideNav?: React.ReactNode;
+}
+
+const GridContainer = styled(Box)<{ hasSideNav: boolean }>`
+  display: grid;
+  grid-template-columns: ${({ hasSideNav }) => (hasSideNav ? `auto 1fr` : '1fr')};
+`;
+
+const OverflowingItem = styled(Box)`
+  overflow-x: hidden;
+`;
+
+const RootLayout = ({ sideNav, children }: LayoutProps) => {
+  return (
+    <GridContainer hasSideNav={Boolean(sideNav)}>
+      {sideNav}
+      <OverflowingItem paddingBottom={10}>{children}</OverflowingItem>
+    </GridContainer>
+  );
+};
+
+const Layouts = {
+  Root: RootLayout,
+  Header: HeaderLayout,
+  BaseHeader: BaseHeaderLayout,
+  Grid: GridLayout,
+  Action: ActionLayout,
+  Content: ContentLayout,
+};
+
+export { Layouts, type LayoutProps };

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -66,3 +66,9 @@ export type { RBACContext, RBACMiddleware } from './core/apis/rbac';
  */
 export { translatedErrors } from './utils/translatedErrors';
 export { getFetchClient } from './utils/getFetchClient';
+
+/**
+ * Components
+ */
+
+export { Layouts, type LayoutProps } from './components/Layouts/Layout';

--- a/packages/core/admin/admin/src/pages/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/HomePage.tsx
@@ -6,7 +6,6 @@ import {
   Flex,
   Grid,
   GridItem,
-  Layout,
   Main,
   Typography,
   Link,
@@ -32,6 +31,7 @@ import styled from 'styled-components';
 import { ContentBox } from '../components/ContentBox';
 import { GuidedTourHomepage } from '../components/GuidedTour/Homepage';
 import { useGuidedTour } from '../components/GuidedTour/Provider';
+import { Layouts } from '../components/Layouts/Layout';
 import { Page } from '../components/PageHelpers';
 import { useAppInfo } from '../features/AppInfo';
 import { useTracking } from '../features/Tracking';
@@ -74,7 +74,7 @@ const HomePageCE = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage({
           id: 'HomePage.head.title',
@@ -145,7 +145,7 @@ const HomePageCE = () => {
           </Grid>
         </Box>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/InstalledPluginsPage.tsx
+++ b/packages/core/admin/admin/src/pages/InstalledPluginsPage.tsx
@@ -1,21 +1,10 @@
 import * as React from 'react';
 
-import {
-  ContentLayout,
-  HeaderLayout,
-  Layout,
-  Table,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-  Typography,
-  useNotifyAT,
-} from '@strapi/design-system';
+import { Table, Tbody, Td, Th, Thead, Tr, Typography, useNotifyAT } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
+import { Layouts } from '../components/Layouts/Layout';
 import { Page } from '../components/PageHelpers';
 import { useNotification } from '../features/Notifications';
 import { useAPIErrorHandler } from '../hooks/useAPIErrorHandler';
@@ -61,9 +50,9 @@ const InstalledPluginsPage = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: 'global.plugins',
             defaultMessage: 'Plugins',
@@ -73,7 +62,7 @@ const InstalledPluginsPage = () => {
             defaultMessage: 'List of the installed plugins in the project.',
           })}
         />
-        <ContentLayout>
+        <Layouts.Content>
           <Table colCount={2} rowCount={data?.plugins?.length ?? 0 + 1}>
             <Thead>
               <Tr>
@@ -120,9 +109,9 @@ const InstalledPluginsPage = () => {
               })}
             </Tbody>
           </Table>
-        </ContentLayout>
+        </Layouts.Content>
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
+++ b/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
@@ -5,12 +5,13 @@
  *
  */
 
-import { ContentLayout, EmptyStateLayout, HeaderLayout, LinkButton } from '@strapi/design-system';
+import { EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { ArrowRight } from '@strapi/icons';
 import { EmptyPictures } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import { Layouts } from '../components/Layouts/Layout';
 import { Page } from '../components/PageHelpers';
 
 export const InternalErrorPage = () => {
@@ -18,14 +19,14 @@ export const InternalErrorPage = () => {
 
   return (
     <Page.Main labelledBy="title">
-      <HeaderLayout
+      <Layouts.Header
         id="title"
         title={formatMessage({
           id: 'content-manager.pageNotFound',
           defaultMessage: 'Page not found',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <EmptyStateLayout
           action={
             // @ts-expect-error We need to accept the props of the component passed in the `as` prop
@@ -44,7 +45,7 @@ export const InternalErrorPage = () => {
           icon={<EmptyPictures width="16rem" />}
           shadow="tableShadow"
         />
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 
 import {
   Box,
-  ContentLayout,
   Flex,
-  Layout,
   Searchbar,
   Tab,
   TabGroup,
@@ -17,6 +15,7 @@ import { GlassesSquare } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
 
 import { ContentBox } from '../../components/ContentBox';
+import { Layouts } from '../../components/Layouts/Layout';
 import { Page } from '../../components/PageHelpers';
 import { Pagination } from '../../components/Pagination';
 import { useTypedSelector } from '../../core/store/hooks';
@@ -163,7 +162,7 @@ const MarketplacePage = () => {
   const installedPackageNames = Object.keys(dependencies ?? {});
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Main>
         <Page.Title>
           {formatMessage({
@@ -172,7 +171,7 @@ const MarketplacePage = () => {
           })}
         </Page.Title>
         <PageHeader isOnline={isOnline} npmPackageType={npmPackageType} />
-        <ContentLayout>
+        <Layouts.Content>
           <TabGroup
             label={formatMessage({
               id: 'admin.pages.MarketPlacePage.tab-group.label',
@@ -301,9 +300,9 @@ const MarketplacePage = () => {
               />
             </a>
           </Box>
-        </ContentLayout>
+        </Layouts.Content>
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackagesGrid.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackagesGrid.tsx
@@ -1,8 +1,9 @@
-import { Box, Flex, Grid, GridItem, GridLayout, Typography } from '@strapi/design-system';
+import { Box, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
+import { Layouts } from '../../../components/Layouts/Layout';
 import { Page } from '../../../components/PageHelpers';
 import { AppInfoContextValue } from '../../../features/AppInfo';
 
@@ -50,13 +51,13 @@ const NpmPackagesGrid = ({
   if (npmPackages.length === 0) {
     return (
       <Box position="relative">
-        <GridLayout>
+        <Layouts.Grid size="M">
           {Array(12)
             .fill(null)
             .map((_, idx) => (
               <EmptyPluginCard key={idx} height="234px" hasRadius />
             ))}
-        </GridLayout>
+        </Layouts.Grid>
         <Box position="absolute" top={11} width="100%">
           <Flex alignItems="center" justifyContent="center" direction="column">
             <EmptyDocuments width="160px" height="88px" />

--- a/packages/core/admin/admin/src/pages/Marketplace/components/OfflineLayout.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/OfflineLayout.tsx
@@ -1,5 +1,7 @@
-import { Box, Flex, Layout, Main, Typography } from '@strapi/design-system';
+import { Box, Flex, Main, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
+
+import { Layouts } from '../../../components/Layouts/Layout';
 
 import { PageHeader } from './PageHeader';
 
@@ -7,7 +9,7 @@ const OfflineLayout = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
         <PageHeader />
         <Flex
@@ -49,7 +51,7 @@ const OfflineLayout = () => {
           </svg>
         </Flex>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Marketplace/components/PageHeader.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/PageHeader.tsx
@@ -1,7 +1,8 @@
-import { HeaderLayout, LinkButton } from '@strapi/design-system';
+import { LinkButton } from '@strapi/design-system';
 import { Upload } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
+import { Layouts } from '../../../components/Layouts/Layout';
 import { useTracking } from '../../../features/Tracking';
 
 import type { NpmPackageType } from '../MarketplacePage';
@@ -18,7 +19,7 @@ const PageHeader = ({ isOnline, npmPackageType = 'plugin' }: PageHeaderProps) =>
   const tracking = npmPackageType === 'provider' ? 'didSubmitProvider' : 'didSubmitPlugin';
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       title={formatMessage({
         id: 'global.marketplace',
         defaultMessage: 'Marketplace',

--- a/packages/core/admin/admin/src/pages/NotFoundPage.tsx
+++ b/packages/core/admin/admin/src/pages/NotFoundPage.tsx
@@ -4,12 +4,13 @@
  * This is the page we show when the user visits a url that doesn't have a route
  *
  */
-import { LinkButton, ContentLayout, EmptyStateLayout, HeaderLayout } from '@strapi/design-system';
+import { LinkButton, EmptyStateLayout } from '@strapi/design-system';
 import { ArrowRight } from '@strapi/icons';
 import { EmptyPictures } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import { Layouts } from '../components/Layouts/Layout';
 import { Page } from '../components/PageHelpers';
 
 export const NotFoundPage = () => {
@@ -17,14 +18,14 @@ export const NotFoundPage = () => {
 
   return (
     <Page.Main labelledBy="title">
-      <HeaderLayout
+      <Layouts.Header
         id="title"
         title={formatMessage({
           id: 'content-manager.pageNotFound',
           defaultMessage: 'Page not found',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <EmptyStateLayout
           action={
             // @ts-expect-error We need to accept the props of the component passed in the `as` prop
@@ -43,7 +44,7 @@ export const NotFoundPage = () => {
           icon={<EmptyPictures width="16rem" />}
           shadow="tableShadow"
         />
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/core/admin/admin/src/pages/ProfilePage.tsx
+++ b/packages/core/admin/admin/src/pages/ProfilePage.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
 
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  HeaderLayout,
-  useNotifyAT,
-  Grid,
-  GridItem,
-  Typography,
-} from '@strapi/design-system';
+import { Box, Button, Flex, useNotifyAT, Grid, GridItem, Typography } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
@@ -18,6 +8,7 @@ import * as yup from 'yup';
 
 import { Form, FormHelpers } from '../components/Form';
 import { InputRenderer } from '../components/FormInputs/Renderer';
+import { Layouts } from '../components/Layouts/Layout';
 import { Page } from '../components/PageHelpers';
 import { useTypedDispatch, useTypedSelector } from '../core/store/hooks';
 import { useAuth } from '../features/Auth';
@@ -190,7 +181,7 @@ const ProfilePage = () => {
       >
         {({ isSubmitting, modified }) => (
           <>
-            <HeaderLayout
+            <Layouts.Header
               title={getDisplayName(user)}
               primaryAction={
                 <Button
@@ -204,13 +195,13 @@ const ProfilePage = () => {
               }
             />
             <Box paddingBottom={10}>
-              <ContentLayout>
+              <Layouts.Content>
                 <Flex direction="column" alignItems="stretch" gap={6}>
                   <UserInfoSection />
                   {!hasLockedRole && <PasswordSection />}
                   <PreferencesSection localeNames={localeNames} />
                 </Flex>
-              </ContentLayout>
+              </Layouts.Content>
             </Box>
           </>
         )}

--- a/packages/core/admin/admin/src/pages/Settings/Layout.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/Layout.tsx
@@ -1,7 +1,7 @@
-import { Layout as DSLayout } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { Navigate, Outlet, useMatch } from 'react-router-dom';
 
+import { Layouts } from '../../components/Layouts/Layout';
 import { Page } from '../../components/PageHelpers';
 import { useSettingsMenu } from '../../hooks/useSettingsMenu';
 
@@ -27,7 +27,7 @@ const Layout = () => {
   }
 
   return (
-    <DSLayout sideNav={<SettingsNav menu={menu} />}>
+    <Layouts.Root sideNav={<SettingsNav menu={menu} />}>
       <Page.Title>
         {formatMessage({
           id: 'global.settings',
@@ -35,7 +35,7 @@ const Layout = () => {
         })}
       </Page.Title>
       <Outlet />
-    </DSLayout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import { Button, Flex, HeaderLayout } from '@strapi/design-system';
+import { Button, Flex } from '@strapi/design-system';
 import { Check, ArrowClockwise } from '@strapi/icons';
 import { MessageDescriptor, useIntl } from 'react-intl';
 
 import { ConfirmDialog } from '../../../../components/ConfirmDialog';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { BackButton } from '../../../../features/BackButton';
 import { useNotification } from '../../../../features/Notifications';
 import { useAPIErrorHandler } from '../../../../hooks/useAPIErrorHandler';
@@ -139,7 +140,7 @@ export const FormHead = <TToken extends Token | null>({
   };
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       title={token?.name || formatMessage(title)}
       primaryAction={
         canEditInputs ? (

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
-import { ContentLayout, Flex } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 import { Formik, Form, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import { useLocation, useMatch, useNavigate } from 'react-router-dom';
 
 import { useGuidedTour } from '../../../../../components/GuidedTour/Provider';
+import { Layouts } from '../../../../../components/Layouts/Layout';
 import { Page } from '../../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../../core/store/hooks';
 import { useNotification } from '../../../../../features/Notifications';
@@ -357,7 +358,7 @@ export const EditView = () => {
                   regenerateUrl="/admin/api-tokens/"
                 />
 
-                <ContentLayout>
+                <Layouts.Content>
                   <Flex direction="column" alignItems="stretch" gap={6}>
                     {Boolean(apiToken?.name) && (
                       <TokenBox token={apiToken?.accessKey} tokenType={API_TOKEN_TYPE} />
@@ -380,7 +381,7 @@ export const EditView = () => {
                       }
                     />
                   </Flex>
-                </ContentLayout>
+                </Layouts.Content>
               </Form>
             );
           }}

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ContentLayout, EmptyStateLayout, HeaderLayout, LinkButton } from '@strapi/design-system';
+import { EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { Data } from '@strapi/types';
@@ -9,6 +9,7 @@ import { useIntl } from 'react-intl';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { useGuidedTour } from '../../../../components/GuidedTour/Provider';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { useNotification } from '../../../../features/Notifications';
@@ -138,7 +139,7 @@ export const ListView = () => {
           { name: 'API Tokens' }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({ id: 'Settings.apiTokens.title', defaultMessage: 'API Tokens' })}
         subtitle={formatMessage({
           id: 'Settings.apiTokens.description',
@@ -171,7 +172,7 @@ export const ListView = () => {
         <Page.NoPermissions />
       ) : (
         <Page.Main aria-busy={isLoading}>
-          <ContentLayout>
+          <Layouts.Content>
             {apiTokens.length > 0 && (
               <Table
                 permissions={{ canRead, canDelete, canUpdate }}
@@ -214,7 +215,7 @@ export const ListView = () => {
                 })}
               />
             ) : null}
-          </ContentLayout>
+          </Layouts.Content>
         </Page.Main>
       )}
     </>

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
@@ -1,21 +1,11 @@
 import * as React from 'react';
 
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  Layout,
-  Link,
-  Typography,
-} from '@strapi/design-system';
+import { Box, Button, Flex, Grid, GridItem, Link, Typography } from '@strapi/design-system';
 import { Check, ExternalLink } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useAppInfo } from '../../../../features/AppInfo';
 import { useConfiguration } from '../../../../features/Configuration';
@@ -109,7 +99,7 @@ const ApplicationInfoPage = () => {
     logos.auth.custom === serverLogos.auth.custom && logos.menu.custom === serverLogos.menu.custom;
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage(
           { id: 'Settings.PageTitle', defaultMessage: 'Settings - {name}' },
@@ -123,7 +113,7 @@ const ApplicationInfoPage = () => {
       </Page.Title>
       <Page.Main>
         <form onSubmit={handleSubmit}>
-          <HeaderLayout
+          <Layouts.Header
             title={formatMessage({
               id: 'Settings.application.title',
               defaultMessage: 'Overview',
@@ -140,7 +130,7 @@ const ApplicationInfoPage = () => {
               )
             }
           />
-          <ContentLayout>
+          <Layouts.Content>
             <Flex direction="column" alignItems="stretch" gap={6}>
               <Flex
                 direction="column"
@@ -286,10 +276,10 @@ const ApplicationInfoPage = () => {
                 </Box>
               )}
             </Flex>
-          </ContentLayout>
+          </Layouts.Content>
         </form>
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/PurchaseAuditLogs.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/PurchaseAuditLogs.tsx
@@ -1,22 +1,17 @@
-import {
-  Box,
-  Layout,
-  Main,
-  HeaderLayout,
-  EmptyStateLayout,
-  LinkButton,
-} from '@strapi/design-system';
+import { Box, Main, EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 import { EmptyPermissions } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
+
+import { Layouts } from '../../../components/Layouts/Layout';
 
 const PurchaseAuditLogs = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({ id: 'global.auditLogs', defaultMessage: 'Audit Logs' })}
           subtitle={formatMessage({
             id: 'Settings.permissions.auditLogs.listview.header.subtitle',
@@ -48,7 +43,7 @@ const PurchaseAuditLogs = () => {
           />
         </Box>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/PurchaseSingleSignOn.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/PurchaseSingleSignOn.tsx
@@ -1,22 +1,17 @@
-import {
-  Box,
-  Layout,
-  Main,
-  HeaderLayout,
-  EmptyStateLayout,
-  LinkButton,
-} from '@strapi/design-system';
+import { Box, Main, EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 import { EmptyPermissions } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
+
+import { Layouts } from '../../../components/Layouts/Layout';
 
 const PurchaseSingleSignOn = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: 'Settings.sso.title',
             defaultMessage: 'Single Sign-On',
@@ -51,7 +46,7 @@ const PurchaseSingleSignOn = () => {
           />
         </Box>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
@@ -3,11 +3,9 @@ import * as React from 'react';
 import {
   Box,
   Button,
-  ContentLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
   Main,
   Textarea,
   TextInput,
@@ -20,6 +18,7 @@ import { useNavigate, useMatch } from 'react-router-dom';
 import styled from 'styled-components';
 import * as yup from 'yup';
 
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { BackButton } from '../../../../features/BackButton';
@@ -191,7 +190,7 @@ const CreatePage = () => {
         {({ values, errors, handleReset, handleChange, isSubmitting }) => (
           <Form>
             <>
-              <HeaderLayout
+              <Layouts.Header
                 primaryAction={
                   <Flex gap={2}>
                     <Button
@@ -225,7 +224,7 @@ const CreatePage = () => {
                 })}
                 navigationAction={<BackButton />}
               />
-              <ContentLayout>
+              <Layouts.Content>
                 <Flex direction="column" alignItems="stretch" gap={6}>
                   <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
                     <Flex direction="column" alignItems="stretch" gap={4}>
@@ -298,7 +297,7 @@ const CreatePage = () => {
                     />
                   </Box>
                 </Flex>
-              </ContentLayout>
+              </Layouts.Content>
             </>
           </Form>
         )}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
-import { Box, Button, ContentLayout, Flex, HeaderLayout, Main } from '@strapi/design-system';
+import { Box, Button, Flex, Main } from '@strapi/design-system';
 import { Formik, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import { Navigate, useMatch } from 'react-router-dom';
 import * as yup from 'yup';
 
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { BackButton } from '../../../../features/BackButton';
@@ -185,7 +186,7 @@ const EditPage = () => {
       >
         {({ handleSubmit, values, errors, handleChange, handleBlur, isSubmitting }) => (
           <form onSubmit={handleSubmit}>
-            <HeaderLayout
+            <Layouts.Header
               primaryAction={
                 <Flex gap={2}>
                   <Button
@@ -211,7 +212,7 @@ const EditPage = () => {
               })}
               navigationAction={<BackButton />}
             />
-            <ContentLayout>
+            <Layouts.Content>
               <Flex direction="column" alignItems="stretch" gap={6}>
                 <RoleForm
                   disabled={isFormDisabled}
@@ -230,7 +231,7 @@ const EditPage = () => {
                   />
                 </Box>
               </Flex>
-            </ContentLayout>
+            </Layouts.Content>
           </form>
         )}
       </Formik>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 
 import {
-  ActionLayout,
   Button,
-  ContentLayout,
-  HeaderLayout,
   Table,
   Tbody,
   TFooter,
@@ -21,6 +18,7 @@ import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 
 import { ConfirmDialog } from '../../../../components/ConfirmDialog';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { SearchInput } from '../../../../components/SearchInput';
 import { useTypedSelector } from '../../../../core/store/hooks';
@@ -130,7 +128,7 @@ const ListPage = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         primaryAction={
           canCreate ? (
             <Button onClick={handleNewRoleClick} startIcon={<Plus />} size="S">
@@ -152,7 +150,7 @@ const ListPage = () => {
         as="h2"
       />
       {canRead && (
-        <ActionLayout
+        <Layouts.Action
           startActions={
             <SearchInput
               label={formatMessage(
@@ -169,7 +167,7 @@ const ListPage = () => {
         />
       )}
       {canRead && (
-        <ContentLayout>
+        <Layouts.Content>
           <Table
             colCount={colCount}
             rowCount={rowCount}
@@ -259,7 +257,7 @@ const ListPage = () => {
               ))}
             </Tbody>
           </Table>
-        </ContentLayout>
+        </Layouts.Content>
       )}
       <ConfirmDialog
         isOpen={isWarningDeleteAllOpened}

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
-import { Box, ContentLayout, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
+import { Box, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 import { Formik, Form, FormikErrors, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import { useLocation, useNavigate, useMatch } from 'react-router-dom';
 import * as yup from 'yup';
 
 import { useGuidedTour } from '../../../../components/GuidedTour/Provider';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { useNotification } from '../../../../features/Notifications';
@@ -268,7 +269,7 @@ const EditView = () => {
                 isSubmitting={isSubmitting}
                 regenerateUrl="/admin/transfer/tokens/"
               />
-              <ContentLayout>
+              <Layouts.Content>
                 <Flex direction="column" alignItems="stretch" gap={6}>
                   {transferToken &&
                     Boolean(transferToken?.name) &&
@@ -284,7 +285,7 @@ const EditView = () => {
                     transferToken={transferToken}
                   />
                 </Flex>
-              </ContentLayout>
+              </Layouts.Content>
             </Form>
           );
         }}

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ContentLayout, EmptyStateLayout, HeaderLayout, LinkButton } from '@strapi/design-system';
+import { EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { Data } from '@strapi/types';
@@ -8,6 +8,7 @@ import * as qs from 'qs';
 import { useIntl } from 'react-intl';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { useNotification } from '../../../../features/Notifications';
@@ -148,7 +149,7 @@ const ListView = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: 'Settings.transferTokens.title',
           defaultMessage: 'Transfer Tokens',
@@ -184,7 +185,7 @@ const ListView = () => {
         <Page.NoPermissions />
       ) : (
         <Page.Main aria-busy={isLoading}>
-          <ContentLayout>
+          <Layouts.Content>
             {transferTokens.length > 0 && (
               <Table
                 permissions={{ canRead, canDelete, canUpdate }}
@@ -227,7 +228,7 @@ const ListView = () => {
                 })}
               />
             ) : null}
-          </ContentLayout>
+          </Layouts.Content>
         </Page.Main>
       )}
     </>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react';
 
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  Typography,
-} from '@strapi/design-system';
+import { Box, Button, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import pick from 'lodash/pick';
 import { useIntl } from 'react-intl';
@@ -19,6 +10,7 @@ import * as yup from 'yup';
 import { Update } from '../../../../../../shared/contracts/user';
 import { Form, FormHelpers } from '../../../../components/Form';
 import { InputRenderer } from '../../../../components/FormInputs/Renderer';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { BackButton } from '../../../../features/BackButton';
@@ -192,7 +184,7 @@ const EditPage = () => {
         {({ isSubmitting, modified }) => {
           return (
             <>
-              <HeaderLayout
+              <Layouts.Header
                 primaryAction={
                   <Button
                     disabled={isSubmitting || !canUpdate || !modified}
@@ -216,7 +208,7 @@ const EditPage = () => {
                 )}
                 navigationAction={<BackButton />}
               />
-              <ContentLayout>
+              <Layouts.Content>
                 {user?.registrationToken && (
                   <Box paddingBottom={6}>
                     <MagicLink registrationToken={user.registrationToken} />
@@ -285,7 +277,7 @@ const EditPage = () => {
                     </Flex>
                   </Box>
                 </Flex>
-              </ContentLayout>
+              </Layouts.Content>
             </>
           );
         }}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -1,14 +1,6 @@
 import * as React from 'react';
 
-import {
-  ActionLayout,
-  ContentLayout,
-  HeaderLayout,
-  Flex,
-  Typography,
-  Status,
-  IconButton,
-} from '@strapi/design-system';
+import { Flex, Typography, Status, IconButton } from '@strapi/design-system';
 import { Pencil, Trash } from '@strapi/icons';
 import * as qs from 'qs';
 import { MessageDescriptor, useIntl } from 'react-intl';
@@ -16,6 +8,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 import { SanitizedAdminUser } from '../../../../../../shared/contracts/shared';
 import { Filters } from '../../../../components/Filters';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { Pagination } from '../../../../components/Pagination';
 import { SearchInput } from '../../../../components/SearchInput';
@@ -125,7 +118,7 @@ const ListPageCE = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         primaryAction={canCreate && <CreateAction onClick={handleToggle} />}
         title={title}
         subtitle={formatMessage({
@@ -133,7 +126,7 @@ const ListPageCE = () => {
           defaultMessage: 'All the users who have access to the Strapi admin panel',
         })}
       />
-      <ActionLayout
+      <Layouts.Action
         startActions={
           <>
             <SearchInput
@@ -150,7 +143,7 @@ const ListPageCE = () => {
           </>
         }
       />
-      <ContentLayout>
+      <Layouts.Content>
         <Table.Root rows={users} headers={headers}>
           <Table.ActionBar />
           <Table.Content>
@@ -221,7 +214,7 @@ const ListPageCE = () => {
           <Pagination.PageSize />
           <Pagination.Links />
         </Pagination.Root>
-      </ContentLayout>
+      </Layouts.Content>
       {isModalOpened && <ModalForm onToggle={handleToggle} />}
     </Page.Main>
   );

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
@@ -2,15 +2,11 @@ import * as React from 'react';
 
 import {
   useNotifyAT,
-  ActionLayout,
   BaseCheckbox,
   Button,
-  ContentLayout,
   EmptyStateLayout,
   Flex,
-  HeaderLayout,
   IconButton,
-  Layout,
   Switch,
   Table,
   Tbody,
@@ -30,6 +26,7 @@ import { NavLink, useNavigate } from 'react-router-dom';
 
 import { UpdateWebhook } from '../../../../../../shared/contracts/webhooks';
 import { ConfirmDialog } from '../../../../components/ConfirmDialog';
+import { Layouts } from '../../../../components/Layouts/Layout';
 import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { useNotification } from '../../../../features/Notifications';
@@ -153,7 +150,7 @@ const ListPage = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage(
           { id: 'Settings.PageTitle', defaultMessage: 'Settings - {name}' },
@@ -163,7 +160,7 @@ const ListPage = () => {
         )}
       </Page.Title>
       <Page.Main aria-busy={isLoading}>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({ id: 'Settings.webhooks.title', defaultMessage: 'Webhooks' })}
           subtitle={formatMessage({
             id: 'Settings.webhooks.list.description',
@@ -189,7 +186,7 @@ const ListPage = () => {
           }
         />
         {webhooksToDeleteLength > 0 && canDelete && (
-          <ActionLayout
+          <Layouts.Action
             startActions={
               <>
                 <Typography variant="epsilon" textColor="neutral600">
@@ -217,7 +214,7 @@ const ListPage = () => {
             }
           />
         )}
-        <ContentLayout>
+        <Layouts.Content>
           {numberOfWebhooks > 0 ? (
             <Table
               colCount={5}
@@ -397,14 +394,14 @@ const ListPage = () => {
               }
             />
           )}
-        </ContentLayout>
+        </Layouts.Content>
       </Page.Main>
       <ConfirmDialog
         isOpen={showModal}
         onClose={() => setShowModal((prev) => !prev)}
         onConfirm={confirmDelete}
       />
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
@@ -1,21 +1,13 @@
 import * as React from 'react';
 
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  TextInput,
-} from '@strapi/design-system';
+import { Box, Button, Flex, Grid, GridItem, TextInput } from '@strapi/design-system';
 import { Check, Play as Publish } from '@strapi/icons';
 import { Field, Form, FormikHelpers, FormikProvider, useFormik } from 'formik';
 import { IntlShape, useIntl } from 'react-intl';
 import * as yup from 'yup';
 
 import { TriggerWebhook } from '../../../../../../../shared/contracts/webhooks';
+import { Layouts } from '../../../../../components/Layouts/Layout';
 import { BackButton } from '../../../../../features/BackButton';
 import { useEnterprise } from '../../../../../hooks/useEnterprise';
 
@@ -100,7 +92,7 @@ const WebhookForm = ({
   return (
     <FormikProvider value={formik}>
       <Form>
-        <HeaderLayout
+        <Layouts.Header
           primaryAction={
             <Flex gap={2}>
               <Button
@@ -142,7 +134,7 @@ const WebhookForm = ({
           }
           navigationAction={<BackButton />}
         />
-        <ContentLayout>
+        <Layouts.Content>
           <Flex direction="column" alignItems="stretch" gap={4}>
             {showTriggerResponse && (
               <TriggerContainer
@@ -184,7 +176,7 @@ const WebhookForm = ({
               </Flex>
             </Box>
           </Flex>
-        </ContentLayout>
+        </Layouts.Content>
       </Form>
     </FormikProvider>
   );

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -1,15 +1,9 @@
-import {
-  ActionLayout,
-  ContentLayout,
-  Flex,
-  HeaderLayout,
-  IconButton,
-  Typography,
-} from '@strapi/design-system';
+import { Flex, IconButton, Typography } from '@strapi/design-system';
 import { Eye } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { Filters } from '../../../../../../../admin/src/components/Filters';
+import { Layouts } from '../../../../../../../admin/src/components/Layouts/Layout';
 import { Page } from '../../../../../../../admin/src/components/PageHelpers';
 import { Pagination } from '../../../../../../../admin/src/components/Pagination';
 import { Table } from '../../../../../../../admin/src/components/Table';
@@ -109,7 +103,7 @@ const ListPage = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: 'global.auditLogs',
           defaultMessage: 'Audit Logs',
@@ -119,7 +113,7 @@ const ListPage = () => {
           defaultMessage: 'Logs of all the activities that happened in your environment',
         })}
       />
-      <ActionLayout
+      <Layouts.Action
         startActions={
           <Filters.Root options={displayedFilters}>
             <Filters.Trigger />
@@ -128,7 +122,7 @@ const ListPage = () => {
           </Filters.Root>
         }
       />
-      <ContentLayout>
+      <Layouts.Content>
         <Table.Root rows={results} headers={headers} isLoading={isLoading}>
           <Table.Content>
             <Table.Head>
@@ -210,7 +204,7 @@ const ListPage = () => {
           <Pagination.PageSize options={['12', '24', '50', '100']} />
           <Pagination.Links />
         </Pagination.Root>
-      </ContentLayout>
+      </Layouts.Content>
       {query?.id && (
         <Modal handleClose={() => setQuery({ id: '' }, 'remove')} logId={query.id.toString()} />
       )}

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
@@ -1,11 +1,8 @@
 import {
   Button,
-  ContentLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
-  Layout,
   MultiSelect,
   MultiSelectOption,
   SingleSelectOption,
@@ -18,6 +15,7 @@ import { Formik, Form, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import * as yup from 'yup';
 
+import { Layouts } from '../../../../../../admin/src/components/Layouts/Layout';
 import { Page } from '../../../../../../admin/src/components/PageHelpers';
 import { useTypedSelector } from '../../../../../../admin/src/core/store/hooks';
 import { useNotification } from '../../../../../../admin/src/features/Notifications';
@@ -111,7 +109,7 @@ export const SingleSignOnPage = () => {
   const isLoadingData = isLoadingRoles || isLoadingPermissions || isLoadingProviderOptions;
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage(
           { id: 'Settings.PageTitle', defaultMessage: 'Settings - {name}' },
@@ -136,7 +134,7 @@ export const SingleSignOnPage = () => {
         >
           {({ handleChange, isSubmitting, values, setFieldValue, dirty, errors }) => (
             <Form>
-              <HeaderLayout
+              <Layouts.Header
                 primaryAction={
                   <Button
                     disabled={!dirty}
@@ -160,7 +158,7 @@ export const SingleSignOnPage = () => {
                   defaultMessage: 'Configure the settings for the Single Sign-On feature.',
                 })}
               />
-              <ContentLayout>
+              <Layouts.Content>
                 {isSubmitting || isLoadingData ? (
                   <Page.Loading />
                 ) : (
@@ -288,12 +286,12 @@ export const SingleSignOnPage = () => {
                     </Grid>
                   </Flex>
                 )}
-              </ContentLayout>
+              </Layouts.Content>
             </Form>
           )}
         </Formik>
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react';
 
-import { Form, FormProps, useForm, InputRenderer, BackButton } from '@strapi/admin/strapi-admin';
 import {
-  Button,
-  ContentLayout,
-  Divider,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  Layout,
-  Main,
-  Typography,
-} from '@strapi/design-system';
+  Form,
+  FormProps,
+  useForm,
+  InputRenderer,
+  BackButton,
+  Layouts,
+} from '@strapi/admin/strapi-admin';
+import { Button, Divider, Flex, Grid, GridItem, Main, Typography } from '@strapi/design-system';
 import { generateNKeysBetween } from 'fractional-indexing';
 import pipe from 'lodash/fp/pipe';
 import { useIntl } from 'react-intl';
@@ -88,11 +84,11 @@ const ConfigurationForm = ({
   }, [layout, settings]);
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
         <Form initialValues={initialValues} onSubmit={onSubmit} method="PUT">
           <Header name={settings.displayName ?? ''} />
-          <ContentLayout>
+          <Layouts.Content>
             <Flex
               alignItems="stretch"
               background="neutral0"
@@ -170,10 +166,10 @@ const ConfigurationForm = ({
                 </GridItem>
               </Grid>
             </Flex>
-          </ContentLayout>
+          </Layouts.Content>
         </Form>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 
@@ -282,7 +278,7 @@ const Header = ({ name }: HeaderProps) => {
   const isSubmitting = useForm('Header', (state) => state.isSubmitting);
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       title={formatMessage(
         {
           id: getTranslation('components.SettingsViewWrapper.pluginHeader.title'),

--- a/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
@@ -1,15 +1,7 @@
 import * as React from 'react';
 
-import { Form } from '@strapi/admin/strapi-admin';
-import {
-  Box,
-  ContentLayout,
-  Divider,
-  Flex,
-  Grid,
-  GridItem,
-  Typography,
-} from '@strapi/design-system';
+import { Form, Layouts } from '@strapi/admin/strapi-admin';
+import { Box, Divider, Flex, Grid, GridItem, Typography } from '@strapi/design-system';
 import { Schema } from '@strapi/types';
 import pipe from 'lodash/fp/pipe';
 import { useIntl } from 'react-intl';
@@ -216,7 +208,7 @@ const VersionContent = () => {
   }, [components, version.data, version.schema]);
 
   return (
-    <ContentLayout>
+    <Layouts.Content>
       <Box paddingBottom={8}>
         <Form disabled={true} method="PUT" initialValues={transformedData}>
           <Flex direction="column" alignItems="stretch" gap={6} position="relative">
@@ -264,7 +256,7 @@ const VersionContent = () => {
           </Box>
         </>
       )}
-    </ContentLayout>
+    </Layouts.Content>
   );
 };
 

--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -5,8 +5,9 @@ import {
   useNotification,
   useQueryParams,
   useRBAC,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
-import { BaseHeaderLayout, Button, Typography, Flex, Link } from '@strapi/design-system';
+import { Button, Typography, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, WarningCircle } from '@strapi/icons';
 import { UID } from '@strapi/types';
 import { stringify } from 'qs';
@@ -107,7 +108,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
 
   return (
     <>
-      <BaseHeaderLayout
+      <Layouts.BaseHeader
         id={headerId}
         title={formatDate(new Date(version.createdAt), {
           year: 'numeric',

--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
-import { Page, useGuidedTour } from '@strapi/admin/strapi-admin';
-import { Layout as DSLayout } from '@strapi/design-system';
+import { Page, useGuidedTour, Layouts } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
 import { Navigate, Route, Routes, useLocation, useMatch } from 'react-router-dom';
 
@@ -89,14 +88,14 @@ const Layout = () => {
           defaultMessage: 'Content Manager',
         })}
       </Page.Title>
-      <DSLayout sideNav={<LeftMenu />}>
+      <Layouts.Root sideNav={<LeftMenu />}>
         <DragLayer renderItem={renderDraglayerItem} />
         <Routes>
           {routes.map((route) => (
             <Route key={route.path} {...route} />
           ))}
         </Routes>
-      </DSLayout>
+      </Layouts.Root>
     </>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/ListConfiguration/ListConfigurationPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListConfiguration/ListConfigurationPage.tsx
@@ -7,8 +7,9 @@ import {
   useTracking,
   useAPIErrorHandler,
   Page,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
-import { ContentLayout, Divider, Flex, Layout, Main } from '@strapi/design-system';
+import { Divider, Flex, Main } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { Navigate } from 'react-router-dom';
 
@@ -119,7 +120,7 @@ const ListConfiguration = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>{`Configure ${list.settings.displayName} List View`}</Page.Title>
       <Main>
         <Form initialValues={initialValues} onSubmit={handleSubmit} method="PUT">
@@ -128,7 +129,7 @@ const ListConfiguration = () => {
             model={model}
             name={list.settings.displayName ?? ''}
           />
-          <ContentLayout>
+          <Layouts.Content>
             <Flex
               alignItems="stretch"
               background="neutral0"
@@ -145,10 +146,10 @@ const ListConfiguration = () => {
               <Divider />
               <SortDisplayedFields />
             </Flex>
-          </ContentLayout>
+          </Layouts.Content>
         </Form>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/content-manager/admin/src/pages/ListConfiguration/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListConfiguration/components/Header.tsx
@@ -1,5 +1,5 @@
-import { useForm, BackButton } from '@strapi/admin/strapi-admin';
-import { Button, HeaderLayout } from '@strapi/design-system';
+import { useForm, BackButton, Layouts } from '@strapi/admin/strapi-admin';
+import { Button } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { capitalise } from '../../../utils/strings';
@@ -18,7 +18,7 @@ const Header = ({ name }: HeaderProps) => {
   const isSubmitting = useForm('Header', (state) => state.isSubmitting);
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       navigationAction={<BackButton />}
       primaryAction={
         <Button size="S" disabled={!modified} type="submit" loading={isSubmitting}>

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -12,16 +12,9 @@ import {
   useAPIErrorHandler,
   useQueryParams,
   useRBAC,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
-import {
-  ActionLayout,
-  Button,
-  ContentLayout,
-  HeaderLayout,
-  Flex,
-  Typography,
-  ButtonProps,
-} from '@strapi/design-system';
+import { Button, Flex, Typography, ButtonProps } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import isEqual from 'lodash/isEqual';
 import { stringify } from 'qs';
@@ -196,7 +189,7 @@ const ListViewPage = () => {
   return (
     <Page.Main>
       <Page.Title>{`${contentTypeTitle}`}</Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         primaryAction={canCreate ? <CreateButton /> : null}
         subtitle={formatMessage(
           {
@@ -209,7 +202,7 @@ const ListViewPage = () => {
         title={contentTypeTitle}
         navigationAction={<BackButton />}
       />
-      <ActionLayout
+      <Layouts.Action
         endActions={
           <>
             <InjectionZone area="listView.actions" />
@@ -242,7 +235,7 @@ const ListViewPage = () => {
           </>
         }
       />
-      <ContentLayout>
+      <Layouts.Content>
         <Flex gap={4} direction="column" alignItems="stretch">
           <Table.Root rows={results} headers={tableHeaders} isLoading={isLoading}>
             <Table.ActionBar />
@@ -324,7 +317,7 @@ const ListViewPage = () => {
             <Pagination.Links />
           </Pagination.Root>
         </Flex>
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/NoContentTypePage.tsx
+++ b/packages/core/content-manager/admin/src/pages/NoContentTypePage.tsx
@@ -1,5 +1,5 @@
-import { Page } from '@strapi/admin/strapi-admin';
-import { ContentLayout, EmptyStateLayout, HeaderLayout, LinkButton } from '@strapi/design-system';
+import { Page, Layouts } from '@strapi/admin/strapi-admin';
+import { EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { Plus } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
@@ -12,13 +12,13 @@ const NoContentType = () => {
 
   return (
     <Page.Main>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: getTranslation('header.name'),
           defaultMessage: 'Content',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <EmptyStateLayout
           action={
             <LinkButton
@@ -43,7 +43,7 @@ const NoContentType = () => {
           icon={<EmptyDocuments width="16rem" />}
           shadow="tableShadow"
         />
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/NoPermissionsPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/NoPermissionsPage.tsx
@@ -1,5 +1,4 @@
-import { Page } from '@strapi/admin/strapi-admin';
-import { ContentLayout, HeaderLayout } from '@strapi/design-system';
+import { Page, Layouts } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
 
 import { getTranslation } from '../utils/translations';
@@ -9,15 +8,15 @@ const NoPermissions = () => {
 
   return (
     <>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: getTranslation('header.name'),
           defaultMessage: 'Content',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <Page.NoPermissions />
-      </ContentLayout>
+      </Layouts.Content>
     </>
   );
 };

--- a/packages/core/content-releases/admin/src/pages/PurchaseContentReleases.tsx
+++ b/packages/core/content-releases/admin/src/pages/PurchaseContentReleases.tsx
@@ -1,11 +1,5 @@
-import {
-  Box,
-  Layout,
-  Main,
-  HeaderLayout,
-  EmptyStateLayout,
-  LinkButton,
-} from '@strapi/design-system';
+import { Layouts } from '@strapi/admin/strapi-admin';
+import { Box, Main, EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 import { EmptyPermissions } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
@@ -14,9 +8,9 @@ const PurchaseContentReleases = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: 'content-releases.pages.Releases.title',
             defaultMessage: 'Releases',
@@ -51,7 +45,7 @@ const PurchaseContentReleases = () => {
           />
         </Box>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -12,13 +12,12 @@ import {
   useQueryParams,
   useRBAC,
   useStrapiApp,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
 import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
 import {
   Button,
-  ContentLayout,
   Flex,
-  HeaderLayout,
   IconButton,
   Main,
   Tr,
@@ -353,7 +352,7 @@ const ReleaseDetailsLayout = ({
 
   return (
     <Main aria-busy={isLoadingDetails}>
-      <HeaderLayout
+      <Layouts.Header
         title={release.name}
         subtitle={
           <Flex gap={2} lineHeight={6}>
@@ -628,7 +627,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
 
   if (Object.keys(releaseActions).length === 0) {
     return (
-      <ContentLayout>
+      <Layouts.Content>
         <EmptyStateLayout
           action={
             <LinkButton
@@ -653,7 +652,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
               'This release is empty. Open the Content Manager, select an entry and add it to the release.',
           })}
         />
-      </ContentLayout>
+      </Layouts.Content>
     );
   }
 
@@ -699,7 +698,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
   const options = hasI18nEnabled ? GROUP_BY_OPTIONS : GROUP_BY_OPTIONS_NO_LOCALE;
 
   return (
-    <ContentLayout>
+    <Layouts.Content>
       <Flex gap={8} direction="column" alignItems="stretch">
         <Flex>
           <SingleSelect
@@ -833,7 +832,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
           <Pagination.Links />
         </Pagination.Root>
       </Flex>
-    </ContentLayout>
+    </Layouts.Content>
   );
 };
 

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -8,6 +8,7 @@ import {
   useNotification,
   useQueryParams,
   useRBAC,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
 import { useLicenseLimits } from '@strapi/admin/strapi-admin/ee';
 import {
@@ -15,13 +16,11 @@ import {
   Badge,
   Box,
   Button,
-  ContentLayout,
   Divider,
   EmptyStateLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
   Main,
   Tab,
   TabGroup,
@@ -291,7 +290,7 @@ const ReleasesPage = () => {
 
   return (
     <Main aria-busy={isLoading}>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: 'content-releases.pages.Releases.title',
           defaultMessage: 'Releases',
@@ -315,7 +314,7 @@ const ReleasesPage = () => {
           ) : null
         }
       />
-      <ContentLayout>
+      <Layouts.Content>
         <>
           {hasReachedMaximumPendingReleases && (
             <StyledAlert
@@ -404,7 +403,7 @@ const ReleasesPage = () => {
             <Pagination.Links />
           </Pagination.Root>
         </>
-      </ContentLayout>
+      </Layouts.Content>
       {releaseModalShown && (
         <ReleaseModal
           handleClose={toggleAddReleaseModal}

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -396,15 +396,6 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
   color: #666687;
 }
 
-.c0 {
-  display: grid;
-  grid-template-columns: auto 1fr;
-}
-
-.c46 {
-  overflow-x: hidden;
-}
-
 .c1 {
   width: 23.2rem;
   background: #f6f6f9;
@@ -509,6 +500,15 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 
 .c19 svg path {
   fill: #8e8ea9;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
+
+.c46 {
+  overflow-x: hidden;
 }
 
 <div>

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/index.test.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/index.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable check-file/filename-naming-convention */
-import { Layout, lightTheme, ThemeProvider } from '@strapi/design-system';
+import { Layouts } from '@strapi/admin/strapi-admin';
+import { lightTheme, ThemeProvider } from '@strapi/design-system';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
@@ -23,9 +24,9 @@ const makeApp = () => {
     <IntlProvider messages={{}} defaultLocale="en" textComponent="span" locale="en">
       <ThemeProvider theme={lightTheme}>
         <MemoryRouter>
-          <Layout sideNav={<ContentTypeBuilderNav />}>
+          <Layouts.Root sideNav={<ContentTypeBuilderNav />}>
             <div />
-          </Layout>
+          </Layouts.Root>
         </MemoryRouter>
       </ThemeProvider>
     </IntlProvider>

--- a/packages/core/content-type-builder/admin/src/pages/App/index.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/App/index.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable check-file/no-index */
 import { lazy, Suspense, useEffect, useRef } from 'react';
 
-import { Page, useGuidedTour } from '@strapi/admin/strapi-admin';
-import { Layout } from '@strapi/design-system';
+import { Page, useGuidedTour, Layouts } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
 import { Route, Routes } from 'react-router-dom';
 
@@ -42,14 +41,14 @@ const App = () => {
           {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
           {/* @ts-ignore */}
           <DataManagerProvider>
-            <Layout sideNav={<ContentTypeBuilderNav />}>
+            <Layouts.Root sideNav={<ContentTypeBuilderNav />}>
               <Suspense fallback={<Page.Loading />}>
                 <Routes>
                   <Route path="content-types/:uid" element={<ListView />} />
                   <Route path={`component-categories/:categoryUid/*`} element={<RecursivePath />} />
                 </Routes>
               </Suspense>
-            </Layout>
+            </Layouts.Root>
           </DataManagerProvider>
         </FormModalNavigationProvider>
       </AutoReloadOverlayBlockerProvider>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -1,5 +1,5 @@
-import { BackButton, useTracking } from '@strapi/admin/strapi-admin';
-import { Box, Button, ContentLayout, Flex, HeaderLayout } from '@strapi/design-system';
+import { BackButton, useTracking, Layouts } from '@strapi/admin/strapi-admin';
+import { Box, Button, Flex } from '@strapi/design-system';
 import { Check, Pencil, Plus } from '@strapi/icons';
 import get from 'lodash/get';
 import has from 'lodash/has';
@@ -117,7 +117,7 @@ const ListView = () => {
 
   return (
     <>
-      <HeaderLayout
+      <Layouts.Header
         id="title"
         primaryAction={
           isInDevelopmentMode && (
@@ -170,7 +170,7 @@ const ListView = () => {
         })}
         navigationAction={<BackButton />}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <Flex direction="column" alignItems="stretch" gap={4}>
           <Flex justifyContent="flex-end">
             <Flex gap={2}>
@@ -195,7 +195,7 @@ const ListView = () => {
             />
           </Box>
         </Flex>
-      </ContentLayout>
+      </Layouts.Content>
     </>
   );
 };

--- a/packages/core/email/admin/src/pages/Settings.tsx
+++ b/packages/core/email/admin/src/pages/Settings.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 
-import { Page, useNotification, useFetchClient } from '@strapi/admin/strapi-admin';
+import { Page, useNotification, useFetchClient, Layouts } from '@strapi/admin/strapi-admin';
 import {
   Box,
   Button,
-  ContentLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
   SingleSelectOption,
   SingleSelect,
   TextInput,
@@ -136,7 +134,7 @@ const SettingsPage = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         id="title"
         title={formatMessage({
           id: 'email.Settings.email.plugin.title',
@@ -148,7 +146,7 @@ const SettingsPage = () => {
         })}
       />
 
-      <ContentLayout>
+      <Layouts.Content>
         {data && (
           <form onSubmit={handleSubmit}>
             <Flex direction="column" alignItems="stretch" gap={7}>
@@ -308,7 +306,7 @@ const SettingsPage = () => {
             </Flex>
           </form>
         )}
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/core/review-workflows/admin/src/routes/purchase-review-workflows.tsx
+++ b/packages/core/review-workflows/admin/src/routes/purchase-review-workflows.tsx
@@ -1,11 +1,5 @@
-import {
-  Box,
-  Layout,
-  Main,
-  HeaderLayout,
-  EmptyStateLayout,
-  LinkButton,
-} from '@strapi/design-system';
+import { Layouts } from '@strapi/admin/strapi-admin';
+import { Box, Main, EmptyStateLayout, LinkButton } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 import { EmptyPermissions } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
@@ -14,9 +8,9 @@ const PurchaseReviewWorkflows = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: 'Settings.review-workflows.list.page.title',
             defaultMessage: 'Review Workflows',
@@ -51,7 +45,7 @@ const PurchaseReviewWorkflows = () => {
           />
         </Box>
       </Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/review-workflows/admin/src/routes/settings/components/Layout.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/Layout.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { Page } from '@strapi/admin/strapi-admin';
-import { Box, ContentLayout, HeaderLayout } from '@strapi/design-system';
+import { Page, Layouts } from '@strapi/admin/strapi-admin';
+import { Box } from '@strapi/design-system';
 import { XYCoord, useDragLayer } from 'react-dnd';
 import { useIntl } from 'react-intl';
 
@@ -61,7 +61,7 @@ const DragLayerRendered = () => {
 const Root: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <Page.Main>
-      <ContentLayout>{children}</ContentLayout>
+      <Layouts.Content>{children}</Layouts.Content>
     </Page.Main>
   );
 };
@@ -86,7 +86,7 @@ const Header: React.FC<HeaderProps> = ({ title, subtitle, navigationAction, prim
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         navigationAction={navigationAction}
         primaryAction={primaryAction}
         title={title}

--- a/packages/core/upload/admin/src/components/EmptyAssets/EmptyAssetGrid.jsx
+++ b/packages/core/upload/admin/src/components/EmptyAssets/EmptyAssetGrid.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Layouts } from '@strapi/admin/strapi-admin';
 import { Box } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -13,25 +14,14 @@ const EmptyAssetCard = styled(Box)`
   opacity: 0.33;
 `;
 
-const GridColSize = {
-  S: 180,
-  M: 250,
-};
-
 const PlaceholderSize = {
   S: 138,
   M: 234,
 };
 
-const GridLayout = styled(Box)`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(${({ size }) => `${GridColSize[size]}px`}, 1fr));
-  grid-gap: ${({ theme }) => theme.spaces[4]};
-`;
-
 export const EmptyAssetGrid = ({ count, size }) => {
   return (
-    <GridLayout size={size}>
+    <Layouts.Grid size={size}>
       {Array(count)
         .fill(null)
         .map((_, idx) => (
@@ -42,7 +32,7 @@ export const EmptyAssetGrid = ({ count, size }) => {
             hasRadius
           />
         ))}
-    </GridLayout>
+    </Layouts.Grid>
   );
 };
 

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/index.jsx
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/index.jsx
@@ -1,8 +1,13 @@
 import React, { useReducer, useState } from 'react';
 
-import { ConfirmDialog, useTracking, useNotification, Page } from '@strapi/admin/strapi-admin';
-import { Button, ContentLayout, HeaderLayout, Layout } from '@strapi/design-system';
-import { Link } from '@strapi/design-system';
+import {
+  ConfirmDialog,
+  useTracking,
+  useNotification,
+  Page,
+  Layouts,
+} from '@strapi/admin/strapi-admin';
+import { Button, Link } from '@strapi/design-system';
 import { ArrowLeft, Check } from '@strapi/icons';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
@@ -55,10 +60,10 @@ const ConfigureTheView = ({ config }) => {
   };
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Main aria-busy={isSubmittingForm}>
         <form onSubmit={handleSubmit}>
-          <HeaderLayout
+          <Layouts.Header
             navigationAction={
               <Link as={NavLink} startIcon={<ArrowLeft />} to={`/plugins/${pluginID}`} id="go-back">
                 {formatMessage({ id: getTrad('config.back'), defaultMessage: 'Back' })}
@@ -84,14 +89,14 @@ const ConfigureTheView = ({ config }) => {
             })}
           />
 
-          <ContentLayout>
+          <Layouts.Content>
             <Settings
               data-testid="settings"
               pageSize={modifiedData.pageSize || ''}
               sort={modifiedData.sort || ''}
               onChange={handleChange}
             />
-          </ContentLayout>
+          </Layouts.Content>
 
           <ConfirmDialog
             isOpen={showWarningSubmit}
@@ -106,7 +111,7 @@ const ConfigureTheView = ({ config }) => {
           </ConfirmDialog>
         </form>
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.jsx.snap
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.jsx.snap
@@ -452,6 +452,10 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   max-width: 100%;
 }
 
+.c3:focus-visible {
+  outline: none;
+}
+
 .c0 {
   display: grid;
   grid-template-columns: 1fr;
@@ -459,10 +463,6 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
 
 .c2 {
   overflow-x: hidden;
-}
-
-.c3:focus-visible {
-  outline: none;
 }
 
 @media (max-width:1100px) {

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/Header.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
-import { Button, Flex, HeaderLayout, Link } from '@strapi/design-system';
+import { useQueryParams, Layouts } from '@strapi/admin/strapi-admin';
+import { Button, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, Plus } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
@@ -29,7 +29,7 @@ export const Header = ({
   };
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       title={formatMessage({
         id: getTrad('plugin.name'),
         defaultMessage: `Media Library`,

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
@@ -6,17 +6,15 @@ import {
   Pagination,
   useTracking,
   useQueryParams,
+  Layouts,
 } from '@strapi/admin/strapi-admin';
 import {
-  ActionLayout,
   BaseCheckbox,
   Box,
-  ContentLayout,
   Divider,
   Flex,
   GridItem,
   IconButton,
-  Layout,
   Typography,
   VisuallyHidden,
 } from '@strapi/design-system';
@@ -217,7 +215,7 @@ export const MediaLibrary = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Main>
         <Header
           breadcrumbs={
@@ -228,7 +226,7 @@ export const MediaLibrary = () => {
           onToggleUploadAssetDialog={toggleUploadAssetDialog}
           folder={currentFolder}
         />
-        <ActionLayout
+        <Layouts.Action
           startActions={
             <>
               {canUpdate && isGridView && (assetCount > 0 || folderCount > 0) && (
@@ -306,7 +304,7 @@ export const MediaLibrary = () => {
           }
         />
 
-        <ContentLayout>
+        <Layouts.Content>
           {selected.length > 0 && (
             <BulkActions
               currentFolder={currentFolder}
@@ -478,7 +476,7 @@ export const MediaLibrary = () => {
             <Pagination.PageSize />
             <Pagination.Links />
           </Pagination.Root>
-        </ContentLayout>
+        </Layouts.Content>
       </Page.Main>
 
       {showUploadAssetDialog && (
@@ -515,6 +513,6 @@ export const MediaLibrary = () => {
           trackedLocation="upload"
         />
       )}
-    </Layout>
+    </Layouts.Root>
   );
 };

--- a/packages/core/upload/admin/src/pages/App/components/Header.jsx
+++ b/packages/core/upload/admin/src/pages/App/components/Header.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
-import { Button, Flex, HeaderLayout, Link } from '@strapi/design-system';
+import { useQueryParams, Layouts } from '@strapi/admin/strapi-admin';
+import { Button, Flex, Link } from '@strapi/design-system';
 import { ArrowLeft, Plus } from '@strapi/icons';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
@@ -28,7 +28,7 @@ export const Header = ({
   };
 
   return (
-    <HeaderLayout
+    <Layouts.Header
       title={formatMessage({
         id: getTrad('plugin.name'),
         defaultMessage: `Media Library`,

--- a/packages/core/upload/admin/src/pages/SettingsPage/index.jsx
+++ b/packages/core/upload/admin/src/pages/SettingsPage/index.jsx
@@ -1,21 +1,9 @@
 import React, { useReducer } from 'react';
 
-import { Page, useNotification, useFetchClient } from '@strapi/admin/strapi-admin';
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  Layout,
-  ToggleInput,
-  Typography,
-} from '@strapi/design-system';
+import { Page, useNotification, useFetchClient, Layouts } from '@strapi/admin/strapi-admin';
+import { Box, Button, Flex, Grid, GridItem, ToggleInput, Typography } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import isEqual from 'lodash/isEqual';
-
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery } from 'react-query';
 
@@ -102,7 +90,7 @@ export const SettingsPage = () => {
         })}
       </Page.Title>
       <form onSubmit={handleSubmit}>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: getTrad('settings.header.label'),
             defaultMessage: 'Media Library',
@@ -126,8 +114,8 @@ export const SettingsPage = () => {
             defaultMessage: 'Configure the settings for the Media Library',
           })}
         />
-        <ContentLayout>
-          <Layout>
+        <Layouts.Content>
+          <Layouts.Root>
             <Flex direction="column" alignItems="stretch" gap={12}>
               <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
                 <Flex direction="column" alignItems="stretch" gap={4}>
@@ -231,8 +219,8 @@ export const SettingsPage = () => {
                 </Flex>
               </Box>
             </Flex>
-          </Layout>
-        </ContentLayout>
+          </Layouts.Root>
+        </Layouts.Content>
       </form>
     </Page.Main>
   );

--- a/packages/plugins/cloud/admin/src/pages/HomePage.tsx
+++ b/packages/plugins/cloud/admin/src/pages/HomePage.tsx
@@ -4,8 +4,8 @@
  *
  */
 
-import { Box, GridLayout, Flex, Typography } from '@strapi/design-system';
-import { Link } from '@strapi/design-system';
+import { Box, Flex, Typography, Link } from '@strapi/design-system';
+import { Layouts } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -84,10 +84,10 @@ const HomePage = () => {
         </Flex>
       </Box>
       <Box padding={10}>
-        <GridLayout>
+        <Layouts.Grid size="M">
           <GithubBox />
           <CloudBox />
-        </GridLayout>
+        </Layouts.Grid>
         <Box padding={6} borderRadius={8} hasRadius background="neutral0" borderColor="neutral200">
           <Box paddingBottom={2}>
             <Typography variant="delta" fontWeight="bold" textColor="neutral1000" as="p">

--- a/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
+++ b/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
@@ -3,11 +3,9 @@ import * as React from 'react';
 import {
   Box,
   Button,
-  ContentLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
   TextInput,
   ToggleInput,
   Typography,
@@ -15,7 +13,7 @@ import {
 } from '@strapi/design-system';
 // Strapi Icons
 import { Check, Eye as Show, EyeStriked as Hide } from '@strapi/icons';
-import { translatedErrors, useRBAC } from '@strapi/strapi/admin';
+import { translatedErrors, useRBAC, Layouts } from '@strapi/strapi/admin';
 import { Form, Formik, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -74,7 +72,7 @@ export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
       }) => {
         return (
           <Form noValidate onSubmit={handleSubmit}>
-            <HeaderLayout
+            <Layouts.Header
               title={formatMessage({
                 id: getTrad('plugin.name'),
                 defaultMessage: 'Documentation',
@@ -96,7 +94,7 @@ export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
                 </Button>
               }
             />
-            <ContentLayout>
+            <Layouts.Content>
               <Box
                 background="neutral0"
                 hasRadius
@@ -186,7 +184,7 @@ export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
                   </Grid>
                 </Flex>
               </Box>
-            </ContentLayout>
+            </Layouts.Content>
           </Form>
         );
       }}

--- a/packages/plugins/documentation/admin/src/pages/App.tsx
+++ b/packages/plugins/documentation/admin/src/pages/App.tsx
@@ -3,11 +3,8 @@ import * as React from 'react';
 
 import {
   LinkButton,
-  ContentLayout,
   Flex,
-  HeaderLayout,
   IconButton,
-  Layout,
   Table,
   Tbody,
   Td,
@@ -24,6 +21,7 @@ import {
   Page,
   useAPIErrorHandler,
   useNotification,
+  Layouts,
 } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -122,10 +120,10 @@ const App = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>{title}</Page.Title>
       <Page.Main>
-        <HeaderLayout
+        <Layouts.Header
           title={title}
           subtitle={formatMessage({
             id: getTrad('pages.PluginPage.header.description'),
@@ -144,7 +142,7 @@ const App = () => {
             </OpenDocLink>
           }
         />
-        <ContentLayout>
+        <Layouts.Content>
           {data?.docVersions.length ? (
             <Table colCount={colCount} rowCount={rowCount}>
               <Thead>
@@ -235,14 +233,14 @@ const App = () => {
           ) : (
             <EmptyStateLayout content="" icon={null} />
           )}
-        </ContentLayout>
+        </Layouts.Content>
         <ConfirmDialog
           onConfirm={handleConfirmDelete}
           onClose={handleShowConfirmDelete}
           isOpen={showConfirmDelete}
         />
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
+++ b/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 
-import { Page, useAPIErrorHandler, useNotification, useRBAC } from '@strapi/admin/strapi-admin';
-import { ContentLayout, EmptyStateLayout, HeaderLayout } from '@strapi/design-system';
+import {
+  Page,
+  useAPIErrorHandler,
+  useNotification,
+  useRBAC,
+  Layouts,
+} from '@strapi/admin/strapi-admin';
+import { EmptyStateLayout } from '@strapi/design-system';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { useIntl } from 'react-intl';
 
@@ -42,7 +48,7 @@ const SettingsPage = () => {
 
   return (
     <Page.Main tabIndex={-1}>
-      <HeaderLayout
+      <Layouts.Header
         primaryAction={<CreateLocale disabled={!canCreate} />}
         title={formatMessage({
           id: getTranslation('plugin.name'),
@@ -53,7 +59,7 @@ const SettingsPage = () => {
           defaultMessage: 'Configure the settings',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         {locales.length > 0 ? (
           <LocaleTable locales={locales} canDelete={canDelete} canUpdate={canUpdate} />
         ) : (
@@ -66,7 +72,7 @@ const SettingsPage = () => {
             action={<CreateLocale disabled={!canCreate} variant="secondary" />}
           />
         )}
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
@@ -1,16 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Button,
-  ContentLayout,
-  Flex,
-  Grid,
-  GridItem,
-  HeaderLayout,
-  Typography,
-  useNotifyAT,
-} from '@strapi/design-system';
+import { Box, Button, Flex, Grid, GridItem, Typography, useNotifyAT } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import {
   useAPIErrorHandler,
@@ -20,8 +10,8 @@ import {
   useNotification,
   useFetchClient,
   useRBAC,
+  Layouts,
 } from '@strapi/strapi/admin';
-
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
@@ -133,7 +123,7 @@ const AdvancedSettingsPage = () => {
         {({ values, isSubmitting, modified }) => {
           return (
             <>
-              <HeaderLayout
+              <Layouts.Header
                 title={formatMessage({
                   id: getTrad('HeaderNav.link.advancedSettings'),
                   defaultMessage: 'Advanced Settings',
@@ -150,7 +140,7 @@ const AdvancedSettingsPage = () => {
                   </Button>
                 }
               />
-              <ContentLayout>
+              <Layouts.Content>
                 <Box
                   background="neutral0"
                   hasRadius
@@ -207,7 +197,7 @@ const AdvancedSettingsPage = () => {
                     </Grid>
                   </Flex>
                 </Box>
-              </ContentLayout>
+              </Layouts.Content>
             </>
           );
         }}

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/index.jsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
 import { useTracking } from '@strapi/admin/strapi-admin';
-import { ContentLayout, HeaderLayout, useNotifyAT } from '@strapi/design-system';
+import { useNotifyAT } from '@strapi/design-system';
 import {
   Page,
   useAPIErrorHandler,
   useNotification,
   useFetchClient,
   useRBAC,
+  Layouts,
 } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
@@ -125,13 +126,13 @@ const EmailTemplatesPage = () => {
           }
         )}
       </Page.Title>
-      <HeaderLayout
+      <Layouts.Header
         title={formatMessage({
           id: getTrad('HeaderNav.link.emailTemplates'),
           defaultMessage: 'Email templates',
         })}
       />
-      <ContentLayout>
+      <Layouts.Content>
         <EmailTable onEditClick={handleEditClick} canUpdate={canUpdate} />
         {isModalOpen && (
           <EmailForm
@@ -140,7 +141,7 @@ const EmailTemplatesPage = () => {
             onSubmit={handleSubmit}
           />
         )}
-      </ContentLayout>
+      </Layouts.Content>
     </Page.Main>
   );
 };

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/index.jsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 
-import { useTracking } from '@strapi/admin/strapi-admin';
+import { useTracking, Layouts } from '@strapi/admin/strapi-admin';
 import {
-  ContentLayout,
-  HeaderLayout,
   IconButton,
-  Layout,
   Table,
   Tbody,
   Td,
@@ -147,7 +144,7 @@ export const ProvidersPage = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage(
           { id: 'Settings.PageTitle', defaultMessage: 'Settings - {name}' },
@@ -160,13 +157,13 @@ export const ProvidersPage = () => {
         )}
       </Page.Title>
       <Page.Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: getTrad('HeaderNav.link.providers'),
             defaultMessage: 'Providers',
           })}
         />
-        <ContentLayout>
+        <Layouts.Content>
           <Table colCount={3} rowCount={providers.length + 1}>
             <Thead>
               <Tr>
@@ -233,7 +230,7 @@ export const ProvidersPage = () => {
               ))}
             </Tbody>
           </Table>
-        </ContentLayout>
+        </Layouts.Content>
       </Page.Main>
       <FormModal
         initialData={data[providerToEditName]}
@@ -251,7 +248,7 @@ export const ProvidersPage = () => {
         onSubmit={handleSubmit}
         providerToEditName={providerToEditName}
       />
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.jsx
@@ -2,18 +2,16 @@ import * as React from 'react';
 
 import {
   Button,
-  ContentLayout,
   Flex,
   Grid,
   GridItem,
-  HeaderLayout,
   Main,
   Textarea,
   TextInput,
   Typography,
 } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
-import { Page, useTracking, useNotification, useFetchClient } from '@strapi/strapi/admin';
+import { Page, useTracking, useNotification, useFetchClient, Layouts } from '@strapi/strapi/admin';
 import { Formik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
@@ -85,7 +83,7 @@ export const CreatePage = () => {
       >
         {({ handleSubmit, values, handleChange, errors }) => (
           <Form noValidate onSubmit={handleSubmit}>
-            <HeaderLayout
+            <Layouts.Header
               primaryAction={
                 !isLoadingPlugins && (
                   <Button type="submit" loading={mutation.isLoading} startIcon={<Check />}>
@@ -105,7 +103,7 @@ export const CreatePage = () => {
                 defaultMessage: 'Define the rights given to the role',
               })}
             />
-            <ContentLayout>
+            <Layouts.Content>
               <Flex
                 background="neutral0"
                 direction="column"
@@ -175,7 +173,7 @@ export const CreatePage = () => {
                   />
                 )}
               </Flex>
-            </ContentLayout>
+            </Layouts.Content>
           </Form>
         )}
       </Formik>

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
 import {
-  ContentLayout,
-  HeaderLayout,
   Main,
   Button,
   Flex,
@@ -19,6 +17,7 @@ import {
   useAPIErrorHandler,
   useNotification,
   useFetchClient,
+  Layouts,
 } from '@strapi/strapi/admin';
 import { Formik, Form } from 'formik';
 import { useIntl } from 'react-intl';
@@ -102,7 +101,7 @@ export const EditPage = () => {
       >
         {({ handleSubmit, values, handleChange, errors }) => (
           <Form noValidate onSubmit={handleSubmit}>
-            <HeaderLayout
+            <Layouts.Header
               primaryAction={
                 !isLoadingPlugins ? (
                   <Button
@@ -122,7 +121,7 @@ export const EditPage = () => {
               subtitle={role.description}
               navigationAction={<BackButton />}
             />
-            <ContentLayout>
+            <Layouts.Content>
               <Flex
                 background="neutral0"
                 direction="column"
@@ -192,7 +191,7 @@ export const EditPage = () => {
                   />
                 )}
               </Flex>
-            </ContentLayout>
+            </Layouts.Content>
           </Form>
         )}
       </Formik>

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -1,10 +1,6 @@
 import React, { useState } from 'react';
 
 import {
-  ActionLayout,
-  ContentLayout,
-  HeaderLayout,
-  Layout,
   Table,
   Th,
   Thead,
@@ -28,6 +24,7 @@ import {
   useQueryParams,
   useFetchClient,
   useRBAC,
+  Layouts,
 } from '@strapi/strapi/admin';
 import { useIntl } from 'react-intl';
 import { useMutation, useQuery } from 'react-query';
@@ -156,7 +153,7 @@ export const RolesListPage = () => {
   }
 
   return (
-    <Layout>
+    <Layouts.Root>
       <Page.Title>
         {formatMessage(
           { id: 'Settings.PageTitle', defaultMessage: 'Settings - {name}' },
@@ -164,7 +161,7 @@ export const RolesListPage = () => {
         )}
       </Page.Title>
       <Page.Main>
-        <HeaderLayout
+        <Layouts.Header
           title={formatMessage({
             id: 'global.roles',
             defaultMessage: 'Roles',
@@ -192,7 +189,7 @@ export const RolesListPage = () => {
           navigationAction={<BackButton />}
         />
 
-        <ActionLayout
+        <Layouts.Action
           startActions={
             <SearchInput
               label={formatMessage({
@@ -203,7 +200,7 @@ export const RolesListPage = () => {
           }
         />
 
-        <ContentLayout>
+        <Layouts.Content>
           {!canRead && <Page.NoPermissions />}
           {canRead && sortedRoles && sortedRoles?.length ? (
             <Table colCount={colCount} rowCount={rowCount}>
@@ -252,14 +249,14 @@ export const RolesListPage = () => {
           ) : (
             <EmptyStateLayout content={formatMessage(emptyLayout[emptyContent])} />
           )}
-        </ContentLayout>
+        </Layouts.Content>
         <ConfirmDialog
           onConfirm={handleConfirmDelete}
           onClose={handleShowConfirmDelete}
           isOpen={showConfirmDelete}
         />
       </Page.Main>
-    </Layout>
+    </Layouts.Root>
   );
 };
 

--- a/packages/utils/eslint-config-custom/front/typescript.js
+++ b/packages/utils/eslint-config-custom/front/typescript.js
@@ -8,17 +8,22 @@ module.exports = {
         jest: true,
       },
     },
+    {
+      files: ['**/*.js', '**/*.jsx'],
+      rules: {
+        /**
+         * This is useful to have for JS files, it's overwritten
+         * by `plugin:@typescript-eslint/recommended` for TS files.
+         */
+        'no-undef': 'error',
+      },
+    },
   ],
   globals: {
     process: true,
   },
   rules: {
     '@typescript-eslint/no-explicit-any': 'warn',
-    /**
-     * This is useful to have for JS files, it's overwritten
-     * by `plugin:@typescript-eslint/recommended` for TS files.
-     */
-    'no-undef': 'error',
     /**
      * This causes problems with PropTypes, once we've removed PropTypes
      * we can remove this rule back to the recommended setting.


### PR DESCRIPTION
### What does it do?

* Removed CMS specific components

### Why is it needed?

* With new design system V2, we are moving any specific CMS specific component to its own package as DS expands to cloud as well.

### How to test it?

* Everything (layouts) should look as it used to be 

### Related issue(s)/PR(s)

* unblocks https://github.com/strapi/design-system/pull/1703
* resolves DX-1381