### PR TITLE
Fix Koa Query Type

### DIFF
--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -20,3 +20,25 @@ export const createStrapi = (options: Partial<StrapiOptions> = {}): Core.Strapi 
 
   return strapi;
 };
+
+// Augment Koa query type based on Strapi query middleware
+
+import * as qs from 'qs';
+
+declare module 'koa' {
+  type ParsedQuery = ReturnType<typeof qs.parse>;
+
+  export interface BaseRequest {
+    _querycache?: ParsedQuery;
+
+    get query(): ParsedQuery;
+    set query(obj: any);
+  }
+
+  export interface BaseContext {
+    _querycache?: ParsedQuery;
+
+    get query(): ParsedQuery;
+    set query(obj: any);
+  }
+}

--- a/packages/core/core/src/middlewares/query.ts
+++ b/packages/core/core/src/middlewares/query.ts
@@ -1,8 +1,8 @@
-import qs, { IParseOptions } from 'qs';
+import qs from 'qs';
 import type Koa from 'koa';
 import type { Core } from '@strapi/types';
 
-type Config = IParseOptions;
+type Config = Parameters<typeof qs.parse>[1];
 
 const defaults: Config = {
   strictNullHandling: true,
@@ -22,6 +22,7 @@ const addQsParser = (app: Koa, settings: Config) => {
      */
     get() {
       const qstr = this.querystring;
+
       this._querycache = this._querycache || {};
       const cache = this._querycache;
 
@@ -38,7 +39,7 @@ const addQsParser = (app: Koa, settings: Config) => {
     set(obj) {
       this.querystring = qs.stringify(obj);
     },
-  });
+  } satisfies PropertyDescriptor & ThisType<Koa.BaseRequest>);
 
   return app;
 };


### PR DESCRIPTION
### What does it do?

Augment koa query type in `BaseRequest` and `BaseContext`

### Why is it needed?

We're modifying the default query type to be able to use `qs` instead of `node:querystring`. This change reflects that in the types.

### How to test it?

See #20230 for reproduction steps

### Related issue(s)/PR(s)

fixes #20230
