### PR TITLE
fix: show relations to draft entries in list view

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -137,10 +137,10 @@ export default {
       .countRelations({ toOne: false, toMany: true })
       .build();
 
-    const { locale, status } = await getDocumentLocaleAndStatus(query, model);
+    const { locale } = await getDocumentLocaleAndStatus(query, model);
 
     const { results: documents, pagination } = await documentManager.findPage(
-      { ...permissionQuery, populate, locale, status },
+      { ...permissionQuery, populate, locale },
       model
     );
 

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -454,7 +454,7 @@ export default {
       ordering: 'desc',
     });
 
-    const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));
+    const relationsUnion = uniqBy('documentId', concat(sanitizedRes.results, res.results));
 
     ctx.body = {
       pagination: res.pagination || {

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -454,7 +454,7 @@ export default {
       ordering: 'desc',
     });
 
-    const relationsUnion = uniqBy('documentId', concat(sanitizedRes.results, res.results));
+    const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));
 
     ctx.body = {
       pagination: res.pagination || {

--- a/tests/api/core/content-manager/index.test.api.js
+++ b/tests/api/core/content-manager/index.test.api.js
@@ -281,7 +281,7 @@ describe('Relations', () => {
 
       expect(body.results).toMatchObject([
         { title: 'Article 1', tags: { count: 3 } },
-        { title: 'Article 2', tags: { count: 0 } },
+        { title: 'Article 2', tags: { count: 1 } },
       ]);
     });
 

--- a/tests/api/core/content-manager/index.test.api.js
+++ b/tests/api/core/content-manager/index.test.api.js
@@ -273,6 +273,18 @@ describe('Relations', () => {
       expect(tags.length).toBe(3);
     });
 
+    test('Get tags count in articles list', async () => {
+      const { body } = await rq({
+        url: '/content-manager/collection-types/api::article.article',
+        method: 'GET',
+      });
+
+      expect(body.results).toMatchObject([
+        { title: 'Article 1', tags: { count: 3 } },
+        { title: 'Article 2', tags: { count: 0 } },
+      ]);
+    });
+
     test('Update article1 remove one tag', async () => {
       const { body } = await rq({
         url: `/content-manager/collection-types/api::article.article/${data.articles[0].documentId}`,


### PR DESCRIPTION
### What does it do?

- Fixes an issue where the relations were not populated in the list view when the related entries were drafts.
- Also fixes an issue where the Relation Input component would display a relation to a published entry twice (once as draft, once as published)
- Re-enables an API test suite for the CM

### How to test it?

- create an Address in getstarted
- link it to some draft Categories
- you should see the relations count in the addresses list view
- publish some categories
- the relations count in the addresses list view should not change
- opening the address edit view, you should only see one Category per actual category in the relation input

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/20604