### PR TITLE
fix: create locale column if it does not exist

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-continue */
-import type { UID, Modules } from '@strapi/types';
+import type { UID } from '@strapi/types';
 import type { Database, Migration } from '@strapi/database';
 import { async, contentTypes } from '@strapi/utils';
 
-type DiscardDraftParams<TSchemaUID extends UID.ContentType> =
-  Modules.Documents.ServiceParams<TSchemaUID>['discardDraft'];
 type DocumentVersion = { documentId: string; locale: string };
 type Knex = Parameters<Migration['up']>[0];
 
@@ -18,29 +16,21 @@ export async function* getBatchToDiscard({
   db,
   trx,
   uid,
-  isLocalized,
   batchSize = 1000,
 }: {
   db: Database;
   trx: Knex;
   uid: string;
-  isLocalized: boolean;
   batchSize?: number;
 }) {
   let offset = 0;
   let hasMore = true;
 
-  const fields = ['id', 'documentId'];
-
-  if (isLocalized) {
-    fields.push('locale');
-  }
-
   while (hasMore) {
     // Look for the published entries to discard
     const batch: DocumentVersion[] = await db
       .queryBuilder(uid)
-      .select(fields)
+      .select(['id', 'documentId', 'locale'])
       .where({ publishedAt: { $ne: null } })
       .limit(batchSize)
       .offset(offset)
@@ -67,36 +57,22 @@ const migrateUp = async (trx: Knex, db: Database) => {
 
     const uid = meta.uid as UID.ContentType;
     const model = strapi.getModel(uid);
-
     const hasDP = contentTypes.hasDraftAndPublish(model);
-    const isLocalized = strapi
-      .plugin('i18n')
-      .service('content-types')
-      .isLocalizedContentType(model);
-
     if (!hasDP) {
       continue;
     }
 
-    const discardDraft = async (entry: DocumentVersion) => {
-      const params: DiscardDraftParams<typeof uid> = { documentId: entry.documentId };
-
-      // Only add the locale param if the model is localized
-      if (isLocalized) {
-        params.locale = entry.locale;
-      }
-
+    const discardDraft = async (entry: DocumentVersion) =>
       strapi
         .documents(uid)
-        // Discard draft by referencing the documentId (and locale if the model is localized)
-        .discardDraft(params);
-    };
+        // Discard draft by referencing the documentId and locale
+        .discardDraft({ documentId: entry.documentId, locale: entry.locale });
 
     /**
      * Load a batch of entries (batched to prevent loading millions of rows at once ),
      * and discard them using the document service.
      */
-    for await (const batch of getBatchToDiscard({ db, trx, uid: meta.uid, isLocalized })) {
+    for await (const batch of getBatchToDiscard({ db, trx, uid: meta.uid })) {
       await async.map(batch, discardDraft, { concurrency: 10 });
     }
   }

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
@@ -34,7 +34,9 @@ export const createdLocale: Migration = {
       }
 
       // Create locale column if it doesn't exist
-      if (isNil(meta.attributes.locale)) {
+      const hasLocaleColumn = await knex.schema.hasColumn(meta.tableName, 'locale');
+
+      if (meta.attributes.locale && !hasLocaleColumn) {
         await createLocaleColumn(knex, meta.tableName);
       }
     }


### PR DESCRIPTION
### What does it do?

Fix an issue where locale columns did not exist during the v4->v5 migrations,

The `5.0.0-03-locale.ts` migration was not working properly and not creating the `locale` column 
