### PR TITLE
fix(content-manager): bulk actions modal don't force to use modal

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -472,12 +472,12 @@ const DocumentActionModal = ({
         <Modal.Header>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <Modal.Body>
-          {typeof Content === 'function' ? <Content onClose={handleClose} /> : Content}
-        </Modal.Body>
-        <Modal.Footer>
-          {typeof Footer === 'function' ? <Footer onClose={handleClose} /> : Footer}
-        </Modal.Footer>
+        {typeof Content === 'function' ? (
+          <Content onClose={handleClose} />
+        ) : (
+          <Modal.Body>{Content}</Modal.Body>
+        )}
+        {typeof Footer === 'function' ? <Footer onClose={handleClose} /> : Footer}
       </Modal.Content>
     </Modal.Root>
   );

--- a/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
@@ -273,7 +273,7 @@ const ReleaseActionModalForm: DocumentActionComponent = ({
         />
       ),
       footer: ({ onClose }) => (
-        <>
+        <Modal.Footer>
           <Button onClick={onClose} variant="tertiary" name="cancel">
             {formatMessage({
               id: 'content-releases.content-manager-edit-view.add-to-release.cancel-button',
@@ -292,7 +292,7 @@ const ReleaseActionModalForm: DocumentActionComponent = ({
               defaultMessage: 'Continue',
             })}
           </Button>
-        </>
+        </Modal.Footer>
       ),
     },
   };

--- a/packages/plugins/i18n/admin/src/components/BulkLocaleActionModal.tsx
+++ b/packages/plugins/i18n/admin/src/components/BulkLocaleActionModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { FormErrors, Table, useTable } from '@strapi/admin/strapi-admin';
-import { Box, Typography, IconButton, Flex, Tooltip, Status } from '@strapi/design-system';
+import { Box, Typography, IconButton, Flex, Tooltip, Status, Modal } from '@strapi/design-system';
 import { Pencil, CheckCircle, CrossCircle, ArrowsCounterClockwise } from '@strapi/icons';
 import { Modules } from '@strapi/types';
 import { stringify } from 'qs';
@@ -197,7 +197,7 @@ const BulkLocaleActionModal = ({
   };
 
   return (
-    <React.Fragment>
+    <Modal.Body>
       <Typography>{getFormattedCountMessage()}</Typography>
       <Box marginTop={5}>
         <Table.Content>
@@ -271,7 +271,7 @@ const BulkLocaleActionModal = ({
           </Table.Body>
         </Table.Content>
       </Box>
-    </React.Fragment>
+    </Modal.Body>
   );
 };
 

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -15,7 +15,7 @@ import {
   unstable_useDocumentActions as useDocumentActions,
   buildValidParams,
 } from '@strapi/content-manager/strapi-admin';
-import { Flex, Status, Typography, Button } from '@strapi/design-system';
+import { Flex, Status, Typography, Button, Modal } from '@strapi/design-system';
 import { WarningCircle, ListPlus, Trash } from '@strapi/icons';
 import { Modules } from '@strapi/types';
 import { useIntl } from 'react-intl';
@@ -514,7 +514,7 @@ const BulkLocalePublishAction: DocumentActionComponent = ({
         );
       },
       footer: () => (
-        <Flex justifyContent="flex-end" width="100%">
+        <Modal.Footer justifyContent="flex-end">
           <Button
             loading={isDraftRelationsLoading}
             disabled={!hasPermission || localesToPublish.length === 0}
@@ -526,7 +526,7 @@ const BulkLocalePublishAction: DocumentActionComponent = ({
               defaultMessage: 'Publish',
             })}
           </Button>
-        </Flex>
+        </Modal.Footer>
       ),
     },
   };


### PR DESCRIPTION
### What does it do?

Fix the UI error on Bulk Publish modal. Bulk Publish API shouldn't force user to always wrap render in `Modal.Body` and `Modal.Footer` so users can build custom modals as they want (Bulk publish use case).

We can discuss later if we want to have a different API to add context when adding a Bulk Action modal. 

### How to test it?

Check all the modals from Bulk Actions (currently we have Bulk Publish, Add To Release, Publish multiple locales)
