### PR TITLE
fix: allow '.default' to be ignored during schema validation

### DIFF
--- a/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
+++ b/packages/core/data-transfer/src/engine/__tests__/engine.test.ts
@@ -12,7 +12,6 @@ import type {
   ILink,
   ISourceProvider,
   ITransferEngineOptions,
-  MaybePromise,
   TransferFilterPreset,
 } from '../../../types';
 import {
@@ -827,7 +826,7 @@ describe('Transfer engine', () => {
           ['private', (v: boolean) => !v],
           ['required', (v: boolean) => !v],
           ['configurable', (v: boolean) => v],
-          ['default', (v: unknown) => () => null],
+          ['default', () => () => null],
         ])(
           `Don't throw on ignorable attribute's properties: %s`,
           (attributeName, transformValue) => {

--- a/packages/core/data-transfer/src/engine/validation/schemas/index.ts
+++ b/packages/core/data-transfer/src/engine/validation/schemas/index.ts
@@ -13,21 +13,25 @@ const isAttributeIgnorable = (diff: Diff) => {
     // Need a valid string attribute name
     typeof diff.path[1] === 'string' &&
     // The diff must be on ignorable attribute properties
-    ['private', 'required', 'configurable'].includes(diff.path[2])
+    ['private', 'required', 'configurable', 'default'].includes(diff.path[2])
   );
 };
 
 // TODO: clean up the type checking, which will require cleaning up the typings in utils/json.ts
-// exclude admin tables that are not transferrable and are optionally available (such as audit logs which are only available in EE)
+// exclude admin tables that are not transferable and are optionally available (such as audit logs which are only available in EE)
 const isOptionalAdminType = (diff: Diff) => {
+  // added/deleted
   if ('value' in diff && isObject(diff.value)) {
     const name = (diff?.value as Struct.ContentTypeSchema)?.info?.singularName;
     return (OPTIONAL_CONTENT_TYPES as ReadonlyArray<string | undefined>).includes(name);
   }
+
+  // modified
   if ('values' in diff && isArray(diff.values) && isObject(diff.values[0])) {
     const name = (diff?.values[0] as Struct.ContentTypeSchema)?.info?.singularName;
     return (OPTIONAL_CONTENT_TYPES as ReadonlyArray<string | undefined>).includes(name);
   }
+
   return false;
 };
 

--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -12,8 +12,7 @@ import type { Struct } from '@strapi/types';
 
 import type { IAsset, IMetadata, ISourceProvider, ProviderType, IFile } from '../../../../types';
 
-import { createDecryptionCipher } from '../../../utils/encryption';
-import { collect } from '../../../utils/stream';
+import * as utils from '../../../utils';
 import { ProviderInitializationError, ProviderTransferError } from '../../../errors/providers';
 import { isFilePathInDirname, isPathEquivalent, unknownPathToPosix } from './utils';
 
@@ -108,13 +107,19 @@ class LocalFileSourceProvider implements ISourceProvider {
   }
 
   async getSchemas() {
-    const schemas = await collect<Struct.Schema>(this.createSchemasReadStream());
+    const schemaCollection = await utils.stream.collect<Struct.Schema>(
+      this.createSchemasReadStream()
+    );
 
-    if (isEmpty(schemas)) {
+    if (isEmpty(schemaCollection)) {
       throw new ProviderInitializationError('Could not load schemas from Strapi data file.');
     }
 
-    return keyBy('uid', schemas);
+    // Group schema by UID
+    const schemas = keyBy('uid', schemaCollection);
+
+    // Transform to valid JSON
+    return utils.schema.schemasToValidJSON(schemas);
   }
 
   createEntitiesReadStream(): Readable {
@@ -191,7 +196,7 @@ class LocalFileSourceProvider implements ISourceProvider {
     }
 
     if (encryption.enabled && encryption.key) {
-      streams.push(createDecryptionCipher(encryption.key));
+      streams.push(utils.encryption.createDecryptionCipher(encryption.key));
     }
 
     if (compression.enabled) {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -183,10 +183,11 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
   getSchemas(): Record<string, Struct.Schema> {
     assertValidStrapi(this.strapi, 'Not able to get Schemas');
-    const schemas = {
+
+    const schemas = utils.schema.schemasToValidJSON({
       ...this.strapi.contentTypes,
       ...this.strapi.components,
-    };
+    });
 
     return utils.schema.mapSchemasValues(schemas);
   }

--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -85,10 +85,10 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   getSchemas(): Record<string, Struct.Schema> {
     assertValidStrapi(this.strapi, 'Not able to get Schemas');
 
-    const schemas = {
+    const schemas = utils.schema.schemasToValidJSON({
       ...this.strapi.contentTypes,
       ...this.strapi.components,
-    };
+    });
 
     return utils.schema.mapSchemasValues(schemas);
   }

--- a/packages/core/data-transfer/src/utils/schema.ts
+++ b/packages/core/data-transfer/src/utils/schema.ts
@@ -25,3 +25,7 @@ const VALID_SCHEMA_PROPERTIES = [
 export const mapSchemasValues = (schemas: Utils.String.Dict<Struct.Schema>) => {
   return mapValues(pick(VALID_SCHEMA_PROPERTIES), schemas) as Utils.String.Dict<Struct.Schema>;
 };
+
+export const schemasToValidJSON = (schemas: Utils.String.Dict<Struct.Schema>) => {
+  return JSON.parse(JSON.stringify(schemas));
+};


### PR DESCRIPTION
### What does it do?

- Add 'default' to the list of ignorable attributes's properties
- Sanitize schemas to be valid JSON to make sure no invalid JSON properties are present during the checks

### Why is it needed?

strapi import on identical apps is currently broken because of 'default' not being present all the time

### How to test it?

See #20388 for reproduction

### Related issue(s)/PR(s)

fix #20388
