### PR TITLE
fix(content-manager): configure the view edit button should be type button

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -390,6 +390,7 @@ const Field = ({ attribute, components, name, index, onMoveField, onRemoveField 
             </Typography>
             <Flex>
               <IconButton
+                type="button"
                 variant="ghost"
                 background="transparent"
                 onClick={(e) => {
@@ -408,6 +409,7 @@ const Field = ({ attribute, components, name, index, onMoveField, onRemoveField 
                 <Pencil />
               </IconButton>
               <IconButton
+                type="button"
                 variant="ghost"
                 onClick={handleRemoveField}
                 background="transparent"


### PR DESCRIPTION
### What does it do?

Buttons inside forms are by default "submit" type, for the edit button on each field of the configure the view page we don't want them to be "submit" type, instead we mark them as "button" type so they don't have a default behaviour. 

### How to test it?

1. Go to the Edit View of any entry
2. Go to the Configure the view page
3. Try to click the edit button of one field
4. It should open the modal and nothing else

### Related issue(s)/PR(s)

Closes #21006 
