### PR TITLE
feat(create-strapi-app): remove the cloud project creation part

### DIFF
--- a/packages/cli/create-strapi-app/src/cloud.ts
+++ b/packages/cli/create-strapi-app/src/cloud.ts
@@ -1,5 +1,4 @@
 import inquirer from 'inquirer';
-import { resolve } from 'node:path';
 import { cli as cloudCli, services as cloudServices } from '@strapi/cloud-cli';
 import parseToChalk from './utils/parse-to-chalk';
 
@@ -16,13 +15,13 @@ function assertCloudError(e: unknown): asserts e is CloudError {
   }
 }
 
-export async function handleCloudProject(projectName: string): Promise<void> {
+export async function handleCloudLogin(): Promise<void> {
   const logger = cloudServices.createLogger({
     silent: false,
     debug: process.argv.includes('--debug'),
     timestamp: false,
   });
-  let cloudApiService = await cloudServices.cloudApiFactory();
+  const cloudApiService = await cloudServices.cloudApiFactory();
   const defaultErrorMessage =
     'An error occurred while trying to interact with Strapi Cloud. Use strapi deploy command once the project is generated.';
 
@@ -48,36 +47,9 @@ export async function handleCloudProject(projectName: string): Promise<void> {
       logger,
       cwd: process.cwd(),
     };
-    const projectCreationSpinner = logger.spinner('Creating project on Strapi Cloud');
 
     try {
-      const tokenService = await cloudServices.tokenServiceFactory(cliContext);
-      const loginSuccess = await cloudCli.login.action(cliContext);
-      if (!loginSuccess) {
-        return;
-      }
-      logger.debug('Retrieving token');
-      const token = await tokenService.retrieveToken();
-
-      cloudApiService = await cloudServices.cloudApiFactory(token);
-
-      logger.debug('Retrieving config');
-      const { data: config } = await cloudApiService.config();
-      logger.debug('config', config);
-      const defaultProjectValues = config.projectCreation?.defaults || {};
-      logger.debug('default project values', defaultProjectValues);
-      projectCreationSpinner.start();
-      const { data: project } = await cloudApiService.createProject({
-        nodeVersion: process.versions?.node?.slice(1, 3) || '20',
-        region: 'NYC',
-        plan: 'trial',
-        ...defaultProjectValues,
-        name: projectName,
-      });
-      projectCreationSpinner.succeed('Project created on Strapi Cloud');
-      const projectPath = resolve(projectName);
-      logger.debug(project, projectPath);
-      await cloudServices.local.save({ project }, { directoryPath: projectPath });
+      await cloudCli.login.action(cliContext);
     } catch (e: Error | CloudError | unknown) {
       logger.debug(e);
       try {
@@ -86,22 +58,14 @@ export async function handleCloudProject(projectName: string): Promise<void> {
           const message =
             typeof e.response.data === 'string'
               ? e.response.data
-              : 'We are sorry, but we are not able to create a Strapi Cloud project for you at the moment.';
-          if (projectCreationSpinner.isSpinning) {
-            projectCreationSpinner.fail(message);
-          } else {
-            logger.warn(message);
-          }
+              : 'We are sorry, but we are not able to log you into Strapi Cloud at the moment.';
+          logger.warn(message);
           return;
         }
       } catch (e) {
         /* empty */
       }
-      if (projectCreationSpinner.isSpinning) {
-        projectCreationSpinner.fail(defaultErrorMessage);
-      } else {
-        logger.error(defaultErrorMessage);
-      }
+      logger.error(defaultErrorMessage);
     }
   }
 }

--- a/packages/cli/create-strapi-app/src/cloud.ts
+++ b/packages/cli/create-strapi-app/src/cloud.ts
@@ -21,7 +21,7 @@ export async function handleCloudLogin(): Promise<void> {
     debug: process.argv.includes('--debug'),
     timestamp: false,
   });
-  const cloudApiService = await cloudServices.cloudApiFactory();
+  const cloudApiService = await cloudServices.cloudApiFactory({ logger });
   const defaultErrorMessage =
     'An error occurred while trying to interact with Strapi Cloud. Use strapi deploy command once the project is generated.';
 

--- a/packages/cli/create-strapi-app/src/create-strapi-app.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi-app.ts
@@ -1,15 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import commander from 'commander';
-import {
-  checkInstallPath,
-  checkRequirements,
-  generateNewApp,
-  type NewOptions,
-} from '@strapi/generate-new';
+import { checkInstallPath, generateNewApp, type NewOptions } from '@strapi/generate-new';
 import promptUser from './utils/prompt-user';
 import type { Program } from './types';
-import { handleCloudProject } from './cloud';
+import { handleCloudLogin } from './cloud';
 
 const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8'));
 
@@ -61,8 +56,7 @@ async function generateApp(
   }
 
   if (!options.skipCloud) {
-    checkRequirements();
-    await handleCloudProject(projectName);
+    await handleCloudLogin();
   }
 
   return generateNewApp(projectName, options).then(() => {

--- a/packages/generators/app/src/index.ts
+++ b/packages/generators/app/src/index.ts
@@ -13,7 +13,6 @@ import machineID from './utils/machine-id';
 import type { Scope, NewOptions } from './types';
 
 export { default as checkInstallPath } from './utils/check-install-path';
-export { default as checkRequirements } from './utils/check-requirements';
 
 export type { NewOptions } from './types';
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removing the cloud project creation part on create-strapi-app.

### Why is it needed?

As we experienced some issues with the actual flow, we decided to remove that part.

Issues:
- Delays the strapi project creation by ~10s
- Active the free trial when the project is generated
- If the user remove his project and creates another, he cannot re-use the Cloud CLI to create a project as he as already used his free trial.

### How to test it?

 The create-strapi-app command should not create a project on Cloud anymore.
The project should be created on Cloud during the first `strapi deploy` command (this is already handled in the deploy command).

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
