### PR TITLE
fix(chore): increase specificity of the Lightning icon color

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -57,7 +57,7 @@ const NavLinkWrapper = styled(Box)`
 `;
 
 const BadgeIcon = styled(Icon)`
-  & {
+  &&& {
     path {
       fill: ${({ theme }) => theme.colors.warning500};
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the color issue that we have in the Left menu with the Lightning icon color

### Why is it needed?

Because we want to use this color for the icon
<img width="65" alt="Schermata 2024-06-07 alle 16 37 08" src="https://github.com/strapi/strapi/assets/2589748/c7a685b4-4cb2-411e-8630-599dfffa83b9">
So to override the style with higher specificity I used this trick recommended in the styled components doc
https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity

### How to test it?

Open a Strapi App with Community Edition license