### PR TITLE
fix(cloud-cli): avoid blocking event loop in deploy command

### DIFF
--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -6,7 +6,7 @@ import * as crypto from 'node:crypto';
 import { apiConfig } from '../config/api';
 import { compressFilesToTar } from '../utils/compress-files';
 import createProjectAction from '../create-project/action';
-import type { CLIContext, ProjectInfos } from '../types';
+import type { CLIContext, CloudApiService, CloudCliConfig, ProjectInfos } from '../types';
 import { getTmpStoragePath } from '../config/local';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { notificationServiceFactory } from '../services/notification';
@@ -137,6 +137,22 @@ async function getProject(ctx: CLIContext) {
   return project;
 }
 
+async function getConfig({
+  ctx,
+  cloudApiService,
+}: {
+  ctx: CLIContext;
+  cloudApiService: CloudApiService;
+}): Promise<CloudCliConfig | null> {
+  try {
+    const { data: cliConfig } = await cloudApiService.config();
+    return cliConfig;
+  } catch (e) {
+    ctx.logger.debug('Failed to get cli config', e);
+    return null;
+  }
+}
+
 export default async (ctx: CLIContext) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
   const token = await getValidToken(ctx, promptLogin);
@@ -159,7 +175,13 @@ export default async (ctx: CLIContext) => {
   const notificationService = notificationServiceFactory(ctx);
   const buildLogsService = buildLogsServiceFactory(ctx);
 
-  const { data: cliConfig } = await cloudApiService.config();
+  const cliConfig = await getConfig({ ctx, cloudApiService });
+  if (!cliConfig) {
+    ctx.logger.error(
+      'An error occurred while retrieving data from Strapi Cloud. Please try check your network or again later.'
+    );
+    return;
+  }
 
   let maxSize: number = parseInt(cliConfig.maxProjectFileSize, 10);
   if (Number.isNaN(maxSize)) {
@@ -186,10 +208,11 @@ export default async (ctx: CLIContext) => {
       chalk.underline(`${apiConfig.dashboardBaseUrl}/projects/${project.name}/deployments`)
     );
   } catch (e: Error | unknown) {
+    ctx.logger.debug(e);
     if (e instanceof Error) {
       ctx.logger.error(e.message);
     } else {
-      throw e;
+      ctx.logger.error('An error occurred while deploying the project. Please try again later.');
     }
   }
 };

--- a/packages/cli/cloud/src/services/build-logs.ts
+++ b/packages/cli/cloud/src/services/build-logs.ts
@@ -62,6 +62,7 @@ const buildLogsServiceFactory = ({ logger }: CLIContext) => {
           if (retries > MAX_RETRIES) {
             spinner.fail('We were unable to connect to the server to get build logs at this time.');
             es.close();
+            clearExistingTimeout(); // Important to clear the event loop from remaining timeout - avoid to wait for nothing while the timeout is running
             reject(new Error('Max retries reached'));
           }
         };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds some logs and handle a timeout that was not properly cleared before ending the deploy action.

### Why is it needed?

Avoid our users waiting for unnecessary time when something wrong happens with the logs from the build engine.

### How to test it?

You may need to edit the code to try to get logs from a not found URL (I added 123 in the URL for example), in the build engine service.
Then run the deploy command on a strapi project. You will reach the max retries and the command should gracefully quit the node process.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
