### PR TITLE
fix: drop slug fields index

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.ts
@@ -9,10 +9,12 @@ import type { Knex } from 'knex';
 
 import type { Migration } from '../common';
 
-const dropIndex = async (knex: Knex, tableName: string, columName: string) => {
+const dropIndex = async (knex: Knex, tableName: string, columnName: string) => {
   try {
     await knex.schema.alterTable(tableName, (table) => {
-      table.dropUnique([columName]);
+      // NOTE: Can not use "identifiers" utility, as the 5.0.0-01 migration does not rename this particular index
+      // to `tableName_columnName_uq`.
+      table.dropUnique([columnName], `${tableName}_${columnName}_unique`);
     });
   } catch (error) {
     // If unique index does not exist, do nothing

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-05-drop-slug-unique-index.ts
@@ -1,0 +1,41 @@
+/**
+ * In V4 slug fields contained a unique index.
+ * In V5 slug fields should not have a unique index.
+ *
+ * This migration drops existing unique indexes from slug fields so downstream migrations
+ * can work on the data without violating the unique index.
+ */
+import type { Knex } from 'knex';
+
+import type { Migration } from '../common';
+
+const dropIndex = async (knex: Knex, tableName: string, columName: string) => {
+  try {
+    await knex.schema.alterTable(tableName, (table) => {
+      table.dropUnique([columName]);
+    });
+  } catch (error) {
+    // If unique index does not exist, do nothing
+  }
+};
+
+export const dropSlugFieldsIndex: Migration = {
+  name: '5.0.0-05-drop-slug-fields-index',
+  async up(knex, db) {
+    for (const meta of db.metadata.values()) {
+      const hasTable = await knex.schema.hasTable(meta.tableName);
+      if (!hasTable) {
+        continue;
+      }
+
+      for (const attribute of Object.values(meta.attributes)) {
+        if (attribute.type === 'uid' && attribute.columnName) {
+          await dropIndex(knex, meta.tableName, attribute.columnName);
+        }
+      }
+    }
+  },
+  async down() {
+    throw new Error('not implemented');
+  },
+};

--- a/packages/core/database/src/migrations/internal-migrations/index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/index.ts
@@ -3,6 +3,7 @@ import { createdDocumentId } from './5.0.0-02-document-id';
 import { renameIdentifiersLongerThanMaxLength } from './5.0.0-01-convert-identifiers-long-than-max-length';
 import { createdLocale } from './5.0.0-03-locale';
 import { createdPublishedAt } from './5.0.0-04-published-at';
+import { dropSlugFieldsIndex } from './5.0.0-05-drop-slug-unique-index';
 
 /**
  * List of all the internal migrations. The array order will be the order in which they are executed.
@@ -18,4 +19,5 @@ export const internalMigrations: Migration[] = [
   createdDocumentId,
   createdLocale,
   createdPublishedAt,
+  dropSlugFieldsIndex,
 ];


### PR DESCRIPTION
### What does it do?

Adds a migration to drop the unique index of slug fields, those are automatically removed by the strapi schema diff, but that diff is executed after the migrations, and  `discard-draft` migration will fail if there are such indexes.
