### PR TITLE
fix: draft validations

### DIFF
--- a/packages/core/core/src/services/entity-validator/__tests__/biginteger-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/biginteger-validators.test.ts
@@ -37,178 +37,208 @@ describe('BigInteger validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validate the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    // iterate on mockOptions.isDraft from false to true
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger' },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 1,
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrBigIntegerUnique: 2 });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 1,
+              },
+              entity: null,
             },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator(1);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validate the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: null,
-            },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 1,
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(1)).toBe(1);
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrBigIntegerUnique: 2 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 2,
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator(2);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrBigIntegerUnique: 3 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 3,
-            },
-            entity: { id: 1, attrBigIntegerUnique: 3 },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(3)).toBe(3);
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 4,
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(4);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          publishedAt: null,
-          locale: 'en',
-          attrBigIntegerUnique: 4,
-        },
+        expect(await validator(1)).toBe(1);
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.biginteger(
-          {
-            attr: { type: 'biginteger', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrBigIntegerUnique',
-              value: 5,
+      test('it does not validate the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 1,
+              },
+              entity: null,
             },
-            entity: { id: 1, attrBigIntegerUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator(5);
+        await validator(1);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrBigIntegerUnique: 5,
-          id: {
-            $ne: 1,
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validate the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: null,
+              },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 1,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(1)).toBe(1);
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrBigIntegerUnique: 2 });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 2,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator(2);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrBigIntegerUnique: 3 });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 3,
+              },
+              entity: { id: 1, attrBigIntegerUnique: 3 },
+            },
+            mockOptions
+          )
+        );
+
+        expect(await validator(3)).toBe(3);
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 4,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(4);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            publishedAt: { $notNull: true },
+            locale: 'en',
+            attrBigIntegerUnique: 4,
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
+      });
+
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.biginteger(
+            {
+              attr: { type: 'biginteger', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrBigIntegerUnique',
+                value: 5,
+              },
+              entity: { id: 1, attrBigIntegerUnique: 42 },
+            },
+            options
+          )
+        );
+
+        await validator(5);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrBigIntegerUnique: 5,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
+          },
+        });
       });
     });
   });

--- a/packages/core/core/src/services/entity-validator/__tests__/biginteger-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/biginteger-validators.test.ts
@@ -206,6 +206,7 @@ describe('BigInteger validator', () => {
             locale: 'en',
             attrBigIntegerUnique: 4,
           },
+          select: ['id'],
         });
       });
 
@@ -238,6 +239,7 @@ describe('BigInteger validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/date-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/date-validators.test.ts
@@ -165,6 +165,7 @@ describe('Date validator', () => {
             publishedAt: { $notNull: true },
             attrDateUnique: '2021-11-29',
           },
+          select: ['id'],
         });
       });
 
@@ -194,6 +195,7 @@ describe('Date validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/date-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/date-validators.test.ts
@@ -37,156 +37,164 @@ describe('Date validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrDateUnique: '2021-11-29' });
 
-      await validator('2021-11-29');
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: null,
+            },
+            options
+          )
+        );
 
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: null },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('2021-11-29')).toBe('2021-11-29');
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrDateUnique: '2021-11-29' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('2021-11-29');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrDateUnique: '2021-11-29' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: { id: 1, attrDateUnique: '2021-11-29' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('2021-11-29')).toBe('2021-11-29');
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator('2021-11-29');
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrDateUnique: '2021-11-29',
-        },
+        expect(await validator('2021-11-29')).toBe('2021-11-29');
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.date(
-          {
-            attr: { type: 'date', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
-            entity: { id: 1, attrDateUnique: '2021-12-15' },
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29');
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: null },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator('2021-11-29')).toBe('2021-11-29');
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrDateUnique: '2021-11-29' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('2021-11-29');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29');
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrDateUnique: '2021-11-29',
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator('2021-11-29');
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrDateUnique: '2021-11-29',
-          id: {
-            $ne: 1,
+        const validator = strapiUtils.validateYupSchema(
+          Validators.date(
+            {
+              attr: { type: 'date', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateUnique', value: '2021-11-29' },
+              entity: { id: 1, attrDateUnique: '2021-12-15' },
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29');
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrDateUnique: '2021-11-29',
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
       });
     });
   });

--- a/packages/core/core/src/services/entity-validator/__tests__/datetime-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/datetime-validators.test.ts
@@ -165,6 +165,7 @@ describe('Datetime validator', () => {
             publishedAt: { $notNull: true },
             attrDateTimeUnique: '2021-11-29T00:00:00.000Z',
           },
+          select: ['id'],
         });
       });
 
@@ -194,6 +195,7 @@ describe('Datetime validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/datetime-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/datetime-validators.test.ts
@@ -37,156 +37,164 @@ describe('Datetime validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: { id: 1, attrDateTimeUnique: '2021-11-29T00:00:00.000Z' },
-          },
-          mockOptions
-        )
-      );
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrDateTimeUnique: '2021-11-29T00:00:00.000Z' });
 
-      await validator('2021-11-29T00:00:00.000Z');
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
 
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: null },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('2021-11-29T00:00:00.000Z')).toBe('2021-11-29T00:00:00.000Z');
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrDateTimeUnique: '2021-11-29T00:00:00.000Z' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('2021-11-29T00:00:00.000Z');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrDateTimeUnique: '2021-11-29T00:00:00.000Z' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: { id: 1, attrDateTimeUnique: '2021-11-29T00:00:00.000Z' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('2021-11-29T00:00:00.000Z')).toBe('2021-11-29T00:00:00.000Z');
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator('2021-11-29T00:00:00.000Z');
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrDateTimeUnique: '2021-11-29T00:00:00.000Z',
-        },
+        expect(await validator('2021-11-29T00:00:00.000Z')).toBe('2021-11-29T00:00:00.000Z');
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.datetime(
-          {
-            attr: { type: 'datetime', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
-            entity: { id: 1, attrDateTimeUnique: '2021-12-25T00:00:00.000Z' },
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: { id: 1, attrDateTimeUnique: '2021-11-29T00:00:00.000Z' },
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29T00:00:00.000Z');
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: null },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator('2021-11-29T00:00:00.000Z')).toBe('2021-11-29T00:00:00.000Z');
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrDateTimeUnique: '2021-11-29T00:00:00.000Z' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('2021-11-29T00:00:00.000Z');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29T00:00:00.000Z');
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrDateTimeUnique: '2021-11-29T00:00:00.000Z',
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator('2021-11-29T00:00:00.000Z');
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrDateTimeUnique: '2021-11-29T00:00:00.000Z',
-          id: {
-            $ne: 1,
+        const validator = strapiUtils.validateYupSchema(
+          Validators.datetime(
+            {
+              attr: { type: 'datetime', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrDateTimeUnique', value: '2021-11-29T00:00:00.000Z' },
+              entity: { id: 1, attrDateTimeUnique: '2021-12-25T00:00:00.000Z' },
+            },
+            options
+          )
+        );
+
+        await validator('2021-11-29T00:00:00.000Z');
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrDateTimeUnique: '2021-11-29T00:00:00.000Z',
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
       });
     });
   });

