### PR TITLE
fix(content-manager): dont count draft relations on the list view

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -29,7 +29,7 @@ import { SINGLE_TYPES } from '../../../constants/collections';
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
 import { useDoc } from '../../../hooks/useDocument';
 import { useDocumentActions } from '../../../hooks/useDocumentActions';
-import { CLONE_PATH } from '../../../router';
+import { CLONE_PATH, LIST_PATH } from '../../../router';
 import { useGetDraftRelationCountQuery } from '../../../services/documents';
 import { isBaseQueryError, buildValidParams } from '../../../utils/api';
 import { getTranslation } from '../../../utils/translations';
@@ -516,6 +516,7 @@ const PublishAction: DocumentActionComponent = ({
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
   const { _unstableFormatValidationErrors: formatValidationErrors } = useAPIErrorHandler();
+  const isListView = useMatch(LIST_PATH) !== null;
   const isCloning = useMatch(CLONE_PATH) !== null;
   const { formatMessage } = useIntl();
   const { canPublish, canCreate, canUpdate } = useDocumentRBAC(
@@ -591,7 +592,9 @@ const PublishAction: DocumentActionComponent = ({
   }, [documentId, modified, formValues, setLocalCountOfDraftRelations]);
 
   React.useEffect(() => {
-    if (documentId) {
+    if (documentId && !isListView) {
+      // We don't want to call count draft relations if in the list view. There is no
+      // use for the response.
       const fetchDraftRelationsCount = async () => {
         const { data, error } = await countDraftRelations({
           collectionType,
@@ -611,7 +614,7 @@ const PublishAction: DocumentActionComponent = ({
 
       fetchDraftRelationsCount();
     }
-  }, [documentId, countDraftRelations, collectionType, model, params]);
+  }, [isListView, documentId, countDraftRelations, collectionType, model, params]);
 
   const isDocumentPublished =
     (document?.[PUBLISHED_AT_ATTRIBUTE_NAME] ||


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Don't call the `countDraftRelations` from the content manager list view

### Why is it needed?

- There is no use for the response from these calls in the list view
- When bulk publishing from the list view we make a call to `API/countManyEntriesDraftRelations` which provides the data we need
- It was causing performance issues as a call was made for every entry in the list view table

### How to test it?

Navigate to the CM list view and inspect the network tab

### Related issue(s)/PR(s)

DX-1501

Fixes https://github.com/strapi/strapi/issues/20736
