### PR TITLE
Update MySQL2 Dependency to v3.10.0

### DIFF
--- a/packages/generators/app/src/utils/db-client-dependencies.ts
+++ b/packages/generators/app/src/utils/db-client-dependencies.ts
@@ -2,7 +2,7 @@ import type { ClientName } from '../types';
 
 const sqlClientModule = {
   mysql: { mysql: '2.18.1' },
-  mysql2: { mysql2: '3.9.4' },
+  mysql2: { mysql2: '3.10.0' },
   postgres: { pg: '8.8.0' },
   sqlite: { 'better-sqlite3': '8.6.0' },
   'sqlite-legacy': { sqlite3: '5.1.2' },


### PR DESCRIPTION
### What does it do?

Updates MySQL2 generation package from v3.9.4 to 3.10.0 to resolve the following:

- https://github.com/strapi/strapi/security/dependabot/263
- https://github.com/strapi/strapi/security/dependabot/271
- https://github.com/strapi/strapi/security/dependabot/267

MySQL2 changelog: https://github.com/sidorares/node-mysql2/blob/master/Changelog.md

### Why is it needed?

Resolves security vulnerabilities that most likely do not impact us

### How to test it?

Create a new app and connect it to a MySQL 8+ database

### Related issue(s)/PR(s)

N/A
