### PR TITLE
chore: add e2e and typescript to skipped_tests workflow

### DIFF
--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -36,6 +36,13 @@ jobs:
     steps:
       - run: echo "Skipped"
 
+  typescript:
+    runs-on: ubuntu-latest
+    needs: [build]
+    name: 'typescript'
+    steps:
+      - run: echo "Skipped"
+
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
     needs: [lint]
@@ -70,6 +77,26 @@ jobs:
     name: 'CLI Tests'
     needs: [changes, build]
     runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped"
+
+  e2e_ce:
+    runs-on: ubuntu-latest
+    needs: [lint, unit_back, unit_front]
+    name: '[CE] e2e (browser: ${{ matrix.project }})'
+    strategy:
+      matrix:
+        node: [18, 20]
+    steps:
+      - run: echo "Skipped"
+
+  e2e_ee:
+    runs-on: ubuntu-latest
+    needs: [lint, unit_back, unit_front]
+    name: '[EE] e2e (browser: ${{ matrix.project }})'
+    strategy:
+      matrix:
+        node: [18, 20]
     steps:
       - run: echo "Skipped"
 


### PR DESCRIPTION
### What does it do?

adds typescript, e2e_ce, and e2e_ee to skipped_tests

### Why is it needed?

Allows `aggregate_test_result` to complete even when tests are skipped 

### How to test it?

CI should pass

### Related issue(s)/PR(s)

I think this is why https://github.com/strapi/strapi/pull/21065 is being blocked
