### PR TITLE
fix(content-manager): change buttons of dialog to have fullWidth

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -432,14 +432,14 @@ const DocumentActionConfirmDialog = ({
         <Dialog.Body>{content}</Dialog.Body>
         <Dialog.Footer>
           <Dialog.Cancel>
-            <Button variant="tertiary">
+            <Button variant="tertiary" fullWidth>
               {formatMessage({
                 id: 'app.components.Button.cancel',
                 defaultMessage: 'Cancel',
               })}
             </Button>
           </Dialog.Cancel>
-          <Button onClick={handleConfirm} variant={variant}>
+          <Button onClick={handleConfirm} variant={variant} fullWidth>
             {formatMessage({
               id: 'app.components.Button.confirm',
               defaultMessage: 'Confirm',


### PR DESCRIPTION
### What does it do?

Width of dialog buttons should be 100%

### How to test it?

Try to delete document or delete locale 

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20816
