### PR TITLE
Fix file path parsing to allow cross-platform compatibility

### DIFF
--- a/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
+++ b/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
@@ -37,11 +37,6 @@ describe('filePathToPropPath', () => {
       expect(filePathToPropPath('./config/test.js')).toEqual(['config', 'test']);
     });
 
-    test('Win32 Separators', () => {
-      expect(filePathToPropPath('config\\test.js')).toEqual(['config', 'test']);
-      expect(filePathToPropPath('.\\config\\test.js')).toEqual(['config', 'test']);
-    });
-
     test('Mixed Separators (win32 + posix)', () => {
       expect(filePathToPropPath('src\\config/test.js')).toEqual(['src', 'config', 'test']);
       expect(filePathToPropPath('.\\config/test.js')).toEqual(['config', 'test']);

--- a/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
+++ b/packages/core/core/src/utils/__tests__/filepath-to-prop-path.test.ts
@@ -25,4 +25,26 @@ describe('filePathToPropPath', () => {
     expect(filePathToPropPath('./config/test.js', false)).toEqual(['config']);
     expect(filePathToPropPath('./config/test.key.js', false)).toEqual(['config', 'test']);
   });
+
+  describe('Separators', () => {
+    test('Win32 Separators', () => {
+      expect(filePathToPropPath('config\\test.js')).toEqual(['config', 'test']);
+      expect(filePathToPropPath('.\\config\\test.js')).toEqual(['config', 'test']);
+    });
+
+    test('Posix Separators', () => {
+      expect(filePathToPropPath('config/test.js')).toEqual(['config', 'test']);
+      expect(filePathToPropPath('./config/test.js')).toEqual(['config', 'test']);
+    });
+
+    test('Win32 Separators', () => {
+      expect(filePathToPropPath('config\\test.js')).toEqual(['config', 'test']);
+      expect(filePathToPropPath('.\\config\\test.js')).toEqual(['config', 'test']);
+    });
+
+    test('Mixed Separators (win32 + posix)', () => {
+      expect(filePathToPropPath('src\\config/test.js')).toEqual(['src', 'config', 'test']);
+      expect(filePathToPropPath('.\\config/test.js')).toEqual(['config', 'test']);
+    });
+  });
 });

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -16,7 +16,7 @@ export const filePathToPropPath = (
     // Make sure it's lowercase
     fp.lowerCase,
     // Split the cleaned path by matching every possible separator (either "/" or "\" depending on the OS)
-    fp.split(new RegExp(`${path.win32.sep}|${path.posix.sep}`)),
+    fp.split(new RegExp(`${path.win32.sep}|${path.posix.sep}`, 'g')),
     // Make sure to remove leading '.' from the different path parts
     fp.map(fp.trimCharsStart('.')),
     // join + split in case some '.' characters are still present in different parts of the path

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -31,7 +31,7 @@ export const filePathToPropPath = (
 };
 
 const removeRelativePrefix = (filePath: string) => {
-  return filePath.startsWith(`.\\${path.win32.sep}`) || filePath.startsWith(`.${path.posix.sep}`)
+  return filePath.startsWith(`.${path.win32.sep}`) || filePath.startsWith(`.${path.posix.sep}`)
     ? filePath.slice(2)
     : filePath;
 };

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -9,7 +9,7 @@ export const filePathToPropPath = (
   useFileNameAsKey: boolean = true
 ): string[] => {
   const transform = fp.pipe(
-    // Remove the relative path prefix (posix or win32) and ".\" (win32) prefixes
+    // Remove the relative path prefixes: './' for posix (and some win32) and ".\" for win32
     removeRelativePrefix,
     // Remove the path metadata and extensions
     fp.replace(/(\.settings|\.json|\.js)/g, ''),

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import _ from 'lodash';
 
 /**
@@ -9,7 +10,7 @@ export const filePathToPropPath = (filePath: string, useFileNameAsKey = true) =>
   const prop = cleanPath
     .replace(/(\.settings|\.json|\.js)/g, '')
     .toLowerCase()
-    .split('/')
+    .split(path.sep)
     .map((p) => _.trimStart(p, '.'))
     .join('.')
     .split('.');

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -13,10 +13,11 @@ export const filePathToPropPath = (
     removeRelativePrefix,
     // Remove the path metadata and extensions
     fp.replace(/(\.settings|\.json|\.js)/g, ''),
-    // Make sure it's lowercase
-    fp.lowerCase,
+    // Transform to lowercase
+    // Note: We're using fp.toLower instead of fp.lowercase as the latest removes special characters such as "/"
+    fp.toLower,
     // Split the cleaned path by matching every possible separator (either "/" or "\" depending on the OS)
-    fp.split(new RegExp(`${path.win32.sep}|${path.posix.sep}`, 'g')),
+    fp.split(new RegExp(`[${path.win32.sep}|${path.posix.sep}]`, 'g')),
     // Make sure to remove leading '.' from the different path parts
     fp.map(fp.trimCharsStart('.')),
     // join + split in case some '.' characters are still present in different parts of the path

--- a/packages/core/core/src/utils/filepath-to-prop-path.ts
+++ b/packages/core/core/src/utils/filepath-to-prop-path.ts
@@ -17,7 +17,7 @@ export const filePathToPropPath = (
     // Note: We're using fp.toLower instead of fp.lowercase as the latest removes special characters such as "/"
     fp.toLower,
     // Split the cleaned path by matching every possible separator (either "/" or "\" depending on the OS)
-    fp.split(new RegExp(`[${path.win32.sep}|${path.posix.sep}]`, 'g')),
+    fp.split(new RegExp(`[\\${path.win32.sep}|${path.posix.sep}]`, 'g')),
     // Make sure to remove leading '.' from the different path parts
     fp.map(fp.trimCharsStart('.')),
     // join + split in case some '.' characters are still present in different parts of the path
@@ -31,7 +31,7 @@ export const filePathToPropPath = (
 };
 
 const removeRelativePrefix = (filePath: string) => {
-  return filePath.startsWith(`.${path.win32.sep}`) || filePath.startsWith(`.${path.posix.sep}`)
+  return filePath.startsWith(`.\\${path.win32.sep}`) || filePath.startsWith(`.${path.posix.sep}`)
     ? filePath.slice(2)
     : filePath;
 };


### PR DESCRIPTION
### What does it do?

Add support for cross-platform handling of separators (win32 and posix) when parsing file paths 
Added unit test to avoid regression

### Why is it needed?

It's not possible to start the server on Windows with components in the app.

See #20057 for more information

### How to test it?

- On Windows, you should now be able to load components without errors and the server should start
- You can also verify it works by running the added unit tests

### Related issue(s)/PR(s)

**Original**
close #20057

**Duplicates**
close #20638
close #20631