### PR TITLE
test: fix broken e2e tests

### DIFF
--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -525,7 +525,6 @@ test.describe('Edit View', () => {
       await expect(page.getByRole('menuitem', { name: 'Discard changes' })).not.toBeDisabled();
 
       await page.getByRole('menuitem', { name: 'Discard changes' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Changes discarded');

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -236,7 +236,7 @@ test.describe('Edit View', () => {
       await expect(page.getByRole('menuitem', { name: 'Discard changes' })).not.toBeDisabled();
 
       await page.getByRole('menuitem', { name: 'Discard changes' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirmation' })).toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Changes discarded');
@@ -301,7 +301,7 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'More actions' }).click();
       await page.getByRole('menuitem', { name: 'Delete document' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirmation' })).toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Deleted Document');
@@ -527,7 +527,7 @@ test.describe('Edit View', () => {
       await expect(page.getByRole('menuitem', { name: 'Discard changes' })).not.toBeDisabled();
 
       await page.getByRole('menuitem', { name: 'Discard changes' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirmation' })).toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Changes discarded');

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -236,7 +236,6 @@ test.describe('Edit View', () => {
       await expect(page.getByRole('menuitem', { name: 'Discard changes' })).not.toBeDisabled();
 
       await page.getByRole('menuitem', { name: 'Discard changes' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Changes discarded');
@@ -301,7 +300,6 @@ test.describe('Edit View', () => {
 
       await page.getByRole('button', { name: 'More actions' }).click();
       await page.getByRole('menuitem', { name: 'Delete document' }).click();
-      await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Deleted Document');

--- a/tests/e2e/tests/content-manager/listview.spec.ts
+++ b/tests/e2e/tests/content-manager/listview.spec.ts
@@ -72,7 +72,7 @@ test.describe('List View', () => {
       await page.waitForSelector('text=Are you sure you want to publish these entries?');
 
       const confirmPublishButton = page
-        .getByLabel('Confirmation')
+        .getByLabel('Confirm')
         .getByRole('button', { name: 'Publish' });
       await confirmPublishButton.click();
 
@@ -96,7 +96,7 @@ test.describe('List View', () => {
       // Wait for the confirmation dialog to appear
       await page.waitForSelector('text=Are you sure you want to unpublish these entries?');
       const unpublishButton = page
-        .getByLabel('Confirmation')
+        .getByLabel('Confirm')
         .getByRole('button', { name: 'Unpublish' });
       await unpublishButton.click();
 
@@ -114,7 +114,7 @@ test.describe('List View', () => {
       // Wait for the selected entries modal to appear
       await page.waitForSelector('text=Are you sure you want to delete these entries?');
       const confirmDeleteButton = page
-        .getByLabel('Confirmation')
+        .getByLabel('Confirm')
         .getByRole('button', { name: 'Confirm' });
       await confirmDeleteButton.click();
 

--- a/tests/e2e/tests/content-manager/listview.spec.ts
+++ b/tests/e2e/tests/content-manager/listview.spec.ts
@@ -95,9 +95,7 @@ test.describe('List View', () => {
 
       // Wait for the confirmation dialog to appear
       await page.waitForSelector('text=Are you sure you want to unpublish these entries?');
-      const unpublishButton = page
-        .getByLabel('Confirm')
-        .getByRole('button', { name: 'Unpublish' });
+      const unpublishButton = page.getByLabel('Confirm').getByRole('button', { name: 'Unpublish' });
       await unpublishButton.click();
 
       await expect(page.getByRole('gridcell', { name: 'draft' })).toHaveCount(2);

--- a/tests/e2e/tests/content-manager/listview.spec.ts
+++ b/tests/e2e/tests/content-manager/listview.spec.ts
@@ -95,7 +95,7 @@ test.describe('List View', () => {
 
       // Wait for the confirmation dialog to appear
       await page.waitForSelector('text=Are you sure you want to unpublish these entries?');
-      const unpublishButton = page.getByLabel('Confirm').getByRole('button', { name: 'Unpublish' });
+      const unpublishButton = page.getByLabel('Confirm').getByRole('button', { name: 'Confirm' });
       await unpublishButton.click();
 
       await expect(page.getByRole('gridcell', { name: 'draft' })).toHaveCount(2);

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -3,9 +3,15 @@ import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
-import { createCollectionType, navToHeader, skipCtbTour } from '../../../utils/shared';
+import {
+  createCollectionType,
+  describeOnCondition,
+  navToHeader,
+  skipCtbTour,
+} from '../../../utils/shared';
 
-test.skip('Edit collection type', () => {
+// TODO: fix the test so that it doesn't fail on CI
+describeOnCondition(!process.env.CI)('Edit collection type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -3,9 +3,15 @@ import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
-import { createSingleType, navToHeader, skipCtbTour } from '../../../utils/shared';
+import {
+  createSingleType,
+  describeOnCondition,
+  navToHeader,
+  skipCtbTour,
+} from '../../../utils/shared';
 
-test.skip('Edit single type', () => {
+// TODO: fix the test so that it doesn't fail on CI
+describeOnCondition(!process.env.CI)('Edit single type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 

--- a/tests/e2e/tests/i18n/settings.spec.ts
+++ b/tests/e2e/tests/i18n/settings.spec.ts
@@ -125,7 +125,6 @@ test.describe('Settings', () => {
     await expect(page.getByRole('heading', { name: 'Internationalization' })).toBeVisible();
     await page.getByRole('button', { name: 'Delete French (fr) locale' }).click();
 
-    await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
     await page.getByRole('button', { name: 'Confirm' }).click();
     await findAndClose(page, 'Success:Locale successfully deleted');
 

--- a/tests/e2e/tests/i18n/settings.spec.ts
+++ b/tests/e2e/tests/i18n/settings.spec.ts
@@ -125,7 +125,7 @@ test.describe('Settings', () => {
     await expect(page.getByRole('heading', { name: 'Internationalization' })).toBeVisible();
     await page.getByRole('button', { name: 'Delete French (fr) locale' }).click();
 
-    await expect(page.getByRole('dialog', { name: 'Confirmation' })).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Confirm' })).toBeVisible();
     await page.getByRole('button', { name: 'Confirm' }).click();
     await findAndClose(page, 'Success:Locale successfully deleted');
 


### PR DESCRIPTION

### What does it do?

allow tests to run locally (copied from `develop` branch)

### Why is it needed?

These tests are currently failing on CI and blocking a lot of PRs, but they pass locally. This will allow people to still run the tests locally but unblock the CI until we have time to solve the issue.

### How to test it?

Tests should pass on CI with these specific tests skipped, and pass locally with the tests running.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
