### PR TITLE
feat: customize localization label actions in history

### DIFF
--- a/examples/getstarted/src/api/category/content-types/category/schema.json
+++ b/examples/getstarted/src/api/category/content-types/category/schema.json
@@ -41,7 +41,7 @@
     "datetime": {
       "pluginOptions": {
         "i18n": {
-          "localized": true
+          "localized": false
         }
       },
       "type": "datetime"

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -219,6 +219,39 @@ type VersionInputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
 };
 
 /**
+ * Checks if the i18n plugin added a label action to the field and modifies it
+ * to adapt the wording for the history page.
+ */
+const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) => {
+  if (!labelAction || typeof labelAction !== 'object' || !('props' in labelAction)) {
+    return labelAction;
+  }
+
+  const customLabelAction =
+    typeof labelAction === 'object' && labelAction != null && 'props' in labelAction
+      ? { ...labelAction, props: { ...labelAction.props } }
+      : labelAction;
+  const labelActionTitleId =
+    labelAction && typeof labelAction === 'object' && labelAction.props.title.id;
+
+  if (labelActionTitleId === 'i18n.Field.localized') {
+    customLabelAction.props.title = {
+      id: 'history.content.localized',
+      defaultMessage:
+        'This value is specific to this locale. If you restore this version, the content will not replaced for other locales.',
+    };
+  } else if (labelActionTitleId === 'i18n.Field.not-localized') {
+    customLabelAction.props.title = {
+      id: 'history.content.not-localized',
+      defaultMessage:
+        'This value is common to all locales. If you restore this version and save the changes, the content will be replaced for all locales.',
+    };
+  }
+
+  return customLabelAction;
+};
+
+/**
  * @internal
  *
  * @description An abstraction around the regular form input renderer designed specifically
@@ -229,8 +262,11 @@ const VersionInputRenderer = ({
   visible,
   hint: providedHint,
   shouldIgnoreRBAC = false,
+  labelAction,
   ...props
 }: VersionInputRendererProps) => {
+  const customLabelAction = getLabelAction(labelAction);
+
   const { formatMessage } = useIntl();
   const version = useHistoryContext('VersionContent', (state) => state.selectedVersion);
   const configuration = useHistoryContext('VersionContent', (state) => state.configuration);
@@ -316,14 +352,22 @@ const VersionInputRenderer = ({
     const CustomInput = lazyComponentStore[props.attribute.customField];
 
     if (CustomInput) {
-      // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
-      return <CustomInput {...props} hint={hint} disabled={fieldIsDisabled} />;
+      return (
+        <CustomInput
+          {...props}
+          // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
+          hint={hint}
+          labelAction={customLabelAction}
+          disabled={fieldIsDisabled}
+        />
+      );
     }
 
     return (
       <FormInputRenderer
         {...props}
         hint={hint}
+        labelAction={customLabelAction}
         // @ts-expect-error – this workaround lets us display that the custom field is missing.
         type={props.attribute.customField}
         disabled={fieldIsDisabled}
@@ -336,7 +380,9 @@ const VersionInputRenderer = ({
    * we need to handle the them before other custom inputs coming from the useLibrary hook.
    */
   if (props.type === 'media') {
-    return <CustomMediaInput {...props} disabled={fieldIsDisabled} />;
+    return (
+      <CustomMediaInput {...props} labelAction={customLabelAction} disabled={fieldIsDisabled} />
+    );
   }
   /**
    * This is where we handle ONLY the fields from the `useLibrary` hook.
@@ -344,8 +390,15 @@ const VersionInputRenderer = ({
   const addedInputTypes = Object.keys(fields);
   if (!attributeHasCustomFieldProperty(props.attribute) && addedInputTypes.includes(props.type)) {
     const CustomInput = fields[props.type];
-    // @ts-expect-error – TODO: fix this type error in the useLibrary hook.
-    return <CustomInput {...props} hint={hint} disabled={fieldIsDisabled} />;
+    return (
+      <CustomInput
+        {...props}
+        // @ts-expect-error – TODO: fix this type error in the useLibrary hook.
+        hint={hint}
+        labelAction={customLabelAction}
+        disabled={fieldIsDisabled}
+      />
+    );
   }
 
   /**
@@ -370,19 +423,50 @@ const VersionInputRenderer = ({
           {...props}
           layout={[...layout, ...(remainingFieldsLayout || [])]}
           hint={hint}
+          labelAction={customLabelAction}
           disabled={fieldIsDisabled}
         >
           {(inputProps) => <VersionInputRenderer {...inputProps} shouldIgnoreRBAC={true} />}
         </ComponentInput>
       );
     case 'dynamiczone':
-      return <DynamicZone {...props} hint={hint} disabled={fieldIsDisabled} />;
+      return (
+        <DynamicZone
+          {...props}
+          hint={hint}
+          labelAction={customLabelAction}
+          disabled={fieldIsDisabled}
+        />
+      );
     case 'relation':
-      return <CustomRelationInput {...props} hint={hint} disabled={fieldIsDisabled} />;
+      return (
+        <CustomRelationInput
+          {...props}
+          hint={hint}
+          labelAction={customLabelAction}
+          disabled={fieldIsDisabled}
+        />
+      );
     case 'richtext':
-      return <Wysiwyg {...props} hint={hint} type={props.type} disabled={fieldIsDisabled} />;
+      return (
+        <Wysiwyg
+          {...props}
+          hint={hint}
+          type={props.type}
+          labelAction={customLabelAction}
+          disabled={fieldIsDisabled}
+        />
+      );
     case 'uid':
-      return <UIDInput {...props} hint={hint} type={props.type} disabled={fieldIsDisabled} />;
+      return (
+        <UIDInput
+          {...props}
+          hint={hint}
+          type={props.type}
+          labelAction={customLabelAction}
+          disabled={fieldIsDisabled}
+        />
+      );
     /**
      * Enumerations are a special case because they require options.
      */
