### PR TITLE
chore: add cli tests to clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "setup": "yarn && yarn clean && yarn build --skip-nx-cache",
     "test:api": "node tests/scripts/run-api-tests.js",
     "test:api:clean": "rimraf ./coverage",
-    "test:clean": "yarn test:api:clean && yarn test:e2e:clean",
+    "test:clean": "yarn test:api:clean ; yarn test:e2e:clean ; yarn test:cli:clean",
     "test:cli": "node tests/scripts/run-cli-tests.js",
     "test:cli:clean": "node tests/scripts/run-cli-tests.js clean",
     "test:cli:debug": "node tests/scripts/run-cli-tests.js --debug",


### PR DESCRIPTION
### What does it do?

- adds cli to clean
- allow all clean scripts to run even if one fails

### Why is it needed?

it wasn't cleaning cli test apps

### How to test it?

run `yarn test:clean`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
