### PR TITLE
Fix transfer document id in DTS

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -841,7 +841,11 @@ class TransferEngine<
           const { type, data } = entity;
           const attributes = schemas[type].attributes;
 
-          const attributesToRemove = difference(Object.keys(data), Object.keys(attributes));
+          const attributesToRemove = difference(
+            Object.keys(data).filter((attr) => attr !== 'documentId'),
+            Object.keys(attributes)
+          );
+
           const updatedEntity = set('data', omit(attributesToRemove, data), entity);
 
           callback(null, updatedEntity);

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -3,7 +3,7 @@ import { extname } from 'path';
 import { EOL } from 'os';
 import type Chain from 'stream-chain';
 import { chain } from 'stream-chain';
-import { isEmpty, uniq, last, isNumber, difference, set, omit, pick } from 'lodash/fp';
+import { isEmpty, uniq, last, isNumber, set, pick } from 'lodash/fp';
 import { diff as semverDiff } from 'semver';
 
 import type { Struct, Utils } from '@strapi/types';

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -3,7 +3,7 @@ import { extname } from 'path';
 import { EOL } from 'os';
 import type Chain from 'stream-chain';
 import { chain } from 'stream-chain';
-import { isEmpty, uniq, last, isNumber, difference, set, omit } from 'lodash/fp';
+import { isEmpty, uniq, last, isNumber, difference, set, omit, pick } from 'lodash/fp';
 import { diff as semverDiff } from 'semver';
 
 import type { Struct, Utils } from '@strapi/types';
@@ -840,13 +840,8 @@ class TransferEngine<
 
           const { type, data } = entity;
           const attributes = schemas[type].attributes;
-
-          const attributesToRemove = difference(
-            Object.keys(data).filter((attr) => attr !== 'documentId'),
-            Object.keys(attributes)
-          );
-
-          const updatedEntity = set('data', omit(attributesToRemove, data), entity);
+          const attributesToKeep = Object.keys(attributes).concat('documentId');
+          const updatedEntity = set('data', pick(attributesToKeep, data), entity);
 
           callback(null, updatedEntity);
         },


### PR DESCRIPTION
### What does it do?

- filtering out documentId key from data, so it's not removed when consolidating destination and source schemas

### Why is it needed?

- documentId property was not being transferred with the entities 

### How to test it?

- attempt a transfer ( import, export, or a transfer between two projects)
- documentId should not change, translations should be preserved and publishing status should be preserved as well

