### PR TITLE
Block-Editor: Enable pasting HTML (from Google Doc and RichText)

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,5 @@
     "node": ">=18.0.0 <=20.x.x",
     "npm": ">=6.0.0"
   },
-  "isStrapiMonorepo": true,
-  "dependencies": {
-    "slate-hyperscript": "0.100.0"
-  }
+  "isStrapiMonorepo": true
 }

--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
     "node": ">=18.0.0 <=20.x.x",
     "npm": ">=6.0.0"
   },
-  "isStrapiMonorepo": true
+  "isStrapiMonorepo": true,
+  "dependencies": {
+    "slate-hyperscript": "0.100.0"
+  }
 }

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/BlocksEditor.tsx
@@ -24,6 +24,7 @@ import { BlocksContent, type BlocksContentProps } from './BlocksContent';
 import { BlocksToolbar } from './BlocksToolbar';
 import { EditorLayout } from './EditorLayout';
 import { type ModifiersStore, modifiers } from './Modifiers';
+import { withHtml } from './plugins/withHTML';
 import { withImages } from './plugins/withImages';
 import { withLinks } from './plugins/withLinks';
 import { withStrapiSchema } from './plugins/withStrapiSchema';
@@ -175,7 +176,14 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
   ({ disabled = false, name, onChange, value, error, ...contentProps }, forwardedRef) => {
     const { formatMessage } = useIntl();
     const [editor] = React.useState(() =>
-      pipe(withHistory, withImages, withStrapiSchema, withReact, withLinks)(createEditor())
+      pipe(
+        withHistory,
+        withImages,
+        withStrapiSchema,
+        withReact,
+        withLinks,
+        withHtml
+      )(createEditor())
     );
     const [liveText, setLiveText] = React.useState('');
     const ariaDescriptionId = React.useId();

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
@@ -1,0 +1,96 @@
+import { Transforms } from 'slate';
+import { jsx } from 'slate-hyperscript';
+import { type Editor } from 'slate';
+
+const ELEMENT_TAGS = {
+  A: (el: HTMLAnchorElement) => ({ type: 'link', url: el.getAttribute('href') }),
+  BLOCKQUOTE: () => ({ type: 'quote' }),
+  H1: () => ({ type: 'heading-one' }),
+  H2: () => ({ type: 'heading-two' }),
+  H3: () => ({ type: 'heading-three' }),
+  H4: () => ({ type: 'heading-four' }),
+  H5: () => ({ type: 'heading-five' }),
+  H6: () => ({ type: 'heading-six' }),
+  IMG: (el: HTMLImageElement) => ({ type: 'image', url: el.getAttribute('src') }),
+  LI: () => ({ type: 'list-item' }),
+  OL: () => ({ type: 'numbered-list' }),
+  P: () => ({ type: 'paragraph' }),
+  PRE: () => ({ type: 'code' }),
+  UL: () => ({ type: 'bulleted-list' }),
+};
+
+// COMPAT: `B` is omitted here because Google Docs uses `<b>` in weird ways.
+const TEXT_TAGS = {
+  CODE: () => ({ code: true }),
+  DEL: () => ({ strikethrough: true }),
+  EM: () => ({ italic: true }),
+  I: () => ({ italic: true }),
+  S: () => ({ strikethrough: true }),
+  STRONG: () => ({ bold: true }),
+  U: () => ({ underline: true }),
+};
+
+const deserialize = (el: HTMLElement) => {
+  if (el.nodeType === 3) {
+    return el.textContent;
+  } else if (el.nodeType !== 1) {
+    return null;
+  } else if (el.nodeName === 'BR') {
+    return '\n';
+  }
+
+  const { nodeName } = el;
+  let parent = el;
+
+  if (nodeName === 'PRE' && el.childNodes[0] && el.childNodes[0].nodeName === 'CODE') {
+    parent = el.childNodes[0] as HTMLElement;
+  }
+  let children = Array.from(parent.childNodes).map(deserialize).flat();
+
+  if (children.length === 0) {
+    children = [{ text: '' }];
+  }
+
+  if (el.nodeName === 'BODY') {
+    return jsx('fragment', {}, children);
+  }
+
+  if (ELEMENT_TAGS[nodeName]) {
+    const attrs = ELEMENT_TAGS[nodeName](el);
+    return jsx('element', attrs, children);
+  }
+
+  if (TEXT_TAGS[nodeName]) {
+    const attrs = TEXT_TAGS[nodeName](el);
+    return children.map((child) => jsx('text', attrs, child));
+  }
+
+  return children;
+};
+
+export function withHtml(editor: Editor) {
+  const { insertData, isInline, isVoid } = editor;
+
+  editor.isInline = (element) => {
+    return element.type === 'link' ? true : isInline(element);
+  };
+
+  editor.isVoid = (element) => {
+    return element.type === 'image' ? true : isVoid(element);
+  };
+
+  editor.insertData = (data) => {
+    const html = data.getData('text/html');
+
+    if (html) {
+      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      const fragment = deserialize(parsed.body);
+      Transforms.insertFragment(editor, fragment);
+      return;
+    }
+
+    insertData(data);
+  };
+
+  return editor;
+}

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
@@ -74,7 +74,7 @@ const deserialize = (
   } else if (el.nodeType !== 1) {
     return null;
   } else if (el.nodeName === 'BR') {
-    return jsx('element', {}, [{ text: '' }]);
+    return jsx('element', { type: 'paragraph' }, [{ text: '' }]);
   }
 
   const { nodeName } = el;

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withHTML.ts
@@ -1,6 +1,6 @@
 import { Transforms } from 'slate';
-import { jsx } from 'slate-hyperscript';
 import { type Editor } from 'slate';
+import { jsx } from 'slate-hyperscript';
 
 const ELEMENT_TAGS = {
   A: (el: HTMLAnchorElement) => ({ type: 'link', url: el.getAttribute('href') }),

--- a/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withLinks.ts
+++ b/packages/core/admin/admin/src/content-manager/components/BlocksInput/plugins/withLinks.ts
@@ -1,14 +1,12 @@
 import { type BaseEditor, Path, Transforms, Range, Point, Editor } from 'slate';
 
-import { insertLink } from '../utils/links';
-
 interface LinkEditor extends BaseEditor {
   lastInsertedLinkPath: Path | null;
   shouldSaveLinkPath: boolean;
 }
 
 const withLinks = (editor: Editor) => {
-  const { isInline, apply, insertText, insertData } = editor;
+  const { isInline, apply, insertText } = editor;
 
   // Links are inline elements, so we need to override the isInline method for slate
   editor.isInline = (element) => {
@@ -71,26 +69,6 @@ const withLinks = (editor: Editor) => {
     }
 
     insertText(text);
-  };
-
-  // Add data as a clickable link if its a valid URL
-  editor.insertData = (data) => {
-    const pastedText = data.getData('text/plain');
-
-    if (pastedText) {
-      try {
-        // eslint-disable-next-line no-new
-        new URL(pastedText);
-        // Do not show link popup on copy-paste a link, so do not save its path
-        editor.shouldSaveLinkPath = false;
-        insertLink(editor, { url: pastedText });
-        return;
-      } catch (error) {
-        // continue normal data insertion
-      }
-    }
-
-    insertData(data);
   };
 
   return editor;

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -157,6 +157,7 @@
     "sift": "16.0.1",
     "slate": "0.94.1",
     "slate-history": "0.93.0",
+    "slate-hyperscript": "0.100.0",
     "slate-react": "0.98.3",
     "style-loader": "3.3.4",
     "typescript": "5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7920,6 +7920,7 @@ __metadata:
     sift: "npm:16.0.1"
     slate: "npm:0.94.1"
     slate-history: "npm:0.93.0"
+    slate-hyperscript: "npm:0.100.0"
     slate-react: "npm:0.98.3"
     style-loader: "npm:3.3.4"
     styled-components: "npm:5.3.3"
@@ -13181,17 +13182,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001541":
-  version: 1.0.30001542
-  resolution: "caniuse-lite@npm:1.0.30001542"
-  checksum: 07b14b8341d7bf0ea386a5fa5b5edbee41d81dfc072d3d11db22dd1d7a929358f522b16fdf3cbd154c8a5cae84662578cf5c9e490e7d7606ee7d156ccf07c9fa
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001576
-  resolution: "caniuse-lite@npm:1.0.30001576"
-  checksum: 51632942733593f310e581bd91c9558b8d75fbf67160a39f8036d2976cd7df9183e96d4c9d9e6f18e0205950b940d9c761bcfb7810962d7899f8a1179fde6e3f
+"caniuse-lite@npm:^1.0.30001541, caniuse-lite@npm:^1.0.30001565":
+  version: 1.0.30001615
+  resolution: "caniuse-lite@npm:1.0.30001615"
+  checksum: 3dfb48e9b8fbf4d550cf204075b170ef4a5bcbc7faf9e14b03dc7456ac1aec2da1405d4fca808bc72b47a2ca0818d6d138aa62769548472440ff605ad1313719
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28224,6 +28224,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slate-hyperscript@npm:0.100.0":
+  version: 0.100.0
+  resolution: "slate-hyperscript@npm:0.100.0"
+  dependencies:
+    is-plain-object: "npm:^5.0.0"
+  peerDependencies:
+    slate: ">=0.65.3"
+  checksum: 4ec39c04675b89db313c102dc19de0351aedd666d5e6ca37b6aa4850ef547fe849cc01aae4db6304c86a1db61aa1b428717fade59e349cf3fdd301bf88648ec6
+  languageName: node
+  linkType: hard
+
 "slate-react@npm:0.98.3":
   version: 0.98.3
   resolution: "slate-react@npm:0.98.3"
@@ -28806,6 +28817,7 @@ __metadata:
     prettier: "npm:2.8.4"
     qs: "npm:6.11.1"
     rimraf: "npm:3.0.2"
+    slate-hyperscript: "npm:0.100.0"
     supertest: "npm:6.3.3"
     ts-jest: "npm:29.1.0"
     typescript: "npm:5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28811,7 +28811,6 @@ __metadata:
     prettier: "npm:2.8.4"
     qs: "npm:6.11.1"
     rimraf: "npm:3.0.2"
-    slate-hyperscript: "npm:0.100.0"
     supertest: "npm:6.3.3"
     ts-jest: "npm:29.1.0"
     typescript: "npm:5.2.2"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Until now, links and formatting (like bold, italic or underlined) in pasted text from Google Docs and RichText documents were not retained. 
We implemented and improved the code from Slate’s PasteHTML example (https://www.slatejs.org/examples/paste-html):
1. We added the package [slate-hyperscript](https://docs.slatejs.org/v/v0.47/other-packages/index-1).
2. We typed the code from the example (which was quite a challenge).
3. We optimized the example to be able to handle text from Google Docs correctly.

### Why is it needed?

Google Docs and RichText are widely used text editors. Pasting text from these is part of the daily work of many content editors and would be a great quality of life improvement.

We use Strapi for different magazine websites. Magazine editors often copy texts from Google Doc or RichText documents. Switching from our custom `Editor.js`-plugin to the new Slate-based Block Editor made this temporarily impossible. 

### How to test it?

1. Create a Google Doc or RichText document. 
2. Create Headlines, Paragraphs, Lists
3. Add links
4. Add some formatting (bold, italic, underline)
5. Copy the document to a Block Editor field

### Related issue(s)/PR(s)

Fixes issue #19051
