### PR TITLE
chore: change document title to entry

### DIFF
--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -84,7 +84,7 @@
   "containers.edit.tabs.label": "Document status",
   "containers.edit.tabs.draft": "draft",
   "containers.edit.tabs.published": "published",
-  "containers.edit.panels.default.title": "Document",
+  "containers.edit.panels.default.title": "Entry",
   "containers.edit.panels.default.more-actions": "More document actions",
   "containers.Edit.delete": "Delete",
   "containers.edit.title.new": "Create an entry",


### PR DESCRIPTION
### What does it do?

Following our designs, the title on top of the publish button should be named "Entry" , and not "Document"

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1c04de22-c20d-4cdf-87d3-4a6a7a411c0e) | ![image](https://github.com/user-attachments/assets/c5fb9014-2165-42e9-9d34-6ecb5a087641) | 


Fixes https://github.com/strapi/strapi/issues/20805