### PR TITLE
fix: media library action container alignment issue

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
@@ -259,7 +259,7 @@ export const MediaLibrary = () => {
           endActions={
             <>
               <CheckPermissions permissions={PERMISSIONS.configureView}>
-                <ActionContainer paddingTop={1} paddingBottom={1}>
+                <ActionContainer>
                   <IconButton
                     forwardedAs={ReactRouterLink}
                     to={{
@@ -274,7 +274,7 @@ export const MediaLibrary = () => {
                   />
                 </ActionContainer>
               </CheckPermissions>
-              <ActionContainer paddingTop={1} paddingBottom={1}>
+              <ActionContainer>
                 <IconButton
                   icon={isGridView ? <List /> : <Grid />}
                   label={


### PR DESCRIPTION
### What does it do?

removes the un-necessary padding-y which causes the alignment issue 

<img width="761" alt="Screenshot 2024-07-09 at 12 14 12 AM" src="https://github.com/strapi/strapi/assets/76926762/875f1eff-3114-45e3-9ad4-b3cb8e7f105a">


`perfectly aligned as all things should be`