### PR TITLE
feat(main-nav): Fix the tooltip position of the links

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import { Divider, Flex, FlexComponent, Tooltip } from '@strapi/design-system';
+import { Divider, Flex, FlexComponent } from '@strapi/design-system';
 import { Feather, Lock, House } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { useLocation, NavLink as RouterNavLink } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { useAuth } from '../features/Auth';

--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import { Divider, Flex, FlexComponent } from '@strapi/design-system';
+import { Divider, Flex, FlexComponent, Tooltip } from '@strapi/design-system';
 import { Feather, Lock, House } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation, NavLink as RouterNavLink } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { useAuth } from '../features/Auth';
@@ -53,29 +53,29 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
 
       <NavListWrapper tag="ul" gap={3} direction="column" flex={1} paddingTop={3} paddingBottom={3}>
         <Flex tag="li">
-          <NavLink.Link
-            to="/"
-            onClick={() => handleClickOnLink('/')}
-            aria-label={formatMessage({ id: 'global.home', defaultMessage: 'Home' })}
-          >
-            <NavLink.Tooltip label={formatMessage({ id: 'global.home', defaultMessage: 'Home' })}>
+          <NavLink.Tooltip label={formatMessage({ id: 'global.home', defaultMessage: 'Home' })}>
+            <NavLink.Link
+              to="/"
+              onClick={() => handleClickOnLink('/')}
+              aria-label={formatMessage({ id: 'global.home', defaultMessage: 'Home' })}
+            >
               <NavLink.Icon label={formatMessage({ id: 'global.home', defaultMessage: 'Home' })}>
                 <House width="2rem" height="2rem" fill="neutral500" />
               </NavLink.Icon>
-            </NavLink.Tooltip>
-          </NavLink.Link>
+            </NavLink.Link>
+          </NavLink.Tooltip>
         </Flex>
         <Flex tag="li">
-          <NavLink.Link
-            to="/content-manager"
-            onClick={() => handleClickOnLink('/content-manager')}
-            aria-label={formatMessage({
+          <NavLink.Tooltip
+            label={formatMessage({
               id: 'global.content-manager',
               defaultMessage: 'Content Manager',
             })}
           >
-            <NavLink.Tooltip
-              label={formatMessage({
+            <NavLink.Link
+              to="/content-manager"
+              onClick={() => handleClickOnLink('/content-manager')}
+              aria-label={formatMessage({
                 id: 'global.content-manager',
                 defaultMessage: 'Content Manager',
               })}
@@ -88,8 +88,8 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
               >
                 <Feather width="2rem" height="2rem" fill="neutral500" />
               </NavLink.Icon>
-            </NavLink.Tooltip>
-          </NavLink.Link>
+            </NavLink.Link>
+          </NavLink.Tooltip>
         </Flex>
         {pluginsSectionLinks.length > 0
           ? pluginsSectionLinks.map((link) => {
@@ -103,12 +103,12 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
               const labelValue = formatMessage(link.intlLabel);
               return (
                 <Flex tag="li" key={link.to}>
-                  <NavLink.Link
-                    to={link.to}
-                    onClick={() => handleClickOnLink(link.to)}
-                    aria-label={labelValue}
-                  >
-                    <NavLink.Tooltip label={labelValue}>
+                  <NavLink.Tooltip label={labelValue}>
+                    <NavLink.Link
+                      to={link.to}
+                      onClick={() => handleClickOnLink(link.to)}
+                      aria-label={labelValue}
+                    >
                       <NavLink.Icon label={labelValue}>
                         <LinkIcon width="2rem" height="2rem" fill="neutral500" />
                       </NavLink.Icon>
@@ -121,8 +121,8 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                           {badgeContent}
                         </NavLink.Badge>
                       )}
-                    </NavLink.Tooltip>
-                  </NavLink.Link>
+                    </NavLink.Link>
+                  </NavLink.Tooltip>
                 </Flex>
               );
             })
@@ -140,12 +140,12 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
 
               return (
                 <Flex tag="li" key={link.to}>
-                  <NavLink.Link
-                    aria-label={labelValue}
-                    to={link.to}
-                    onClick={() => handleClickOnLink(link.to)}
-                  >
-                    <NavLink.Tooltip label={labelValue}>
+                  <NavLink.Tooltip label={labelValue}>
+                    <NavLink.Link
+                      aria-label={labelValue}
+                      to={link.to}
+                      onClick={() => handleClickOnLink(link.to)}
+                    >
                       <NavLink.Icon label={labelValue}>
                         <LinkIcon width="2rem" height="2rem" fill="neutral500" />
                       </NavLink.Icon>
@@ -154,8 +154,8 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                           {badgeContent}
                         </NewNavLinkBadge>
                       )}
-                    </NavLink.Tooltip>
-                  </NavLink.Link>
+                    </NavLink.Link>
+                  </NavLink.Tooltip>
                 </Flex>
               );
             })


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Reverts the order of the NavLink.Tooltip and the NavLink.Link

### Why is it needed?

Because we had a strange behaviour in Safari, the position of the tooltip was starting in the middle of the icon link, wrapping the NavLink.Link with the NavLink.Tooltip solved the issue

### How to test it?

Open the CMS in Safare and check the tooltips position
