### PR TITLE
feat(cli): add project link command to cloud cli

### DIFF
--- a/packages/cli/cloud/src/create-project/action.ts
+++ b/packages/cli/cloud/src/create-project/action.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import { AxiosError } from 'axios';
 import { defaults } from 'lodash/fp';
-import type { CLIContext, ProjectAnswers, CreateProjectInput } from '../types';
+import type { CLIContext, ProjectAnswers, ProjectInput } from '../types';
 import { tokenServiceFactory, cloudApiFactory, local } from '../services';
 import { getProjectNameFromPackageJson } from './utils/get-project-name-from-pkg';
 import { applyDefaultName } from './utils/apply-default-name';
@@ -40,11 +40,7 @@ async function handleError(ctx: CLIContext, error: Error) {
   );
 }
 
-async function createProject(
-  ctx: CLIContext,
-  cloudApi: any,
-  createProjectInput: CreateProjectInput
-) {
+async function createProject(ctx: CLIContext, cloudApi: any, createProjectInput: ProjectInput) {
   const { logger } = ctx;
   const spinner = logger.spinner('Setting up your project...').start();
   try {
@@ -80,7 +76,7 @@ export default async (ctx: CLIContext) => {
   const projectAnswersDefaulted = defaults(defaultValues);
   const projectAnswers = await inquirer.prompt<ProjectAnswers>(questions);
 
-  const createProjectInput: CreateProjectInput = projectAnswersDefaulted(projectAnswers);
+  const createProjectInput: ProjectInput = projectAnswersDefaulted(projectAnswers);
 
   try {
     return await createProject(ctx, cloudApi, createProjectInput);

--- a/packages/cli/cloud/src/create-project/action.ts
+++ b/packages/cli/cloud/src/create-project/action.ts
@@ -40,11 +40,11 @@ async function handleError(ctx: CLIContext, error: Error) {
   );
 }
 
-async function createProject(ctx: CLIContext, cloudApi: any, createProjectInput: ProjectInput) {
+async function createProject(ctx: CLIContext, cloudApi: any, projectInput: ProjectInput) {
   const { logger } = ctx;
   const spinner = logger.spinner('Setting up your project...').start();
   try {
-    const { data } = await cloudApi.createProject(createProjectInput);
+    const { data } = await cloudApi.createProject(projectInput);
     await local.save({ project: data });
     spinner.succeed('Project created successfully!');
     return data;
@@ -76,16 +76,16 @@ export default async (ctx: CLIContext) => {
   const projectAnswersDefaulted = defaults(defaultValues);
   const projectAnswers = await inquirer.prompt<ProjectAnswers>(questions);
 
-  const createProjectInput: ProjectInput = projectAnswersDefaulted(projectAnswers);
+  const projectInput: ProjectInput = projectAnswersDefaulted(projectAnswers);
 
   try {
-    return await createProject(ctx, cloudApi, createProjectInput);
+    return await createProject(ctx, cloudApi, projectInput);
   } catch (e: Error | unknown) {
     if (e instanceof AxiosError && e.response?.status === 401) {
       logger.warn('Oops! Your session has expired. Please log in again to retry.');
       await eraseToken();
       if (await promptLogin(ctx)) {
-        return await createProject(ctx, cloudApi, createProjectInput);
+        return await createProject(ctx, cloudApi, projectInput);
       }
     } else {
       await handleError(ctx, e as Error);

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -13,6 +13,7 @@ import { notificationServiceFactory } from '../services/notification';
 import { loadPkg } from '../utils/pkg';
 import { buildLogsServiceFactory } from '../services/build-logs';
 import { promptLogin } from '../login/action';
+import { trackEvent } from '../utils/analytics';
 
 type PackageJson = {
   name: string;
@@ -166,10 +167,16 @@ export default async (ctx: CLIContext) => {
   }
 
   const cloudApiService = await cloudApiFactory(ctx);
+
   try {
-    await cloudApiService.track('willDeployWithCLI', { projectInternalName: project.name });
+    await trackEvent(
+      cloudApiService,
+      'willDeployWithCLI',
+      { projectInternalName: project.name },
+      ctx
+    );
   } catch (e) {
-    ctx.logger.debug('Failed to track willDeploy', e);
+    /* noop */
   }
 
   const notificationService = notificationServiceFactory(ctx);

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -168,16 +168,9 @@ export default async (ctx: CLIContext) => {
 
   const cloudApiService = await cloudApiFactory(ctx);
 
-  try {
-    await trackEvent(
-      cloudApiService,
-      'willDeployWithCLI',
-      { projectInternalName: project.name },
-      ctx
-    );
-  } catch (e) {
-    /* noop */
-  }
+  await trackEvent(ctx, cloudApiService, 'willDeployWithCLI', {
+    projectInternalName: project.name,
+  });
 
   const notificationService = notificationServiceFactory(ctx);
   const buildLogsService = buildLogsServiceFactory(ctx);

--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import crypto from 'crypto';
 import deployProject from './deploy-project';
+import link from './link';
 import login from './login';
 import logout from './logout';
 import createProject from './create-project';
@@ -10,13 +11,14 @@ import { getLocalConfig, saveLocalConfig } from './config/local';
 
 export const cli = {
   deployProject,
+  link,
   login,
   logout,
   createProject,
   listProjects,
 };
 
-const cloudCommands = [deployProject, login, logout, listProjects];
+const cloudCommands = [deployProject, link, login, logout, listProjects];
 
 async function initCloudCLIConfig() {
   const localConfig = await getLocalConfig();

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -1,0 +1,83 @@
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+
+import type { CLIContext } from '../types';
+import { cloudApiFactory, tokenServiceFactory, local } from '../services';
+import { promptLogin } from '../login/action';
+
+export default async (ctx: CLIContext) => {
+  const { getValidToken } = await tokenServiceFactory(ctx);
+  const token = await getValidToken(ctx, promptLogin);
+  const { logger } = ctx;
+
+  if (!token) {
+    return;
+  }
+
+  try {
+    const existingConfig = await local.retrieve();
+    if (existingConfig.project) {
+      const { shouldRelink } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'shouldRelink',
+          message: `A project named ${chalk.cyan(
+            existingConfig.project.displayName
+              ? existingConfig.project.displayName
+              : existingConfig.project.name
+          )} is already linked to this local folder. Do you want to update the link?`,
+          default: false,
+        },
+      ]);
+
+      if (!shouldRelink) {
+        return;
+      }
+    }
+  } catch (e) {
+    logger.debug('Failed to check project config', e);
+    logger.error('An error occurred while trying to link the project.');
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+  const spinner = logger.spinner('Fetching your projects...\n').start();
+  try {
+    const {
+      data: { data: projectList },
+    } = await cloudApiService.listLinkProjects();
+    spinner.succeed();
+    const projects = Object.values(projectList)
+      .filter((project: any) => !project.isMaintainer)
+      .map((project: any) => {
+        return {
+          name: project.displayName,
+          value: { name: project.name, displayName: project.displayName },
+        };
+      });
+    if (projects.length === 0) {
+      logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      return;
+    }
+    await inquirer
+      .prompt([
+        {
+          type: 'list',
+          name: 'linkProject',
+          message: 'Which project do you want to link?',
+          choices: [...projects],
+        },
+      ])
+      .then(async (answer) => {
+        try {
+          await local.save({ project: { ...answer.linkProject } }, { override: true });
+          logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
+        } catch (e) {
+          logger.debug('Failed to save project', e);
+          logger.error('An error occurred while linking the project.');
+        }
+      });
+  } catch (e) {
+    ctx.logger.debug('Failed to list projects', e);
+    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
+  }
+};

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -1,10 +1,21 @@
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 
+import type { Answers } from 'inquirer';
 import type { CLIContext } from '../types';
 import { LocalSave } from '../services/strapi-info-save';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { promptLogin } from '../login/action';
+import { trackEvent } from '../utils/analytics';
+
+interface LinkProjectValue {
+  name: string;
+  displayName: string;
+}
+
+interface LinkProjectAnswer extends Answers {
+  linkProject: LinkProjectValue | 'quit';
+}
 
 export default async (ctx: CLIContext) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
@@ -15,8 +26,123 @@ export default async (ctx: CLIContext) => {
     return;
   }
 
-  let existingConfig: LocalSave;
+  let existingConfig: LocalSave | null;
 
+  try {
+    existingConfig = await getExistingConfig(ctx, logger);
+    // If user selects not to relink, return
+    if (existingConfig === null) {
+      return;
+    }
+  } catch (e) {
+    return;
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+
+  try {
+    await trackEvent(cloudApiService, 'willLinkProject', {}, ctx);
+  } catch (e) {
+    /* noop */
+  }
+
+  const spinner = logger.spinner('Fetching your projects...\n').start();
+  let projects: unknown[] = [];
+
+  try {
+    const {
+      data: { data: projectList },
+    } = await cloudApiService.listLinkProjects();
+    spinner.succeed();
+    projects = Object.values(projectList)
+      .filter(
+        (project: any) => !(project.isMaintainer || project.name === existingConfig?.project?.name)
+      )
+      .map((project: any) => {
+        return {
+          name: project.displayName,
+          value: { name: project.name, displayName: project.displayName },
+        };
+      });
+    if (projects.length === 0) {
+      logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      return;
+    }
+  } catch (e) {
+    ctx.logger.debug('Failed to list projects', e);
+    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
+  }
+
+  let answer: LinkProjectAnswer | null = null;
+  try {
+    answer = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'linkProject',
+        message: 'Which project do you want to link?',
+        choices: [...projects, { name: chalk.grey('(Quit)'), value: 'quit' }],
+      },
+    ]);
+
+    if (answer === null || answer.linkProject === 'quit') {
+      return;
+    }
+
+    const { confirmLink } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirmLink',
+        message:
+          'Warning: Once linked, deploying from CLI will replace the existing project and its data. Confirm to proceed:',
+        default: false,
+      },
+    ]);
+
+    if (!confirmLink) {
+      try {
+        await trackEvent(
+          cloudApiService,
+          'didNotLinkProject',
+          { projectInternalName: answer.linkProject },
+          ctx
+        );
+      } catch (e) {
+        /* noop */
+      }
+      return;
+    }
+  } catch (e) {
+    logger.error('Failed to get user input', e);
+    return;
+  }
+
+  try {
+    await local.save({ project: answer.linkProject });
+    logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
+    try {
+      await trackEvent(
+        cloudApiService,
+        'didLinkProject',
+        { projectInternalName: answer.linkProject },
+        ctx
+      );
+    } catch (e) {
+      /* noop */
+    }
+  } catch (e) {
+    logger.debug('Failed to link project', e);
+    logger.error('An error occurred while linking the project.');
+    await trackEvent(
+      cloudApiService,
+      'didNotLinkProject',
+      { projectInternalName: answer.linkProject },
+      ctx
+    );
+  }
+};
+
+async function getExistingConfig(ctx: CLIContext, logger: any) {
+  let existingConfig: LocalSave;
   try {
     existingConfig = await local.retrieve();
     if (existingConfig.project) {
@@ -34,101 +160,14 @@ export default async (ctx: CLIContext) => {
       ]);
 
       if (!shouldRelink) {
-        return;
+        return null;
       }
     }
   } catch (e) {
     logger.debug('Failed to check project config', e);
     logger.error('An error occurred while trying to link the project.');
+    throw e;
   }
 
-  const cloudApiService = await cloudApiFactory(ctx, token);
-
-  try {
-    await cloudApiService.track('willLinkProject', {});
-  } catch (e) {
-    ctx.logger.debug('Failed to track willLinkProject', e);
-  }
-  const spinner = logger.spinner('Fetching your projects...\n').start();
-  try {
-    const {
-      data: { data: projectList },
-    } = await cloudApiService.listLinkProjects();
-    spinner.succeed();
-    const projects = Object.values(projectList)
-      .filter(
-        (project: any) => !(project.isMaintainer || project.name === existingConfig?.project?.name)
-      )
-      .map((project: any) => {
-        return {
-          name: project.displayName,
-          value: { name: project.name, displayName: project.displayName },
-        };
-      });
-    if (projects.length === 0) {
-      logger.log("We couldn't find any projects available for linking in Strapi Cloud");
-      return;
-    }
-    await inquirer
-      .prompt([
-        {
-          type: 'list',
-          name: 'linkProject',
-          message: 'Which project do you want to link?',
-          choices: [...projects, { name: chalk.grey('(Quit)'), value: 'quit' }],
-        },
-      ])
-      .then(async (answer) => {
-        if (answer.linkProject === 'quit') {
-          return;
-        }
-        const { confirmLink } = await inquirer.prompt([
-          {
-            type: 'confirm',
-            name: 'confirmLink',
-            message:
-              'Warning: Once linked, deploying from CLI will replace the existing project and its data. Confirm to proceed:',
-            default: false,
-          },
-        ]);
-
-        if (!confirmLink) {
-          try {
-            await cloudApiService.track('didNotLinkProject', {
-              projectInternalName: answer.linkProject,
-            });
-          } catch (e) {
-            ctx.logger.debug('Failed to track didNotLinkProject', e);
-          }
-          return;
-        }
-
-        try {
-          await local.save({ project: { ...answer.linkProject } }, { override: true });
-          logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
-
-          try {
-            await cloudApiService.track('didLinkProject', {
-              projectInternalName: answer.linkProject,
-            });
-          } catch (e) {
-            ctx.logger.debug('Failed to track didLinkProject', e);
-          }
-        } catch (e) {
-          logger.debug('Failed to save project', e);
-          logger.error('An error occurred while linking the project.');
-
-          try {
-            await cloudApiService.track('didNotLinkProject', {
-              projectInternalName: answer.linkProject,
-            });
-          } catch (e) {
-            ctx.logger.debug('Failed to track didNotLinkProject', e);
-          }
-        }
-      });
-  } catch (e) {
-    ctx.logger.debug('Failed to list projects', e);
-    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
-  }
-};
+  return existingConfig;
+}

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -91,6 +91,11 @@ async function getProjectsList(
       data: { data: projectList },
     } = await cloudApiService.listLinkProjects();
     spinner.succeed();
+
+    if (!Array.isArray(projectList)) {
+      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      return null;
+    }
     const projects: ProjectsList = (projectList as unknown as Project[])
       .filter(
         (project: Project) =>

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -52,14 +52,9 @@ async function getExistingConfig(ctx: CLIContext, cloudApiService: CloudApiServi
       ]);
 
       if (!shouldRelink) {
-        await trackEvent(
-          cloudApiService,
-          'didNotLinkProject',
-          {
-            currentProjectName: existingConfig.project?.name,
-          },
-          ctx
-        );
+        await trackEvent(ctx, cloudApiService, 'didNotLinkProject', {
+          currentProjectName: existingConfig.project?.name,
+        });
         return null;
       }
     }
@@ -149,7 +144,7 @@ export default async (ctx: CLIContext) => {
     return;
   }
 
-  await trackEvent(cloudApiService, 'willLinkProject', {}, ctx);
+  await trackEvent(ctx, cloudApiService, 'willLinkProject', {});
 
   const projects: ProjectsList | null | undefined = await getProjectsList(
     ctx,
@@ -179,34 +174,23 @@ export default async (ctx: CLIContext) => {
     ]);
 
     if (!confirmAction) {
-      await trackEvent(
-        cloudApiService,
-        'didNotLinkProject',
-        {
-          cancelledProjectName: answer.linkProject.name,
-          currentProjectName: existingConfig.project?.name,
-        },
-        ctx
-      );
+      await trackEvent(ctx, cloudApiService, 'didNotLinkProject', {
+        cancelledProjectName: answer.linkProject.name,
+        currentProjectName: existingConfig.project?.name,
+      });
       return;
     }
 
     await local.save({ project: answer.linkProject });
     logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
-    await trackEvent(
-      cloudApiService,
-      'didLinkProject',
-      { projectInternalName: answer.linkProject },
-      ctx
-    );
+    await trackEvent(ctx, cloudApiService, 'didLinkProject', {
+      projectInternalName: answer.linkProject,
+    });
   } catch (e) {
     logger.debug('Failed to link project', e);
     logger.error('An error occurred while linking the project.');
-    await trackEvent(
-      cloudApiService,
-      'didNotLinkProject',
-      { projectInternalName: answer.linkProject },
-      ctx
-    );
+    await trackEvent(ctx, cloudApiService, 'didNotLinkProject', {
+      projectInternalName: answer.linkProject,
+    });
   }
 };

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -3,10 +3,14 @@ import chalk from 'chalk';
 
 import type { Answers } from 'inquirer';
 import type { CLIContext } from '../types';