--- a/packages/core/core/src/services/entity-validator/__tests__/email-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/email-validators.test.ts
@@ -21,67 +21,125 @@ describe('Email validator', () => {
   };
 
   describe('email', () => {
-    test('it fails the validation if the string is not a valid email', async () => {
-      expect.assertions(1);
+    describe('draft', () => {
+      test('validation does not fail if the string is not a valid email', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: true }
+          )
+        );
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.email(
-          {
-            attr: { type: 'email' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrEmail', value: 1 },
-            entity: null,
-          },
-          { isDraft: false }
-        )
-      );
-
-      try {
         await validator('invalid-email');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
+      });
 
-    test('it validates the email if it is valid', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.email(
-          {
-            attr: { type: 'email' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrEmail', value: 1 },
-            entity: null,
-          },
-          { isDraft: false }
-        )
-      );
+      test('validation does not fail if the string is empty', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: true }
+          )
+        );
 
-      expect(await validator('valid@email.com')).toBe('valid@email.com');
-    });
-
-    test('it validates non-empty email required field', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.email(
-          {
-            attr: { type: 'email' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrEmail', value: 1 },
-            entity: null,
-          },
-          { isDraft: false }
-        )
-      );
-
-      expect.hasAssertions();
-
-      try {
         await validator('');
-      } catch (err) {
-        if (err instanceof Error) {
+      });
+
+      test('validation fails if not a valid string', async () => {
+        expect.assertions(1);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: true }
+          )
+        );
+
+        try {
+          await validator(1);
+        } catch (err) {
           expect(err).toBeInstanceOf(errors.YupValidationError);
-          expect(err.message).toBe('this cannot be empty');
         }
-      }
+      });
+    });
+
+    describe('published', () => {
+      test('it fails the validation if the string is not a valid email', async () => {
+        expect.assertions(1);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: false }
+          )
+        );
+
+        try {
+          await validator('invalid-email');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it validates the email if it is valid', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: false }
+          )
+        );
+
+        expect(await validator('valid@email.com')).toBe('valid@email.com');
+      });
+
+      test('it validates non-empty email required field', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.email(
+            {
+              attr: { type: 'email' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrEmail', value: 1 },
+              entity: null,
+            },
+            { isDraft: false }
+          )
+        );
+
+        expect.hasAssertions();
+
+        try {
+          await validator('');
+        } catch (err) {
+          if (err instanceof Error) {
+            expect(err).toBeInstanceOf(errors.YupValidationError);
+            expect(err.message).toBe('this cannot be empty');
+          }
+        }
+      });
     });
   });
 });

--- a/packages/core/core/src/services/entity-validator/__tests__/float-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/float-validators.test.ts
@@ -166,6 +166,7 @@ describe('Float validator', () => {
             publishedAt: { $notNull: true },
             attrFloatUnique: 4,
           },
+          select: ['id'],
         });
       });
 
