### PR TITLE
fix: don't check uniqueness for empty strings

### DIFF
--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -339,10 +339,10 @@ const addUniqueValidator = <T extends yup.AnySchema>(
 
   return validator.test('unique', 'This attribute must be unique', async (value) => {
     /**
-     * If the attribute value is `null` we want to skip the unique validation.
-     * Otherwise it'll only accept a single `null` entry in the database.
+     * If the attribute value is `null` or an empty string we want to skip the unique validation.
+     * Otherwise it'll only accept a single entry with that value in the database.
      */
-    if (_.isNil(value)) {
+    if (_.isNil(value) || value === '') {
       return true;
     }
 

--- a/tests/api/core/strapi/document-service/uniqueness.test.api.ts
+++ b/tests/api/core/strapi/document-service/uniqueness.test.api.ts
@@ -65,6 +65,18 @@ describe('Document Service', () => {
         strapi.documents(CATEGORY_UID).publish({ documentId: newCategory.documentId })
       ).rejects.toThrow();
     });
+
+    it('can save and publish multiple entries with an empty string in a unique field', async () => {
+      // Create two categories with empty names (which is a unique field)
+      const category = await strapi.documents(CATEGORY_UID).create({ data: { name: '' } });
+      expect(category).toBeDefined();
+      const category2 = await strapi.documents(CATEGORY_UID).create({ data: { name: '' } });
+      expect(category2).toBeDefined();
+
+      // Publish categories, no error should be thrown
+      await strapi.documents(CATEGORY_UID).publish({ documentId: category.documentId });
+      await strapi.documents(CATEGORY_UID).publish({ documentId: category2.documentId });
+    });
   });
 
   describe('Component unique fields', () => {


### PR DESCRIPTION
### What does it do?

Skips the uniqueness validation when the value is an empty string. This applies to short text, long text, and uid fields.

### Why is it needed?

After checking with @innerdvations, we never want to check uniqueness when no value is provided. Uniqueness was already skipped for null and undefined, but not for empty strings. This was revealed when working on the UID field, but was also an issue for text fields.

### How to test it?

- create a content type with a slug field
- save 2 entries with different slug values, you should be able to save
- try to have the same value in both slugs, you should get an error
- clear the value in both slugs (make them empty), **you should be able to save**

Repeat the same steps for a text value with uniqueness turned on
