### PR TITLE
revert(typescript-utils): replace deleted admin tsconfig

### DIFF
--- a/packages/utils/typescript/tsconfigs/admin.json
+++ b/packages/utils/typescript/tsconfigs/admin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
### What does it do?

Adds back the admin.json tsconfig file

### Why is it needed?

It's being referenced by existing plugins, and plugins created by @strapi/sdk-plugin, possibly other places

### How to test it?

You should be able to reference it in plugins again

### Related issue(s)/PR(s)

DX-1495
