### PR TITLE
chore(cli): replace hardcoded deployment URL

### DIFF
--- a/packages/cli/cloud/src/create-project/action.ts
+++ b/packages/cli/cloud/src/create-project/action.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import { AxiosError } from 'axios';
 import { defaults } from 'lodash/fp';
-import type { CLIContext, ProjectAnswers, ProjectInput } from '../types';
+import type { CLIContext, CloudApiService, ProjectAnswers, ProjectInput } from '../types';
 import { cloudApiFactory, local, tokenServiceFactory } from '../services';
 import { getProjectNameFromPackageJson } from './utils/get-project-name-from-pkg';
 import { promptLogin } from '../login/action';
@@ -44,7 +44,11 @@ async function handleError(ctx: CLIContext, error: Error) {
   );
 }
 
-async function createProject(ctx: CLIContext, cloudApi: any, projectInput: ProjectInput) {
+async function createProject(
+  ctx: CLIContext,
+  cloudApi: CloudApiService,
+  projectInput: ProjectInput
+): Promise<ProjectInput> {
   const { logger } = ctx;
   const spinner = logger.spinner('Setting up your project...').start();
   try {
@@ -58,7 +62,7 @@ async function createProject(ctx: CLIContext, cloudApi: any, projectInput: Proje
   }
 }
 
-export default async (ctx: CLIContext) => {
+export default async (ctx: CLIContext): Promise<ProjectInput | undefined> => {
   const { logger } = ctx;
   const { getValidToken, eraseToken } = await tokenServiceFactory(ctx);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Using API URL to display the deployments for the project when the `strapi deploy` command has ended.


### Why is it needed?

To avoid hard-coded URLs to the Cloud dashboard that may change.

### How to test it?

Try to deploy a Strapi project to Strapi Cloud using `strapi deploy` command (you may need to target the local bin file of strapi binary).

`node /packages/core/strapi/bin/strapi.js`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
