### PR TITLE
fix: add clone actions to history

### DIFF
--- a/tests/api/core/content-manager/content-manager/history/history.test.api.ts
+++ b/tests/api/core/content-manager/content-manager/history/history.test.api.ts
@@ -487,6 +487,29 @@ describeOnCondition(edition === 'EE')('History API', () => {
         )
       ).toBe(false);
     });
+
+    test('Creates a history version when cloning an entry', async () => {
+      // Find an entry and clone it
+      const { documentId: currentDocumentId, ...currentDocumentData } = await strapi
+        .documents(collectionTypeUid)
+        .findFirst();
+      const cloneRes = await rq({
+        method: 'POST',
+        url: `/content-manager/collection-types/${collectionTypeUid}/clone/${currentDocumentId}`,
+        body: currentDocumentData,
+      });
+
+      // Get the history of the cloned entry
+      const cloneHistoryVersions = await rq({
+        method: 'GET',
+        url: `/content-manager/history-versions?contentType=${collectionTypeUid}&documentId=${cloneRes.body.data.documentId}&page=1`,
+      });
+
+      expect(cloneHistoryVersions.body.meta.pagination.total).toBe(1);
+      expect(cloneHistoryVersions.body.data[0].relatedDocumentId).toBe(
+        cloneRes.body.data.documentId
+      );
+    });
   });
 
   describe('Restore a history version', () => {


### PR DESCRIPTION
### What does it do?

Adds clone and auto-clone actions to content history

### Why is it needed?

When you create an entry by cloning an existing one, before, the created entry would have 0 history versions. Now we keep track of who created it, and users no longer land on a empty history page.

### How to test it?

Create an entry via the auto-clone feature. You can do it on the "temp" content type in getstarted since it's simple enough. You can find the duplicate button in the list view in the popover. Go to the history page for the created entry, you should see one history item.

Create an entry via the clone feature on a content type like kitchensink. Click the same duplicate button, then remember to save to actually create the new entry. Same thing, you should see one history item for the new entry.

No new entries should be created for the original entries you used to clone content.