@@ -195,6 +196,7 @@ describe('Float validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/float-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/float-validators.test.ts
@@ -37,238 +37,275 @@ describe('Float validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 1 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrFloatUnique: 2 });
 
-      await validator(1);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
 
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: null },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 2 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(1)).toBe(1);
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrFloatUnique: 2 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 2 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator(2);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrFloatUnique: 3 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 3 },
-            entity: { id: 1, attrFloatUnique: 3 },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(3)).toBe(3);
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 4 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(4);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrFloatUnique: 4,
-        },
+        expect(await validator(2)).toBe(2);
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 5 },
-            entity: { id: 1, attrFloatUnique: 42 },
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 1 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(1);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: null },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(1)).toBe(1);
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrFloatUnique: 2 });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator(2);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 4 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(4);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrFloatUnique: 4,
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator(5);
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrFloatUnique: 5,
-          id: {
-            $ne: 1,
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
+
+        await validator(5);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrFloatUnique: 5,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
       });
     });
   });
 
   describe('min', () => {
-    test('it fails the validation if the float is lower than the define min', async () => {
-      expect.assertions(1);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', min: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 5 },
-            entity: { id: 1, attrFloatUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+      test('it does not fail if the float is lower than the defined min', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
 
-      try {
         await validator(1);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
+      });
     });
 
-    test('it validates the min constraint if the float is higher than the define min', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', min: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 5 },
-            entity: { id: 1, attrFloatUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      expect(await validator(4)).toBe(4);
-    });
-  });
+      test('it fails the validation if the float is lower than the define min', async () => {
+        expect.assertions(1);
 
-  describe('max', () => {
-    test('it fails the validation if the number is float than the define max', async () => {
-      expect.assertions(1);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', max: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 5 },
-            entity: { id: 1, attrFloatUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+        try {
+          await validator(1);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
 
-      try {
-        await validator(4);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
+      test('it validates the min constraint if the float is higher than the define min', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
 
-    test('it validates the max constraint if the float is lower than the define max', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.float(
-          {
-            attr: { type: 'float', max: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrFloatUnique', value: 5 },
-            entity: { id: 1, attrFloatUnique: 42 },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(2)).toBe(2);
+        expect(await validator(4)).toBe(4);
+      });
     });
   });
+
+  describe.each([{ isDraft: true }, { isDraft: false }])(
+    `max - $isDraft`,
+    ({ isDraft }: { isDraft: boolean }) => {
+      const options = { ...mockOptions, isDraft };
+
+      test('it fails the validation if the number is float than the define max', async () => {
+        expect.assertions(1);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', max: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
+
+        try {
+          await validator(4);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it validates the max constraint if the float is lower than the define max', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.float(
+            {
+              attr: { type: 'float', max: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrFloatUnique', value: 5 },
+              entity: { id: 1, attrFloatUnique: 42 },
+            },
+            options
+          )
+        );
+
+        expect(await validator(2)).toBe(2);
+      });
+    }
+  );
 });

--- a/packages/core/core/src/services/entity-validator/__tests__/integer-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/integer-validators.test.ts
@@ -166,6 +166,7 @@ describe('Integer validator', () => {
             publishedAt: { $notNull: true },
             attrIntegerUnique: 4,
           },
+          select: ['id'],
         });
       });
 
@@ -195,6 +196,7 @@ describe('Integer validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/integer-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/integer-validators.test.ts
@@ -37,240 +37,275 @@ describe('Integer validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 1 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrIntegerUnique: 2 });
 
-      await validator(1);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
 
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: null },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 2 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(1)).toBe(1);
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrIntegerUnique: 2 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 2 },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator(2);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrIntegerUnique: 3 });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 3 },
-            entity: { id: 1, attrIntegerUnique: 3 },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(3)).toBe(3);
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-      const valueToCheck = 4;
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: valueToCheck },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(valueToCheck);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrIntegerUnique: valueToCheck,
-        },
+        expect(await validator(2)).toBe(2);
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-      const valueToCheck = 5;
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: valueToCheck },
-            entity: { id: 1, attrIntegerUnique: 42 },
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 1 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(1);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: null },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(1)).toBe(1);
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrIntegerUnique: 2 });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 2 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator(2);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 4 },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(4);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrIntegerUnique: 4,
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator(valueToCheck);
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrIntegerUnique: valueToCheck,
-          id: {
-            $ne: 1,
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
+
+        await validator(5);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrIntegerUnique: 5,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
       });
     });
   });
 
   describe('min', () => {
-    test('it fails the validation if the integer is lower than the define min', async () => {
-      expect.assertions(1);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', min: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
-            entity: { id: 1, attrIntegerUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+      test('it does not fail if the integer is lower than the defined min', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
 
-      try {
         await validator(1);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
+      });
     });
 
-    test('it validates the min constraint if the integer is higher than the define min', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', min: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
-            entity: { id: 1, attrIntegerUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      expect(await validator(4)).toBe(4);
-    });
-  });
+      test('it fails the validation if the integer is lower than the define min', async () => {
+        expect.assertions(1);
 
-  describe('max', () => {
-    test('it fails the validation if the number is integer than the define max', async () => {
-      expect.assertions(1);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', max: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
-            entity: { id: 1, attrIntegerUnique: 42 },
-          },
-          mockOptions
-        )
-      );
+        try {
+          await validator(1);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
 
-      try {
-        await validator(4);
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
+      test('it validates the min constraint if the integer is higher than the define min', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', min: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
 
-    test('it validates the max constraint if the integer is lower than the define max', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.integer(
-          {
-            attr: { type: 'integer', max: 3 },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
-            entity: { id: 1, attrIntegerUnique: 42 },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(2)).toBe(2);
+        expect(await validator(4)).toBe(4);
+      });
     });
   });
+
+  describe.each([{ isDraft: true }, { isDraft: false }])(
+    `max - $isDraft`,
+    ({ isDraft }: { isDraft: boolean }) => {
+      const options = { ...mockOptions, isDraft };
+
+      test('it fails the validation if the number is integer than the define max', async () => {
+        expect.assertions(1);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', max: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
+
+        try {
+          await validator(4);
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it validates the max constraint if the integer is lower than the define max', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.integer(
+            {
+              attr: { type: 'integer', max: 3 },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrIntegerUnique', value: 5 },
+              entity: { id: 1, attrIntegerUnique: 42 },
+            },
+            options
+          )
+        );
+
+        expect(await validator(2)).toBe(2);
+      });
+    }
+  );
 });

--- a/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
@@ -185,6 +185,7 @@ describe('String validator', () => {
             attrStringUnique: valueToCheck,
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
 
@@ -218,6 +219,7 @@ describe('String validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
@@ -37,315 +37,338 @@ describe('String validator', () => {
       fakeFindOne.mockReset();
     });
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string' },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'non-unique-test-data',
+      test('it does not validate unique constraints', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrStringUnique: 'test-data' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'non-unique-test-data',
+              },
+              entity: null,
             },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator('non-unique-test-data');
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: null,
-            },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'non-unique-test-data',
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('non-unique-test-data')).toBe('non-unique-test-data');
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrStringUnique: 'unique-test-data' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'unique-test-data',
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('unique-test-data');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrStringUnique: 'non-updated-unique-test-data' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'non-updated-unique-test-data',
-            },
-            entity: { id: 1, attrStringUnique: 'non-updated-unique-test-data' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('non-updated-unique-test-data')).toBe('non-updated-unique-test-data');
-    });
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const valueToCheck = 'test-data';
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: valueToCheck,
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(valueToCheck);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          attrStringUnique: valueToCheck,
-          publishedAt: null,
-        },
+        expect(await validator('non-unique-test-data')).toBe('non-unique-test-data');
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const valueToCheck = 'test-data';
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: valueToCheck,
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'non-unique-test-data',
+              },
+              entity: null,
             },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator(valueToCheck);
+        await validator('non-unique-test-data');
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrStringUnique: valueToCheck,
-          id: {
-            $ne: 1,
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: null,
+              },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'non-unique-test-data',
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator('non-unique-test-data')).toBe('non-unique-test-data');
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrStringUnique: 'unique-test-data' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'unique-test-data',
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('unique-test-data');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const valueToCheck = 'test-data';
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: valueToCheck,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            attrStringUnique: valueToCheck,
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
+      });
+
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const valueToCheck = 'test-data';
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: valueToCheck,
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrStringUnique: valueToCheck,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
+          },
+        });
       });
     });
   });
 
   describe('minLength', () => {
-    test('it does not validates the minLength constraint if it is a draft', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', minLength: 3 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
-            },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      expect(await validator('a')).toBe('a');
+      test('ignores the minLength constraint', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', minLength: 3 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'a',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        expect(await validator('a')).toBe('a');
+      });
     });
 
