### PR TITLE
V5/main

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -1070,48 +1070,48 @@ export const FormModal = () => {
                 </Tabs.Content>
               </Tabs.Root>
             </Modal.Body>
-            <Modal.Footer>
-              <Button variant="tertiary" onClick={handleClosed}>
-                {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'Cancel' })}
-              </Button>
-              {/* TODO: refactor this component. Nuf said. */}
-              <FormModalEndActions
-                deleteCategory={deleteCategory}
-                deleteContentType={deleteData}
-                deleteComponent={deleteData}
-                categoryName={initialData.name}
-                isAttributeModal={modalType === 'attribute'}
-                isCustomFieldModal={modalType === 'customField'}
-                isComponentToDzModal={modalType === 'addComponentToDynamicZone'}
-                isComponentAttribute={attributeType === 'component'}
-                isComponentModal={modalType === 'component'}
-                isContentTypeModal={modalType === 'contentType'}
-                isCreatingComponent={actionType === 'create'}
-                isCreatingDz={actionType === 'create'}
-                isCreatingComponentAttribute={modifiedData.createComponent || false}
-                isCreatingComponentInDz={modifiedData.createComponent || false}
-                isCreatingComponentWhileAddingAField={isCreatingComponentWhileAddingAField}
-                isCreatingContentType={actionType === 'create'}
-                isEditingAttribute={actionType === 'edit'}
-                isDzAttribute={attributeType === 'dynamiczone'}
-                isEditingCategory={modalType === 'editCategory'}
-                isInFirstComponentStep={step === '1'}
-                onSubmitAddComponentAttribute={handleSubmit}
-                onSubmitAddComponentToDz={handleSubmit}
-                onSubmitCreateComponent={handleSubmit}
-                onSubmitCreateContentType={handleSubmit}
-                onSubmitCreateDz={handleSubmit}
-                onSubmitEditAttribute={handleSubmit}
-                onSubmitEditCategory={handleSubmit}
-                onSubmitEditComponent={handleSubmit}
-                onSubmitEditContentType={handleSubmit}
-                onSubmitEditCustomFieldAttribute={handleSubmit}
-                onSubmitEditDz={handleSubmit}
-                onClickFinish={handleClickFinish}
-              />
-            </Modal.Footer>
           </form>
         )}
+        <Modal.Footer>
+          <Button variant="tertiary" onClick={handleClosed}>
+            {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'Cancel' })}
+          </Button>
+          {/* TODO: refactor this component. Nuf said. */}
+          <FormModalEndActions
+            deleteCategory={deleteCategory}
+            deleteContentType={deleteData}
+            deleteComponent={deleteData}
+            categoryName={initialData.name}
+            isAttributeModal={modalType === 'attribute'}
+            isCustomFieldModal={modalType === 'customField'}
+            isComponentToDzModal={modalType === 'addComponentToDynamicZone'}
+            isComponentAttribute={attributeType === 'component'}
+            isComponentModal={modalType === 'component'}
+            isContentTypeModal={modalType === 'contentType'}
+            isCreatingComponent={actionType === 'create'}
+            isCreatingDz={actionType === 'create'}
+            isCreatingComponentAttribute={modifiedData.createComponent || false}
+            isCreatingComponentInDz={modifiedData.createComponent || false}
+            isCreatingComponentWhileAddingAField={isCreatingComponentWhileAddingAField}
+            isCreatingContentType={actionType === 'create'}
+            isEditingAttribute={actionType === 'edit'}
+            isDzAttribute={attributeType === 'dynamiczone'}
+            isEditingCategory={modalType === 'editCategory'}
+            isInFirstComponentStep={step === '1'}
+            onSubmitAddComponentAttribute={handleSubmit}
+            onSubmitAddComponentToDz={handleSubmit}
+            onSubmitCreateComponent={handleSubmit}
+            onSubmitCreateContentType={handleSubmit}
+            onSubmitCreateDz={handleSubmit}
+            onSubmitEditAttribute={handleSubmit}
+            onSubmitEditCategory={handleSubmit}
+            onSubmitEditComponent={handleSubmit}
+            onSubmitEditContentType={handleSubmit}
+            onSubmitEditCustomFieldAttribute={handleSubmit}
+            onSubmitEditDz={handleSubmit}
+            onClickFinish={handleClickFinish}
+          />
+        </Modal.Footer>
       </Modal.Content>
     </Modal.Root>
   );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Fixes UI display issue in Admin Panel which caused Cancel and Continue buttons to not display when using Safari (in Content Type add dialogs).

The issue was that the ModalFooter was inside a `<form>` tag, but the ModalHeader tag was outside the form.  I simply moved the footer outside the form.

### Why is it needed?
To address UI display issue on Safari and Duck-Duck-Go browser.

### How to test it?
Try to add a new Content Type from the Admin Panel.  See pics in #20574.

### Related issue(s)/PR(s)
#20574

