### PR TITLE
fix(content-manager): fix filters bugs with relations, enums and uids

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Renderer.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Renderer.tsx
@@ -36,6 +36,7 @@ const InputRenderer = memo(
       case 'biginteger':
       case 'timestamp':
       case 'string':
+      case 'uid':
         return <StringInput ref={forwardRef} {...props} />;
       case 'boolean':
         return <BooleanInput ref={forwardRef} {...props} />;

--- a/packages/core/admin/admin/src/components/FormInputs/types.ts
+++ b/packages/core/admin/admin/src/components/FormInputs/types.ts
@@ -36,7 +36,6 @@ interface InputProps {
         | 'media'
         | 'blocks'
         | 'richtext'
-        | 'uid'
         | 'dynamiczone'
         | 'component'
         | 'relation'

--- a/packages/core/admin/admin/src/constants/filters.ts
+++ b/packages/core/admin/admin/src/constants/filters.ts
@@ -158,11 +158,14 @@ const STRING_PARSE_FILTERS = [
   },
 ] satisfies FilterOption[];
 
+const FILTERS_WITH_NO_VALUE = ['$null', '$notNull'];
+
 export {
   BASE_FILTERS,
   NUMERIC_FILTERS,
   IS_SENSITIVE_FILTERS,
   CONTAINS_FILTERS,
   STRING_PARSE_FILTERS,
+  FILTERS_WITH_NO_VALUE,
 };
 export type { FilterOption };

--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -163,6 +163,16 @@ const FiltersImpl = ({ disabled, schema }: FiltersProps) => {
             };
           }
 
+          if (attribute.type === 'enumeration') {
+            filter = {
+              ...filter,
+              options: attribute.enum.map((value) => ({
+                label: value,
+                value,
+              })),
+            };
+          }
+
           return filter;
         })
         .filter(Boolean) as Filters.Filter[]


### PR DESCRIPTION
### What does it do?

Fix multiple issues related to filters on v5:
* Relations filter are using the mainField instead of always the id
* UID filtering is supported 
* enum filtering has the right options

### Related issue(s)/PR(s)

#20483 
#20058 
