### PR TITLE
fix(ctb): validation compares pluralName and collectionName correctly

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
@@ -251,10 +251,9 @@ export const forms = {
       const takenCollectionNames = isEditing
         ? collectionNames.filter((collectionName) => {
             const { schema } = contentTypes[ctUid];
-            const currentPluralName = schema.pluralName;
             const currentCollectionName = schema.collectionName;
 
-            return collectionName !== currentPluralName || collectionName !== currentCollectionName;
+            return collectionName !== currentCollectionName;
           })
         : collectionNames;
 

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -46,7 +46,7 @@ test.describe('Edit collection type', () => {
     await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
   });
 
-  test('Can toggle draft&publish', async ({ page }) => {    
+  test('Can toggle draft&publish', async ({ page }) => {
     await page.getByRole('button', { name: 'Edit' }).click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
@@ -60,7 +60,9 @@ test.describe('Edit collection type', () => {
 
   test('Can add a field with default value', async ({ page }) => {
     await page.getByRole('button', { name: 'Add another field', exact: true }).click();
-    await page.getByRole('button', { name: 'Text Small or long text like title or description' }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
     await page.getByLabel('Name', { exact: true }).fill('testfield');
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByRole('textbox', { name: 'Default value' }).fill('mydefault');

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -67,6 +67,8 @@ test.describe('Edit collection type', () => {
     await createCollectionType(page, {
       name: ctName,
     });
+
+    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
@@ -75,31 +77,40 @@ test.describe('Edit collection type', () => {
     await resetFiles();
   });
 
-  test('Can edit a collection type', async ({ page }) => {
-    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
-    // await page.getByRole('button', { name: 'Create new collection type' }).click();
+  test('Can toggle internationalization', async ({ page }) => {
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Internationalization').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
 
-    // await expect(page.getByRole('heading', { name: 'Create a collection type' })).toBeVisible();
+    await waitForRestart(page);
 
-    // const displayName = page.getByLabel('Display name');
-    // await displayName.fill('Secret Document');
+    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+  });
 
-    // const singularId = page.getByLabel('API ID (Singular)');
-    // await expect(singularId).toHaveValue('secret-document');
+  test('Can toggle draft&publish', async ({ page }) => {    
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Draft & publish').click();
+    await page.getByRole('button', { name: 'Yes, disable' }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
 
-    // const pluralId = page.getByLabel('API ID (Plural)');
-    // await expect(pluralId).toHaveValue('secret-documents');
+    await waitForRestart(page);
 
-    // await page.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+  });
 
-    // await expect(page.getByText('Select a field for your collection type')).toBeVisible();
-    // await page.getByText('Small or long text').click();
-    // await page.getByLabel('Name', { exact: true }).fill('myattribute');
-    // await page.getByRole('button', { name: 'Finish' }).click();
-    // await page.getByRole('button', { name: 'Save' }).click();
+  test('Can add a field with default value', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+    await page.getByRole('button', { name: 'Text Small or long text like title or description' }).click();
+    await page.getByLabel('Name', { exact: true }).fill('testfield');
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByRole('textbox', { name: 'Default value' }).fill('mydefault');
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
 
-    // await waitForRestart(page);
+    await waitForRestart(page);
 
-    // await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
   });
 });

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../../utils/login';
+import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
+import { waitForRestart } from '../../../utils/restart';
+import { resetFiles } from '../../../utils/file-reset';
+import { kebabCase, snakeCase } from 'lodash/fp';
+import pluralize from 'pluralize';
+import { navToHeader, skipCtbTour } from '../../../utils/shared';
+
+type ContentTypeData = {
+  name: string;
+  pluralId?: string;
+  singularId?: string;
+};
+const createCollectionType = async (page, data) => {
+  const { name, singularId, pluralId } = data;
+
+  await page.getByRole('button', { name: 'Create new collection type' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Create a collection type' })).toBeVisible();
+
+  const displayName = page.getByLabel('Display name');
+  await displayName.fill(name);
+
+  const singularIdField = page.getByLabel('API ID (Singular)');
+  await expect(singularIdField).toHaveValue(singularId || kebabCase(name));
+  if (singularId) {
+    singularIdField.fill(singularId);
+  }
+
+  const pluralIdField = page.getByLabel('API ID (Plural)');
+  await expect(pluralIdField).toHaveValue(pluralId || pluralize(kebabCase(name)));
+  if (pluralId) {
+    pluralIdField.fill(pluralId);
+  }
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Create an initial text field for it
+  await expect(page.getByText('Select a field for your collection type')).toBeVisible();
+  await page.getByText('Small or long text').click();
+  await page.getByLabel('Name', { exact: true }).fill('myattribute');
+  await page.getByRole('button', { name: 'Finish' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await waitForRestart(page);
+
+  await expect(page.getByRole('heading', { name })).toBeVisible();
+};
+
+test.describe('Edit collection type', () => {
+  const ctName = 'Secret Document';
+
+  test.beforeEach(async ({ page }) => {
+    await resetFiles();
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await page.goto('/admin');
+
+    await login({ page });
+
+    await page.getByRole('link', { name: 'Content-Type Builder' }).click();
+
+    await skipCtbTour(page);
+
+    // TODO: create a "saveFileState" mechanism to be used so we don't have to do a full server restart before each test
+    // create a collection type to be used
+    await createCollectionType(page, {
+      name: ctName,
+    });
+  });
+
+  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
+  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
+  test.afterAll(async () => {
+    await resetFiles();
+  });
+
+  test('Can edit a collection type', async ({ page }) => {
+    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
+    // await page.getByRole('button', { name: 'Create new collection type' }).click();
+
+    // await expect(page.getByRole('heading', { name: 'Create a collection type' })).toBeVisible();
+
+    // const displayName = page.getByLabel('Display name');
+    // await displayName.fill('Secret Document');
+
+    // const singularId = page.getByLabel('API ID (Singular)');
+    // await expect(singularId).toHaveValue('secret-document');
+
+    // const pluralId = page.getByLabel('API ID (Plural)');
+    // await expect(pluralId).toHaveValue('secret-documents');
+
+    // await page.getByRole('button', { name: 'Continue' }).click();
+
+    // await expect(page.getByText('Select a field for your collection type')).toBeVisible();
+    // await page.getByText('Small or long text').click();
+    // await page.getByLabel('Name', { exact: true }).fill('myattribute');
+    // await page.getByRole('button', { name: 'Finish' }).click();
+    // await page.getByRole('button', { name: 'Save' }).click();
+
+    // await waitForRestart(page);
+
+    // await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+  });
+});

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -49,6 +49,7 @@ const createCollectionType = async (page, data) => {
 };
 
 test.describe('Edit collection type', () => {
+  // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../../utils/login';
+import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
+import { waitForRestart } from '../../../utils/restart';
+import { resetFiles } from '../../../utils/file-reset';
+
+test.describe('Create collection type', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetFiles();
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await page.goto('/admin');
+    await login({ page });
+
+    await page.getByRole('link', { name: 'Content-Type Builder' }).click();
+
+    // close the tutorial modal if it's visible
+    const modal = page.getByRole('button', { name: 'Close' });
+    if (modal.isVisible()) {
+      await modal.click();
+      await expect(modal).not.toBeVisible();
+    }
+  });
+
+  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
+  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
+  test.afterAll(async () => {
+    await resetFiles();
+  });
+
+  test('Can create a single type', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create new single type' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Create a single type' })).toBeVisible();
+
+    const displayName = page.getByLabel('Display name');
+    await displayName.fill('Secret Document');
+
+    const singularId = page.getByLabel('API ID (Singular)');
+    await expect(singularId).toHaveValue('secret-document');
+
+    const pluralId = page.getByLabel('API ID (Plural)');
+    await expect(pluralId).toHaveValue('secret-documents');
+
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(page.getByText('Select a field for your single type')).toBeVisible();
+    await page.getByText('Small or long text').click();
+    await page.getByLabel('Name', { exact: true }).fill('myattribute');
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await waitForRestart(page);
+
+    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+  });
+});

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -3,9 +3,10 @@ import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
-import { createCollectionType, navToHeader, skipCtbTour } from '../../../utils/shared';
+import { createSingleType, navToHeader, skipCtbTour } from '../../../utils/shared';
 
-test.describe('Edit collection type', () => {
+
+test.describe('Edit single type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 
@@ -22,7 +23,7 @@ test.describe('Edit collection type', () => {
 
     // TODO: create a "saveFileState" mechanism to be used so we don't have to do a full server restart before each test
     // create a collection type to be used
-    await createCollectionType(page, {
+    await createSingleType(page, {
       name: ctName,
     });
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -5,7 +5,6 @@ import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
 import { createSingleType, navToHeader, skipCtbTour } from '../../../utils/shared';
 
-
 test.describe('Edit single type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
@@ -47,7 +46,7 @@ test.describe('Edit single type', () => {
     await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
   });
 
-  test('Can toggle draft&publish', async ({ page }) => {    
+  test('Can toggle draft&publish', async ({ page }) => {
     await page.getByRole('button', { name: 'Edit' }).click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
@@ -61,7 +60,9 @@ test.describe('Edit single type', () => {
 
   test('Can add a field with default value', async ({ page }) => {
     await page.getByRole('button', { name: 'Add another field', exact: true }).click();
-    await page.getByRole('button', { name: 'Text Small or long text like title or description' }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
     await page.getByLabel('Name', { exact: true }).fill('testfield');
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByRole('textbox', { name: 'Default value' }).fill('mydefault');

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -1,4 +1,7 @@
 import { test, Page, expect } from '@playwright/test';
+import { waitForRestart } from './restart';
+import pluralize from 'pluralize';
+import { kebabCase } from 'lodash/fp';
 
 /**
  * Execute a test suite only if the condition is true
@@ -61,4 +64,83 @@ export const findAndClose = async (
 
   // Click the 'Close' button.
   await closeBtn.click();
+};
+
+
+type ContentTypeData = {
+  name: string;
+  pluralId?: string;
+  singularId?: string;
+};
+
+export const createSingleType = async (page, data) => {
+  const { name, singularId, pluralId } = data;
+
+  await page.getByRole('button', { name: 'Create new single type' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Create a single type' })).toBeVisible();
+
+  const displayName = page.getByLabel('Display name');
+  await displayName.fill(name);
+
+  const singularIdField = page.getByLabel('API ID (Singular)');
+  await expect(singularIdField).toHaveValue(singularId || kebabCase(name));
+  if (singularId) {
+    singularIdField.fill(singularId);
+  }
+
+  const pluralIdField = page.getByLabel('API ID (Plural)');
+  await expect(pluralIdField).toHaveValue(pluralId || pluralize(kebabCase(name)));
+  if (pluralId) {
+    pluralIdField.fill(pluralId);
+  }
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Create an initial text field for it
+  await expect(page.getByText('Select a field for your single type')).toBeVisible();
+  await page.getByText('Small or long text').click();
+  await page.getByLabel('Name', { exact: true }).fill('myattribute');
+  await page.getByRole('button', { name: 'Finish' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await waitForRestart(page);
+
+  await expect(page.getByRole('heading', { name })).toBeVisible();
+};
+
+export const createCollectionType = async (page, data) => {
+  const { name, singularId, pluralId } = data;
+
+  await page.getByRole('button', { name: 'Create new collection type' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Create a collection type' })).toBeVisible();
+
+  const displayName = page.getByLabel('Display name');
+  await displayName.fill(name);
+
+  const singularIdField = page.getByLabel('API ID (Singular)');
+  await expect(singularIdField).toHaveValue(singularId || kebabCase(name));
+  if (singularId) {
+    singularIdField.fill(singularId);
+  }
+
+  const pluralIdField = page.getByLabel('API ID (Plural)');
+  await expect(pluralIdField).toHaveValue(pluralId || pluralize(kebabCase(name)));
+  if (pluralId) {
+    pluralIdField.fill(pluralId);
+  }
+
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Create an initial text field for it
+  await expect(page.getByText('Select a field for your collection type')).toBeVisible();
+  await page.getByText('Small or long text').click();
+  await page.getByLabel('Name', { exact: true }).fill('myattribute');
+  await page.getByRole('button', { name: 'Finish' }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await waitForRestart(page);
+
+  await expect(page.getByRole('heading', { name })).toBeVisible();
 };

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -25,6 +25,24 @@ export const navToHeader = async (page: Page, navItems: string[], headerText: st
 };
 
 /**
+ * Skip the tour if the modal is visible
+ */
+export const skipCtbTour = async (page: Page) => {
+  const modalSelector = 'role=button[name="Skip the tour"]';
+
+  try {
+    await page.waitForSelector(modalSelector, { timeout: 1000 });
+    const modal = page.locator(modalSelector);
+    if (await modal.isVisible()) {
+      await modal.click();
+      await expect(modal).not.toBeVisible();
+    }
+  } catch (e) {
+    // The modal did not appear, continue with the test
+  }
+};
+
+/**
  * Look for an element containing text, and then click a sibling close button
  */
 export const findAndClose = async (

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -66,7 +66,6 @@ export const findAndClose = async (
   await closeBtn.click();
 };
 
-
 type ContentTypeData = {
   name: string;
   pluralId?: string;


### PR DESCRIPTION
### What does it do?

Fixes the comparison in the validator so that takenCollectionNames only includes collectionNames and not also collectionNames equal to the current pluralName (which meant that it would then compare its pluralName against its own collectionName and fail validation because they were equal)

### Why is it needed?

To allow saving content types after changing the value of i18n or d&p

### How to test it?

See https://github.com/strapi/strapi/issues/19750 for details. It should now allow saving.

e2e tests have also been added, which fail without the change and pass with the change

### Related issue(s)/PR(s)

DX-1160

Fixes https://github.com/strapi/strapi/issues/19750