### PR TITLE
fix: prevent duplicate history versions on publish

### DIFF
--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -50,6 +50,19 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
           return next();
         }
 
+        /**
+         * When a document is published, the draft version of the document is also updated.
+         * It creates confusion for users because they see two history versions each publish action.
+         * To avoid this, we silence the update action during a publish request,
+         * so that they only see the published version of the document in the history.
+         */
+        if (
+          context.action === 'update' &&
+          strapi.requestContext.get().request.url.endsWith('/actions/publish')
+        ) {
+          return next();
+        }
+
         const contentTypeUid = context.contentType.uid;
         // Ignore content types not created by the user
         if (!contentTypeUid.startsWith('api::')) {

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -58,7 +58,7 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
          */
         if (
           context.action === 'update' &&
-          strapi.requestContext.get().request.url.endsWith('/actions/publish')
+          strapi.requestContext.get()?.request.url.endsWith('/actions/publish')
         ) {
           return next();
         }

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -148,15 +148,12 @@ describeOnCondition(edition === 'EE')('History', () => {
       // Go to the history page
       await goToHistoryPage(page);
       await page.waitForURL(ARTICLE_HISTORY_URL);
-      // Publish also creates a new draft so we expect the count to increase by 2
-      await expect(versionCards).toHaveCount(4);
+      await expect(versionCards).toHaveCount(3);
       // Assert the current version is the most recent published version
       await expect(titleInput).toHaveValue('Being from Kansas City');
       // The current version is the most recent draft
-      await expect(currentVersion.getByText('Draft')).toBeVisible();
+      await expect(currentVersion.getByText('Published')).toBeVisible();
       await expect(titleInput).toHaveValue('Being from Kansas City');
-      // The second in the list is the published version
-      await expect(previousVersion.getByText('Published')).toBeVisible();
       previousVersion.click();
       await expect(titleInput).toHaveValue('Being from Kansas City');
 
@@ -172,7 +169,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       // Go to the history page
       await goToHistoryPage(page);
       await page.waitForURL(ARTICLE_HISTORY_URL);
-      await expect(versionCards).toHaveCount(5);
+      await expect(versionCards).toHaveCount(4);
       // Assert the current version is the modified version
       await expect(currentVersion.getByText('Modified')).toBeVisible();
       await expect(titleInput).toHaveValue('Being from Kansas City, Missouri');
@@ -364,14 +361,13 @@ describeOnCondition(edition === 'EE')('History', () => {
       // Go to the history page
       await goToHistoryPage(page);
       await page.waitForURL('**/content-manager/single-types/api::homepage.homepage/history**');
-      // Publish also creates a new draft so we expect the count to increase by 2
-      await expect(versionCards).toHaveCount(4);
-      // The current version is the most recent draft
-      await expect(currentVersion.getByText('Draft')).toBeVisible();
+      await expect(versionCards).toHaveCount(3);
+      // The current version is the most recent published
+      await expect(currentVersion.getByText('Published')).toBeVisible();
       await expect(titleInput).toHaveValue('Welcome to AFC Richmond');
-      // The second in the list is the published version
+      // The second in the list is the draft version
       await previousVersion.click();
-      await expect(previousVersion.getByText('Published')).toBeVisible();
+      await expect(previousVersion.getByText('Draft')).toBeVisible();
       await expect(titleInput).toHaveValue('Welcome to AFC Richmond');
 
       // Go back to the entry
@@ -385,7 +381,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       // Go to the history page
       await goToHistoryPage(page);
       await page.waitForURL(HISTORY_URL);
-      await expect(versionCards).toHaveCount(5);
+      await expect(versionCards).toHaveCount(4);
       // Assert the current version is the most recent published version
       await expect(titleInput).toHaveValue('Welcome to AFC Richmond!');
       await expect(currentVersion.getByText('Modified')).toBeVisible();


### PR DESCRIPTION
### What does it do?

Prevents the creation of a duplicate history item when publishing a document.

Because of how D&P works in v5, when publishing a document, both the draft and the published document get updated, which until now created two items in content history. This was confusing to users. Now they should only see the published entry in history when they publish a document.

### How to test it?

Publish a document, check history.