### PR TITLE
fix color in disabled buttons

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -298,14 +298,7 @@ const DocumentActionsMenu = ({
                   gap={2}
                   tag="span"
                 >
-                  <Box
-                    tag="span"
-                    color={
-                      !action.disabled ? convertActionVariantToColor(action.variant) : 'inherit'
-                    }
-                  >
-                    {action.icon}
-                  </Box>
+                  <span>{action.icon}</span>
                   {action.label}
                 </Flex>
                 {/* TODO: remove this in 5.1 release */}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -293,8 +293,17 @@ const DocumentActionsMenu = ({
               key={action.id}
             >
               <Flex justifyContent="space-between" gap={4}>
-                <Flex color={convertActionVariantToColor(action.variant)} gap={2} tag="span">
-                  <Box tag="span" color={convertActionVariantToIconColor(action.variant)}>
+                <Flex
+                  color={!action.disabled ? convertActionVariantToColor(action.variant) : 'inherit'}
+                  gap={2}
+                  tag="span"
+                >
+                  <Box
+                    tag="span"
+                    color={
+                      !action.disabled ? convertActionVariantToColor(action.variant) : 'inherit'
+                    }
+                  >
                     {action.icon}
                   </Box>
                   {action.label}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It fixes a UI problem we had in the Document actions when some of them are disabled, instead of using the variant color it is better to inherit the disabled color

### Why is it needed?

Because otherwise, the UI is wrong, we show some disabled buttons with the enabled color

### How to test it?

- Go to the CM and add a new document to a collection
- before saving, click on the More button in the Header, you can see the Delete document and Delete locale buttons disabled with the correct color

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20759 
