### PR TITLE
fix: navigation issues

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
@@ -150,7 +150,7 @@ const CreatePage = () => {
         message: formatMessage({ id: 'Settings.roles.created', defaultMessage: 'created' }),
       });
 
-      navigate(res.data.id.toString(), { replace: true });
+      navigate(`../roles/${res.data.id.toString()}`, { replace: true });
     } catch (err) {
       toggleNotification({
         type: 'danger',

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -721,10 +721,13 @@ const UpdateAction: DocumentActionComponent = ({
             /**
              * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
              */
-            navigate({
-              pathname: `../${collectionType}/${model}/${res.data.documentId}`,
-              search: rawQuery,
-            });
+            navigate(
+              {
+                pathname: `../${collectionType}/${model}/${res.data.documentId}`,
+                search: rawQuery,
+              },
+              { replace: true }
+            );
           } else if (
             'error' in res &&
             isBaseQueryError(res.error) &&


### PR DESCRIPTION
### What does it do?

- saving a new RBAC role redirected to a 404
- adds "replace: true" to the navigation when an entry is initially created

### Why is it needed?

When saving for the first time, the path is rewritten, but the redirection isn't perceptible to the user. When he then clicks on the back button, the expectation is to land on the list view, not the create view

### How to test it?

- Create and save an RBAC role
- Create and an RBAC role by duplicating an existing one
- In the CM, create a new entry in a collection type. Upon saving, if you go back you should not land on the create page


Fix https://github.com/strapi/strapi/issues/20217