### PR TITLE
fix(content-manager): fix discard action in different locale than the default one

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
@@ -289,12 +289,13 @@ const useDocumentActions: UseDocumentActions = () => {
 
   const [discardDocument] = useDiscardDocumentMutation();
   const discard: IUseDocumentActs['discard'] = React.useCallback(
-    async ({ collectionType, model, documentId }) => {
+    async ({ collectionType, model, documentId, params }) => {
       try {
         const res = await discardDocument({
           collectionType,
           model,
           documentId,
+          params,
         });
 
         if ('error' in res) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- it passes the params (with the locale selected) to the discard endpoints

### Why is it needed?

Without the locale every time we try to discard some changes in a document with a different locale than the default one the discard has no effect

### How to test it?

- Go to a content-type with i18n enabled, and add a new locale in the setting
- then create a new document with the new locale
- Save and publish the document
- and then modify the document and Save
- click on the Document menu and click "Discard changes"
- then confirm that you want to discard the last changes
- the value changed needs to be discarded and replaced with the last one published 

### Related issue(s)/PR(s)

CS-707

Here you can see a video with the bug

https://github.com/strapi/strapi/assets/2589748/ad17e00d-4adf-41ce-98a4-dc6fda57238a

