### PR TITLE
fix: CMReleasesContainer test

### DIFF
--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -283,7 +283,6 @@ export const CMReleasesContainer = () => {
       }
     : skipToken;
   // Get all 'pending' releases that have the entry attached
-  // @ts-expect-error – we'll fix this when we fix content-releases for v5
   const response = useGetReleasesForEntryQuery(fetchParams);
   const releases = response.data?.data;
 
@@ -440,7 +439,6 @@ export const CMReleasesContainer = () => {
         <AddActionToReleaseModal
           handleClose={toggleModal}
           contentTypeUid={contentTypeUid}
-          // @ts-expect-error – we'll fix this when we fix content-releases for v5
           entryId={id}
         />
       )}

--- a/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
+++ b/packages/core/content-releases/admin/src/components/CMReleasesContainer.tsx
@@ -262,6 +262,7 @@ export const CMReleasesContainer = () => {
     collectionType: string;
   }>();
   const isCreatingEntry = id === 'create';
+  const entryId = parseInt(id!, 10);
   const { allowedActions } = useRBAC(PERMISSIONS);
 
   const { canCreateAction, canRead: canMain, canDeleteAction } = allowedActions;
@@ -278,7 +279,7 @@ export const CMReleasesContainer = () => {
   const fetchParams = canFetch
     ? {
         contentTypeUid: contentTypeUid,
-        entryId: id,
+        entryId,
         hasEntryAttached: true,
       }
     : skipToken;
@@ -439,7 +440,7 @@ export const CMReleasesContainer = () => {
         <AddActionToReleaseModal
           handleClose={toggleModal}
           contentTypeUid={contentTypeUid}
-          entryId={id}
+          entryId={entryId}
         />
       )}
     </Box>

--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useAPIErrorHandler, useNotification, useAuth, useRBAC } from '@strapi/admin/strapi-admin';
-import { Flex, IconButton, Typography, Menu, Link } from '@strapi/design-system';
+import { Flex, IconButton, Typography, Menu } from '@strapi/design-system';
 import { Cross, More, Pencil } from '@strapi/icons';
 import { isAxiosError } from 'axios';
 import { useIntl } from 'react-intl';
@@ -227,7 +227,7 @@ const Root = ({ children, hasTriggerBorder = false }: RootProps) => {
     // A user can access the dropdown if they have permissions to delete a release-action OR update a release
     allowedActions.canDeleteAction || allowedActions.canUpdate ? (
       <Menu.Root>
-        {/* 
+        {/*
           TODO Fix in the DS
           - as={IconButton} has TS error:  Property 'icon' does not exist on type 'IntrinsicAttributes & TriggerProps & RefAttributes<HTMLButtonElement>'
           - The Icon doesn't actually show unless you hack it with some padding...and it's still a little strange

--- a/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/CMReleasesContainer.test.tsx
@@ -30,9 +30,6 @@ const render = (
       ),
     },
     initialEntries,
-    userEventOptions: {
-      skipHover: true,
-    },
   });
 
 describe('CMReleasesContainer', () => {
@@ -123,16 +120,14 @@ describe('CMReleasesContainer', () => {
     render();
 
     const informationBox = await screen.findByRole('complementary', { name: 'Releases' });
+    await within(informationBox).findAllByRole('button', { name: /release action options/i });
     const release1 = await within(informationBox).findByText('release1');
     const release2 = await within(informationBox).findByText('release2');
     expect(release1).toBeInTheDocument();
     expect(release2).toBeInTheDocument();
   });
 
-  /**
-   * TODO: this needs re-implementing without the act warning appearing.
-   */
-  it.skip('should show the scheduled date for a release', async () => {
+  it('should show the scheduled date for a release', async () => {
     // Mock the response from the server
     server.use(
       rest.get('/content-releases', (req, res, ctx) => {
@@ -155,6 +150,7 @@ describe('CMReleasesContainer', () => {
     render();
 
     await screen.findByRole('complementary', { name: 'Releases' });
+    await screen.findByRole('button', { name: /release action options/i });
     expect(screen.getByText('01/01/2024 at 11:00 (UTC+01:00)')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes "update not wrapped in act()" error coming from CMReleasesContainer. I found that the async request at the root of the issue seemed to be [the useRBAC call in ReleaseActionMenu](https://github.com/strapi/strapi/blob/301d2027a59183bfa76012748eaeef6b5ffae9d1/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx#L224).

Also fixes an unrelated TS error

### Related

same bug as #20233