### PR TITLE
fix (content-manager): load relation main fields on all pages

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -446,11 +446,15 @@ export default {
     const loadedIds = res.results.map((item: any) => item.id);
     addFiltersClause(permissionQuery, { id: { $in: loadedIds } });
 
+    /**
+     * Load the relations with the main field, the sanitized permission query
+     * will exclude the relations the user does not have access to.
+     *
+     * Pagination is not necessary as the permissionQuery contains the ids to load.
+     */
     const sanitizedRes = await loadRelations({ id: entryId }, targetField, {
       ...strapi.get('query-params').transform(targetUid, permissionQuery),
       ordering: 'desc',
-      page: ctx.request.query.page,
-      pageSize: ctx.request.query.pageSize,
     });
 
     const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));

--- a/tests/api/core/content-manager/api/relations-permissions.test.api.js
+++ b/tests/api/core/content-manager/api/relations-permissions.test.api.js
@@ -58,10 +58,11 @@ const createEntry = async (model, data, populate) => {
   return body;
 };
 
-const getRelations = async (rq, uid, field, id) => {
+const getRelations = async (rq, uid, field, id, params = {}) => {
   const res = await rq({
     method: 'GET',
     url: `/content-manager/relations/${uid}/${id}/${field}`,
+    qs: params,
   });
 
   return res;
@@ -164,6 +165,46 @@ describe('Relation permissions', () => {
     expect(products.results).toHaveLength(1);
     // Main field should be visible
     expect(products.results[0].name).toBe(product.name);
+  });
+
+  /**
+   * Prevent relations being loaded without the main field if user has appropriate permissions.
+   * Ref: https://github.com/strapi/strapi/issues/19625
+   */
+  test('Permissive user can read multiple pages of shop products', async () => {
+    // Add more products
+    const products = [];
+
+    for (let i = 0; i < 10; i += 1) {
+      const productEntry = await createEntry('api::product.product', { name: `Product ${i}` });
+      products.push(productEntry.data.id);
+    }
+
+    const shop = await createEntry('api::shop.shop', { name: 'Shop', products }, populateShop);
+
+    const { body: firstPage } = await getRelations(
+      rqPermissive,
+      'api::shop.shop',
+      'products',
+      shop.data.documentId,
+      { page: 1, pageSize: 5 }
+    );
+
+    expect(firstPage.results).toHaveLength(5);
+    // Expect results to have the name field (main field)
+    expect(firstPage.results[0].name).toBeDefined();
+
+    const { body: secondPage } = await getRelations(
+      rqPermissive,
+      'api::shop.shop',
+      'products',
+      shop.data.documentId,
+      { page: 2, pageSize: 5 }
+    );
+
+    expect(secondPage.results).toHaveLength(5);
+    // Expect results to have the name field (main field)
+    expect(secondPage.results[0].name).toBeDefined();
   });
 
   test('Restricted user cannot read shop products mainField', async () => {


### PR DESCRIPTION
### What does it do?
As described in https://github.com/strapi/strapi/issues/19625 , in the edit view, the relation mainfield was not displayed on pages other than the first one.

This fix will also be necessary in the v4 branch.

