### PR TITLE
fix(content-manager): remove i18n search params when navigating

### DIFF
--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -103,14 +103,7 @@ const LeftMenu = () => {
    */
   const getPluginsParamsForLink = (link: ContentManagerLink) => {
     const schema = schemas.find((schema) => schema.uid === link.uid);
-    const isI18nEnabled = Boolean(
-      schema?.pluginOptions &&
-        'i18n' in schema?.pluginOptions &&
-        // 'localized' is not typed on pluginOptions.i18n so it can't be accessed directly
-        Object.entries(schema.pluginOptions.i18n || {}).filter(
-          ([key, value]) => key === 'localized' && value === true
-        )
-    );
+    const isI18nEnabled = Boolean((schema?.pluginOptions?.i18n as any)?.localized);
 
     // The search params have the i18n plugin
     if (query.plugins && 'i18n' in query.plugins) {

--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -120,18 +120,7 @@ const LeftMenu = () => {
                     key={link.uid}
                     to={{
                       pathname: link.to,
-                      /**
-                       * We re-add the plugins query to the params available in the menu,
-                       * this means once you've changed the locale in the app, you continue
-                       * to see the same locale when changing content-type.
-                       *
-                       * NOTE: if you go to a content-type that does not have i18n enabled,
-                       * we return the default documents anyway.
-                       */
-                      search: stringify({
-                        ...parse(link.search ?? ''),
-                        plugins: query.plugins,
-                      }),
+                      search: link.search ?? '',
                     }}
                   >
                     {link.title}

--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { useQueryParams } from '@strapi/admin/strapi-admin';
 import {
   useCollator,
   useFilter,
@@ -10,7 +9,6 @@ import {
   SubNavSection,
   SubNavSections,
 } from '@strapi/design-system';
-import { parse, stringify } from 'qs';
 import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 
@@ -19,7 +17,6 @@ import { getTranslation } from '../utils/translations';
 
 const LeftMenu = () => {
   const [search, setSearch] = React.useState('');
-  const [{ query }] = useQueryParams<{ plugins?: object }>();
   const { formatMessage, locale } = useIntl();
   const collectionTypeLinks = useTypedSelector(
     (state) => state['content-manager'].app.collectionTypeLinks

--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -97,10 +97,6 @@ const LeftMenu = () => {
     defaultMessage: 'Content',
   });
 
-  /**
-   * @description
-   * Removes i18n from the plugins search param if the schema does not have i18n enabled
-   */
   const getPluginsParamsForLink = (link: ContentManagerLink) => {
     const schema = schemas.find((schema) => schema.uid === link.uid);
     const isI18nEnabled = Boolean((schema?.pluginOptions?.i18n as any)?.localized);

--- a/packages/core/content-manager/admin/src/index.ts
+++ b/packages/core/content-manager/admin/src/index.ts
@@ -3,7 +3,6 @@ import { Feather } from '@strapi/icons';
 import { PLUGIN_ID } from './constants/plugin';
 import { ContentManagerPlugin } from './content-manager';
 import { reducer } from './modules/reducers';
-import { contentManagerApi } from './services/api';
 import { prefixPluginTranslations } from './utils/translations';
 
 // eslint-disable-next-line import/no-default-export

--- a/tests/e2e/tests/i18n/listview.spec.ts
+++ b/tests/e2e/tests/i18n/listview.spec.ts
@@ -56,7 +56,7 @@ test.describe('List view', () => {
     await expect(page.getByRole('gridcell', { name: 'Available in' })).not.toBeVisible();
   });
 
-  test('As a user I want to be able to navigate to the locale of a document and when I go back to my list-view i expect to still be showing that locale, not the default.', async ({
+  test('As a user I want to be able to navigate from one localized content-type to another and persist the last selected locale', async ({
     page,
   }) => {
     /**
@@ -93,22 +93,30 @@ test.describe('List view', () => {
     expect(new URL(page.url()).searchParams.get('plugins[i18n][locale]')).toEqual('es');
 
     /**
-     * Go to a different content-type that doesn't have i18n enabled and check the query persists
+     * Go to another localized content-type and assert the locale is still Spanish
+     */
+    await page.getByRole('link', { name: 'Article' }).click();
+    await page.waitForURL(
+      /\/admin\/content-manager\/collection-types\/api::article.article(\?.*)?/
+    );
+    expect(new URL(page.url()).searchParams.get('plugins[i18n][locale]')).toEqual('es');
+
+    /**
+     * Go to another non-localized content-type and assert i18n is not in the search params
      */
     await page.getByRole('link', { name: 'Author' }).click();
     await page.waitForURL(/\/admin\/content-manager\/collection-types\/api::author.author(\?.*)?/);
     await expect(page.getByRole('heading', { name: 'Author' })).toBeVisible();
-    expect(new URL(page.url()).searchParams.get('plugins[i18n][locale]')).toEqual('es');
+    expect(new URL(page.url()).searchParams.has('plugins[i18n][locale]')).toEqual(false);
 
     /**
-     * Go back to the products list-view and assert that the locale is still es
-     * even though the current content-type does not have i18n enabled
+     * Go back to a localized content-type and assert the locale is the default locale
      */
     await page.getByRole('link', { name: 'Products' }).click();
     await page.waitForURL(
       /\/admin\/content-manager\/collection-types\/api::product.product(\?.*)?/
     );
     await expect(page.getByRole('heading', { name: 'Products' })).toBeVisible();
-    expect(new URL(page.url()).searchParams.get('plugins[i18n][locale]')).toEqual('es');
+    expect(new URL(page.url()).searchParams.get('plugins[i18n][locale]')).toEqual('en');
   });
 });


### PR DESCRIPTION
### What does it do?

- Remove the i18n plugin search params that persist when changing content-types in the content-manager
- Remove unused import

### Why is it needed?

- It doesn't make sense to have the search params for content-types that do not have i18n enabled
- It breaks the history page (and probably other queries) if the search params are present on a content-type that does not have i18n enabled

### How to test it?
- Go to a content-type with i18n enabled, you should see in the search params something like `&plugins[i18n][locale]=fr`
- Now select another content-type from the side nav that you know doesn't have i18n enabled, the search params `&plugins[i18n][locale]=fr` should no longer be present.
- Go to setting -> internationalization. Change the default locale to another locale. Go back to a content-type with i18n enabled. It should (by default) query the newly selected default locale.
- Selecting a locale and then moving to another contentType with i18n should keep the last selected locale active

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