@@ -391,6 +475,7 @@ const VersionInputRenderer = ({
         <FormInputRenderer
           {...props}
           hint={hint}
+          labelAction={customLabelAction}
           options={props.attribute.enum.map((value) => ({ value }))}
           // @ts-expect-error – Temp workaround so we don't forget custom-fields don't work!
           type={props.customField ? 'custom-field' : props.type}
@@ -404,6 +489,7 @@ const VersionInputRenderer = ({
         <FormInputRenderer
           {...restProps}
           hint={hint}
+          labelAction={customLabelAction}
           // @ts-expect-error – Temp workaround so we don't forget custom-fields don't work!
           type={props.customField ? 'custom-field' : props.type}
           disabled={fieldIsDisabled}

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -227,7 +227,7 @@ const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) =
     return labelAction;
   }
 
-	// TODO: find a better way to do this rather than access internals
+  // TODO: find a better way to do this rather than access internals
   const labelActionTitleId = labelAction.props.title.id;
 
   if (labelActionTitleId === 'i18n.Field.localized') {
@@ -236,7 +236,7 @@ const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) =
       title: {
         id: 'history.content.localized',
         defaultMessage:
-          'This value is specific to this locale. If you restore this version, the content will not replaced for other locales.',
+          'This value is specific to this locale. If you restore this version, the content will not be replaced for other locales.',
       },
     });
   }

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -84,7 +84,7 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
   ) {
     return (
       <>
-        <Field.Label>{props.label}</Field.Label>
+        <Field.Label action={props.labelAction}>{props.label}</Field.Label>
         <Box marginTop={1}>
           {/* @ts-expect-error – we dont need closeLabel */}
           <StyledAlert variant="default">

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -227,6 +227,7 @@ const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) =
     return labelAction;
   }
 
