### PR TITLE
Fix the dimensions of the More button

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -268,9 +268,9 @@ const DocumentActionsMenu = ({
         disabled={isDisabled}
         size="S"
         endIcon={null}
-        paddingTop="7px"
-        paddingLeft="9px"
-        paddingRight="9px"
+        paddingTop="4px"
+        paddingLeft="7px"
+        paddingRight="7px"
         variant={variant}
       >
         <More aria-hidden focusable={false} />

--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -230,7 +230,7 @@ const Root = ({ children }: RootProps) => {
     // A user can access the dropdown if they have permissions to delete a release-action OR update a release
     allowedActions.canDeleteAction || allowedActions.canUpdate ? (
       <Menu.Root>
-        <Menu.Trigger variant="tertiary" endIcon={null} paddingLeft={2} paddingRight={2}>
+        <Menu.Trigger variant="tertiary" endIcon={null} paddingLeft="7px" paddingRight="7px">
           <AccessibleIcon
             label={formatMessage({
               id: 'content-releases.content-manager-edit-view.release-action-menu',

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -414,8 +414,8 @@ const ReleaseDetailsLayout = ({
                 label={<More />}
                 variant="tertiary"
                 endIcon={null}
-                paddingLeft={2}
-                paddingRight={2}
+                paddingLeft="7px"
+                paddingRight="7px"
                 aria-label={formatMessage({
                   id: 'content-releases.header.actions.open-release-actions',
                   defaultMessage: 'Release edit and delete menu',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

it fixes the dimensions of the More button in the Header, in the Document menu and in the Edit view

### Why is it needed?

Because the button needs to be a square with the More icon inside centered

### How to test it?

Open an entry and check
- the header
<img width="237" alt="Schermata 2024-07-19 alle 17 34 51" src="https://github.com/user-attachments/assets/75915143-14ba-4fc5-896f-91257cef52dc">

- the Document menu
<img width="337" alt="Schermata 2024-07-19 alle 17 35 09" src="https://github.com/user-attachments/assets/00d5f8d0-1ece-461a-ac29-bcfb3ce2ee06">

- and the Release section in the Edit view
<img width="300" alt="Schermata 2024-07-19 alle 17 35 40" src="https://github.com/user-attachments/assets/f731ce54-244e-4a30-beea-8183bf1f9924">

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20764
