### PR TITLE
fix: inconsistent publish permissions

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -666,8 +666,6 @@ const PublishAction: DocumentActionComponent = ({
      *  - the document is already published & not modified
      *  - the document is being created & not modified
      *  - the user doesn't have the permission to publish
-     *  - the user doesn't have the permission to create a new document
-     *  - the user doesn't have the permission to update the document
      */
     disabled:
       isCloning ||
@@ -676,8 +674,7 @@ const PublishAction: DocumentActionComponent = ({
       activeTab === 'published' ||
       (!modified && isDocumentPublished) ||
       (!modified && !document?.documentId) ||
-      !canPublish ||
-      Boolean((!document?.documentId && !canCreate) || (document?.documentId && !canUpdate)),
+      !canPublish,
     label: formatMessage({
       id: 'app.utils.publish',
       defaultMessage: 'Publish',
@@ -754,14 +751,8 @@ const UpdateAction: DocumentActionComponent = ({
      * - the form is submitting
      * - the document is not modified & we're not cloning (you can save a clone entity straight away)
      * - the active tab is the published tab
-     * - the user doesn't have the permission to create a new document
-     * - the user doesn't have the permission to update the document
      */
-    disabled:
-      isSubmitting ||
-      (!modified && !isCloning) ||
-      activeTab === 'published' ||
-      Boolean((!documentId && !canCreate) || (documentId && !canUpdate)),
+    disabled: isSubmitting || (!modified && !isCloning) || activeTab === 'published',
     label: formatMessage({
       id: 'content-manager.containers.Edit.save',
       defaultMessage: 'Save',

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -410,7 +410,7 @@ export default {
           throw new errors.ForbiddenError();
         }
 
-        document = await createDocument(ctx);
+        document = await createDocument(ctx, { populate });
       }
 
       const isUpdate = !isCreate;

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -404,7 +404,7 @@ export default {
        * 2. User can update and publish a document
        *    Action will be allowed, but document will not be updated, only published with the latest draft
        */
-      const isCreate = !isNil(id);
+      const isCreate = isNil(id);
       if (isCreate) {
         if (permissionChecker.cannot.create()) {
           throw new errors.ForbiddenError();

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -393,6 +393,8 @@ export default {
 
       let document: any;
 
+      const { locale } = await getDocumentLocaleAndStatus(body, model);
+
       /**
        * Publish can be called on two scenarios:
        * 1. Create a new document and publish it in one request
@@ -415,7 +417,7 @@ export default {
 
       const isUpdate = !isCreate;
       if (isUpdate) {
-        document = await documentManager.findOne(id!, model, { populate });
+        document = await documentManager.findOne(id!, model, { populate, locale });
 
         if (!document) {
           throw new errors.NotFoundError('Document not found');
@@ -430,8 +432,6 @@ export default {
       if (permissionChecker.cannot.publish(document)) {
         throw new errors.ForbiddenError();
       }
-
-      const { locale } = await getDocumentLocaleAndStatus(body, model);
 
       const publishResult = await documentManager.publish(document.documentId, model, {
         locale,

--- a/tests/api/core/admin/admin-permissions-custom-conditions.test.api.js
+++ b/tests/api/core/admin/admin-permissions-custom-conditions.test.api.js
@@ -267,6 +267,7 @@ describe('Admin Permissions - Conditions', () => {
     const res = await rq({
       method: 'POST',
       url: `/content-manager/collection-types/api::article.article/${documentId}/actions/publish`,
+      body: { ...localTestData.cheapArticle, category: localTestData.categories[0].documentId },
     });
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
### What does it do?

There is an inconsistency on the content manager publish / update permisions.

Scenario:
- User has permissions to publish and not update
- Expected behaviour: User can publish but not update draft
- Current behaviour: User can not publish

And also, there was a workaround about this, bulk publishing multiple locales.
See more [CS-838](https://strapi-inc.atlassian.net/browse/CS-838)

This is only the first step to fix the inconsistency, some FE work will be required (enabling the publish button on this scenario)

[CS-838]: https://strapi-inc.atlassian.net/browse/CS-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