### PR TITLE
feat: history version on bulk publish locales

### DIFF
--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -143,14 +143,14 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
         });
 
         await strapi.db.transaction(async ({ onCommit }) => {
+          // .createVersion() is executed asynchronously,
+          // onCommit prevents creating a history version
+          // when the transaction has already been committed
           onCommit(async () => {
             for (const entry of localeEntries) {
               const status = await serviceUtils.getVersionStatus(uid, entry);
 
-              // .createVersion is executed asynchronously,
-              // onCommit prevents creating a history version
-              // when the transaction has already been committed
-              getService(strapi, 'history').createVersion({
+              await getService(strapi, 'history').createVersion({
                 contentType: uid,
                 data: omit(FIELDS_TO_IGNORE, entry) as Modules.Documents.AnyDocument,
                 relatedDocumentId: documentId,

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -1,6 +1,6 @@
-import type { Core, Modules } from '@strapi/types';
+import type { Core, Modules, UID } from '@strapi/types';
 
-import { omit } from 'lodash/fp';
+import { omit, castArray } from 'lodash/fp';
 
 import { scheduleJob } from 'node-schedule';
 
@@ -9,6 +9,86 @@ import { FIELDS_TO_IGNORE, HISTORY_VERSION_UID } from '../constants';
 
 import { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
 import { createServiceUtils } from './utils';
+
+/**
+ * Filters out actions that should not create a history version.
+ */
+const shouldCreateHistoryVersion = (
+  context: Modules.Documents.Middleware.Context
+): context is Modules.Documents.Middleware.Context & {
+  action: 'create' | 'update' | 'clone' | 'publish' | 'unpublish' | 'discardDraft';
+  contentType: UID.CollectionType;
+} => {
+  // Ignore requests that are not related to the content manager
+  if (!strapi.requestContext.get()?.request.url.startsWith('/content-manager')) {
+    return false;
+  }
+
+  // NOTE: cannot do type narrowing with array includes
+  if (
+    context.action !== 'create' &&
+    context.action !== 'update' &&
+    context.action !== 'clone' &&
+    context.action !== 'publish' &&
+    context.action !== 'unpublish' &&
+    context.action !== 'discardDraft'
+  ) {
+    return false;
+  }
+
+  /**
+   * When a document is published, the draft version of the document is also updated.
+   * It creates confusion for users because they see two history versions each publish action.
+   * To avoid this, we silence the update action during a publish request,
+   * so that they only see the published version of the document in the history.
+   */
+  if (
+    context.action === 'update' &&
+    strapi.requestContext.get()?.request.url.endsWith('/actions/publish')
+  ) {
+    return false;
+  }
+
+  // Ignore content types not created by the user
+  if (!context.contentType.uid.startsWith('api::')) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Returns the content type schema (and its components schemas).
+ * Used to determine if changes were made in the content type builder since a history version was created.
+ * And therefore which fields can be restored and which cannot.
+ */
+const getSchemas = (uid: UID.CollectionType) => {
+  const attributesSchema = strapi.getModel(uid).attributes;
+
+  // TODO: Handle nested components
+  const componentsSchemas = Object.keys(attributesSchema).reduce(
+    (currentComponentSchemas, key) => {
+      const fieldSchema = attributesSchema[key];
+
+      if (fieldSchema.type === 'component') {
+        const componentSchema = strapi.getModel(fieldSchema.component).attributes;
+        return {
+          ...currentComponentSchemas,
+          [fieldSchema.component]: componentSchema,
+        };
+      }
+
+      // Ignore anything that's not a component
+      return currentComponentSchemas;
+    },
+    {} as CreateHistoryVersion['componentsSchemas']
+  );
+
+  return {
+    schema: omit(FIELDS_TO_IGNORE, attributesSchema) as CreateHistoryVersion['schema'],
+    componentsSchemas,
+  };
+};
 
 const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
   const state: {
@@ -27,110 +107,58 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
       if (state.isInitialized) {
         return;
       }
-      /**
-       * TODO: Fix the types for the middleware
-       */
+
       strapi.documents.use(async (context, next) => {
-        // Ignore requests that are not related to the content manager
-        if (!strapi.requestContext.get()?.request.url.startsWith('/content-manager')) {
-          return next();
-        }
-
-        // NOTE: cannot do type narrowing with array includes
-        if (
-          context.action !== 'create' &&
-          context.action !== 'update' &&
-          context.action !== 'clone' &&
-          context.action !== 'publish' &&
-          context.action !== 'unpublish' &&
-          context.action !== 'discardDraft'
-        ) {
-          return next();
-        }
-
-        /**
-         * When a document is published, the draft version of the document is also updated.
-         * It creates confusion for users because they see two history versions each publish action.
-         * To avoid this, we silence the update action during a publish request,
-         * so that they only see the published version of the document in the history.
-         */
-        if (
-          context.action === 'update' &&
-          strapi.requestContext.get()?.request.url.endsWith('/actions/publish')
-        ) {
-          return next();
-        }
-
-        const contentTypeUid = context.contentType.uid;
-        // Ignore content types not created by the user
-        if (!contentTypeUid.startsWith('api::')) {
-          return next();
-        }
-
         const result = (await next()) as any;
 
-        const documentContext = {
-          documentId:
-            context.action === 'create' || context.action === 'clone'
-              ? result.documentId
-              : context.params.documentId,
-          locale: context.params?.locale,
-        };
-
-        const defaultLocale = await serviceUtils.getDefaultLocale();
-        const locale = documentContext.locale || defaultLocale;
-
-        if (Array.isArray(locale)) {
-          strapi.log.warn(
-            '[Content manager history middleware]: An array of locales was provided, but only a single locale is supported for the findOne operation.'
-          );
-          // TODO calls picked from the middleware could contain an array of
-          // locales. This is incompatible with our call to findOne below.
-          return next();
+        if (!shouldCreateHistoryVersion(context)) {
+          return result;
         }
 
-        const document = await strapi.documents(contentTypeUid).findOne({
-          documentId: documentContext.documentId,
-          locale,
-          populate: serviceUtils.getDeepPopulate(contentTypeUid),
+        // On create/clone actions, the documentId is not available before creating the action is executed
+        const documentId =
+          context.action === 'create' || context.action === 'clone'
+            ? result.documentId
+            : context.params.documentId;
+
+        // Apply default locale if not available in the request
+        const defaultLocale = await serviceUtils.getDefaultLocale();
+        const locales = castArray(context.params?.locale || defaultLocale);
+        if (!locales.length) {
+          return result;
+        }
+
+        // All schemas related to the content type
+        const uid = context.contentType.uid;
+        const schemas = getSchemas(uid);
+
+        // Find all affected entries
+        const localeEntries = await strapi.db.query(uid).findMany({
+          where: {
+            documentId,
+            locale: { $in: locales },
+            publishedAt: null,
+          },
+          populate: serviceUtils.getDeepPopulate(uid, true /* use database syntax */),
         });
-        const status = await serviceUtils.getVersionStatus(contentTypeUid, document);
 
-        /**
-         * Store schema of both the fields and the fields of the attributes, as it will let us know
-         * if changes were made in the CTB since a history version was created,
-         * and therefore which fields can be restored and which cannot.
-         */
-        const attributesSchema = strapi.getModel(contentTypeUid).attributes;
-        const componentsSchemas: CreateHistoryVersion['componentsSchemas'] = Object.keys(
-          attributesSchema
-        ).reduce((currentComponentSchemas, key) => {
-          const fieldSchema = attributesSchema[key];
-
-          if (fieldSchema.type === 'component') {
-            const componentSchema = strapi.getModel(fieldSchema.component).attributes;
-            return {
-              ...currentComponentSchemas,
-              [fieldSchema.component]: componentSchema,
-            };
-          }
-
-          // Ignore anything that's not a component
-          return currentComponentSchemas;
-        }, {});
-
-        // Prevent creating a history version for an action that wasn't actually executed
         await strapi.db.transaction(async ({ onCommit }) => {
-          onCommit(() => {
-            getService(strapi, 'history').createVersion({
-              contentType: contentTypeUid,
-              data: omit(FIELDS_TO_IGNORE, document) as Modules.Documents.AnyDocument,
-              schema: omit(FIELDS_TO_IGNORE, attributesSchema),
-              componentsSchemas,
-              relatedDocumentId: documentContext.documentId,
-              locale,
-              status,
-            });
+          onCommit(async () => {
+            for (const entry of localeEntries) {
+              const status = await serviceUtils.getVersionStatus(uid, entry);
+
+              // .createVersion is executed asynchronously,
+              // onCommit prevents creating a history version
+              // when the transaction has already been committed
+              getService(strapi, 'history').createVersion({
+                contentType: uid,
+                data: omit(FIELDS_TO_IGNORE, entry) as Modules.Documents.AnyDocument,
+                relatedDocumentId: documentId,
+                locale: entry.locale,
+                status,
+                ...schemas,
+              });
+            }
           });
         });
 

--- a/packages/core/content-manager/server/src/history/services/utils.ts
+++ b/packages/core/content-manager/server/src/history/services/utils.ts
@@ -179,10 +179,14 @@ export const createServiceUtils = ({ strapi }: { strapi: Core.Strapi }) => {
    * @description
    * Creates a populate object that looks for all the relations that need
    * to be saved in history, and populates only the fields needed to later retrieve the content.
+   *
+   * @param uid - The content type UID
+   * @param useDatabaseSyntax - Whether to use the database syntax for populate, defaults to false
    */
-  const getDeepPopulate = (uid: UID.Schema) => {
+  const getDeepPopulate = (uid: UID.Schema, useDatabaseSyntax = false) => {
     const model = strapi.getModel(uid);
     const attributes = Object.entries(model.attributes);
+    const fieldSelector = useDatabaseSyntax ? 'select' : 'fields';
 
     return attributes.reduce((acc: any, [attributeName, attribute]) => {
       switch (attribute.type) {
@@ -195,13 +199,13 @@ export const createServiceUtils = ({ strapi }: { strapi: Core.Strapi }) => {
 
           const isVisible = contentTypes.isVisibleAttribute(model, attributeName);
           if (isVisible) {
-            acc[attributeName] = { fields: ['documentId', 'locale', 'publishedAt'] };
+            acc[attributeName] = { [fieldSelector]: ['documentId', 'locale', 'publishedAt'] };
           }
           break;
         }
 
         case 'media': {
-          acc[attributeName] = { fields: ['id'] };
+          acc[attributeName] = { [fieldSelector]: ['id'] };
           break;
         }
 

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -268,7 +268,13 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     opts: GetMetadataOptions = {}
   ) {
     if (!document) {
-      return document;
+      return {
+        data: document,
+        meta: {
+          availableLocales: [],
+          availableStatus: [],
+        },
+      };
     }
 
     const hasDraftAndPublish = contentTypes.hasDraftAndPublish(strapi.getModel(uid));

--- a/tests/api/core/content-manager/content-manager/history/history.test.api.ts
+++ b/tests/api/core/content-manager/content-manager/history/history.test.api.ts
@@ -339,6 +339,9 @@ describeOnCondition(edition === 'EE')('History API', () => {
   });
 
   afterAll(async () => {
+    // Delete all locales that have been created
+    await strapi.db.query('plugin::i18n.locale').deleteMany({ where: { code: { $ne: 'en' } } });
+
     await strapi.destroy();
     await builder.cleanup();
   });
@@ -666,6 +669,53 @@ describeOnCondition(edition === 'EE')('History API', () => {
       expect(currentDocument['images']).toHaveLength(2);
       expect(restoredDocument['image']).toBe(null);
       expect(restoredDocument['images']).toHaveLength(1);
+    });
+  });
+
+  describe('Bulk actions create versions', () => {
+    it('Creates a history version when bulk publishing document entries', async () => {
+      // Creating a new entry in multiple locales
+      const enProduct = await createEntry({
+        uid: collectionTypeUid,
+        data: { name: 'Product - En' },
+      });
+
+      const frProduct = await updateEntry({
+        uid: collectionTypeUid,
+        documentId: enProduct.data.documentId,
+        locale: 'fr',
+        data: { name: 'Product - Fr' },
+      });
+
+      // Publishing both locales should result in 2 publish history versions (one for each locale)
+      const bulkPublishResult = await rq({
+        method: 'POST',
+        url: `/content-manager/collection-types/${collectionTypeUid}/actions/bulkPublish`,
+        qs: { locale: ['en', 'fr'] },
+        body: { documentIds: [enProduct.data.documentId] },
+      });
+
+      expect(bulkPublishResult.statusCode).toBe(200);
+
+      const enHistoryVersions = await rq({
+        method: 'GET',
+        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${enProduct.data.documentId}`,
+      });
+
+      const frHistoryVersions = await rq({
+        method: 'GET',
+        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${frProduct.data.documentId}`,
+      });
+
+      // Create + Publish = 2 versions
+      expect(enHistoryVersions.body.data).toHaveLength(2);
+      // First one should be the publish version
+      expect(enHistoryVersions.body.data[0].status).toBe('published');
+
+      // Create + Publish = 2 versions
+      expect(frHistoryVersions.body.data).toHaveLength(2);
+      // First one should be the publish version
+      expect(frHistoryVersions.body.data[0].status).toBe('published');
     });
   });
 });


### PR DESCRIPTION
### What does it do?

- Creates a history version when bulk publishing multiple locales of the same document.
- Splitted the history document service middleware as it was getting a bit long. 

### How to test it?

- Go to the Edit View of an entry
- Bulk publish one or more locales
- See that each locale has a "publish" history version created

