### PR TITLE
fix(cli): Update 'project not found' error message in deploy command

### DIFF
--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -102,8 +102,8 @@ async function upload(
       progressBar.stop();
       if (e instanceof AxiosError && e.response?.data) {
         if (e.response.status === 404) {
-          ctx.logger.error(
-            `The project does not exist. Remove the ${local.LOCAL_SAVE_FILENAME} file and try again.`
+          ctx.logger.warn(
+            `The project does not exist. Please link your local project to a Strapi Cloud project using the link command.`
           );
         } else {
           ctx.logger.error(e.response.data);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update the error log in the cli `deploy` command to suggest the usage of `link` command when a project is not found.

### Why is it needed?

Previously, when a project was not found, we couldn't do anything so we logged an error. Now, users can use the strapi link command to link a project to the existing project folder.

### How to test it?

Try to deploy in a project with wrong project name in `.strapi-cloud.json` config and you should see the right warning log.
