### PR TITLE
fix: return only drafts on relations from no DP to DP

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -1,4 +1,4 @@
-import { prop, uniq, uniqBy, concat, flow } from 'lodash/fp';
+import { prop, uniq, uniqBy, concat, flow, isEmpty } from 'lodash/fp';
 
 import { isOperatorOfType, contentTypes, relations, errors } from '@strapi/utils';
 import type { Data, Modules, UID } from '@strapi/types';
@@ -329,7 +329,7 @@ export default {
 
       // Add the status and locale filters if they are provided
       const publishedAt = getPublishedAtClause(status, targetUid);
-      if (publishedAt) {
+      if (!isEmpty(publishedAt)) {
         where[`${alias}.published_at`] = publishedAt;
       }
       if (filterByLocale) {

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -328,8 +328,9 @@ export default {
       }
 
       // Add the status and locale filters if they are provided
-      if (status) {
-        where[`${alias}.published_at`] = getPublishedAtClause(status, targetUid);
+      const publishedAt = getPublishedAtClause(status, targetUid);
+      if (publishedAt) {
+        where[`${alias}.published_at`] = publishedAt;
       }
       if (filterByLocale) {
         where[`${alias}.locale`] = locale;


### PR DESCRIPTION
### What does it do?

It was noticed during the development of https://github.com/strapi/strapi/pull/21010 (specifically [here](https://github.com/strapi/strapi/pull/21010#discussion_r1716882293)) That a relation from a Content Type with disabled DP to another one with enabled DP can show both the relation targetting the draft and the published version, see:

![image](https://github.com/user-attachments/assets/0ba15068-f8a9-47fd-bf3a-ec6c29d6815e)

This is at least confusing, and we should only show one relation.

We have debated multiple solutions, and atm product and engineering proposals are contradictory and we need to get to an agreement.

Product:
- From the content type without DP, show only the published version of the relation, and fallback to the draft


Engineering:
- From the content type without DP, show only the draft relation. 
That way, modifying the relation from that side does not interfere with live data from the other side.


This PR implements the engineering proposal, which is just a one liner. And can serve to start a discussion with @yanniskadiri 