### PR TITLE
test: enable CTB tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
         uses: ./.github/actions/yarn-nm-install
 
       - name: Install Playwright Browsers
-        run: npx playwright@1.42.1 install --with-deps
+        run: npx playwright@1.46.1 install --with-deps
 
       - name: Monorepo build
         uses: ./.github/actions/run-build
@@ -217,7 +217,7 @@ jobs:
         uses: ./.github/actions/yarn-nm-install
 
       - name: Install Playwright Browsers
-        run: npx playwright@1.42.1 install --with-deps
+        run: npx playwright@1.46.1 install --with-deps
 
       - name: Monorepo build
         uses: ./.github/actions/run-build

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@commitlint/cli": "19.2.0",
     "@commitlint/config-conventional": "19.1.0",
     "@commitlint/prompt-cli": "19.2.0",
-    "@playwright/test": "1.42.1",
+    "@playwright/test": "1.46.1",
     "@strapi/admin-test-utils": "workspace:*",
     "@strapi/eslint-config": "0.2.0",
     "@swc/cli": "0.3.10",

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -37,8 +37,8 @@ const getEnvBool = (envVar, defaultValue) => {
 const createConfig = ({ port, testDir, appDir }) => ({
   testDir,
 
-  /* default timeout for a jest test to 30s */
-  timeout: getEnvNum(process.env.PLAYWRIGHT_TIMEOUT, 30 * 1000),
+  /* default timeout for a test to 30s */
+  timeout: getEnvNum(process.env.PLAYWRIGHT_TIMEOUT, 90 * 1000),
 
   expect: {
     /**

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -52,7 +52,7 @@ const createConfig = ({ port, testDir, appDir }) => ({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 3 : 0,
+  retries: process.env.CI ? 4 : 2,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -37,7 +37,7 @@ const getEnvBool = (envVar, defaultValue) => {
 const createConfig = ({ port, testDir, appDir }) => ({
   testDir,
 
-  /* default timeout for a test to 30s */
+  /* default timeout for a test */
   timeout: getEnvNum(process.env.PLAYWRIGHT_TIMEOUT, 90 * 1000),
 
   expect: {

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -48,6 +48,7 @@ describeOnCondition(edition === 'EE')('History', () => {
   });
 
   test.afterAll(async () => {
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
     await resetFiles();
   });
 

--- a/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
@@ -6,8 +6,8 @@ import { resetFiles } from '../../../utils/file-reset';
 
 test.describe('Create collection type', () => {
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await resetFiles();
     await page.goto('/admin');
     await login({ page });
 
@@ -24,6 +24,7 @@ test.describe('Create collection type', () => {
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
   test.afterAll(async () => {
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
     await resetFiles();
   });
 

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -15,8 +15,8 @@ test.describe('Edit collection type', () => {
   const ctName = 'Secret Document';
 
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await resetFiles();
     await page.goto('/admin');
 
     await login({ page });

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -10,8 +10,7 @@ import {
   skipCtbTour,
 } from '../../../utils/shared';
 
-// TODO: fix the test so that it doesn't fail on CI
-describeOnCondition(!process.env.CI)('Edit collection type', () => {
+test.describe('Edit collection type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 

--- a/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
@@ -6,8 +6,8 @@ import { resetFiles } from '../../../utils/file-reset';
 
 test.describe('Create collection type', () => {
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await resetFiles();
     await page.goto('/admin');
     await login({ page });
 
@@ -24,6 +24,7 @@ test.describe('Create collection type', () => {
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
   test.afterAll(async () => {
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
     await resetFiles();
   });
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -10,8 +10,7 @@ import {
   skipCtbTour,
 } from '../../../utils/shared';
 
-// TODO: fix the test so that it doesn't fail on CI
-describeOnCondition(!process.env.CI)('Edit single type', () => {
+test.describe('Edit single type', () => {
   // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
   const ctName = 'Secret Document';
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -15,8 +15,8 @@ test.describe('Edit single type', () => {
   const ctName = 'Secret Document';
 
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await resetFiles();
     await page.goto('/admin');
 
     await login({ page });

--- a/tests/e2e/utils/file-reset.ts
+++ b/tests/e2e/utils/file-reset.ts
@@ -33,6 +33,8 @@ export const pollHealthCheck = async (interval = 1_000, timeout = 30_000) => {
   throw new Error('Timeout reached, service did not become available in time.');
 };
 
+// resetFiles resets the filesystem state back to the original state, removing uploaded files, schemas, etc
+// NOTE: in some cases, call resetFiles without first using resetDatabase* can cause the restart to fail
 export const resetFiles = async () => {
   if (process.env.TEST_APP_PATH) {
     console.log('Restoring filesystem');

--- a/tests/e2e/utils/file-reset.ts
+++ b/tests/e2e/utils/file-reset.ts
@@ -6,7 +6,7 @@ function delay(seconds: number) {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1_000));
 }
 
-export const pollHealthCheck = async (interval = 1_000, timeout = 30_000) => {
+export const pollHealthCheck = async (interval = 1_000, timeout = 60_000) => {
   const url = `http://127.0.0.1:${process.env.PORT ?? 1337}/_health`;
   console.log(`Starting to poll: ${url}`);
 

--- a/tests/e2e/utils/file-reset.ts
+++ b/tests/e2e/utils/file-reset.ts
@@ -3,10 +3,10 @@ import execa from 'execa';
 const gitUser = ['-c', 'user.name=Strapi CLI', '-c', 'user.email=test@strapi.io'];
 
 function delay(seconds: number) {
-  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1_000));
 }
 
-export const pollHealthCheck = async (interval = 1000, timeout = 30000) => {
+export const pollHealthCheck = async (interval = 1_000, timeout = 30_000) => {
   const url = `http://127.0.0.1:${process.env.PORT ?? 1337}/_health`;
   console.log(`Starting to poll: ${url}`);
 
@@ -19,18 +19,18 @@ export const pollHealthCheck = async (interval = 1000, timeout = 30000) => {
         console.log('The service is up and running!');
         return; // Exit if the service is up
       }
-      // If the response is not okay, throw an error to catch it below
-      throw new Error('Service not ready');
     } catch (error) {
-      console.log('Waiting for the service to come up...');
-      // Wait for the specified interval before trying again
-      await new Promise((resolve) => setTimeout(resolve, interval));
-      elapsed += interval; // Update the elapsed time
+      // do nothing
     }
+
+    console.log('Waiting for the service to come up...');
+    // Wait for the specified interval before trying again
+    await new Promise((resolve) => setTimeout(resolve, interval));
+    elapsed += interval; // Update the elapsed time
   }
 
   // If we've exited the loop because of the timeout
-  console.error('Timeout reached, service did not become available in time.');
+  throw new Error('Timeout reached, service did not become available in time.');
 };
 
 export const resetFiles = async () => {
@@ -50,6 +50,6 @@ export const resetFiles = async () => {
   // wait for server to restart after modifying files
   console.log('Waiting for Strapi to restart...');
   // TODO: this is both a waste of time and flaky. We need to find a way to access playwright server output and watch for the "up" log to appear
-  await delay(3); // give it time to detect file changes and begin its restart
+  await delay(4); // give it time to detect file changes and begin its restart
   await pollHealthCheck(); // give it time to come back up
 };

--- a/tests/e2e/utils/restart.ts
+++ b/tests/e2e/utils/restart.ts
@@ -19,7 +19,7 @@ export const waitForRestart = async (page, timeout = 60000) => {
   const initialWaitForModal = 3_000; // Time to wait for the modal to initially appear
   let elapsedTime = 0;
   const checkInterval = 2_000; // millseconds to poll for server coming back up
-  const reloadTimeout = 30_000; // millseconds before trying to reload the page
+  const waitForRestartTimeout = 30_000; // millseconds before trying to reload the page
 
   // Initially wait for the modal to become visible
   try {
@@ -34,7 +34,7 @@ export const waitForRestart = async (page, timeout = 60000) => {
 
   // Now wait until the modal is not visible or until the reloadTimeout
   let modalVisible = await isModalVisible(page);
-  while (modalVisible && elapsedTime < reloadTimeout) {
+  while (modalVisible && elapsedTime < waitForRestartTimeout) {
     await new Promise((r) => setTimeout(r, checkInterval));
     elapsedTime += checkInterval;
     modalVisible = await isModalVisible(page);

--- a/tests/e2e/utils/restart.ts
+++ b/tests/e2e/utils/restart.ts
@@ -34,16 +34,8 @@ export const waitForRestart = async (page, timeout = 60000) => {
     modalVisible = await isModalVisible(page);
   }
 
-  // If modal is still visible after reloadTimeout, reload the page and wait again
   if (modalVisible) {
-    console.log("Restart overlay didn't disappear after 15 seconds. Reloading page...");
-    await page.reload({ waitUntil: 'domcontentloaded' });
-    // Optionally, wait again for the modal to disappear after reloading
-  }
-
-  // Final check to ensure the modal has disappeared
-  if (await isModalVisible(page)) {
-    throw new Error('Restart overlay did not disappear after waiting and reloading.');
+    throw new Error("Restart modal didn't close")
   }
 
   console.log('Restart overlay has disappeared, proceeding with the test.');

--- a/tests/e2e/utils/restart.ts
+++ b/tests/e2e/utils/restart.ts
@@ -11,8 +11,7 @@ const isModalVisible = async (page: Page) => {
 };
 
 /**
- * Wait for a restart modal to appear, but instead of failing if it doesn't, attempt to
- * refresh the page and see if it comes back up
+ * Wait for a restart modal to appear and then disappear
  */
 export const waitForRestart = async (page, timeout = 60000) => {
   test.setTimeout(100_000); // Increase timeout, sometimes server restarts are very slow

--- a/tests/e2e/utils/restart.ts
+++ b/tests/e2e/utils/restart.ts
@@ -35,7 +35,7 @@ export const waitForRestart = async (page, timeout = 60000) => {
   }
 
   if (modalVisible) {
-    throw new Error("Restart modal didn't close")
+    throw new Error("Restart modal didn't close");
   }
 
   console.log('Restart overlay has disappeared, proceeding with the test.');

--- a/tests/e2e/utils/restart.ts
+++ b/tests/e2e/utils/restart.ts
@@ -1,48 +1,46 @@
 import { type Page, test } from '@playwright/test';
 
-// Function to check modal visibility
-const isModalVisible = async (page: Page) => {
-  return await Promise.any([
-    page.waitForSelector('text="Waiting for restart..."', { state: 'visible' }),
-    page.waitForSelector('text="is taking longer"', { state: 'visible' }),
-  ])
-    .then(() => true)
-    .catch(() => false);
-};
-
 /**
  * Wait for a restart modal to appear and then disappear
  */
-export const waitForRestart = async (page, timeout = 60000) => {
-  test.setTimeout(100_000); // Increase timeout, sometimes server restarts are very slow
+export const waitForRestart = async (page: Page, timeout = 60_000) => {
+  test.setTimeout(120_000); // Increase timeout, sometimes server restarts are very slow
 
-  const initialWaitForModal = 3_000; // Time to wait for the modal to initially appear
-  let elapsedTime = 0;
-  const checkInterval = 2_000; // millseconds to poll for server coming back up
-  const waitForRestartTimeout = 30_000; // millseconds before trying to reload the page
+  const initialWaitForModal = 2_000; // Time to wait for the modal to initially appear
+  const waitForRestartTimeout = timeout; // milliseconds before trying to wait for modal to disappear
+  const checkInterval = 2_000; // milliseconds to poll for the modal being hidden
 
-  // Initially wait for the modal to become visible
+  // Initially wait for either of the modal messages to become visible
   try {
-    await page.waitForSelector('text="Waiting for restart..."', {
-      state: 'visible',
-      timeout: initialWaitForModal,
-    });
+    await Promise.any([
+      page.waitForSelector('text="Waiting for restart..."', {
+        state: 'visible',
+        timeout: initialWaitForModal,
+      }),
+      page.waitForSelector('text="is taking longer"', {
+        state: 'visible',
+        timeout: initialWaitForModal,
+      }),
+    ]);
   } catch (error) {
-    console.log('The modal did not become visible within the initial wait period.');
+    console.log('Neither of the modals became visible within the initial wait period.');
     throw error; // Or handle this scenario as appropriate
   }
 
-  // Now wait until the modal is not visible or until the reloadTimeout
-  let modalVisible = await isModalVisible(page);
-  while (modalVisible && elapsedTime < waitForRestartTimeout) {
+  // Now wait until both of the modal messages are not visible anymore
+  let elapsedTime = 0;
+  while (elapsedTime < waitForRestartTimeout) {
+    const isWaitingForRestartVisible = await page.isVisible('text="Waiting for restart..."');
+    const isTakingLongerVisible = await page.isVisible('text="is taking longer"');
+
+    if (!isWaitingForRestartVisible && !isTakingLongerVisible) {
+      console.log('Restart overlay has disappeared, proceeding with the test.');
+      return;
+    }
+
     await new Promise((r) => setTimeout(r, checkInterval));
     elapsedTime += checkInterval;
-    modalVisible = await isModalVisible(page);
   }
 
-  if (modalVisible) {
-    throw new Error("Restart modal didn't close");
-  }
-
-  console.log('Restart overlay has disappeared, proceeding with the test.');
+  throw new Error("Restart modal didn't close within the expected time.");
 };

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -71,6 +71,11 @@ export const findAndClose = async (
 };
 
 export const createSingleType = async (page, data) => {
+  // TODO: fix webkit bug with selecting ctb attributes
+  if (page.context()._browser._name === 'webkit') {
+    return test.fixme();
+  }
+
   const { name, singularId, pluralId } = data;
 
   await page.getByRole('button', { name: 'Create new single type' }).click();
@@ -107,6 +112,11 @@ export const createSingleType = async (page, data) => {
 };
 
 export const createCollectionType = async (page, data) => {
+  // TODO: fix webkit bug with selecting ctb attributes
+  if (page.context()._browser._name === 'webkit') {
+    return test.fixme();
+  }
+
   const { name, singularId, pluralId } = data;
 
   await page.getByRole('button', { name: 'Create new collection type' }).click();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,14 +5689,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.42.1":
-  version: 1.42.1
-  resolution: "@playwright/test@npm:1.42.1"
+"@playwright/test@npm:1.46.1":
+  version: 1.46.1
+  resolution: "@playwright/test@npm:1.46.1"
   dependencies:
-    playwright: "npm:1.42.1"
+    playwright: "npm:1.46.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/e5d7c1ffedabb934643edb010038edcb70d51d224fb6444844a854d94365a6179d4407a83da176cae37ccd42b62c148843e0b6f9b4c6506048e06558c00d4267
+  checksum: 10c0/b2d33f33bedfa5a5c72cfc5ee212dfbf531d9c46320b0af901e71ab61b96845e43cc636181b33b3faae27f2f87ce2d44017ac65235bf9c95209f476477b16f93
   languageName: node
   linkType: hard
 
@@ -26024,27 +26024,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.42.1":
-  version: 1.42.1
-  resolution: "playwright-core@npm:1.42.1"
+"playwright-core@npm:1.46.1":
+  version: 1.46.1
+  resolution: "playwright-core@npm:1.46.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/9bb0be6defa32eb1b01429615f10c2ad17dcf701656c081a250369c1eb3b0dcc2a0ee21188cd653cdd2303ca73ff94df0d270b178fe3897eba274793dab368ce
+  checksum: 10c0/98e48e271caccaa6c54b3c591cbddbef36a679eef011b38e2af11fbaba0aab1f997b45f9207c4099468a0c79047a1e879bbd9e81bd880ae24501a0ee3c7a33c7
   languageName: node
   linkType: hard
 
-"playwright@npm:1.42.1":
-  version: 1.42.1
-  resolution: "playwright@npm:1.42.1"
+"playwright@npm:1.46.1":
+  version: 1.46.1
+  resolution: "playwright@npm:1.46.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.42.1"
+    playwright-core: "npm:1.46.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/91dcbfe92d75ca9eb4bfff69bb1ec28007b5a96f6187f48e52aa0f6acf8c24f6039ed6467c152964cc92f4ab64b85dc665b13c52b2fb9f7b9182ddb9db404e37
+  checksum: 10c0/2a328a2073313136192d74b48b981d9aeb1d4cc54926ed235f638c875f9de59c41370bb20bb2d8cf30126c52c6e25cc02db21ffafeb487c92c84c52c84846912
   languageName: node
   linkType: hard
 
@@ -29205,7 +29205,7 @@ __metadata:
     "@commitlint/cli": "npm:19.2.0"
     "@commitlint/config-conventional": "npm:19.1.0"
     "@commitlint/prompt-cli": "npm:19.2.0"
-    "@playwright/test": "npm:1.42.1"
+    "@playwright/test": "npm:1.46.1"
     "@strapi/admin-test-utils": "workspace:*"
     "@strapi/eslint-config": "npm:0.2.0"
     "@swc/cli": "npm:0.3.10"


### PR DESCRIPTION
### What does it do?

- Re-enables to CTB e2e tests on github
- Skips them only on webkit due to a known bug that will be fixed later
- Increases the timeout waiting for server restart (that was one reason they were failing before)
- does db reset before file reset (another cause of them failing)
- updates playwright version

### Why is it needed?

They were being skipped

### How to test it?

CTB e2e tests should run and pass (only being skipped on webkit)

### Related issue(s)/PR(s)

DX-1516