### PR TITLE
fix: do not populate morph relations on count draft relations

### DIFF
--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -244,6 +244,12 @@ const getDeepPopulateDraftCount = (uid: UID.Schema) => {
 
     switch (attribute.type) {
       case 'relation': {
+        // TODO: Support polymorphic relations
+        const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+        if (isMorphRelation) {
+          break;
+        }
+
         if (isVisibleAttribute(model, attributeName)) {
           populateAcc[attributeName] = {
             count: true,


### PR DESCRIPTION
### What does it do?

Morph relations were populated as regular relation on the count draft relations, it throws an error in v5.
We do not officially support morph relations, so when the time comes we can correctly populate the morph relation if necessary.

Another similar PR was opened, but we missed this spot.