### PR TITLE
fix: create locale column when migrating from v4

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -50,9 +50,11 @@ async function* getBatchToDiscard({
 }
 
 /**
- * This migration makes use of the document service.
- * This one assumes the `locale` column exists. In v4, that was not the case
- * for content types with i18n disabled, so we need to create it for those cases.
+ * This migration makes use of the document service,
+ * which assumes the `locale` column always exists.
+ * In v4, that was not the case, for content types with i18n disabled.
+ *
+ * This function creates the `locale` column if it doesn't exist.
  */
 const createLocaleColumn = async (db: Knex, tableName: string) => {
   await db.schema.alterTable(tableName, (table) => {

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -50,7 +50,7 @@ async function* getBatchToDiscard({
 }
 
 /**
- * This migrations makes use of the document service.
+ * This migration makes use of the document service.
  * This one assumes the `locale` column exists. In v4, that was not the case
  * for content types with i18n disabled, so we need to create it for those cases.
  */

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-continue */
-import { isNil } from 'lodash/fp';
-
 import type { UID } from '@strapi/types';
 import type { Database, Migration } from '@strapi/database';
 import { async, contentTypes } from '@strapi/utils';
@@ -49,19 +47,6 @@ async function* getBatchToDiscard({
   }
 }
 
-/**
- * This migration makes use of the document service,
- * which assumes the `locale` column always exists.
- * In v4, that was not the case, for content types with i18n disabled.
- *
- * This function creates the `locale` column if it doesn't exist.
- */
-const createLocaleColumn = async (db: Knex, tableName: string) => {
-  await db.schema.alterTable(tableName, (table) => {
-    table.string('locale');
-  });
-};
-
 const migrateUp = async (trx: Knex, db: Database) => {
   for (const meta of db.metadata.values()) {
     const hasTable = await trx.schema.hasTable(meta.tableName);
@@ -75,11 +60,6 @@ const migrateUp = async (trx: Knex, db: Database) => {
     const hasDP = contentTypes.hasDraftAndPublish(model);
     if (!hasDP) {
       continue;
-    }
-
-    // Create locale column if it doesn't exist
-    if (isNil(meta.attributes.locale)) {
-      await createLocaleColumn(trx, meta.tableName);
     }
 
     const discardDraft = async (entry: DocumentVersion) =>

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
@@ -1,0 +1,45 @@
+import type { Knex } from 'knex';
+import { isNil } from 'lodash/fp';
+
+import type { Migration } from '../common';
+
+/**
+ * In v4, content types with disabled i18n did not have any locale column.
+ * In v5, we need to add a `locale` column to all content types.
+ * Other downstream migrations will make use of this column.
+ *
+ * This function creates the `locale` column if it doesn't exist.
+ */
+const createLocaleColumn = async (db: Knex, tableName: string) => {
+  await db.schema.alterTable(tableName, (table) => {
+    table.string('locale');
+  });
+};
+
+export const createdLocale: Migration = {
+  name: '5.0.0-03-created-locale',
+  async up(knex, db) {
+    for (const meta of db.metadata.values()) {
+      const hasTable = await knex.schema.hasTable(meta.tableName);
+
+      if (!hasTable) {
+        continue;
+      }
+
+      // Ignore non-content types
+      const uid = meta.uid;
+      const model = strapi.getModel(uid);
+      if (!model) {
+        continue;
+      }
+
+      // Create locale column if it doesn't exist
+      if (isNil(meta.attributes.locale)) {
+        await createLocaleColumn(knex, meta.tableName);
+      }
+    }
+  },
+  async down() {
+    throw new Error('not implemented');
+  },
+};

--- a/packages/core/database/src/migrations/internal-migrations/index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/index.ts
@@ -1,6 +1,7 @@
 import type { Migration } from '../common';
 import { createdDocumentId } from './5.0.0-02-document-id';
 import { renameIdentifiersLongerThanMaxLength } from './5.0.0-01-convert-identifiers-long-than-max-length';
+import { createdLocale } from './5.0.0-03-locale';
 
 /**
  * List of all the internal migrations. The array order will be the order in which they are executed.
@@ -14,4 +15,5 @@ import { renameIdentifiersLongerThanMaxLength } from './5.0.0-01-convert-identif
 export const internalMigrations: Migration[] = [
   renameIdentifiersLongerThanMaxLength,
   createdDocumentId,
+  createdLocale,
 ];


### PR DESCRIPTION
### What does it do?
Migrating from v4 content types with i18n disabled resulted in the following error:
![image](https://github.com/strapi/strapi/assets/20578351/f84576e6-5812-4b22-aaa2-fff98ac56cf8)

The cause was the `locale` column not being in the database for those content types. It is assumed , in v5, that the locale column will be present even if i18n is disabled on a content type.

This fix proposes adding a locale column in the discard-draft migration,  similarly to how we add the document_id in another migration.


