### PR TITLE
chore: getstarted schema sync between v4-v5

### DIFF
--- a/examples/getstarted/src/api/category/content-types/category/schema.json
+++ b/examples/getstarted/src/api/category/content-types/category/schema.json
@@ -59,6 +59,12 @@
       "relation": "manyToMany",
       "target": "api::relation-locale.relation-locale",
       "mappedBy": "categories"
+    },
+    "relation": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::relation-locale.relation-locale",
+      "mappedBy": "category"
     }
   }
 }

--- a/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
+++ b/examples/getstarted/src/api/relation-locale/content-types/relation-locale/schema.json
@@ -69,6 +69,12 @@
       },
       "component": "basic.relation",
       "required": true
+    },
+    "category": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::category.category",
+      "inversedBy": "relation"
     }
   }
 }


### PR DESCRIPTION
### What does it do?

Some changes were made to the getstarted schema in v5. In order for us to test the v4->v5 migrations, those schemas need to be the same, hence this PR updates the `relation-locale` content type in v4 to be the same as in v5.

This fixes a failing internal migration (discard draft) that was assuming the relation existed in the v4 database data.

Fixes #20953