### PR TITLE
test(front): enable skipped tests

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/tests/AssetCardBase.test.jsx
+++ b/packages/core/upload/admin/src/components/AssetCard/tests/AssetCardBase.test.jsx
@@ -20,7 +20,7 @@ const render = (props) => ({
 
 describe('AssetCardBase', () => {
   describe('Interaction', () => {
-    it.only('should call onSelect when the checkbox is clicked', async () => {
+    it('should call onSelect when the checkbox is clicked', async () => {
       const onSelect = jest.fn();
       const { getByRole, user } = render({
         onSelect,

--- a/packages/core/upload/admin/src/components/FolderCard/tests/FolderCard.test.jsx
+++ b/packages/core/upload/admin/src/components/FolderCard/tests/FolderCard.test.jsx
@@ -70,7 +70,7 @@ describe('FolderCard', () => {
     ).toBeInTheDocument();
   });
 
-  test.only('renders as a link with to prop', () => {
+  test('renders as a link with to prop', () => {
     const { container } = setup({
       to: '/michka-page',
     });

--- a/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.jsx.snap
+++ b/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.jsx.snap
@@ -48,13 +48,6 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   right: 16px;
 }
 
-.c13 {
-  font-size: 1.4rem;
-  line-height: 1.43;
-  font-weight: 500;
-  color: currentcolor;
-}
-
 .c3 {
   align-items: center;
   display: flex;
@@ -68,6 +61,13 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   flex-direction: column;
 }
 
+.c13 {
+  font-size: 1.4rem;
+  line-height: 1.43;
+  font-weight: 500;
+  color: currentcolor;
+}
+
 .c17 {
   border: 0;
   clip: rect(0 0 0 0);
@@ -79,73 +79,45 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   width: 1px;
 }
 
-.c5 {
-  height: 18px;
-  min-width: 18px;
-  margin: 0;
-  border-radius: 4px;
-  border: 1px solid #c0c0cf;
-  -webkit-appearance: none;
-  background-color: #ffffff;
-  cursor: pointer;
-}
-
-.c5:checked {
-  background-color: #4945ff;
-  border: 1px solid #4945ff;
-}
-
-.c5:checked:after {
-  content: '';
-  display: block;
-  position: relative;
-  background: url("data:image/svg+xml,%3csvg%20width='10'%20height='8'%20viewBox='0%200%2010%208'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3e%3cpath%20d='M8.55323%200.396973C8.63135%200.316355%208.76051%200.315811%208.83931%200.395768L9.86256%201.43407C9.93893%201.51157%209.93935%201.6359%209.86349%201.7139L4.06401%207.67724C3.9859%207.75755%203.85707%207.75805%203.77834%207.67834L0.13866%203.99333C0.0617798%203.91549%200.0617102%203.79032%200.138504%203.7124L1.16213%202.67372C1.24038%202.59432%201.36843%202.59422%201.4468%202.67348L3.92174%205.17647L8.55323%200.396973Z'%20fill='white'%20/%3e%3c/svg%3e") no-repeat no-repeat center center;
-  width: 10px;
-  height: 10px;
-  left: 50%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%);
-}
-
-.c5:checked:disabled:after {
-  background: url("data:image/svg+xml,%3csvg%20width='10'%20height='8'%20viewBox='0%200%2010%208'%20fill='none'%20xmlns='http://www.w3.org/2000/svg'%3e%3cpath%20d='M8.55323%200.396973C8.63135%200.316355%208.76051%200.315811%208.83931%200.395768L9.86256%201.43407C9.93893%201.51157%209.93935%201.6359%209.86349%201.7139L4.06401%207.67724C3.9859%207.75755%203.85707%207.75805%203.77834%207.67834L0.13866%203.99333C0.0617798%203.91549%200.0617102%203.79032%200.138504%203.7124L1.16213%202.67372C1.24038%202.59432%201.36843%202.59422%201.4468%202.67348L3.92174%205.17647L8.55323%200.396973Z'%20fill='%238E8EA9'%20/%3e%3c/svg%3e") no-repeat no-repeat center center;
-}
-
-.c5:disabled {
-  background-color: #dcdce4;
-  border: 1px solid #c0c0cf;
-}
-
-.c5:indeterminate {
-  background-color: #4945ff;
-  border: 1px solid #4945ff;
-}
-
-.c5:indeterminate:after {
-  content: '';
-  display: block;
-  position: relative;
-  color: white;
-  height: 2px;
-  width: 10px;
-  background-color: #ffffff;
-  left: 50%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%);
-}
-
-.c5:indeterminate:disabled {
-  background-color: #dcdce4;
-  border: 1px solid #c0c0cf;
-}
-
-.c5:indeterminate:disabled:after {
-  background-color: #8e8ea9;
-}
-
 .c16 {
   position: absolute;
   top: 12px;
+}
+
+.c5 {
+  background: #ffffff;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 4px;
+  border: 1px solid #c0c0cf;
+  position: relative;
+  z-index: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 2rem;
+}
+
+.c5[data-state='checked'],
+.c5[data-state='indeterminate'] {
+  border: 1px solid #4945ff;
+  background-color: #4945ff;
+}
+
+.c5[data-disabled] {
+  background-color: #dcdce4;
+}
+
+.c5::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .c1 {
@@ -179,6 +151,12 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
   outline-offset: -2px;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  .c5 {
+    transition: border-color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94),background-color 120ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+}
+
 <div>
   <div
     class="c0 "
@@ -198,15 +176,15 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
       <div
         class="c4"
       >
-        <div
-          class=""
-        >
-          <input
-            aria-labelledby="folder-3-title"
-            class="c5"
-            type="checkbox"
-          />
-        </div>
+        <button
+          aria-checked="false"
+          aria-labelledby="folder-3-title"
+          class="c5"
+          data-state="unchecked"
+          role="checkbox"
+          type="button"
+          value="false"
+        />
       </div>
       <div
         class="c6"
@@ -320,13 +298,6 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   right: 16px;
 }
 
-.c11 {
-  font-size: 1.4rem;
-  line-height: 1.43;
-  font-weight: 500;
-  color: currentcolor;
-}
-
 .c3 {
   align-items: center;
   display: flex;
@@ -338,6 +309,13 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
   align-items: flex-start;
   display: flex;
   flex-direction: column;
+}
+
+.c11 {
+  font-size: 1.4rem;
+  line-height: 1.43;
+  font-weight: 500;
+  color: currentcolor;
 }
 
 .c15 {


### PR DESCRIPTION
### What does it do?

remove `.only` from a couple tests and udpates the snapshots for them

### Why is it needed?

they shouldn't have been committed

### How to test it?

tests should pass

### Related issue(s)/PR(s)

