### PR TITLE
enhancement: improve gitignore in generated projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ packages/generators/app/files/public/
 schema.graphql
 dist
 .nx
+.tsbuildinfo
+.eslintcache
 
 ############################
 # Example app
@@ -126,8 +128,9 @@ front-workspace.code-workspace
 .yarnrc
 
 ############################
-# Yarn
+# Package managers
 ############################
+
 .pnp.*
 .yarn/*
 !.yarn/patches
@@ -135,6 +138,9 @@ front-workspace.code-workspace
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+yarn-error.log
+pnpm-debug.log
+npm-debug.log
 
 ############################
 # Playwright

--- a/packages/cli/create-strapi-starter/src/resources/gitignore
+++ b/packages/cli/create-strapi-starter/src/resources/gitignore
@@ -82,6 +82,8 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
+.tsbuildinfo
+.eslintcache
 
 ############################
 # Node.js
@@ -100,6 +102,21 @@ node_modules
 ############################
 
 coverage
+
+############################
+# Package managers
+############################
+
+.yarn/*
+!.yarn/cache
+!.yarn/unplugged
+!.yarn/patches
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+yarn-error.log
+
 
 ############################
 # Strapi

--- a/packages/generators/app/src/resources/dot-files/common/gitignore
+++ b/packages/generators/app/src/resources/dot-files/common/gitignore
@@ -82,6 +82,8 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
+.tsbuildinfo
+.eslintcache
 
 ############################
 # Node.js
@@ -94,6 +96,20 @@ logs
 results
 node_modules
 .node_history
+
+############################
+# Package managers
+############################
+
+.yarn/*
+!.yarn/cache
+!.yarn/unplugged
+!.yarn/patches
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+yarn-error.log
 
 ############################
 # Tests


### PR DESCRIPTION
### What does it do?

Adds package manager files, .tsbuildinfo, and .eslintcache to generated project gitignore and the root gitignore

I did not do the individual strapi package gitignore files because tbh they shouldn't even exist unless they are overriding the root level one, but we can deal with that later.

### Why is it needed?

To ignore more files, but specifically it is needed for .tsbuildinfo because that is now created when building typescript projects in v5

### How to test it?

Generate a new typescript project, build it, and see that it ignores those files.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
