### PR TITLE
feat: sync unidirectional relations

### DIFF
--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -247,7 +247,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
           documentId,
           publishedAt: { $ne: null },
         },
-        select: ['id'],
+        select: ['id', 'locale'],
       }),
     ]);
 
@@ -313,7 +313,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     ]);
 
     // Transform published entry data and create draft versions
-    const draftEntries = await async.map(versionsToDraft, async (entry: any) =>
+    const draftEntries = await async.map(versionsToDraft, (entry: any) =>
       entries.discardDraft(entry, queryParams)
     );
 

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue */
 import { UID, Schema } from '@strapi/types';
-import { async, traverseEntity } from '@strapi/utils';
+import { async } from '@strapi/utils';
 
 interface RelationToSync {
   uid: string;
@@ -27,19 +27,19 @@ const syncUnidirectionalRelations = async (
   const contentTypes = Object.values(strapi.contentTypes) as Schema.ContentType[];
   const components = Object.values(strapi.components) as Schema.Component[];
 
-  for (const contentType of [...contentTypes, ...components]) {
+  for (const model of [...contentTypes, ...components]) {
     // If the content type has a relation to the current content type
-    for (const [name, attribute] of Object.entries(contentType.attributes) as any) {
+    for (const [name, attribute] of Object.entries(model.attributes) as any) {
       if (attribute.type !== 'relation') continue;
       if (attribute.target !== uid) continue;
       // If its inversed by or mapped by, ignore
       if (attribute.inversedBy || attribute.mappedBy) continue;
 
-      relationsToSync.push({ uid: contentType.uid, attribute: name });
+      relationsToSync.push({ uid: model.uid, attribute: name });
     }
   }
 
-  await strapi.db.transaction(async ({ trx }) =>
+  await strapi.db.transaction(({ trx }) =>
     async.map(newEntries, async (newEntry: { id: string; locale: string }) => {
       // Entries should match by locale
       const oldEntry = oldEntries.find((entry) => entry.locale === newEntry.locale);

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-continue */
+import { UID } from '@strapi/types';
+import { async } from '@strapi/utils';
+
+interface RelationToSync {
+  uid: string;
+  attribute: string;
+}
+
+/**
+ * Updates uni directional relations to target the right entries when overriding published or draft entries.
+ *
+ * 1. Finds all content types that target the content type that's about to be published/discarded
+ * 2. For each relation, update them to target the new entry
+ *
+ * @param oldEntries - The old entries that will be removed.
+ * @param newEntries - The new entries that unidirectional relations should target.
+ */
+const syncUnidirectionalRelations = async (
+  uid: UID.ContentType | UID.Component,
+  oldEntries: { id: string; locale: string }[],
+  newEntries: { id: string; locale: string }[]
+) => {
+  const relationsToSync: RelationToSync[] = [];
+
+  // Iterate all components and content types
+  // TODO: Do the same for components
+  for (const contentType of Object.values(strapi.contentTypes)) {
+    // If the content type has a relation to the current content type
+    for (const [name, attribute] of Object.entries(contentType.attributes) as any) {
+      if (attribute.type !== 'relation') continue;
+      if (attribute.target !== uid) continue;
+      // If its inversed by or mapped by, ignore
+      if (attribute.inversedBy || attribute.mappedBy) continue;
+
+      relationsToSync.push({ uid: contentType.uid, attribute: name });
+    }
+  }
+
+  await strapi.db.transaction(async ({ trx }) =>
+    async.map(newEntries, async (newEntry: { id: string; locale: string }) => {
+      // Entries should match by locale
+      const oldEntry = oldEntries.find((entry) => entry.locale === newEntry.locale);
+      if (!oldEntry) return;
+
+      // Update all relations to the new entry
+      for (const { uid, attribute: name } of relationsToSync) {
+        const model = strapi.db.metadata.get(uid);
+        const attribute = model.attributes[name];
+        if (attribute?.type === 'relation') {
+          // @ts-expect-error - FIX
+          const joinTable = attribute.joinTable;
+          if (!joinTable) continue;
+          const { name } = joinTable.inverseJoinColumn;
+
+          await strapi.db
+            .getConnection()
+            .from(joinTable.name)
+            .where(name, oldEntry.id)
+            .update(name, newEntry.id)
+            .transacting(trx);
+        }
+      }
+    })
+  );
+};
+
+export { syncUnidirectionalRelations };

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue */
-import { UID } from '@strapi/types';
-import { async } from '@strapi/utils';
+import { UID, Schema } from '@strapi/types';
+import { async, traverseEntity } from '@strapi/utils';
 
 interface RelationToSync {
   uid: string;
@@ -17,15 +17,17 @@ interface RelationToSync {
  * @param newEntries - The new entries that unidirectional relations should target.
  */
 const syncUnidirectionalRelations = async (
-  uid: UID.ContentType | UID.Component,
+  uid: UID.ContentType,
   oldEntries: { id: string; locale: string }[],
   newEntries: { id: string; locale: string }[]
 ) => {
   const relationsToSync: RelationToSync[] = [];
 
   // Iterate all components and content types
-  // TODO: Do the same for components
-  for (const contentType of Object.values(strapi.contentTypes)) {
+  const contentTypes = Object.values(strapi.contentTypes) as Schema.ContentType[];
+  const components = Object.values(strapi.components) as Schema.Component[];
+
+  for (const contentType of [...contentTypes, ...components]) {
     // If the content type has a relation to the current content type
     for (const [name, attribute] of Object.entries(contentType.attributes) as any) {
       if (attribute.type !== 'relation') continue;

--- a/tests/api/core/strapi/document-service/relations/unidirectional-relations.ts
+++ b/tests/api/core/strapi/document-service/relations/unidirectional-relations.ts
@@ -1,0 +1,101 @@
+/**
+ * Unidirectional relations need special handling when publishing/un publishing.
+ *
+ * When publishing or un publishing an entry, other entries with a relation targeting this one might lose its relation.
+ * This is only the case with unidirectional relations, but not bidirectional relations.
+ */
+import { Core } from '@strapi/types';
+import { testInTransaction } from '../../../../utils';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+let strapi: Core.Strapi;
+const builder = createTestBuilder();
+let rq;
+
+const PRODUCT_UID = 'api::product.product';
+const TAG_UID = 'api::tag.tag';
+
+const productModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    tag: {
+      type: 'relation',
+      relation: 'oneToOne',
+      target: TAG_UID,
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'Product',
+  singularName: 'product',
+  pluralName: 'products',
+  description: '',
+  collectionName: '',
+};
+
+const tagModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'Tag',
+  singularName: 'tag',
+  pluralName: 'tags',
+  description: '',
+  collectionName: '',
+};
+
+// TODO: Add tests for components
+// TODO: Test discard draft
+describe('Document Service unidirectional relations', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([tagModel, productModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    // TAGS
+    await strapi.db.query(TAG_UID).createMany({
+      data: [
+        { documentId: 'Tag1', name: 'Tag1', publishedAt: null },
+        { documentId: 'Tag2', name: 'Tag2', publishedAt: null },
+        { documentId: 'Tag3', name: 'Tag3', publishedAt: null },
+      ],
+    });
+
+    // PRODUCTS
+    await strapi.documents(PRODUCT_UID).create({
+      data: {
+        name: 'Product1',
+        tag: { documentId: 'Tag1' },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  testInTransaction('X to One', async () => {
+    // Publish tag1. Product1 relation should target the new published tag1 id
+    const tag1 = await strapi.documents(TAG_UID).publish({ documentId: 'Tag1' });
+
+    const product1 = await strapi
+      .documents(PRODUCT_UID)
+      .findFirst({ filters: { name: 'Product1' }, populate: ['tag'] });
+
+    expect(product1).toMatchObject({
+      name: 'Product1',
+      tag: { id: tag1.id },
+    });
+  });
+
+  testInTransaction.todo('X to Many', async () => {});
+});

--- a/tests/api/plugins/i18n/content-manager/non-localized-fields.test.api.js
+++ b/tests/api/plugins/i18n/content-manager/non-localized-fields.test.api.js
@@ -286,7 +286,7 @@ describe('i18n', () => {
 
       test('Modify a scalar non localized field - Unpublish + Discard', async () => {
         // Publish the default locale entry
-        let res = await publish('api::category.category', documentId, { [attribute]: 'publish' });
+        let res = await publish('api::category.category', documentId, { [attribute]: 'unpublish' });
         expect(res.statusCode).toBe(200);
 
         // Update the default locale draft entry with random data
@@ -310,7 +310,7 @@ describe('i18n', () => {
           });
 
           // The locale should now have the same value as the default locale.
-          expect(localeRes[attribute]).toEqual('unpbulish');
+          expect(localeRes[attribute]).toEqual('unpublish');
         }
       });
 

--- a/tests/api/plugins/i18n/content-manager/non-localized-fields.test.api.js
+++ b/tests/api/plugins/i18n/content-manager/non-localized-fields.test.api.js
@@ -155,6 +155,38 @@ const transformConnectToDisconnect = (data) => {
   return data;
 };
 
+const create = async (uid, payload) => {
+  return rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/${uid}`,
+    body: payload,
+  });
+};
+
+const update = async (uid, documentId, payload) => {
+  return rq({
+    method: 'PUT',
+    url: `/content-manager/collection-types/${uid}/${documentId}`,
+    body: payload,
+  });
+};
+
+const publish = async (uid, documentId, payload) => {
+  return rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/${uid}/${documentId}/actions/publish`,
+    body: payload,
+  });
+};
+
+const unpublish = async (uid, documentId, payload) => {
+  return rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/${uid}/${documentId}/actions/unpublish`,
+    body: payload,
+  });
+};
+
 describe('i18n', () => {
   const builder = createTestBuilder();
 
@@ -190,42 +222,20 @@ describe('i18n', () => {
     beforeAll(async () => {
       // Create a document with an entry in every locale with the localized
       // field filled in. This field can be different across locales
-      const res = await rq({
-        method: 'POST',
-        url: `/content-manager/collection-types/api::category.category`,
-        body: {
-          name: `Test`,
-        },
-      });
+      const res = await create('api::category.category', { name: `Test` });
       documentId = res.body.data.documentId;
 
       for (const locale of allLocaleCodes) {
-        await rq({
-          method: 'PUT',
-          url: `/content-manager/collection-types/api::category.category/${documentId}`,
-          body: {
-            locale,
-            name: `Test ${locale}`,
-          },
+        await update('api::category.category', documentId, {
+          locale,
+          name: `Test ${locale}`,
         });
       }
 
       // Create 2 tags in the default locale
       const [tag1, tag2] = await Promise.all([
-        rq({
-          method: 'POST',
-          url: `/content-manager/collection-types/api::tag.tag`,
-          body: {
-            name: `Test tag`,
-          },
-        }),
-        rq({
-          method: 'POST',
-          url: `/content-manager/collection-types/api::tag.tag`,
-          body: {
-            name: `Test tag 2`,
-          },
-        }),
+        create('api::tag.tag', { name: `Test tag` }),
+        create('api::tag.tag', { name: `Test tag 2` }),
       ]);
       data.tags.push(tag1.body.data);
       data.tags.push(tag2.body.data);
@@ -233,21 +243,13 @@ describe('i18n', () => {
       for (const locale of tagsAvailableIn) {
         // Create 2 tags for every other locale that supports tags
         const [localeTag1, localeTag2] = await Promise.all([
-          rq({
-            method: 'PUT',
-            url: `/content-manager/collection-types/api::tag.tag/${tag1.body.data.documentId}`,
-            body: {
-              locale,
-              name: `Test tag ${locale}`,
-            },
+          update('api::tag.tag', tag1.body.data.documentId, {
+            locale,
+            name: `Test tag ${locale}`,
           }),
-          rq({
-            method: 'PUT',
-            url: `/content-manager/collection-types/api::tag.tag/${tag2.body.data.documentId}`,
-            body: {
-              locale,
-              name: `Test tag ${locale} 2`,
-            },
+          update('api::tag.tag', tag2.body.data.documentId, {
+            locale,
+            name: `Test tag ${locale} 2`,
           }),
         ]);
 
@@ -260,76 +262,80 @@ describe('i18n', () => {
     const actionsToTest = [['publish'], ['unpublish + discard'], ['update']];
 
     describe('Scalar non localized fields', () => {
-      describe.each(actionsToTest)('', (method) => {
-        test(`Modify a scalar non localized field - Method ${method}`, async () => {
-          const isPublish = method === 'publish';
-          const isUnpublish = method.includes('unpublish');
+      const attribute = 'nonLocalized';
 
-          const key = 'nonLocalized';
-          // Update the non localized field
-          const updatedValue = `${key}::Update Test::${method}`;
+      test('Modify a scalar non localized field - Publish', async () => {
+        const res = await publish('api::category.category', documentId, { [attribute]: 'publish' });
 
-          let res;
-          if (isPublish) {
-            // Publish the default locale entry
-            res = await rq({
-              method: 'POST',
-              url: `/content-manager/collection-types/api::category.category/${documentId}/actions/publish`,
-              body: {
-                [key]: updatedValue,
-              },
-            });
-          } else if (isUnpublish) {
-            // Publish the default locale entry
-            await rq({
-              method: 'POST',
-              url: `/content-manager/collection-types/api::category.category/${documentId}/actions/publish`,
-              body: {
-                [key]: updatedValue,
-              },
-            });
+        expect(res.statusCode).toBe(200);
 
-            // Update the default locale draft entry with random data
-            const randomData = 'random';
-            await rq({
-              method: 'PUT',
-              url: `/content-manager/collection-types/api::category.category/${documentId}`,
-              body: {
-                [key]: randomData,
-              },
-            });
+        // Expect all locales to be updates, both draft and published versions
+        for (const locale of allLocaleCodes) {
+          const localeRes = await strapi.db.query('api::category.category').findOne({
+            where: {
+              documentId,
+              publishedAt: null,
+              locale: { $eq: locale },
+            },
+          });
 
-            // Unpublish the default locale entry
-            res = await rq({
-              method: 'POST',
-              url: `/content-manager/collection-types/api::category.category/${documentId}/actions/unpublish`,
-              body: {
-                discardDraft: true,
-              },
-            });
-          } else {
-            res = await rq({
-              method: 'PUT',
-              url: `/content-manager/collection-types/api::category.category/${documentId}`,
-              body: {
-                [key]: updatedValue,
-              },
-            });
-          }
+          // The locale should now have the same value as the default locale.
+          expect(localeRes[attribute]).toEqual('publish');
+        }
+      });
 
-          for (const locale of allLocaleCodes) {
-            const localeRes = await strapi.db.query('api::category.category').findOne({
-              where: {
-                documentId,
-                publishedAt: null,
-                locale: { $eq: locale },
-              },
-            });
+      test('Modify a scalar non localized field - Unpublish + Discard', async () => {
+        // Publish the default locale entry
+        let res = await publish('api::category.category', documentId, { [attribute]: 'publish' });
+        expect(res.statusCode).toBe(200);
 
-            // The locale should now have the same value as the default locale.
-            expect(localeRes[key]).toEqual(updatedValue);
-          }
+        // Update the default locale draft entry with random data
+        const randomData = 'random';
+        res = await update('api::category.category', documentId, { [attribute]: randomData });
+        expect(res.statusCode).toBe(200);
+
+        // Unpublish the default locale entry
+        res = await unpublish('api::category.category', documentId, { discardDraft: true });
+
+        expect(res.statusCode).toBe(200);
+
+        // Expect all locales to be updates, both draft and published versions
+        for (const locale of allLocaleCodes) {
+          const localeRes = await strapi.db.query('api::category.category').findOne({
+            where: {
+              documentId,
+              publishedAt: null,
+              locale: { $eq: locale },
+            },
+          });
+
+          // The locale should now have the same value as the default locale.
+          expect(localeRes[attribute]).toEqual('unpbulish');
+        }
+      });
+
+      test('Modify a scalar non localized field - Update', async () => {
+        const updatedValue = 'update';
+
+        const res = await update('api::category.category', documentId, {
+          [attribute]: updatedValue,
         });
+
+        expect(res.statusCode).toBe(200);
+
+        // Expect all locales to be updates, both draft and published versions
+        for (const locale of allLocaleCodes) {
+          const localeRes = await strapi.db.query('api::category.category').findOne({
+            where: {
+              documentId,
+              publishedAt: null,
+              locale: { $eq: locale },
+            },
+          });
+
+          // The locale should now have the same value as the default locale.
+          expect(localeRes[attribute]).toEqual(updatedValue);
+        }
       });
     });
 


### PR DESCRIPTION
### What does it do?

Updates uni directional relations to target the right entries when overriding published or draft entries.

Based on the following [notion RFC](https://www.notion.so/strapi/Unidirectional-relations-on-publish-discard-29d0133709c646b088f377727c9c7ff1)
