### PR TITLE
chore(ci): remove mysql_native_password in test container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -289,7 +289,7 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
-        image: bitnami/mysql:latest
+        image: mysql:latest
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi
@@ -444,7 +444,7 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
-        image: bitnami/mysql:latest
+        image: mysql:latest
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -289,7 +289,7 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
-        image: mysql:latest
+        image: bitnami/mysql:latest
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi
@@ -444,7 +444,6 @@ jobs:
     services:
       mysql:
         image: bitnami/mysql:latest
-        tag:
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,7 +295,6 @@ jobs:
           MYSQL_USER: strapi
           MYSQL_PASSWORD: strapi
           MYSQL_DATABASE: strapi_test
-          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
@@ -444,13 +443,13 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
-        image: mysql:latest
+        image: bitnami/mysql:latest
+        tag:
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi
           MYSQL_PASSWORD: strapi
           MYSQL_DATABASE: strapi_test
-          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,6 @@ services:
   mysql:
     image: mysql
     restart: always
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: strapi_test
       MYSQL_USER: strapi


### PR DESCRIPTION
### What does it do?

Removes `MYSQL_AUTHENTICATION_PLUGIN=mysql_native_password`

### Why is it needed?

8.4 (which mysql:latest now points to) throws an error instead of deprecation warning when using mysql_native_password

### How to test it?


### Related issue(s)/PR(s)

DX-1439
