### PR TITLE
fix: trigger review worklfow webhooks

### DIFF
--- a/packages/core/review-workflows/server/src/controllers/stages.ts
+++ b/packages/core/review-workflows/server/src/controllers/stages.ts
@@ -122,7 +122,12 @@ export default {
     const workflow = await workflowService.assertContentTypeBelongsToWorkflow(modelUID);
     workflowService.assertStageBelongsToWorkflow(stageId, workflow);
 
-    const updatedEntity = await stagesService.updateEntity({ id: entity.id, modelUID }, stageId);
+    const updatedEntity = await stagesService.updateEntity(
+      entity.documentId,
+      entity.locale,
+      modelUID,
+      stageId
+    );
 
     ctx.body = { data: await sanitizeOutput(updatedEntity) };
   },

--- a/packages/core/review-workflows/server/src/services/document-service-middleware.ts
+++ b/packages/core/review-workflows/server/src/services/document-service-middleware.ts
@@ -94,6 +94,7 @@ const handleStageOnUpdate: Middleware = async (ctx, next) => {
     strapi.eventHub.emit(WORKFLOW_UPDATE_STAGE, {
       model: model.modelName,
       uid: model.uid,
+      // TODO v6: Rename to "entry", which is what it is used for regular CRUD updates
       entity: {
         // @ts-expect-error
         id: result?.id,

--- a/tests/api/core/review-workflows/review-workflows-webhooks.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows-webhooks.test.api.ts
@@ -1,0 +1,124 @@
+import { omit } from 'lodash/fp';
+
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAuthRequest } from 'api-tests/request';
+import { createTestBuilder } from 'api-tests/builder';
+import { describeOnCondition, createUtils } from 'api-tests/utils';
+
+import {
+  STAGE_MODEL_UID,
+  WORKFLOW_MODEL_UID,
+} from '../../../../packages/core/review-workflows/server/src/constants/workflows';
+import { WORKFLOW_UPDATE_STAGE } from '../../../../packages/core/review-workflows/server/src/constants/webhook-events';
+
+const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+const productUID = 'api::product.product';
+const model = {
+  pluginOptions: {},
+  draftAndPublish: false,
+  singularName: 'product',
+  pluralName: 'products',
+  displayName: 'Product',
+  kind: 'collectionType',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  options: {
+    reviewWorkflows: true,
+  },
+};
+
+describeOnCondition(edition === 'EE')('Review workflows', () => {
+  const builder = createTestBuilder();
+  let rq;
+  let strapi;
+  let stageA;
+  let stageB;
+  let workflow;
+
+  const createEntry = async (uid, data) => {
+    const { body } = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${uid}`,
+      body: data,
+    });
+
+    return body.data;
+  };
+
+  beforeAll(async () => {
+    await builder.addContentTypes([model]).build();
+
+    // @ts-expect-error - We don't have the type for this
+    strapi = await createStrapiInstance({ bypassAuth: false });
+    rq = await createAuthRequest({ strapi });
+
+    stageA = await strapi.db.query(STAGE_MODEL_UID).create({
+      data: { name: 'Stage A' },
+    });
+    stageB = await strapi.db.query(STAGE_MODEL_UID).create({
+      data: { name: 'Stage B' },
+    });
+    workflow = await strapi.db.query(WORKFLOW_MODEL_UID).create({
+      data: {
+        contentTypes: [],
+        name: 'workflow',
+        stages: [stageA.id, stageB.id],
+      },
+    });
+
+    // Update workflow to assign product content type
+    await rq.put(`/review-workflows/workflows/${workflow.id}?populate=*`, {
+      body: { data: { contentTypes: [productUID] } },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test(`Updating entity stage should trigger ${WORKFLOW_UPDATE_STAGE}`, async () => {
+    expect.hasAssertions();
+
+    const entry = await createEntry(productUID, { name: 'Product' });
+
+    strapi.eventHub.on(WORKFLOW_UPDATE_STAGE, (payload) => {
+      expect(payload).toMatchObject({
+        entity: {
+          documentId: entry.documentId,
+          id: entry.id,
+          status: 'draft',
+          locale: entry.locale,
+        },
+        model: 'product',
+        uid: productUID,
+        workflow: {
+          id: workflow.id,
+          stages: {
+            from: {
+              id: stageA.id,
+              name: stageA.name,
+            },
+            to: {
+              id: stageB.id,
+              name: stageB.name,
+            },
+          },
+        },
+      });
+    });
+
+    await rq({
+      method: 'PUT',
+      url: `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
+      body: {
+        data: { id: stageB.id },
+      },
+      qs: { locale: entry.locale },
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Review workflows `entryUpdate` webhook was not being triggered. 

Webhook is only triggered when using the document service, it listens to document updates. So the change involved using the document service instead of the used strapi.db.query
