### PR TITLE
feat(cm): add optimistic document updates

### DIFF
--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -335,6 +335,20 @@ const documentApi = contentManagerApi.injectEndpoints({
           'Relations',
         ];
       },
+      async onQueryStarted({ data, ...patch }, { dispatch, queryFulfilled }) {
+        // Optimistically update the cache with the new data
+        const patchResult = dispatch(
+          documentApi.util.updateQueryData('getDocument', patch, (draft) => {
+            Object.assign(draft.data, data);
+          })
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          // Rollback the optimistic update if there's an error
+          patchResult.undo();
+        }
+      },
     }),
     unpublishDocument: builder.mutation<
       Unpublish.Response,


### PR DESCRIPTION
### What does it do?

Adds optimistic behavior to the RTK updateDocument API. We now assume that the backend won't throw errors when the user saves content, so that we can immediately update the UI with the new content when the user clicks update.

If the backend _does_ throw however, then the local state update is rollbacked, as you can see here:

https://github.com/strapi/strapi/assets/8087692/4a79c1d5-a1f7-47cd-a1df-caea9761e21d



### Why is it needed?

- It prevents flickering in the edit view: when you save an update, you would see the old version of your content for a split second.
- Fixes an issue in Blocks: #20028 (the Slate state wasn't kept properly in sync with the RTK state during that "flickering" phase)

### How to test it?

- Update content in the edit view, and save. The content in the inputs should not change, not even for a split second. Try both collection and single types, and try a variety of different fields.
- Add a new block to the end of a blocks field and save. The app shouldn't crash

### Related issue(s)/PR(s)

- need for [optimistic updates mentioned before there](https://github.com/strapi/strapi/pull/20558#issuecomment-2178849160)
- fixes #20028