### PR TITLE
chore: remove missing workflow dep

### DIFF
--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -68,7 +68,7 @@ jobs:
 
   cli:
     name: 'CLI Tests'
-    needs: [changes, build, typescript]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skipped"


### PR DESCRIPTION
### What does it do?

remove 'typescript' from the CLI needs, because it doesn't actually exist

### Why is it needed?

it's sometimes breaking CI checks

### How to test it?

CI should pass

### Related issue(s)/PR(s)

Example of PR it is blocking: https://github.com/strapi/strapi/pull/21065
