### PR TITLE
Add: Strapi deploy command to README files

### DIFF
--- a/packages/generators/app/src/resources/files/js/README.md
+++ b/packages/generators/app/src/resources/files/js/README.md
@@ -36,6 +36,10 @@ yarn build
 
 Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
 
+```
+yarn strapi deploy
+```
+
 ## 📚 Learn more
 
 - [Resource center](https://strapi.io/resource-center) - Strapi resource center.

--- a/packages/generators/app/src/resources/files/ts/README.md
+++ b/packages/generators/app/src/resources/files/ts/README.md
@@ -36,6 +36,10 @@ yarn build
 
 Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
 
+```
+yarn strapi deploy
+```
+
 ## 📚 Learn more
 
 - [Resource center](https://strapi.io/resource-center) - Strapi resource center.


### PR DESCRIPTION
### What does it do?

Insert the new `yarn strapi deploy` command in the README files.

### Why is it needed?

Give more visibility to this useful command for our users to quickly and easily deploy their project.

