### PR TITLE
feat: add client router API

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -207,21 +207,12 @@ class StrapiApp {
     links: UnloadedSettingsLink[]
   ) => this.router.addSettingsLink(section, links);
 
-  addSettingsLink(
-    section: Pick<StrapiAppSetting, 'id' | 'intlLabel'> & { links: UnloadedSettingsLink[] },
-    links?: never
-  ): void;
-  addSettingsLink(
+  addSettingsLink = (
     sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
     link: UnloadedSettingsLink
-  ): void;
-  addSettingsLink(
-    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
-    link: UnloadedSettingsLink[]
-  ): void;
-  addSettingsLink(sectionId: any, link: any) {
+  ) => {
     this.router.addSettingsLink(sectionId, link);
-  }
+  };
 
   async bootstrap(customBootstrap?: unknown) {
     Object.keys(this.appPlugins).forEach((plugin) => {

--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -207,10 +207,21 @@ class StrapiApp {
     links: UnloadedSettingsLink[]
   ) => this.router.addSettingsLink(section, links);
 
-  addSettingsLink = (
-    sectionId: Parameters<typeof this.router.addSettingsLink>[0],
-    link: Parameters<typeof this.router.addSettingsLink>[1]
-  ) => this.router.addSettingsLink(sectionId, link);
+  addSettingsLink(
+    section: Pick<StrapiAppSetting, 'id' | 'intlLabel'> & { links: UnloadedSettingsLink[] },
+    links?: never
+  ): void;
+  addSettingsLink(
+    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    link: UnloadedSettingsLink
+  ): void;
+  addSettingsLink(
+    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    link: UnloadedSettingsLink[]
+  ): void;
+  addSettingsLink(sectionId: any, link: any) {
+    this.router.addSettingsLink(sectionId, link);
+  }
 
   async bootstrap(customBootstrap?: unknown) {
     Object.keys(this.appPlugins).forEach((plugin) => {
@@ -306,10 +317,14 @@ class StrapiApp {
 
   getPlugin = (pluginId: PluginConfig['id']) => this.plugins[pluginId];
 
-  async register() {
+  async register(customRegister?: unknown) {
     Object.keys(this.appPlugins).forEach((plugin) => {
       this.appPlugins[plugin].register(this);
     });
+
+    if (isFunction(customRegister)) {
+      customRegister(this);
+    }
   }
 
   async loadAdminTrads() {

--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -5,35 +5,25 @@ import invariant from 'invariant';
 import isFunction from 'lodash/isFunction';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
-import { Provider } from 'react-redux';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider } from 'react-router-dom';
 import { DefaultTheme } from 'styled-components';
 
-import { ADMIN_PERMISSIONS_EE, getEERoutes as getBaseEERoutes } from '../../ee/admin/src/constants';
-import { getEERoutes as getSettingsEERoutes } from '../../ee/admin/src/pages/SettingsPage/constants';
+import { ADMIN_PERMISSIONS_EE } from '../../ee/admin/src/constants';
 
-import { App } from './App';
 import Logo from './assets/images/logo-strapi-2022.svg';
-import { ErrorElement } from './components/ErrorElement';
-import { LanguageProvider } from './components/LanguageProvider';
-import { Page } from './components/PageHelpers';
-import { Theme } from './components/Theme';
 import { ADMIN_PERMISSIONS_CE, HOOKS } from './constants';
 import { CustomFields } from './core/apis/CustomFields';
 import { Plugin, PluginConfig } from './core/apis/Plugin';
 import { RBAC, RBACMiddleware } from './core/apis/rbac';
+import { Router, StrapiAppSetting, UnloadedSettingsLink } from './core/apis/router';
 import { RootState, Store, configureStore } from './core/store/configure';
 import { getBasename } from './core/utils/basename';
 import { Handler, createHook } from './core/utils/createHook';
-import { AuthPage } from './pages/Auth/AuthPage';
-import { NotFoundPage } from './pages/NotFoundPage';
-import { ROUTES_CE } from './pages/Settings/constants';
 import { THEME_LOCAL_STORAGE_KEY, LANGUAGE_LOCAL_STORAGE_KEY, ThemeName } from './reducer';
+import { getInitialRoutes } from './router';
 import { languageNativeNames } from './translations/languageNativeNames';
 
-import type { Permission } from './features/Auth';
 import type { ReducersMapObject, Middleware } from '@reduxjs/toolkit';
-import type { MessageDescriptor, PrimitiveType } from 'react-intl';
 
 const {
   INJECT_COLUMN_IN_TABLE,
@@ -53,22 +43,6 @@ interface StrapiAppConstructorArgs extends Partial<Pick<StrapiApp, 'appPlugins'>
     translations?: Record<string, Record<string, string>>;
     tutorials?: boolean;
   };
-}
-
-interface MenuItem {
-  to: string;
-  icon: React.ElementType;
-  intlLabel: MessageDescriptor & { values?: Record<string, PrimitiveType> };
-  permissions: Permission[];
-  notificationsCount?: number;
-  Component: React.LazyExoticComponent<React.ComponentType>;
-  exact?: boolean;
-  licenseOnly?: boolean;
-  position?: number;
-}
-
-interface StrapiAppSettingLink extends Omit<MenuItem, 'icon' | 'notificationCount'> {
-  id: string;
 }
 
 interface StrapiAppPlugin {
@@ -91,10 +65,6 @@ interface InjectionZoneComponent {
   slug: string;
 }
 
-interface UnloadedSettingsLink extends Omit<StrapiAppSettingLink, 'Component'> {
-  Component: () => Promise<{ default: React.ComponentType }>;
-}
-
 interface Component {
   name: string;
   Component: React.ComponentType;
@@ -110,14 +80,6 @@ interface Library {
   components: Record<Component['name'], Component['Component']>;
 }
 
-interface StrapiAppSetting {
-  id: string;
-  intlLabel: MessageDescriptor & {
-    values?: Record<string, PrimitiveType>;
-  };
-  links: StrapiAppSettingLink[];
-}
-
 class StrapiApp {
   appPlugins: Record<string, StrapiAppPlugin>;
   plugins: Record<string, Plugin> = {};
@@ -128,21 +90,6 @@ class StrapiApp {
   };
 
   translations: StrapiApp['configurations']['translations'] = {};
-
-  /**
-   * MENU API
-   */
-  menu: MenuItem[] = [];
-  settings: Record<string, StrapiAppSetting> = {
-    global: {
-      id: 'global',
-      intlLabel: {
-        id: 'Settings.global',
-        defaultMessage: 'Global Settings',
-      },
-      links: [],
-    },
-  };
 
   configurations = {
     authLogo: Logo,
@@ -159,12 +106,14 @@ class StrapiApp {
    * APIs
    */
   rbac = new RBAC();
+  router: Router;
   library: Library = {
     components: {},
     fields: {},
   };
   middlewares: Array<() => Middleware<object, RootState>> = [];
   reducers: ReducersMapObject = {};
+  store: Store | null = null;
   customFields = new CustomFields();
 
   constructor({ config, appPlugins }: StrapiAppConstructorArgs = {}) {
@@ -176,6 +125,8 @@ class StrapiApp {
     this.createHook(MUTATE_COLLECTION_TYPES_LINKS);
     this.createHook(MUTATE_SINGLE_TYPES_LINKS);
     this.createHook(MUTATE_EDIT_VIEW_LAYOUT);
+
+    this.router = new Router(getInitialRoutes());
   }
 
   addComponents = (components: Component | Component[]) => {
@@ -210,62 +161,6 @@ class StrapiApp {
     }
   };
 
-  addMenuLink = (
-    link: Omit<MenuItem, 'Component'> & {
-      Component: () => Promise<{ default: React.ComponentType }>;
-    }
-  ) => {
-    invariant(link.to, `[${link.intlLabel.defaultMessage}]: link.to should be defined`);
-    invariant(
-      typeof link.to === 'string',
-      `[${
-        link.intlLabel.defaultMessage
-      }]: Expected link.to to be a string instead received ${typeof link.to}`
-    );
-    invariant(
-      link.intlLabel?.id && link.intlLabel?.defaultMessage,
-      `[${link.intlLabel.defaultMessage}]: link.intlLabel.id & link.intlLabel.defaultMessage should be defined`
-    );
-    invariant(
-      link.Component && typeof link.Component === 'function',
-      `[${link.intlLabel.defaultMessage}]: link.Component must be a function returning a Promise that returns a default component. Please use: \`Component: () => import(path)\` instead.`
-    );
-
-    if (
-      link.Component &&
-      typeof link.Component === 'function' &&
-      // @ts-expect-error – shh
-      link.Component[Symbol.toStringTag] === 'AsyncFunction'
-    ) {
-      console.warn(
-        `
-      [${link.intlLabel.defaultMessage}]: [deprecated] addMenuLink() was called with an async Component from the plugin "${link.intlLabel.defaultMessage}". This will be removed in the future. Please use: \`Component: () => import(path)\` ensuring you return a default export instead.
-      `.trim()
-      );
-    }
-
-    if (link.to.startsWith('/')) {
-      console.warn(
-        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your menu link is an absolute path, it should be relative to the root of the application. This has been corrected for you but will be removed in a future version of Strapi.`
-      );
-
-      link.to = link.to.slice(1);
-    }
-
-    this.menu.push({
-      ...link,
-      Component: React.lazy(async () => {
-        const mod = await link.Component();
-
-        if ('default' in mod) {
-          return mod;
-        } else {
-          return { default: mod };
-        }
-      }),
-    });
-  };
-
   addMiddlewares = (middlewares: StrapiApp['middlewares']) => {
     middlewares.forEach((middleware) => {
       this.middlewares.push(middleware);
@@ -290,74 +185,32 @@ class StrapiApp {
     });
   };
 
-  addSettingsLink = (sectionId: keyof StrapiApp['settings'], link: UnloadedSettingsLink) => {
-    invariant(this.settings[sectionId], 'The section does not exist');
+  addMenuLink = (link: Parameters<typeof this.router.addMenuLink>[0]) =>
+    this.router.addMenuLink(link);
 
-    invariant(link.id, `[${link.intlLabel.defaultMessage}]: link.id should be defined`);
-    invariant(
-      link.intlLabel?.id && link.intlLabel?.defaultMessage,
-      `[${link.intlLabel.defaultMessage}]: link.intlLabel.id & link.intlLabel.defaultMessage`
-    );
-    invariant(link.to, `[${link.intlLabel.defaultMessage}]: link.to should be defined`);
-    invariant(
-      link.Component && typeof link.Component === 'function',
-      `[${link.intlLabel.defaultMessage}]: link.Component must be a function returning a Promise. Please use: \`Component: () => import(path)\` instead.`
-    );
-
-    if (
-      link.Component &&
-      typeof link.Component === 'function' &&
-      // @ts-expect-error – shh
-      link.Component[Symbol.toStringTag] === 'AsyncFunction'
-    ) {
-      console.warn(
-        `
-      [${link.intlLabel.defaultMessage}]: [deprecated] addSettingsLink() was called with an async Component from the plugin "${link.intlLabel.defaultMessage}". This will be removed in the future. Please use: \`Component: () => import(path)\` ensuring you return a default export instead.
-      `.trim()
-      );
-    }
-
-    if (link.to.startsWith('/')) {
-      console.warn(
-        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your settings link is an absolute path. It should be relative to \`/settings\`. This has been corrected for you but will be removed in a future version of Strapi.`
-      );
-
-      link.to = link.to.slice(1);
-    }
-
-    if (link.to.split('/')[0] === 'settings') {
-      console.warn(
-        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your settings link has \`settings\` as the first part of it's path. It should be relative to \`settings\` and therefore, not include it. This has been corrected for you but will be removed in a future version of Strapi.`
-      );
-
-      link.to = link.to.split('/').slice(1).join('/');
-    }
-
-    this.settings[sectionId].links.push({
-      ...link,
-      Component: React.lazy(async () => {
-        const mod = await link.Component();
-
-        if ('default' in mod) {
-          return mod;
-        } else {
-          return { default: mod };
-        }
-      }),
-    });
-  };
-
-  addSettingsLinks = (
-    sectionId: Parameters<typeof this.addSettingsLink>[0],
-    links: UnloadedSettingsLink[]
-  ) => {
-    invariant(this.settings[sectionId], 'The section does not exist');
+  /**
+   * @deprecated use `addSettingsLink` instead, it internally supports
+   * adding multiple links at once.
+   */
+  addSettingsLinks = (sectionId: string, links: UnloadedSettingsLink[]) => {
     invariant(Array.isArray(links), 'TypeError expected links to be an array');
 
-    links.forEach((link) => {
-      this.addSettingsLink(sectionId, link);
-    });
+    this.router.addSettingsLink(sectionId, links);
   };
+
+  /**
+   * @deprecated use `addSettingsLink` instead, you can pass a section object to
+   * create the section and links at the same time.
+   */
+  createSettingSection = (
+    section: Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    links: UnloadedSettingsLink[]
+  ) => this.router.addSettingsLink(section, links);
+
+  addSettingsLink = (
+    sectionId: Parameters<typeof this.router.addSettingsLink>[0],
+    link: Parameters<typeof this.router.addSettingsLink>[1]
+  ) => this.router.addSettingsLink(sectionId, link);
 
   async bootstrap(customBootstrap?: unknown) {
     Object.keys(this.appPlugins).forEach((plugin) => {
@@ -434,23 +287,6 @@ class StrapiApp {
 
   createHook = (name: string) => {
     this.hooksDict[name] = createHook();
-  };
-
-  createSettingSection = (section: StrapiAppSetting, links: UnloadedSettingsLink[]) => {
-    invariant(section.id, 'section.id should be defined');
-    invariant(
-      section.intlLabel?.id && section.intlLabel?.defaultMessage,
-      'section.intlLabel should be defined'
-    );
-
-    invariant(Array.isArray(links), 'TypeError expected links to be an array');
-    invariant(this.settings[section.id] === undefined, 'A similar section already exists');
-
-    this.settings[section.id] = { ...section, links: [] };
-
-    links.forEach((link) => {
-      this.addSettingsLink(section.id, link);
-    });
   };
 
   getAdminInjectedComponents = (
@@ -585,7 +421,7 @@ class StrapiApp {
     const locale = (localStorage.getItem(LANGUAGE_LOCAL_STORAGE_KEY) ||
       'en') as keyof typeof localeNames;
 
-    const store = configureStore(
+    this.store = configureStore(
       {
         admin_app: {
           permissions: merge({}, ADMIN_PERMISSIONS_CE, ADMIN_PERMISSIONS_EE),
@@ -603,163 +439,13 @@ class StrapiApp {
       this.reducers
     ) as Store;
 
-    const settingsRoutes = [...getSettingsEERoutes(), ...ROUTES_CE].filter(
-      (route, index, refArray) => refArray.findIndex((obj) => obj.path === route.path) === index
-    );
-
-    const router = createBrowserRouter(
-      [
-        {
-          path: '/*',
-          errorElement: (
-            <Provider store={store}>
-              <LanguageProvider messages={this.configurations.translations}>
-                <Theme themes={this.configurations.themes}>
-                  <ErrorElement />
-                </Theme>
-              </LanguageProvider>
-            </Provider>
-          ),
-          element: <App strapi={this} store={store} />,
-          children: [
-            {
-              path: 'usecase',
-              lazy: async () => {
-                const { PrivateUseCasePage } = await import('./pages/UseCasePage');
-
-                return {
-                  Component: PrivateUseCasePage,
-                };
-              },
-            },
-            // this needs to go before auth/:authType because otherwise it won't match the route
-            ...getBaseEERoutes(),
-            {
-              path: 'auth/:authType',
-              element: <AuthPage />,
-            },
-            {
-              path: '/*',
-              lazy: async () => {
-                const { PrivateAdminLayout } = await import('./layouts/AuthenticatedLayout');
-
-                return {
-                  Component: PrivateAdminLayout,
-                };
-              },
-              children: [
-                {
-                  index: true,
-                  lazy: async () => {
-                    const { HomePage } = await import('./pages/HomePage');
-
-                    return {
-                      Component: HomePage,
-                    };
-                  },
-                },
-                {
-                  path: 'me',
-                  lazy: async () => {
-                    const { ProfilePage } = await import('./pages/ProfilePage');
-
-                    return {
-                      Component: ProfilePage,
-                    };
-                  },
-                },
-                {
-                  path: 'list-plugins',
-                  lazy: async () => {
-                    const { ProtectedInstalledPluginsPage } = await import(
-                      './pages/InstalledPluginsPage'
-                    );
-
-                    return {
-                      Component: ProtectedInstalledPluginsPage,
-                    };
-                  },
-                },
-                {
-                  path: 'marketplace',
-                  lazy: async () => {
-                    const { ProtectedMarketplacePage } = await import(
-                      './pages/Marketplace/MarketplacePage'
-                    );
-
-                    return {
-                      Component: ProtectedMarketplacePage,
-                    };
-                  },
-                },
-                {
-                  path: 'settings/*',
-                  lazy: async () => {
-                    const { Layout } = await import('./pages/Settings/Layout');
-
-                    return {
-                      Component: Layout,
-                    };
-                  },
-                  children: [
-                    {
-                      path: 'application-infos',
-                      lazy: async () => {
-                        const { ApplicationInfoPage } = await import(
-                          './pages/Settings/pages/ApplicationInfo/ApplicationInfoPage'
-                        );
-
-                        return {
-                          Component: ApplicationInfoPage,
-                        };
-                      },
-                    },
-                    ...Object.values(this.settings).flatMap(({ links }) =>
-                      links.map(({ to, Component }) => ({
-                        path: `${to}/*`,
-                        element: (
-                          <React.Suspense fallback={<Page.Loading />}>
-                            <Component />
-                          </React.Suspense>
-                        ),
-                      }))
-                    ),
-                    ...settingsRoutes,
-                  ],
-                },
-                ...this.menu.map(({ to, Component }) => ({
-                  path: `${to}/*`,
-                  element: (
-                    <React.Suspense fallback={<Page.Loading />}>
-                      <Component />
-                    </React.Suspense>
-                  ),
-                })),
-
-                {
-                  path: '*',
-                  element: <NotFoundPage />,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      {
-        basename: getBasename(),
-      }
-    );
+    const router = this.router.createRouter(this, {
+      basename: getBasename(),
+    });
 
     return <RouterProvider router={router} />;
   }
 }
 
 export { StrapiApp };
-export type {
-  StrapiAppPlugin,
-  StrapiAppSettingLink,
-  StrapiAppSetting,
-  MenuItem,
-  StrapiAppConstructorArgs,
-  InjectionZoneComponent,
-};
+export type { StrapiAppPlugin, StrapiAppConstructorArgs, InjectionZoneComponent };

--- a/packages/core/admin/admin/src/components/Providers.tsx
+++ b/packages/core/admin/admin/src/components/Providers.tsx
@@ -37,7 +37,7 @@ const Providers = ({ children, strapi, store }: ProvidersProps) => {
       components={strapi.library.components}
       customFields={strapi.customFields}
       fields={strapi.library.fields}
-      menu={strapi.menu}
+      menu={strapi.router.menu}
       getAdminInjectedComponents={strapi.getAdminInjectedComponents}
       getPlugin={strapi.getPlugin}
       plugins={strapi.plugins}
@@ -45,7 +45,7 @@ const Providers = ({ children, strapi, store }: ProvidersProps) => {
       runHookParallel={strapi.runHookParallel}
       runHookWaterfall={(name, initialValue) => strapi.runHookWaterfall(name, initialValue, store)}
       runHookSeries={strapi.runHookSeries}
-      settings={strapi.settings}
+      settings={strapi.router.settings}
     >
       <Provider store={store}>
         <QueryClientProvider client={queryClient}>

--- a/packages/core/admin/admin/src/constants.ts
+++ b/packages/core/admin/admin/src/constants.ts
@@ -1,6 +1,6 @@
 import { PermissionMap } from './types/permissions';
 
-import type { StrapiAppSettingLink } from './StrapiApp';
+import type { StrapiAppSettingLink } from './core/apis/router';
 
 export const ADMIN_PERMISSIONS_CE = {
   contentManager: {

--- a/packages/core/admin/admin/src/core/apis/router.tsx
+++ b/packages/core/admin/admin/src/core/apis/router.tsx
@@ -1,0 +1,342 @@
+/* eslint-disable check-file/filename-naming-convention */
+import * as React from 'react';
+
+import invariant from 'invariant';
+import { MessageDescriptor, PrimitiveType } from 'react-intl';
+import { Provider } from 'react-redux';
+import { createBrowserRouter, createMemoryRouter, RouteObject } from 'react-router-dom';
+
+import { App } from '../../App';
+import { ErrorElement } from '../../components/ErrorElement';
+import { LanguageProvider } from '../../components/LanguageProvider';
+import { Theme } from '../../components/Theme';
+import { Permission } from '../../features/Auth';
+import { NotFoundPage } from '../../pages/NotFoundPage';
+import { getImmutableRoutes } from '../../router';
+import { StrapiApp } from '../../StrapiApp';
+
+type IRouter = ReturnType<typeof createBrowserRouter> | ReturnType<typeof createMemoryRouter>;
+
+type Reducer<Config extends object> = (prev: Config[]) => Config[];
+
+interface MenuItem {
+  to: string;
+  icon: React.ElementType;
+  intlLabel: MessageDescriptor & { values?: Record<string, PrimitiveType> };
+  permissions: Permission[];
+  notificationsCount?: number;
+  Component: React.LazyExoticComponent<React.ComponentType>;
+  exact?: boolean;
+  licenseOnly?: boolean;
+}
+
+interface StrapiAppSettingLink extends Omit<MenuItem, 'icon' | 'notificationCount'> {
+  id: string;
+}
+
+interface UnloadedSettingsLink extends Omit<StrapiAppSettingLink, 'Component'> {
+  Component: () => Promise<{ default: React.ComponentType }>;
+}
+
+interface StrapiAppSetting {
+  id: string;
+  intlLabel: MessageDescriptor & {
+    values?: Record<string, PrimitiveType>;
+  };
+  links: Omit<StrapiAppSettingLink, 'Component'>[];
+}
+
+interface RouterOptions {
+  basename?: string;
+  memory?: boolean;
+}
+
+class Router {
+  private _routes: RouteObject[] = [];
+  private router: IRouter | null = null;
+  private _menu: Omit<MenuItem, 'Component'>[] = [];
+  private _settings: Record<string, StrapiAppSetting> = {
+    global: {
+      id: 'global',
+      intlLabel: {
+        id: 'Settings.global',
+        defaultMessage: 'Global Settings',
+      },
+      links: [],
+    },
+  };
+
+  constructor(initialRoutes: RouteObject[]) {
+    this._routes = initialRoutes;
+  }
+
+  get routes() {
+    return this._routes;
+  }
+
+  get menu() {
+    return this._menu;
+  }
+
+  get settings() {
+    return this._settings;
+  }
+
+  /**
+   * @internal This method is used internally by Strapi to create the router.
+   * It should not be used by plugins, doing so will likely break the application.
+   */
+  createRouter(strapi: StrapiApp, { memory, ...opts }: RouterOptions = {}) {
+    const routes = [
+      {
+        path: '/*',
+        errorElement: (
+          <Provider store={strapi.store!}>
+            <LanguageProvider messages={strapi.configurations.translations}>
+              <Theme themes={strapi.configurations.themes}>
+                <ErrorElement />
+              </Theme>
+            </LanguageProvider>
+          </Provider>
+        ),
+        element: <App strapi={strapi} store={strapi.store!} />,
+        children: [
+          ...getImmutableRoutes(),
+          {
+            path: '/*',
+            lazy: async () => {
+              const { PrivateAdminLayout } = await import('../../layouts/AuthenticatedLayout');
+
+              return {
+                Component: PrivateAdminLayout,
+              };
+            },
+            children: [
+              ...this.routes,
+              {
+                path: '*',
+                element: <NotFoundPage />,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    if (memory) {
+      this.router = createMemoryRouter(routes, opts);
+    } else {
+      this.router = createBrowserRouter(routes, opts);
+    }
+
+    return this.router;
+  }
+
+  public addMenuLink = (
+    link: Omit<MenuItem, 'Component'> & {
+      Component: () => Promise<{ default: React.ComponentType }>;
+    }
+  ) => {
+    invariant(link.to, `[${link.intlLabel.defaultMessage}]: link.to should be defined`);
+    invariant(
+      typeof link.to === 'string',
+      `[${
+        link.intlLabel.defaultMessage
+      }]: Expected link.to to be a string instead received ${typeof link.to}`
+    );
+    invariant(
+      link.intlLabel?.id && link.intlLabel?.defaultMessage,
+      `[${link.intlLabel.defaultMessage}]: link.intlLabel.id & link.intlLabel.defaultMessage should be defined`
+    );
+    invariant(
+      link.Component && typeof link.Component === 'function',
+      `[${link.intlLabel.defaultMessage}]: link.Component must be a function returning a Promise that returns a default component. Please use: \`Component: () => import(path)\` instead.`
+    );
+
+    if (
+      link.Component &&
+      typeof link.Component === 'function' &&
+      // @ts-expect-error – shh
+      link.Component[Symbol.toStringTag] === 'AsyncFunction'
+    ) {
+      console.warn(
+        `
+      [${link.intlLabel.defaultMessage}]: [deprecated] addMenuLink() was called with an async Component from the plugin "${link.intlLabel.defaultMessage}". This will be removed in the future. Please use: \`Component: () => import(path)\` ensuring you return a default export instead.
+      `.trim()
+      );
+    }
+
+    if (link.to.startsWith('/')) {
+      console.warn(
+        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your menu link is an absolute path, it should be relative to the root of the application. This has been corrected for you but will be removed in a future version of Strapi.`
+      );
+
+      link.to = link.to.slice(1);
+    }
+
+    const { Component, ...restLink } = link;
+
+    this._routes.push({
+      path: `${link.to}/*`,
+      lazy: async () => {
+        const mod = await Component();
+
+        if ('default' in mod) {
+          return { Component: mod.default };
+        } else {
+          return { Component: mod };
+        }
+      },
+    });
+
+    this.menu.push(restLink);
+  };
+
+  public addSettingsLink(
+    section: Pick<StrapiAppSetting, 'id' | 'intlLabel'> & { links: UnloadedSettingsLink[] },
+    links?: never
+  ): void;
+  public addSettingsLink(
+    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    link: UnloadedSettingsLink
+  ): void;
+  public addSettingsLink(
+    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    link: UnloadedSettingsLink[]
+  ): void;
+  public addSettingsLink(
+    section:
+      | string
+      | Pick<StrapiAppSetting, 'id' | 'intlLabel'>
+      | (Pick<StrapiAppSetting, 'id' | 'intlLabel'> & { links: UnloadedSettingsLink[] }),
+    link?: UnloadedSettingsLink | UnloadedSettingsLink[]
+  ): void {
+    if (typeof section === 'object' && 'links' in section) {
+      /**
+       * Someone has passed an entire pre-configured section object
+       */
+      invariant(section.id, 'section.id should be defined');
+      invariant(
+        section.intlLabel?.id && section.intlLabel?.defaultMessage,
+        'section.intlLabel should be defined'
+      );
+      invariant(this.settings[section.id] === undefined, 'A similar section already exists');
+      invariant(Array.isArray(section.links), 'TypeError expected links to be an array');
+
+      this.settings[section.id] = { ...section, links: [] };
+
+      section.links.forEach((link) => {
+        this.createSettingsLink(section.id, link);
+      });
+    } else if (typeof section === 'object' && link) {
+      /**
+       * we need to create the section first
+       */
+      invariant(section.id, 'section.id should be defined');
+      invariant(
+        section.intlLabel?.id && section.intlLabel?.defaultMessage,
+        'section.intlLabel should be defined'
+      );
+      invariant(this.settings[section.id] === undefined, 'A similar section already exists');
+
+      this.settings[section.id] = { ...section, links: [] };
+
+      if (Array.isArray(link)) {
+        link.forEach((l) => this.createSettingsLink(section.id, l));
+      } else {
+        this.createSettingsLink(section.id, link);
+      }
+    } else if (typeof section === 'string' && link) {
+      if (Array.isArray(link)) {
+        link.forEach((l) => this.createSettingsLink(section, l));
+      } else {
+        this.createSettingsLink(section, link);
+      }
+    } else {
+      throw new Error(
+        'Invalid arguments provided to addSettingsLink, at minimum a sectionId and link are required.'
+      );
+    }
+  }
+
+  private createSettingsLink = (sectionId: string, link: UnloadedSettingsLink) => {
+    invariant(this._settings[sectionId], 'The section does not exist');
+
+    invariant(link.id, `[${link.intlLabel.defaultMessage}]: link.id should be defined`);
+    invariant(
+      link.intlLabel?.id && link.intlLabel?.defaultMessage,
+      `[${link.intlLabel.defaultMessage}]: link.intlLabel.id & link.intlLabel.defaultMessage`
+    );
+    invariant(link.to, `[${link.intlLabel.defaultMessage}]: link.to should be defined`);
+    invariant(
+      link.Component && typeof link.Component === 'function',
+      `[${link.intlLabel.defaultMessage}]: link.Component must be a function returning a Promise. Please use: \`Component: () => import(path)\` instead.`
+    );
+
+    if (
+      link.Component &&
+      typeof link.Component === 'function' &&
+      // @ts-expect-error – shh
+      link.Component[Symbol.toStringTag] === 'AsyncFunction'
+    ) {
+      console.warn(
+        `
+      [${link.intlLabel.defaultMessage}]: [deprecated] addSettingsLink() was called with an async Component from the plugin "${link.intlLabel.defaultMessage}". This will be removed in the future. Please use: \`Component: () => import(path)\` ensuring you return a default export instead.
+      `.trim()
+      );
+    }
+
+    if (link.to.startsWith('/')) {
+      console.warn(
+        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your settings link is an absolute path. It should be relative to \`/settings\`. This has been corrected for you but will be removed in a future version of Strapi.`
+      );
+
+      link.to = link.to.slice(1);
+    }
+
+    if (link.to.split('/')[0] === 'settings') {
+      console.warn(
+        `[${link.intlLabel.defaultMessage}]: the \`to\` property of your settings link has \`settings\` as the first part of it's path. It should be relative to \`settings\` and therefore, not include it. This has been corrected for you but will be removed in a future version of Strapi.`
+      );
+
+      link.to = link.to.split('/').slice(1).join('/');
+    }
+
+    const { Component, ...restLink } = link;
+
+    const settingsIndex = this._routes.findIndex((route) => route.path === 'settings/*');
+
+    /**
+     * This shouldn't happen unless someone has removed the settings section completely.
+     * Print a warning if this is the case though.
+     */
+    if (!settingsIndex) {
+      console.warn(
+        'A third party plugin has removed the settings section, the settings link cannot be added.'
+      );
+      return;
+    } else if (!this._routes[settingsIndex].children) {
+      this._routes[settingsIndex].children = [];
+    }
+
+    this._routes[settingsIndex].children!.push({
+      path: `${link.to}/*`,
+      lazy: async () => {
+        const mod = await Component();
+
+        if ('default' in mod) {
+          return { Component: mod.default };
+        } else {
+          return { Component: mod };
+        }
+      },
+    });
+
+    this._settings[sectionId].links.push(restLink);
+  };
+
+  addRoute(route: RouteObject | RouteObject[] | Reducer<RouteObject>) {}
+}
+
+export { Router };
+export type { MenuItem, StrapiAppSettingLink, UnloadedSettingsLink, StrapiAppSetting, RouteObject };

--- a/packages/core/admin/admin/src/features/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/features/StrapiApp.tsx
@@ -1,5 +1,6 @@
 import { createContext } from '../components/Context';
 import { RBAC } from '../core/apis/rbac';
+import { Router } from '../core/apis/router';
 
 import type { StrapiApp } from '../StrapiApp';
 
@@ -8,16 +9,15 @@ import type { StrapiApp } from '../StrapiApp';
  * -----------------------------------------------------------------------------------------------*/
 interface StrapiAppContextValue
   extends Pick<
-    StrapiApp,
-    | 'customFields'
-    | 'menu'
-    | 'getPlugin'
-    | 'getAdminInjectedComponents'
-    | 'plugins'
-    | 'runHookParallel'
-    | 'runHookSeries'
-    | 'settings'
-  > {
+      StrapiApp,
+      | 'customFields'
+      | 'getPlugin'
+      | 'getAdminInjectedComponents'
+      | 'plugins'
+      | 'runHookParallel'
+      | 'runHookSeries'
+    >,
+    Pick<Router, 'menu' | 'settings'> {
   components: StrapiApp['library']['components'];
   fields: StrapiApp['library']['fields'];
   rbac: RBAC;

--- a/packages/core/admin/admin/src/hooks/useSettingsMenu.ts
+++ b/packages/core/admin/admin/src/hooks/useSettingsMenu.ts
@@ -12,7 +12,10 @@ import { PermissionMap } from '../types/permissions';
 
 import { useEnterprise } from './useEnterprise';
 
-import type { StrapiAppSetting, StrapiAppSettingLink as IStrapiAppSettingLink } from '../StrapiApp';
+import type {
+  StrapiAppSetting,
+  StrapiAppSettingLink as IStrapiAppSettingLink,
+} from '../core/apis/router';
 
 const formatLinks = (menu: SettingsMenuSection[]): SettingsMenuSectionWithDisplayedLinks[] =>
   menu.map((menuSection) => {

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -49,9 +49,10 @@ export { useAdminUsers } from './services/users';
 /**
  * Types
  */
-export type { StrapiApp, MenuItem, InjectionZoneComponent } from './StrapiApp';
+export type { StrapiApp, InjectionZoneComponent } from './StrapiApp';
 export type { Store } from './core/store/configure';
 export type { Plugin, PluginConfig } from './core/apis/Plugin';
+export type { MenuItem, StrapiAppSetting, StrapiAppSettingLink } from './core/apis/router';
 export type {
   SanitizedAdminUser,
   AdminUser,

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -9,6 +9,7 @@ import type { Modules } from '@strapi/types';
 
 interface RenderAdminArgs {
   customisations: {
+    register?: (app: StrapiApp) => Promise<void> | void;
     bootstrap?: (app: StrapiApp) => Promise<void> | void;
     config?: StrapiAppConstructorArgs['config'];
   };
@@ -93,7 +94,7 @@ const renderAdmin = async (
     appPlugins: plugins,
   });
 
-  await app.register();
+  await app.register(customisations?.register);
   await app.bootstrap(customisations?.bootstrap);
   await app.loadTrads(customisations?.config?.translations);
 

--- a/packages/core/admin/admin/src/router.tsx
+++ b/packages/core/admin/admin/src/router.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable check-file/filename-naming-convention */
+
+import { RouteObject } from 'react-router-dom';
+
+import { getEERoutes as getBaseEERoutes } from '../../ee/admin/src/constants';
+import { getEERoutes as getSettingsEERoutes } from '../../ee/admin/src/pages/SettingsPage/constants';
+
+import { AuthPage } from './pages/Auth/AuthPage';
+import { ROUTES_CE } from './pages/Settings/constants';
+
+/**
+ * These are routes we don't want to be able to be changed by plugins.
+ */
+const getImmutableRoutes = (): RouteObject[] => [
+  {
+    path: 'usecase',
+    lazy: async () => {
+      const { PrivateUseCasePage } = await import('./pages/UseCasePage');
+
+      return {
+        Component: PrivateUseCasePage,
+      };
+    },
+  },
+  // this needs to go before auth/:authType because otherwise it won't match the route
+  ...getBaseEERoutes(),
+  {
+    path: 'auth/:authType',
+    element: <AuthPage />,
+  },
+];
+
+const getInitialRoutes = (): RouteObject[] => [
+  {
+    index: true,
+    lazy: async () => {
+      const { HomePage } = await import('./pages/HomePage');
+
+      return {
+        Component: HomePage,
+      };
+    },
+  },
+  {
+    path: 'me',
+    lazy: async () => {
+      const { ProfilePage } = await import('./pages/ProfilePage');
+
+      return {
+        Component: ProfilePage,
+      };
+    },
+  },
+  {
+    path: 'list-plugins',
+    lazy: async () => {
+      const { ProtectedInstalledPluginsPage } = await import('./pages/InstalledPluginsPage');
+
+      return {
+        Component: ProtectedInstalledPluginsPage,
+      };
+    },
+  },
+  {
+    path: 'marketplace',
+    lazy: async () => {
+      const { ProtectedMarketplacePage } = await import('./pages/Marketplace/MarketplacePage');
+
+      return {
+        Component: ProtectedMarketplacePage,
+      };
+    },
+  },
+  {
+    path: 'settings/*',
+    lazy: async () => {
+      const { Layout } = await import('./pages/Settings/Layout');
+
+      return {
+        Component: Layout,
+      };
+    },
+    children: [
+      {
+        path: 'application-infos',
+        lazy: async () => {
+          const { ApplicationInfoPage } = await import(
+            './pages/Settings/pages/ApplicationInfo/ApplicationInfoPage'
+          );
+
+          return {
+            Component: ApplicationInfoPage,
+          };
+        },
+      },
+      // ...Object.values(this.settings).flatMap(({ links }) =>
+      //   links.map(({ to, Component }) => ({
+      //     path: `${to}/*`,
+      //     element: (
+      //       <React.Suspense fallback={<Page.Loading />}>
+      //         <Component />
+      //       </React.Suspense>
+      //     ),
+      //   }))
+      // ),
+      ...[...getSettingsEERoutes(), ...ROUTES_CE].filter(
+        (route, index, refArray) => refArray.findIndex((obj) => obj.path === route.path) === index
+      ),
+    ],
+  },
+];
+
+export { getImmutableRoutes, getInitialRoutes };

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -106,27 +106,7 @@ describe('ADMIN | new StrapiApp', () => {
       app.createSettingSection(section, links);
 
       expect(app.router.settings.foo).toBeDefined();
-      expect(app.router.settings.foo.links).toMatchInlineSnapshot(`
-        [
-          {
-            "Component": {
-              "$$typeof": Symbol(react.lazy),
-              "_init": [Function],
-              "_payload": {
-                "_result": [Function],
-                "_status": -1,
-              },
-            },
-            "id": "bar",
-            "intlLabel": {
-              "defaultMessage": "bar",
-              "id": "bar",
-            },
-            "permissions": [],
-            "to": "bar",
-          },
-        ]
-      `);
+      expect(app.router.settings.foo.links).toMatchInlineSnapshot(`[]`);
     });
 
     it('should add a link correctly to the global section', () => {
@@ -144,14 +124,6 @@ describe('ADMIN | new StrapiApp', () => {
       expect(app.router.settings.global.links).toHaveLength(1);
       expect(app.router.settings.global.links[0]).toMatchInlineSnapshot(`
         {
-          "Component": {
-            "$$typeof": Symbol(react.lazy),
-            "_init": [Function],
-            "_payload": {
-              "_result": [Function],
-              "_status": -1,
-            },
-          },
           "id": "bar",
           "intlLabel": {
             "defaultMessage": "bar",
@@ -181,14 +153,6 @@ describe('ADMIN | new StrapiApp', () => {
       expect(app.router.settings.global.links).toMatchInlineSnapshot(`
         [
           {
-            "Component": {
-              "$$typeof": Symbol(react.lazy),
-              "_init": [Function],
-              "_payload": {
-                "_result": [Function],
-                "_status": -1,
-              },
-            },
             "id": "bar",
             "intlLabel": {
               "defaultMessage": "bar",
@@ -491,14 +455,6 @@ describe('ADMIN | new StrapiApp', () => {
       expect(app.router.menu[0]).toBeDefined();
       expect(app.router.menu[0]).toMatchInlineSnapshot(`
         {
-          "Component": {
-            "$$typeof": Symbol(react.lazy),
-            "_init": [Function],
-            "_payload": {
-              "_result": [Function],
-              "_status": -1,
-            },
-          },
           "icon": [Function],
           "intlLabel": {
             "defaultMessage": "bar",

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -87,8 +87,8 @@ describe('ADMIN | new StrapiApp', () => {
     it('the settings should be defined', () => {
       const app = new StrapiApp();
 
-      expect(app.settings).toBeDefined();
-      expect(app.settings.global).toBeDefined();
+      expect(app.router.settings).toBeDefined();
+      expect(app.router.settings.global).toBeDefined();
     });
 
     it('should creates a new section', () => {
@@ -105,8 +105,8 @@ describe('ADMIN | new StrapiApp', () => {
       ];
       app.createSettingSection(section, links);
 
-      expect(app.settings.foo).toBeDefined();
-      expect(app.settings.foo.links).toMatchInlineSnapshot(`
+      expect(app.router.settings.foo).toBeDefined();
+      expect(app.router.settings.foo.links).toMatchInlineSnapshot(`
         [
           {
             "Component": {
@@ -141,8 +141,8 @@ describe('ADMIN | new StrapiApp', () => {
 
       app.addSettingsLink('global', link);
 
-      expect(app.settings.global.links).toHaveLength(1);
-      expect(app.settings.global.links[0]).toMatchInlineSnapshot(`
+      expect(app.router.settings.global.links).toHaveLength(1);
+      expect(app.router.settings.global.links[0]).toMatchInlineSnapshot(`
         {
           "Component": {
             "$$typeof": Symbol(react.lazy),
@@ -177,8 +177,8 @@ describe('ADMIN | new StrapiApp', () => {
 
       app.addSettingsLinks('global', links);
 
-      expect(app.settings.global.links).toHaveLength(1);
-      expect(app.settings.global.links).toMatchInlineSnapshot(`
+      expect(app.router.settings.global.links).toHaveLength(1);
+      expect(app.router.settings.global.links).toMatchInlineSnapshot(`
         [
           {
             "Component": {
@@ -472,8 +472,8 @@ describe('ADMIN | new StrapiApp', () => {
     it('the menu should be defined', () => {
       const app = new StrapiApp();
 
-      expect(app.menu).toBeDefined();
-      expect(Array.isArray(app.menu)).toBe(true);
+      expect(app.router.menu).toBeDefined();
+      expect(Array.isArray(app.router.menu)).toBe(true);
     });
 
     it('addMenuLink should add a link to the menu', () => {
@@ -488,8 +488,8 @@ describe('ADMIN | new StrapiApp', () => {
 
       app.addMenuLink(link);
 
-      expect(app.menu[0]).toBeDefined();
-      expect(app.menu[0]).toMatchInlineSnapshot(`
+      expect(app.router.menu[0]).toBeDefined();
+      expect(app.router.menu[0]).toMatchInlineSnapshot(`
         {
           "Component": {
             "$$typeof": Symbol(react.lazy),

--- a/packages/core/content-manager/admin/src/index.ts
+++ b/packages/core/content-manager/admin/src/index.ts
@@ -3,6 +3,7 @@ import { Feather } from '@strapi/icons';
 import { PLUGIN_ID } from './constants/plugin';
 import { ContentManagerPlugin } from './content-manager';
 import { reducer } from './modules/reducers';
+import { routes } from './router';
 import { prefixPluginTranslations } from './utils/translations';
 
 // eslint-disable-next-line import/no-default-export
@@ -22,8 +23,19 @@ export default {
         defaultMessage: 'Content Manager',
       },
       permissions: [],
-      Component: () => import('./layout').then((mod) => ({ default: mod.Layout })),
       position: 1,
+    });
+
+    app.router.addRoute({
+      path: 'content-manager/*',
+      lazy: async () => {
+        const { Layout } = await import('./layout');
+
+        return {
+          Component: Layout,
+        };
+      },
+      children: routes,
     });
 
     app.registerPlugin(cm.config);

--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Page, useGuidedTour, Layouts } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
-import { Navigate, Route, Routes, useLocation, useMatch } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes, useLocation, useMatch } from 'react-router-dom';
 
 import { DragLayer, DragLayerProps } from './components/DragLayer';
 import { CardDragPreview } from './components/DragPreviews/CardDragPreview';
@@ -90,11 +90,7 @@ const Layout = () => {
       </Page.Title>
       <Layouts.Root sideNav={<LeftMenu />}>
         <DragLayer renderItem={renderDraglayerItem} />
-        <Routes>
-          {routes.map((route) => (
-            <Route key={route.path} {...route} />
-          ))}
-        </Routes>
+        <Outlet />
       </Layouts.Root>
     </>
   );

--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Page, useGuidedTour, Layouts } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
-import { Navigate, Outlet, Route, Routes, useLocation, useMatch } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useMatch } from 'react-router-dom';
 
 import { DragLayer, DragLayerProps } from './components/DragLayer';
 import { CardDragPreview } from './components/DragPreviews/CardDragPreview';
@@ -12,7 +12,6 @@ import { RelationDragPreview } from './components/DragPreviews/RelationDragPrevi
 import { LeftMenu } from './components/LeftMenu';
 import { ItemTypes } from './constants/dragAndDrop';
 import { useContentManagerInitData } from './hooks/useContentManagerInitData';
-import { routes } from './router';
 import { getTranslation } from './utils/translations';
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* adds first iteration of the client router API (marked as alpha)

### Why is it needed?

* enables users to add route objects to the react-router i.e. to use `loaders` and `actions`.
* enables users to completely modify routes e.g replace the homepage

### Related issue(s)/PR(s)

* resolves DX-1177
