### PR TITLE
fix(webhooks): ensure id sent to client is always a string

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
@@ -116,7 +116,7 @@ const EditPage = () => {
           message: formatMessage({ id: 'Settings.webhooks.created' }),
         });
 
-        navigate(res.data.id, { replace: true });
+        navigate(`/settings/webhooks/${res.data.id}`, { replace: true });
       } else {
         const res = await updateWebhook({ id: id!, ...cleanData(data) });
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
@@ -116,7 +116,7 @@ const EditPage = () => {
           message: formatMessage({ id: 'Settings.webhooks.created' }),
         });
 
-        navigate(`/settings/webhooks/${res.data.id}`, { replace: true });
+        navigate(`../webhooks/${res.data.id}`, { replace: true });
       } else {
         const res = await updateWebhook({ id: id!, ...cleanData(data) });
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
@@ -392,7 +392,7 @@ const ListPage = () => {
       </Page.Main>
       <ConfirmDialog
         isOpen={showModal}
-        onClose={() => setShowModal((prev) => !prev)}
+        onClose={() => setShowModal(false)}
         onConfirm={confirmDelete}
       />
     </Layouts.Root>

--- a/packages/core/admin/shared/contracts/webhooks.ts
+++ b/packages/core/admin/shared/contracts/webhooks.ts
@@ -26,7 +26,7 @@ export declare namespace GetWebhook {
   }
 
   export interface Params {
-    id: string;
+    id: Modules.WebhookStore.Webhook['id'];
   }
 
   export interface Response {
@@ -60,7 +60,7 @@ export declare namespace UpdateWebhook {
   }
 
   export interface Params {
-    id: string;
+    id: Modules.WebhookStore.Webhook['id'];
   }
 
   export interface Response {
@@ -79,7 +79,7 @@ export declare namespace DeleteWebhook {
   }
 
   export interface Params {
-    id: string;
+    id: Modules.WebhookStore.Webhook['id'];
   }
 
   export interface Response {
@@ -94,7 +94,7 @@ export declare namespace DeleteWebhook {
 export declare namespace DeleteWebhooks {
   export interface Request {
     body: {
-      ids: string[];
+      ids: Modules.WebhookStore.Webhook['id'][];
     };
     query: {};
   }
@@ -115,7 +115,7 @@ export declare namespace TriggerWebhook {
   }
 
   export interface Params {
-    id: string;
+    id: Modules.WebhookStore.Webhook['id'];
   }
 
   export interface Response {

--- a/packages/core/core/src/services/webhook-runner.ts
+++ b/packages/core/core/src/services/webhook-runner.ts
@@ -6,10 +6,12 @@ import createdDebugger from 'debug';
 import _ from 'lodash';
 import type { Logger } from '@strapi/logger';
 
+import type { Modules } from '@strapi/types';
 import WorkerQueue from './worker-queue';
-import type { Webhook } from './webhook-store';
 import type { EventHub } from './event-hub';
 import type { Fetch } from '../utils/fetch';
+
+type Webhook = Modules.WebhookStore.Webhook;
 
 interface Config {
   defaultHeaders: Record<string, string>;

--- a/packages/core/core/src/services/webhook-store.ts
+++ b/packages/core/core/src/services/webhook-store.ts
@@ -4,6 +4,7 @@
 
 import { errors } from '@strapi/utils';
 import type { Model, Database } from '@strapi/database';
+import type { Modules } from '@strapi/types';
 
 const { ValidationError } = errors;
 
@@ -33,31 +34,14 @@ const webhookModel: Model = {
   },
 };
 
-interface DBInput {
-  name: string;
-  url: string;
-  headers: Record<string, string>;
-  events: string[];
+type Webhook = Modules.WebhookStore.Webhook;
+
+interface DBOutput extends Omit<Webhook, 'id' | 'isEnabled'> {
+  id: string | number;
   enabled: boolean;
 }
 
-interface DBOutput {
-  id: string;
-  name: string;
-  url: string;
-  headers: Record<string, string>;
-  events: string[];
-  enabled: boolean;
-}
-
-export interface Webhook {
-  id: string;
-  name: string;
-  url: string;
-  headers: Record<string, string>;
-  events: string[];
-  isEnabled: boolean;
-}
+type DBInput = Omit<DBOutput, 'id'>;
 
 const toDBObject = (data: Webhook): DBInput => {
   return {
@@ -71,7 +55,7 @@ const toDBObject = (data: Webhook): DBInput => {
 
 const fromDBObject = (row: DBOutput): Webhook => {
   return {
-    id: row.id,
+    id: typeof row.id === 'number' ? row.id.toString() : row.id,
     name: row.name,
     url: row.url,
     headers: row.headers,

--- a/packages/core/core/src/services/webhook-store.ts
+++ b/packages/core/core/src/services/webhook-store.ts
@@ -35,12 +35,7 @@ const webhookModel: Model = {
 };
 
 type Webhook = Modules.WebhookStore.Webhook;
-
-interface DBOutput extends Omit<Webhook, 'id' | 'isEnabled'> {
-  id: string | number;
-  enabled: boolean;
-}
-
+type DBOutput = Omit<Webhook, 'id' | 'isEnabled'> & { id: string | number; enabled: boolean };
 type DBInput = Omit<DBOutput, 'id'>;
 
 const toDBObject = (data: Webhook): DBInput => {


### PR DESCRIPTION
### What does it do?

Frontend
- Fix create action not redirecting to the created entry
- Fix delete action in the list view not closing the confirm dialog
- Fix update action not opening the EditPage

Backend
- Refactor to use the Webhook type exported from @strapi/types
- Ensure the webhook store returns webhooks with string ids as the type dictates

I set it up this way since the Webhook type id is set as string, so I assume that's what we want to be dealing with even if db.query returns a number... Open to discussion not sure it's the best solution 🤷 

### Why is it needed?

Otherwise the client expects a string but receives a number this breaks client side redirects when navigate receives a number instead of a string

### How to test it?

- Go to the webhooks page, settings -> webhooks
- Create a webhook, on create the url should change from /create to /:id
- Go to the list view and try to click the row or the pencil icon to update, it should redirect to the webhook edit page
- Go the list view and try to delete one or many webhooks, the modal should close on delete
