### PR TITLE
Cockroach DB for v5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -445,7 +445,7 @@ jobs:
   api_ee_crdb:
     runs-on: ubuntu-latest
     needs: [changes, build, typescript, unit_back, unit_front]
-    name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    name: '[EE] API Integration (crdb, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,6 +299,40 @@ jobs:
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
           jestOptions: '--shard=${{ matrix.shard }}'
+  api_ce_crdb:
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    needs: [changes, build, typescript, unit_back, unit_front]
+    name: '[CE] API Integration (crdb, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    strategy:
+      matrix:
+        node: [18, 20]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    services:
+      cockroachdb:
+        image: timveil/cockroachdb-single-node:latest
+        # Set health checks to wait until cockroachdb has started
+        options: >-
+          --health-cmd "curl http://cockroachdb:8080/health?ready=1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 26257:26257
+          - 8080:8080
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - uses: ./.github/actions/run-api-tests
+        with:
+          dbOptions: '--dbclient=cockroachdb --dbhost=localhost --dbport=26257 --dbname=defaultdb --dbusername=root --dbpassword=""'
+          jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_mysql:
     if: needs.changes.outputs.backend == 'true'
@@ -405,6 +439,45 @@ jobs:
       - uses: ./.github/actions/run-api-tests
         with:
           dbOptions: '--dbclient=postgres --dbhost=localhost --dbport=5432 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          runEE: true
+          jestOptions: '--shard=${{ matrix.shard }}'
+
+  api_ee_crdb:
+    runs-on: ubuntu-latest
+    needs: [changes, build, typescript, unit_back, unit_front]
+    name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+    env:
+      STRAPI_LICENSE: ${{ secrets.strapiLicense }}
+    strategy:
+      matrix:
+        node: [18, 20]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    services:
+      cockroachdb:
+        # Docker Hub image
+        image: timveil/cockroachdb-single-node:latest
+        # Set health checks to wait until cockroachdb has started
+        options: >-
+          --health-cmd "curl http://cockroachdb:8080/health?ready=1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 26257:26257
+          - 8080:8080
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - uses: ./.github/actions/run-api-tests
+        with:
+          dbOptions: '--dbclient=cockroachdb --dbhost=localhost --dbport=26257 --dbname=defaultdb --dbusername=root --dbpassword=""'
           runEE: true
           jestOptions: '--shard=${{ matrix.shard }}'
 

