### PR TITLE
feat(release-settings): apply rbac permission in the release settings page

### DIFF
--- a/packages/core/admin/admin/src/types/permissions.ts
+++ b/packages/core/admin/admin/src/types/permissions.ts
@@ -8,7 +8,7 @@ type SettingsPermissions =
   | 'users'
   | 'webhooks';
 
-type EESettingsPermissions = 'auditLogs' | 'review-workflows' | 'sso';
+type EESettingsPermissions = 'auditLogs' | 'review-workflows' | 'sso' | 'releases';
 
 type CRUDPermissions = {
   main?: Permission[];

--- a/packages/core/admin/ee/admin/src/constants.ts
+++ b/packages/core/admin/ee/admin/src/constants.ts
@@ -21,9 +21,23 @@ export const ADMIN_PERMISSIONS_EE = {
       read: [{ action: 'admin::provider-login.read', subject: null }],
       update: [{ action: 'admin::provider-login.update', subject: null }],
     },
+    releases: {
+      read: [
+        {
+          action: 'plugin::content-releases.settings.read',
+          subject: null,
+        },
+      ],
+      update: [
+        {
+          action: 'plugin::content-releases.settings.update',
+          subject: null,
+        },
+      ],
+    },
   },
 } satisfies {
-  settings: Pick<PermissionMap['settings'], 'auditLogs' | 'review-workflows' | 'sso'>;
+  settings: Pick<PermissionMap['settings'], 'auditLogs' | 'review-workflows' | 'sso' | 'releases'>;
 };
 
 /**

--- a/packages/core/content-releases/admin/src/constants.ts
+++ b/packages/core/content-releases/admin/src/constants.ts
@@ -72,3 +72,26 @@ export const PERMISSIONS = {
     },
   ],
 } satisfies Record<string, StrapiPermission[]>;
+
+export const PERMISSIONS_SETTINGS = {
+  read: [
+    {
+      action: 'plugin::content-releases.settings.read',
+      subject: null,
+      id: '',
+      actionParameters: {},
+      properties: {},
+      conditions: [],
+    },
+  ],
+  update: [
+    {
+      action: 'plugin::content-releases.settings.update',
+      subject: null,
+      id: '',
+      actionParameters: {},
+      properties: {},
+      conditions: [],
+    },
+  ],
+} satisfies Record<string, StrapiPermission[]>;

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -65,8 +65,8 @@ const admin: Plugin.Config.AdminInput = {
         },
         permissions: [],
         async Component() {
-          const { SettingsPage } = await import('./pages/SettingsPage');
-          return { default: SettingsPage };
+          const { ProtectedReleasesSettingsPage } = await import('./pages/ReleasesSettingsPage');
+          return { default: ProtectedReleasesSettingsPage };
         },
       });
 

--- a/packages/core/content-releases/admin/src/modules/hooks.ts
+++ b/packages/core/content-releases/admin/src/modules/hooks.ts
@@ -1,0 +1,11 @@
+import { Dispatch } from '@reduxjs/toolkit';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+import type { Store } from '@strapi/admin/strapi-admin';
+
+type RootState = ReturnType<Store['getState']>;
+
+const useTypedDispatch: () => Dispatch = useDispatch;
+const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export { useTypedSelector, useTypedDispatch };

--- a/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
@@ -96,7 +96,7 @@ export const ReleasesSettingsPage = () => {
         <Form
           method="PUT"
           initialValues={{
-            defaultTimezone: data?.data.defaultTimezone || '',
+            defaultTimezone: data?.data.defaultTimezone,
           }}
           onSubmit={handleSubmit}
           validationSchema={SETTINGS_SCHEMA}

--- a/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
@@ -27,7 +27,7 @@ import { getTimezones } from '../utils/time';
 
 import type { UpdateSettings } from '../../../shared/contracts/settings';
 
-export const ReleasesSettingsPage = () => {
+const ReleasesSettingsPage = () => {
   const { formatMessage } = useIntl();
   const { formatAPIError } = useAPIErrorHandler();
   const { toggleNotification } = useNotification();

--- a/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   isFetchError,
   useNotification,
   useField,
+  useRBAC,
 } from '@strapi/admin/strapi-admin';
 import {
   Button,
@@ -20,19 +21,28 @@ import { Check } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { SETTINGS_SCHEMA } from '../../../shared/validation-schemas';
+import { useTypedSelector } from '../modules/hooks';
 import { useGetReleaseSettingsQuery, useUpdateReleaseSettingsMutation } from '../services/release';
 import { getTimezones } from '../utils/time';
 
 import type { UpdateSettings } from '../../../shared/contracts/settings';
 
-export const SettingsPage = () => {
+export const ReleasesSettingsPage = () => {
   const { formatMessage } = useIntl();
+  const { formatAPIError } = useAPIErrorHandler();
+  const { toggleNotification } = useNotification();
   const { data, isLoading: isLoadingSettings } = useGetReleaseSettingsQuery();
   const [updateReleaseSettings, { isLoading: isSubmittingForm }] =
     useUpdateReleaseSettingsMutation();
-  const { toggleNotification } = useNotification();
-  const { formatAPIError } = useAPIErrorHandler();
+  const permissions = useTypedSelector(
+    (state) => state.admin_app.permissions['settings']?.['releases']
+  );
+  const {
+    allowedActions: { canUpdate },
+  } = useRBAC(permissions);
+
   const { timezoneList } = getTimezones(new Date());
+
   const handleSubmit = async (body: UpdateSettings.Request['body']) => {
     const { defaultTimezone } = body;
     const isBodyTimezoneValid = timezoneList.some((timezone) => timezone.value === defaultTimezone);
@@ -85,13 +95,9 @@ export const SettingsPage = () => {
       <Page.Main aria-busy={isLoadingSettings} tabIndex={-1}>
         <Form
           method="PUT"
-          initialValues={
-            data?.data.defaultTimezone
-              ? data.data
-              : {
-                  defaultTimezone: null,
-                }
-          }
+          initialValues={{
+            defaultTimezone: data?.data.defaultTimezone || '',
+          }}
           onSubmit={handleSubmit}
           validationSchema={SETTINGS_SCHEMA}
         >
@@ -100,17 +106,19 @@ export const SettingsPage = () => {
               <>
                 <Layouts.Header
                   primaryAction={
-                    <Button
-                      disabled={!modified || isSubmittingForm}
-                      loading={isSubmitting}
-                      startIcon={<Check />}
-                      type="submit"
-                    >
-                      {formatMessage({
-                        id: 'global.save',
-                        defaultMessage: 'Save',
-                      })}
-                    </Button>
+                    canUpdate ? (
+                      <Button
+                        disabled={!modified || isSubmittingForm}
+                        loading={isSubmitting}
+                        startIcon={<Check />}
+                        type="submit"
+                      >
+                        {formatMessage({
+                          id: 'global.save',
+                          defaultMessage: 'Save',
+                        })}
+                      </Button>
+                    ) : null
                   }
                   title={formatMessage({
                     id: 'content-releases.pages.Settings.releases.title',
@@ -154,6 +162,12 @@ export const SettingsPage = () => {
 };
 
 const TimezoneDropdown = () => {
+  const permissions = useTypedSelector(
+    (state) => state.admin_app.permissions['settings']?.['releases']
+  );
+  const {
+    allowedActions: { canUpdate },
+  } = useRBAC(permissions);
   const { formatMessage } = useIntl();
   const { timezoneList } = getTimezones(new Date());
   const field = useField('defaultTimezone');
@@ -177,7 +191,8 @@ const TimezoneDropdown = () => {
         onChange={(value) => field.onChange('defaultTimezone', value)}
         onTextValueChange={(value) => field.onChange('defaultTimezone', value)}
         onClear={() => field.onChange('defaultTimezone', '')}
-        value={field.value ?? ''}
+        value={field.value}
+        disabled={!canUpdate}
       >
         {timezoneList.map((timezone) => (
           <ComboboxOption key={timezone.value} value={timezone.value}>
@@ -188,5 +203,21 @@ const TimezoneDropdown = () => {
       <Field.Hint />
       <Field.Error />
     </Field.Root>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * ProtectedSettingsPage
+ * -----------------------------------------------------------------------------------------------*/
+
+export const ProtectedReleasesSettingsPage = () => {
+  const permissions = useTypedSelector(
+    (state) => state.admin_app.permissions['settings']?.['releases']?.read
+  );
+
+  return (
+    <Page.Protect permissions={permissions}>
+      <ReleasesSettingsPage />
+    </Page.Protect>
   );
 };

