### PR TITLE
chore: add type to bulk action actions

### DIFF
--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -106,7 +106,7 @@ interface BulkActionComponentProps extends ListViewContext {}
 
 interface BulkActionComponent
   extends DescriptionComponent<BulkActionComponentProps, BulkActionDescription> {
-  actionType?: 'delete' | 'publish' | 'unpublish';
+  type?: 'delete' | 'publish' | 'unpublish';
 }
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
@@ -109,7 +109,7 @@ const BulkActionsRenderer = () => {
  * BulkActionAction
  * -----------------------------------------------------------------------------------------------*/
 
-interface Action extends BulkActionDescription, Pick<BulkActionComponent, 'actionType'> {
+interface Action extends BulkActionDescription {
   id: string;
 }
 
@@ -138,7 +138,6 @@ const BulkActionAction = (action: Action) => {
           break;
         case 'dialog':
         case 'modal': {
-          if (action.actionType === 'delete') trackUsage('willBulkDeleteEntries');
           e.preventDefault();
           setDialogId(id);
         }
@@ -323,7 +322,6 @@ const DeleteAction: BulkActionComponent = ({ documents, model }) => {
   if (!hasDeletePermission) return null;
 
   return {
-    actionType: 'delete',
     variant: 'danger-light',
     label: formatMessage({ id: 'global.delete', defaultMessage: 'Delete' }),
     dialog: {
@@ -363,6 +361,8 @@ const DeleteAction: BulkActionComponent = ({ documents, model }) => {
   };
 };
 
+DeleteAction.type = 'delete';
+
 const UnpublishAction: BulkActionComponent = ({ documents, model }) => {
   const { formatMessage } = useIntl();
   const { schema } = useDoc();
@@ -387,7 +387,6 @@ const UnpublishAction: BulkActionComponent = ({ documents, model }) => {
   if (!showUnpublishButton) return null;
 
   return {
-    actionType: 'unpublish',
     variant: 'tertiary',
     label: formatMessage({ id: 'app.utils.unpublish', defaultMessage: 'Unpublish' }),
     dialog: {
@@ -430,6 +429,8 @@ const UnpublishAction: BulkActionComponent = ({ documents, model }) => {
     },
   };
 };
+
+UnpublishAction.type = 'unpublish';
 
 const Emphasis = (chunks: React.ReactNode) => (
   <Typography fontWeight="semiBold" textColor="danger500">


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds `type` to the action signature (no the description interface)

### Why is it needed?

* users can use the reducer pattern for adding bulk actions and remove ones like `publish` or `delete` or swap them out, similar to how document actions work
