### PR TITLE
test: fix ctb edit collection type

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -36,7 +36,7 @@ test.describe('Edit collection type', () => {
   });
 
   test('Can toggle internationalization', async ({ page }) => {
-    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Finish' }).click();
@@ -47,10 +47,10 @@ test.describe('Edit collection type', () => {
   });
 
   test('Can toggle draft&publish', async ({ page }) => {
-    await page.getByRole('button', { name: 'Edit' }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
-    await page.getByRole('button', { name: 'Yes, disable' }).click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
     await page.getByRole('button', { name: 'Finish' }).click();
 
     await waitForRestart(page);


### PR DESCRIPTION
### What does it do?

- find first button now that there are multiple role:edit buttons on the page
- use correct text for confirm modal

### Why is it needed?

the test is broken

### How to test it?

Note: The test still fails because of an actual bug; the [modal does not close even after confirming it correctly](https://github.com/strapi/strapi/issues/19953)

but now if you run the tests you see that it doesn't break on the edit button or the modal close click

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/19953
