### PR TITLE
RBAC Action Aliases - v4

### DIFF
--- a/packages/core/admin/server/src/config/admin-actions.ts
+++ b/packages/core/admin/server/src/config/admin-actions.ts
@@ -50,6 +50,12 @@ export const actions = [
     section: 'settings',
     category: 'users and roles',
     subCategory: 'users',
+    aliases: [
+      {
+        actionId: 'plugin::content-manager.explorer.read',
+        subjects: ['admin::user'],
+      },
+    ],
   },
   {
     uid: 'users.update',
@@ -82,6 +88,12 @@ export const actions = [
     section: 'settings',
     category: 'users and roles',
     subCategory: 'roles',
+    aliases: [
+      {
+        actionId: 'plugin::content-manager.explorer.read',
+        subjects: ['admin::role'],
+      },
+    ],
   },
   {
     uid: 'roles.update',

--- a/packages/core/admin/server/src/domain/action/__tests__/action-provider.test.ts
+++ b/packages/core/admin/server/src/domain/action/__tests__/action-provider.test.ts
@@ -8,12 +8,12 @@ const providerMethods = [
   'appliesToProperty',
   'delete',
   'get',
-  'getWhere',
   'values',
   'keys',
   'has',
   'size',
   'clear',
+  'unstable_aliases',
 ];
 
 describe('Action Provider', () => {
@@ -369,6 +369,145 @@ describe('Action Provider', () => {
             subject: 'foo',
           })
         );
+      });
+    });
+    describe('Aliases', () => {
+      test('Return an empty array when there is no alias pointing to the given action', async () => {
+        const provider = createActionProvider();
+        const actions = [
+          {
+            section: 'settings',
+            displayName: 'Foo bar',
+            uid: 'foo',
+            pluginName: 'bar',
+            category: 'category',
+            subCategory: 'subcategory',
+          },
+          {
+            section: 'settings',
+            displayName: 'Bar foo',
+            category: 'category',
+            uid: 'bar',
+          },
+        ];
+
+        await provider.registerMany(actions);
+
+        const aliases = provider.unstable_aliases('plugin::bar.foo');
+
+        expect(aliases).toStrictEqual([]);
+      });
+
+      test(`Return an empty array when there is an alias but the subject don't match`, async () => {
+        const provider = createActionProvider();
+        const actions = [
+          {
+            section: 'settings',
+            displayName: 'Foo bar',
+            uid: 'foo',
+            pluginName: 'bar',
+            category: 'category',
+            subCategory: 'subcategory',
+          },
+          {
+            section: 'settings',
+            displayName: 'Bar foo',
+            category: 'category',
+            uid: 'bar',
+            aliases: [{ actionId: 'plugin::bar.foo', subjects: ['baz'] }],
+          },
+        ];
+
+        await provider.registerMany(actions);
+
+        const aliases = provider.unstable_aliases('plugin::bar.foo', 'bar');
+
+        expect(aliases).toStrictEqual([]);
+        expect(aliases).toHaveLength(0);
+      });
+
+      test(`Return an empty array when there is an alias but no subject is passed (when required)`, async () => {
+        const provider = createActionProvider();
+        const actions = [
+          {
+            section: 'settings',
+            displayName: 'Foo bar',
+            uid: 'foo',
+            pluginName: 'bar',
+            category: 'category',
+            subCategory: 'subcategory',
+          },
+          {
+            section: 'settings',
+            displayName: 'Bar foo',
+            category: 'category',
+            uid: 'bar',
+            aliases: [{ actionId: 'plugin::bar.foo', subjects: ['baz'] }],
+          },
+        ];
+
+        await provider.registerMany(actions);
+
+        const aliases = provider.unstable_aliases('plugin::bar.foo');
+
+        expect(aliases).toStrictEqual([]);
+        expect(aliases).toHaveLength(0);
+      });
+
+      test('Return 1 result when there is a valid alias pointing to the given action', async () => {
+        const provider = createActionProvider();
+        const actions = [
+          {
+            section: 'settings',
+            displayName: 'Foo bar',
+            uid: 'foo',
+            pluginName: 'bar',
+            category: 'category',
+            subCategory: 'subcategory',
+          },
+          {
+            section: 'settings',
+            displayName: 'Bar foo',
+            category: 'category',
+            uid: 'bar',
+            aliases: [{ actionId: 'plugin::bar.foo' }],
+          },
+        ];
+
+        await provider.registerMany(actions);
+
+        const aliases = provider.unstable_aliases('plugin::bar.foo');
+
+        expect(aliases).toHaveLength(1);
+        expect(aliases).toStrictEqual(['api::bar']);
+      });
+
+      test('Return 1 result when there is a valid alias pointing to the given action with a valid subject', async () => {
+        const provider = createActionProvider();
+        const actions = [
+          {
+            section: 'settings',
+            displayName: 'Foo bar',
+            uid: 'foo',
+            pluginName: 'bar',
+            category: 'category',
+            subCategory: 'subcategory',
+          },
+          {
+            section: 'settings',
+            displayName: 'Bar foo',
+            category: 'category',
+            uid: 'bar',
+            aliases: [{ actionId: 'plugin::bar.foo', subjects: ['baz'] }],
+          },
+        ];
+
+        await provider.registerMany(actions);
+
+        const aliases = provider.unstable_aliases('plugin::bar.foo', 'baz');
+
+        expect(aliases).toHaveLength(1);
+        expect(aliases).toStrictEqual(['api::bar']);
       });
     });
   });

