### PR TITLE
fix: invalid path separator

### DIFF
--- a/packages/core/strapi/src/load/__tests__/filepath-to-prop-path.test.ts
+++ b/packages/core/strapi/src/load/__tests__/filepath-to-prop-path.test.ts
@@ -25,4 +25,21 @@ describe('filePathToPropPath', () => {
     expect(filePathToPropPath('./config/test.js', false)).toEqual(['config']);
     expect(filePathToPropPath('./config/test.key.js', false)).toEqual(['config', 'test']);
   });
+
+  describe('Separators', () => {
+    test('Win32 Separators', () => {
+      expect(filePathToPropPath('config\\test.js')).toEqual(['config', 'test']);
+      expect(filePathToPropPath('.\\config\\test.js')).toEqual(['config', 'test']);
+    });
+
+    test('Posix Separators', () => {
+      expect(filePathToPropPath('config/test.js')).toEqual(['config', 'test']);
+      expect(filePathToPropPath('./config/test.js')).toEqual(['config', 'test']);
+    });
+
+    test('Mixed Separators (win32 + posix)', () => {
+      expect(filePathToPropPath('src\\config/test.js')).toEqual(['src', 'config', 'test']);
+      expect(filePathToPropPath('.\\config/test.js')).toEqual(['config', 'test']);
+    });
+  });
 });

--- a/packages/core/strapi/src/load/filepath-to-prop-path.ts
+++ b/packages/core/strapi/src/load/filepath-to-prop-path.ts
@@ -1,18 +1,37 @@
-import _ from 'lodash';
+import path from 'node:path';
+import fp from 'lodash/fp';
 
 /**
  * Returns a path (as an array) from a file path
  */
-export default (filePath: string, useFileNameAsKey = true) => {
-  const cleanPath = filePath.startsWith('./') ? filePath.slice(2) : filePath;
+export default (
+  entryPath: string,
+  useFileNameAsKey: boolean = true
+): string[] => {
+  const transform = fp.pipe(
+    // Remove the relative path prefixes: './' for posix (and some win32) and ".\" for win32
+    removeRelativePrefix,
+    // Remove the path metadata and extensions
+    fp.replace(/(\.settings|\.json|\.js)/g, ''),
+    // Transform to lowercase
+    // Note: We're using fp.toLower instead of fp.lowercase as the latest removes special characters such as "/"
+    fp.toLower,
+    // Split the cleaned path by matching every possible separator (either "/" or "\" depending on the OS)
+    fp.split(new RegExp(`[\\${path.win32.sep}|${path.posix.sep}]`, 'g')),
+    // Make sure to remove leading '.' from the different path parts
+    fp.map(fp.trimCharsStart('.')),
+    // join + split in case some '.' characters are still present in different parts of the path
+    fp.join('.'),
+    fp.split('.'),
+    // Remove the last portion of the path array if the file name shouldn't be used as a key
+    useFileNameAsKey ? fp.identity : fp.slice(0, -1)
+  );
 
-  const prop = cleanPath
-    .replace(/(\.settings|\.json|\.js)/g, '')
-    .toLowerCase()
-    .split('/')
-    .map((p) => _.trimStart(p, '.'))
-    .join('.')
-    .split('.');
+  return transform(entryPath) as string[];
+};
 
-  return useFileNameAsKey === true ? prop : prop.slice(0, -1);
+const removeRelativePrefix = (filePath: string) => {
+  return filePath.startsWith(`.${path.win32.sep}`) || filePath.startsWith(`.${path.posix.sep}`)
+    ? filePath.slice(2)
+    : filePath;
 };

--- a/packages/core/strapi/src/load/filepath-to-prop-path.ts
+++ b/packages/core/strapi/src/load/filepath-to-prop-path.ts
@@ -4,10 +4,7 @@ import fp from 'lodash/fp';
 /**
  * Returns a path (as an array) from a file path
  */
-export default (
-  entryPath: string,
-  useFileNameAsKey: boolean = true
-): string[] => {
+export default (entryPath: string, useFileNameAsKey: boolean = true): string[] => {
   const transform = fp.pipe(
     // Remove the relative path prefixes: './' for posix (and some win32) and ".\" for win32
     removeRelativePrefix,


### PR DESCRIPTION
### What does it do?
Copy of https://github.com/strapi/strapi/pull/20680 on the v4 branch (develop)

Adds support for cross-platform handling of separators (win32 and posix) when parsing file paths.


### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20730
