### PR TITLE
Allow morph-like attributes to request a count (populate)

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,27 +1,51 @@
 import { createTransformer } from '../convert-query-params';
 import { Model } from '../types';
 
-const schema: Model = {
-  kind: 'collectionType',
-  info: {
-    singularName: 'dog',
-    pluralName: 'dogs',
-  },
-  options: {
-    populateCreatorFields: true,
-  },
-  attributes: {
-    title: {
-      type: 'string',
+const models = {
+  'api::dog.dog': {
+    uid: 'api::dog.dog',
+    modelType: 'contentType',
+    kind: 'collectionType',
+    info: {
+      displayName: 'Dog',
+      singularName: 'dog',
+      pluralName: 'dogs',
     },
-    createdAt: { type: 'timestamp' },
-    updatedAt: { type: 'timestamp' },
+    options: {
+      populateCreatorFields: true,
+    },
+    attributes: {
+      title: {
+        type: 'string',
+      },
+      dz: { type: 'dynamiczone', components: ['default.cpa', 'default.cpb'] },
+      morph_to_one: { type: 'relation', relation: 'morphToOne' },
+      morph_to_many: { type: 'relation', relation: 'morphToMany' },
+      createdAt: { type: 'timestamp' },
+      updatedAt: { type: 'timestamp' },
+    },
   },
-};
+  'default.cpa': {
+    uid: 'default.cpa',
+    modelType: 'component',
+    attributes: {
+      field: { type: 'string' },
+    },
+  },
+  'default.cpb': {
+    uid: 'default.cpb',
+    modelType: 'component',
+    attributes: {
+      field: { type: 'integer' },
+    },
+  },
+} satisfies Record<string, Model>;
 
-const { private_convertFiltersQueryParams } = createTransformer({
-  getModel: () => schema,
-});
+const { private_convertFiltersQueryParams, private_convertPopulateQueryParams } = createTransformer(
+  {
+    getModel: (uid: string) => models[uid],
+  }
+);
 
 describe('convert-query-params', () => {
   describe('convertFiltersQueryParams', () => {
@@ -44,7 +68,7 @@ describe('convert-query-params', () => {
     ])('keeps: %s', (key, input) => {
       const expectedOutput = { ...input };
 
-      const res = private_convertFiltersQueryParams(input, schema);
+      const res = private_convertFiltersQueryParams(input, models['api::dog.dog']);
       expect(res).toEqual(expectedOutput);
     });
 
@@ -54,7 +78,7 @@ describe('convert-query-params', () => {
       ['invalid operator', { $nope: 'test' }],
       ['uppercase operator', { $GT: new Date() }],
     ])('removes: %s', (key, input) => {
-      const res = private_convertFiltersQueryParams(input, schema);
+      const res = private_convertFiltersQueryParams(input, models['api::dog.dog']);
       expect(res).toEqual({});
     });
 
@@ -64,7 +88,78 @@ describe('convert-query-params', () => {
   test.todo('convertSortQueryParams');
   test.todo('convertStartQueryParams');
   test.todo('convertLimitQueryParams');
-  test.todo('convertPopulateQueryParams');
+
+  describe('convertPopulateQueryParams', () => {
+    describe('Morph-Like Attributes', () => {
+      test.each<[label: string, key: string]>([
+        ['dynamic zone', 'dz'],
+        ['morph to one', 'morph_to_one'],
+        ['morph to many', 'morph_to_many'],
+      ])('Invalid populate property for %s', (_, key) => {
+        const invalidPopulate = { [key]: { filters: { id: { $in: [1, 2, 3] } } } };
+
+        expect(() =>
+          private_convertPopulateQueryParams(invalidPopulate, models['api::dog.dog'])
+        ).toThrowError(
+          `Invalid nested populate for dog.${key} (api::dog.dog). Expected a fragment ("on") or "count" but found {"filters":{"id":{"$in":[1,2,3]}}}`
+        );
+      });
+
+      test.each(['morph_to_one', 'morph_to_many'])(
+        'Morph (%s) relation can define a populate fragment',
+        (key) => {
+          const populate = {
+            [key]: { on: { 'api::dog.dog': { fields: ['title'], populate: 'createdBy' } } },
+          };
+
+          const newPopulate = private_convertPopulateQueryParams(populate, models['api::dog.dog']);
+
+          expect(newPopulate).toStrictEqual({
+            [key]: {
+              on: {
+                'api::dog.dog': { populate: ['createdBy'], select: ['id', 'documentId', 'title'] },
+              },
+            },
+          });
+        }
+      );
+
+      test('Dynamic zone can define a populate fragment', () => {
+        const populate = {
+          dz: {
+            on: {
+              'default.cpa': { filters: { field: { $contains: 'foo' } } },
+              'default.cpb': { filters: { field: { $gt: 0 } } },
+            },
+          },
+        };
+
+        const newPopulate = private_convertPopulateQueryParams(populate, models['api::dog.dog']);
+
+        expect(newPopulate).toStrictEqual({
+          dz: {
+            on: {
+              'default.cpa': { where: { field: { $contains: 'foo' } } },
+              'default.cpb': { where: { field: { $gt: 0 } } },
+            },
+          },
+        });
+      });
+
+      test.each<[label: string, key: string]>([
+        ['dynamic zone', 'dz'],
+        ['morph to one', 'morph_to_one'],
+        ['morph to many', 'morph_to_many'],
+      ])('%s attributes can request a count', (_, key) => {
+        const populate = { [key]: { count: true } };
+
+        const newPopulate = private_convertPopulateQueryParams(populate, models['api::dog.dog']);
+
+        expect(newPopulate).toStrictEqual({ [key]: { count: true } });
+      });
+    });
+  });
+
   test.todo('convertFieldsQueryParams');
   test.todo('transformParamsToQuery');
 });

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -328,10 +328,18 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     throw new InvalidPopulateError();
   };
 
-  const hasFragmentPopulateDefined = (
+  const hasPopulateFragmentDefined = (
     populate: PopulateObjectParams
   ): populate is PopulateObjectParams & Required<Pick<PopulateObjectParams, 'on'>> => {
     return typeof populate === 'object' && 'on' in populate && !isNil(populate.on);
+  };
+
+  const hasCountDefined = (
+    populate: PopulateObjectParams
+  ): populate is PopulateObjectParams & { count: boolean } => {
+    return (
+      typeof populate === 'object' && 'count' in populate && typeof populate.count === 'boolean'
+    );
   };
 
   const convertPopulateObject = (populate: PopulateAttributesParams, schema?: Model) => {
@@ -341,6 +349,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
     const { attributes } = schema;
     return Object.entries(populate).reduce((acc, [key, subPopulate]) => {
+      // Try converting strings to regular booleans if possible
       if (_.isString(subPopulate)) {
         try {
           const subPopulateAsBoolean = parseType({ type: 'boolean', value: subPopulate });
@@ -363,31 +372,46 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
       }
 
       // Allow adding an 'on' strategy to populate queries for morphTo relations and dynamic zones
-      const isAllowedAttributeForFragmentPopulate =
+      const isMorphLikeRelationalAttribute =
         isDynamicZoneAttribute(attribute) || isMorphToRelationalAttribute(attribute);
 
-      if (isAllowedAttributeForFragmentPopulate) {
-        if (hasFragmentPopulateDefined(subPopulate)) {
-          // does it have 'on' AND no other property
-          return {
-            ...acc,
-            [key]: {
-              on: Object.entries(subPopulate.on).reduce(
-                (acc, [type, typeSubPopulate]) => ({
-                  ...acc,
-                  [type]: convertNestedPopulate(typeSubPopulate, getModel(type)),
-                }),
-                {}
-              ),
-            },
-          };
-        }
-        throw new Error(
-          `Invalid nested populate. Expected a fragment ("on") but found ${JSON.stringify(subPopulate)}`
+      if (isMorphLikeRelationalAttribute) {
+        const hasInvalidProperties = Object.keys(subPopulate).some(
+          (key) => !['on', 'count'].includes(key)
         );
+
+        if (hasInvalidProperties) {
+          throw new Error(
+            `Invalid nested populate for ${schema.info?.singularName}.${key} (${schema.uid}). Expected a fragment ("on") or "count" but found ${JSON.stringify(subPopulate)}`
+          );
+        }
+
+        let newSubPopulate = {};
+
+        // { on: { ... } }
+        if (hasPopulateFragmentDefined(subPopulate)) {
+          // transform the fragment and assign it to the new sub-populate object
+          Object.assign(newSubPopulate, {
+            on: Object.entries(subPopulate.on).reduce(
+              (acc, [type, typeSubPopulate]) => ({
+                ...acc,
+                [type]: convertNestedPopulate(typeSubPopulate, getModel(type)),
+              }),
+              {}
+            ),
+          });
+        }
+
+        // { count: true | false }
+        if (hasCountDefined(subPopulate)) {
+          Object.assign(newSubPopulate, { count: subPopulate.count });
+        }
+
+        return { ...acc, [key]: newSubPopulate };
       }
 
-      if (!isAllowedAttributeForFragmentPopulate && hasFragmentPopulateDefined(subPopulate)) {
+      // Edge case when trying to use the fragment ('on') on a non-morph like attribute
+      if (!isMorphLikeRelationalAttribute && hasPopulateFragmentDefined(subPopulate)) {
         throw new Error(`Using fragments is not permitted to populate "${key}" in "${schema.uid}"`);
       }
 

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -386,7 +386,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
           );
         }
 
-        let newSubPopulate = {};
+        const newSubPopulate = {};
 
         // { on: { ... } }
         if (hasPopulateFragmentDefined(subPopulate)) {


### PR DESCRIPTION
### What does it do?

Allow morph-like attributes to request a count at the root level.

### Why is it needed?

This is breaking some CM features, + is was a regression when we removed the root level nested populate params

### How to test it?

- Tests
- Start the getstarted, head to the CM, and try to create a kitchensink entity. It should succeed.

