### PR TITLE
V5 fix: wrong date saved

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -25,10 +25,10 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(date) => {
-            field.onChange(name, date ? convertLocalDateToUTCDate(date) : undefined);
+            field.onChange(name, date ? convertLocalDateToUTCDate(date) : null);
           }}
-          onClear={() => field.onChange(name, undefined)}
-          value={value ? convertLocalDateToUTCDate(value) : undefined}
+          onClear={() => field.onChange(name, null)}
+          value={value ? convertLocalDateToUTCDate(value) : value}
           {...props}
         />
         <Field.Hint />

--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -25,7 +25,7 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(date) => {
-            field.onChange(name, date);
+            field.onChange(name, date ? convertLocalDateToUTCDate(date) : undefined);
           }}
           onClear={() => field.onChange(name, undefined)}
           value={value ? convertLocalDateToUTCDate(value) : undefined}

--- a/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
@@ -11,7 +11,7 @@ import { InputProps } from './types';
 const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const { formatMessage } = useIntl();
-    const field = useField(name);
+    const field = useField<Date | null>(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);
 
     const composedRefs = useComposedRefs(ref, fieldRef);

--- a/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
@@ -11,7 +11,7 @@ import { InputProps } from './types';
 const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const { formatMessage } = useIntl();
-    const field = useField<Date>(name);
+    const field = useField(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);
 
     const composedRefs = useComposedRefs(ref, fieldRef);
@@ -24,9 +24,9 @@ const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(date) => {
-            field.onChange(name, date);
+            field.onChange(name, date ? date : null);
           }}
-          onClear={() => field.onChange(name, undefined)}
+          onClear={() => field.onChange(name, null)}
           value={value}
           {...props}
         />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the issue we had with Date fields, everytime we change a date and save we were saving the locale date and not the utc one resulting that the value shown is the day before

### Why is it needed?

Otherwise after saving the date we show the day before

### How to test it?

1. Create an entry on a collection with a date field, add a date value and save
2. After save you need to see the date saved and not the date with the day before

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20569
