### PR TITLE
Add user info to auth error

### DIFF
--- a/packages/core/admin/server/src/controllers/authentication.ts
+++ b/packages/core/admin/server/src/controllers/authentication.ts
@@ -44,6 +44,9 @@ export default {
           strapi.eventHub.emit('admin.auth.error', {
             error: new Error(info.message),
             provider: 'local',
+            user: {
+              email: ctx.request.body.email
+            }
           });
           throw new ApplicationError(info.message);
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I added information about the user to the event in order to later use this information to understand who failed the authorization procedure.

### Why is it needed?

I added information about the user to the event in order to later use this information to understand who failed the authorization procedure.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
