### PR TITLE
fix(content-manager): add isFetching to loading check

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -97,7 +97,7 @@ const ListViewPage = () => {
   });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
-  const { data, error, isLoading } = useGetAllDocumentsQuery({
+  const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery({
     model,
     params,
   });
@@ -170,7 +170,7 @@ const ListViewPage = () => {
     return formattedHeaders;
   }, [displayedHeaders, formatMessage, list, runHookWaterfall, schema?.options?.draftAndPublish]);
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return <Page.Loading />;
   }
 

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -97,7 +97,7 @@ const ListViewPage = () => {
   });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
-  const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery({
+  const { data, error, isFetching } = useGetAllDocumentsQuery({
     model,
     params,
   });
@@ -170,7 +170,7 @@ const ListViewPage = () => {
     return formattedHeaders;
   }, [displayedHeaders, formatMessage, list, runHookWaterfall, schema?.options?.draftAndPublish]);
 
-  if (isLoading || isFetching) {
+  if (isFetching) {
     return <Page.Loading />;
   }
 
@@ -239,7 +239,7 @@ const ListViewPage = () => {
       />
       <Layouts.Content>
         <Flex gap={4} direction="column" alignItems="stretch">
-          <Table.Root rows={results} headers={tableHeaders} isLoading={isLoading}>
+          <Table.Root rows={results} headers={tableHeaders} isLoading={isFetching}>
             <TableActionsBar />
             <Table.Content>
               <Table.Head>


### PR DESCRIPTION
### What does it do?

Add a new variable to the isLoading check on the add column to table hook.

### Why is it needed?

When rendering the additional columns added by plugins, we have two values that are separated: the model and collectionType information (found in the URL and accessible using the useDoc hook) and the list view data.

When a user moves from one ContentType list view to another, there is a moment when the model changes to the new one, but the data still reflects the old one because we are in the process of fetching the new data. To avoid this, we use an isLoading check. However, this is insufficient because isLoading is true only the first time a query is performed. Instead, we need to check both isLoading and isFetching to ensure that whenever the user is fetching different data, nothing is displayed.

This approach helps us avoid the "Not found" error in the list view.

### How to test it?

1. Go to the list view and move between different content types.
2. Should not have any error.
