### PR TITLE
chore(cloud-cli): migrate to fs-extra

### DIFF
--- a/packages/cli/cloud/src/utils/compress-files.ts
+++ b/packages/cli/cloud/src/utils/compress-files.ts
@@ -39,26 +39,25 @@ const isIgnoredFile = (folderPath: string, file: string, ignorePatterns: string[
 const getFiles = async (
   dirPath: string,
   ignorePatterns: string[] = [],
-  arrayOfFiles: string[] = [],
   subfolder: string = ''
 ): Promise<string[]> => {
+  const arrayOfFiles: string[] = [];
   const entries = await fse.readdir(path.join(dirPath, subfolder));
 
-  entries.forEach((entry) => {
+  for (const entry of entries) {
     const entryPathFromRoot = path.join(subfolder, entry);
     const entryPath = path.relative(dirPath, entryPathFromRoot);
     const isIgnored = isIgnoredFile(dirPath, entryPathFromRoot, ignorePatterns);
 
-    if (isIgnored) {
-      return;
+    if (!isIgnored) {
+      if (fse.statSync(entryPath).isDirectory()) {
+        const subFiles = await getFiles(dirPath, ignorePatterns, entryPathFromRoot);
+        arrayOfFiles.push(...subFiles);
+      } else {
+        arrayOfFiles.push(entryPath);
+      }
     }
-
-    if (fse.statSync(entryPath).isDirectory()) {
-      getFiles(dirPath, ignorePatterns, arrayOfFiles, entryPathFromRoot);
-    } else {
-      arrayOfFiles.push(entryPath);
-    }
-  });
+  }
   return arrayOfFiles;
 };
 

--- a/packages/cli/cloud/src/utils/compress-files.ts
+++ b/packages/cli/cloud/src/utils/compress-files.ts
@@ -1,5 +1,4 @@
-// TODO Migrate to fs-extra
-import * as fs from 'fs';
+import * as fse from 'fs-extra';
 import * as tar from 'tar';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
@@ -19,29 +18,6 @@ const IGNORED_PATTERNS = [
   '**/.vscode/**',
 ];
 
-const getFiles = (
-  dirPath: string,
-  ignorePatterns: string[] = [],
-  arrayOfFiles: string[] = [],
-  subfolder: string = ''
-): string[] => {
-  const entries = fs.readdirSync(path.join(dirPath, subfolder));
-  entries.forEach((entry) => {
-    const entryPathFromRoot = path.join(subfolder, entry);
-    const entryPath = path.relative(dirPath, entryPathFromRoot);
-    const isIgnored = isIgnoredFile(dirPath, entryPathFromRoot, ignorePatterns);
-    if (isIgnored) {
-      return;
-    }
-    if (fs.statSync(entryPath).isDirectory()) {
-      getFiles(dirPath, ignorePatterns, arrayOfFiles, entryPathFromRoot);
-    } else {
-      arrayOfFiles.push(entryPath);
-    }
-  });
-  return arrayOfFiles;
-};
-
 const isIgnoredFile = (folderPath: string, file: string, ignorePatterns: string[]): boolean => {
   ignorePatterns.push(...IGNORED_PATTERNS);
   const relativeFilePath = path.join(folderPath, file);
@@ -60,10 +36,40 @@ const isIgnoredFile = (folderPath: string, file: string, ignorePatterns: string[
   return isIgnored;
 };
 
-const readGitignore = (folderPath: string): string[] => {
+const getFiles = async (
+  dirPath: string,
+  ignorePatterns: string[] = [],
+  arrayOfFiles: string[] = [],
+  subfolder: string = ''
+): Promise<string[]> => {
+  const entries = await fse.readdir(path.join(dirPath, subfolder));
+
+  entries.forEach((entry) => {
+    const entryPathFromRoot = path.join(subfolder, entry);
+    const entryPath = path.relative(dirPath, entryPathFromRoot);
+    const isIgnored = isIgnoredFile(dirPath, entryPathFromRoot, ignorePatterns);
+
+    if (isIgnored) {
+      return;
+    }
+
+    if (fse.statSync(entryPath).isDirectory()) {
+      getFiles(dirPath, ignorePatterns, arrayOfFiles, entryPathFromRoot);
+    } else {
+      arrayOfFiles.push(entryPath);
+    }
+  });
+  return arrayOfFiles;
+};
+
+const readGitignore = async (folderPath: string): Promise<string[]> => {
   const gitignorePath = path.resolve(folderPath, '.gitignore');
-  if (!fs.existsSync(gitignorePath)) return [];
-  const gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
+  const pathExist = await fse.pathExists(gitignorePath);
+
+  if (!pathExist) return [];
+
+  const gitignoreContent = await fse.readFile(gitignorePath, 'utf8');
+
   return gitignoreContent
     .split(/\r?\n/)
     .filter((line) => Boolean(line.trim()) && !line.startsWith('#'));
@@ -74,8 +80,8 @@ const compressFilesToTar = async (
   folderToCompress: string,
   filename: string
 ): Promise<void> => {
-  const ignorePatterns = readGitignore(folderToCompress);
-  const filesToCompress = getFiles(folderToCompress, ignorePatterns);
+  const ignorePatterns = await readGitignore(folderToCompress);
+  const filesToCompress = await getFiles(folderToCompress, ignorePatterns);
 
   return tar.c(
     {

--- a/packages/cli/cloud/src/utils/pkg.ts
+++ b/packages/cli/cloud/src/utils/pkg.ts
@@ -1,5 +1,4 @@
-// TODO Migrate to fs-extra
-import fs from 'fs/promises';
+import * as fse from 'fs-extra';
 import os from 'os';
 import pkgUp from 'pkg-up';
 import * as yup from 'yup';
@@ -62,7 +61,7 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
     throw new Error('Could not find a package.json in the current directory');
   }
 
-  const buffer = await fs.readFile(pkgPath);
+  const buffer = await fse.readFile(pkgPath);
 
   const pkg = JSON.parse(buffer.toString());
 
@@ -77,11 +76,9 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
  */
 const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
   try {
-    const validatedPkg = await packageJsonSchema.validate(pkg, {
+    return await packageJsonSchema.validate(pkg, {
       strict: true,
     });
-
-    return validatedPkg;
   } catch (err) {
     if (err instanceof yup.ValidationError) {
       switch (err.type) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update Cloud-CLI to use fs-extra everywhere

### Why is it needed?

Maintenance purpose. Was in the todo-list after first release of Cloud CLI.

### How to test it?

You can re-test all the Cloud CLI commands "login", "deploy", "logout".

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