--- a/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
@@ -2,7 +2,8 @@ import { useRBAC } from '@strapi/admin/strapi-admin';
 import { render, server, screen } from '@tests/utils';
 import { rest } from 'msw';
 
-import { ReleasesSettingsPage, ProtectedReleasesSettingsPage } from '../ReleasesSettingsPage';
+import { useTypedSelector } from '../../modules/hooks';
+import { ProtectedReleasesSettingsPage } from '../ReleasesSettingsPage';
 
 jest.mock('@strapi/admin/strapi-admin', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin'),
@@ -10,6 +11,11 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
     isLoading: false,
     allowedActions: { canRead: false, canUpdate: false },
   })),
+}));
+
+jest.mock('../../modules/hooks', () => ({
+  ...jest.requireActual('../../modules/hooks'),
+  useTypedSelector: jest.fn(() => []),
 }));
 
 describe('Releases Settings page', () => {
@@ -37,6 +43,13 @@ describe('Releases Settings page', () => {
       isLoading: false,
       allowedActions: { canRead: true, canUpdate: false },
     }));
+    // @ts-expect-error – mocking
+    useTypedSelector.mockImplementation(() => [
+      {
+        action: 'plugin::content-releases.settings.read',
+        subject: null,
+      },
+    ]);
     server.use(
       rest.get('/content-releases/settings', (req, res, ctx) =>
         res(
@@ -49,7 +62,7 @@ describe('Releases Settings page', () => {
       )
     );
 
-    render(<ReleasesSettingsPage />);
+    render(<ProtectedReleasesSettingsPage />);
 
     const title = await screen.findByRole('heading', { name: 'Releases' });
     expect(title).toBeInTheDocument();
@@ -79,7 +92,7 @@ describe('Releases Settings page', () => {
       )
     );
 
-    render(<ReleasesSettingsPage />);
+    render(<ProtectedReleasesSettingsPage />);
 
     const title = await screen.findByRole('heading', { name: 'Releases' });
     expect(title).toBeInTheDocument();

--- a/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
@@ -32,6 +32,7 @@ describe('Releases Settings page', () => {
   });
 
   it('renders the settings page with read permission', async () => {
+    // @ts-expect-error – mocking
     useRBAC.mockImplementation(() => ({
       isLoading: false,
       allowedActions: { canRead: true, canUpdate: false },
@@ -61,6 +62,7 @@ describe('Releases Settings page', () => {
   });
 
   it('renders the settings page with read and update permissions', async () => {
+    // @ts-expect-error – mocking
     useRBAC.mockImplementation(() => ({
       isLoading: false,
       allowedActions: { canRead: true, canUpdate: true },

--- a/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
@@ -1,0 +1,91 @@
+import { useRBAC } from '@strapi/admin/strapi-admin';
+import { render, server, screen } from '@tests/utils';
+import { rest } from 'msw';
+
+import { ReleasesSettingsPage, ProtectedReleasesSettingsPage } from '../ReleasesSettingsPage';
+
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin'),
+  useRBAC: jest.fn(() => ({
+    isLoading: false,
+    allowedActions: { canRead: false, canUpdate: false },
+  })),
+}));
+
+describe('Releases Settings page', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the no permissions content if you do not have read permission', async () => {
+    // @ts-expect-error – mocking
+    useRBAC.mockImplementation(() => ({
+      isLoading: false,
+      allowedActions: { canRead: false, canUpdate: false },
+    }));
+
+    render(<ProtectedReleasesSettingsPage />);
+
+    expect(
+      screen.getByText("You don't have the permissions to access that content")
+    ).toBeInTheDocument();
+  });
+
+  it('renders the settings page with read permission', async () => {
+    useRBAC.mockImplementation(() => ({
+      isLoading: false,
+      allowedActions: { canRead: true, canUpdate: false },
+    }));
+    server.use(
+      rest.get('/content-releases/settings', (req, res, ctx) =>
+        res(
+          ctx.json({
+            data: {
+              defaultTimezone: '',
+            },
+          })
+        )
+      )
+    );
+
+    render(<ReleasesSettingsPage />);
+
+    const title = await screen.findByRole('heading', { name: 'Releases' });
+    expect(title).toBeInTheDocument();
+
+    const saveButton = screen.queryByRole('button', { name: 'Save' });
+    expect(saveButton).not.toBeInTheDocument();
+
+    const defaultTimezoneCombobox = screen.getByRole('combobox', { name: 'Default timezone' });
+    expect(defaultTimezoneCombobox).toBeDisabled();
+  });
+
+  it('renders the settings page with read and update permissions', async () => {
+    useRBAC.mockImplementation(() => ({
+      isLoading: false,
+      allowedActions: { canRead: true, canUpdate: true },
+    }));
+    server.use(
+      rest.get('/content-releases/settings', (req, res, ctx) =>
+        res(
+          ctx.json({
+            data: {
+              defaultTimezone: '',
+            },
+          })
+        )
+      )
+    );
+
+    render(<ReleasesSettingsPage />);
+
+    const title = await screen.findByRole('heading', { name: 'Releases' });
+    expect(title).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+
+    const defaultTimezoneCombobox = screen.getByRole('combobox', { name: 'Default timezone' });
+    expect(defaultTimezoneCombobox).toBeEnabled();
+  });
+});

--- a/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
+++ b/packages/core/content-releases/admin/src/pages/tests/ReleasesSettingsPage.test.tsx
@@ -42,7 +42,7 @@ describe('Releases Settings page', () => {
         res(
           ctx.json({
             data: {
-              defaultTimezone: '',
+              defaultTimezone: null,
             },
           })
         )

--- a/packages/core/content-releases/admin/tests/utils.tsx
+++ b/packages/core/content-releases/admin/tests/utils.tsx
@@ -10,7 +10,7 @@ import {
   type RenderOptions,
 } from '@strapi/admin/strapi-admin/test';
 
-import { PERMISSIONS } from '../src/constants';
+import { PERMISSIONS, PERMISSIONS_SETTINGS } from '../src/constants';
 
 const render = (
   ui: React.ReactElement,
@@ -18,7 +18,9 @@ const render = (
 ): ReturnType<typeof renderAdmin> =>
   renderAdmin(ui, {
     ...options,
-    providerOptions: { permissions: Object.values(PERMISSIONS).flat() },
+    providerOptions: {
+      permissions: Object.values({ ...PERMISSIONS, ...PERMISSIONS_SETTINGS }).flat(),
+    },
   });
 
 export { render, waitFor, act, screen, server };

--- a/packages/core/content-releases/shared/contracts/settings.ts
+++ b/packages/core/content-releases/shared/contracts/settings.ts
@@ -7,7 +7,7 @@ import { errors } from '@strapi/utils';
 import { Utils } from '@strapi/types';
 
 export interface Settings {
-  defaultTimezone: string | null;
+  defaultTimezone: string | null | undefined;
 }
 
 /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Apply the Read and Update permissions in the Release Settings page

Here the different scenarios:
- NO READ NO UPDATE : we show the No Permissions body content in the page
- READ NO UPDATE: we show the Release Settings Page with the Save button not shown and the Default timezone combobox disabled
- READ UPDATE: we show the normal Release Settings page with all the functionalities enabled

### Why is it needed?

To show the proper content to the different kind of users

### How to test it?

- Open the CMS with a EE license (if you want you can try to check if we show the Purchase page in the settings with CE license)
- As an admin create a new user with the Editor Role (by default the permissions are set to false)
- Go to the settings page, select the Editor Role and in the Settings Tab change the permissions for the Content Releases
- then open a new Tab in the browser and login as an Editor and check the Release Settings page with the different permissions selected

### Related issue(s)/PR(s)

CS-807