--- a/packages/core/core/src/utils/startup-logger.ts
+++ b/packages/core/core/src/utils/startup-logger.ts
@@ -31,6 +31,16 @@ export const createStartupLogger = (app: Core.Strapi) => {
       console.log();
       console.log(chalk.black.bgWhite(_.padEnd(columns, ' Actions available')));
       console.log();
+      if (app.db.dialect.client === 'cockroachdb') {
+        console.log(
+          chalk.black.bgRed(
+            _.padEnd(
+              columns,
+              ' WARNING: CockroachDB is currently experimental. Do not use in production.'
+            )
+          )
+        );
+      }
     },
 
     logFirstStartupMessage() {

--- a/packages/core/database/src/connection.ts
+++ b/packages/core/database/src/connection.ts
@@ -5,6 +5,7 @@ const clientMap = {
   sqlite: 'better-sqlite3',
   mysql: 'mysql2',
   postgres: 'pg',
+  cockroachdb: 'cockroachdb',
 };
 
 function isClientValid(config: { client?: unknown }): config is { client: keyof typeof clientMap } {
@@ -16,7 +17,10 @@ export const createConnection = (userConfig: Knex.Config, strapiConfig?: Partial
     throw new Error(`Unsupported database client ${userConfig.client}`);
   }
 
-  const knexConfig: Knex.Config = { ...userConfig, client: (clientMap as any)[userConfig.client] };
+  const knexConfig: Knex.Config = {
+    ...userConfig,
+    client: (clientMap as any)[userConfig.client],
+  };
 
   // initialization code to run upon opening a new connection
   if (strapiConfig?.pool?.afterCreate) {

--- a/packages/core/database/src/dialects/cockroachdb/index.ts
+++ b/packages/core/database/src/dialects/cockroachdb/index.ts
@@ -1,0 +1,79 @@
+import * as errors from '../../errors';
+import type { Database } from '../..';
+import Dialect from '../dialect';
+import CockroachDBSchemaInspector from './schema-inspector';
+
+export default class CockroachDBDialect extends Dialect {
+  schemaInspector: CockroachDBSchemaInspector;
+
+  constructor(db: Database) {
+    super(db, 'cockroachdb');
+
+    this.schemaInspector = new CockroachDBSchemaInspector(db);
+  }
+
+  useReturning() {
+    return true;
+  }
+
+  async initialize(nativeConnection: unknown) {
+    // Don't cast DATE string to Date()
+    this.db.connection.client.driver.types.setTypeParser(
+      this.db.connection.client.driver.types.builtins.DATE,
+      'text',
+      (v: unknown) => v
+    );
+    // Don't parse JSONB automatically
+    this.db.connection.client.driver.types.setTypeParser(
+      this.db.connection.client.driver.types.builtins.JSONB,
+      'text',
+      (v: unknown) => v
+    );
+    this.db.connection.client.driver.types.setTypeParser(
+      this.db.connection.client.driver.types.builtins.NUMERIC,
+      'text',
+      parseFloat
+    );
+    // sets default int to 32 bit and sets serial normalization to sql_sequence to mimic postgres
+    this.db.connection.client.pool.on('acquireSuccess', async (eventId:any, resource:any) => {
+      resource.query('SET serial_normalization = "sql_sequence";');
+      resource.query('SET default_int_size = 4;');
+      resource.query('SET default_transaction_isolation = "READ COMMITTED";');
+    });
+    // If we're using a schema, set the default path for all table names in queries to use that schema
+    const schemaName = this.db.getSchemaName();
+    if (schemaName) {
+      await this.db.connection
+        .raw(`SET search_path TO "${schemaName}"`)
+        .connection(nativeConnection);
+    }
+  }
+
+  usesForeignKeys() {
+    return true;
+  }
+
+  getSqlType(type: string) {
+    switch (type) {
+      case 'timestamp': {
+        return 'datetime';
+      }
+      default: {
+        return type;
+      }
+    }
+  }
+
+  transformErrors(error: NodeJS.ErrnoException) {
+    switch (error.code) {
+      case '23502': {
+        throw new errors.NotNullError({
+          column: 'column' in error ? `${error.column}` : undefined,
+        });
+      }
+      default: {
+        super.transformErrors(error);
+      }
+    }
+  }
+}

--- a/packages/core/database/src/dialects/cockroachdb/index.ts
+++ b/packages/core/database/src/dialects/cockroachdb/index.ts
@@ -35,7 +35,7 @@ export default class CockroachDBDialect extends Dialect {
       parseFloat
     );
     // sets default int to 32 bit and sets serial normalization to sql_sequence to mimic postgres
-    this.db.connection.client.pool.on('acquireSuccess', async (eventId:any, resource:any) => {
+    this.db.connection.client.pool.on('acquireSuccess', async (eventId: any, resource: any) => {
       resource.query('SET serial_normalization = "sql_sequence";');
       resource.query('SET default_int_size = 4;');
       resource.query('SET default_transaction_isolation = "READ COMMITTED";');

--- a/packages/core/database/src/dialects/cockroachdb/schema-inspector.ts
+++ b/packages/core/database/src/dialects/cockroachdb/schema-inspector.ts
@@ -1,0 +1,307 @@
+import type { Database } from '../..';
+import type { Schema, Column, Index, ForeignKey } from '../../schema/types';
+import type { SchemaInspector } from '../dialect';
+
+interface RawTable {
+  table_name: string;
+}
+
+interface RawColumn {
+  data_type: string;
+  column_name: string;
+  character_maximum_length: number;
+  column_default: string;
+  is_nullable: string;
+}
+
+interface RawIndex {
+  indexrelid: string;
+  index_name: string;
+  column_name: string;
+  is_unique: boolean;
+  is_primary: boolean;
+}
+
+interface RawForeignKey {
+  constraint_name: string;
+}
+
+const SQL_QUERIES = {
+  TABLE_LIST: /* sql */ `
+    SELECT *
+    FROM information_schema.tables
+    WHERE
+      table_schema = ?
+      AND table_type = 'BASE TABLE'
+      AND table_name != 'geometry_columns'
+      AND table_name != 'spatial_ref_sys';
+  `,
+  LIST_COLUMNS: /* sql */ `
+    SELECT data_type, column_name, character_maximum_length, column_default, is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = ? AND table_name = ?;
+  `,
+  INDEX_LIST: /* sql */ `
+    SELECT
+      ix.indexrelid,
+      i.relname as index_name,
+      a.attname as column_name,
+      ix.indisunique as is_unique,
+      ix.indisprimary as is_primary
+    FROM
+      pg_class t,
+      pg_namespace s,
+      pg_class i,
+      pg_index ix,
+      pg_attribute a
+    WHERE
+      t.oid = ix.indrelid
+      AND i.oid = ix.indexrelid
+      AND a.attrelid = t.oid
+      AND a.attnum = ANY(ix.indkey)
+      AND t.relkind = 'r'
+      AND t.relnamespace = s.oid
+      AND s.nspname = ?
+      AND t.relname = ?;
+  `,
+  FOREIGN_KEY_LIST: /* sql */ `
+    SELECT
+      constraint_name
+    FROM information_schema.table_constraints
+    WHERE
+      constraint_type = 'FOREIGN KEY'
+      AND constraint_schema = ?
+      AND table_name = ?
+  `,
+  FOREIGN_KEY_REFERENCES: /* sql */ `
+    SELECT
+      constraint_name,
+      column_name
+    FROM information_schema.key_column_usage
+    WHERE constraint_name = ANY(string_to_array(?, ','))
+    AND table_schema = ?
+    AND table_name = ?;
+  `,
+  FOREIGN_KEY_REFERENCES_CONSTRAIN: /* sql */ `
+    SELECT
+      update_rule as on_update,
+      delete_rule as on_delete,
+      unique_constraint_name
+    FROM information_schema.referential_constraints
+    WHERE constraint_name = ANY(string_to_array(?, ','))
+    AND constraint_schema = ?;
+  `,
+  FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE: /* sql */ `
+    SELECT
+      table_name AS foreign_table,
+      column_name AS fk_column_name
+    FROM information_schema.key_column_usage
+    WHERE constraint_name = ?
+    AND table_schema = ?;
+  `,
+};
+
+const toStrapiType = (column: RawColumn) => {
+  const rootType = column.data_type.toLowerCase().match(/[^(), ]+/)?.[0];
+
+  switch (rootType) {
+    case 'integer': {
+      // find a way to figure out the increments
+      return { type: 'integer' };
+    }
+    case 'text': {
+      return { type: 'text', args: ['longtext'] };
+    }
+    case 'boolean': {
+      return { type: 'boolean' };
+    }
+    case 'character': {
+      return { type: 'string', args: [column.character_maximum_length] };
+    }
+    case 'timestamp': {
+      return { type: 'datetime', args: [{ useTz: false, precision: 6 }] };
+    }
+    case 'date': {
+      return { type: 'date' };
+    }
+    case 'time': {
+      return { type: 'time', args: [{ precision: 3 }] };
+    }
+    case 'numeric': {
+      return { type: 'decimal', args: [10, 2] };
+    }
+    case 'real':
+    case 'double': {
+      return { type: 'double' };
+    }
+    case 'bigint': {
+      return { type: 'bigInteger' };
+    }
+    case 'jsonb': {
+      return { type: 'jsonb' };
+    }
+    default: {
+      return { type: 'specificType', args: [column.data_type] };
+    }
+  }
+};
+
+const getIndexType = (index: RawIndex) => {
+  if (index.is_primary) {
+    return 'primary';
+  }
+
+  if (index.is_unique) {
+    return 'unique';
+  }
+};
+
+export default class CockroachDBSchemaInspector implements SchemaInspector {
+  db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  async getSchema() {
+    const schema: Schema = { tables: [] };
+
+    const tables = await this.getTables();
+
+    schema.tables = await Promise.all(
+      tables.map(async (tableName) => {
+        const columns = await this.getColumns(tableName);
+        const indexes = await this.getIndexes(tableName);
+        const foreignKeys = await this.getForeignKeys(tableName);
+
+        return {
+          name: tableName,
+          columns,
+          indexes,
+          foreignKeys,
+        };
+      })
+    );
+
+    return schema;
+  }
+
+  getDatabaseSchema(): string {
+    return this.db.getSchemaName() || 'public';
+  }
+
+  async getTables(): Promise<string[]> {
+    const { rows } = await this.db.connection.raw<{ rows: RawTable[] }>(SQL_QUERIES.TABLE_LIST, [
+      this.getDatabaseSchema(),
+    ]);
+
+    return rows.map((row) => row.table_name);
+  }
+
+  async getColumns(tableName: string): Promise<Column[]> {
+    const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.LIST_COLUMNS, [
+      this.getDatabaseSchema(),
+      tableName,
+    ]);
+
+    return rows.map((row) => {
+      const { type, args = [], ...rest } = toStrapiType(row);
+
+      const defaultTo =
+        row.column_default && row.column_default.includes('nextval(') ? null : row.column_default;
+
+      return {
+        type,
+        args,
+        defaultTo,
+        name: row.column_name,
+        notNullable: row.is_nullable === 'NO',
+        unsigned: false,
+        ...rest,
+      };
+    });
+  }
+
+  async getIndexes(tableName: string): Promise<Index[]> {
+    const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.INDEX_LIST, [
+      this.getDatabaseSchema(),
+      tableName,
+    ]);
+
+    const ret: Record<RawIndex['indexrelid'], Index> = {};
+
+    for (const index of rows) {
+      if (index.column_name === 'id') {
+        continue;
+      }
+
+      if (!ret[index.indexrelid]) {
+        ret[index.indexrelid] = {
+          columns: [index.column_name],
+          name: index.index_name,
+          type: getIndexType(index),
+        };
+      } else {
+        ret[index.indexrelid].columns.push(index.column_name);
+      }
+    }
+
+    return Object.values(ret);
+  }
+
+  async getForeignKeys(tableName: string): Promise<ForeignKey[]> {
+    const { rows } = await this.db.connection.raw<{ rows: RawForeignKey[] }>(
+      SQL_QUERIES.FOREIGN_KEY_LIST,
+      [this.getDatabaseSchema(), tableName]
+    );
+
+    const ret: Record<RawForeignKey['constraint_name'], ForeignKey> = {};
+
+    for (const fk of rows) {
+      ret[fk.constraint_name] = {
+        name: fk.constraint_name,
+        columns: [],
+        referencedColumns: [],
+        referencedTable: null,
+        onUpdate: null,
+        onDelete: null,
+      } as unknown as ForeignKey;
+    }
+
+    const constraintNames = Object.keys(ret).join(',');
+
+    const dbSchema = this.getDatabaseSchema();
+    if (constraintNames.length > 0) {
+      const { rows: fkReferences } = await this.db.connection.raw(
+        SQL_QUERIES.FOREIGN_KEY_REFERENCES,
+        [constraintNames, dbSchema, tableName]
+      );
+
+      for (const fkReference of fkReferences) {
+        ret[fkReference.constraint_name].columns.push(fkReference.column_name);
+
+        const { rows: fkReferencesConstraint } = await this.db.connection.raw(
+          SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN,
+          [fkReference.constraint_name, dbSchema]
+        );
+
+        for (const fkReferenceC of fkReferencesConstraint) {
+          const { rows: fkReferencesConstraintReference } = await this.db.connection.raw(
+            SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE,
+            [fkReferenceC.unique_constraint_name, dbSchema]
+          );
+          for (const fkReferenceConst of fkReferencesConstraintReference) {
+            ret[fkReference.constraint_name].referencedTable = fkReferenceConst.foreign_table;
+            ret[fkReference.constraint_name].referencedColumns.push(
+              fkReferenceConst.fk_column_name
+            );
+          }
+          ret[fkReference.constraint_name].onUpdate = fkReferenceC.on_update.toUpperCase();
+          ret[fkReference.constraint_name].onDelete = fkReferenceC.on_delete.toUpperCase();
+        }
+      }
+    }
+
+    return Object.values(ret);
+  }
+}

--- a/packages/core/database/src/dialects/index.ts
+++ b/packages/core/database/src/dialects/index.ts
@@ -1,6 +1,7 @@
 import type { Database } from '..';
 import Dialect from './dialect';
 import PostgresClass from './postgresql';
+import CockroachDBClass from './cockroachdb';
 import MysqlClass from './mysql';
 import SqliteClass from './sqlite';
 
@@ -11,6 +12,8 @@ const getDialectClass = (client: string): typeof Dialect => {
   switch (client) {
     case 'postgres':
       return PostgresClass;
+    case 'cockroachdb':
+      return CockroachDBClass;
     case 'mysql':
       return MysqlClass;
     case 'sqlite':
@@ -27,6 +30,8 @@ const getDialectName = (client: unknown) => {
   switch (client) {
     case 'postgres':
       return 'postgres';
+    case 'cockroachdb':
+      return 'cockroachdb';
     case 'mysql':
       return 'mysql';
     case 'sqlite':

--- a/packages/core/database/src/query/helpers/search.ts
+++ b/packages/core/database/src/query/helpers/search.ts
@@ -38,6 +38,7 @@ export const applySearch = (knex: Knex.QueryBuilder, query: string, ctx: Ctx) =>
   }
 
   switch (db.dialect.client) {
+    case 'cockroachdb':
     case 'postgres': {
       searchColumns.forEach((attr) => {
         const columnName = toColumnName(meta, attr);

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -446,8 +446,9 @@ const applyWhere = (qb: Knex.QueryBuilder, where: Where) => {
 
 const fieldLowerFn = (qb: Knex.QueryBuilder) => {
   // Postgres & Cockroach requires string to be passed
-  if (typeof qb.client.config.client === 'string' && 
-      ['postgres', 'cockroachdb'].includes(qb.client.config.client)
+  if (
+    typeof qb.client.config.client === 'string' &&
+    ['postgres', 'cockroachdb'].includes(qb.client.config.client)
   ) {
     return 'LOWER(CAST(?? AS VARCHAR))';
   }

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -445,8 +445,10 @@ const applyWhere = (qb: Knex.QueryBuilder, where: Where) => {
 };
 
 const fieldLowerFn = (qb: Knex.QueryBuilder) => {
-  // Postgres requires string to be passed
-  if (qb.client.config.client === 'postgres') {
+  // Postgres & Cockroach requires string to be passed
+  if (typeof qb.client.config.client === 'string' && 
+      ['postgres', 'cockroachdb'].includes(qb.client.config.client)
+  ) {
     return 'LOWER(CAST(?? AS VARCHAR))';
   }
 

--- a/packages/core/database/src/schema/builder.ts
+++ b/packages/core/database/src/schema/builder.ts
@@ -97,6 +97,14 @@ export default (db: Database) => {
           debug(`Updating table: ${table.name}`);
           // alter table
           const schemaBuilder = this.getSchemaBuilder(trx);
+          console.log("====ALTERING TABLE=====");
+          console.log(schemaBuilder);
+          console.log("table");
+          console.log(table);
+          console.log("indexes", table.indexes);
+          console.log("columns", table.columns);
+          console.log("foreignKeys", table.foreignKeys);
+          console.log("====ALTERING TABLE=====");
 
           await helpers.alterTable(schemaBuilder, table);
         }

--- a/packages/core/database/src/schema/builder.ts
+++ b/packages/core/database/src/schema/builder.ts
@@ -97,14 +97,14 @@ export default (db: Database) => {
           debug(`Updating table: ${table.name}`);
           // alter table
           const schemaBuilder = this.getSchemaBuilder(trx);
-          console.log("====ALTERING TABLE=====");
+          console.log('====ALTERING TABLE=====');
           console.log(schemaBuilder);
-          console.log("table");
+          console.log('table');
           console.log(table);
-          console.log("indexes", table.indexes);
-          console.log("columns", table.columns);
-          console.log("foreignKeys", table.foreignKeys);
-          console.log("====ALTERING TABLE=====");
+          console.log('indexes', table.indexes);
+          console.log('columns', table.columns);
+          console.log('foreignKeys', table.foreignKeys);
+          console.log('====ALTERING TABLE=====');
 
           await helpers.alterTable(schemaBuilder, table);
         }

--- a/packages/core/database/src/schema/builder.ts
+++ b/packages/core/database/src/schema/builder.ts
@@ -97,14 +97,6 @@ export default (db: Database) => {
           debug(`Updating table: ${table.name}`);
           // alter table
           const schemaBuilder = this.getSchemaBuilder(trx);
-          console.log('====ALTERING TABLE=====');
-          console.log(schemaBuilder);
-          console.log('table');
-          console.log(table);
-          console.log('indexes', table.indexes);
-          console.log('columns', table.columns);
-          console.log('foreignKeys', table.foreignKeys);
-          console.log('====ALTERING TABLE=====');
 
           await helpers.alterTable(schemaBuilder, table);
         }

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -256,8 +256,8 @@ export default (db: Database) => {
     }
 
     for (const srcIndex of srcTable.indexes) {
-      console.log("destTable", destTable);
-      console.log("srcIndex", srcIndex);
+      console.log('destTable', destTable);
+      console.log('srcIndex', srcIndex);
       if (!helpers.hasIndex(destTable, srcIndex.name)) {
         removedIndexes.push(srcIndex);
       }

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -256,8 +256,6 @@ export default (db: Database) => {
     }
 
     for (const srcIndex of srcTable.indexes) {
-      console.log('destTable', destTable);
-      console.log('srcIndex', srcIndex);
       if (!helpers.hasIndex(destTable, srcIndex.name)) {
         removedIndexes.push(srcIndex);
       }

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -71,8 +71,8 @@ export default (db: Database) => {
    */
   const diffIndexes = (oldIndex: Index, index: Index): IndexDiff => {
     const changes: string[] = [];
-
-    if (!_.isEqual(oldIndex.columns, index.columns)) {
+    // we need to sort the array because sometimes the column indexes are returned in a different order
+    if (!_.isEqual(oldIndex.columns.sort(), index.columns.sort())) {
       changes.push('columns');
     }
 
@@ -256,6 +256,8 @@ export default (db: Database) => {
     }
 
     for (const srcIndex of srcTable.indexes) {
+      console.log("destTable", destTable);
+      console.log("srcIndex", srcIndex);
       if (!helpers.hasIndex(destTable, srcIndex.name)) {
         removedIndexes.push(srcIndex);
       }

--- a/packages/core/upload/server/src/controllers/admin-folder-file.ts
+++ b/packages/core/upload/server/src/controllers/admin-folder-file.ts
@@ -153,6 +153,7 @@ export default {
             case 'sqlite':
               replaceQuery = '? || SUBSTRING(??, ?)';
               break;
+            case 'cockroachdb':
             case 'postgres':
               replaceQuery = 'CONCAT(?::TEXT, SUBSTRING(??, ?::INTEGER))';
               break;

--- a/packages/generators/app/src/create-customized-project.ts
+++ b/packages/generators/app/src/create-customized-project.ts
@@ -47,12 +47,12 @@ async function askDbInfosAndTest(scope: Scope) {
 }
 
 async function askDatabaseInfos(scope: Scope) {
-  const { client } = await inquirer.prompt<{ client: 'sqlite' | 'postgres' | 'mysql' }>([
+  const { client } = await inquirer.prompt<{ client: 'sqlite' | 'postgres' | 'mysql' | 'cockroachdb' }>([
     {
       type: 'list',
       name: 'client',
       message: 'Choose your default database client',
-      choices: ['sqlite', 'postgres', 'mysql'],
+      choices: ['sqlite', 'postgres', 'mysql', 'cockroachdb (experimental)'],
       default: 'sqlite',
     },
   ]);

--- a/packages/generators/app/src/create-customized-project.ts
+++ b/packages/generators/app/src/create-customized-project.ts
@@ -47,7 +47,9 @@ async function askDbInfosAndTest(scope: Scope) {
 }
 
 async function askDatabaseInfos(scope: Scope) {
-  const { client } = await inquirer.prompt<{ client: 'sqlite' | 'postgres' | 'mysql' | 'cockroachdb' }>([
+  const { client } = await inquirer.prompt<{
+    client: 'sqlite' | 'postgres' | 'mysql' | 'cockroachdb';
+  }>([
     {
       type: 'list',
       name: 'client',

--- a/packages/generators/app/src/types.ts
+++ b/packages/generators/app/src/types.ts
@@ -45,7 +45,7 @@ export interface Configuration {
   dependencies: Record<string, string>;
 }
 
-export type ClientName = 'mysql' | 'postgres' | 'sqlite';
+export type ClientName = 'mysql' | 'postgres' | 'sqlite' | 'cockroachdb';
 
 export interface DatabaseInfo {
   client?: string;

--- a/packages/generators/app/src/utils/db-client-dependencies.ts
+++ b/packages/generators/app/src/utils/db-client-dependencies.ts
@@ -3,6 +3,7 @@ import type { ClientName } from '../types';
 const sqlClientModule = {
   mysql: { mysql2: '3.6.2' },
   postgres: { pg: '8.8.0' },
+  cockroachdb: { pg: '8.8.0' },
   sqlite: { 'better-sqlite3': '9.4.3' },
 };
 

--- a/packages/generators/app/src/utils/db-configs.ts
+++ b/packages/generators/app/src/utils/db-configs.ts
@@ -9,5 +9,6 @@ export default {
     useNullAsDefault: true,
   },
   postgres: {},
+  cockroachdb: {},
   mysql: {},
 };

--- a/packages/generators/app/src/utils/db-questions.ts
+++ b/packages/generators/app/src/utils/db-questions.ts
@@ -2,11 +2,12 @@ import type { Question } from 'inquirer';
 import type { Scope } from '../types';
 
 interface QuestionFactory {
-  (options: { scope: Scope; client: 'postgres' | 'mysql' | 'sqlite' }): Question;
+  (options: { scope: Scope; client: 'postgres' | 'mysql' | 'sqlite' | 'cockroachdb' }): Question;
 }
 
 const DEFAULT_PORTS = {
   postgres: 5432,
+  cockroachdb: 26257,
   mysql: 3306,
   sqlite: undefined,
 };
@@ -69,5 +70,6 @@ const filename: QuestionFactory = () => ({
 export default {
   sqlite: [filename],
   postgres: [database, host, port, username, password, ssl],
+  cockroachdb: [database, host, port, username, password, ssl],
   mysql: [database, host, port, username, password, ssl],
 };

--- a/tests/scripts/generate-test-app.js
+++ b/tests/scripts/generate-test-app.js
@@ -17,6 +17,17 @@ const databases = {
       schema: 'myschema',
     },
   },
+  cockroachdb: {
+    client: 'cockroachdb',
+    connection: {
+      host: '127.0.0.1',
+      port: 26257,
+      database: 'defaultdb',
+      username: 'root',
+      password: '',
+      schema: 'public',
+    },
+  },
   mysql: {
     client: 'mysql',
     connection: {

--- a/tests/scripts/run-api-tests.js
+++ b/tests/scripts/run-api-tests.js
@@ -23,6 +23,17 @@ const databases = {
       schema: 'myschema',
     },
   },
+  cockroachdb: {
+    client: 'cockroachdb',
+    connection: {
+      host: '127.0.0.1',
+      port: 26257,
+      database: 'defaultdb',
+      username: 'root',
+      password: '',
+      schema: 'public',
+    },
+  },
   mysql: {
     client: 'mysql',
     connection: {


### PR DESCRIPTION
CRDB is finally working with Strapi, passing all tests, documentation written, and ready for review.

to test use the following docker-compose file and connection config.

```js
  connection: {
    client: 'cockroachdb',
    connection: {
      host: env('DATABASE_HOST', 'localhost'),
      port: env.int('DATABASE_PORT', 26257),
      database: env('DATABASE_NAME', 'strapi'),
      user: env('DATABASE_USERNAME', 'root'),
      password: env('DATABASE_PASSWORD', ''),
      ssl: env.bool('DATABASE_SSL', false) && {
        key: env('DATABASE_SSL_KEY', undefined),
        cert: env('DATABASE_SSL_CERT', undefined),
        ca: env('DATABASE_SSL_CA', undefined),
        capath: env('DATABASE_SSL_CAPATH', undefined),
        cipher: env('DATABASE_SSL_CIPHER', undefined),
        rejectUnauthorized: env.bool(
          'DATABASE_SSL_REJECT_UNAUTHORIZED',
          true
        ),
      },
      schema: env('DATABASE_SCHEMA', 'public'),
    },
    useNullAsDefault: true,
  },
  ```
  Docker Compose
```yaml
version: '3.7'

services:
  cockroachdb:
    image: cockroachdb/cockroach:latest
    container_name: cockroachdb
    command: start-single-node --insecure
    ports:
      - "26257:26257"
      - "8080:8080"
    environment:
      - COCKROACH_DATABASE=strapi
    volumes:
      - cockroachdb_data:/cockroach/cockroach-data

volumes:
  cockroachdb_data:
  ```
