### PR TITLE
fix(review-workflows): invalidate document queries when stage & assignee is changed

### DIFF
--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -169,6 +169,7 @@ const documentApi = contentManagerApi.injectEndpoints({
       }),
       providesTags: (result, _error, arg) => {
         return [
+          { type: 'Document', id: `ALL_LIST` },
           { type: 'Document', id: `${arg.model}_LIST` },
           ...(result?.results.map(({ documentId }) => ({
             type: 'Document' as const,

--- a/packages/core/review-workflows/admin/src/services/api.ts
+++ b/packages/core/review-workflows/admin/src/services/api.ts
@@ -1,7 +1,7 @@
 import { adminApi } from '@strapi/admin/strapi-admin';
 
 const reviewWorkflowsApi = adminApi.enhanceEndpoints({
-  addTagTypes: ['ReviewWorkflow', 'ReviewWorkflowStages'],
+  addTagTypes: ['ReviewWorkflow', 'ReviewWorkflowStages', 'Document'],
 });
 
 export { reviewWorkflowsApi };

--- a/packages/core/review-workflows/admin/src/services/api.ts
+++ b/packages/core/review-workflows/admin/src/services/api.ts
@@ -1,7 +1,7 @@
 import { adminApi } from '@strapi/admin/strapi-admin';
 
 const reviewWorkflowsApi = adminApi.enhanceEndpoints({
-  addTagTypes: ['ReviewWorkflow', 'ReviewWorkflowStages', 'Document'],
+  addTagTypes: ['ReviewWorkflow', 'ReviewWorkflowStages', 'Document', 'ContentTypeSettings'],
 });
 
 export { reviewWorkflowsApi };

--- a/packages/core/review-workflows/admin/src/services/content-manager.ts
+++ b/packages/core/review-workflows/admin/src/services/content-manager.ts
@@ -16,7 +16,7 @@ interface ContentTypes {
 
 const SINGLE_TYPES = 'single-types';
 
-const contentManagerApi = reviewWorkflowsApi.enhanceEndpoints({}).injectEndpoints({
+const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
   endpoints: (builder) => ({
     getStages: builder.query<
       {

--- a/packages/core/review-workflows/admin/src/services/content-manager.ts
+++ b/packages/core/review-workflows/admin/src/services/content-manager.ts
@@ -14,7 +14,9 @@ interface ContentTypes {
   singleType: ContentType[];
 }
 
-const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
+const SINGLE_TYPES = 'single-types';
+
+const contentManagerApi = reviewWorkflowsApi.enhanceEndpoints({}).injectEndpoints({
   endpoints: (builder) => ({
     getStages: builder.query<
       {
@@ -51,6 +53,15 @@ const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
         },
       }),
       transformResponse: (res: UpdateStage.Response) => res.data,
+      invalidatesTags: (_result, _error, { slug, id, model }) => {
+        return [
+          {
+            type: 'Document',
+            id: slug !== SINGLE_TYPES ? `${model}_${id}` : model,
+          },
+          { type: 'Document', id: `${model}_LIST` },
+        ];
+      },
     }),
     updateAssignee: builder.mutation<
       UpdateAssignee.Response['data'],
@@ -65,6 +76,15 @@ const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
         },
       }),
       transformResponse: (res: UpdateAssignee.Response) => res.data,
+      invalidatesTags: (_result, _error, { slug, id, model }) => {
+        return [
+          {
+            type: 'Document',
+            id: slug !== SINGLE_TYPES ? `${model}_${id}` : model,
+          },
+          { type: 'Document', id: `${model}_LIST` },
+        ];
+      },
     }),
     getContentTypes: builder.query<ContentTypes, void>({
       query: () => ({

--- a/packages/core/review-workflows/admin/src/services/settings.ts
+++ b/packages/core/review-workflows/admin/src/services/settings.ts
@@ -60,7 +60,12 @@ const settingsApi = reviewWorkflowsApi.injectEndpoints({
         data,
       }),
       transformResponse: (res: Create.Response) => res.data,
-      invalidatesTags: [{ type: 'ReviewWorkflow' as const, id: 'LIST' }, 'ReviewWorkflowStages'],
+      invalidatesTags: [
+        { type: 'ReviewWorkflow' as const, id: 'LIST' },
+        'ReviewWorkflowStages',
+        { type: 'Document', id: `ALL_LIST` },
+        { type: 'ContentTypeSettings', id: 'LIST' },
+      ],
     }),
     updateWorkflow: builder.mutation<
       Update.Response['data'],
@@ -75,6 +80,8 @@ const settingsApi = reviewWorkflowsApi.injectEndpoints({
       invalidatesTags: (res, _err, arg) => [
         { type: 'ReviewWorkflow' as const, id: arg.id },
         'ReviewWorkflowStages',
+        { type: 'Document', id: `ALL_LIST` },
+        { type: 'ContentTypeSettings', id: 'LIST' },
       ],
     }),
     deleteWorkflow: builder.mutation<Delete.Response['data'], Delete.Params>({
@@ -86,6 +93,8 @@ const settingsApi = reviewWorkflowsApi.injectEndpoints({
       invalidatesTags: (res, _err, arg) => [
         { type: 'ReviewWorkflow' as const, id: arg.id },
         'ReviewWorkflowStages',
+        { type: 'Document', id: `ALL_LIST` },
+        { type: 'ContentTypeSettings', id: 'LIST' },
       ],
     }),
   }),


### PR DESCRIPTION
### What does it do?

Make sure to invalidate document queries when RW stage or assignee is changed so we can see the change on the Edit View.

### How to test it?

1. Go to an entry with RW.
2. Change the stage of the entry.

Closes #20745 
