### PR TITLE
chore: v5/main workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - develop
+      - v5/main
 
 jobs:
   check-pr-status:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v5/main
   pull_request:
 
 permissions:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v5/main
   pull_request:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - v5/main
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
### What does it do?

Sets up missing workflows for v5/main

### Why is it needed?

security-lock-analysis and pr-status were being required to merge but not being required to run, which means currently all(?) `v5/main` PRs must be force merged

### How to test it?

security-lock-analysis and pr-status should run on this PR's workflow

### Related issue(s)/PR(s)
