### PR TITLE
fix(content-manager): dont perform unnecessary requests

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableActions.tsx
@@ -52,9 +52,10 @@ const TableActions = ({ document }: TableActionsProps) => {
   return (
     <DescriptionComponentRenderer
       props={props}
-      descriptions={(
-        plugins['content-manager'].apis as ContentManagerPlugin['config']['apis']
-      ).getDocumentActions()}
+      descriptions={(plugins['content-manager'].apis as ContentManagerPlugin['config']['apis'])
+        .getDocumentActions()
+        // We explicitly remove the PublishAction from description so we never render it and we don't make unnecessary requests.
+        .filter((action) => action.name !== 'PublishAction')}
     >
       {(actions) => {
         const tableRowActions = actions.filter((action) => {


### PR DESCRIPTION
### What does it do?

`DescriptionComponentRenderer` receive all the possible buttons and all the components are rendered even if at the end they are not showed. So we explicitly remove the publish button as it is not showed in the ListView and because the PublishAction button performs requests that we don't want to make at the list view.

### How to test it?

1. Go to any CT on the Content Manager. 
2. It should not have any request to countDraftRelations endpoint

### Related issue(s)/PR(s)

closes #20736 
