### PR TITLE
fix(admin): not authenticated upon registration

### DIFF
--- a/packages/core/admin/admin/src/features/Auth.tsx
+++ b/packages/core/admin/admin/src/features/Auth.tsx
@@ -50,7 +50,7 @@ interface AuthContextValue {
   isLoading: boolean;
   permissions: Permission[];
   refetchPermissions: () => Promise<void>;
-  setToken: (token: string | null) => void;
+  setToken: (token: string) => void;
   token: string | null;
   user?: User;
 }
@@ -144,11 +144,10 @@ const AuthProvider = ({ children, _defaultPermissions = [] }: AuthProviderProps)
     }
   }, [dispatch, user]);
 
-  React.useEffect(() => {
-    if (token) {
-      storeToken(token, false);
-    }
-  }, [token]);
+  const updateToken = React.useCallback((newToken: string) => {
+    setToken(newToken);
+    storeToken(newToken);
+  }, []);
 
   React.useEffect(() => {
     /**
@@ -272,7 +271,7 @@ const AuthProvider = ({ children, _defaultPermissions = [] }: AuthProviderProps)
       permissions={userPermissions}
       checkUserHasPermissions={checkUserHasPermissions}
       refetchPermissions={refetchPermissions}
-      setToken={setToken}
+      setToken={updateToken}
       isLoading={isLoading}
     >
       {children}

--- a/packages/core/admin/admin/src/hooks/useFetchClient.ts
+++ b/packages/core/admin/admin/src/hooks/useFetchClient.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { useAuth } from '../features/Auth';
 import { getFetchClient } from '../utils/getFetchClient';
 
 /**
@@ -50,12 +51,14 @@ const useFetchClient = () => {
     };
   }, []);
 
+  const token = useAuth('useFetchClient', (auth) => auth.token);
+
   return React.useMemo(
     () =>
       getFetchClient({
         signal: controller.current!.signal,
       }),
-    []
+    [token]
   );
 };
 

--- a/packages/core/admin/admin/src/hooks/useFetchClient.ts
+++ b/packages/core/admin/admin/src/hooks/useFetchClient.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { useAuth } from '../features/Auth';
 import { getFetchClient } from '../utils/getFetchClient';
 
 /**

--- a/packages/core/admin/admin/src/hooks/useFetchClient.ts
+++ b/packages/core/admin/admin/src/hooks/useFetchClient.ts
@@ -51,14 +51,12 @@ const useFetchClient = () => {
     };
   }, []);
 
-  const token = useAuth('useFetchClient', (auth) => auth.token);
-
   return React.useMemo(
     () =>
       getFetchClient({
         signal: controller.current!.signal,
       }),
-    [token]
+    []
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -487,16 +487,6 @@ const Register = ({ hasAdmin }: RegisterProps) => {
   );
 };
 
-interface RegisterFormValues {
-  firstname: string;
-  lastname: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-  registrationToken: string | undefined;
-  news: boolean;
-}
-
 type StringKeys<T> = {
   [K in keyof T]: T[K] extends string | undefined ? K : never;
 }[keyof T];

--- a/tests/e2e/tests/admin/signup.spec.ts
+++ b/tests/e2e/tests/admin/signup.spec.ts
@@ -99,5 +99,6 @@ test.describe('Sign Up', () => {
     await page.getByRole('button', { name: "Let's start" }).click();
 
     await expect(page).toHaveTitle(TITLE_HOME);
+    await page.getByRole('link', { name: 'Content-Type Builder' }).click();
   });
 });

--- a/tests/e2e/tests/admin/signup.spec.ts
+++ b/tests/e2e/tests/admin/signup.spec.ts
@@ -98,7 +98,8 @@ test.describe('Sign Up', () => {
   }) => {
     await page.getByRole('button', { name: "Let's start" }).click();
 
+    // Ensure home page is loaded and the permissions are fetched
     await expect(page).toHaveTitle(TITLE_HOME);
-    await page.getByRole('link', { name: 'Content-Type Builder' }).click();
+    await expect(page.getByRole('link', { name: 'Content-Type Builder' })).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

Fixes the issue where Strapi thought you didn't have Super Admin permissions immediately after creating the first admin user (until you refreshed)

Stops relying on useEffect to store the JWT updates in the localStorage, as it would run after the page redirection, so too late to be picked up by the fetch client

Also deletes a type that had been written twice in the same file

### How to test it?

Delete your admin users in your database, it will prompt Strapi to register a first admin user. After signing up, make sure you see all the expected options in the main nav.

### Related issue(s)/PR(s)

fixes #20332
