### PR TITLE
fix: policies registry returns same data types as other registries

### DIFF
--- a/packages/core/core/src/registries/__tests__/policies.test.ts
+++ b/packages/core/core/src/registries/__tests__/policies.test.ts
@@ -41,4 +41,15 @@ describe('Policy util', () => {
       expect(registry.get('test-policy', { apiName: 'test-api' })).toBe(policyFn);
     });
   });
+
+  describe('keys', () => {
+    test('Returns an array of strings', () => {
+      const keysRegistry = createPoliciesRegistry();
+      const policyFn = () => {};
+
+      keysRegistry.set('plugin::test-plugin.test-policy', policyFn as any);
+
+      expect(keysRegistry.keys()).toStrictEqual(['plugin::test-plugin.test-policy']);
+    });
+  });
 });

--- a/packages/core/core/src/registries/policies.ts
+++ b/packages/core/core/src/registries/policies.ts
@@ -1,5 +1,5 @@
 import { pickBy, has, castArray } from 'lodash/fp';
-import type { Core, UID } from '@strapi/types';
+import type { Core } from '@strapi/types';
 import { addNamespace, hasNamespace } from './namespace';
 
 const PLUGIN_PREFIX = 'plugin::';
@@ -109,22 +109,7 @@ const policiesRegistry = () => {
      * Returns a map with all the policies in a namespace
      */
     getAll(namespace: string) {
-      const filteredPolicies = pickBy((_, uid) => hasNamespace(uid, namespace))(
-        Object.fromEntries(policies)
-      );
-
-      // Return an enumerable object of the same format as controllers, services, etc
-      const map = {};
-      for (const uid of Object.keys(filteredPolicies) as UID.Policy[]) {
-        Object.defineProperty(map, uid, {
-          enumerable: true,
-          get: () => {
-            return this.get(uid);
-          },
-        });
-      }
-
-      return map;
+      return pickBy((_, uid) => hasNamespace(uid, namespace))(Object.fromEntries(policies));
     },
 
     /**


### PR DESCRIPTION
### What does it do?

- fixes policies registry to return the same data types as controllers, services, etc

### Why is it needed?

fixes the `strapi policies:list` command and makes the policies `keys()` return type consistent with other registries

### How to test it?

Policies should all work fine
especially check that `strapi policies:list` should return policies

### Related issue(s)/PR(s)

DX-1505 

Fixes #20893 