### PR TITLE
fix: rich text editor ui issues

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -50,13 +50,13 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
 
     if (collectionType === COLLECTION_TYPES) {
       return {
-        pathname: `/content-manager/${collectionType}/${version.contentType}/${version.relatedDocumentId}`,
+        pathname: '..',
         search: pluginsQueryParams,
       };
     }
 
     return {
-      pathname: `/content-manager/${collectionType}/${version.contentType}`,
+      pathname: '..',
       search: pluginsQueryParams,
     };
   };
@@ -74,7 +74,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
       });
 
       if ('data' in response) {
-        navigate(getNextNavigation());
+        navigate(getNextNavigation(), { relative: 'path' });
 
         toggleNotification({
           type: 'success',
@@ -134,7 +134,13 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
           </Typography>
         }
         navigationAction={
-          <Link startIcon={<ArrowLeft />} tag={NavLink} to={getNextNavigation()} isExternal={false}>
+          <Link
+            startIcon={<ArrowLeft />}
+            tag={NavLink}
+            to={getNextNavigation()}
+            relative="path"
+            isExternal={false}
+          >
             {formatMessage({
               id: 'global.back',
               defaultMessage: 'Back',

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -575,13 +575,13 @@ const PublishAction: DocumentActionComponent = ({
         );
 
         if ('data' in res && collectionType !== SINGLE_TYPES) {
-          /**
-           * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
-           */
-          navigate({
-            pathname: `../${collectionType}/${model}/${res.data.documentId}`,
-            search: rawQuery,
-          });
+          navigate(
+            {
+              pathname: `../${res.data.documentId}`,
+              search: rawQuery,
+            },
+            { relative: 'path' }
+          );
         } else if (
           'error' in res &&
           isBaseQueryError(res.error) &&
@@ -674,13 +674,13 @@ const UpdateAction: DocumentActionComponent = ({
           );
 
           if ('data' in res) {
-            /**
-             * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
-             */
-            navigate({
-              pathname: `../${collectionType}/${model}/${res.data.documentId}`,
-              search: rawQuery,
-            });
+            navigate(
+              {
+                pathname: `../${res.data.documentId}`,
+                search: rawQuery,
+              },
+              { relative: 'path' }
+            );
           } else if (
             'error' in res &&
             isBaseQueryError(res.error) &&
@@ -718,15 +718,12 @@ const UpdateAction: DocumentActionComponent = ({
           );
 
           if ('data' in res && collectionType !== SINGLE_TYPES) {
-            /**
-             * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
-             */
             navigate(
               {
-                pathname: `../${collectionType}/${model}/${res.data.documentId}`,
+                pathname: `../${res.data.documentId}`,
                 search: rawQuery,
               },
-              { replace: true }
+              { replace: true, relative: 'path' }
             );
           } else if (
             'error' in res &&

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -103,7 +103,7 @@ const DragIconButton = styled<IconButtonComponent<'div'>>(IconButton)<{
   }
   svg {
     height: auto;
-    width: ${({ theme }) => theme.spaces[3]};
+    min-width: ${({ theme }) => theme.spaces[3]};
 
     path {
       fill: ${({ theme }) => theme.colors.neutral700};
@@ -248,7 +248,7 @@ const DragAndDropElement = ({
             // For some blocks top margin added to drag handle to align at the text level
             $dragHandleTopMargin={dragHandleTopMargin}
           >
-            <Drag color="neutral600" />
+            <Drag color="primary500" />
           </DragIconButton>
           {children}
         </DragItem>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -253,7 +253,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
               <BlocksContent {...contentProps} />
               {!isExpandedMode && (
                 <ExpandIconButton
-                  aria-label={formatMessage({
+                  label={formatMessage({
                     id: getTranslation('components.Blocks.expand'),
                     defaultMessage: 'Expand',
                   })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
@@ -76,7 +76,7 @@ const EditorLayout = ({
               <Flex height="100%" alignItems="flex-start" direction="column">
                 {children}
                 <CollapseIconButton
-                  aria-label={formatMessage({
+                  label={formatMessage({
                     id: getTranslation('components.Blocks.collapse'),
                     defaultMessage: 'Collapse',
                   })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/WysiwygFooter.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/WysiwygFooter.tsx
@@ -15,7 +15,7 @@ const WysiwygFooter = ({ onToggleExpand }: WysiwygFooterProps) => {
     <Box padding={2} background="neutral100" borderRadius={`0 0 0.4rem 0.4rem`}>
       <Flex justifyContent="flex-end" alignItems="flex-end">
         <ExpandButton id="expand" onClick={onToggleExpand}>
-          <Typography>
+          <Typography textColor="neutral800">
             {formatMessage({
               id: 'components.WysiwygBottomControls.fullscreen',
               defaultMessage: 'Expand',


### PR DESCRIPTION
### What does it do?

Chore:
- Uses React Router relative links to simplify the routing logic. [It relies on relative="path" API](https://reactrouter.com/en/main/components/link#relative)

Fixes:
- Fixes the color issue on the "expand" button in the markdown editor
- Fixes the Blocks editor issue where the drag handle icon was not visible
- Fixes the Blocks editor issue where the tooltip was not visible on the expand/collapse buttons
