### PR TITLE
fix(content-manager): error when content type has no i18n enabled

### DIFF
--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -36,7 +36,12 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
     }> {
       const model = strapi.getModel(params.query.contentType);
       const isLocalizedContentType = serviceUtils.isLocalizedContentType(model);
-      const locale = isLocalizedContentType ? params.query.locale : null;
+      const defaultLocale = await serviceUtils.getDefaultLocale();
+
+      let locale = null;
+      if (isLocalizedContentType) {
+        locale = params.query.locale || defaultLocale;
+      }
 
       const [{ results, pagination }, localeDictionary] = await Promise.all([
         query.findPage({

--- a/packages/core/content-manager/server/src/history/services/history.ts
+++ b/packages/core/content-manager/server/src/history/services/history.ts
@@ -34,7 +34,10 @@ const createHistoryService = ({ strapi }: { strapi: Core.Strapi }) => {
       results: HistoryVersions.HistoryVersionDataResponse[];
       pagination: HistoryVersions.Pagination;
     }> {
-      const locale = params.query.locale || (await serviceUtils.getDefaultLocale());
+      const model = strapi.getModel(params.query.contentType);
+      const isLocalizedContentType = serviceUtils.isLocalizedContentType(model);
+      const locale = isLocalizedContentType ? params.query.locale : null;
+
       const [{ results, pagination }, localeDictionary] = await Promise.all([
         query.findPage({
           ...params.query,

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -1,4 +1,5 @@
 import type { Core, Modules, UID } from '@strapi/types';
+import { contentTypes } from '@strapi/utils';
 
 import { omit, castArray } from 'lodash/fp';
 
@@ -139,11 +140,9 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
         const localeEntries = await strapi.db.query(uid).findMany({
           where: {
             documentId,
-            ...(isLocalizedContentType
-              ? {
-                  locale: { $in: locales },
-                  publishedAt: null,
-                }
+            ...(isLocalizedContentType ? { locale: { $in: locales } } : {}),
+            ...(contentTypes.hasDraftAndPublish(strapi.contentTypes[uid])
+              ? { publishedAt: null }
               : {}),
           },
           populate: serviceUtils.getDeepPopulate(uid, true /* use database syntax */),

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -131,13 +131,20 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
         // All schemas related to the content type
         const uid = context.contentType.uid;
         const schemas = getSchemas(uid);
+        const model = strapi.getModel(uid);
+
+        const isLocalizedContentType = serviceUtils.isLocalizedContentType(model);
 
         // Find all affected entries
         const localeEntries = await strapi.db.query(uid).findMany({
           where: {
             documentId,
-            locale: { $in: locales },
-            publishedAt: null,
+            ...(isLocalizedContentType
+              ? {
+                  locale: { $in: locales },
+                  publishedAt: null,
+                }
+              : {}),
           },
           populate: serviceUtils.getDeepPopulate(uid, true /* use database syntax */),
         });

--- a/packages/core/content-manager/server/src/history/services/utils.ts
+++ b/packages/core/content-manager/server/src/history/services/utils.ts
@@ -118,8 +118,12 @@ export const createServiceUtils = ({ strapi }: { strapi: Core.Strapi }) => {
   };
 
   const localesService = strapi.plugin('i18n')?.service('locales');
+  const i18nContentTypeService = strapi.plugin('i18n')?.service('content-types');
 
   const getDefaultLocale = async () => (localesService ? localesService.getDefaultLocale() : null);
+
+  const isLocalizedContentType = (model: Schema.ContentType) =>
+    i18nContentTypeService ? i18nContentTypeService.isLocalizedContentType(model) : false;
 
   /**
    *
@@ -328,6 +332,7 @@ export const createServiceUtils = ({ strapi }: { strapi: Core.Strapi }) => {
     getRelationRestoreValue,
     getMediaRestoreValue,
     getDefaultLocale,
+    isLocalizedContentType,
     getLocaleDictionary,
     getRetentionDays,
     getVersionStatus,

--- a/tests/api/core/content-manager/content-manager/history/history.test.api.ts
+++ b/tests/api/core/content-manager/content-manager/history/history.test.api.ts
@@ -464,7 +464,7 @@ describeOnCondition(edition === 'EE')('History API', () => {
     test('Finds many versions with pagination params', async () => {
       const collectionType = await rq({
         method: 'GET',
-        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${collectionTypeDocumentId}&page=1&pageSize=1`,
+        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${collectionTypeDocumentId}&page=1&pageSize=1&locale=en`,
       });
 
       expect(collectionType.body.data).toHaveLength(1);
@@ -479,7 +479,7 @@ describeOnCondition(edition === 'EE')('History API', () => {
     test('Finds many versions with sensitive data', async () => {
       const collectionType = await rq({
         method: 'GET',
-        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${collectionTypeDocumentId}&page=1&pageSize=1`,
+        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${collectionTypeDocumentId}&page=1&pageSize=1&locale=en`,
       });
 
       expect(collectionType.body.data).toHaveLength(1);
@@ -704,18 +704,20 @@ describeOnCondition(edition === 'EE')('History API', () => {
 
       const frHistoryVersions = await rq({
         method: 'GET',
-        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${frProduct.data.documentId}`,
+        url: `/content-manager/history-versions/?contentType=${collectionTypeUid}&documentId=${frProduct.data.documentId}&locale=fr`,
       });
 
       // Create + Publish = 2 versions
       expect(enHistoryVersions.body.data).toHaveLength(2);
-      // First one should be the publish version
+      // First one should be the publish version and english locale
       expect(enHistoryVersions.body.data[0].status).toBe('published');
+      expect(enHistoryVersions.body.data[0].locale.code).toBe('en');
 
       // Create + Publish = 2 versions
       expect(frHistoryVersions.body.data).toHaveLength(2);
-      // First one should be the publish version
+      // First one should be the publish version and french locale
       expect(frHistoryVersions.body.data[0].status).toBe('published');
+      expect(frHistoryVersions.body.data[0].locale.code).toBe('fr');
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Fix a bug related to the history page of content type without localisation enabled. Now we considered these type of content types and we allow saving history of content types with no i18n.

### How to test it?

1. Go to a Content Type with no i18n enabled and create and edit one entry.
2. Go to the history page of that entry
3. It should show the history without errors

### Related issue(s)/PR(s)

closes https://github.com/strapi/strapi/issues/20945