+	// TODO: find a better way to do this rather than access internals
   const labelActionTitleId = labelAction.props.title.id;
 
   if (labelActionTitleId === 'i18n.Field.localized') {

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -223,32 +223,36 @@ type VersionInputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
  * to adapt the wording for the history page.
  */
 const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) => {
-  if (!labelAction || typeof labelAction !== 'object' || !('props' in labelAction)) {
+  if (!React.isValidElement(labelAction)) {
     return labelAction;
   }
 
-  const customLabelAction =
-    typeof labelAction === 'object' && labelAction != null && 'props' in labelAction
-      ? { ...labelAction, props: { ...labelAction.props } }
-      : labelAction;
-  const labelActionTitleId =
-    labelAction && typeof labelAction === 'object' && labelAction.props.title.id;
+  const labelActionTitleId = labelAction.props.title.id;
 
   if (labelActionTitleId === 'i18n.Field.localized') {
-    customLabelAction.props.title = {
-      id: 'history.content.localized',
-      defaultMessage:
-        'This value is specific to this locale. If you restore this version, the content will not replaced for other locales.',
-    };
-  } else if (labelActionTitleId === 'i18n.Field.not-localized') {
-    customLabelAction.props.title = {
-      id: 'history.content.not-localized',
-      defaultMessage:
-        'This value is common to all locales. If you restore this version and save the changes, the content will be replaced for all locales.',
-    };
+    return React.cloneElement(labelAction, {
+      ...labelAction.props,
+      title: {
+        id: 'history.content.localized',
+        defaultMessage:
+          'This value is specific to this locale. If you restore this version, the content will not replaced for other locales.',
+      },
+    });
   }
 
-  return customLabelAction;
+  if (labelActionTitleId === 'i18n.Field.not-localized') {
+    return React.cloneElement(labelAction, {
+      ...labelAction.props,
+      title: {
+        id: 'history.content.not-localized',
+        defaultMessage:
+          'This value is common to all locales. If you restore this version and save the changes, the content will be replaced for all locales.',
+      },
+    });
+  }
+
+  // Label action is unrelated to i18n, don't touch it.
+  return labelAction;
 };
 
 /**

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -268,6 +268,8 @@
   "history.content.missing-relations.title": "{number, plural, =1 {Missing relation} other {{number} missing relations}}",
   "history.content.missing-relations.message": "{number, plural, =1 {It has} other {They have}} been deleted and can't be restored.",
   "history.content.no-relations": "No relations.",
+  "history.content.localized": "This value is specific to this locale. If you restore this version, the content will not replaced for other locales.",
+  "history.content.not-localized": "This value is common to all locales. If you restore this version, the content will be replaced for all locales.",
   "history.restore.confirm.button": "Restore",
   "history.restore.confirm.title": "Are you sure you want to restore this version?",
   "history.restore.confirm.message": "{isDraft, select, true {The restored content will override your draft.} other {The restored content won't be published, it will override the draft and be saved as pending changes. You'll be able to publish the changes at anytime.}}",

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -268,7 +268,7 @@
   "history.content.missing-relations.title": "{number, plural, =1 {Missing relation} other {{number} missing relations}}",
   "history.content.missing-relations.message": "{number, plural, =1 {It has} other {They have}} been deleted and can't be restored.",
   "history.content.no-relations": "No relations.",
-  "history.content.localized": "This value is specific to this locale. If you restore this version, the content will not replaced for other locales.",
+  "history.content.localized": "This value is specific to this locale. If you restore this version, the content will not be replaced for other locales.",
   "history.content.not-localized": "This value is common to all locales. If you restore this version, the content will be replaced for all locales.",
   "history.restore.confirm.button": "Restore",
   "history.restore.confirm.title": "Are you sure you want to restore this version?",

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
@@ -99,7 +99,7 @@ const LabelAction = ({ title, icon }: LabelActionProps) => {
 
   return (
     <Span tag="span">
-      <VisuallyHidden tag="span">{`(${formatMessage(title)})`}</VisuallyHidden>
+      <VisuallyHidden tag="span">{formatMessage(title)}</VisuallyHidden>
       {React.cloneElement(icon as React.ReactElement, {
         'aria-hidden': true,
         focusable: false, // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable

--- a/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
@@ -15,12 +15,13 @@ interface MutateEditViewArgs {
 }
 
 const mutateEditViewHook = ({ layout }: MutateEditViewArgs): MutateEditViewArgs => {
+  // If i18n isn't explicitly enabled on the content type, then no field can be localized
   if (
-    'i18n' in layout.options &&
-    typeof layout.options.i18n === 'object' &&
-    layout.options.i18n !== null &&
-    'localized' in layout.options.i18n &&
-    !layout.options.i18n.localized
+    !('i18n' in layout.options) ||
+    (typeof layout.options.i18n === 'object' &&
+      layout.options.i18n !== null &&
+      'localized' in layout.options.i18n &&
+      !layout.options.i18n.localized)
   ) {
     return { layout };
   }


### PR DESCRIPTION
### What does it do?

Changes the i18n label action wording on the history page. It does it by mutating the labelAction component at the field level in history when it detects that it comes from i18n.

There's a completely different way to solve the problem that I also explored. It requires adding another CM hook to let the i18n plugin. But it prevents us from directly using the edit view layout in history, so it ends up requiring a lot more changes. Even though this current solution feels more hacky, I personally prefer it.

### Why is it needed?

Instead of:

>This value is the same across all locales

When in history we want to show:

>This value is common to all locales. If you restore this version, the content will be replaced for all locales.

So that users are aware that their actions on one locale can affect the others.

### How to test it?

The i18n tooltip is actually broken 😅 but that's unrelated to this PR, it already happens in the edit view on v5/main. So to test this current change, inspect the icons in the devtools. You can use the `category` content type on kitchen sink which now has both localized and non localized fields.
