### PR TITLE
Fix: disable bulk selection conditionally

### DIFF
--- a/packages/core/admin/admin/src/components/Table.tsx
+++ b/packages/core/admin/admin/src/components/Table.tsx
@@ -254,7 +254,7 @@ const ActionBar = ({ children }: Table.ActionBarProps) => {
  * HeaderCheckboxCell
  * -----------------------------------------------------------------------------------------------*/
 
-const HeaderCheckboxCell = () => {
+const HeaderCheckboxCell = ({ disabled = false }: { disabled?: boolean }) => {
   const rows = useTable('HeaderCheckboxCell', (state) => state.rows);
   const selectedRows = useTable('HeaderCheckboxCell', (state) => state.selectedRows);
   const selectRow = useTable('HeaderCheckboxCell', (state) => state.selectRow);
@@ -289,7 +289,7 @@ const HeaderCheckboxCell = () => {
           id: 'global.select-all-entries',
           defaultMessage: 'Select all entries',
         })}
-        disabled={rows.length === 0}
+        disabled={disabled || rows.length === 0}
         checked={areAllEntriesSelected}
         indeterminate={isIndeterminate}
         onChange={handleSelectAll}
@@ -390,7 +390,7 @@ const Cell = Td;
 /* -------------------------------------------------------------------------------------------------
  * Row
  * -----------------------------------------------------------------------------------------------*/
-const CheckboxCell = ({ id, ...props }: Table.CheckboxCellProps) => {
+const CheckboxCell = ({ id, disabled = false, ...props }: Table.CheckboxCellProps) => {
   const rows = useTable('CheckboxCell', (state) => state.rows);
   const selectedRows = useTable('CheckboxCell', (state) => state.selectedRows);
   const selectRow = useTable('CheckboxCell', (state) => state.selectRow);
@@ -413,7 +413,7 @@ const CheckboxCell = ({ id, ...props }: Table.CheckboxCellProps) => {
           },
           { target: id }
         )}
-        disabled={rows.length === 0}
+        disabled={disabled || rows.length === 0}
         checked={isChecked}
         onChange={handleSelectRow}
       />
@@ -526,7 +526,9 @@ namespace Table {
 
   export interface CellProps extends RawTdProps {}
 
-  export interface CheckboxCellProps extends Pick<BaseRow, 'id'>, Omit<RawTdProps, 'id'> {}
+  export interface CheckboxCellProps extends Pick<BaseRow, 'id'>, Omit<RawTdProps, 'id'> {
+    disabled?: boolean;
+  }
 }
 
 export { Table, useTable };

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -129,9 +129,14 @@ const ListViewPage = () => {
     }
   }, [pagination, formatMessage, query, navigate]);
 
-  const { canCreate } = useDocumentRBAC('ListViewPage', ({ canCreate }) => ({
-    canCreate,
-  }));
+  const { canCreate, canDelete, canPublish } = useDocumentRBAC(
+    'ListViewPage',
+    ({ canCreate, canDelete, canPublish }) => ({
+      canCreate,
+      canDelete,
+      canPublish,
+    })
+  );
 
   const runHookWaterfall = useStrapiApp('ListViewPage', ({ runHookWaterfall }) => runHookWaterfall);
   /**
@@ -244,7 +249,7 @@ const ListViewPage = () => {
             </Table.ActionBar>
             <Table.Content>
               <Table.Head>
-                <Table.HeaderCheckboxCell />
+                <Table.HeaderCheckboxCell disabled={!canDelete && !canPublish} />
                 {tableHeaders.map((header: ListFieldLayout) => (
                   <Table.HeaderCell key={header.name} {...header} />
                 ))}
@@ -259,7 +264,7 @@ const ListViewPage = () => {
                       key={row.id}
                       onClick={handleRowClick(row.documentId)}
                     >
-                      <Table.CheckboxCell id={row.id} />
+                      <Table.CheckboxCell id={row.id} disabled={!canDelete && !canPublish} />
                       {tableHeaders.map(({ cellFormatter, ...header }) => {
                         if (header.name === 'status') {
                           const { status } = row;


### PR DESCRIPTION
### What does it do?
Fixes the bug where if user doesn't have delete or publish permission, `select`/ `select all` is still enabled which is misleading as nothing happens on selecting muliple entries. So if user doesnt have delete/publish permissions disabling  entries selection.
