### PR TITLE
fix(content-manager): pass components data to format function for edit layout

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -264,7 +264,8 @@ const formatEditLayout = (
         layout: convertEditLayoutToFieldLayouts(
           configuration.layouts.edit,
           components[uid].attributes,
-          configuration.metadatas
+          configuration.metadatas,
+          { configurations: data.components, schemas: components }
         ),
         settings: {
           ...configuration.settings,


### PR DESCRIPTION
### What does it do?

Pass complete components data to format edit layout function so it works when you change the fields name in configure the view for nested components.

### How to test it?

Follow the steps mentioned on the [issue](https://github.com/strapi/strapi/issues/20978). It should work without errors.

### Related issue(s)/PR(s)

Closes #20978 
