### PR TITLE
chore: release peer version constraint using ^

### DIFF
--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -92,8 +92,8 @@
     "@strapi/strapi": "^4.15.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=16.0.0 <=20.x.x",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -77,7 +77,7 @@
     "styled-components": "5.3.3"
   },
   "peerDependencies": {
-    "koa": "2.13.4",
+    "koa": "^2.13.4",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^5.2.0",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -59,8 +59,8 @@
     "@strapi/strapi": "^4.4.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "5.3.4",
-    "styled-components": "5.3.3"
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.3"
   },
   "engines": {
     "node": ">=18.0.0 <=20.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7979,8 +7979,8 @@ __metadata:
     "@strapi/strapi": ^4.15.1
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -8285,8 +8285,8 @@ __metadata:
     "@strapi/strapi": ^4.4.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: 5.3.4
-    styled-components: 5.3.3
+    react-router-dom: ^5.3.4
+    styled-components: ^5.3.3
   languageName: unknown
   linkType: soft
 
@@ -8446,7 +8446,7 @@ __metadata:
     styled-components: "npm:5.3.3"
     yup: "npm:0.32.9"
   peerDependencies:
-    koa: 2.13.4
+    koa: ^2.13.4
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^5.2.0


### PR DESCRIPTION
### What does it do?

Describe the technical changes you did.

Using `^` range to release the version constraints of the `peerDependencies`.

### Why is it needed?

The original peer constraints are way too strict. We have `styled-components@5.3.6` in our project and the version can't be accepted because it's not `5.3.3`.

### Related issue(s)/PR(s)

There is a similar pr I submitted last year: https://github.com/strapi/strapi/pull/16348