### PR TITLE
NPS: Update frequency of the NPS in v5

### DIFF
--- a/packages/core/admin/admin/src/components/NpsSurvey.tsx
+++ b/packages/core/admin/admin/src/components/NpsSurvey.tsx
@@ -59,9 +59,9 @@ const FieldWrapper = styled(Field.Root)`
 
 const delays = {
   postResponse: 90 * 24 * 60 * 60 * 1000, // 90 days in ms
-  postFirstDismissal: 7 * 24 * 60 * 60 * 1000, // 7 days in ms
+  postFirstDismissal: 14 * 24 * 60 * 60 * 1000, // 14 days in ms
   postSubsequentDismissal: 90 * 24 * 60 * 60 * 1000, // 90 days in ms
-  display: 5 * 60 * 1000, // 5 minutes in ms
+  display: 30 * 60 * 1000, // 30 minutes in ms
 };
 
 const ratingArray = [...Array(11).keys()];

--- a/packages/core/admin/admin/src/components/tests/NpsSurvey.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/NpsSurvey.test.tsx
@@ -239,8 +239,8 @@ describe('NPS survey', () => {
 
   it('respects the delay after first user dismissal', async () => {
     const initialDate = new Date('2020-01-01');
-    const withinDelay = new Date('2020-01-04');
-    const beyondDelay = new Date('2020-01-08');
+    const withinDelay = new Date('2020-01-08');
+    const beyondDelay = new Date('2020-01-15');
 
     localStorageMock.getItem.mockImplementation((key) => {
       if (key === NPS_KEY) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It changes the delays to display the NPS for the first time (from 5 minutes to 30 minutes) and after the first dismissal (from 7 days to 14 days)

### Why is it needed?

Many users complain about the frequency of NPS

### How to test it?

 - Register for the first time on Strapi and on the Registration page accept the Newsletter checkbox
 - then wait after 30 minutes of activity and you will be able to see the NPS survey at the bottom of the page
 - when the NPS survey is displayed, close it by closing the modal
 - then after 14 days the survey will be proposed again
### Related issue(s)/PR(s)

CS-795
