### PR TITLE
fix: removing white space in readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,10 @@
 <br />
 
 <p align="center">
-  <a href="https://www.npmjs.org/package/@strapi/strapi">
-    <img src="https://img.shields.io/npm/v/@strapi/strapi/latest.svg" alt="NPM Version" />
-  </a>
-  <a href="https://github.com/strapi/strapi/actions/workflows/tests.yml">
-    <img src="https://github.com/strapi/strapi/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" />
-  </a>
-  <a href="https://discord.strapi.io">
-    <img src="https://img.shields.io/discord/811989166782021633?label=Discord" alt="Strapi on Discord" />
-  </a>
-  <a href="https://github.com/strapi/strapi/actions/workflows/nightly.yml">
-    <img src="https://github.com/strapi/strapi/actions/workflows/nightly.yml/badge.svg" alt="Strapi Nightly Release Build Status" />
-  </a>
+  <a href="https://www.npmjs.org/package/@strapi/strapi"><img src="https://img.shields.io/npm/v/@strapi/strapi/latest.svg" alt="NPM Version" /></a>
+  <a href="https://github.com/strapi/strapi/actions/workflows/tests.yml"><img src="https://github.com/strapi/strapi/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://discord.strapi.io"><img src="https://img.shields.io/discord/811989166782021633?label=Discord" alt="Strapi on Discord" /></a>
+  <a href="https://github.com/strapi/strapi/actions/workflows/nightly.yml"><img src="https://github.com/strapi/strapi/actions/workflows/nightly.yml/badge.svg" alt="Strapi Nightly Release Build Status" /></a>
 </p>
 
 <br>


### PR DESCRIPTION
### What does it do?

Removes the white space in the links in the readme file.

**Before**
<img width="680" alt="strapi-readme-before" src="https://github.com/user-attachments/assets/aa06bf86-72da-410e-8aca-947ddf3fd469">

**After**
<img width="646" alt="strapi-readme-after" src="https://github.com/user-attachments/assets/e99ef7a7-e084-4d45-bec1-cdd08f1612a3">

### Why is it needed?

Just a small, nit-picky, cosmetic fix to the readme which I noticed recently.

### How to test it?

Ensure all links still work. Although the only diff is the removal of whitespace between the a tag and img tags.
