### PR TITLE
feat(cli): Add projects list command

### DIFF
--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -4,6 +4,7 @@ import deployProject from './deploy-project';
 import login from './login';
 import logout from './logout';
 import createProject from './create-project';
+import listProjects from './list-projects';
 import { CLIContext } from './types';
 import { getLocalConfig, saveLocalConfig } from './config/local';
 
@@ -12,9 +13,10 @@ export const cli = {
   login,
   logout,
   createProject,
+  listProjects,
 };
 
-const cloudCommands = [deployProject, login, logout];
+const cloudCommands = [deployProject, login, logout, listProjects];
 
 async function initCloudCLIConfig() {
   const localConfig = await getLocalConfig();

--- a/packages/cli/cloud/src/list-projects/action.ts
+++ b/packages/cli/cloud/src/list-projects/action.ts
@@ -1,0 +1,27 @@
+import type { CLIContext } from '../types';
+import { cloudApiFactory, tokenServiceFactory } from '../services';
+import { promptLogin } from '../login/action';
+
+export default async (ctx: CLIContext) => {
+  const { getValidToken } = await tokenServiceFactory(ctx);
+  const token = await getValidToken(ctx, promptLogin);
+  const { logger } = ctx;
+
+  if (!token) {
+    return;
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+  const spinner = logger.spinner('Fetching your projects...').start();
+
+  try {
+    const {
+      data: { data: projectList },
+    } = await cloudApiService.listProjects();
+    spinner.succeed();
+    logger.log(projectList);
+  } catch (e) {
+    ctx.logger.debug('Failed to list projects', e);
+    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
+  }
+};

--- a/packages/cli/cloud/src/list-projects/command.ts
+++ b/packages/cli/cloud/src/list-projects/command.ts
@@ -3,7 +3,7 @@ import { runAction } from '../utils/helpers';
 import action from './action';
 
 /**
- * `$ deploy project to the cloud`
+ * `$ list project from the cloud`
  */
 const command: StrapiCloudCommand = ({ command, ctx }) => {
   command

--- a/packages/cli/cloud/src/list-projects/command.ts
+++ b/packages/cli/cloud/src/list-projects/command.ts
@@ -1,0 +1,18 @@
+import { type StrapiCloudCommand } from '../types';
+import { runAction } from '../utils/helpers';
+import action from './action';
+
+/**
+ * `$ deploy project to the cloud`
+ */
+const command: StrapiCloudCommand = ({ command, ctx }) => {
+  command
+    .command('cloud:projects')
+    .alias('projects')
+    .description('List Strapi Cloud projects')
+    .option('-d, --debug', 'Enable debugging mode with verbose logs')
+    .option('-s, --silent', "Don't log anything")
+    .action(() => runAction('listProjects', action)(ctx));
+};
+
+export default command;

--- a/packages/cli/cloud/src/list-projects/index.ts
+++ b/packages/cli/cloud/src/list-projects/index.ts
@@ -1,0 +1,12 @@
+import action from './action';
+import command from './command';
+import type { StrapiCloudCommandInfo } from '../types';
+
+export { action, command };
+
+export default {
+  name: 'list-projects',
+  description: 'List Strapi Cloud projects',
+  action,
+  command,
+} as StrapiCloudCommandInfo;

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -25,6 +25,12 @@ export type DeployResponse = {
 
 export type TrackPayload = Record<string, unknown>;
 
+export type ListProjectsResponse = {
+  data: {
+    data: string;
+  };
+};
+
 export interface CloudApiService {
   deploy(
     deployInput: {
@@ -47,7 +53,7 @@ export interface CloudApiService {
 
   config(): Promise<AxiosResponse<CloudCliConfig>>;
 
-  listProjects(): Promise<AxiosResponse<ProjectInfos[]>>;
+  listProjects(): Promise<AxiosResponse<ListProjectsResponse>>;
 
   track(event: string, payload?: TrackPayload): Promise<AxiosResponse<void>>;
 }
@@ -132,8 +138,21 @@ export async function cloudApiFactory(
       }
     },
 
-    listProjects() {
-      return axiosCloudAPI.get<ProjectInfos[]>('/projects');
+    async listProjects(): Promise<AxiosResponse<ListProjectsResponse>> {
+      try {
+        const response = await axiosCloudAPI.get('/projects');
+
+        if (response.status !== 200) {
+          throw new Error('Error fetching cloud projects from the server.');
+        }
+
+        return response;
+      } catch (error) {
+        logger.debug(
+          "🥲 Oops! Couldn't retrieve your project's list from the server. Please try again."
+        );
+        throw error;
+      }
     },
 
     track(event, payload = {}) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR introduces projects listing command into cloud CLI

### Why is it needed?

It gives users the chance to list their projects deployed in Strapi Cloud from the CLI

### How to test it?

- Verify that the projects command is listed among the available commands.
- Ensure that the `projects` command executes correctly.
- If the user is not logged in the user should be prompted to login
- If the user logs in it should continue with the project fetching
- Confirm that any 500 error returned from the server is handled gracefully, without causing the CLI to crash
- The rest of the commands should function correctly