-    test('it fails the validation if the string is shorter than the define minLength', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', minLength: 3 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
+
+      test('it fails the validation if the string is shorter than the define minLength', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', minLength: 3 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
             },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      try {
-        await validator('a');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
+        try {
+          await validator('a');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
 
-    test('it validates the minLength constraint if the string is longer than the define minLength', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', minLength: 3 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
+      test('it validates the minLength constraint if the string is longer than the define minLength', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', minLength: 3 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
             },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      expect(await validator('this string is longer than the minLenght')).toBe(
-        'this string is longer than the minLenght'
-      );
-    });
-  });
-
-  describe('maxLength', () => {
-    test('it does not validates the maxLength constraint if the attribute maxLength is not an integer', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', maxLength: 123 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
-            },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('a')).toBe('a');
-    });
-
-    test('it fails the validation if the string is longer than the define maxLength', async () => {
-      expect.assertions(1);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', maxLength: 3 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
-            },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('this string is too long');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the maxLength constraint if the string is shorter than the define maxLength', async () => {
-      const validator = strapiUtils.validateYupSchema(
-        Validators.string(
-          {
-            attr: { type: 'string', maxLength: 3 },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrStringUnique',
-              value: 'test-data',
-            },
-            entity: { id: 1, attrStringUnique: 'other-data' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('a')).toBe('a');
+        expect(await validator('this string is longer than the minLenght')).toBe(
+          'this string is longer than the minLenght'
+        );
+      });
     });
   });
+
+  describe.each([{ isDraft: true }, { isDraft: false }])(
+    'maxLength - $isDraft',
+    ({ isDraft }: { isDraft: boolean }) => {
+      const options = { ...mockOptions, isDraft };
+
+      test('it does not validates the maxLength constraint if the attribute maxLength is not an integer', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', maxLength: 123 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        expect(await validator('a')).toBe('a');
+      });
+
+      test('it fails the validation if the string is longer than the define maxLength', async () => {
+        expect.assertions(1);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', maxLength: 3 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('this string is too long');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      test('it validates the maxLength constraint if the string is shorter than the define maxLength', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', maxLength: 3 },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        expect(await validator('a')).toBe('a');
+      });
+    }
+  );
 
   describe('regExp', () => {
+    const options = { ...mockOptions, isDraft: false };
+
     test('it fails the validation of an empty string for a required field', async () => {
       expect.assertions(1);
 
@@ -360,7 +383,7 @@ describe('String validator', () => {
             },
             entity: { id: 1, attrStringUnique: 'other-data' },
           },
-          mockOptions
+          options
         )
       );
 
@@ -383,7 +406,7 @@ describe('String validator', () => {
             },
             entity: { id: 1, attrStringUnique: 'other-data' },
           },
-          mockOptions
+          options
         )
       );
 
@@ -402,7 +425,7 @@ describe('String validator', () => {
             },
             entity: { id: 1, attrStringUnique: 'other-data' },
           },
-          mockOptions
+          options
         )
       );
 
@@ -421,7 +444,7 @@ describe('String validator', () => {
             },
             entity: { id: 1, attrStringUnique: 'other-data' },
           },
-          mockOptions
+          options
         )
       );
 

--- a/packages/core/core/src/services/entity-validator/__tests__/time-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/time-validators.test.ts
@@ -167,6 +167,7 @@ describe('Time validator', () => {
             publishedAt: { $notNull: true },
             attrTimeUnique: '00:00:00.000Z',
           },
+          select: ['id'],
         });
       });
 
@@ -196,6 +197,7 @@ describe('Time validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/time-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/time-validators.test.ts
@@ -37,158 +37,166 @@ describe('Time validator', () => {
       },
     };
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+      test('it ignores the unique constraint', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrTimeUnique: '00:00:00.000Z' });
 
-      await validator('00:00:00.000Z');
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
 
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: null },
-            entity: { id: 1, attrTimeUnique: '00:00:00.000Z' },
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('00:00:00.000Z')).toBe('00:00:00.000Z');
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrTimeUnique: '00:00:00.000Z' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('00:00:00.000Z');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrTimeUnique: '00:00:00.000Z' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
-            entity: { id: 1, attrTimeUnique: '00:00:00.000Z' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('00:00:00.000Z')).toBe('00:00:00.000Z');
-    });
-
-    const valueToCheck = '00:00:00.000Z';
-
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: valueToCheck },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(valueToCheck);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrTimeUnique: '00:00:00.000Z',
-        },
+        expect(await validator('00:00:00.000Z')).toBe('00:00:00.000Z');
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.time(
-          {
-            attr: { type: 'time', unique: true },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrTimeUnique', value: valueToCheck },
-            entity: { id: 1, attrTimeUnique: '01:00:00.000Z' },
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator('00:00:00.000Z');
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: null },
+              entity: { id: 1, attrTimeUnique: '00:00:00.000Z' },
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator('00:00:00.000Z')).toBe('00:00:00.000Z');
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrTimeUnique: '00:00:00.000Z' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: '00:00:00.000Z' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('00:00:00.000Z');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      const valueToCheck = '00:00:00.000Z';
+
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: valueToCheck },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrTimeUnique: '00:00:00.000Z',
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator(valueToCheck);
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrTimeUnique: valueToCheck,
-          id: {
-            $ne: 1,
+        const validator = strapiUtils.validateYupSchema(
+          Validators.time(
+            {
+              attr: { type: 'time', unique: true },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrTimeUnique', value: valueToCheck },
+              entity: { id: 1, attrTimeUnique: '01:00:00.000Z' },
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrTimeUnique: valueToCheck,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
       });
     });
   });

--- a/packages/core/core/src/services/entity-validator/__tests__/timestamp-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/timestamp-validators.test.ts
@@ -185,6 +185,7 @@ describe('Time validator', () => {
             publishedAt: { $notNull: true },
             attrTimestampUnique: valueToCheck,
           },
+          select: ['id'],
         });
       });
 
