### PR TITLE
chore: global backbutton on history page and fix e2e tests

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -6,13 +6,14 @@ import {
   useQueryParams,
   useRBAC,
   Layouts,
+  BackButton,
 } from '@strapi/admin/strapi-admin';
-import { Button, Typography, Flex, Link } from '@strapi/design-system';
-import { ArrowLeft, WarningCircle } from '@strapi/icons';
+import { Button, Typography, Flex } from '@strapi/design-system';
+import { WarningCircle } from '@strapi/icons';
 import { UID } from '@strapi/types';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { NavLink, useNavigate, useParams, type To } from 'react-router-dom';
+import { useNavigate, useParams, type To } from 'react-router-dom';
 
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { PERMISSIONS } from '../../constants/plugin';
@@ -133,14 +134,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
             )}
           </Typography>
         }
-        navigationAction={
-          <Link startIcon={<ArrowLeft />} tag={NavLink} to={getNextNavigation()}>
-            {formatMessage({
-              id: 'global.back',
-              defaultMessage: 'Back',
-            })}
-          </Link>
-        }
+        navigationAction={<BackButton />}
         sticky={false}
         primaryAction={
           <Button

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionHeader.test.tsx
@@ -78,12 +78,6 @@ describe('VersionHeader', () => {
 
       expect(await screen.findByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
       expect(await screen.findByText('Test Title (kitchensink)')).toBeInTheDocument();
-
-      const backLink = screen.getByRole('link', { name: 'Back' });
-      expect(backLink).toHaveAttribute(
-        'href',
-        '/content-manager/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr'
-      );
     });
 
     it('should display the correct title and subtitle for a localized entry', async () => {
@@ -109,12 +103,6 @@ describe('VersionHeader', () => {
       expect(
         await screen.findByText('Test Title (kitchensink), in English (en)')
       ).toBeInTheDocument();
-
-      const backLink = screen.getByRole('link', { name: 'Back' });
-      expect(backLink).toHaveAttribute(
-        'href',
-        '/content-manager/collection-types/api::kitchensink.kitchensink/pcwmq3rlmp5w0be3cuplhnpr?plugins[i18n][locale]=en'
-      );
     });
 
     it('should display the correct subtitle without an entry title (mainField)', async () => {
@@ -160,12 +148,6 @@ describe('VersionHeader', () => {
 
       expect(await screen.findByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
       expect(await screen.findByText('Test Title (homepage)')).toBeInTheDocument();
-
-      const backLink = screen.getByRole('link', { name: 'Back' });
-      expect(backLink).toHaveAttribute(
-        'href',
-        '/content-manager/single-types/api::homepage.homepage'
-      );
     });
 
     it('should display the correct title and subtitle for a localized entry', async () => {
@@ -188,12 +170,6 @@ describe('VersionHeader', () => {
 
       expect(await screen.findByText('1/1/2022, 12:00 AM')).toBeInTheDocument();
       expect(await screen.findByText('Test Title (homepage), in English (en)')).toBeInTheDocument();
-
-      const backLink = screen.getByRole('link', { name: 'Back' });
-      expect(backLink).toHaveAttribute(
-        'href',
-        '/content-manager/single-types/api::homepage.homepage?plugins[i18n][locale]=en'
-      );
     });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Uses the global app Back Button  on history pages
Fixes history E2E tests according to this change (I think they have been failing on any PR into v5/main)

### Why is it needed?

CI stability and consistent back button behaviour

