### PR TITLE
chore: only delete tables,columns,idx,fks we track

### DIFF
--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -315,6 +315,8 @@ export const transformContentTypesToModels = (
         ...documentIdAttribute,
         ...transformAttributes(contentType, identifiers),
       },
+      indexes: contentType.indexes as Model['indexes'],
+      foreignKeys: contentType.foreignKeys as Model['foreignKeys'],
     };
 
     // Add indexes to model

--- a/packages/core/database/src/schema/__tests__/schema-diff.test.ts
+++ b/packages/core/database/src/schema/__tests__/schema-diff.test.ts
@@ -31,15 +31,17 @@ describe('diffSchemas', () => {
       foreignKeys: [],
     };
 
-    const srcSchema: Schema = {
+    const databaseSchema: Schema = {
       tables: [],
     };
 
-    const destSchema: Schema = {
+    const userSchema: Schema = {
       tables: [testTable],
     };
 
-    expect(await diffSchemas(srcSchema, destSchema)).toStrictEqual({
+    expect(
+      await diffSchemas({ databaseSchema, userSchema, previousSchema: userSchema })
+    ).toStrictEqual({
       status: 'CHANGED',
       diff: {
         tables: {
@@ -60,15 +62,19 @@ describe('diffSchemas', () => {
       foreignKeys: [],
     };
 
-    const srcSchema = {
+    const databaseSchema = {
       tables: [testTable],
     };
 
-    const destSchema = {
+    const userSchema = {
       tables: [],
     };
 
-    expect(await diffSchemas(srcSchema, destSchema)).toStrictEqual({
+    const previousSchema = {
+      tables: [testTable],
+    };
+
+    expect(await diffSchemas({ databaseSchema, userSchema, previousSchema })).toStrictEqual({
       status: 'CHANGED',
       diff: {
         tables: {
@@ -89,15 +95,17 @@ describe('diffSchemas', () => {
       foreignKeys: [],
     };
 
-    const srcSchema = {
+    const databaseSchema = {
       tables: [testTable],
     };
 
-    const destSchema = {
+    const userSchema = {
       tables: [testTable],
     };
 
-    expect(await diffSchemas(srcSchema, destSchema)).toStrictEqual({
+    expect(
+      await diffSchemas({ databaseSchema, userSchema, previousSchema: userSchema })
+    ).toStrictEqual({
       status: 'UNCHANGED',
       diff: {
         tables: {
@@ -110,9 +118,42 @@ describe('diffSchemas', () => {
     });
   });
 
+  test('UnTracked Table', async () => {
+    const testTable = {
+      name: 'my_table',
+      columns: [],
+      indexes: [],
+      foreignKeys: [],
+    };
+
+    const databaseSchema = {
+      tables: [testTable],
+    };
+
+    const userSchema = {
+      tables: [],
+    };
+
+    const previousSchema = {
+      tables: [],
+    };
+
+    expect(await diffSchemas({ databaseSchema, userSchema, previousSchema })).toStrictEqual({
+      status: 'UNCHANGED',
+      diff: {
+        tables: {
+          added: [],
+          updated: [],
+          unchanged: [],
+          removed: [],
+        },
+      },
+    });
+  });
+
   describe('Changed table', () => {
     test('added column', async () => {
-      const srcSchema: Schema = {
+      const databaseSchema: Schema = {
         tables: [
           {
             name: 'my_table',
@@ -123,7 +164,7 @@ describe('diffSchemas', () => {
         ],
       };
 
-      const destSchema: Schema = {
+      const userSchema: Schema = {
         tables: [
           {
             name: 'my_table',
@@ -140,7 +181,9 @@ describe('diffSchemas', () => {
         ],
       };
 
-      expect(await diffSchemas(srcSchema, destSchema)).toStrictEqual({
+      expect(
+        await diffSchemas({ databaseSchema, userSchema, previousSchema: userSchema })
+      ).toStrictEqual({
         status: 'CHANGED',
         diff: {
           tables: {
@@ -225,15 +268,19 @@ describe('diffSchemas', () => {
       },
     } as any;
 
-    const srcSchema: Schema = {
+    const databaseSchema: Schema = {
       tables: [...testTables, coreStoreTable],
     };
 
-    const destSchema = {
+    const userSchema = {
       tables: [coreStoreTable],
     };
 
-    expect(await diffSchemas(srcSchema, destSchema)).toStrictEqual({
+    const previousSchema = {
+      tables: [coreStoreTable, testTables[1]],
+    };
+
+    expect(await diffSchemas({ databaseSchema, userSchema, previousSchema })).toStrictEqual({
       status: 'CHANGED',
       diff: {
         tables: {

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -16,6 +16,23 @@ import type {
 } from './types';
 import type { Database } from '..';
 
+type PersistedTable = {
+  name: string;
+  dependsOn?: Array<{ name: string }>;
+};
+
+type TableDiffContext = {
+  previousTable?: Table;
+  databaseTable: Table;
+  userSchemaTable: Table;
+};
+
+type SchemaDiffContext = {
+  previousSchema: Schema;
+  databaseSchema: Schema;
+  userSchema: Schema;
+};
+
 // TODO: get that list dynamically instead
 const RESERVED_TABLE_NAMES = [
   'strapi_migrations',
@@ -194,30 +211,37 @@ export default (db: Database) => {
     };
   };
 
-  const diffTableColumns = (srcTable: Table, destTable: Table): ColumnsDiff => {
+  const diffTableColumns = (diffCtx: TableDiffContext): ColumnsDiff => {
+    const { databaseTable, userSchemaTable, previousTable } = diffCtx;
+
     const addedColumns: Column[] = [];
     const updatedColumns: ColumnDiff['diff'][] = [];
     const unchangedColumns: Column[] = [];
     const removedColumns: Column[] = [];
 
-    for (const destColumn of destTable.columns) {
-      const srcColumn = helpers.findColumn(srcTable, destColumn.name);
-      if (srcColumn) {
-        const { status, diff } = diffColumns(srcColumn, destColumn);
+    for (const userSchemaColumn of userSchemaTable.columns) {
+      const databaseColumn = helpers.findColumn(databaseTable, userSchemaColumn.name);
+
+      if (databaseColumn) {
+        const { status, diff } = diffColumns(databaseColumn, userSchemaColumn);
 
         if (status === statuses.CHANGED) {
           updatedColumns.push(diff);
         } else {
-          unchangedColumns.push(srcColumn);
+          unchangedColumns.push(databaseColumn);
         }
       } else {
-        addedColumns.push(destColumn);
+        addedColumns.push(userSchemaColumn);
       }
     }
 
-    for (const srcColumn of srcTable.columns) {
-      if (!helpers.hasColumn(destTable, srcColumn.name)) {
-        removedColumns.push(srcColumn);
+    for (const databaseColumn of databaseTable.columns) {
+      if (
+        !helpers.hasColumn(userSchemaTable, databaseColumn.name) &&
+        previousTable &&
+        helpers.hasColumn(previousTable, databaseColumn.name)
+      ) {
+        removedColumns.push(databaseColumn);
       }
     }
 
@@ -234,30 +258,36 @@ export default (db: Database) => {
     };
   };
 
-  const diffTableIndexes = (srcTable: Table, destTable: Table): IndexesDiff => {
+  const diffTableIndexes = (diffCtx: TableDiffContext): IndexesDiff => {
+    const { databaseTable, userSchemaTable, previousTable } = diffCtx;
+
     const addedIndexes: Index[] = [];
     const updatedIndexes: IndexDiff['diff'][] = [];
     const unchangedIndexes: Index[] = [];
     const removedIndexes: Index[] = [];
 
-    for (const destIndex of destTable.indexes) {
-      const srcIndex = helpers.findIndex(srcTable, destIndex.name);
-      if (srcIndex) {
-        const { status, diff } = diffIndexes(srcIndex, destIndex);
+    for (const userSchemaIndex of userSchemaTable.indexes) {
+      const databaseIndex = helpers.findIndex(databaseTable, userSchemaIndex.name);
+      if (databaseIndex) {
+        const { status, diff } = diffIndexes(databaseIndex, userSchemaIndex);
 
         if (status === statuses.CHANGED) {
           updatedIndexes.push(diff);
         } else {
-          unchangedIndexes.push(srcIndex);
+          unchangedIndexes.push(databaseIndex);
         }
       } else {
-        addedIndexes.push(destIndex);
+        addedIndexes.push(userSchemaIndex);
       }
     }
 
-    for (const srcIndex of srcTable.indexes) {
-      if (!helpers.hasIndex(destTable, srcIndex.name)) {
-        removedIndexes.push(srcIndex);
+    for (const databaseIndex of databaseTable.indexes) {
+      if (
+        !helpers.hasIndex(userSchemaTable, databaseIndex.name) &&
+        previousTable &&
+        helpers.hasIndex(previousTable, databaseIndex.name)
+      ) {
+        removedIndexes.push(databaseIndex);
       }
     }
 
@@ -274,7 +304,9 @@ export default (db: Database) => {
     };
   };
 
-  const diffTableForeignKeys = (srcTable: Table, destTable: Table): ForeignKeysDiff => {
+  const diffTableForeignKeys = (diffCtx: TableDiffContext): ForeignKeysDiff => {
+    const { databaseTable, userSchemaTable, previousTable } = diffCtx;
+
     const addedForeignKeys: ForeignKey[] = [];
     const updatedForeignKeys: ForeignKeyDiff['diff'][] = [];
     const unchangedForeignKeys: ForeignKey[] = [];
@@ -292,24 +324,28 @@ export default (db: Database) => {
       };
     }
 
-    for (const destForeignKey of destTable.foreignKeys) {
-      const srcForeignKey = helpers.findForeignKey(srcTable, destForeignKey.name);
-      if (srcForeignKey) {
-        const { status, diff } = diffForeignKeys(srcForeignKey, destForeignKey);
+    for (const userSchemaForeignKeys of userSchemaTable.foreignKeys) {
+      const databaseForeignKeys = helpers.findForeignKey(databaseTable, userSchemaForeignKeys.name);
+      if (databaseForeignKeys) {
+        const { status, diff } = diffForeignKeys(databaseForeignKeys, userSchemaForeignKeys);
 
         if (status === statuses.CHANGED) {
           updatedForeignKeys.push(diff);
         } else {
-          unchangedForeignKeys.push(srcForeignKey);
+          unchangedForeignKeys.push(databaseForeignKeys);
         }
       } else {
-        addedForeignKeys.push(destForeignKey);
+        addedForeignKeys.push(userSchemaForeignKeys);
       }
     }
 
-    for (const srcForeignKey of srcTable.foreignKeys) {
-      if (!helpers.hasForeignKey(destTable, srcForeignKey.name)) {
-        removedForeignKeys.push(srcForeignKey);
+    for (const databaseForeignKeys of databaseTable.foreignKeys) {
+      if (
+        !helpers.hasForeignKey(userSchemaTable, databaseForeignKeys.name) &&
+        previousTable &&
+        helpers.hasForeignKey(previousTable, databaseForeignKeys.name)
+      ) {
+        removedForeignKeys.push(databaseForeignKeys);
       }
     }
 
@@ -328,17 +364,19 @@ export default (db: Database) => {
     };
   };
 
-  const diffTables = (srcTable: Table, destTable: Table): TableDiff => {
-    const columnsDiff = diffTableColumns(srcTable, destTable);
-    const indexesDiff = diffTableIndexes(srcTable, destTable);
-    const foreignKeysDiff = diffTableForeignKeys(srcTable, destTable);
+  const diffTables = (diffCtx: TableDiffContext): TableDiff => {
+    const { databaseTable } = diffCtx;
+
+    const columnsDiff = diffTableColumns(diffCtx);
+    const indexesDiff = diffTableIndexes(diffCtx);
+    const foreignKeysDiff = diffTableForeignKeys(diffCtx);
 
     const hasChanged = [columnsDiff, indexesDiff, foreignKeysDiff].some(hasChangedStatus);
 
     return {
       status: hasChanged ? statuses.CHANGED : statuses.UNCHANGED,
       diff: {
-        name: srcTable.name,
+        name: databaseTable.name,
         indexes: indexesDiff.diff,
         foreignKeys: foreignKeysDiff.diff,
         columns: columnsDiff.diff,
@@ -346,27 +384,37 @@ export default (db: Database) => {
     };
   };
 
-  const diffSchemas = async (srcSchema: Schema, destSchema: Schema): Promise<SchemaDiff> => {
+  const diffSchemas = async (schemaDiffCtx: SchemaDiffContext): Promise<SchemaDiff> => {
+    const { previousSchema, databaseSchema, userSchema } = schemaDiffCtx;
+
     const addedTables: Table[] = [];
     const updatedTables: TableDiff['diff'][] = [];
     const unchangedTables: Table[] = [];
     const removedTables: Table[] = [];
 
-    for (const destTable of destSchema.tables) {
-      const srcTable = helpers.findTable(srcSchema, destTable.name);
-      if (srcTable) {
-        const { status, diff } = diffTables(srcTable, destTable);
+    // for each table in the user schema, check if it already exists in the database schema
+    for (const userSchemaTable of userSchema.tables) {
+      const databaseTable = helpers.findTable(databaseSchema, userSchemaTable.name);
+      const previousTable = helpers.findTable(previousSchema, userSchemaTable.name);
+
+      if (databaseTable) {
+        const { status, diff } = diffTables({
+          previousTable,
+          databaseTable,
+          userSchemaTable,
+        });
 
         if (status === statuses.CHANGED) {
           updatedTables.push(diff);
         } else {
-          unchangedTables.push(srcTable);
+          unchangedTables.push(databaseTable);
         }
       } else {
-        addedTables.push(destTable);
+        addedTables.push(userSchemaTable);
       }
     }
 
+    // maintain audit logs table from EE -> CE
     const parsePersistedTable = (persistedTable: string | Table) => {
       if (typeof persistedTable === 'string') {
         return persistedTable;
@@ -374,8 +422,9 @@ export default (db: Database) => {
       return persistedTable.name;
     };
 
-    const persistedTables = helpers.hasTable(srcSchema, 'strapi_core_store_settings')
-      ? (await strapi.store.get({
+    const persistedTables = helpers.hasTable(databaseSchema, 'strapi_core_store_settings')
+      ? // TODO: replace with low level db query instead
+        (await strapi.store.get({
           type: 'core',
           key: 'persisted_tables',
         })) ?? []
@@ -383,13 +432,22 @@ export default (db: Database) => {
 
     const reservedTables = [...RESERVED_TABLE_NAMES, ...persistedTables.map(parsePersistedTable)];
 
-    type PersistedTable = {
-      name: string;
-      dependsOn?: Array<{ name: string }>;
-    };
+    // for all tables in the database schema, check if they are not in the user schema
+    for (const databaseTable of databaseSchema.tables) {
+      // NOTE: if db table is not in the user schema and is not in the previous stored schema leave it alone. it is a user custom table that we should not touch
+      if (
+        !helpers.hasTable(userSchema, databaseTable.name) &&
+        !helpers.hasTable(previousSchema, databaseTable.name)
+      ) {
+        continue;
+      }
 
-    for (const srcTable of srcSchema.tables) {
-      if (!helpers.hasTable(destSchema, srcTable.name) && !reservedTables.includes(srcTable.name)) {
+      // if a db table is not in the user schema I want to delete it
+      if (
+        !helpers.hasTable(userSchema, databaseTable.name) &&
+        helpers.hasTable(previousSchema, databaseTable.name) &&
+        !reservedTables.includes(databaseTable.name)
+      ) {
         const dependencies = persistedTables
           .filter((table: PersistedTable) => {
             const dependsOn = table?.dependsOn;
@@ -398,15 +456,17 @@ export default (db: Database) => {
               return;
             }
 
-            return dependsOn.some((table) => table.name === srcTable.name);
+            return dependsOn.some((table) => table.name === databaseTable.name);
           })
           .map((dependsOnTable: PersistedTable) => {
-            return srcSchema.tables.find((srcTable) => srcTable.name === dependsOnTable.name);
+            return databaseSchema.tables.find(
+              (databaseTable) => databaseTable.name === dependsOnTable.name
+            );
           })
           // In case the table is not found, filter undefined values
           .filter((table: PersistedTable) => !_.isNil(table));
 
-        removedTables.push(srcTable, ...dependencies);
+        removedTables.push(databaseTable, ...dependencies);
       }
     }
 

--- a/packages/core/database/src/schema/index.ts
+++ b/packages/core/database/src/schema/index.ts
@@ -74,9 +74,31 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
     async syncSchema() {
       debug('Synchronizing database schema');
 
-      const DBSchema = await db.dialect.schemaInspector.getSchema();
+      const databaseSchema = await db.dialect.schemaInspector.getSchema();
+      const storedSchema = await this.schemaStorage.read();
+      let previousSchema: Schema;
 
-      const { status, diff } = await this.schemaDiff.diff(DBSchema, this.schema);
+      if (!storedSchema) {
+        previousSchema = this.schema;
+      } else {
+        previousSchema = storedSchema.schema;
+      }
+
+      /*
+        3way diff - DB schema / previous metadataSchema / new metadataSchema
+
+        - When something doesn't exist in the previous metadataSchema -> It's not tracked by us and should be ignored
+        - If no previous metadataSchema => use new metadataSchema so we start tracking them and ignore everything else
+        - Apply this logic to Tables / Columns / Indexes / FKs ...
+        - Handle errors (indexes or fks on incompatible stuff ...)
+
+      */
+
+      const { status, diff } = await this.schemaDiff.diff({
+        previousSchema,
+        databaseSchema,
+        userSchema: this.schema,
+      });
 
       if (status === 'CHANGED') {
         await this.builder.updateSchema(diff);

--- a/packages/core/database/src/schema/index.ts
+++ b/packages/core/database/src/schema/index.ts
@@ -76,13 +76,6 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
 
       const databaseSchema = await db.dialect.schemaInspector.getSchema();
       const storedSchema = await this.schemaStorage.read();
-      let previousSchema: Schema;
-
-      if (!storedSchema) {
-        previousSchema = this.schema;
-      } else {
-        previousSchema = storedSchema.schema;
-      }
 
       /*
         3way diff - DB schema / previous metadataSchema / new metadataSchema
@@ -95,7 +88,7 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       */
 
       const { status, diff } = await this.schemaDiff.diff({
-        previousSchema,
+        previousSchema: storedSchema?.schema,
         databaseSchema,
         userSchema: this.schema,
       });

--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -24,7 +24,12 @@ export default (db: Database) => {
   };
 
   return {
-    async read() {
+    async read(): Promise<{
+      id: number;
+      time: Date;
+      hash: string;
+      schema: Schema;
+    } | null> {
       await checkTableExists();
 
       const res = await db

--- a/packages/core/types/src/struct/schema.ts
+++ b/packages/core/types/src/struct/schema.ts
@@ -211,6 +211,13 @@ export interface ContentTypeSchema extends BaseSchema {
    * @internal
    */
   indexes?: unknown[];
+
+  /**
+   * Optional attribute to indicate the foreignKeys to be created on the database for this content type.
+   *
+   * @internal
+   */
+  foreignKeys?: unknown[];
 }
 
 /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

> ⚠️ This requires heavy beta testing before it gets into the RC

### What does it do?

- Uses previsouly stored schema to force delete resources we are sure we have been tracking.
- This will leave alone any extra table, column, index, fks manually managed by users outside of strapi schema sync.

### Why is it needed?

- Make strapi db sync safer for users

### How to test it?

- Manually create tables, columns, indexes in your db and restart and see they are still there. 
- Then add them into the schema once, then remove them and see they get deleted from the db once they are considered tracked

### Related issue(s)/PR(s)

- Closes https://github.com/strapi/strapi/issues/13732

### Ideas for followup improvements

- [ ] Review `forceMigration` options
- [ ] Add logging for certain situations
