### PR TITLE
fix(admin): add bottom padding to pagination component

### DIFF
--- a/packages/core/admin/admin/src/components/Pagination.tsx
+++ b/packages/core/admin/admin/src/components/Pagination.tsx
@@ -107,7 +107,13 @@ const Root = React.forwardRef<HTMLDivElement, RootProps>(
     };
 
     return (
-      <Flex ref={forwardedRef} paddingTop={4} alignItems="flex-end" justifyContent="space-between">
+      <Flex
+        ref={forwardedRef}
+        paddingTop={4}
+        paddingBottom={4}
+        alignItems="flex-end"
+        justifyContent="space-between"
+      >
         <PaginationProvider
           currentQuery={query}
           page={query.page}


### PR DESCRIPTION
### What does it do?

Add a bottom padding to the pagination component so it looks with more space on pages where it's the last element.

### Example before the change

![image](https://github.com/strapi/strapi/assets/23050694/8ee92934-a7bd-4e6f-accd-928094f0efb2)

### Example after the change

![Screenshot 2024-06-14 at 17 03 19](https://github.com/strapi/strapi/assets/23050694/f22bfd30-9944-4f2f-9a49-b6602f46a6c9)