+import type { CloudApiService } from '../services/cli-api';
+
 import { LocalSave } from '../services/strapi-info-save';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { promptLogin } from '../login/action';
 import { trackEvent } from '../utils/analytics';
+
+const QUIT_OPTION = 'Quit';
 
 interface LinkProjectValue {
   name: string;
@@ -14,132 +18,20 @@ interface LinkProjectValue {
 }
 
 interface LinkProjectAnswer extends Answers {
-  linkProject: LinkProjectValue | 'quit';
+  linkProject: LinkProjectValue;
 }
 
-export default async (ctx: CLIContext) => {
-  const { getValidToken } = await tokenServiceFactory(ctx);
-  const token = await getValidToken(ctx, promptLogin);
-  const { logger } = ctx;
+interface LinkProjectInput extends Answers {
+  linkProject: LinkProjectValue | string;
+}
 
-  if (!token) {
-    return;
-  }
-
-  let existingConfig: LocalSave | null;
-
-  try {
-    existingConfig = await getExistingConfig(ctx, logger);
-    // If user selects not to relink, return
-    if (existingConfig === null) {
-      return;
-    }
-  } catch (e) {
-    return;
-  }
-
-  const cloudApiService = await cloudApiFactory(ctx, token);
-
-  try {
-    await trackEvent(cloudApiService, 'willLinkProject', {}, ctx);
-  } catch (e) {
-    /* noop */
-  }
-
-  const spinner = logger.spinner('Fetching your projects...\n').start();
-  let projects: unknown[] = [];
-
-  try {
-    const {
-      data: { data: projectList },
-    } = await cloudApiService.listLinkProjects();
-    spinner.succeed();
-    projects = Object.values(projectList)
-      .filter(
-        (project: any) => !(project.isMaintainer || project.name === existingConfig?.project?.name)
-      )
-      .map((project: any) => {
-        return {
-          name: project.displayName,
-          value: { name: project.name, displayName: project.displayName },
-        };
-      });
-    if (projects.length === 0) {
-      logger.log("We couldn't find any projects available for linking in Strapi Cloud");
-      return;
-    }
-  } catch (e) {
-    ctx.logger.debug('Failed to list projects', e);
-    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
-  }
-
-  let answer: LinkProjectAnswer | null = null;
-  try {
-    answer = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'linkProject',
-        message: 'Which project do you want to link?',
-        choices: [...projects, { name: chalk.grey('(Quit)'), value: 'quit' }],
-      },
-    ]);
-
-    if (answer === null || answer.linkProject === 'quit') {
-      return;
-    }
-
-    const { confirmLink } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'confirmLink',
-        message:
-          'Warning: Once linked, deploying from CLI will replace the existing project and its data. Confirm to proceed:',
-        default: false,
-      },
-    ]);
-
-    if (!confirmLink) {
-      try {
-        await trackEvent(
-          cloudApiService,
-          'didNotLinkProject',
-          { projectInternalName: answer.linkProject },
-          ctx
-        );
-      } catch (e) {
-        /* noop */
-      }
-      return;
-    }
-  } catch (e) {
-    logger.error('Failed to get user input', e);
-    return;
-  }
-
-  try {
-    await local.save({ project: answer.linkProject });
-    logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
-    try {
-      await trackEvent(
-        cloudApiService,
-        'didLinkProject',
-        { projectInternalName: answer.linkProject },
-        ctx
-      );
-    } catch (e) {
-      /* noop */
-    }
-  } catch (e) {
-    logger.debug('Failed to link project', e);
-    logger.error('An error occurred while linking the project.');
-    await trackEvent(
-      cloudApiService,
-      'didNotLinkProject',
-      { projectInternalName: answer.linkProject },
-      ctx
-    );
-  }
-};
+type ProjectsList = {
+  name: string;
+  value: {
+    name: string;
+    displayName: string;
+  };
+}[];
 
 async function getExistingConfig(ctx: CLIContext, logger: any) {
   let existingConfig: LocalSave;
@@ -171,3 +63,155 @@ async function getExistingConfig(ctx: CLIContext, logger: any) {
 
   return existingConfig;
 }
+
+async function getProjectsList(
+  cloudApiService: CloudApiService,
+  logger: any,
+  existingConfig: LocalSave
+) {
+  const spinner = logger.spinner('Fetching your projects...\n').start();
+
+  try {
+    const {
+      data: { data: projectList },
+    } = await cloudApiService.listLinkProjects();
+    spinner.succeed();
+    const projects: ProjectsList = Object.values(projectList)
+      .filter(
+        (project: any) => !(project.isMaintainer || project.name === existingConfig?.project?.name)
+      )
+      .map((project: any) => {
+        return {
+          name: project.displayName,
+          value: { name: project.name, displayName: project.displayName },
+        };
+      });
+    if (projects.length === 0) {
+      logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      return;
+    }
+    return projects;
+  } catch (e) {
+    logger.debug('Failed to list projects', e);
+    spinner.fail('An error occurred while fetching your projects from Strapi Cloud.');
+    throw e;
+  }
+}
+
+async function getUserSelection(
+  projects: ProjectsList,
+  logger: any
+): Promise<LinkProjectAnswer | null> {
+  try {
+    const answer: LinkProjectInput = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'linkProject',
+        message: 'Which project do you want to link?',
+        choices: [...projects, { name: chalk.grey(`(${QUIT_OPTION})`), value: null }],
+      },
+    ]);
+
+    if (!answer.linkProject) {
+      return null;
+    }
+
+    return answer as LinkProjectAnswer;
+  } catch (e) {
+    logger.debug('Failed to get user input', e);
+    logger.error('An error occurred while trying to link the project.');
+    return null;
+  }
+}
+
+export default async (ctx: CLIContext) => {
+  const { getValidToken } = await tokenServiceFactory(ctx);
+  const token = await getValidToken(ctx, promptLogin);
+  const { logger } = ctx;
+
+  if (!token) {
+    return;
+  }
+
+  let existingConfig: LocalSave | null;
+
+  try {
+    existingConfig = await getExistingConfig(ctx, logger);
+    // If user selects not to relink, return
+    if (existingConfig === null) {
+      return;
+    }
+  } catch (e) {
+    return;
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+
+  try {
+    await trackEvent(cloudApiService, 'willLinkProject', {}, ctx);
+  } catch (e) {
+    /* noop */
+  }
+
+  let projects: ProjectsList | undefined;
+
+  try {
+    projects = await getProjectsList(cloudApiService, logger, existingConfig);
+  } catch (e) {
+    return;
+  }
+
+  if (!projects) {
+    return;
+  }
+
+  let answer: LinkProjectAnswer | null = null;
+
+  try {
+    answer = await getUserSelection(projects, logger);
+  } catch (e) {
+    return;
+  }
+
+  if (!answer) {
+    return;
+  }
+
+  try {
+    const { confirmAction } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'confirmAction',
+        message:
+          'Warning: Once linked, deploying from CLI will replace the existing project and its data. Confirm to proceed:',
+        default: false,
+      },
+    ]);
+
+    if (!confirmAction) {
+      return;
+    }
+
+    await local.save({ project: answer.linkProject });
+    logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
+    try {
+      await trackEvent(
+        cloudApiService,
+        'didLinkProject',
+        { projectInternalName: answer.linkProject },
+        ctx
+      );
+    } catch (e) {
+      /* noop */
+    }
+  } catch (e) {
+    logger.debug('Failed to link project', e);
+    logger.error('An error occurred while linking the project.');
+    await trackEvent(
+      cloudApiService,
+      'didNotLinkProject',
+      { projectInternalName: answer.linkProject },
+      ctx
+    );
+  }
+};