--- a/packages/core/admin/server/src/domain/action/index.ts
+++ b/packages/core/admin/server/src/domain/action/index.ts
@@ -1,18 +1,77 @@
 import { curry, pipe, merge, set, pick, omit, includes, isArray, prop } from 'lodash/fp';
 import { Utils } from '@strapi/types';
 
+export interface ActionAlias {
+  /**
+   * The action ID to alias
+   */
+  actionId: string;
+
+  /**
+   * An optional array of subject to restrict the alias usage
+   */
+  subjects?: string[];
+}
+
 export type Action = {
-  actionId: string; // The unique identifier of the action
-  section: string; // The section linked to the action - These can be 'contentTypes' | 'plugins' | 'settings' | 'internal'
-  displayName: string; // The human readable name of an action
-  category: string; // The main category of an action
-  subCategory?: string; // The secondary category of an action (only for settings and plugins section)
-  pluginName?: string; // The plugin which provide the action
-  subjects?: string[]; // A list of subjects on which the action can be applied
+  /**
+   * The unique identifier of the action
+   */
+  actionId: string;
+
+  /**
+   * The section linked to the action - These can be 'contentTypes' | 'plugins' | 'settings' | 'internal'
+   */
+  section: string;
+
+  /**
+   * The human readable name of an action
+   */
+  displayName: string;
+
+  /**
+   * The main category of an action
+   */
+  category: string;
+
+  /**
+   * The secondary category of an action (only for settings and plugins section)
+   */
+  subCategory?: string;
+
+  /**
+   * The plugin that provides the action
+   */
+  pluginName?: string;
+
+  /**
+   * A list of subjects on which the action can be applied
+   */
+  subjects?: string[];
+
+  /**
+   * The options of an action
+   */
   options: {
-    // The options of an action
-    applyToProperties: string[] | null; // The list of properties that can be associated with an action
+    /**
+     * The list of properties that can be associated with an action
+     */
+    applyToProperties: string[] | null;
   };
+
+  /**
+   * An optional array of @see {@link ActionAlias}.
+   *
+   * It represents the possible aliases for the current action.
+   *
+   * Aliases are unidirectional.
+   *
+   * Note: This is an internal property and probably shouldn't be used outside Strapi core features.
+   *       Its behavior might change at any time without notice.
+   *
+   * @internal
+   */
+  aliases?: ActionAlias[];
 };
 
 /**
@@ -50,6 +109,7 @@ const actionFields = [
   'subjects',
   'options',
   'actionId',
+  'aliases',
 ] as const;
 
 /**

--- a/packages/core/admin/server/src/domain/condition/__tests__/condition-provider.test.ts
+++ b/packages/core/admin/server/src/domain/condition/__tests__/condition-provider.test.ts
@@ -7,7 +7,6 @@ const providerMethods = [
   'registerMany',
   'delete',
   'get',
-  'getWhere',
   'values',
   'keys',
   'has',

--- a/packages/core/admin/server/src/validation/action-provider.ts
+++ b/packages/core/admin/server/src/validation/action-provider.ts
@@ -56,6 +56,14 @@ const registerProviderActionSchema = yup
         options: yup.object({
           applyToProperties: yup.array().of(yup.string()),
         }),
+        aliases: yup
+          .array(
+            yup.object({
+              actionId: yup.string(),
+              subjects: yup.array(yup.string()).nullable(),
+            })
+          )
+          .nullable(),
       })
       .noUnknown()
   );

--- a/packages/core/admin/server/src/validation/common-validators.ts
+++ b/packages/core/admin/server/src/validation/common-validators.ts
@@ -118,7 +118,7 @@ export const permission = yup
           return isNil(subject);
         }
 
-        if (isArray(action.subjects)) {
+        if (isArray(action.subjects) && !isNil(subject)) {
           return action.subjects.includes(subject);
         }
 

--- a/packages/core/content-manager/server/src/controllers/__tests__/relations.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/relations.test.ts
@@ -43,6 +43,9 @@ describe('Relations', () => {
           services: {
             'permission-checker': {
               create: jest.fn().mockReturnValue({
+                can: {
+                  read: jest.fn().mockReturnValue(true),
+                },
                 cannot: {
                   read: jest.fn().mockReturnValue(false),
                 },
@@ -121,6 +124,20 @@ describe('Relations', () => {
     });
 
     test('Replace mainField by id when mainField is not listable', async () => {
+      global.strapi.plugins['content-manager'].services[
+        'permission-checker'
+      ].create.mockReturnValue({
+        can: {
+          read: jest.fn().mockReturnValue(true),
+        },
+        cannot: {
+          read: jest.fn().mockReturnValue(false),
+        },
+        sanitizedQuery: {
+          read: jest.fn((queryParams) => queryParams),
+        },
+      });
+
       const ctx = createContext(
         {
           params: {
@@ -166,6 +183,9 @@ describe('Relations', () => {
       global.strapi.plugins['content-manager'].services[
         'permission-checker'
       ].create.mockReturnValue({
+        can: {
+          read: jest.fn().mockReturnValue(true),
+        },
         cannot: {
           read: jest.fn().mockReturnValue(false),
         },
@@ -240,6 +260,9 @@ describe('Relations', () => {
   test('Replace mainField by id when mainField is not accessible with RBAC', async () => {
     global.strapi.plugins['content-manager'].services['permission-checker'].create
       .mockReturnValueOnce({
+        can: {
+          read: jest.fn().mockReturnValue(true),
+        },
         cannot: {
           read: jest.fn().mockReturnValue(false),
         },
@@ -248,6 +271,9 @@ describe('Relations', () => {
         },
       })
       .mockReturnValueOnce({
+        can: {
+          read: jest.fn().mockReturnValue(false),
+        },
         cannot: {
           read: jest.fn().mockReturnValue(true),
         },

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -23,24 +23,21 @@ const sanitizeMainField = (model: any, mainField: any, userAbility: any) => {
     model: model.uid,
   });
 
-  if (!isListable(model, mainField)) {
+  // Whether the main field can be displayed or not, regardless of permissions.
+  const isMainFieldListable = isListable(model, mainField);
+  // Whether the user has the permission to access the model's main field (using RBAC abilities)
+  const canReadMainField = permissionChecker.can.read(null, mainField);
+
+  if (!isMainFieldListable || !canReadMainField) {
+    // Default to 'id' if the actual main field shouldn't be displayed
     return 'id';
   }
 
-  if (permissionChecker.cannot.read(null, mainField)) {
-    // Allow reading role name if user can read the user model
-    if (model.uid === 'plugin::users-permissions.role') {
-      const userPermissionChecker = getService('permission-checker').create({
-        userAbility,
-        model: 'plugin::users-permissions.user',
-      });
+  // Edge cases
 
-      if (userPermissionChecker.can.read()) {
-        return 'name';
-      }
-    }
-
-    return 'id';
+  // 1. Enforce 'name' as the main field for users and permissions' roles
+  if (model.uid === 'plugin::users-permissions.role') {
+    return 'name';
   }
 
   return mainField;

--- a/packages/core/content-manager/server/src/policies/hasPermissions.ts
+++ b/packages/core/content-manager/server/src/policies/hasPermissions.ts
@@ -7,6 +7,11 @@ const { createPolicy } = policy;
 export default createPolicy({
   name: 'plugin::content-manager.hasPermissions',
   validator: validateHasPermissionsInput,
+  /**
+   * NOTE: Action aliases are currently not checked at this level (policy).
+   *       This is currently the intended behavior to avoid changing the behavior of API related permissions.
+   *       If you want to add support for it, please create a dedicated RFC with a list of potential side effect this could have.
+   */
   handler(ctx: Context, config = {}) {
     const { actions = [], hasAtLeastOne = false }: { actions: string[]; hasAtLeastOne: boolean } =
       config;

--- a/packages/core/content-manager/server/src/services/permission-checker.ts
+++ b/packages/core/content-manager/server/src/services/permission-checker.ts
@@ -25,19 +25,38 @@ const createPermissionChecker =
       model,
     });
 
