### PR TITLE
fix(content-manager): dismiss bulk list view publish

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
@@ -32,7 +32,7 @@ const ConfirmBulkActionDialog = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Dialog.Root onOpenChange={onToggleDialog} open={isOpen}>
+    <Dialog.Root open={isOpen}>
       <Dialog.Content>
         <Dialog.Header>
           {formatMessage({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### Why is it needed?

Clicking cancel at the confirmation stage of a bulk list view publish does nothing.
The modal is being toggled multiple times and therefore staying visible

### Related issue(s)/PR(s)

DX-1482