@@ -217,6 +218,7 @@ describe('Time validator', () => {
             locale: 'en',
             publishedAt: { $notNull: true },
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/__tests__/timestamp-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/timestamp-validators.test.ts
@@ -38,178 +38,186 @@ describe('Time validator', () => {
       },
     };
 
-    test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      const options = { ...mockOptions, isDraft: true };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp' },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: '1638140400',
+      test('it ignores the unique validation ', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrTimestampUnique: '1638140400' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: '1638140400',
+              },
+              entity: null,
             },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator('1638140400');
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: null,
-            },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: '1638140400',
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('1638140400')).toBe('1638140400');
-    });
-
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrTimestampUnique: '1638140400' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: '1638140400',
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      try {
-        await validator('1638140400');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
-
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrTimestampUnique: '1638140400' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: '1638140400',
-            },
-            entity: { id: 1, attrTimestampUnique: '1638140400' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('1638140400')).toBe('1638140400');
-    });
-
-    const valueToCheck = '1638140400';
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: valueToCheck,
-            },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(valueToCheck);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrTimestampUnique: valueToCheck,
-        },
+        expect(await validator('1638140400')).toBe('1638140400');
       });
     });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.timestamp(
-          {
-            attr: { type: 'timestamp', unique: true },
-            model: fakeModel,
-            updatedAttribute: {
-              name: 'attrTimestampUnique',
-              value: valueToCheck,
+      test('it does not validates the unique constraint if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: '1638140400',
+              },
+              entity: null,
             },
-            entity: { id: 1, attrTimestampUnique: '1000000000' },
-          },
-          mockOptions
-        )
-      );
+            options
+          )
+        );
 
-      await validator(valueToCheck);
+        await validator('1638140400');
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          attrTimestampUnique: valueToCheck,
-          id: {
-            $ne: 1,
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: null,
+              },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: '1638140400',
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator('1638140400')).toBe('1638140400');
+      });
+
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrTimestampUnique: '1638140400' });
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: '1638140400',
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('1638140400');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      const valueToCheck = '1638140400';
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: valueToCheck,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrTimestampUnique: valueToCheck,
           },
-          locale: 'en',
-          publishedAt: null,
-        },
+        });
+      });
+
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.timestamp(
+            {
+              attr: { type: 'timestamp', unique: true },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrTimestampUnique',
+                value: valueToCheck,
+              },
+              entity: { id: 1, attrTimestampUnique: '1000000000' },
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            attrTimestampUnique: valueToCheck,
+            id: {
+              $ne: 1,
+            },
+            locale: 'en',
+            publishedAt: { $notNull: true },
+          },
+        });
       });
     });
   });

--- a/packages/core/core/src/services/entity-validator/__tests__/uid-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/uid-validators.test.ts
@@ -38,167 +38,177 @@ describe('UID validator', () => {
   };
 
   describe('unique', () => {
-    test('it validates the unique constraint if there is no other record in the database', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+    describe('draft', () => {
+      test('ignores unique validation', async () => {
+        fakeFindOne.mockResolvedValueOnce({ attrUidUnique: 'unique-uid' });
+        const valueToCheck = 'non-unique-uid';
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: 'non-unique-uid' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
+              entity: null,
+            },
+            mockOptions
+          )
+        );
 
-      expect(await validator('non-unique-uid')).toBe('non-unique-uid');
-      expect(fakeFindOne).toHaveBeenCalled();
-    });
-
-    test('it does not validates the unique constraint if the attribute value is `null`', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: null },
-            entity: null,
-          },
-          mockOptions
-        ).nullable()
-      );
-
-      await validator(null);
-
-      expect(fakeFindOne).not.toHaveBeenCalled();
-    });
-
-    test.only('it always validates the unique constraint even if the attribute is not set as unique', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-      const valueToCheck = 'non-unique-uid';
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator(valueToCheck)).toBe(valueToCheck);
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrUidUnique: valueToCheck,
-        },
+        expect(await validator(valueToCheck)).toBe(valueToCheck);
       });
     });
 
-    test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
-      expect.assertions(1);
-      fakeFindOne.mockResolvedValueOnce({ attrUidUnique: 'unique-uid' });
+    describe('published', () => {
+      const options = { ...mockOptions, isDraft: false };
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: 'unique-uid' },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
+      test('it validates the unique constraint if there is no other record in the database', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      try {
-        await validator('unique-uid');
-      } catch (err) {
-        expect(err).toBeInstanceOf(errors.YupValidationError);
-      }
-    });
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: 'non-unique-uid' },
+              entity: null,
+            },
+            options
+          )
+        );
 
-    test('it validates the unique constraint if the attribute data has not changed even if there is a record in the database with the same attribute value', async () => {
-      fakeFindOne.mockResolvedValueOnce({ attrUidUnique: 'unchanged-unique-uid' });
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: 'unchanged-unique-uid' },
-            entity: { id: 1, attrUidUnique: 'unchanged-unique-uid' },
-          },
-          mockOptions
-        )
-      );
-
-      expect(await validator('unchanged-unique-uid')).toBe('unchanged-unique-uid');
-    });
-
-    const valueToCheck = 'unique-uid';
-    test('it checks the database for records with the same value for the checked attribute', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
-
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
-            entity: null,
-          },
-          mockOptions
-        )
-      );
-
-      await validator(valueToCheck);
-
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrUidUnique: valueToCheck,
-        },
+        expect(await validator('non-unique-uid')).toBe('non-unique-uid');
+        expect(fakeFindOne).toHaveBeenCalled();
       });
-    });
 
-    test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
-      fakeFindOne.mockResolvedValueOnce(null);
+      test('it does not validates the unique constraint if the attribute value is `null`', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
 
-      const validator = strapiUtils.validateYupSchema(
-        Validators.uid(
-          {
-            attr: { type: 'uid' },
-            model: fakeModel,
-            updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
-            entity: { id: 1, attrUidUnique: 'other-uid' },
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: null },
+              entity: null,
+            },
+            options
+          ).nullable()
+        );
+
+        await validator(null);
+
+        expect(fakeFindOne).not.toHaveBeenCalled();
+      });
+
+      test('it always validates the unique constraint even if the attribute is not set as unique', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+        const valueToCheck = 'non-unique-uid';
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(valueToCheck)).toBe(valueToCheck);
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrUidUnique: valueToCheck,
           },
-          mockOptions
-        )
-      );
+        });
+      });
 
