### PR TITLE
chore(data-transfer): update ws dependency to 8.17.1 for CVE-2024-37890

### DIFF
--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -57,7 +57,7 @@
     "stream-json": "1.8.0",
     "tar": "6.1.13",
     "tar-stream": "2.2.0",
-    "ws": "8.13.0"
+    "ws": "8.18.0"
   },
   "devDependencies": {
     "@strapi/pack-up": "4.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8434,7 +8434,7 @@ __metadata:
     tar: "npm:6.1.13"
     tar-stream: "npm:2.2.0"
     typescript: "npm:5.2.2"
-    ws: "npm:8.13.0"
+    ws: "npm:8.18.0"
   peerDependencies:
     "@strapi/strapi": ^4.14.4
   languageName: unknown
@@ -32132,9 +32132,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.13.0, ws@npm:^8.2.3, ws@npm:^8.8.0":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
+"ws@npm:8.18.0, ws@npm:^8.2.3, ws@npm:^8.8.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -32143,7 +32143,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/579817dbbab3ee46669129c220cfd81ba6cdb9ab5c3e9a105702dd045743c4ab72e33bb384573827c0c481213417cc880e41bc097e0fc541a0b79fa3eb38207d
+  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update the `ws` dependency in the `data-transfer` package.

### Why is it needed?

To solve the [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)

### How to test it?

Make sure it still works (seems to be covered by tests)

### Related issue(s)/PR(s)

#20578