### PR TITLE
fix clone entity, #20509

### DIFF
--- a/packages/core/database/src/entity-manager/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/regular-relations.ts
@@ -514,14 +514,15 @@ const cleanInverseOrderColumn = async ({
         )
         WHERE `t1`.`:joinColumnName` = :id
       */
+      const joinTableName = addSchema(strapi.db, joinTable.name);
       // New inverse order will be the max value + 1
       const selectMaxInverseOrder = con.raw(`max(${inverseOrderColumnName}) + 1`);
 
-      const subQuery = con(`${joinTable.name} as t2`)
+      const subQuery = con(`${joinTableName} as t2`)
         .select(selectMaxInverseOrder)
         .whereRaw(`t2.${inverseJoinColumn.name} = t1.${inverseJoinColumn.name}`);
 
-      await con(`${joinTable.name} as t1`)
+      await con(`${joinTableName} as t1`)
         .where(`t1.${joinColumn.name}`, id)
         .update({ [inverseOrderColumnName]: subQuery })
         .transacting(trx);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added information about the schema when executing a request for clear inverse order column

### Why is it needed?

Merging this PR will solve the entity duplication error when using a potgresql database when using a non-default schema.

### How to test it?

For testing, you need to use a postgresql database (declared in docker-compose.dev.yml is sufficient). You need to run the getstarted application on NOT THE DEFAULT SCHEMA postgresql (If the schema is default for postgresql, then the query without specifying the schema will succeed and the problem will not appear). After launch, you need to create 2 collection type entities:
1. Products (singular api id = product, plural api id = products) with field name (short text).
2. Products by region (singular api id = product-by-region, plural api id = products-by-region) with field name (short text) and relation manyToOne to products (in products by region there is one link to products and in products there are many links to products by region)

Next, you need to create several products (product1 and product2). Then go to products by region and create a product: product from New York with a link to product1. After saving this product, you must return to the page for storing products by region and click the “Duplicate” button. 

Also, when you enable logging of database queries, you can see a corrected database query of the following type (the query includes a schema):
```
update "test"."products_by_region_product_links" as "t1" set "product_by_region_order" = (select max(product_by_region_order) + 1 from "test"."products_by_region_product_links" as "t2" where t2.product_id = t1.product_id) where "t1"."product_by_region_id" = ?
```

### Related issue(s)/PR(s)

fixes #20509 
