### PR TITLE
chore: fix prettier version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Complete installation requirements can be found in the documentation under <a hr
 **Supported operating systems**:
 
 | OS              | Recommended | Minimum    |
-|-----------------|-------------|------------|
+| --------------- | ----------- | ---------- |
 | Ubuntu          | 24.04       | LTS        |
 | Debian          | 11          | LTS        |
 | RHEL            | 9           | LTS        |
@@ -97,7 +97,7 @@ Complete installation requirements can be found in the documentation under <a hr
 Strapi only supports maintenance and LTS versions of Node.js. Please refer to the <a href="https://nodejs.org/en/about/releases/">Node.js release schedule</a> for more information. NPM versions installed by default with Node.js are supported. Generally it's recommended to use yarn over npm where possible.
 
 | Strapi Version  | Recommended | Minimum |
-|-----------------|-------------|---------|
+| --------------- | ----------- | ------- |
 | 5.0.0 and up    | 20.x        | 18.x    |
 | 4.14.5 and up   | 20.x        | 18.x    |
 | 4.11.0 and up   | 18.x        | 16.x    |
@@ -107,7 +107,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 **Database:**
 
 | Database   | Recommended | Minimum |
-|------------|-------------|---------|
+| ---------- | ----------- | ------- |
 | MySQL      | 8.0         | 8.0     |
 | MariaDB    | 11.2        | 10.3    |
 | PostgreSQL | 16.0        | 14.0    |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 As of April 2024 (and until this document is updated), only the v4.x.x _GA_ or _STABLE_ releases of Strapi are supported for updates and bug fixes. Any previous versions are currently not supported and users are advised to use them "at their own risk".
 
 | Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes                |
-|---------|-------------|----------------|----------------|------------------------|----------------------|
+| ------- | ----------- | -------------- | -------------- | ---------------------- | -------------------- |
 | 5.x.x   | GA          | October 2024   | Further Notice | Further Notice         | LTS (Future)         |
 | 5.x.x   | RC          | N/A            | October 2024   | N/A                    | Non-Production Usage |
 | 5.x.x   | Beta        | N/A            | N/A            | N/A                    | Not Supported        |

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "lodash": "4.17.21",
     "nx": "18.2.2",
     "plop": "2.7.6",
-    "prettier": "3.2.5",
+    "prettier": "3.3.3",
     "prettier-2": "npm:prettier@^2",
     "qs": "6.11.1",
     "rimraf": "5.0.5",

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -470,7 +470,7 @@ const AttributeTag = ({
     formattedValue = selectedOption
       ? typeof selectedOption === 'string'
         ? selectedOption
-        : selectedOption.label ?? selectedOption.value
+        : (selectedOption.label ?? selectedOption.value)
       : value;
   }
 

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -180,7 +180,9 @@ const Register = ({ hasAdmin }: RegisterProps) => {
 
   React.useEffect(() => {
     if (error) {
-      const message: string = isBaseQueryError(error) ? formatAPIError(error) : error.message ?? '';
+      const message: string = isBaseQueryError(error)
+        ? formatAPIError(error)
+        : (error.message ?? '');
 
       toggleNotification({
         type: 'danger',

--- a/packages/core/core/src/factories.ts
+++ b/packages/core/core/src/factories.ts
@@ -27,7 +27,7 @@ const createCoreController = <
   }): TController & Core.CoreAPI.Controller.ContentType<TUID> => {
     const baseController = createController({ contentType: strapi.contentType(uid) });
 
-    const userCtrl = typeof cfg === 'function' ? cfg({ strapi }) : cfg ?? ({} as any);
+    const userCtrl = typeof cfg === 'function' ? cfg({ strapi }) : (cfg ?? ({} as any));
 
     for (const methodName of Object.keys(baseController) as Array<keyof typeof baseController>) {
       if (userCtrl[methodName] === undefined) {
@@ -64,7 +64,7 @@ function createCoreService<
   }): TService & Core.CoreAPI.Service.ContentType<TUID> => {
     const baseService = createService({ contentType: strapi.contentType(uid) });
 
-    const userService = typeof cfg === 'function' ? cfg({ strapi }) : cfg ?? ({} as any);
+    const userService = typeof cfg === 'function' ? cfg({ strapi }) : (cfg ?? ({} as any));
 
     for (const methodName of Object.keys(baseService) as Array<keyof typeof baseService>) {
       if (userService[methodName] === undefined) {

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -425,10 +425,10 @@ export default (db: Database) => {
 
     const persistedTables = helpers.hasTable(databaseSchema, 'strapi_core_store_settings')
       ? // TODO: replace with low level db query instead
-        (await strapi.store.get({
+        ((await strapi.store.get({
           type: 'core',
           key: 'persisted_tables',
-        })) ?? []
+        })) ?? [])
       : [];
 
     const reservedTables = [...RESERVED_TABLE_NAMES, ...persistedTables.map(parsePersistedTable)];

--- a/packages/core/database/src/schema/schema.ts
+++ b/packages/core/database/src/schema/schema.ts
@@ -30,7 +30,7 @@ const createColumn = (name: string, attribute: Attribute): Column => {
     notNullable: false,
     unsigned: false,
     ...opts,
-    ...('column' in attribute ? attribute.column ?? {} : {}),
+    ...('column' in attribute ? (attribute.column ?? {}) : {}),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26340,6 +26340,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:3.3.3":
+  version: 3.3.3
+  resolution: "prettier@npm:3.3.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/b85828b08e7505716324e4245549b9205c0cacb25342a030ba8885aba2039a115dbcf75a0b7ca3b37bc9d101ee61fab8113fc69ca3359f2a226f1ecc07ad2e26
+  languageName: node
+  linkType: hard
+
 "pretty-error@npm:^4.0.0":
   version: 4.0.0
   resolution: "pretty-error@npm:4.0.0"
@@ -29259,7 +29268,7 @@ __metadata:
     lodash: "npm:4.17.21"
     nx: "npm:18.2.2"
     plop: "npm:2.7.6"
-    prettier: "npm:3.2.5"
+    prettier: "npm:3.3.3"
     prettier-2: "npm:prettier@^2"
     qs: "npm:6.11.1"
     rimraf: "npm:5.0.5"


### PR DESCRIPTION
### What does it do?

- updates prettier to 3.3.3 universally
- runs `yarn prettier:write`

### Why is it needed?

CI was failing from a version mismatch

### How to test it?

CI should pass
`yarn prettier:check` should also pass locally with no warnings

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
