### PR TITLE
fix(core): disallow required on relation fields on schemas

### DIFF
--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -216,7 +216,7 @@ type ValidationFn = (
 ) => <TSchema extends AnySchema>(schema: TSchema) => TSchema;
 
 const addRequiredValidation: ValidationFn = (attribute) => (schema) => {
-  if (attribute.required) {
+  if (attribute.required && attribute.type !== 'relation') {
     return schema.required({
       id: translatedErrors.required.id,
       defaultMessage: 'This field is required.',

--- a/packages/core/core/src/services/entity-validator/index.ts
+++ b/packages/core/core/src/services/entity-validator/index.ts
@@ -216,11 +216,6 @@ const createRelationValidator =
       validator = yup.mixed();
     }
 
-    validator = addRequiredValidation(createOrUpdate)(validator, {
-      attr: { required: !isDraft && attr.required },
-      updatedAttribute,
-    });
-
     return validator;
   };
 

--- a/packages/core/core/src/services/entity-validator/index.ts
+++ b/packages/core/core/src/services/entity-validator/index.ts
@@ -202,22 +202,19 @@ const createDzValidator =
     return validator;
   };
 
-const createRelationValidator =
-  (createOrUpdate: CreateOrUpdate) =>
-  (
-    { attr, updatedAttribute }: ValidatorMeta<Schema.Attribute.Relation>,
-    { isDraft }: ValidatorContext
-  ) => {
-    let validator;
+const createRelationValidator = ({
+  updatedAttribute,
+}: ValidatorMeta<Schema.Attribute.Relation>) => {
+  let validator;
 
-    if (Array.isArray(updatedAttribute.value)) {
-      validator = yup.array().of(yup.mixed());
-    } else {
-      validator = yup.mixed();
-    }
+  if (Array.isArray(updatedAttribute.value)) {
+    validator = yup.array().of(yup.mixed());
+  } else {
+    validator = yup.mixed();
+  }
 
-    return validator;
-  };
+  return validator;
+};
 
 const createScalarAttributeValidator =
   (createOrUpdate: CreateOrUpdate) => (metas: ValidatorMeta, options: ValidatorContext) => {
@@ -256,13 +253,10 @@ const createAttributeValidator =
       } else if (metas.attr.type === 'dynamiczone') {
         validator = createDzValidator(createOrUpdate)(metas, options);
       } else if (metas.attr.type === 'relation') {
-        validator = createRelationValidator(createOrUpdate)(
-          {
-            attr: metas.attr,
-            updatedAttribute: metas.updatedAttribute,
-          },
-          options
-        );
+        validator = createRelationValidator({
+          attr: metas.attr,
+          updatedAttribute: metas.updatedAttribute,
+        });
       }
 
       validator = preventCast(validator);

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -158,13 +158,6 @@ export const transformAttribute = (
         },
       };
     }
-    case 'relation': {
-      if (attribute.required) {
-        throw new Error(
-          `Required relations are not supported, please remove it from ${contentType.collectionName} schema on the attribute ${name}`
-        );
-      }
-    }
     default: {
       return attribute;
     }

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -158,6 +158,13 @@ export const transformAttribute = (
         },
       };
     }
+    case 'relation': {
+      if (attribute.required) {
+        throw new Error(
+          `Required relations are not supported, please remove it from ${contentType.collectionName} schema on the attribute ${name}`
+        );
+      }
+    }
     default: {
       return attribute;
     }


### PR DESCRIPTION
### What does it do?

* Check required is not present on relation fields on schemas and throw an error asking user to change it if it's present. 
* Remove required check from relations fields 
