### PR TITLE
Prevent Vite hmr from Hijacking WS Upgrade Events

### DIFF
--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import browserslist from 'browserslist';
 import { createStrapi } from '@strapi/core';
 import { Core, Modules } from '@strapi/types';
+import type { Server } from 'node:http';
 
 import type { CLIContext } from '../cli/types';
 import { getStrapiAdminEnvVars, loadEnv } from './core/env';
@@ -18,6 +19,8 @@ interface BaseOptions {
   sourcemaps?: boolean;
   bundler?: 'webpack' | 'vite';
   open?: boolean;
+  hmrServer?: Server;
+  hmrClientPort?: number;
 }
 
 interface BuildContext<TOptions = unknown> extends BaseContext {

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -87,7 +87,10 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<InlineConfig
     server: {
       middlewareMode: true,
       open: ctx.options.open,
-      hmr: { server: ctx.strapi.server.httpServer },
+      hmr: {
+        server: ctx.options.hmrServer,
+        clientPort: ctx.options.hmrClientPort,
+      },
     },
     appType: 'custom',
   };

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -104,11 +104,9 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
         // Manually close the hmr server
         // /!\ This operation MUST be done after calling .close() on the vite
         //      instance to avoid flaky behaviors with attached clients
-        await new Promise<void>((resolve, reject) =>
-          hmrServer.close((err) => {
-            err ? reject(err) : resolve();
-          })
-        );
+        await new Promise<void>((resolve, reject) => {
+          hmrServer.close((err) => (err ? reject(err) : resolve()));
+        });
       }
     },
   };

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -100,10 +100,12 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
     async close() {
       await vite.close();
 
-      // Manually close the hmr server
-      // /!\ This operation MUST be done after calling .close() on the vite
-      //      instance to avoid flaky behaviors with attached clients
-      await new Promise((resolve) => hmrServer.close(resolve));
+      if (hmrServer.listening) {
+        // Manually close the hmr server
+        // /!\ This operation MUST be done after calling .close() on the vite
+        //      instance to avoid flaky behaviors with attached clients
+        await new Promise((resolve) => hmrServer.close(resolve));
+      }
     },
   };
 };

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import http from 'node:http';
 import fs from 'node:fs/promises';
 import type { Core } from '@strapi/types';
 
@@ -10,9 +11,43 @@ interface ViteWatcher {
   close(): Promise<void>;
 }
 
+const HMR_DEFAULT_PORT = 5173;
+
+const createHMRServer = () => {
+  return http.createServer(
+    // http server request handler. keeps the same with
+    // https://github.com/websockets/ws/blob/45e17acea791d865df6b255a55182e9c42e5877a/lib/websocket-server.js#L88-L96
+    (_, res) => {
+      const body = http.STATUS_CODES[426]; // Upgrade Required
+
+      res.writeHead(426, {
+        'Content-Length': body?.length ?? 0,
+        'Content-Type': 'text/plain',
+      });
+
+      res.end(body);
+    }
+  );
+};
+
 const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
+  const hmrServer = createHMRServer();
+
+  ctx.options.hmrServer = hmrServer;
+  ctx.options.hmrClientPort = HMR_DEFAULT_PORT;
+
   const config = await resolveDevelopmentConfig(ctx);
   const finalConfig = await mergeConfigWithUserConfig(config, ctx);
+
+  const hmrConfig = config.server?.hmr;
+
+  // If the server used for Vite hmr is the one we've created (<> no user override)
+  if (typeof hmrConfig === 'object' && hmrConfig.server === hmrServer) {
+    // Only restart the hmr server when Strapi's server is listening
+    strapi.server.httpServer.on('listening', async () => {
+      hmrServer.listen(hmrConfig.clientPort ?? hmrConfig.port ?? HMR_DEFAULT_PORT);
+    });
+  }
 
   ctx.logger.debug('Vite config', finalConfig);
 
@@ -64,6 +99,11 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
   return {
     async close() {
       await vite.close();
+
+      // Manually close the hmr server
+      // /!\ This operation MUST be done after calling .close() on the vite
+      //      instance to avoid flaky behaviors with attached clients
+      await new Promise((resolve) => hmrServer.close(resolve));
     },
   };
 };

--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -104,7 +104,11 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
         // Manually close the hmr server
         // /!\ This operation MUST be done after calling .close() on the vite
         //      instance to avoid flaky behaviors with attached clients
-        await new Promise((resolve) => hmrServer.close(resolve));
+        await new Promise<void>((resolve, reject) =>
+          hmrServer.close((err) => {
+            err ? reject(err) : resolve();
+          })
+        );
       }
     },
   };


### PR DESCRIPTION
### What does it do?

Introduce a dedicated HTTP server used by vite hmr, and reference it in the related vite configuration.

### Why is it needed?

[Vite hmr hijacks any WS upgrade events](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/ws.ts#L149). 

Since the current hmr config is re-using Strapi HTTP server, this behavior prevents Strapi data transfer requests from triggering remote transfers (handling custom WS connections (with policies, middleware, etc...)).

### How to test it?

Both remote data transfers and vite hmr should be working fine.

### Related issue(s)/PR(s)

fixes #20649