### PR TITLE
Handle non-localized content-types in discard-draft migration

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-continue */
-import type { UID, Modules, Utils } from '@strapi/types';
+import type { UID, Modules } from '@strapi/types';
 import type { Database, Migration } from '@strapi/database';
 import { async, contentTypes } from '@strapi/utils';
 

--- a/packages/core/core/src/migrations/draft-publish.ts
+++ b/packages/core/core/src/migrations/draft-publish.ts
@@ -36,7 +36,7 @@ const enableDraftAndPublish = async ({ oldContentTypes, contentTypes }: Input) =
       const isLocalized = strapi
         .plugin('i18n')
         .service('content-types')
-        .isLocalizedContentType(oldContentType);
+        .isLocalizedContentType(contentType);
 
       // if d&p was enabled set publishedAt to eq createdAt
       if (


### PR DESCRIPTION
### What does it do?

Adds a check to conditionally set locale in the `discardDraft`'s params.

### Why is it needed?

This can break app with no i18n
See https://github.com/strapi/strapi/issues/20225

### How to test it?

See reproduction steps in https://github.com/strapi/strapi/issues/20225

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/20225