### PR TITLE
chore: add workflow to update Browserslist DB

### DIFF
--- a/.github/workflows/caniuse.yml
+++ b/.github/workflows/caniuse.yml
@@ -1,0 +1,33 @@
+name: Update Browserslist database
+
+on:
+  schedule:
+    # runs twice a month, day 1 & day 15.
+    - cron: '0 2 1,15 * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-browserslist-database:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+      - name: Update Browserslist database and create PR if applies
+        uses: c2corg/browserslist-update-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: browserslist-update
+          base_branch: main
+          commit_message: 'chore(deps): update Browserslist db'
+          title: 'chore(deps): update Browserslist db'
+          labels: 'pr: chore, source: dependencies'
+          reviewers: 'joshuaellis,simotae14,madhurisandbhor'


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a script to keep browserslist up to date

### Why is it needed?

So we don't see:
```shell
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```
ALL THE TIME
