### PR TITLE
fix: v5 migration does not link locales

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -1,10 +1,21 @@
+/**
+ * NOTE: This migration avoids using the `identifiers` utility.
+ * As the `5.0.0-01-convert-identifiers-long-than-max-length`
+ * migration does not convert the `localizations` join tables, as they are not
+ * tables that exist anymore in v5.
+ *
+ * Hence the `identifiers` utility would return the wrong join table name.
+ *
+ * Database join table name: `categories_localizations_links`
+ * Actual `identifiers` returned join table name: `categories_localizations_lnk`
+ */
 import { createId } from '@paralleldrive/cuid2';
+import { snakeCase } from 'lodash/fp';
 import type { Knex } from 'knex';
 
 import type { Migration } from '../common';
 import type { Database } from '../..';
 import type { Meta } from '../../metadata';
-import { identifiers } from '../../utils/identifiers';
 
 interface Params {
   joinColumn: string;
@@ -96,9 +107,8 @@ const getNextIdsToCreateDocumentId = async (
 // Migrate document ids for tables that have localizations
 const migrateDocumentIdsWithLocalizations = async (db: Database, knex: Knex, meta: Meta) => {
   const singularName = meta.singularName.toLowerCase();
-  const joinColumn = identifiers.getJoinColumnAttributeIdName(singularName);
-  const inverseJoinColumn = identifiers.getInverseJoinColumnAttributeIdName(singularName);
-
+  const joinColumn = snakeCase(`${singularName}_id`);
+  const inverseJoinColumn = snakeCase(`inv_${singularName}_id`);
   let ids: number[];
 
   do {
@@ -106,7 +116,7 @@ const migrateDocumentIdsWithLocalizations = async (db: Database, knex: Knex, met
       joinColumn,
       inverseJoinColumn,
       tableName: meta.tableName,
-      joinTableName: identifiers.getJoinTableName(meta.tableName, `localizations`),
+      joinTableName: snakeCase(`${meta.tableName}_localizations_links`),
     });
 
     if (ids.length > 0) {
@@ -138,7 +148,7 @@ const createDocumentIdColumn = async (knex: Knex, tableName: string) => {
 };
 
 const hasLocalizationsJoinTable = async (knex: Knex, tableName: string) => {
-  const joinTableName = identifiers.getJoinTableName(tableName, 'localizations');
+  const joinTableName = snakeCase(`${tableName}_localizations_links`);
   return knex.schema.hasTable(joinTableName);
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -9,7 +9,7 @@
  *
  * Database join table name: `categories_localizations_links`
  * Actual `identifiers` returned join table name: `categories_localizations_lnk`
- * 
+ *
  */
 import { createId } from '@paralleldrive/cuid2';
 import { snakeCase } from 'lodash/fp';

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -2,12 +2,14 @@
  * NOTE: This migration avoids using the `identifiers` utility.
  * As the `5.0.0-01-convert-identifiers-long-than-max-length`
  * migration does not convert the `localizations` join tables, as they are not
- * tables that exist anymore in v5.
+ * tables that exist anymore in v5 and are not in the db metadata.
  *
- * Hence the `identifiers` utility would return the wrong join table name.
+ * This migration therefore relies on the fact that those tables still exist, and
+ * references them directly.
  *
  * Database join table name: `categories_localizations_links`
  * Actual `identifiers` returned join table name: `categories_localizations_lnk`
+ * 
  */
 import { createId } from '@paralleldrive/cuid2';
 import { snakeCase } from 'lodash/fp';


### PR DESCRIPTION
### What does it do?

If you had a content-type with i18n enabled and multiple locales in v4, when you use the upgrade tool to migrate to v5 the locales are no longer properly linked (different document ID)

![image](https://github.com/user-attachments/assets/0acc97a1-76bf-45e8-bc7d-0091b98dca6e)

We renamed some of our table names in v5, mostly to fit long content types /field names into the database. The migration to migrate to document ids expected the locale join table to be renamed to the new format, but it wasn't.

This PR adds the necessary changes so the locales share the same document id.

Ideally , we would have some automated tests.


### How to test it?

- Using a v4 project, create multiple locales of the same entry in a content type with i18n.
- Migrate to v5
- You should see a single document with multiple locales

fixes: https://github.com/strapi/strapi/issues/21037