### PR TITLE
fix: components count in ctb menu

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
@@ -23,22 +23,19 @@ export const ContentTypeBuilderNav = () => {
   const { menu, searchValue, onSearchChange } = useContentTypeBuilderMenu();
   const { formatMessage } = useIntl();
 
+  const pluginName = formatMessage({
+    id: getTrad('plugin.name'),
+    defaultMessage: 'Content-Type Builder',
+  });
+
   return (
-    <SubNav
-      aria-label={formatMessage({
-        id: `${getTrad('plugin.name')}`,
-        defaultMessage: 'Content-Types Builder',
-      })}
-    >
+    <SubNav aria-label={pluginName}>
       <SubNavHeader
         searchable
         value={searchValue}
         onClear={() => onSearchChange('')}
         onChange={(e) => onSearchChange(e.target.value)}
-        label={formatMessage({
-          id: `${getTrad('plugin.name')}`,
-          defaultMessage: 'Content-Types Builder',
-        })}
+        label={pluginName}
         searchLabel={formatMessage({
           id: 'global.search',
           defaultMessage: 'Search',
@@ -53,7 +50,7 @@ export const ContentTypeBuilderNav = () => {
                 defaultMessage: section.title.defaultMessage,
               })}
               collapsable
-              badgeLabel={section.links.length.toString()}
+              badgeLabel={section.linksCount}
             >
               {section.links.map((link) => {
                 if (link.links) {

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
@@ -50,7 +50,7 @@ export const ContentTypeBuilderNav = () => {
                 defaultMessage: section.title.defaultMessage,
               })}
               collapsable
-              badgeLabel={section.linksCount}
+              badgeLabel={section.linksCount.toString()}
             >
               {section.links.map((link) => {
                 if (link.links) {

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -405,7 +405,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
     class="c0"
   >
     <nav
-      aria-label="Content-Types Builder"
+      aria-label="Content-Type Builder"
       class="c1"
     >
       <div
@@ -417,7 +417,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
           <h2
             class="c5"
           >
-            Content-Types Builder
+            Content-Type Builder
           </h2>
           <button
             aria-disabled="false"
@@ -730,7 +730,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                     <span
                       class="c28"
                     >
-                      2
+                      3
                     </span>
                   </div>
                 </div>

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/mockData.ts
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/mockData.ts
@@ -31,6 +31,7 @@ export const mockData = [
         restrictRelationsTo: null,
       },
     ],
+    linksCount: 2,
   },
   {
     name: 'singleTypes',
@@ -54,6 +55,7 @@ export const mockData = [
         restrictRelationsTo: null,
       },
     ],
+    linksCount: 1,
   },
   {
     name: 'components',
@@ -96,5 +98,6 @@ export const mockData = [
         ],
       },
     ],
+    linksCount: 3,
   },
 ];

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
@@ -175,6 +175,8 @@ export const useContentTypeBuilderMenu = () => {
     const hasChild = section.links.some((l) => Array.isArray(l.links));
 
     if (hasChild) {
+      let filteredLinksCount = 0;
+
       return {
         ...section,
         links: section.links
@@ -185,22 +187,26 @@ export const useContentTypeBuilderMenu = () => {
               return null;
             }
 
+            filteredLinksCount += filteredLinks.length;
+
             return {
               ...link,
               links: filteredLinks.sort((a: any, b: any) => formatter.compare(a.title, b.title)),
             };
           })
           .filter(Boolean),
-        linksCount: section.links.reduce((acc, link) => acc + link.links.length, 0),
+        linksCount: filteredLinksCount,
       };
     }
 
+    const fileteredLinks = section.links
+      .filter((link) => startsWith(link.title, search))
+      .sort((a, b) => formatter.compare(a.title, b.title));
+
     return {
       ...section,
-      links: section.links
-        .filter((link) => startsWith(link.title, search))
-        .sort((a, b) => formatter.compare(a.title, b.title)),
-      linksCount: section.links.length,
+      links: fileteredLinks,
+      linksCount: fileteredLinks.length,
     };
   });
 

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
@@ -191,6 +191,7 @@ export const useContentTypeBuilderMenu = () => {
             };
           })
           .filter(Boolean),
+        linksCount: section.links.reduce((acc, link) => acc + link.links.length, 0),
       };
     }
 
@@ -199,6 +200,7 @@ export const useContentTypeBuilderMenu = () => {
       links: section.links
         .filter((link) => startsWith(link.title, search))
         .sort((a, b) => formatter.compare(a.title, b.title)),
+      linksCount: section.links.length,
     };
   });
 

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
@@ -199,14 +199,14 @@ export const useContentTypeBuilderMenu = () => {
       };
     }
 
-    const fileteredLinks = section.links
+    const filteredLinks = section.links
       .filter((link) => startsWith(link.title, search))
       .sort((a, b) => formatter.compare(a.title, b.title));
 
     return {
       ...section,
-      links: fileteredLinks,
-      linksCount: fileteredLinks.length,
+      links: filteredLinks,
+      linksCount: filteredLinks.length,
     };
   });
 


### PR DESCRIPTION
### What does it do?

- The CTB menu counted the amount of folders, not of components. Fixes it
- Fixes a defaultMessage that didn't match the translation file values (hence the snapshot update)

### How to test it?

Open the CTB, make sure the count of components, single types and collection types is accurate. Use the search to filter the result, the counts should be updated.
