### PR TITLE
feat: discard drafts when enabling draft and publish on ct

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -12,7 +12,7 @@ type Knex = Parameters<Migration['up']>[0];
  * Versions with only a draft version will be ignored.
  * Only versions with a published version (which always have a draft version) will be discarded.
  */
-async function* getBatchToDiscard({
+export async function* getBatchToDiscard({
   db,
   trx,
   uid,

--- a/tests/api/core/strapi/migrations/migration-draft-publish.test.api.js
+++ b/tests/api/core/strapi/migrations/migration-draft-publish.test.api.js
@@ -118,8 +118,8 @@ describe('Migration - draft and publish', () => {
 
           // Published dog should have a publishedAt value
           expect(draftDog.publishedAt).toBe(null);
-          // Updated at value should be different
-          expect(draftDog.updatedAt).not.toBe(publishedDog.updatedAt);
+          // Updated at value should be the same
+          expect(draftDog.updatedAt).toBe(publishedDog.updatedAt);
         });
 
         data.dogs = sortDogs(dogs.filter((dog) => dog.publishedAt));


### PR DESCRIPTION
### What does it do?

On V5, content types without draft and publish have a single version , where the publishedAt value is filled with a date.
Content Types with draft and publish have two versions, a draft and a published version, where the publishedAt value is null on drafts and filled with a date on published versions.

When enabling draft and publish on a content type, we were copying the single version with the publishedAt value filled and updating the publishedAt value to be null. 

This process did not copy components or relations, and now all documents are processed in batch, to call the `documents.discard`method, which takes care of that, at the cost of processing one version at a time.