### PR TITLE
Fix Upgrade Tool Targeted Files For Plugins

### DIFF
--- a/packages/utils/upgrade/src/modules/format/formats.ts
+++ b/packages/utils/upgrade/src/modules/format/formats.ts
@@ -19,7 +19,7 @@ export const codemodUID = (uid: string) => {
 };
 
 export const projectDetails = (project: AppProject | PluginProject) => {
-  return `Project: TYPE=${projectType(project.type)}, CWD=${path(project.cwd)}, PATHS=${project.paths.map(path)}`;
+  return `Project: TYPE=${projectType(project.type)}; CWD=${path(project.cwd)}; PATHS=${project.paths.map(path)}`;
 };
 
 export const projectType = (type: ProjectType) => chalk.cyan(type);

--- a/packages/utils/upgrade/src/modules/format/formats.ts
+++ b/packages/utils/upgrade/src/modules/format/formats.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 import { constants as timerConstants } from '../timer';
 
-import type { ProjectType } from '../project';
+import type { AppProject, PluginProject, ProjectType } from '../project';
 import type { Codemod } from '../codemod';
 import type { Version } from '../version';
 import type { Report } from '../report';
@@ -16,6 +16,10 @@ export const version = (version: Version.LiteralVersion | Version.SemVer) => {
 
 export const codemodUID = (uid: string) => {
   return chalk.bold.cyan(uid);
+};
+
+export const projectDetails = (project: AppProject | PluginProject) => {
+  return `Project: TYPE=${projectType(project.type)}, CWD=${path(project.cwd)}, PATHS=${project.paths.map(path)}`;
 };
 
 export const projectType = (type: ProjectType) => chalk.cyan(type);

--- a/packages/utils/upgrade/src/modules/project/__tests__/project.test.ts
+++ b/packages/utils/upgrade/src/modules/project/__tests__/project.test.ts
@@ -8,7 +8,12 @@ jest.mock('fs', () => fs);
 
 const srcFilename = (cwd: string, filename: string) => path.join(cwd, 'src', filename);
 const srcFilenames = (cwd: string) => {
-  return Object.keys(srcFiles).map((filename) => srcFilename(cwd, filename));
+  return Object.keys(defaultFiles).map((filename) => srcFilename(cwd, filename));
+};
+
+const pluginServerFilename = (cwd: string, filename: string) => path.join(cwd, 'server', filename);
+const pluginServerFilenames = (cwd: string) => {
+  return Object.keys(defaultFiles).map((filename) => pluginServerFilename(cwd, filename));
 };
 
 const currentStrapiVersion = '1.2.3';
@@ -29,7 +34,7 @@ const pluginPackageJSONFile = `{
   }
 }`;
 
-const srcFiles = {
+const defaultFiles = {
   'a.ts': 'console.log("a.ts")',
   'b.ts': 'console.log("b.ts")',
   'c.js': 'console.log("c.js")',
@@ -40,12 +45,12 @@ const srcFiles = {
 
 const appVolume = {
   'package.json': appPackageJSONFile,
-  src: srcFiles,
+  src: defaultFiles,
 };
 
 const pluginVolume = {
   'package.json': pluginPackageJSONFile,
-  src: srcFiles,
+  server: defaultFiles,
 };
 
 describe('Project', () => {
@@ -70,7 +75,7 @@ describe('Project', () => {
     });
 
     test('Fails on project without package.json file', async () => {
-      vol.fromNestedJSON({ src: srcFiles }, defaultCWD);
+      vol.fromNestedJSON({ src: defaultFiles }, defaultCWD);
 
       expect(() => projectFactory(defaultCWD)).toThrow(
         `Could not find a package.json file in ${defaultCWD}`
@@ -79,7 +84,7 @@ describe('Project', () => {
 
     test('Fails when not a plugin and no @strapi/strapi dependency found', async () => {
       vol.fromNestedJSON(
-        { 'package.json': `{ "name": "test", "version": "1.2.3" }`, src: srcFiles },
+        { 'package.json': `{ "name": "test", "version": "1.2.3" }`, src: defaultFiles },
         defaultCWD
       );
 
@@ -92,7 +97,7 @@ describe('Project', () => {
       vol.fromNestedJSON(
         {
           'package.json': `{ "name": "test", "version": "1.2.3", "dependencies": { "@strapi/strapi": "^4.0.0" } }`,
-          src: srcFiles,
+          src: defaultFiles,
         },
         defaultCWD
       );
@@ -133,7 +138,10 @@ describe('Project', () => {
 
       expect(project.files.length).toBe(7);
       expect(project.files).toStrictEqual(
-        expect.arrayContaining([path.join(defaultCWD, 'package.json'), ...srcFilenames(defaultCWD)])
+        expect.arrayContaining([
+          path.join(defaultCWD, 'package.json'),
+          ...pluginServerFilenames(defaultCWD),
+        ])
       );
 
       expect(project.cwd).toBe(defaultCWD);
@@ -172,7 +180,10 @@ describe('Project', () => {
 
       expect(project.files.length).toBe(7);
       expect(project.files).toStrictEqual(
-        expect.arrayContaining([path.join(defaultCWD, 'package.json'), ...srcFilenames(defaultCWD)])
+        expect.arrayContaining([
+          path.join(defaultCWD, 'package.json'),
+          ...pluginServerFilenames(defaultCWD),
+        ])
       );
 
       expect(project.cwd).toBe(defaultCWD);

--- a/packages/utils/upgrade/src/modules/project/constants.ts
+++ b/packages/utils/upgrade/src/modules/project/constants.ts
@@ -1,8 +1,12 @@
 export const PROJECT_PACKAGE_JSON = 'package.json';
 
-export const PROJECT_DEFAULT_ALLOWED_ROOT_PATHS = ['src', 'config', 'public'];
+export const PROJECT_APP_ALLOWED_ROOT_PATHS = ['src', 'config', 'public'];
 
-export const PROJECT_DEFAULT_CODE_EXTENSIONS = [
+export const PROJECT_PLUGIN_ALLOWED_ROOT_PATHS = ['admin', 'server'];
+
+export const PROJECT_PLUGIN_ROOT_FILES = ['strapi-admin.js', 'strapi-server.js'];
+
+export const PROJECT_CODE_EXTENSIONS = [
   // Source files
   'js',
   'mjs',
@@ -12,14 +16,9 @@ export const PROJECT_DEFAULT_CODE_EXTENSIONS = [
   'tsx',
 ];
 
-export const PROJECT_DEFAULT_JSON_EXTENSIONS = ['json'];
+export const PROJECT_JSON_EXTENSIONS = ['json'];
 
-export const PROJECT_DEFAULT_ALLOWED_EXTENSIONS = [
-  ...PROJECT_DEFAULT_CODE_EXTENSIONS,
-  ...PROJECT_DEFAULT_JSON_EXTENSIONS,
-];
-
-export const PROJECT_DEFAULT_PATTERNS = ['package.json'];
+export const PROJECT_ALLOWED_EXTENSIONS = [...PROJECT_CODE_EXTENSIONS, ...PROJECT_JSON_EXTENSIONS];
 
 export const SCOPED_STRAPI_PACKAGE_PREFIX = '@strapi/';
 

--- a/packages/utils/upgrade/src/modules/project/types.ts
+++ b/packages/utils/upgrade/src/modules/project/types.ts
@@ -22,3 +22,7 @@ export type MinimalPackageJSON = {
   version: string;
   dependencies?: Record<string, string>;
 } & Utils.JSONObject;
+
+export interface ProjectConfig {
+  paths: string[];
+}

--- a/packages/utils/upgrade/src/tasks/__tests__/codemods.test.ts
+++ b/packages/utils/upgrade/src/tasks/__tests__/codemods.test.ts
@@ -43,6 +43,7 @@ describe('codemods task', () => {
   });
 
   (projectFactory as jest.Mock).mockReturnValue({
+    paths: [],
     dry: jest.fn().mockReturnThis(),
     onSelectCodemods: jest.fn().mockReturnThis(),
     setLogger: jest.fn().mockReturnThis(),

--- a/packages/utils/upgrade/src/tasks/codemods/list-codemods.ts
+++ b/packages/utils/upgrade/src/tasks/codemods/list-codemods.ts
@@ -13,7 +13,7 @@ export const listCodemods = async (options: ListCodemodsOptions) => {
   const project = projectFactory(cwd);
   const range = findRangeFromTarget(project, target);
 
-  logger.debug(`Project: ${f.projectType(project.type)} found in ${f.path(cwd)}`);
+  logger.debug(f.projectDetails(project));
   logger.debug(`Range: set to ${f.versionRange(range)}`);
 
   // Create a codemod repository targeting the default location of the codemods

--- a/packages/utils/upgrade/src/tasks/codemods/run-codemods.ts
+++ b/packages/utils/upgrade/src/tasks/codemods/run-codemods.ts
@@ -17,7 +17,7 @@ export const runCodemods = async (options: RunCodemodsOptions) => {
   const project = projectFactory(cwd);
   const range = findRangeFromTarget(project, options.target);
 
-  logger.debug(`Project: ${f.projectType(project.type)} found in ${f.path(cwd)}`);
+  logger.debug(f.projectDetails(project));
   logger.debug(`Range: set to ${f.versionRange(range)}`);
 
   const codemodRunner = codemodRunnerFactory(project, range)

--- a/packages/utils/upgrade/src/tasks/upgrade/upgrade.ts
+++ b/packages/utils/upgrade/src/tasks/upgrade/upgrade.ts
@@ -19,12 +19,16 @@ export const upgrade = async (options: UpgradeOptions) => {
 
   const project = projectFactory(cwd);
 
+  logger.debug(f.projectDetails(project));
+
   if (!isApplicationProject(project)) {
     throw new Error(
       `The "${options.target}" upgrade can only be run on a Strapi project; for plugins, please use "codemods".`
     );
   }
+
   const npmPackage = npmPackageFactory(upgraderConstants.STRAPI_PACKAGE_NAME);
+
   // Load all versions from the registry
   await npmPackage.refresh();
 
@@ -46,11 +50,11 @@ export const upgrade = async (options: UpgradeOptions) => {
       .addRequirement(requirements.major.REQUIRE_LATEST_FOR_CURRENT_MAJOR);
   }
 
-  // Make sure the git repository is in an optimal state before running the upgrade
+  // Make sure the git repository is in an optional state before running the upgrade
   // Mainly used to ease rollbacks in case the upgrade is corrupted
   upgrader.addRequirement(requirements.common.REQUIRE_GIT.asOptional());
 
-  // Actually run the upgrade process once configured
+  // Actually run the upgrade process once configured,
   // The response contains information about the final status (success/error)
   const upgradeReport = await upgrader.upgrade();
 


### PR DESCRIPTION
### What does it do?

Refactors the handling of project files by differentiating between application and plugin projects.

It introduces new constants for allowable root paths and specific root files for both project types.

The `Project` class is updated to accept a configuration object, which includes paths specific to either applications or plugins.

`AppProject` and `PluginProject` constructors are updated to define their specific paths.

### Why is it needed?

The previous approach used generic constants that led to inconsistencies and (most importantly) errors when dealing with different types of projects (app/plugin).

### How to test it?

1. Create a sample application and plugin projects in their respective directories.
2. Run the upgrade tasks (e.g., `list-codemods`, `run-codemods`, `upgrade`) with the `debug` flag enabled to ensure project details, including paths, are correctly logged.
3. Verify that the correct paths are being used for scanning project files in both application and plugin contexts.
4. Perform various codemod and upgrade operations on both types of projects to ensure that the file handling works as expected.

### Related issue(s)/PR(s)

#20944