### PR TITLE
fix: (v4) marketplace hide install button when incompatible

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -154,16 +154,15 @@ const NpmPackageCard = ({
             defaultMessage: 'More',
           })}
         </LinkButton>
-        {isCompatible && (
-          <InstallPluginButton
-            isInstalled={isInstalled}
-            isInDevelopmentMode={isInDevelopmentMode}
-            commandToCopy={commandToCopy}
-            strapiAppVersion={strapiAppVersion}
-            strapiPeerDepVersion={attributes.strapiVersion}
-            pluginName={attributes.name}
-          />
-        )}
+        <InstallPluginButton
+          isInstalled={isInstalled}
+          isInDevelopmentMode={isInDevelopmentMode}
+          isCompatible={isCompatible}
+          commandToCopy={commandToCopy}
+          strapiAppVersion={strapiAppVersion}
+          strapiPeerDepVersion={attributes.strapiVersion}
+          pluginName={attributes.name}
+        />
       </Flex>
     </Flex>
   );
@@ -178,11 +177,13 @@ interface InstallPluginButtonProps
   commandToCopy: string;
   pluginName: string;
   strapiPeerDepVersion?: string;
+  isCompatible?: boolean;
 }
 
 const InstallPluginButton = ({
   isInstalled,
   isInDevelopmentMode,
+  isCompatible,
   commandToCopy,
   strapiAppVersion,
   strapiPeerDepVersion,
@@ -221,7 +222,7 @@ const InstallPluginButton = ({
   }
 
   // In development, show install button
-  if (isInDevelopmentMode) {
+  if (isInDevelopmentMode && isCompatible !== false) {
     return (
       <CardButton
         strapiAppVersion={strapiAppVersion}

--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -59,6 +59,9 @@ const NpmPackageCard = ({
     attributes.slug
   }`;
 
+  const versionRange = semver.validRange(attributes.strapiVersion);
+  const isCompatible = semver.satisfies(strapiAppVersion ?? '', versionRange ?? '');
+
   return (
     <Flex
       direction="column"
@@ -151,14 +154,16 @@ const NpmPackageCard = ({
             defaultMessage: 'More',
           })}
         </LinkButton>
-        <InstallPluginButton
-          isInstalled={isInstalled}
-          isInDevelopmentMode={isInDevelopmentMode}
-          commandToCopy={commandToCopy}
-          strapiAppVersion={strapiAppVersion}
-          strapiPeerDepVersion={attributes.strapiVersion}
-          pluginName={attributes.name}
-        />
+        {isCompatible && (
+          <InstallPluginButton
+            isInstalled={isInstalled}
+            isInDevelopmentMode={isInDevelopmentMode}
+            commandToCopy={commandToCopy}
+            strapiAppVersion={strapiAppVersion}
+            strapiPeerDepVersion={attributes.strapiVersion}
+            pluginName={attributes.name}
+          />
+        )}
       </Flex>
     </Flex>
   );

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
@@ -46,23 +46,16 @@ describe('Marketplace page - layout', () => {
     expect(getByRole('button', { name: 'Filters' })).toBeVisible();
   });
 
-  it('disables the button and shows compatibility tooltip message when version provided', async () => {
-    const { findByTestId, findAllByTestId } = render();
+  it('does not display the button when incompatible version provided', async () => {
+    const { findAllByTestId, queryByText } = render();
 
     const alreadyInstalledCard = (await findAllByTestId('npm-package-card')).find((div) =>
       div.innerHTML.includes('Transformer')
     )!;
-
-    const button = within(alreadyInstalledCard)
-      .getByText(/copy install command/i)
-      .closest('button')!;
-
-    // User event throws an error that there are no pointer events
-    fireEvent.mouseOver(button);
-    const tooltip = await findByTestId('tooltip-Transformer');
-    expect(button).toBeDisabled();
-    expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveTextContent('Update your Strapi version: "4.1.0" to: "4.0.7"');
+  
+    const button = within(alreadyInstalledCard).queryByText(/copy install command/i);
+  
+    expect(button).not.toBeInTheDocument();
   });
 
   it('shows compatibility tooltip message when no version provided', async () => {

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
@@ -52,9 +52,9 @@ describe('Marketplace page - layout', () => {
     const alreadyInstalledCard = (await findAllByTestId('npm-package-card')).find((div) =>
       div.innerHTML.includes('Transformer')
     )!;
-  
+
     const button = within(alreadyInstalledCard).queryByText(/copy install command/i);
-  
+
     expect(button).not.toBeInTheDocument();
   });
 

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePlugins.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePlugins.test.tsx
@@ -101,13 +101,6 @@ describe('Marketplace page - plugins tab', () => {
     )!;
     const alreadyInstalledText = within(alreadyInstalledCard).queryByText(/installed/i);
     expect(alreadyInstalledText).toBeVisible();
-
-    // Plugin that's not installed
-    const notInstalledCard = getAllByTestId('npm-package-card').find((div) =>
-      div.innerHTML.includes('Comments')
-    )!;
-    const notInstalledText = within(notInstalledCard).queryByText(/copy install command/i);
-    expect(notInstalledText).toBeVisible();
   });
 
   it('shows plugins filters popover', async () => {

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
@@ -119,13 +119,6 @@ describe('Marketplace page - providers tab', () => {
       .find((div) => div.innerHTML.includes('Cloudinary'))!;
     const alreadyInstalledText = within(alreadyInstalledCard).queryByText(/installed/i);
     expect(alreadyInstalledText).toBeVisible();
-
-    // Provider that's not installed
-    const notInstalledCard = screen
-      .getAllByTestId('npm-package-card')
-      .find((div) => div.innerHTML.includes('Rackspace'))!;
-    const notInstalledText = within(notInstalledCard).queryByText(/copy install command/i);
-    expect(notInstalledText).toBeVisible();
   });
 
   it('shows providers filters popover', async () => {


### PR DESCRIPTION
### What does it do?

Hides the install button for incompatible versions

### Why is it needed?

v5 plugins are entering the marketplace, and this will be the initial approach to guiding users to the correct plugin version

more updates will be coming after v5 launch to improve the experience

### How to test it?

Only compatible plugins should show the install button.

You can set up a proxy to mock the data from market-api.strapi.io or verify with some existing plugins that are out of the current version range. Which there currently aren't any, but in a few hours the marketplace cache should pick up that we've upgraded the documentation plugin to 5.0.0.

### Related issue(s)/PR(s)

DX-1531