### PR TITLE
fix: admin path not taken into account on build & security middleware

### DIFF
--- a/packages/core/core/src/middlewares/__tests__/security.test.ts
+++ b/packages/core/core/src/middlewares/__tests__/security.test.ts
@@ -27,6 +27,13 @@ describe('Security middleware', () => {
       {
         strapi: {
           plugin: () => null,
+          config: {
+            get(key: string) {
+              if (key === 'admin.path') {
+                return '/admin';
+              }
+            },
+          },
         } as any,
       }
     )!;

--- a/packages/core/core/src/middlewares/security.ts
+++ b/packages/core/core/src/middlewares/security.ts
@@ -87,10 +87,11 @@ export const security: Core.MiddlewareFactory<Config> =
      * It only applies in development, and only on GET requests
      * that are part of the admin route.
      */
+
     if (
       ['development', 'test'].includes(process.env.NODE_ENV ?? '') &&
       ctx.method === 'GET' &&
-      ['/admin'].some((str) => ctx.path.startsWith(str))
+      ctx.path.startsWith(strapi.config.get('admin.path'))
     ) {
       helmetConfig = mergeConfig(helmetConfig, {
         contentSecurityPolicy: {

--- a/packages/core/strapi/src/node/vite/plugins.ts
+++ b/packages/core/strapi/src/node/vite/plugins.ts
@@ -32,7 +32,7 @@ const buildFilesPlugin = (ctx: BuildContext): Plugin => {
       }
 
       const entryFileName = entryFile.fileName;
-      const entryPath = ['/admin'.replace(/\/+$/, ''), entryFileName].join('/');
+      const entryPath = [ctx.basePath.replace(/\/+$/, ''), entryFileName].join('/');
 
       this.emitFile({
         type: 'asset',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix https://github.com/strapi/strapi/issues/20473

### How to test

- set `'url': '/dashboard'` in `config/admin.js`
- get to http://localhost:1337 in dev mode -> it should redirect to /dashboard & work just fine
- run yarn build and yarn start
- - get to http://localhost:1337 in dev mode -> it should redirect to /dashboard & work just fine