### PR TITLE
Fix CM : Back arrow issue >> Relation field cache is not invalidated when going "back"

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -133,8 +133,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       {
         model,
         targetField,
-        // below we don't run the query if there is no id.
-        id: id!,
+        id,
         params: {
           ...params,
           pageSize: RELATIONS_TO_DISPLAY,
@@ -143,7 +142,6 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       },
       {
         refetchOnMountOrArgChange: true,
-        skip: !id,
         selectFromResult: (result) => {
           return {
             ...result,

--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -41,6 +41,9 @@ const relationsApi = contentManagerApi.injectEndpoints({
       }
     >({
       query: ({ model, id, targetField, params }) => {
+        if (id === undefined) {
+          return { url: '', method: 'GET', config: { params: {} } }; // Return a dummy URL to prevent the query
+        }
         return {
           url: `/content-manager/relations/${model}/${id}/${targetField}`,
           method: 'GET',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It fixes the cache issue we had in the CM when we create an entry with Relations and after saving we click the Back button, we are redirected to the create entry page with the form not all empty, the relations are still in place

### Why is it needed?

We want to show all the fields empty in the Create entry page

### How to test it?

1. Create an entry in a collection with a Relation field and add a relation
2. Save the entry and then click the Back Button
3. you need to see the Form empty, even for the Relation field

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20217
