### PR TITLE
Fix the Time field format on saving

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Time.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Time.tsx
@@ -23,7 +23,7 @@ const TimeInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(time) => {
-            field.onChange(name, time);
+            field.onChange(name, `${time}:00.000`);
           }}
           onClear={() => field.onChange(name, undefined)}
           value={field.value ?? ''}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

it fixes the Time format in a Time field, because right now when we try to save we receive an error

### Why is it needed?

Time format in component is not valid when filling in an entry using this component.

1. Create a component with a Time field which will be a type "time (ex: 00:00 AM)
![326825843-ad52f314-2186-45c1-a06c-eeb9d2db845f](https://github.com/strapi/strapi/assets/2589748/49055cf2-3434-41de-8657-86e9f2291bf4)


2. Use this component in a collection type
![326826250-9c8e341a-5d88-4164-ad9b-12421f6083cd](https://github.com/strapi/strapi/assets/2589748/0f020ddb-5c36-4c9a-81f7-61b0b15e80b0)

3. In CM, create an entry for this CT and save
![326826697-d55d4703-9e94-43f7-9171-33dd65a45dba](https://github.com/strapi/strapi/assets/2589748/9172de12-89e4-45f1-b2e7-3dfee930e82e)

4. See error on Component (it works with classic Time field outside of component)
![326827533-dc234610-9308-4bff-90bf-2bb791b44cbe](https://github.com/strapi/strapi/assets/2589748/a0e429b6-4e59-4d84-8c87-975575233df6)


### How to test it?

Repeat the above steps to check if the error is still present

### Related issue(s)/PR(s)

[Let us know if this is related to any issue/pull request](https://github.com/strapi/strapi/issues/20236)
