### PR TITLE
fix(admin): date picker jumps around due to timezones

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, memo } from 'react';
 
+import { getLocalTimeZone, parseAbsolute, toCalendarDate } from '@internationalized/date';
 import { DatePicker, useComposedRefs, Field } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
@@ -27,7 +28,7 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
             field.onChange(name, date);
           }}
           onClear={() => field.onChange(name, undefined)}
-          value={value}
+          value={value ? convertLocalDateToUTCDate(value) : undefined}
           {...props}
         />
         <Field.Hint />
@@ -36,6 +37,18 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
     );
   }
 );
+
+const convertLocalDateToUTCDate = (date: Date): Date => {
+  const utcDateString = date.toISOString();
+  const timeZone = getLocalTimeZone();
+  const zonedDateTime = parseAbsolute(utcDateString, timeZone);
+
+  /**
+   * ZonedDateTime can't have weeks added,
+   * see – https://github.com/adobe/react-spectrum/issues/3667
+   */
+  return toCalendarDate(zonedDateTime).toDate('UTC');
+};
 
 const MemoizedDateInput = memo(DateInput);
 

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -75,6 +75,7 @@
   },
   "dependencies": {
     "@casl/ability": "6.5.0",
+    "@internationalized/date": "3.5.4",
     "@radix-ui/react-context": "1.0.1",
     "@radix-ui/react-toolbar": "1.0.4",
     "@reduxjs/toolkit": "1.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4111,6 +4111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@internationalized/date@npm:3.5.4":
+  version: 3.5.4
+  resolution: "@internationalized/date@npm:3.5.4"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 0e38a3be70fbbbce291ec5a977fadb5f3a7dc2ca9a921494bd892e9ff6c8bba9cd44cd8767e5f50cf2d7e422ab2d5323da2eb7595142d8b487c83500ab135abe
+  languageName: node
+  linkType: hard
+
 "@internationalized/number@npm:3.5.2":
   version: 3.5.2
   resolution: "@internationalized/number@npm:3.5.2"
@@ -7660,6 +7669,7 @@ __metadata:
   resolution: "@strapi/admin@workspace:packages/core/admin"
   dependencies:
     "@casl/ability": "npm:6.5.0"
+    "@internationalized/date": "npm:3.5.4"
     "@radix-ui/react-context": "npm:1.0.1"
     "@radix-ui/react-toolbar": "npm:1.0.4"
     "@reduxjs/toolkit": "npm:1.9.7"


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* handles timezones with the date picker

### Why is it needed?

* the date picker is timezone aware (should we want to start working with them) but the date it converts it too doesn't handle it well, making it think it should be X time prior

### How to test it?

* add a date
* blur the input
* date should stay what you set

### Related issue(s)/PR(s)

* resolves #20321
* resolves DX-1462
