### PR TITLE
fix(upload): mock usefolderstructure to fix flaky frontend test

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/tests/MediaLibrary.test.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/tests/MediaLibrary.test.jsx
@@ -67,6 +67,11 @@ jest.mock('../../../../hooks/useMediaLibraryPermissions');
 jest.mock('../../../../hooks/useFolders');
 jest.mock('../../../../hooks/useFolder');
 jest.mock('../../../../hooks/useAssets');
+jest.mock('../../../../hooks/useFolderStructure', () => ({
+  useFolderStructure: jest
+    .fn()
+    .mockReturnValue({ data: [{ label: 'Folder 1', value: 1, children: [] }], isLoading: false }),
+}));
 jest.mock('../../../../hooks/useSelectionState', () => ({
   useSelectionState: jest
     .fn()


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Mock usefolderstructure to fix flaky frontend test

The isLoading state here 
`packages/core/upload/admin/src/components/BulkMoveDialog/BulkMoveDialog.jsx`


was causing a state update that failed this test case
https://github.com/strapi/strapi/blob/47fed6c2b2716a33bc5b44c7465d4be77be27a84/packages/core/upload/admin/src/pages/App/MediaLibrary/tests/MediaLibrary.test.jsx#L361-L362


### How to test it?

Run the tests. To check flaky tests like this I've been using a (pretty hacky) script that looks like

```
#!/bin/zsh
# multi-run.zsh

# COMMAND='npx nx run @strapi/upload:test:front --runInBand --skip-nx-cache'
COMMAND='yarn test:front packages/core/upload/admin/src/pages/App/MediaLibrary/tests/MediaLibrary.test.jsx'

TIMES=10
fail_count=0

for i in {1..$TIMES}; do
  echo "Attempt $i of $TIMES"
  if ! eval $COMMAND; then
    echo "Command failed on attempt $i"
    ((fail_count++))
  fi
done

echo "Command failed $fail_count times out of $TIMES attempts."
```