### PR TITLE
fix: wrong table name in v5 document ID migration

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -138,7 +138,7 @@ const createDocumentIdColumn = async (knex: Knex, tableName: string) => {
 };
 
 const hasLocalizationsJoinTable = async (knex: Knex, tableName: string) => {
-  const joinTableName = identifiers.getJoinTableName(tableName, 'localizations');
+  const joinTableName = identifiers.getJoinTableName(tableName, 'localizations_links');
   return knex.schema.hasTable(joinTableName);
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -106,7 +106,7 @@ const migrateDocumentIdsWithLocalizations = async (db: Database, knex: Knex, met
       joinColumn,
       inverseJoinColumn,
       tableName: meta.tableName,
-      joinTableName: identifiers.getJoinTableName(meta.tableName, `localizations`),
+      joinTableName: identifiers.getJoinTableName(meta.tableName, `localizations_links`),
     });
 
     if (ids.length > 0) {


### PR DESCRIPTION
### What does it do?

Fixes the wrong table in the join for creating documentIDs with content-types that have i18n enabled

### Why is it needed?

Localization links are broken after migrating (different document IDs)

### How to test it?

See GitHub Issue

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/21037