--- a/packages/cli/cloud/src/link/command.ts
+++ b/packages/cli/cloud/src/link/command.ts
@@ -3,16 +3,16 @@ import { runAction } from '../utils/helpers';
 import action from './action';
 
 /**
- * `$ list project from the cloud`
+ * `$ link local directory to project of the cloud`
  */
 const command: StrapiCloudCommand = ({ command, ctx }) => {
   command
-    .command('cloud:projects')
-    .alias('projects')
-    .description('List Strapi Cloud projects')
+    .command('cloud:link')
+    .alias('link')
+    .description('Link a local directory to a Strapi Cloud project')
     .option('-d, --debug', 'Enable debugging mode with verbose logs')
     .option('-s, --silent', "Don't log anything")
-    .action(() => runAction('projects', action)(ctx));
+    .action(() => runAction('link', action)(ctx));
 };
 
 export default command;

--- a/packages/cli/cloud/src/link/index.ts
+++ b/packages/cli/cloud/src/link/index.ts
@@ -1,0 +1,12 @@
+import action from './action';
+import command from './command';
+import type { StrapiCloudCommandInfo } from '../types';
+
+export { action, command };
+
+export default {
+  name: 'link-project',
+  description: 'link a local directory to a Strapi Cloud project',
+  action,
+  command,
+} as StrapiCloudCommandInfo;

