### PR TITLE
Add lifecycles when transforming contentTypes to models

### DIFF
--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.test.ts
@@ -236,6 +236,7 @@ const expectedModels = [
         columns: ['document_id'],
       },
     ],
+    lifecycles: {},
   },
   {
     uid: 'api::categories.categories',
@@ -252,12 +253,14 @@ const expectedModels = [
         columns: ['document_id'],
       },
     ],
+    lifecycles: {},
   },
   {
     uid: 'api::empty.empty',
     singularName: 'empty',
     tableName: 'empty',
     attributes: { id: { type: 'increments' } },
+    lifecycles: {},
   },
 ];
 

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -318,7 +318,7 @@ export const transformContentTypesToModels = (
       },
       indexes: contentType.indexes as Model['indexes'],
       foreignKeys: contentType.foreignKeys as Model['foreignKeys'],
-      lifecycles: contentType?.lifecycles ?? {}, 
+      lifecycles: contentType?.lifecycles ?? {},
     };
 
     // Add indexes to model

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -318,7 +318,7 @@ export const transformContentTypesToModels = (
       },
       indexes: contentType.indexes as Model['indexes'],
       foreignKeys: contentType.foreignKeys as Model['foreignKeys'],
-      lifecycles: contentType?.lifecycles,
+      lifecycles: contentType?.lifecycles ?? {}, 
     };
 
     // Add indexes to model

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -60,7 +60,8 @@ export const getComponentFkIndexName = (contentType: string, identifiers: Identi
 // const { ID_COLUMN: id, FIELD_COLUMN: field, ORDER_COLUMN: order } = identifiers;
 
 export type LoadedContentTypeModel = Struct.ContentTypeSchema &
-  Required<Pick<Struct.ContentTypeSchema, 'collectionName' | 'uid' | 'modelName'>>;
+  Required<Pick<Struct.ContentTypeSchema, 'collectionName' | 'uid' | 'modelName'>> &
+  Pick<Model, 'lifecycles'>;
 
 // Transforms an attribute (particularly for relation types) into the format that strapi/database accepts
 export const transformAttribute = (
@@ -317,6 +318,7 @@ export const transformContentTypesToModels = (
       },
       indexes: contentType.indexes as Model['indexes'],
       foreignKeys: contentType.foreignKeys as Model['foreignKeys'],
+      lifecycles: contentType?.lifecycles,
     };
 
     // Add indexes to model


### PR DESCRIPTION
### What does it do?

- We probably forgot to include lifecycles when transforming contentTypes into models format,
so this adds the lifecycles attribute

### Why is it needed?

- Lifecycles are not triggered in V5

### How to test it?

- Add some lifecycles to any contentType, maybe some logs, and check if they are triggered
- look at issue #20551 

### Related issue(s)/PR(s)

fixes #20551 