-    const toSubject = (entity?: Entity) =>
-      entity ? permissionsManager.toSubject(entity, model) : model;
+    const { actionProvider } = strapi.service('admin::permission');
+
+    const toSubject = (entity?: Entity) => {
+      return entity ? permissionsManager.toSubject(entity, model) : model;
+    };
 
     // @ts-expect-error preserve the parameter order
     // eslint-disable-next-line @typescript-eslint/default-param-last
     const can = (action: string, entity?: Entity, field: string) => {
-      return userAbility.can(action, toSubject(entity), field);
+      const subject = toSubject(entity);
+      const aliases = actionProvider.unstable_aliases(action, model) as string[];
+
+      return (
+        // Test the original action to see if it passes
+        userAbility.can(action, subject, field) ||
+        // Else try every known alias if at least one of them succeed, then the user "can"
+        aliases.some((alias) => userAbility.can(alias, subject, field))
+      );
     };
 
     // @ts-expect-error preserve the parameter order
     // eslint-disable-next-line @typescript-eslint/default-param-last
     const cannot = (action: string, entity?: Entity, field: string) => {
-      return userAbility.cannot(action, toSubject(entity), field);
+      const subject = toSubject(entity);
+      const aliases = actionProvider.unstable_aliases(action, model) as string[];
+
+      return (
+        // Test both the original action
+        userAbility.cannot(action, subject, field) &&
+        // and every known alias, if all of them fail (cannot), then the user truly "cannot"
+        aliases.every((alias) => userAbility.cannot(alias, subject, field))
+      );
     };
 
     const sanitizeOutput = (data: Entity, { action = ACTIONS.read }: { action?: string } = {}) => {

--- a/packages/core/utils/src/__tests__/provider-factory.test.ts
+++ b/packages/core/utils/src/__tests__/provider-factory.test.ts
@@ -1,16 +1,6 @@
 import providerFactory from '../provider-factory';
 
-const providerMethods = [
-  'register',
-  'delete',
-  'get',
-  'getWhere',
-  'values',
-  'keys',
-  'has',
-  'size',
-  'clear',
-];
+const providerMethods = ['register', 'delete', 'get', 'values', 'keys', 'has', 'size', 'clear'];
 
 describe('Provider Factory', () => {
   describe('Core', () => {
@@ -201,50 +191,6 @@ describe('Provider Factory', () => {
         const result = provider.get('key');
 
         expect(result).toBeUndefined();
-      });
-    });
-
-    describe('GetWhere', () => {
-      const items = [
-        { key: 'keyA', value: { foo: 'barA', bar: 'foo1' } },
-        { key: 'keyB', value: { foo: 'barB', bar: 'foo2' } },
-        { key: 'keyC', value: { foo: 'barC', bar: 'foo1' } },
-        { key: 'keyD', value: { foo: 'barD', bar: 'foo2' } },
-      ];
-      const provider = providerFactory();
-
-      const sortItems = (a, b) => (a.key < b.key ? -1 : 1);
-      const pickItems = (...indexes) => indexes.map((index) => items[index].value);
-
-      beforeAll(async () => {
-        for (const item of items) {
-          await provider.register(item.key, item.value);
-        }
-      });
-
-      test('Calling getWhere without filters returns every registered items', async () => {
-        const expected = items.map((i) => i.value).sort(sortItems);
-
-        const results = provider.getWhere();
-
-        expect(results).toStrictEqual(expect.any(Array));
-        expect(results).toHaveLength(items.length);
-        expect(results.sort(sortItems)).toEqual(expected);
-      });
-
-      test.each([
-        [{ foo: 'barA' }, pickItems(0)],
-        [{ bar: 'foo1' }, pickItems(0, 2)],
-        [{ bar: 'foo2' }, pickItems(1, 3)],
-        [{ foo: 'barD', bar: 'foo2' }, pickItems(3)],
-        [{ foo: 'barC', bar: 'foo2' }, []],
-        [{ foobar: 'foobar' }, []],
-        [{}, pickItems(0, 1, 2, 3)],
-      ])('Filters %s', (filters, expected) => {
-        const results = provider.getWhere(filters);
-
-        expect(results).toStrictEqual(expect.any(Array));
-        expect(results).toStrictEqual(expected);
       });
     });
 

--- a/packages/core/utils/src/provider-factory.ts
+++ b/packages/core/utils/src/provider-factory.ts
@@ -31,36 +31,35 @@ export interface Options {
 
 type Item = Record<string, unknown>;
 
-export interface Provider {
+export interface Provider<T = unknown> {
   hooks: ProviderHooksMap;
-  register(key: string, item: Item): Promise<Provider>;
-  delete(key: string): Promise<Provider>;
-  get(key: string): Item | undefined;
-  getWhere(filters?: Record<string, unknown>): Item[];
-  values(): Item[];
+  register(key: string, item: T): Promise<Provider<T>>;
+  delete(key: string): Promise<Provider<T>>;
+  get(key: string): T | undefined;
+  values(): T[];
   keys(): string[];
   has(key: string): boolean;
   size(): number;
-  clear(): Promise<Provider>;
+  clear(): Promise<Provider<T>>;
 }
 
-export type ProviderFactory = (options?: Options) => Provider;
+export type ProviderFactory<T> = (options?: Options) => Provider<T>;
 
 /**
  * A Provider factory
  */
-const providerFactory: ProviderFactory = (options = {}) => {
+const providerFactory = <T = Item>(options: Options = {}): Provider<T> => {
   const { throwOnDuplicates = true } = options;
 
   const state = {
     hooks: createProviderHooksMap(),
-    registry: new Map<string, Item>(),
+    registry: new Map<string, T>(),
   };
 
   return {
     hooks: state.hooks,
 
-    async register(key: string, item: Item) {
+    async register(key: string, item: T) {
       if (throwOnDuplicates && this.has(key)) {
         throw new Error(`Duplicated item key: ${key}`);
       }
@@ -90,19 +89,6 @@ const providerFactory: ProviderFactory = (options = {}) => {
 
     get(key: string) {
       return state.registry.get(key);
-    },
-
-    getWhere(filters = {}) {
-      const items = this.values();
-      const filtersEntries = Object.entries(filters);
-
-      if (filtersEntries.length === 0) {
-        return items;
-      }
-
-      return items.filter((item) => {
-        return filtersEntries.every(([key, value]) => item[key] === value);
-      });
     },
 
     values() {

--- a/packages/plugins/i18n/server/src/services/permissions/actions.ts
+++ b/packages/plugins/i18n/server/src/services/permissions/actions.ts
@@ -1,14 +1,43 @@
-import { capitalize, isArray, getOr, prop } from 'lodash/fp';
+import { isArray, getOr, prop } from 'lodash/fp';
 import { getService } from '../../utils';
 
-const actions = ['create', 'read', 'update', 'delete'].map((uid) => ({
-  section: 'settings',
-  category: 'Internationalization',
-  subCategory: 'Locales',
-  pluginName: 'i18n',
-  displayName: capitalize(uid),
-  uid: `locale.${uid}`,
-}));
+const actions = [
+  {
+    section: 'settings',
+    category: 'Internationalization',
+    subCategory: 'Locales',
+    pluginName: 'i18n',
+    displayName: 'Create',
+    uid: 'locale.create',
+  },
+  {
+    section: 'settings',
+    category: 'Internationalization',
+    subCategory: 'Locales',
+    pluginName: 'i18n',
+    displayName: 'Read',
+    uid: 'locale.read',
+    aliases: [
+      { actionId: 'plugin::content-manager.explorer.read', subjects: ['plugin::i18n.locale'] },
+    ],
+  },
+  {
+    section: 'settings',
+    category: 'Internationalization',
+    subCategory: 'Locales',
+    pluginName: 'i18n',
+    displayName: 'Update',
+    uid: 'locale.update',
+  },
+  {
+    section: 'settings',
+    category: 'Internationalization',
+    subCategory: 'Locales',
+    pluginName: 'i18n',
+    displayName: 'Delete',
+    uid: 'locale.delete',
+  },
+];
 
 const addLocalesPropertyIfNeeded = ({ value: action }: any) => {
   const {

--- a/packages/plugins/users-permissions/server/bootstrap/users-permissions-actions.js
+++ b/packages/plugins/users-permissions/server/bootstrap/users-permissions-actions.js
@@ -16,6 +16,12 @@ module.exports = {
       uid: 'roles.read',
       subCategory: 'roles',
       pluginName: 'users-permissions',
+      aliases: [
+        {
+          actionId: 'plugin::content-manager.explorer.read',
+          subjects: ['plugin::users-permissions.role'],
+        },
+      ],
     },
     {
       section: 'plugins',

--- a/tests/api/core/content-manager/api/relations-permissions.test.api.js
+++ b/tests/api/core/content-manager/api/relations-permissions.test.api.js
@@ -102,6 +102,9 @@ describe('Relations', () => {
         action: 'plugin::content-manager.explorer.read',
         subject: 'plugin::users-permissions.user',
       },
+      {
+        action: 'plugin::users-permissions.roles.read',
+      },
     ]);
     rqPermissive = await createUserAndReq('permissive', [
       // Can read shops and products
@@ -116,6 +119,9 @@ describe('Relations', () => {
       {
         action: 'plugin::content-manager.explorer.read',
         subject: 'plugin::users-permissions.user',
+      },
+      {
+        action: 'plugin::users-permissions.roles.read',
       },
     ]);
   };


### PR DESCRIPTION
:warning:  **This PR is a v4 port of https://github.com/strapi/strapi/pull/20878.**

### What does it do?

#### Action Aliases

Introduce a new `aliases` property on admin actions (`RBAC`).

This property is defined as an optional array of action alias.

```ts
interface ActionAlias {
  /**
   * The action ID to alias
   */
  actionId: string;

  /**
   * An optional array of subject to restrict the alias usage
   */
  subjects?: string[];
}

type Action = {
  // other properties ...

  /**
   * An optional array of @see {@link ActionAlias}.
   *
   * It represents the possible aliases for the current action.
   *
   * Aliases are unidirectionals.
   *
   * Note: This is an internal property and probably shouldn't be used outside of Strapi core features.
   *       Its behavior might change at any time without notice.
   *
   * @private
   */
  aliases?: ActionAlias[];
};
```

#### Action Provider

A new method `unstable_aliases` is added to the admin action provider (`RBAC`).

```ts
declare function unstable_aliases(actionId: string, subject?: string | null): string[];
```

It returns an array of `actionId` that can be used as aliases for the given `actionId` and `subject`.

- When an alias doesn't declare a `subjects` property, it only checks actions ID
- When an alias has an array of subjects declared, it ensures both the actions ID and subjects matches   

#### New Aliases

A default set of aliases for common use cases have been defined:

- `admin::users.read` is an alias of `plugin::content-manager.explorer.read`(`admin::user`)
- `admin::users.roles` is an alias of `plugin::content-manager.explorer.read`(`admin::role`)
- `plugin::i18n.locale.read` is an alias of `plugin::content-manager.explorer.read`(`plugin::i18n.locale`)

### Why is it needed?

The initial idea came when looking at #19001. The issue being hidden content-types (`admin::user`, `plugin::i18n.locale`, etc...) not having a content manager action being registered for them (only CTs being displayed in the CM have one).

Since it is possible to create a relation to `admin::user` (manual exception), this is why even super admin can't see the main field for the relation (because the needed permission doesn't even exist).

**Note:** It's also already possible to declare manual relations to any internal content-type from the schema file (e.g. `locale`)

This is a limitation in how permissions are defined. However, simpler solutions like only adding the hidden content-types (mostly internal ones like `upload::file` or `upload::folder`) to the list of allowed subjects for the `plugin::content-manager.explorer.read` action might lead to unwanted side effects (like adding them to the roles' edit permission table).

The proposed (internal) `aliases` feature mitigates the issue by adding more flexible options when checking permissions while limiting side effects on already existing features and behaviors. 

### How to test it?

1. Create a content-type with a relation to `admin::user` (`CT`)
2. Create a non super-admin user (`A`), go the content manager
3. From the super-admin account (`B`), set the following permissions for (`A`)'s role
  - In `Collection Types`: allow every CRUD operation on `CT`
  - In `Settings`: make sure `Read` is **not** checked in `Users & Roles`
4. As (`A`) Go to `Content-Manager` > `CT` > `Create new entry`
5. When opening the select input for the `admin::user` relation, only document IDs should be visible
6. As (`B`), update (`A`)'s role permissions, and check the `Read` box in `Settings` > `Users & Roles
7. As (`A`), try opening the select input again, the proper main field should be displayed (by default `firstname`)

### Related issue(s)/PR(s)

#19001

### Notes

- Aliases are unidirectional to allow setting more granular permissions
- The aliases defined in this PR are just meant to address common scenarios, but this is meant to be extended based on future use cases
- While this is set as an internal feature (for now), it could be interesting to imagine the potential use cases for plugin & user app if made public

### Screenshots

![Screenshot from 2024-07-25 00-43-21](https://github.com/user-attachments/assets/97f56cb2-a9fc-4fb6-bad0-d49025c0027b)
![Screenshot from 2024-07-25 00-44-03](https://github.com/user-attachments/assets/85f294fb-5072-4762-b03b-8a755147aaab)


fixes #19001 