### PR TITLE
fix(typescript-utils): add tsBuildInfoFile to fix incremental options

### DIFF
--- a/packages/utils/typescript/tsconfigs/server.json
+++ b/packages/utils/typescript/tsconfigs/server.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
 
+    "tsBuildInfoFile": "./.tsbuildinfo",
     "incremental": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
### What does it do?

Adds a tsBuildInfoFile to tsconfig so that incremental option works

### Why is it needed?

v5 plugins are receiving build errors in v5 because of this missing config value (among other things that are solved in strapi/sdk-plugin)

### How to test it?

using this updated config should allow to build without receiving the error `[ERROR]  Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified.`

### Related issue(s)/PR(s)

DX-1400