--- a/packages/cli/cloud/src/link/index.ts
+++ b/packages/cli/cloud/src/link/index.ts
@@ -6,7 +6,7 @@ export { action, command };
 
 export default {
   name: 'link-project',
-  description: 'link a local directory to a Strapi Cloud project',
+  description: 'Link a local directory to a Strapi Cloud project',
   action,
   command,
 } as StrapiCloudCommandInfo;

--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -62,12 +62,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
     logger.debug(e);
     return false;
   }
-
-  try {
-    await trackEvent(cloudApiService, 'willLoginAttempt', {}, ctx);
-  } catch (e) {
-    /* noop */
-  }
+  await trackEvent(ctx, cloudApiService, 'willLoginAttempt', {});
 
   logger.debug('🔐 Creating device authentication request...', {
     client_id: cliConfig.clientId,
@@ -160,11 +155,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
             'There seems to be a problem with your login information. Please try logging in again.'
           );
           spinnerFail();
-          try {
-            await trackEvent(cloudApiService, 'didNotLogin', { loginMethod: 'cli' }, ctx);
-          } catch (e) {
-            /* noop */
-          }
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli' });
           return false;
         }
         if (
@@ -173,11 +164,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
         ) {
           logger.debug(e);
           spinnerFail();
-          try {
-            await trackEvent(cloudApiService, 'didNotLogin', { loginMethod: 'cli' }, ctx);
-          } catch (e) {
-            /* noop */
-          }
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli' });
           return false;
         }
         // Await interval before retrying
