### PR TITLE
fix: json input stringifying value when it shouldn't

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Json.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Json.tsx
@@ -16,20 +16,34 @@ const JsonInput = forwardRef<JSONInputRef, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const field = useField(name);
     const fieldRef = useFocusInputField(name);
-
     const composedRefs = useComposedRefs(ref, fieldRef);
+
+    const handleChange = (json: string) => {
+      if (required && !json.length) {
+        // Default to null when the field is not required and there is no input value
+        field.onChange(name, null);
+      } else {
+        try {
+          field.onChange(name, JSON.parse(json));
+        } catch (e) {
+          /**
+           * Save the string value even though it's invalid to keep providing visual feedback.
+           * We rely to the validations to prevent invalid data from being saved
+           */
+          field.onChange(name, json);
+        }
+      }
+    };
 
     return (
       <Field.Root error={field.error} name={name} hint={hint} required={required}>
         <Field.Label action={labelAction}>{label}</Field.Label>
         <JSONInputImpl
           ref={composedRefs}
-          value={field.value}
-          onChange={(json) => {
-            // Default to null when the field is not required and there is no input value
-            const value = required && !json.length ? null : json;
-            field.onChange(name, value);
-          }}
+          value={
+            typeof field.value == 'object' ? JSON.stringify(field.value, null, 2) : field.value
+          }
+          onChange={handleChange}
           minHeight={`25.2rem`}
           maxHeight={`50.4rem`}
           {...props}

--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -182,7 +182,14 @@ const createAttributeSchema = (
         }
 
         try {
-          JSON.parse(value);
+          /**
+           * Only allow saving if the value is an object, not a string.
+           * It can be a string is the JSON field fails to parse the value.
+           * This is done to ensure we keep giving live visual feedback, even the JSON is invalid.
+           */
+          if (typeof value !== 'object') {
+            return false;
+          }
 
           return true;
         } catch (err) {


### PR DESCRIPTION
### What does it do?

Ensures that even though the JSON input from the design system deals with string data, at the Content Manager, we manipulate JSON objects instead.

In v5 users noticed the data type in the database for JSON inputs had become string instead of json objects. This was because in v5 we were sending stringified JSON data from the admin, instead of objects like in v4.

so what this does:
- ensures all saved data for JSON inputs is objects
- prevents crashed if the data in the database was a string instead of an object
- auto-formats json data in the input

### How to test it?

- try to write invalid json in an input. You should see your update, but a validation should stop you from saving it
- write and save valid content in an input. Open a database explorer. You should see the content saved as JSON (not in a string)

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20655