### PR TITLE
chore: put ee LICENSE in correct place

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "./dist",
+    "ee/LICENSE",
     "strapi-server.js",
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
** Still determining the best way to handle this internally so that it doesn't happen again **

### What does it do?

Includes the ee/LICENSE file

### Why is it needed?

It should be there, it was missing after switching to releasing typescript dist dirs

### How to test it?

`npm pack` in the admin package and see that the license file now exists where it didn't before

### Related issue(s)/PR(s)

DX-1453
