### PR TITLE
fix: admin validation broken when json is still an object

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Json.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Json.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo } from 'react';
+import * as React from 'react';
 
 import {
   JSONInput as JSONInputImpl,
@@ -12,7 +12,7 @@ import { useField } from '../Form';
 
 import { InputProps } from './types';
 
-const JsonInput = forwardRef<JSONInputRef, InputProps>(
+const JsonInput = React.forwardRef<JSONInputRef, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const field = useField(name);
     const fieldRef = useFocusInputField(name);
@@ -43,6 +43,6 @@ const JsonInput = forwardRef<JSONInputRef, InputProps>(
   }
 );
 
-const MemoizedJsonInput = memo(JsonInput);
+const MemoizedJsonInput = React.memo(JsonInput);
 
 export { MemoizedJsonInput as JsonInput };

--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -181,6 +181,16 @@ const createAttributeSchema = (
           return true;
         }
 
+        // If the value was created via content API and wasn't changed, then it's still an object
+        if (typeof value === 'object') {
+          try {
+            JSON.stringify(value);
+            return true;
+          } catch (err) {
+            return false;
+          }
+        }
+
         try {
           JSON.parse(value);
 


### PR DESCRIPTION
### What does it do?

In the admin validation, handles the case where JSON content is in object form, not stringified.

### Why is it needed?

The JSON value will be an object if it was created via the content API and hasn't been modified in the input.

### How to test it?

- Create a kitchensink entry via the content API, give the json field an object value.
- Find the entry in the CM, modify another field without touching the json field
- Save. You shouldn't get a validation error.

### Related issue(s)/PR(s)

fixes #20882