### PR TITLE
fix: draft tag color & release menu icons size

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
@@ -18,7 +18,7 @@ interface DocumentStatusProps
  */
 const DocumentStatus = ({ status = 'draft', ...restProps }: DocumentStatusProps) => {
   const statusVariant =
-    status === 'draft' ? 'primary' : status === 'published' ? 'success' : 'alternative';
+    status === 'draft' ? 'secondary' : status === 'published' ? 'success' : 'alternative';
 
   return (
     <Status {...restProps} showBullet={false} size={'S'} variant={statusVariant}>

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -105,16 +105,16 @@ const StyledMenuItem = styled(MenuItem)<{
 `;
 
 const PencilIcon = styled(Pencil)`
-  width: ${({ theme }) => theme.spaces[3]};
-  height: ${({ theme }) => theme.spaces[3]};
+  width: ${({ theme }) => theme.spaces[4]};
+  height: ${({ theme }) => theme.spaces[4]};
   path {
     fill: ${({ theme }) => theme.colors.neutral600};
   }
 `;
 
 const TrashIcon = styled(Trash)`
-  width: ${({ theme }) => theme.spaces[3]};
-  height: ${({ theme }) => theme.spaces[3]};
+  width: ${({ theme }) => theme.spaces[4]};
+  height: ${({ theme }) => theme.spaces[4]};
   path {
     fill: ${({ theme }) => theme.colors.danger600};
   }

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -106,7 +106,7 @@ const LocalePickerAction: HeaderActionComponent = ({
       const permissionsToCheck = currentLocaleDoc ? canCreate : canRead;
 
       const statusVariant =
-        status === 'draft' ? 'primary' : status === 'published' ? 'success' : 'alternative';
+        status === 'draft' ? 'secondary' : status === 'published' ? 'success' : 'alternative';
 
       return {
         disabled: !permissionsToCheck.includes(locale.code),


### PR DESCRIPTION
### What does it do?

Fix two IU issues:
* [Draft tag color was not the right one](https://github.com/strapi/strapi/issues/20814)
* [Release menu icons size is wrong](https://github.com/strapi/strapi/issues/20776)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20776
https://github.com/strapi/strapi/issues/20814
