### PR TITLE
fix: show media dialog in blocks and markdown editors

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Image.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Image.tsx
@@ -196,9 +196,11 @@ const imageBlocks: Pick<BlocksStore, 'image'> = {
       });
     },
     handleConvert: () => {
-      // All the logic is managed inside the ImageDialog component,
-      // because the blocks are only created when the user selects images in the modal and submits
-      // and if he closes the modal, then no changes are made to the editor
+      /**
+       * All the logic is managed inside the ImageDialog component,
+       * because the blocks are only created when the user selects images in the modal and submits
+       * and if he closes the modal, then no changes are made to the editor
+       */
       return () => <ImageDialog />;
     },
     snippets: ['!['],

--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
@@ -22,6 +22,7 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
         <AssetDialog
           allowedTypes={allowedTypes}
           folderId={folderId}
+          open
           onClose={() => {
             setStep(undefined);
             setFolderId(null);

--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
@@ -38,11 +38,17 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
 
     case STEPS.FolderCreate:
       return (
-        <EditFolderDialog onClose={() => setStep(STEPS.AssetSelect)} parentFolderId={folderId} />
+        <EditFolderDialog
+          open
+          onClose={() => setStep(STEPS.AssetSelect)}
+          parentFolderId={folderId}
+        />
       );
 
     default:
-      return <UploadAssetDialog onClose={() => setStep(STEPS.AssetSelect)} folderId={folderId} />;
+      return (
+        <UploadAssetDialog open onClose={() => setStep(STEPS.AssetSelect)} folderId={folderId} />
+      );
   }
 };
 

--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/index.jsx
@@ -23,11 +23,7 @@ export const MediaLibraryDialog = ({ onClose, onSelectAssets, allowedTypes }) =>
           allowedTypes={allowedTypes}
           folderId={folderId}
           open
-          onClose={() => {
-            setStep(undefined);
-            setFolderId(null);
-            onClose();
-          }}
+          onClose={onClose}
           onValidate={onSelectAssets}
           onAddAsset={() => setStep(STEPS.AssetUpload)}
           onAddFolder={() => setStep(STEPS.FolderCreate)}


### PR DESCRIPTION
### What does it do?

The media dialog did not display in the rich text editors (both Blocks and Markdown). This fixes it

The open/closed state is actually managed outside of the MediaLibraryDialog, by conditionally rendering it. So when it is rendered, it should always display its content, hence the `open={true}`

Also removes some unnecessary onClose code, because since the component is now remounted when we reopen it, the state will be reinitialized, no need to do it manually

### How to test it?

- Add an image to a blocks field. Create a folder too from within the dialog.
- Do the same in a markdown field

### Related issue(s)/PR(s)

fix #20743