### PR TITLE
Chore(CLI): Add validation to prevent deployment of suspended projects

### DIFF
--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -160,6 +160,7 @@ export default async (ctx: CLIContext) => {
   try {
     const { data: projectInfo } = await cloudApiService.getProject({ name: project.name });
     const isProjectSuspended = projectInfo.suspendedAt;
+
     if (isProjectSuspended) {
       ctx.logger.warn(
         'Oops! This project has been suspended. \n Please reactivate it from the dashboard to continue deploying: '
@@ -167,7 +168,6 @@ export default async (ctx: CLIContext) => {
       ctx.logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects/${project.name}`));
       return;
     }
-    console.log('paso por checkeo de info');
   } catch (e: Error | unknown) {
     if (e instanceof AxiosError && e.response?.data) {
       if (e.response.status === 404) {

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -158,14 +158,17 @@ export default async (ctx: CLIContext) => {
   const cloudApiService = await cloudApiFactory(ctx, token);
 
   try {
-    const { data: projectInfo } = await cloudApiService.getProject({ name: project.name });
-    const isProjectSuspended = projectInfo.suspendedAt;
+    const {
+      data: { data: projectData, metadata },
+    } = await cloudApiService.getProject({ name: project.name });
+
+    const isProjectSuspended = projectData.suspendedAt;
 
     if (isProjectSuspended) {
-      ctx.logger.warn(
-        'Oops! This project has been suspended. \n Please reactivate it from the dashboard to continue deploying: '
+      ctx.logger.log(
+        '\n Oops! This project has been suspended. \n\n Please reactivate it from the dashboard to continue deploying: '
       );
-      ctx.logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects/${project.name}`));
+      ctx.logger.log(chalk.underline(`${metadata.dashboardUrls.project}`));
       return;
     }
   } catch (e: Error | unknown) {

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -188,13 +188,13 @@ export async function cloudApiFactory(
         const response = await axiosCloudAPI.get(`/projects/${name}`);
 
         if (response.status !== 200) {
-          throw new Error("Error fetching project's info from the server.");
+          throw new Error("Error fetching project's details.");
         }
 
         return response;
       } catch (error) {
         logger.debug(
-          "🥲 Oops! Couldn't retrieve your project's info from the server. Please try again."
+          "🥲 Oops! There was a problem retrieving your project's details. Please try again."
         );
         throw error;
       }

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -64,6 +64,8 @@ export interface CloudApiService {
 
   listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
 
+  getProject(project: { name: string }): Promise<AxiosResponse>;
+
   track(event: string, payload?: TrackPayload): Promise<AxiosResponse<void>>;
 }
 
@@ -176,6 +178,23 @@ export async function cloudApiFactory(
       } catch (error) {
         logger.debug(
           "🥲 Oops! Couldn't retrieve your project's list from the server. Please try again."
+        );
+        throw error;
+      }
+    },
+
+    async getProject({ name }): Promise<AxiosResponse<unknown>> {
+      try {
+        const response = await axiosCloudAPI.get(`/projects/${name}`);
+
+        if (response.status !== 200) {
+          throw new Error("Error fetching project's info from the server.");
+        }
+
+        return response;
+      } catch (error) {
+        logger.debug(
+          "🥲 Oops! Couldn't retrieve your project's info from the server. Please try again."
         );
         throw error;
       }

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -38,6 +38,20 @@ export type ListLinkProjectsResponse = {
   };
 };
 
+export type GetProjectResponse = {
+  data: {
+    updatedAt: string;
+    suspendedAt?: string;
+    isTrial: boolean;
+  };
+  metadata: {
+    dashboardUrls: {
+      project: string;
+      deployments: string;
+    };
+  };
+};
+
 export interface CloudApiService {
   deploy(
     deployInput: {
@@ -64,7 +78,7 @@ export interface CloudApiService {
 
   listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
 
-  getProject(project: { name: string }): Promise<AxiosResponse>;
+  getProject(project: { name: string }): Promise<AxiosResponse<GetProjectResponse>>;
 
   track(event: string, payload?: TrackPayload): Promise<AxiosResponse<void>>;
 }
@@ -183,7 +197,7 @@ export async function cloudApiFactory(
       }
     },
 
-    async getProject({ name }): Promise<AxiosResponse<unknown>> {
+    async getProject({ name }): Promise<AxiosResponse<GetProjectResponse>> {
       try {
         const response = await axiosCloudAPI.get(`/projects/${name}`);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds a new validation that prevents deployment if the project is in a suspended status.

### Why is it needed?

Currently, the deployment process continues even if the project is suspended, only failing after the user completes the upload without the CLI providing any prior warning.

### How to test it?

- Try the deploy command on a suspended project:
    - 	The deployment should not initiate.
    -   A message should be displayed explaining why the deployment didn’t start, along with a link to the dashboard where you can view the suspension reason and take action.

