### PR TITLE
fix(content-releases): await release status update after createMany actions

### DIFF
--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -45,7 +45,9 @@ const releaseActionController = {
       const releaseActions = await Promise.all(
         releaseActionsArgs.map(async (releaseActionArgs) => {
           try {
-            const action = await releaseService.createAction(releaseId, releaseActionArgs);
+            const action = await releaseService.createAction(releaseId, releaseActionArgs, {
+              disableUpdateReleaseStatus: true,
+            });
 
             return action;
           } catch (error) {
@@ -63,6 +65,10 @@ const releaseActionController = {
     });
 
     const newReleaseActions = releaseActions.filter((action) => action !== null);
+
+    if (newReleaseActions.length > 0) {
+      releaseService.updateReleaseStatus(releaseId);
+    }
 
     ctx.body = {
       data: newReleaseActions,

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -424,7 +424,8 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => {
 
     async createAction(
       releaseId: CreateReleaseAction.Request['params']['releaseId'],
-      action: Pick<CreateReleaseAction.Request['body'], 'type' | 'entry'>
+      action: Pick<CreateReleaseAction.Request['body'], 'type' | 'entry'>,
+      { disableUpdateReleaseStatus = false }: { disableUpdateReleaseStatus?: boolean } = {}
     ) {
       const { validateEntryContentType, validateUniqueEntry } = getService('release-validation', {
         strapi,
@@ -466,7 +467,9 @@ const createReleaseService = ({ strapi }: { strapi: LoadedStrapi }) => {
         populate: { release: { fields: ['id'] }, entry: { fields: ['id'] } },
       });
 
-      this.updateReleaseStatus(releaseId);
+      if (!disableUpdateReleaseStatus) {
+        this.updateReleaseStatus(releaseId);
+      }
 
       return releaseAction;
     },


### PR DESCRIPTION
### What does it do?

On createAction function we run the updateReleaseStatus function without awaiting for it. This is on purpose because updateReleaseStatus function could be expensive to run, so we want to return an answer and let this run on the background.

For bulk add to release we create a transaction so we can catch a possible error when adding one entry to a release and rollback everything, so we call `createAction` for each entry user is adding, this create two problems:
* We are calling `updateReleaseStatus` for each entry added to the release, this is inefficient.
* Depending on how long takes `updateReleaseStatus`, and considering this is inside a transaction, we could end up running queries when transaction is ended, causing crash errors.

To fix all this, I add a new option to `createAction` so we can disable calling `updateReleaseStatus`, and then we can run it after all entries are added to the release.

### How to test it?

1. Go to any Content Type with draft & publish enabled
2. Bulk add entries to a release
3. It should work without errors on console