-      await validator(valueToCheck);
+      test('it fails the validation of the unique constraint if the database contains a record with the same attribute value', async () => {
+        expect.assertions(1);
+        fakeFindOne.mockResolvedValueOnce({ attrUidUnique: 'unique-uid' });
 
-      expect(fakeFindOne).toHaveBeenCalledWith({
-        where: {
-          locale: 'en',
-          publishedAt: null,
-          attrUidUnique: valueToCheck,
-        },
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: 'unique-uid' },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        try {
+          await validator('unique-uid');
+        } catch (err) {
+          expect(err).toBeInstanceOf(errors.YupValidationError);
+        }
+      });
+
+      const valueToCheck = 'unique-uid';
+      test('it checks the database for records with the same value for the checked attribute', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            publishedAt: { $notNull: true },
+            attrUidUnique: valueToCheck,
+          },
+        });
+      });
+
+      test('it checks the database for records with the same value but not the same id for the checked attribute if an entity is passed', async () => {
+        fakeFindOne.mockResolvedValueOnce(null);
+
+        const validator = strapiUtils.validateYupSchema(
+          Validators.uid(
+            {
+              attr: { type: 'uid' },
+              model: fakeModel,
+              updatedAttribute: { name: 'attrUidUnique', value: valueToCheck },
+              entity: { id: 1, attrUidUnique: 'other-uid' },
+            },
+            options
+          )
+        );
+
+        await validator(valueToCheck);
+
+        expect(fakeFindOne).toHaveBeenCalledWith({
+          where: {
+            locale: 'en',
+            id: { $ne: 1 },
+            publishedAt: { $notNull: true },
+            attrUidUnique: valueToCheck,
+          },
+        });
       });
     });
   });
 
   describe('regExp', () => {
+    const options = { ...mockOptions, isDraft: false };
+
     test('it fails to validate the uid if it does not fit the requried format', async () => {
       expect.assertions(1);
       fakeFindOne.mockResolvedValueOnce(null);
@@ -211,7 +221,7 @@ describe('UID validator', () => {
             updatedAttribute: { name: 'attrUidUnique', value: 'non-unique-uid' },
             entity: null,
           },
-          mockOptions
+          options
         )
       );
 
@@ -233,7 +243,7 @@ describe('UID validator', () => {
             updatedAttribute: { name: 'attrUidUnique', value: 'non-unique-uid' },
             entity: null,
           },
-          mockOptions
+          options
         )
       );
 

--- a/packages/core/core/src/services/entity-validator/__tests__/uid-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/uid-validators.test.ts
@@ -124,6 +124,7 @@ describe('UID validator', () => {
             publishedAt: { $notNull: true },
             attrUidUnique: valueToCheck,
           },
+          select: ['id'],
         });
       });
 
@@ -174,6 +175,7 @@ describe('UID validator', () => {
             publishedAt: { $notNull: true },
             attrUidUnique: valueToCheck,
           },
+          select: ['id'],
         });
       });
 
@@ -201,6 +203,7 @@ describe('UID validator', () => {
             publishedAt: { $notNull: true },
             attrUidUnique: valueToCheck,
           },
+          select: ['id'],
         });
       });
     });

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -1,3 +1,13 @@
+/**
+ * Validators check if the entry data meets specific criteria before saving or publishing.
+ * (e.g., length, range, format).
+ *
+ * Drafts have limited validations (mainly max constraints),
+ * while published content undergoes full validation.
+ *
+ * The system also takes locales into account when validating data.
+ * E.g, unique fields must be unique within the same locale.
+ */
 import _ from 'lodash';
 import { yup } from '@strapi/utils';
 import type { Schema, Struct, Modules } from '@strapi/types';
@@ -377,7 +387,9 @@ const addUniqueValidator = <T extends yup.AnySchema>(
     }
 
     // The validation should pass if there is no other record found from the query
-    return !(await strapi.db.query(model.uid).findOne({ where: scalarAttributeWhere }));
+    return !(await strapi.db
+      .query(model.uid)
+      .findOne({ where: scalarAttributeWhere, select: ['id'] }));
   });
 };
 

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -80,8 +80,9 @@ const addMinIntegerValidator = (
     attr,
   }: {
     attr: Schema.Attribute.Integer | Schema.Attribute.BigInteger;
-  }
-) => (_.isNumber(attr.min) ? validator.min(_.toInteger(attr.min)) : validator);
+  },
+  { isDraft }: ValidatorOptions
+) => (_.isNumber(attr.min) && !isDraft ? validator.min(_.toInteger(attr.min)) : validator);
 
 /**
  * Adds max integer validator
@@ -104,8 +105,9 @@ const addMinFloatValidator = (
     attr,
   }: {
     attr: Schema.Attribute.Decimal | Schema.Attribute.Float;
-  }
-) => (_.isNumber(attr.min) ? validator.min(attr.min) : validator);
+  },
+  { isDraft }: ValidatorOptions
+) => (_.isNumber(attr.min) && !isDraft ? validator.min(attr.min) : validator);
 
 /**
  * Adds max float/decimal validator
@@ -134,9 +136,10 @@ const addStringRegexValidator = (
       | Schema.Attribute.Password
       | Schema.Attribute.Email
       | Schema.Attribute.UID;
-  }
+  },
+  { isDraft }: ValidatorOptions
 ) => {
-  return 'regex' in attr && !_.isUndefined(attr.regex)
+  return 'regex' in attr && !_.isUndefined(attr.regex) && !isDraft
     ? validator.matches(new RegExp(attr.regex), { excludeEmptyString: !attr.required })
     : validator;
 };
@@ -325,8 +328,6 @@ const addUniqueValidator = <T extends yup.AnySchema>(
   };
 
   return validator.test('unique', 'This attribute must be unique', async (value) => {
-    const isPublish = options.isDraft === false;
-
     /**
      * If the attribute value is `null` we want to skip the unique validation.
      * Otherwise it'll only accept a single `null` entry in the database.
@@ -336,12 +337,9 @@ const addUniqueValidator = <T extends yup.AnySchema>(
     }
 
     /**
-     * If we are updating a draft and the value is unchanged we skip the unique verification. This will
-     * prevent the validator to be triggered in case the user activated the
-     * unique constraint after already creating multiple entries with
-     * the same attribute value for that field.
+     * We don't validate any unique constraint for draft entries.
      */
