### PR TITLE
Fix prevent category edits

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/SelectCategory.tsx
+++ b/packages/core/content-type-builder/admin/src/components/SelectCategory.tsx
@@ -15,6 +15,7 @@ interface SelectCategoryProps {
   name: string;
   onChange: (value: { target: { name: string; value: any; type: string } }) => void;
   value?: string;
+  isCreating?: boolean;
 }
 
 export const SelectCategory = ({
@@ -23,6 +24,7 @@ export const SelectCategory = ({
   name,
   onChange,
   value = undefined,
+  isCreating,
 }: SelectCategoryProps) => {
   const { formatMessage } = useIntl();
   const { allComponentsCategories } = useDataManager();
@@ -43,7 +45,13 @@ export const SelectCategory = ({
   return (
     <Field.Root error={errorMessage} name={name}>
       <Field.Label>{label}</Field.Label>
-      <Combobox onChange={handleChange} onCreateOption={handleCreateOption} value={value} creatable>
+      <Combobox
+        disabled={!isCreating}
+        onChange={handleChange}
+        onCreateOption={handleCreateOption}
+        value={value}
+        creatable
+      >
         {categories.map((category) => (
           <ComboboxOption key={category} value={category}>
             {category}

--- a/packages/core/content-type-builder/admin/src/components/SelectCategory.tsx
+++ b/packages/core/content-type-builder/admin/src/components/SelectCategory.tsx
@@ -46,6 +46,8 @@ export const SelectCategory = ({
     <Field.Root error={errorMessage} name={name}>
       <Field.Label>{label}</Field.Label>
       <Combobox
+        // TODO: re-enable category edits, renaming categories of already existing components currently breaks other functionality
+        // See https://github.com/strapi/strapi/issues/20356
         disabled={!isCreating}
         onChange={handleChange}
         onCreateOption={handleCreateOption}


### PR DESCRIPTION
### What does it do?

disable the ability to edit a category name, by disabling the drop down menu in the CTB

### Why is it needed?

- Category edits don't work now, they will be worked on later in a bigger editing initiative 
- Prevent users from editing a category name and facing an error or losing there data

### How to test it?

- Attempt to edit a component, you shouldn't be able to change the category 

### Related issue(s)/PR(s)

#20356 
