### PR TITLE
Fix: Time format error when saving default value for a time field

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
+++ b/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
@@ -423,7 +423,7 @@ const GenericInput = ({
             clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
             disabled={disabled}
             onChange={(time) => {
-              onChange({ target: { name, value: `${time}`, type } });
+              onChange({ target: { name, value: time ? `${time}:00.000` : time, type } });
             }}
             onClear={() => {
               onChange({ target: { name, value: null, type } });


### PR DESCRIPTION
### What does it do?

it resolves the issue related to the #20875 
### Why is it needed?

issue #20875 

### How to test it?

Create a collection with 1 date field which accepts the time format (HH::MM) and then chose some default value for the field and save the collection. 

Now try to insert new record in the collection.

### Related issue(s)/PR(s)
#20875 