### PR TITLE
fix: review workflows cache issues

### DIFF
--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -368,7 +368,7 @@ const releaseApi = adminApi
               data,
             };
           },
-          invalidatesTags: (result, error, arg) => [{ type: 'ReleaseSettings' }],
+          invalidatesTags: (_result, _error, _arg) => [{ type: 'ReleaseSettings' }],
         }),
       };
     },

--- a/packages/core/review-workflows/admin/src/routes/content-manager/[model]/[id]/components/AssigneeSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/[model]/[id]/components/AssigneeSelect.tsx
@@ -8,9 +8,8 @@ import {
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
 import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
-import { Combobox, ComboboxOption, Field, Flex } from '@strapi/design-system';
+import { Combobox, ComboboxOption, Field } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
-import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 import { useTypedSelector } from '../../../../../modules/hooks';
@@ -26,7 +25,6 @@ const AssigneeSelect = () => {
     id,
     slug: model = '',
   } = useParams<{ collectionType: string; slug: string; id: string }>();
-  const dispatch = useDispatch();
   const permissions = useTypedSelector((state) => state.admin_app.permissions);
   const { formatMessage } = useIntl();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
@@ -78,17 +76,6 @@ const AssigneeSelect = () => {
     });
 
     if ('data' in res) {
-      // Invalidates the content-manager's API cache for the document to update the stage.
-      dispatch({
-        type: 'contentManagerApi/invalidateTags',
-        payload: [
-          {
-            type: 'Document',
-            id: `${model}_${id}`,
-          },
-        ],
-      });
-
       toggleNotification({
         type: 'success',
         message: formatMessage({

--- a/packages/core/review-workflows/admin/src/routes/content-manager/[model]/[id]/components/StageSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/[model]/[id]/components/StageSelect.tsx
@@ -12,7 +12,6 @@ import {
   Typography,
 } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
-import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 import { LimitsModal } from '../../../../../components/LimitsModal';
@@ -38,7 +37,6 @@ export const StageSelect = () => {
     slug: string;
     id: string;
   }>();
-  const dispatch = useDispatch();
   const { formatMessage } = useIntl();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { toggleNotification } = useNotification();
@@ -120,17 +118,6 @@ export const StageSelect = () => {
           });
 
           if ('data' in res) {
-            // Invalidates the content-manager's API cache for the document to update the stage.
-            dispatch({
-              type: 'contentManagerApi/invalidateTags',
-              payload: [
-                {
-                  type: 'Document',
-                  id: `${model}_${id}`,
-                },
-              ],
-            });
-
             toggleNotification({
               type: 'success',
               message: formatMessage({

--- a/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
@@ -119,7 +119,7 @@ const EditPage = () => {
     error,
     update,
     create,
-  } = useReviewWorkflows({ id: isCreatingWorkflow ? undefined : id });
+  } = useReviewWorkflows();
   const permissions = useTypedSelector(
     (state) => state.admin_app.permissions['settings']?.['review-workflows']
   );
@@ -188,7 +188,7 @@ const EditPage = () => {
         if ('error' in res && isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
           helpers.setErrors(formatValidationErrors(res.error));
         } else if ('data' in res) {
-          navigate(`../${res.data.id}`);
+          navigate(`../${res.data.id}`, { replace: true });
         }
       }
     } catch (error) {
@@ -397,7 +397,7 @@ const EditPage = () => {
                         {
                           count:
                             contentTypesFromOtherWorkflows?.filter((contentType) =>
-                              currentWorkflow?.contentTypes?.includes(contentType)
+                              values.contentTypes.includes(contentType)
                             ).length ?? 0,
                         }
                       )}

--- a/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
@@ -16,7 +16,6 @@ import { Button, Dialog, Flex, Typography } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import { useIntl } from 'react-intl';
-import { useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import * as yup from 'yup';
 
@@ -113,7 +112,6 @@ const EditPage = () => {
   const { _unstableFormatValidationErrors: formatValidationErrors } = useAPIErrorHandler();
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
-  const dispatch = useDispatch();
   const {
     isLoading: isLoadingWorkflow,
     meta,
@@ -183,19 +181,6 @@ const EditPage = () => {
 
         if ('error' in res && isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
           helpers.setErrors(formatValidationErrors(res.error));
-        } else if ('data' in res) {
-          for (const uid of res.data.contentTypes) {
-            // Invalidates the content-manager's API cache for the document layout so we can see RW enabled.
-            dispatch({
-              type: 'contentManagerApi/invalidateTags',
-              payload: [
-                {
-                  type: 'ContentTypesConfiguration',
-                  id: uid,
-                },
-              ],
-            });
-          }
         }
       } else {
         const res = await create(data);
@@ -203,19 +188,6 @@ const EditPage = () => {
         if ('error' in res && isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
           helpers.setErrors(formatValidationErrors(res.error));
         } else if ('data' in res) {
-          for (const uid of res.data.contentTypes) {
-            // Invalidates the content-manager's API cache for the document layout so we can see RW enabled.
-            dispatch({
-              type: 'contentManagerApi/invalidateTags',
-              payload: [
-                {
-                  type: 'ContentTypesConfiguration',
-                  id: uid,
-                },
-              ],
-            });
-          }
-
           navigate(`../${res.data.id}`);
         }
       }

--- a/packages/core/review-workflows/admin/src/routes/settings/components/Stages.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/Stages.tsx
@@ -626,7 +626,6 @@ const PermissionsField = ({ disabled, name, placeholder, required }: Permissions
                 defaultMessage: 'Apply to all stages',
               })}
               size="L"
-              variant="secondary"
             >
               <Duplicate />
             </IconButton>

--- a/packages/core/review-workflows/admin/src/routes/settings/hooks/useReviewWorkflows.ts
+++ b/packages/core/review-workflows/admin/src/routes/settings/hooks/useReviewWorkflows.ts
@@ -27,11 +27,10 @@ const useReviewWorkflows = (params: UseReviewWorkflowsArgs = {}) => {
   const { formatMessage } = useIntl();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
 
-  const { id = '', skip = false, ...queryParams } = params;
+  const { skip = false, ...queryParams } = params;
 
   const { data, isLoading, error } = useGetWorkflowsQuery(
     {
-      id,
       populate: 'stages',
       ...queryParams,
     },

--- a/packages/core/review-workflows/admin/src/services/content-manager.ts
+++ b/packages/core/review-workflows/admin/src/services/content-manager.ts
@@ -51,6 +51,15 @@ const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
         },
       }),
       transformResponse: (res: UpdateStage.Response) => res.data,
+      // @ts-expect-error - FIXME: TS isn't aware that "Document" was added as a tag
+      invalidatesTags(result, error, args) {
+        return [
+          {
+            type: 'Document',
+            id: `${args.model}_${args.id}`,
+          },
+        ];
+      },
     }),
     updateAssignee: builder.mutation<
       UpdateAssignee.Response['data'],
@@ -65,6 +74,15 @@ const contentManagerApi = reviewWorkflowsApi.injectEndpoints({
         },
       }),
       transformResponse: (res: UpdateAssignee.Response) => res.data,
+      // @ts-expect-error - FIXME: TSisn't aware that "Document" was added as a tag
+      invalidatesTags(result, error, args) {
+        return [
+          {
+            type: 'Document',
+            id: `${args.model}_${args.id}`,
+          },
+        ];
+      },
     }),
     getContentTypes: builder.query<ContentTypes, void>({
       query: () => ({

--- a/packages/core/review-workflows/admin/src/services/settings.ts
+++ b/packages/core/review-workflows/admin/src/services/settings.ts
@@ -1,12 +1,6 @@
 import { reviewWorkflowsApi } from './api';
 
-import type {
-  Create,
-  Update,
-  Delete,
-  GetAll,
-  Get,
-} from '../../../shared/contracts/review-workflows';
+import type { Create, Update, Delete, GetAll } from '../../../shared/contracts/review-workflows';
 
 const settingsApi = reviewWorkflowsApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -18,39 +12,25 @@ const settingsApi = reviewWorkflowsApi.injectEndpoints({
       GetWorkflowsParams | void
     >({
       query: (args) => {
-        const { id, ...params } = args ?? {};
-
         return {
-          url: `/review-workflows/workflows${id ? `/${id}` : ''}`,
+          url: '/review-workflows/workflows',
           method: 'GET',
           config: {
-            params,
+            params: args ?? {},
           },
         };
       },
-      transformResponse: (res: GetAll.Response | Get.Response) => {
-        let workflows: GetAll.Response['data'] = [];
-
-        if (Array.isArray(res.data)) {
-          workflows = res.data;
-        } else {
-          workflows = [res.data];
-        }
-
+      transformResponse: (res: GetAll.Response) => {
         return {
-          workflows,
+          workflows: res.data,
           meta: 'meta' in res ? res.meta : undefined,
         };
       },
-      providesTags: (res, _err, arg) => {
-        if (typeof arg === 'object' && 'id' in arg && arg.id !== '') {
-          return [{ type: 'ReviewWorkflow' as const, id: arg.id }];
-        } else {
-          return [
-            ...(res?.workflows.map(({ id }) => ({ type: 'ReviewWorkflow' as const, id })) ?? []),
-            { type: 'ReviewWorkflow' as const, id: 'LIST' },
-          ];
-        }
+      providesTags: (res) => {
+        return [
+          ...(res?.workflows.map(({ id }) => ({ type: 'ReviewWorkflow' as const, id })) ?? []),
+          { type: 'ReviewWorkflow' as const, id: 'LIST' },
+        ];
       },
     }),
     createWorkflow: builder.mutation<Create.Response['data'], Create.Request['body']>({
@@ -112,7 +92,7 @@ const settingsApi = reviewWorkflowsApi.injectEndpoints({
   overrideExisting: false,
 });
 
-type GetWorkflowsParams = Get.Params | (GetAll.Request['query'] & { id?: never });
+type GetWorkflowsParams = GetAll.Request['query'];
 
 const {
   useGetWorkflowsQuery,

--- a/packages/core/review-workflows/shared/contracts/review-workflows.ts
+++ b/packages/core/review-workflows/shared/contracts/review-workflows.ts
@@ -112,22 +112,6 @@ namespace GetAll {
   }
 }
 
-namespace Get {
-  export interface Request {
-    body: {};
-    query: {};
-  }
-
-  export interface Params {
-    id: Entity['id'];
-  }
-
-  export interface Response {
-    data: Workflow;
-    error?: errors.ApplicationError;
-  }
-}
-
 namespace Update {
   export interface Request {
     body: {
@@ -180,7 +164,6 @@ export type {
   Stage,
   Workflow,
   GetAll,
-  Get,
   Update,
   Create,
   Delete,


### PR DESCRIPTION
### What does it do?

Fixes some review workflow issues:

- The cache is now updates when changing an entry's stage. I'm using RTK's invalitateTags method for it to be more declarative. Unfortunately I need to silence a TS issue, but I think it's acceptable considering the previous solution called dispatch directly, which provided no type safety
- Clears document cache when a workflow is updated or created, so that the workflow changes are visible on the edit view and the list view
- Fixes an issue in the modal warning you that creating new workflow means some content types will lose their original workflow. It got the count of affected content types wrong (always said 0)
- Fixes that same modal which never worked when updating a workflow, because it relied on data from the other workflows, and other workflows were not actually fetched.

### How to test it?

- create a review workflow, assign it to a content type
- go to that content type, you should see the workflow information, both in edit and list views
- edit the review workflow (e.g. change the stage name)
- go the the CM again, the edit and list views should reflect the changes
- create a new workflow and assign it the same content type
- when saving, you should see a warning that 1 content type will be unlinked from its previous workflow
- go back to the first workflow, assign it the same content type again
- you should see the same modal

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20585