### PR TITLE
[TS] Update position attribute to be optional in relation reordering types

### DIFF
--- a/packages/core/types/src/modules/entity-service/params/attributes/relation.ts
+++ b/packages/core/types/src/modules/entity-service/params/attributes/relation.ts
@@ -11,7 +11,7 @@ interface PositionalArguments {
   end?: boolean;
 }
 
-type WithPositionArguments<T> = T & { position: PositionalArguments };
+type WithPositionArguments<T> = T & { position?: PositionalArguments };
 
 type Set = { set: ShortHand[] | LongHand[] | null };
 type Connect = { connect: ShortHand[] | WithPositionArguments<LongHand>[] };


### PR DESCRIPTION
### What does it do?

Make `position` optional in WithPositionArgument

### Why is it needed?

See: https://github.com/strapi/strapi/issues/19252#issuecomment-2129722983 and more generally https://github.com/strapi/strapi/issues/19252

### How to test it?

See https://github.com/strapi/strapi/issues/19252#issuecomment-2129672212

### Related issue(s)/PR(s)

fix #19252 
