### PR TITLE
fix: data transfer logging

### DIFF
--- a/packages/core/strapi/src/cli/utils/__tests__/logger.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/logger.test.ts
@@ -1,0 +1,91 @@
+import { type Logger, createLogger } from '@strapi/logger';
+import { formatDiagnostic } from '../data-transfer';
+
+jest.mock('@strapi/logger', () => {
+  const actualWinston = jest.requireActual('winston');
+  return {
+    ...actualWinston,
+    createLogger: jest.fn(),
+    configs: {
+      createOutputFileConfiguration: jest.fn(),
+    },
+  };
+});
+
+// Mock console methods to avoid cluttering test output
+const consoleMock = {
+  error: jest.spyOn(console, 'error').mockImplementation(() => {}),
+  warn: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+  info: jest.spyOn(console, 'info').mockImplementation(() => {}),
+};
+
+describe('logger', () => {
+  let mockLogger: jest.Mocked<Logger>;
+
+  beforeEach(() => {
+    // Reset the mocks before each test
+    jest.clearAllMocks();
+
+    // Create a mock logger with jest.fn() methods
+    mockLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    } as any;
+
+    // Mock createLogger to return the mock logger
+    (createLogger as jest.Mock).mockReturnValue(mockLogger);
+  });
+
+  afterEach(() => {
+    // Clear console mocks after each test
+    consoleMock.error.mockClear();
+    consoleMock.warn.mockClear();
+    consoleMock.info.mockClear();
+  });
+
+  describe('formatDiagnostic', () => {
+    it('only creates a single logger', () => {
+      // Call formatDiagnostic to get the diagnostic reporter function
+      const diagnosticReporter = formatDiagnostic('export');
+
+      // Use the diagnostic reporter to log different levels of messages
+      diagnosticReporter({
+        kind: 'error',
+        details: {
+          message: 'Test error',
+          createdAt: new Date(),
+          name: '',
+          severity: 'error',
+          error: new Error(),
+        },
+      });
+      diagnosticReporter({
+        kind: 'warning',
+        details: {
+          message: 'Test warning',
+          createdAt: new Date(),
+        },
+      });
+      diagnosticReporter({
+        kind: 'info',
+        details: {
+          message: 'Test info',
+          createdAt: new Date(),
+        },
+      });
+
+      // Verify createLogger is called only once
+      expect(createLogger).toHaveBeenCalledTimes(1);
+
+      // Verify the mock logger received the logs
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Test error'));
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Test warning'));
+      expect(mockLogger.info).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Test info'));
+    });
+  });
+});

--- a/packages/core/strapi/src/cli/utils/__tests__/logger.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/logger.test.ts
@@ -23,7 +23,6 @@ describe('logger', () => {
   let mockLogger: jest.Mocked<Logger>;
 
   beforeEach(() => {
-    // Reset the mocks before each test
     jest.clearAllMocks();
 
     // Create a mock logger with jest.fn() methods
@@ -47,7 +46,6 @@ describe('logger', () => {
 
   describe('formatDiagnostic', () => {
     it('only creates a single logger', () => {
-      // Call formatDiagnostic to get the diagnostic reporter function
       const diagnosticReporter = formatDiagnostic('export');
 
       // Use the diagnostic reporter to log different levels of messages

--- a/packages/utils/logger/src/configs/output-file-configuration.ts
+++ b/packages/utils/logger/src/configs/output-file-configuration.ts
@@ -3,14 +3,22 @@ import { transports, LoggerOptions } from 'winston';
 import { LEVEL_LABEL, LEVELS } from '../constants';
 import { prettyPrint, excludeColors } from '../formats';
 
-export default (filename: string): LoggerOptions => {
+export default (
+  filename: string,
+  fileTransportOptions: transports.FileTransportOptions = {}
+): LoggerOptions => {
   return {
     level: LEVEL_LABEL,
     levels: LEVELS,
     format: prettyPrint(),
     transports: [
       new transports.Console(),
-      new transports.File({ level: 'error', filename, format: excludeColors }),
+      new transports.File({
+        level: 'error',
+        filename,
+        format: excludeColors,
+        ...fileTransportOptions,
+      }),
     ],
   };
 };


### PR DESCRIPTION
### What does it do?

- only create one log file per cli command run
- change log level to 'info' for file transport

### Why is it needed?

Data transfer commands are currently creating a log file for every individual warning that is sent to the console, and it's an empty file because the file transport was set to 'error'

This way we get only one single file for every data transfer command that is run

### How to test it?

unit test has been added

when you run a data transfer, you should only see a single log file, and it should only be created if there was a reason to create it like a warning or error.

### Related issue(s)/PR(s)

DX-1408