### PR TITLE
fix: history action position in menu

### DIFF
--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -125,7 +125,6 @@ class ContentManagerPlugin {
     ...DEFAULT_ACTIONS,
     ...DEFAULT_TABLE_ROW_ACTIONS,
     ...DEFAULT_HEADER_ACTIONS,
-    HistoryAction,
   ];
   editViewSidePanels: PanelComponent[] = [ActionsPanel];
   headerActions: HeaderActionComponent[] = [];

--- a/packages/core/content-manager/admin/src/history/index.ts
+++ b/packages/core/content-manager/admin/src/history/index.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from '@strapi/types';
+import type { StrapiApp } from '@strapi/admin/strapi-admin';
+import { DocumentActionComponent } from 'src';
+import { HistoryAction } from './components/HistoryAction';
+import { ContentManagerPlugin } from 'src/content-manager';
+
+const historyAdmin: Partial<Plugin.Config.AdminInput> = {
+  bootstrap(app: StrapiApp) {
+    const { addDocumentAction } = app.getPlugin('content-manager').apis as {
+      addDocumentAction: ContentManagerPlugin['addDocumentAction'];
+    };
+
+    /**
+     * Register the document action here using the public API, and not by setting the action in the
+     * Content Manager directly, because this API lets us control the order of the actions array.
+     * We want history to be the last non-delete action in the array.
+     */
+    addDocumentAction((actions) => {
+      const indexOfDeleteAction = actions.findIndex((action) => action.type === 'delete');
+      actions.splice(indexOfDeleteAction, 0, HistoryAction);
+      return actions;
+    });
+  },
+};
+
+export { historyAdmin };

--- a/packages/core/content-manager/admin/src/history/index.ts
+++ b/packages/core/content-manager/admin/src/history/index.ts
@@ -1,8 +1,11 @@
-import type { Plugin } from '@strapi/types';
-import type { StrapiApp } from '@strapi/admin/strapi-admin';
-import { DocumentActionComponent } from 'src';
+/* eslint-disable check-file/no-index */
+
+import { type ContentManagerPlugin } from '../content-manager';
+
 import { HistoryAction } from './components/HistoryAction';
-import { ContentManagerPlugin } from 'src/content-manager';
+
+import type { StrapiApp } from '@strapi/admin/strapi-admin';
+import type { Plugin } from '@strapi/types';
 
 const historyAdmin: Partial<Plugin.Config.AdminInput> = {
   bootstrap(app: StrapiApp) {

--- a/packages/core/content-manager/admin/src/index.ts
+++ b/packages/core/content-manager/admin/src/index.ts
@@ -2,6 +2,7 @@ import { Feather } from '@strapi/icons';
 
 import { PLUGIN_ID } from './constants/plugin';
 import { ContentManagerPlugin } from './content-manager';
+import { historyAdmin } from './history';
 import { reducer } from './modules/reducers';
 import { routes } from './router';
 import { prefixPluginTranslations } from './utils/translations';
@@ -39,6 +40,11 @@ export default {
     });
 
     app.registerPlugin(cm.config);
+  },
+  bootstrap(app: any) {
+    if (typeof historyAdmin.bootstrap === 'function') {
+      historyAdmin.bootstrap(app);
+    }
   },
   async registerTrads({ locales }: { locales: string[] }) {
     const importedTrads = await Promise.all(

--- a/packages/core/content-manager/admin/src/tests/content-manager.test.ts
+++ b/packages/core/content-manager/admin/src/tests/content-manager.test.ts
@@ -166,14 +166,10 @@ describe('content-manager', () => {
     it('should let users add a document action as an array', () => {
       const plugin = new ContentManagerPlugin();
 
-      expect(plugin.documentActions).toHaveLength(1);
+      expect(plugin.documentActions).toHaveLength(0);
 
       // ensure we have our default options
-      expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`
-        [
-          "history",
-        ]
-      `);
+      expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`[]`);
 
       plugin.addDocumentAction([
         () => ({
@@ -183,11 +179,10 @@ describe('content-manager', () => {
         }),
       ]);
 
-      expect(plugin.documentActions).toHaveLength(2);
+      expect(plugin.documentActions).toHaveLength(1);
       // ensure we have our default options, with the new option, which will not have a type
       expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`
         [
-          "history",
           undefined,
         ]
       `);
@@ -196,14 +191,10 @@ describe('content-manager', () => {
     it('should let you mutate the existing array of panels with a reducer function', () => {
       const plugin = new ContentManagerPlugin();
 
-      expect(plugin.documentActions).toHaveLength(1);
+      expect(plugin.documentActions).toHaveLength(0);
 
       // ensure we have our default options
-      expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`
-        [
-          "history",
-        ]
-      `);
+      expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`[]`);
 
       const action: DocumentActionComponent = () => ({
         label: 'Publish & Notify Twitter',
@@ -213,11 +204,10 @@ describe('content-manager', () => {
 
       plugin.addDocumentAction((prev) => [...prev, action]);
 
-      expect(plugin.documentActions).toHaveLength(2);
+      expect(plugin.documentActions).toHaveLength(1);
       // ensure we have our default options, with the new option, which will not have a type. The defaults should still be at the front.
       expect(plugin.documentActions.map((action) => action.type)).toMatchInlineSnapshot(`
         [
-          "history",
           undefined,
         ]
       `);

--- a/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
@@ -19,7 +19,7 @@ import {
   Field,
   Modal,
 } from '@strapi/design-system';
-import { Cursor } from '@strapi/icons';
+import { PaperPlane } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { useFormik } from 'formik';
 import { useIntl } from 'react-intl';
@@ -256,7 +256,7 @@ const ReleaseActionModalForm: DocumentActionComponent = ({
       id: 'content-releases.content-manager-edit-view.add-to-release',
       defaultMessage: 'Add to release',
     }),
-    icon: <Cursor />,
+    icon: <PaperPlane />,
     position: ['panel', 'table-row'],
     dialog: {
       type: 'modal',

--- a/packages/core/strapi/src/admin.ts
+++ b/packages/core/strapi/src/admin.ts
@@ -12,7 +12,6 @@ const render = (mountNode: HTMLElement | null, { plugins, ...restArgs }: RenderA
   return renderAdmin(mountNode, {
     ...restArgs,
     plugins: {
-      // @ts-expect-error – TODO: fix this
       'content-manager': contentManager,
       'content-type-builder': contentTypeBuilder,
       // @ts-expect-error – TODO: fix this


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the position of the history document action in the edit view header. It used to show up last, but the designs specify it has to show up in the middle, right before the "danger" actions.

I'm doing it by using the public addDocumentAction, instead of setting it in the default array. It's the [same approach as done in i18n](https://github.com/strapi/strapi/blob/93fad71560acac3452f5fbd9b63fe0490e9eaedd/packages/plugins/i18n/admin/src/index.ts#L72-L76) to control the action's position in the array.