-    if (!isPublish && value === entity?.[updatedAttribute.name]) {
+    if (options.isDraft) {
       return true;
     }
 
@@ -367,9 +365,8 @@ const addUniqueValidator = <T extends yup.AnySchema>(
      */
     const scalarAttributeWhere: Record<string, any> = {
       [updatedAttribute.name]: value,
+      publishedAt: { $notNull: true },
     };
-
-    scalarAttributeWhere.publishedAt = options.isDraft ? null : { $notNull: true };
 
     if (options?.locale) {
       scalarAttributeWhere.locale = options.locale;
@@ -380,8 +377,7 @@ const addUniqueValidator = <T extends yup.AnySchema>(
     }
 
     // The validation should pass if there is no other record found from the query
-    const queryUid = model.uid;
-    return !(await strapi.db.query(queryUid).findOne({ where: scalarAttributeWhere }));
+    return !(await strapi.db.query(model.uid).findOne({ where: scalarAttributeWhere }));
   });
 };
 
@@ -402,7 +398,7 @@ const stringValidator = (
 
   schema = addMinLengthValidator(schema, metas, options);
   schema = addMaxLengthValidator(schema, metas);
-  schema = addStringRegexValidator(schema, metas);
+  schema = addStringRegexValidator(schema, metas, options);
   schema = addUniqueValidator(schema, metas, options);
 
   return schema;
@@ -413,6 +409,11 @@ export const emailValidator = (
   options: ValidatorOptions
 ) => {
   const schema = stringValidator(metas, options);
+
+  if (options.isDraft) {
+    return schema;
+  }
+
   return schema.email().min(
     1,
     // eslint-disable-next-line no-template-curly-in-string
@@ -425,6 +426,10 @@ export const uidValidator = (
   options: ValidatorOptions
 ) => {
   const schema = stringValidator(metas, options);
+
+  if (options.isDraft) {
+    return schema;
+  }
 
   return schema.matches(/^[A-Za-z0-9-_.~]*$/);
 };
@@ -441,7 +446,7 @@ export const integerValidator = (
 ) => {
   let schema = yup.number().integer();
 
-  schema = addMinIntegerValidator(schema, metas);
+  schema = addMinIntegerValidator(schema, metas, options);
   schema = addMaxIntegerValidator(schema, metas);
   schema = addUniqueValidator(schema, metas, options);
 
@@ -453,7 +458,8 @@ export const floatValidator = (
   options: ValidatorOptions
 ) => {
   let schema = yup.number();
-  schema = addMinFloatValidator(schema, metas);
+
+  schema = addMinFloatValidator(schema, metas, options);
   schema = addMaxFloatValidator(schema, metas);
   schema = addUniqueValidator(schema, metas, options);
 

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -6,7 +6,6 @@ import { findAndClose } from '../../utils/shared';
 type Field = {
   name: string;
   value: string;
-  newValue?: string;
   role?: 'combobox' | 'textbox';
   component?: {
     isSingle: boolean;
@@ -25,84 +24,74 @@ test.describe('Uniqueness', () => {
     await page.getByRole('link', { name: 'Unique' }).click();
   });
 
-  const SCALAR_FIELDS_TO_TEST: Field[] = [
-    { name: 'uniqueString', value: 'unique', newValue: 'unique-1' },
-    { name: 'uniqueNumber', value: '10', newValue: '20' },
-    { name: 'uniqueEmail', value: 'test@strapi.io', newValue: 'test+update@strapi.io' },
-    { name: 'uniqueDate', value: '01/01/2024', newValue: '02/01/2024', role: 'combobox' },
-    { name: 'UID', value: 'unique', newValue: 'unique-1' },
+  const SCALAR_FIELDS: Field[] = [
+    { name: 'uniqueString', value: 'unique' },
+    { name: 'uniqueNumber', value: '10' },
+    { name: 'uniqueEmail', value: 'test@strapi.io' },
+    { name: 'uniqueDate', value: '01/01/2024', role: 'combobox' },
+    { name: 'UID', value: 'unique' },
   ];
 
-  const SINGLE_COMPONENT_FIELDS_TO_TEST: Field[] = [
+  const SINGLE_COMPONENT_FIELDS: Field[] = [
     {
       name: 'ComponentTextShort',
       value: 'unique',
-      newValue: 'unique-1',
       component: { isSingle: true },
     },
     {
       name: 'ComponentTextLong',
       value: 'unique',
-      newValue: 'unique-1',
       component: { isSingle: true },
     },
     {
       name: 'ComponentNumberInteger',
       value: '10',
-      newValue: '20',
       component: { isSingle: true },
     },
     {
       name: 'ComponentNumberFloat',
       value: '3.14',
-      newValue: '3.1415926535897',
       component: { isSingle: true },
     },
     {
       name: 'ComponentEmail',
       value: 'test@strapi.io',
-      newValue: 'test+update@strapi.io',
       component: { isSingle: true },
     },
   ];
 
-  const REPEATABLE_COMPONENT_FIELDS_TO_TEST: Field[] = [
+  const REPEATABLE_COMPONENT_FIELDS: Field[] = [
     {
       name: 'ComponentTextShort',
       value: 'unique',
-      newValue: 'unique-2',
       component: { isSingle: false },
     },
     {
       name: 'ComponentTextLong',
       value: 'unique',
-      newValue: 'unique-2',
       component: { isSingle: false },
     },
     {
       name: 'ComponentNumberInteger',
       value: '10',
-      newValue: '20',
       component: { isSingle: false },
     },
     {
       name: 'ComponentNumberFloat',
       value: '3.14',
-      newValue: '3.1415926535897',
       component: { isSingle: false },
     },
     {
       name: 'ComponentEmail',
       value: 'test@strapi.io',
-      newValue: 'test+update@strapi.io',
       component: { isSingle: false },
     },
   ];
 
   const FIELDS_TO_TEST = [
-    ...SCALAR_FIELDS_TO_TEST,
-    ...SINGLE_COMPONENT_FIELDS_TO_TEST,
-    ...REPEATABLE_COMPONENT_FIELDS_TO_TEST,
+    ...SCALAR_FIELDS,
+    ...SINGLE_COMPONENT_FIELDS,
+    ...REPEATABLE_COMPONENT_FIELDS,
   ] as const satisfies Array<Field>;
 
   const CREATE_URL =
@@ -110,10 +99,11 @@ test.describe('Uniqueness', () => {
   const LIST_URL = /\/admin\/content-manager\/collection-types\/api::unique.unique(\?.*)?/;
   const EDIT_URL = /\/admin\/content-manager\/collection-types\/api::unique.unique\/[^/]+(\?.*)?/;
 
-  const clickSave = async (page) => {
+  const clickSave = async (page: Page) => {
     await page.getByRole('button', { name: 'Save' }).isEnabled();
     await page.getByRole('tab', { name: 'Draft' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Saved document')).toBeVisible();
   };
 
   const extraComponentNavigation = async (field: Field, page: Page) => {
@@ -136,6 +126,35 @@ test.describe('Uniqueness', () => {
     }
   };
 
+  const createNewEntry = async (page: Page, url: RegExp) => {
+    await page.getByRole('link', { name: 'Create new entry' }).first().click();
+    await page.waitForURL(url);
+  };
+
+  const fillField = async (page: Page, field: Field, fieldRole: 'combobox' | 'textbox') => {
+    await extraComponentNavigation(field, page);
+    await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
+  };
+
+  const publishDocument = async (page: Page) => {
+    await page.getByRole('button', { name: 'Publish' }).click();
+    await expect(page.getByText('Published document')).toBeVisible();
+  };
+
+  const navigateToListView = async (page: Page) => {
+    await page.getByRole('link', { name: 'Unique' }).click();
+    if (await page.getByText('Confirmation').isVisible()) {
+      await page.getByRole('button', { name: 'Confirm' }).click();
+    }
+
+    await page.waitForURL(LIST_URL);
+  };
+
+  const changeLocale = async (page: Page, locale: string) => {
+    await page.getByRole('combobox', { name: 'Select a locale' }).click();
+    await page.getByText(locale).click();
+  };
+
   /**
    * @note the unique content type is set up with every type of document level unique field.
    * We are testing that uniqueness is enforced for these fields across all entries of a content type in the same locale.
@@ -155,24 +174,14 @@ test.describe('Uniqueness', () => {
     test(`A user should not be able to duplicate the ${field.name} ${fieldDescription} value in the same content type and dimensions (locale + publication state).`, async ({
       page,
     }) => {
-      await page.getByRole('link', { name: 'Create new entry' }).first().click();
-
-      await page.waitForURL(CREATE_URL);
-
-      /**
-       * Now we're in the edit view. The content within each entry will be valid from the previous test run.
-       */
+      await createNewEntry(page, CREATE_URL);
 
       const fieldRole = 'role' in field ? field.role : 'textbox';
-
-      await extraComponentNavigation(field, page);
-      await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
+      await fillField(page, field, fieldRole);
 
       if (isRepeatableComponentField) {
-        // Add another entry to the repeatable component in this entry that
-        // shares the same value as the first entry. This should trigger a
-        // validation error
-
+        // If the field is a repeatable component field, we add an entry and fill
+        // it with the same value to test uniqueness within the same entity.
         await page.getByRole('button', { name: 'Add an entry' }).click();
         await page
           .getByRole('region')
@@ -181,63 +190,50 @@ test.describe('Uniqueness', () => {
         await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
 
         await clickSave(page);
+        await findAndClose(page, 'Saved document');
 
+        await page.getByRole('button', { name: 'Publish' }).click();
         await expect(page.getByText('Warning:2 errors occurred')).toBeVisible();
-        await expect(page.getByText('This attribute must be unique')).toBeVisible();
+
         await page.getByRole('button', { name: 'Delete' }).nth(1).click();
       }
 
       await clickSave(page);
       await findAndClose(page, 'Saved document');
 
-      await page.getByRole('link', { name: 'Unique' }).click();
-      await page.waitForURL(LIST_URL);
+      await navigateToListView(page);
 
-      /**
-       * Try to create another entry with the same value, the validation should fail
-       */
-      await page.getByRole('link', { name: 'Create new entry' }).first().click();
-
-      await page.waitForURL(CREATE_URL);
-
-      await extraComponentNavigation(field, page);
-      await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
+      await createNewEntry(page, CREATE_URL);
+      await fillField(page, field, fieldRole);
 
       await clickSave(page);
-      await expect(page.getByText('Warning:This attribute must be unique')).toBeVisible();
-      /**
-       * Modify the value and try again, this should save successfully
-       * Either take the new value provided in the field object or generate a random new one
-       */
-      await page
-        .getByRole(fieldRole, {
-          name: field.name,
-        })
-        .fill(field.newValue);
+      await findAndClose(page, 'Saved document');
+
+      await publishDocument(page);
+      await findAndClose(page, 'Published document');
+
+      await navigateToListView(page);
+
+      await createNewEntry(page, CREATE_URL);
+      await fillField(page, field, fieldRole);
 
       await clickSave(page);
-      await expect(page.getByText('Saved document')).toBeVisible();
+      await findAndClose(page, 'Saved document');
 
-      await page.getByRole('link', { name: 'Unique' }).click();
-      await page.waitForURL(LIST_URL);
-
-      /**
-       * Change locale and try to create an entry with the same value as our first entry, this should save successfully
-       */
-      await page.getByRole('combobox', { name: 'Select a locale' }).click();
-
-      await page.getByText('French (fr)').click();
-
-      await page.getByRole('link', { name: 'Create new entry' }).first().click();
-
-      await page.waitForURL(EDIT_URL);
-
-      await extraComponentNavigation(field, page);
-      await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
-
-      await clickSave(page);
       await page.getByRole('button', { name: 'Publish' }).click();
-      await expect(page.getByText('Published document')).toBeVisible();
+      await expect(page.getByText('Warning:This attribute must be unique')).toBeVisible();
+
+      await navigateToListView(page);
+      await changeLocale(page, 'French (fr)');
+
+      await createNewEntry(page, EDIT_URL);
+      await fillField(page, field, fieldRole);
+
+      await clickSave(page);
+      await findAndClose(page, 'Saved document');
+
+      await publishDocument(page);
+      await findAndClose(page, 'Published document');
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Modifies backend validators so, only max validators are applied on draft entries.

This was identified and discussed with the product team during our QA sessions, and we concluded it makes sense to exclude all validations on drafts except the max length/value ones.

This PR only includes de BE side, but will require adapting the FE to not trigger the validations on draft entries.
