### PR TITLE
fix: duplicated audit log events

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -112,11 +112,7 @@ const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
     const processedEvent = processEvent(name, ...args);
 
     if (processedEvent) {
-      // This stores the event when after the transaction is committed,
-      // so it's not stored if the transaction is rolled back
-      await strapi.db.transaction(({ onCommit }) => {
-        onCommit(() => auditLogsService.saveEvent(processedEvent));
-      });
+      await auditLogsService.saveEvent(processedEvent);
     }
   };
 


### PR DESCRIPTION
### What does it do?

Publishing an entry resulted in duplicated "entry.update" logs in the audit logs settings page. 

The cause is a bug in how we stored events in audit logs:

```ts
await strapi.db.transaction(({ onCommit }) => {
        onCommit(() => auditLogsService.saveEvent(processedEvent));
      });
```
See the explanation of why this was introduced in https://github.com/strapi/strapi/pull/16768

This bit of code is not necessary anymore, as the document service emits the events using this same api.
**To dig more: For some reason, nested onCommit calls (a callback inside an oncommit opening another transaction with an onCommit call inside) caused the callbacks to be called twice**
