### PR TITLE
chore(cm): changed the Configure the view link icon in the edit view

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -9,7 +9,7 @@ import {
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
 import { Flex, SingleSelect, SingleSelectOption, Typography } from '@strapi/design-system';
-import { Cog, Pencil, Trash, WarningCircle } from '@strapi/icons';
+import { ListPlus, Pencil, Trash, WarningCircle } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useMatch, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -376,7 +376,7 @@ const ConfigureTheViewAction: DocumentActionComponent = ({ collectionType, model
       id: 'app.links.configure-view',
       defaultMessage: 'Configure the view',
     }),
-    icon: <StyledCog />,
+    icon: <StyledListPlus />,
     onClick: () => {
       navigate(`../${collectionType}/${model}/configurations/edit`);
     },
@@ -390,7 +390,7 @@ ConfigureTheViewAction.type = 'configure-the-view';
  * Because the icon system is completely broken, we have to do
  * this to remove the fill from the cog.
  */
-const StyledCog = styled(Cog)`
+const StyledListPlus = styled(ListPlus)`
   path {
     fill: currentColor;
   }

--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -51,9 +51,9 @@ const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: Heade
 
   const title = isCreating
     ? formatMessage({
-      id: 'content-manager.containers.edit.title.new',
-      defaultMessage: 'Create an entry',
-    })
+        id: 'content-manager.containers.edit.title.new',
+        defaultMessage: 'Create an entry',
+      })
     : documentTitle;
 
   return (

--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -51,9 +51,9 @@ const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: Heade
 
   const title = isCreating
     ? formatMessage({
-        id: 'content-manager.containers.edit.title.new',
-        defaultMessage: 'Create an entry',
-      })
+      id: 'content-manager.containers.edit.title.new',
+      defaultMessage: 'Create an entry',
+    })
     : documentTitle;
 
   return (
@@ -376,7 +376,7 @@ const ConfigureTheViewAction: DocumentActionComponent = ({ collectionType, model
       id: 'app.links.configure-view',
       defaultMessage: 'Configure the view',
     }),
-    icon: <StyledListPlus />,
+    icon: <ListPlus />,
     onClick: () => {
       navigate(`../${collectionType}/${model}/configurations/edit`);
     },
@@ -385,16 +385,6 @@ const ConfigureTheViewAction: DocumentActionComponent = ({ collectionType, model
 };
 
 ConfigureTheViewAction.type = 'configure-the-view';
-
-/**
- * Because the icon system is completely broken, we have to do
- * this to remove the fill from the cog.
- */
-const StyledListPlus = styled(ListPlus)`
-  path {
-    fill: currentColor;
-  }
-`;
 
 const EditTheModelAction: DocumentActionComponent = ({ model }) => {
   const navigate = useNavigate();
@@ -405,7 +395,7 @@ const EditTheModelAction: DocumentActionComponent = ({ model }) => {
       id: 'content-manager.link-to-ctb',
       defaultMessage: 'Edit the model',
     }),
-    icon: <StyledPencil />,
+    icon: <Pencil />,
     onClick: () => {
       navigate(`/plugins/content-type-builder/content-types/${model}`);
     },
@@ -414,16 +404,6 @@ const EditTheModelAction: DocumentActionComponent = ({ model }) => {
 };
 
 EditTheModelAction.type = 'edit-the-model';
-
-/**
- * Because the icon system is completely broken, we have to do
- * this to remove the fill from the cog.
- */
-const StyledPencil = styled(Pencil)`
-  path {
-    fill: currentColor;
-  }
-`;
 
 const DeleteAction: DocumentActionComponent = ({ documentId, model, collectionType, document }) => {
   const navigate = useNavigate();
@@ -440,7 +420,7 @@ const DeleteAction: DocumentActionComponent = ({ documentId, model, collectionTy
       id: 'content-manager.actions.delete.label',
       defaultMessage: 'Delete document',
     }),
-    icon: <StyledTrash />,
+    icon: <Trash />,
     dialog: {
       type: 'dialog',
       title: formatMessage({
@@ -509,16 +489,6 @@ const DeleteAction: DocumentActionComponent = ({ documentId, model, collectionTy
 };
 
 DeleteAction.type = 'delete';
-
-/**
- * Because the icon system is completely broken, we have to do
- * this to remove the fill from the cog.
- */
-const StyledTrash = styled(Trash)`
-  path {
-    fill: currentColor;
-  }
-`;
 
 const DEFAULT_HEADER_ACTIONS = [EditTheModelAction, ConfigureTheViewAction, DeleteAction];
 


### PR DESCRIPTION
### What does it do?

It changes the Cog icon of the Configure the view link of the edit view to a ListPlus icon. 

### Why is it needed?

The edit view is currently the only page where we use the Cog icon to illustrate the Configure the view feature. In every other page we we use the ListPlus icon (my bad, the error comes from my mockups).

### How to test it?

It can be seen in the edit view of any entry.

### Related issue(s)/PR(s)

Not related to any issue or pull request.

https://github.com/strapi/strapi/assets/45385696/a13d90ab-fcbb-4533-a338-8222ccfa4a56

