### PR TITLE
fix: split single & bulk delete

### DIFF
--- a/packages/core/admin/admin/src/components/ConfirmDialog.tsx
+++ b/packages/core/admin/admin/src/components/ConfirmDialog.tsx
@@ -93,7 +93,13 @@ const ConfirmDialog = ({
       <Dialog.Footer>
         {startAction || (
           <Dialog.Cancel>
-            <Button fullWidth variant="tertiary">
+            <Button
+              fullWidth
+              variant="tertiary"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
               {formatMessage({
                 id: 'app.components.Button.cancel',
                 defaultMessage: 'Cancel',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
@@ -103,7 +103,32 @@ const ListPage = () => {
     }
   };
 
-  const confirmDelete = async () => {
+  const deleteWebhook = async (id: string) => {
+    try {
+      const res = await deleteManyWebhooks({
+        ids: [id],
+      });
+
+      if ('error' in res) {
+        toggleNotification({
+          type: 'danger',
+          message: formatAPIError(res.error),
+        });
+
+        return;
+      }
+    } catch {
+      toggleNotification({
+        type: 'danger',
+        message: formatMessage({
+          id: 'notification.error',
+          defaultMessage: 'An error occurred',
+        }),
+      });
+    }
+  };
+
+  const confirmBulkDelete = async () => {
     try {
       const res = await deleteManyWebhooks({
         ids: webhooksToDelete,
@@ -349,20 +374,11 @@ const ListPage = () => {
                           </IconButton>
                         )}
                         {canDelete && (
-                          <IconButton
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setWebhooksToDelete([webhook.id]);
-                              setShowModal(true);
+                          <DeleteActionButton
+                            onDelete={() => {
+                              deleteWebhook(webhook.id);
                             }}
-                            label={formatMessage({
-                              id: 'Settings.webhooks.events.delete',
-                              defaultMessage: 'Delete webhook',
-                            })}
-                            borderWidth={0}
-                          >
-                            <Trash />
-                          </IconButton>
+                          />
                         )}
                       </Flex>
                     </Td>
@@ -392,9 +408,49 @@ const ListPage = () => {
         </Layouts.Content>
       </Page.Main>
       <Dialog.Root open={showModal} onOpenChange={setShowModal}>
-        <ConfirmDialog onConfirm={confirmDelete} />
+        <ConfirmDialog onConfirm={confirmBulkDelete} />
       </Dialog.Root>
     </Layouts.Root>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * DeleteActionButton
+ * -----------------------------------------------------------------------------------------------*/
+
+type DeleteActionButtonProps = {
+  onDelete: () => void;
+};
+
+const DeleteActionButton = ({ onDelete }: DeleteActionButtonProps) => {
+  const [showModal, setShowModal] = React.useState(false);
+  const { formatMessage } = useIntl();
+
+  return (
+    <>
+      <IconButton
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowModal(true);
+        }}
+        label={formatMessage({
+          id: 'Settings.webhooks.events.delete',
+          defaultMessage: 'Delete webhook',
+        })}
+        borderWidth={0}
+      >
+        <Trash />
+      </IconButton>
+
+      <Dialog.Root open={showModal} onOpenChange={setShowModal}>
+        <ConfirmDialog
+          onConfirm={(e) => {
+            e?.stopPropagation();
+            onDelete();
+          }}
+        />
+      </Dialog.Root>
+    </>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
@@ -117,6 +117,8 @@ const ListPage = () => {
 
         return;
       }
+
+      setWebhooksToDelete((prev) => prev.filter((webhookId) => webhookId !== id));
     } catch {
       toggleNotification({
         type: 'danger',

--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -131,7 +131,7 @@ const createBuildContext = async <TOptions extends BaseOptions>({
 
   const features = strapiInstance.config.get('features', undefined);
 
-  const { bundler = 'webpack', ...restOptions } = options;
+  const { bundler = 'vite', ...restOptions } = options;
 
   const buildContext = {
     appDir,

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/index.jsx
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/index.jsx
@@ -104,7 +104,7 @@ const ConfigureTheView = ({ config }) => {
           </Layouts.Content>
 
           <Dialog.Root open={showWarningSubmit} onOpenChange={toggleWarningSubmit}>
-            <ConfirmDialog onConfirm={handleConfirm} variant="success-light">
+            <ConfirmDialog onConfirm={handleConfirm} variant="default">
               {formatMessage({
                 id: getTrad('config.popUpWarning.warning.updateAllSettings'),
                 defaultMessage: 'This will modify all your settings',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Separates concerns between bulk & single webhook delete. the UX was pretty strange (when clicking on the trash icon it opens a confirm but also selects in the bulk delete in the background)

