### PR TITLE
fix: incorrect populate when using morph relations

### DIFF
--- a/packages/core/content-manager/server/src/history/services/utils.ts
+++ b/packages/core/content-manager/server/src/history/services/utils.ts
@@ -187,6 +187,12 @@ export const createServiceUtils = ({ strapi }: { strapi: Core.Strapi }) => {
     return attributes.reduce((acc: any, [attributeName, attribute]) => {
       switch (attribute.type) {
         case 'relation': {
+          // TODO: Support polymorphic relations
+          const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+          if (isMorphRelation) {
+            break;
+          }
+
           const isVisible = contentTypes.isVisibleAttribute(model, attributeName);
           if (isVisible) {
             acc[attributeName] = { fields: ['documentId', 'locale', 'publishedAt'] };

--- a/packages/core/core/src/services/document-service/utils/populate.ts
+++ b/packages/core/core/src/services/document-service/utils/populate.ts
@@ -16,6 +16,12 @@ export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
   return attributes.reduce((acc: any, [attributeName, attribute]) => {
     switch (attribute.type) {
       case 'relation': {
+        // TODO: Support polymorphic relations
+        const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+        if (isMorphRelation) {
+          break;
+        }
+
         // TODO: Should this just be a plain list?
         // Ignore createdBy, updatedBy, ...
         const isVisible = contentTypes.isVisibleAttribute(model, attributeName);


### PR DESCRIPTION
### What does it do?

Polymorphic relations are theoretically not supported, but we do allow them to be defined in the schema.
the Kitchensink Content Type had one, and it was not possible to create or update one in v5/main.

This fix prevents content history and the document service to incorrectly populate morph relations, which need a different kind of syntax than regular relations.
Once we work on polymorphic relations, we will need to fix this.
