### PR TITLE
fix(cli): Update endpoint path for listLinkProjects

### DIFF
--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -182,7 +182,7 @@ export async function cloudApiFactory(
 
     async listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse, unknown>> {
       try {
-        const response = await axiosCloudAPI.get('/projects/linkable');
+        const response = await axiosCloudAPI.get('/projects-linkable');
 
         if (response.status !== 200) {
           throw new Error('Error fetching cloud projects from the server.');


### PR DESCRIPTION

### What does it do?

This PR updates the link command request route to get a list of projects available to link.

### Why is it needed?

The cli-api has a new route for getting the list of linkable projects

### How to test it?

Run the link command and you should get the list of available projects to link

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
