### PR TITLE
fix: content manager header spacings

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -8,11 +8,10 @@ import {
   useStrapiApp,
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
-import { Flex, SingleSelect, SingleSelectOption, Typography } from '@strapi/design-system';
+import { Box, Flex, SingleSelect, SingleSelectOption, Typography } from '@strapi/design-system';
 import { ListPlus, Pencil, Trash, WarningCircle } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { styled } from 'styled-components';
 
 import { RelativeTime } from '../../../components/RelativeTime';
 import {
@@ -57,21 +56,19 @@ const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: Heade
     : documentTitle;
 
   return (
-    <Flex direction="column" alignItems="flex-start" paddingTop={8} paddingBottom={4} gap={3}>
+    <Flex direction="column" alignItems="flex-start" paddingTop={6} paddingBottom={4} gap={2}>
       <BackButton />
-      <Flex
-        width="100%"
-        justifyContent="space-between"
-        paddingTop={1}
-        gap="80px"
-        alignItems="flex-start"
-      >
+      <Flex width="100%" justifyContent="space-between" gap="80px" alignItems="flex-start">
         <Typography variant="alpha" tag="h1">
           {title}
         </Typography>
         <HeaderToolbar />
       </Flex>
-      {status ? <DocumentStatus status={isCloning ? 'draft' : status} /> : null}
+      {status ? (
+        <Box marginTop={1}>
+          <DocumentStatus status={isCloning ? 'draft' : status} />
+        </Box>
+      ) : null}
     </Flex>
   );
 };


### PR DESCRIPTION
### Why is it needed?

The spacings in the code did not match the figma specs. requested by @lucasboilly 

### How to test it?

Open the edit view and measure the header vertical spacings against this design: https://www.figma.com/design/Tt8uHuQezEP0CsWunbulb5/Draft-%26-Publish?node-id=3110-129977&t=dLozjwwg0q2Iubbl-0
### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
