### PR TITLE
Fix Vite HMR Server Restart 

### DIFF
--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -5,8 +5,6 @@ const config = {
   locales: ['it', 'es', 'en'],
 };
 const bootstrap = (app) => {
-  console.log('I AM  BOOTSTRAPPED');
-
   app.getPlugin('content-manager').injectComponent('editView', 'right-links', {
     name: 'PreviewButton',
     Component: () => (

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -613,7 +613,7 @@
   "components.InputSelect.option.placeholder": "Choose here",
   "components.ListRow.empty": "There is no data to be shown.",
   "components.NotAllowedInput.text": "No permissions to see this field",
-  "components.OverlayBlocker.description": "You're using a feature that needs the server to restart. Please wait until the server is up.",
+  "components.OverlayBlocker.description": "You're using a feature that needs the server to restart. The page will reload automatically.",
   "components.OverlayBlocker.description.serverError": "The server should have restarted, please check your logs in the terminal.",
   "components.OverlayBlocker.title": "Waiting for restart...",
   "components.OverlayBlocker.title.serverError": "The restart is taking longer than expected",

--- a/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
@@ -77,7 +77,7 @@ const AutoReloadOverlayBlockerProvider = ({ children }: AutoReloadOverlayBlocker
   let description = {
     id: config?.description || 'components.OverlayBlocker.description',
     defaultMessage:
-      "You're using a feature that needs the server to restart. Please wait until the server is up.",
+      "You're using a feature that needs the server to restart. The page will reload automatically.",
   };
 
   let title = {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -527,7 +527,7 @@ export const FormModal = () => {
           if (canEditContentType(allDataSchema, modifiedData)) {
             onCloseModal();
 
-            submitData(modifiedData);
+            await submitData(modifiedData);
           } else {
             toggleNotification({
               type: 'danger',

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -87,7 +87,7 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<InlineConfig
     server: {
       middlewareMode: true,
       open: ctx.options.open,
-      hmr: true,
+      hmr: { server: ctx.strapi.server.httpServer },
     },
     appType: 'custom',
   };


### PR DESCRIPTION
### What does it do?

The HMR configuration in config.ts has been tweaked; now the server property is set to the instance of the HTTP server that Strapi uses, so that Vite HMR server and Strapi start accepting requests at the same time.

### Why is it needed?

The Vite server was restarting faster than the Strapi HTTP server, hence triggering vite to reload the page before Strapi is ready to accept requests (hence the "Unable to connect" message).

### How to test it?

- Got to the CTB
- Modify a content-type
- The server shouldn't display the "Unable to connect" page and instead only reload when the server is ready

### Related issue(s)/PR(s)

fix #20220