### PR TITLE
Make generated graphql entity non optional

### DIFF
--- a/packages/plugins/graphql/server/src/services/builders/entity.ts
+++ b/packages/plugins/graphql/server/src/services/builders/entity.ts
@@ -24,12 +24,12 @@ export default ({ strapi }: Context) => {
 
         definition(t) {
           // Keep the ID attribute at the top level
-          t.id('id', { resolve: prop('id') });
+          t.nonNull.id('id', { resolve: prop('id') });
 
           if (!isEmpty(attributes)) {
             // Keep the fetched object into a dedicated `attributes` field
             // TODO: [v4] precise why we keep the ID
-            t.field('attributes', {
+            t.nonNull.field('attributes', {
               type: typeName,
               resolve: identity,
             });

--- a/packages/plugins/graphql/server/src/services/builders/queries/collection-type.ts
+++ b/packages/plugins/graphql/server/src/services/builders/queries/collection-type.ts
@@ -101,7 +101,7 @@ export default ({ strapi }: Context) => {
     const findQueryName = getFindQueryName(contentType);
     const responseCollectionTypeName = getEntityResponseCollectionName(contentType);
 
-    t.field(findQueryName, {
+    t.nonNull.field(findQueryName, {
       type: responseCollectionTypeName,
 
       args: getContentTypeArgs(contentType),


### PR DESCRIPTION
fixes #11815

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Fixes #11815
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
It makes the "EntityResponseCollection" and  "id" and "attributes" key of generated graphql "Entity" non optional.




### Why is it needed?
Working with typescript in Strapi is tedious because the aforementioned attributes/types are marked as optional.

The code requires a number of type assertions or optional chaining constructs to eliminate the undefined/null types leading to obscure and hard to read code.



### How to test it?
In Strapi create a simple content type with two non-optional attributes, namely 'title' and 'description'.

The currently generated Schema portion looks as follows:
```graphql
// Current generated schema portion

type Post {
  title: String!
  description: String!
  createdAt: DateTime
  updatedAt: DateTime
  publishedAt: DateTime
}

type PostEntity {
  id: ID
  attributes: Post
}

type PostEntityResponse {
  data: PostEntity
}

type PostEntityResponseCollection {
  data: [PostEntity!]!
  meta: ResponseCollectionMeta!
}
```
After applying this patch the schema will instead contain the following types:

```graphql
// Desired generated schema portion

type Post {
  title: String!
  description: String!
  createdAt: DateTime
  updatedAt: DateTime
  publishedAt: DateTime
}

type PostEntity {
  id: ID!
  attributes: Post!
}

type PostEntityResponse {
  data: PostEntity!
}

type PostEntityResponseCollection {
  data: [PostEntity!]!
  meta: ResponseCollectionMeta!
}

```

### Related issue(s)/PR(s)

#9411 
