### PR TITLE
fix: remove sticky review workflow nav

### DIFF
--- a/packages/core/review-workflows/admin/src/routes/settings/components/Layout.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/Layout.tsx
@@ -86,7 +86,7 @@ const Header: React.FC<HeaderProps> = ({ title, subtitle, navigationAction, prim
           }
         )}
       </Page.Title>
-      <Layouts.Header
+      <Layouts.BaseHeader
         navigationAction={navigationAction}
         primaryAction={primaryAction}
         title={title}

--- a/packages/core/review-workflows/admin/src/routes/settings/components/Stages.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/Stages.tsx
@@ -70,17 +70,9 @@ const Stages = ({ canDelete = true, canUpdate = true, isCreating }: StagesProps)
           position="absolute"
           top="0"
           width={2}
-          zIndex={1}
         />
 
-        <Flex
-          direction="column"
-          alignItems="stretch"
-          gap={6}
-          zIndex={2}
-          position="relative"
-          tag="ol"
-        >
+        <Flex direction="column" alignItems="stretch" gap={6} position="relative" tag="ol">
           {stages.map((stage, index) => {
             return (
               <Box key={stage.__temp_key__} tag="li">


### PR DESCRIPTION
### What does it do?

Fixes the z-index bug in the review workflow edit view by making the header not sticky. I checked with @lucasboilly and the sticky behavior was not necessary on that page

### Related issue(s)/PR(s)

fixes #20211