@@ -192,11 +179,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
       'To access your dashboard, please copy and paste the following URL into your web browser:'
     );
     logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects`));
-    try {
-      await trackEvent(cloudApiService, 'didLogin', { loginMethod: 'cli' }, ctx);
-    } catch (e) {
-      /* noop */
-    }
+    await trackEvent(ctx, cloudApiService, 'didLogin', { loginMethod: 'cli' });
   };
 
   await authenticate();

--- a/packages/cli/cloud/src/logout/action.ts
+++ b/packages/cli/cloud/src/logout/action.ts
@@ -41,9 +41,5 @@ export default async (ctx: CLIContext) => {
     logger.error('🥲 Oops! Something went wrong while logging you out. Please try again.');
     logger.debug(e);
   }
-  try {
-    await trackEvent(cloudApiService, 'didLogout', { loginMethod: 'cli' }, ctx);
-  } catch (e) {
-    /* noop */
-  }
+  await trackEvent(ctx, cloudApiService, 'didLogout', { loginMethod: 'cli' });
 };

--- a/packages/cli/cloud/src/logout/action.ts
+++ b/packages/cli/cloud/src/logout/action.ts
@@ -1,5 +1,6 @@
 import type { CLIContext } from '../types';
 import { tokenServiceFactory, cloudApiFactory } from '../services';
+import { trackEvent } from '../utils/analytics';
 
 const openModule = import('open');
 
@@ -41,8 +42,8 @@ export default async (ctx: CLIContext) => {
     logger.debug(e);
   }
   try {
-    await cloudApiService.track('didLogout', { loginMethod: 'cli' });
+    await trackEvent(cloudApiService, 'didLogout', { loginMethod: 'cli' }, ctx);
   } catch (e) {
-    logger.debug('Failed to track logout event', e);
+    /* noop */
   }
 };

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -10,13 +10,15 @@ import packageJson from '../../package.json';
 export const VERSION = 'v1';
 
 export type ProjectInfos = {
+  id: string;
   name: string;
-  nodeVersion: string;
-  region: string;
+  displayName?: string;
+  nodeVersion?: string;
+  region?: string;
   plan?: string;
   url?: string;
 };
-export type ProjectInput = Omit<ProjectInfos, 'id'>;
+export type CreateProjectInput = Omit<ProjectInfos, 'id'>;
 
 export type DeployResponse = {
   build_id: string;
@@ -26,6 +28,12 @@ export type DeployResponse = {
 export type TrackPayload = Record<string, unknown>;
 
 export type ListProjectsResponse = {
+  data: {
+    data: string;
+  };
+};
+
+export type ListLinkProjectsResponse = {
   data: {
     data: string;
   };
@@ -44,8 +52,8 @@ export interface CloudApiService {
     }
   ): Promise<AxiosResponse<DeployResponse>>;
 
-  createProject(projectInput: ProjectInput): Promise<{
-    data: ProjectInfos;
+  createProject(createProjectInput: CreateProjectInput): Promise<{
+    data: CreateProjectInput;
     status: number;
   }>;
 
@@ -54,6 +62,8 @@ export interface CloudApiService {
   config(): Promise<AxiosResponse<CloudCliConfig>>;
 
   listProjects(): Promise<AxiosResponse<ListProjectsResponse>>;
+
+  listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
 
   track(event: string, payload?: TrackPayload): Promise<AxiosResponse<void>>;
 }
@@ -141,6 +151,23 @@ export async function cloudApiFactory(
     async listProjects(): Promise<AxiosResponse<ListProjectsResponse>> {
       try {
         const response = await axiosCloudAPI.get('/projects');
+
+        if (response.status !== 200) {
+          throw new Error('Error fetching cloud projects from the server.');
+        }
+
+        return response;
+      } catch (error) {
+        logger.debug(
+          "🥲 Oops! Couldn't retrieve your project's list from the server. Please try again."
+        );
+        throw error;
+      }
+    },
+
+    async listLinkProjects(): Promise<AxiosResponse<ListProjectsResponse>> {
+      try {
+        const response = await axiosCloudAPI.get('/projects/link');
 
         if (response.status !== 200) {
           throw new Error('Error fetching cloud projects from the server.');

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -34,7 +34,7 @@ export type ListProjectsResponse = {
 
 export type ListLinkProjectsResponse = {
   data: {
-    data: ProjectInfos[];
+    data: ProjectInfos[] | Record<string, never>;
   };
 };
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -167,7 +167,7 @@ export async function cloudApiFactory(
 
     async listLinkProjects(): Promise<AxiosResponse<ListProjectsResponse>> {
       try {
-        const response = await axiosCloudAPI.get('/projects/link');
+        const response = await axiosCloudAPI.get('/projects/linkable');
 
         if (response.status !== 200) {
           throw new Error('Error fetching cloud projects from the server.');

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -18,7 +18,7 @@ export type ProjectInfos = {
   plan?: string;
   url?: string;
 };
-export type CreateProjectInput = Omit<ProjectInfos, 'id'>;
+export type ProjectInput = Omit<ProjectInfos, 'id'>;
 
 export type DeployResponse = {
   build_id: string;
@@ -50,8 +50,8 @@ export interface CloudApiService {
     }
   ): Promise<AxiosResponse<DeployResponse>>;
 
-  createProject(createProjectInput: CreateProjectInput): Promise<{
-    data: CreateProjectInput;
+  createProject(createProjectInput: ProjectInput): Promise<{
+    data: ProjectInput;
     status: number;
   }>;
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -18,6 +18,7 @@ export type ProjectInfos = {
   plan?: string;
   url?: string;
 };
+
 export type ProjectInput = Omit<ProjectInfos, 'id'>;
 
 export type DeployResponse = {
@@ -33,7 +34,7 @@ export type ListProjectsResponse = {
 
 export type ListLinkProjectsResponse = {
   data: {
-    data: string;
+    data: ProjectInfos[];
   };
 };
 
@@ -163,7 +164,7 @@ export async function cloudApiFactory(
       }
     },
 
-    async listLinkProjects(): Promise<AxiosResponse<ListProjectsResponse>> {
+    async listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse, unknown>> {
       try {
         const response = await axiosCloudAPI.get('/projects/linkable');
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosResponse } from 'axios';
 import fse from 'fs-extra';
 import os from 'os';
 import { apiConfig } from '../config/api';
-import type { CLIContext, CloudCliConfig } from '../types';
+import type { CLIContext, CloudCliConfig, TrackPayload } from '../types';
 import { getLocalConfig } from '../config/local';
 
 import packageJson from '../../package.json';
@@ -24,8 +24,6 @@ export type DeployResponse = {
   build_id: string;
   image: string;
 };
-
-export type TrackPayload = Record<string, unknown>;
 
 export type ListProjectsResponse = {
   data: {

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -5,12 +5,21 @@ import type { ProjectInfos } from './cli-api';
 export const LOCAL_SAVE_FILENAME = '.strapi-cloud.json';
 
 export type LocalSave = {
-  project?: ProjectInfos;
+  project?: Omit<ProjectInfos, 'id'>;
 };
 
-export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {
+export async function save(
+  data: LocalSave,
+  { directoryPath, override }: { directoryPath?: string; override?: boolean } = {}
+) {
   const alreadyInFileData = await retrieve({ directoryPath });
-  const storedData = { ...alreadyInFileData, ...data };
+  let storedData = { ...alreadyInFileData, ...data };
+  if (override) {
+    storedData = data;
+  } else {
+    const alreadyInFileData = await retrieve({ directoryPath });
+    storedData = { ...alreadyInFileData, ...data };
+  }
   const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
   // Ensure the directory exists
   await fse.ensureDir(path.dirname(pathToFile));

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -8,11 +8,9 @@ export type LocalSave = {
   project?: Omit<ProjectInfos, 'id'>;
 };
 
-export async function save(
-  data: LocalSave,
-  { directoryPath, override }: { directoryPath?: string; override?: boolean } = {}
-) {
-  const storedData = override ? data : { ...(await retrieve({ directoryPath })), ...data };
+export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {
+  const alreadyInFileData = await retrieve({ directoryPath });
+  const storedData = { ...alreadyInFileData, ...data };
   const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
   // Ensure the directory exists
   await fse.ensureDir(path.dirname(pathToFile));

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -12,14 +12,7 @@ export async function save(
   data: LocalSave,
   { directoryPath, override }: { directoryPath?: string; override?: boolean } = {}
 ) {
-  const alreadyInFileData = await retrieve({ directoryPath });
-  let storedData = { ...alreadyInFileData, ...data };
-  if (override) {
-    storedData = data;
-  } else {
-    const alreadyInFileData = await retrieve({ directoryPath });
-    storedData = { ...alreadyInFileData, ...data };
-  }
+  const storedData = override ? data : { ...(await retrieve({ directoryPath })), ...data };
   const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
   // Ensure the directory exists
   await fse.ensureDir(path.dirname(pathToFile));

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -46,4 +46,6 @@ export type StrapiCloudCommandInfo = {
   action: (ctx: CLIContext) => Promise<unknown>;
 };
 
+export type TrackPayload = Record<string, unknown>;
+
 export type * from './services/cli-api';

--- a/packages/cli/cloud/src/utils/analytics.ts
+++ b/packages/cli/cloud/src/utils/analytics.ts
@@ -1,0 +1,16 @@
+import type { CLIContext, CloudApiService, TrackPayload } from '../types';
+
+const trackEvent = async (
+  cloudApiService: CloudApiService,
+  eventName: string,
+  eventData: TrackPayload,
+  ctx: CLIContext
+) => {
+  try {
+    await cloudApiService.track(eventName, eventData);
+  } catch (e) {
+    ctx.logger.debug(`Failed to track ${eventName}`, e);
+  }
+};
+
+export { trackEvent };

--- a/packages/cli/cloud/src/utils/analytics.ts
+++ b/packages/cli/cloud/src/utils/analytics.ts
@@ -1,10 +1,10 @@
 import type { CLIContext, CloudApiService, TrackPayload } from '../types';
 
 const trackEvent = async (
+  ctx: CLIContext,
   cloudApiService: CloudApiService,
   eventName: string,
-  eventData: TrackPayload,
-  ctx: CLIContext
+  eventData: TrackPayload
 ) => {
   try {
     await cloudApiService.track(eventName, eventData);


### PR DESCRIPTION
What does it do?
This PR introduces the project `link` command into the Strapi Cloud CLI

Why is it needed?
It gives users a chance to link their local projects to existing projects in Strapi Cloud from the CLI

How to test it?

1. Verify that the projects command is listed among the available commands.
2. Ensure that the link command executes correctly.
3. If the user is not logged in, they should be prompted to log in.
4. If the user is not in a valid project folder, the command should exit with a message.
5. If there is a project already linked to the current folder, it should ask the user if they want to update the current link and correctly display the name of the linked project.
6. If the user selects "no", the command should exit.
7. If the user selects "yes", the command should continue with the project fetching and display a list of projects for which the user is the owner (not maintainer).
8. When the user selects a project, the project config should be created, replacing the existing previous config.
9. A message for successful linking should be displayed.
10. Confirm that any 500 error returned from the server is handled gracefully, without causing the CLI to crash.
11. Verify that the rest of the commands function correctly.