### PR TITLE
chore(content-releases: skip api tests until releases is migrated to v5

### DIFF
--- a/tests/api/plugins/content-releases/releases.test.api.ts
+++ b/tests/api/plugins/content-releases/releases.test.api.ts
@@ -28,7 +28,8 @@ const productModel = {
   },
 };
 
-describeOnCondition(edition === 'EE')('Content Releases API', () => {
+// Skip all releases tests for now until releases is migrated to v5
+describeOnCondition(false /* edition === 'EE' */)('Content Releases API', () => {
   const builder = createTestBuilder();
   let strapi;
   let rq;


### PR DESCRIPTION
Skip API Tests for releases on v5 until releases is migrated to v5