### PR TITLE
Fix: bulk publish modified entry status

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
@@ -385,7 +385,7 @@ const UnpublishAction: BulkActionComponent = ({ documents, model }) => {
   const showUnpublishButton =
     hasDraftAndPublishEnabled &&
     hasPublishPermission &&
-    documents.some((entry) => entry.status === 'published');
+    documents.some((entry) => entry.status === 'published' || entry.status === 'modified');
 
   if (!showUnpublishButton) return null;
 

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -19,7 +19,7 @@ import {
   Loader,
   TypographyComponent,
 } from '@strapi/design-system';
-import { Pencil, CrossCircle, CheckCircle } from '@strapi/icons';
+import { Pencil, CrossCircle, CheckCircle, ArrowsCounterClockwise } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { Link, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -80,13 +80,10 @@ const formatErrorMessages = (errors: FormErrors, parentKey: string, formatMessag
 
 interface EntryValidationTextProps {
   validationErrors?: FormErrors;
-  isPublished?: boolean;
+  status: string;
 }
 
-const EntryValidationText = ({
-  validationErrors,
-  isPublished = false,
-}: EntryValidationTextProps) => {
+const EntryValidationText = ({ validationErrors, status }: EntryValidationTextProps) => {
   const { formatMessage } = useIntl();
 
   if (validationErrors) {
@@ -106,7 +103,7 @@ const EntryValidationText = ({
     );
   }
 
-  if (isPublished) {
+  if (status === 'published') {
     return (
       <Flex gap={2}>
         <CheckCircle fill="success600" />
@@ -114,6 +111,20 @@ const EntryValidationText = ({
           {formatMessage({
             id: 'content-manager.bulk-publish.already-published',
             defaultMessage: 'Already Published',
+          })}
+        </Typography>
+      </Flex>
+    );
+  }
+
+  if (status === 'modified') {
+    return (
+      <Flex gap={2}>
+        <ArrowsCounterClockwise fill="alternative600" />
+        <Typography>
+          {formatMessage({
+            id: 'content-manager.bulk-publish.modified',
+            defaultMessage: 'Ready to publish changes',
           })}
         </Typography>
       </Flex>
@@ -208,7 +219,7 @@ const SelectedEntriesTableContent = ({
               ) : (
                 <EntryValidationText
                   validationErrors={validationErrors[row.documentId]}
-                  isPublished={row.status === 'published'}
+                  status={row.status}
                 />
               )}
             </Table.Cell>

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -63,6 +63,7 @@
   "components.SettingsViewWrapper.pluginHeader.description.list-settings": "Define the settings of the list view.",
   "components.SettingsViewWrapper.pluginHeader.title": "Configure the view — {name}",
   "bulk-publish.already-published": "Already Published",
+  "bulk-publish.modified": "Ready to publish changes",
   "components.TableDelete.delete": "Delete all",
   "components.TableDelete.deleteSelected": "Delete selected",
   "components.TableDelete.label": "{number, plural, one {# entry} other {# entries}} selected",


### PR DESCRIPTION
### What does it do?

1. Updated publication status for modified entry
2. Show unpublish bulk action for the modified entry

### How to test it?
- When you are on a bulk publish modal, if there is a `modified` entry user should see publication status as : `Ready to publish changes`.
- Should show `unpublish` bulk action along with `publish` action for the `modified` entry


