### PR TITLE
FIX - Email not found on forgot password

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -26,7 +26,7 @@ const {
 } = require('./validation/auth');
 
 const { getAbsoluteAdminUrl, getAbsoluteServerUrl, sanitize } = utils;
-const { ApplicationError, ValidationError, ForbiddenError } = utils.errors;
+const { ApplicationError, ValidationError, ForbiddenError, NotFoundError } = utils.errors;
 
 const sanitizeUser = (user, ctx) => {
   const { auth } = ctx.state;
@@ -242,7 +242,7 @@ module.exports = {
       .findOne({ where: { email: email.toLowerCase() } });
 
     if (!user || user.blocked) {
-      return ctx.send({ ok: true });
+      throw new NotFoundError('Email not registered!')
     }
 
     // Generate random token.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Returns an error when email not found on forgotPassword lifecycle.

### Why is it needed?

Because the strapi response when email is finded as the same when it not find

### How to test it?

Just send a POST request to /api/auth/forgot-password with a registered user and one not registered user.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
