### PR TITLE
fix: json fields not parsed properly

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Json.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Json.tsx
@@ -24,7 +24,9 @@ const JsonInput = forwardRef<JSONInputRef, InputProps>(
         <Field.Label action={labelAction}>{label}</Field.Label>
         <JSONInputImpl
           ref={composedRefs}
-          value={field.value}
+          value={
+            typeof field.value == 'object' ? JSON.stringify(field.value, null, 2) : field.value
+          }
           onChange={(json) => {
             // Default to null when the field is not required and there is no input value
             const value = required && !json.length ? null : json;

--- a/packages/core/database/src/fields/json.ts
+++ b/packages/core/database/src/fields/json.ts
@@ -8,12 +8,19 @@ export default class JSONField extends Field {
   fromDB(value: unknown) {
     try {
       if (typeof value === 'string') {
-        return JSON.parse(value);
+        const parsedValue = JSON.parse(value);
+
+        if (typeof parsedValue === 'string') {
+          return JSON.parse(parsedValue);
+        }
+
+        return parsedValue;
       }
     } catch (error) {
       // Just return the value if it's not a valid JSON string
       return value;
     }
+
     return value;
   }
 }

--- a/packages/core/database/src/fields/json.ts
+++ b/packages/core/database/src/fields/json.ts
@@ -2,7 +2,15 @@ import Field from './field';
 
 export default class JSONField extends Field {
   toDB(value: unknown) {
-    return JSON.stringify(value);
+    if (value == null) {
+      return null;
+    }
+
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+
+    return value;
   }
 
   fromDB(value: unknown) {
@@ -10,6 +18,10 @@ export default class JSONField extends Field {
       if (typeof value === 'string') {
         const parsedValue = JSON.parse(value);
 
+        /**
+         * On Strapi 5 until 5.0.0-rc.6, the values were accidentally stringified twice when saved,
+         * so in those cases we need to parse them twice to retrieve the actual value.
+         */
         if (typeof parsedValue === 'string') {
           return JSON.parse(parsedValue);
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Makes sure the JSON fields are parsed properly when read from the database. It turns out sometimes, probably because of v4 to v5 migrations, they were stringified twice, so [they needed to be parsed twice](https://stackoverflow.com/questions/31662849/parse-json-object-that-stringify-twice).

I also made a fix on the frontend to support both string and object types, as both could be sent for users migrating.

### How to test it?

- Write JSON in a JSON field in the edit view, the experience should be normal
- Save and refresh, your changes should be retrieved
- Query the content using the content API, you should see your JSON input in object form, not as a string

### Related issue(s)/PR(s)

replaces #20829
fixes #20655