### PR TITLE
Chore: Removing some people from the issue auto-assignment

### DIFF
--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -45,7 +45,7 @@ jobs:
           actions: 'add-assignees'
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
-          assignees: 'derrickmehaffy, kasonde, bolg55, Eventyret, dennism501, n-alonso'
+          assignees: 'derrickmehaffy, kasonde, bolg55, dennism501'
           random-to: 1
 
       # v3 Legacy Issues


### PR DESCRIPTION
### What does it do?

Removing Simen and Nick from the array of people issues will be auto-assigned to

### Why is it needed?

They no longer work for us

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
