### PR TITLE
fix: fixing countDraftRelations to get locale as a prop

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/ContentTypeFormWrapper.tsx
@@ -397,7 +397,10 @@ const ContentTypeFormWrapper = ({
         } = await fetchClient.get<Contracts.CollectionTypes.CountDraftRelations.Response>(
           isSingleType
             ? `/content-manager/${collectionType}/${slug}/actions/countDraftRelations`
-            : `/content-manager/${collectionType}/${slug}/${id}/actions/countDraftRelations`
+            : `/content-manager/${collectionType}/${slug}/${id}/actions/countDraftRelations`,
+          {
+            params: validParams,
+          }
         );
         trackUsage('didCheckDraftRelations');
 

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -192,7 +192,7 @@ export default {
   async countDraftRelations(ctx: any) {
     const { userAbility } = ctx.state;
     const { model } = ctx.params;
-
+    const { query = {} } = ctx.request;
     const entityManager = getService('entity-manager');
     const permissionChecker = getService('permission-checker').create({ userAbility, model });
 
@@ -200,7 +200,7 @@ export default {
       return ctx.forbidden();
     }
 
-    const entity = await findEntity({}, model);
+    const entity = await findEntity(query, model);
     if (!entity) {
       return ctx.notFound();
     }


### PR DESCRIPTION
### What does it do?

Modified countDraftRelations to retrieve the locale from parameters, allowing it to verify the single type for the specified query locale instead of defaulting to the locale

### Why is it needed?

Currently, countDraftRelations does not retrieve a specified locale. The locale is not provided in the parameters that's why the default locale is used to fetch the entity from the database. If the entity has not been created in the default locale, users will be unable to publish the single type in their specified locale.

### How to test it?

1. Choose a single type that hasn't been created for the default locale yet.
2. Switch to a locale other than the default, and fill in the content.
3. Try to publish it, and the content will be published successfully.

### Related issue(s)/PR(s)

This PR fixes this issue [#20188](https://github.com/strapi/strapi/issues/20188)