### PR TITLE
feat(cli): add browser logout step

### DIFF
--- a/packages/cli/cloud/src/create-project/action.ts
+++ b/packages/cli/cloud/src/create-project/action.ts
@@ -51,7 +51,7 @@ export default async (ctx: CLIContext) => {
   if (!token) {
     return;
   }
-  const cloudApi = await cloudApiFactory(token);
+  const cloudApi = await cloudApiFactory(ctx, token);
   const { data: config } = await cloudApi.config();
   const { questions, defaults: defaultValues } = config.projectCreation;
 

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -26,7 +26,7 @@ async function upload(
   token: string,
   maxProjectFileSize: number
 ) {
-  const cloudApi = await cloudApiFactory(token);
+  const cloudApi = await cloudApiFactory(ctx, token);
   // * Upload project
   try {
     const storagePath = await getTmpStoragePath();
@@ -138,7 +138,7 @@ async function getProject(ctx: CLIContext) {
 
 export default async (ctx: CLIContext) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
-  const cloudApiService = await cloudApiFactory();
+  const cloudApiService = await cloudApiFactory(ctx);
   const token = await getValidToken();
 
   if (!token) {

--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -10,7 +10,7 @@ export default async (ctx: CLIContext): Promise<boolean> => {
   const { logger } = ctx;
   const tokenService = await tokenServiceFactory(ctx);
   const existingToken = await tokenService.retrieveToken();
-  const cloudApiService = await cloudApiFactory(existingToken || undefined);
+  const cloudApiService = await cloudApiFactory(ctx, existingToken || undefined);
 
   const trackFailedLogin = async () => {
     try {
@@ -126,7 +126,7 @@ export default async (ctx: CLIContext): Promise<boolean> => {
           }
 
           logger.debug('🔍 Fetching user information...');
-          const cloudApiServiceWithToken = await cloudApiFactory(authTokenData.access_token);
+          const cloudApiServiceWithToken = await cloudApiFactory(ctx, authTokenData.access_token);
           // Call to get user info to create the user in DB if not exists
           await cloudApiServiceWithToken.getUserInfo();
           logger.debug('🔍 User information fetched successfully!');

--- a/packages/cli/cloud/src/logout/action.ts
+++ b/packages/cli/cloud/src/logout/action.ts
@@ -1,6 +1,8 @@
 import type { CLIContext } from '../types';
 import { tokenServiceFactory, cloudApiFactory } from '../services';
 
+const openModule = import('open');
+
 export default async (ctx: CLIContext) => {
   const { logger } = ctx;
   const { retrieveToken, eraseToken } = await tokenServiceFactory(ctx);
@@ -10,10 +12,27 @@ export default async (ctx: CLIContext) => {
     logger.log("You're already logged out.");
     return;
   }
-  const cloudApiService = await cloudApiFactory(token);
+  const cloudApiService = await cloudApiFactory(ctx, token);
+  const config = await cloudApiService.config();
+  const cliConfig = config.data;
+
   try {
-    // we might want also to perform extra actions like logging out from the auth0 tenant
     await eraseToken();
+
+    openModule.then((open) => {
+      open
+        .default(
+          `${cliConfig.baseUrl}oidc/logout?client_id=${encodeURIComponent(
+            cliConfig.clientId
+          )}&logout_hint=${encodeURIComponent(token)}
+          `
+        )
+        .catch((e: Error) => {
+          // Failing to open the logout URL is not a critical error, so we just log it
+          logger.debug(e.message, e);
+        });
+    });
+
     logger.log(
       '🔌 You have been logged out from the CLI. If you are on a shared computer, please make sure to log out from the Strapi Cloud Dashboard as well.'
     );

--- a/packages/cli/cloud/src/logout/action.ts
+++ b/packages/cli/cloud/src/logout/action.ts
@@ -22,7 +22,7 @@ export default async (ctx: CLIContext) => {
     openModule.then((open) => {
       open
         .default(
-          `${cliConfig.baseUrl}oidc/logout?client_id=${encodeURIComponent(
+          `${cliConfig.baseUrl}/oidc/logout?client_id=${encodeURIComponent(
             cliConfig.clientId
           )}&logout_hint=${encodeURIComponent(token)}
           `

--- a/packages/cli/cloud/src/services/token.ts
+++ b/packages/cli/cloud/src/services/token.ts
@@ -12,7 +12,7 @@ interface DecodedToken {
 }
 
 export async function tokenServiceFactory({ logger }: { logger: CLIContext['logger'] }) {
-  const cloudApiService = await cloudApiFactory();
+  const cloudApiService = await cloudApiFactory({ logger });
 
   async function saveToken(str: string) {
     const appConfig = await getLocalConfig();


### PR DESCRIPTION
### What does it do?

We perform a proper OIDC logout by opening the logout endpoint in the browser. We provide the client ID and token. We do nothing if an error happens during the logout process: the logout happens at least on the app level, this just adds a logout on the Auth0 SSO level.

"chore" changes (unrelated to the initial task):
- Handle errors while fetching the config

### Why is it needed?

This change is needed to address the issue where users are unable to switch between different login providers. By logging out the user from the OIDC provider, the user's session is cleared. This allows the user to choose a different login provider when they attempt to log in again.

### How to test it?

First, use the login command:
Log in in the CLI using one of the login providers (e.g., Google), 

Then, log out (using the logout command):
The CLI should open the OIDC provider's logout URL in a browser. 

Try to log in again. You should be able to choose a different login provider.


<img width="927" alt="7a95c833-d2d8-4060-b5b4-35d24b2f911d" src="https://github.com/strapi/strapi/assets/55534657/f3028503-d842-4340-8ff6-1f45ec4183d2">
