### PR TITLE
fix(history): adjust condition to display missing relations

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -78,7 +78,10 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
       }
     : field.value;
 
-  if (!formattedFieldValue || formattedFieldValue.results.length === 0) {
+  if (
+    !formattedFieldValue ||
+    (formattedFieldValue.results.length === 0 && formattedFieldValue.meta.missingCount === 0)
+  ) {
     return (
       <>
         <FieldLabel>{props.label}</FieldLabel>
@@ -153,16 +156,6 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
             { number: meta.missingCount }
           )}
         </StyledAlert>
-      )}
-      {results.length === 0 && meta.missingCount === 0 && (
-        <Box marginTop={1}>
-          <StyledAlert variant="default">
-            {formatMessage({
-              id: 'content-manager.history.content.no-relations',
-              defaultMessage: 'No relations.',
-            })}
-          </StyledAlert>
-        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
### What does it do?

- Fix condition from return "No relations" for missing relations

### Why is it needed?

- Missing relations are always represented as no relations

### How to test it?

- Go to a content-type with relations like kitchensink
- Create some entries to relate to like Tag
- Attach the relations to kitchensink and create some history versions
- Now go delete some relations
- Access previous versions where the relations existed
- Make sure the correct message is displayed

Relation should display:
- No relations (including no missing relations) should display "No relatins"
- Relations + missing relations should display the existing relations + missing relation message
- Missing relation messages should display the number of missing relations if there are several that are missing.

