### PR TITLE
fix: the left offset of the cloud image

### DIFF
--- a/packages/plugins/cloud/admin/src/pages/HomePage.tsx
+++ b/packages/plugins/cloud/admin/src/pages/HomePage.tsx
@@ -40,7 +40,7 @@ const RightSideCloudContainer = styled(Box)`
 const LeftSideCloudContainer = styled(Box)`
   position: absolute;
   top: 150px;
-  left: 220px;
+  left: 56px;
 
   img {
     width: 15rem;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix a UI issue we had in the cloud plugin

### Why is it needed?

The Cloud background left image had the wrong offset so it seems cut in the layout

### How to test it?

- add the cloud plugin to your Strapi instance with an EE license and check the plugin home page

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20824