### PR TITLE
feature: display cloud dashboard urls in cli

### DIFF
--- a/packages/cli/cloud/src/config/api.ts
+++ b/packages/cli/cloud/src/config/api.ts
@@ -2,4 +2,5 @@ import { env } from '@strapi/utils';
 
 export const apiConfig = {
   apiBaseUrl: env('STRAPI_CLI_CLOUD_API', 'https://cli.cloud.strapi.io'),
+  dashboardBaseUrl: env('STRAPI_CLI_CLOUD_DASHBOARD', 'https://cloud.strapi.io'),
 };

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import chalk from 'chalk';
 import { AxiosError } from 'axios';
 import * as crypto from 'node:crypto';
 import { apiConfig } from '../config/api';
@@ -161,6 +162,15 @@ export default async (ctx: CLIContext) => {
   try {
     notificationService(`${apiConfig.apiBaseUrl}/notifications`, token, cliConfig);
     await buildLogsService(`${apiConfig.apiBaseUrl}/v1/logs/${buildId}`, token, cliConfig);
+
+    ctx.logger.log(
+      'To view the logs in the dashboard, please copy and paste the following URL into your web browser:'
+    );
+    ctx.logger.log(
+      chalk.underline(
+        `${apiConfig.dashboardBaseUrl}/projects/${project.name}/deployments/${buildId}`
+      )
+    );
   } catch (e: Error | unknown) {
     if (e instanceof Error) {
       ctx.logger.error(e.message);

--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosResponse, AxiosError } from 'axios';
+import chalk from 'chalk';
 import { tokenServiceFactory, cloudApiFactory } from '../services';
 import type { CloudCliConfig, CLIContext } from '../types';
+import { apiConfig } from '../config/api';
 
 const openModule = import('open');
 
@@ -29,6 +31,10 @@ export default async (ctx: CLIContext) => {
         } else {
           logger.log('You are already logged in.');
         }
+        logger.log(
+          'To access your dashboard, please copy and paste the following URL into your web browser:'
+        );
+        logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects`));
         return;
       } catch (e) {
         logger.debug('Failed to fetch user info', e);
@@ -165,6 +171,10 @@ export default async (ctx: CLIContext) => {
     }
     spinner.succeed('Authentication successful!');
     logger.log('You are now logged into Strapi Cloud.');
+    logger.log(
+      'To access your dashboard, please copy and paste the following URL into your web browser:'
+    );
+    logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects`));
     try {
       await cloudApiService.track('didLogin', { loginMethod: 'cli' });
     } catch (e) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- After successful login, or after "already logged in" message, we display the link to the dashboard (list of projects):


<img width="804" alt="Screenshot 2024-05-30 at 17 28 17" src="https://github.com/strapi/strapi/assets/55534657/7d7fb815-8a09-4cfc-8c41-1b3f96c9a1ca">




- After build, we display the link to the deployment logs


<img width="991" alt="Screenshot 2024-05-30 at 17 31 34" src="https://github.com/strapi/strapi/assets/55534657/e084558f-1c27-4491-aa2e-86403442bc8a">



### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
