### PR TITLE
fix: (v5) marketplace hide install button when incompatible

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -65,6 +65,9 @@ const NpmPackageCard = ({
     attributes.slug
   }`;
 
+  const versionRange = semver.validRange(attributes.strapiVersion);
+  const isCompatible = semver.satisfies(strapiAppVersion ?? '', versionRange ?? '');
+
   return (
     <Flex
       direction="column"
@@ -158,6 +161,7 @@ const NpmPackageCard = ({
         <InstallPluginButton
           isInstalled={isInstalled}
           isInDevelopmentMode={isInDevelopmentMode}
+          isCompatible={isCompatible}
           commandToCopy={commandToCopy}
           strapiAppVersion={strapiAppVersion}
           strapiPeerDepVersion={attributes.strapiVersion}
@@ -177,11 +181,13 @@ interface InstallPluginButtonProps
   commandToCopy: string;
   pluginName: string;
   strapiPeerDepVersion?: string;
+  isCompatible?: boolean;
 }
 
 const InstallPluginButton = ({
   isInstalled,
   isInDevelopmentMode,
+  isCompatible,
   commandToCopy,
   strapiAppVersion,
   strapiPeerDepVersion,
@@ -220,7 +226,7 @@ const InstallPluginButton = ({
   }
 
   // In development, show install button
-  if (isInDevelopmentMode) {
+  if (isInDevelopmentMode && isCompatible !== false) {
     return (
       <CardButton
         strapiAppVersion={strapiAppVersion}

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
@@ -50,19 +50,16 @@ describe('Marketplace page - layout', () => {
     // Shows the filters button
     expect(getByRole('button', { name: 'Filters' })).toBeVisible();
   });
-
-  it('disables the button', async () => {
+  it('does not display the button when incompatible version provided', async () => {
     const { findAllByTestId } = render();
 
     const alreadyInstalledCard = (await findAllByTestId('npm-package-card')).find((div) =>
       div.innerHTML.includes('Transformer')
     )!;
 
-    const button = within(alreadyInstalledCard)
-      .getByText(/copy install command/i)
-      .closest('button');
+    const button = within(alreadyInstalledCard).queryByText(/copy install command/i);
 
-    expect(button).toBeDisabled();
+    expect(button).not.toBeInTheDocument();
   });
 
   it('shows compatibility tooltip message when no version provided', async () => {

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplaceProviders.test.tsx
@@ -101,13 +101,6 @@ describe('Marketplace page - providers tab', () => {
       .find((div) => div.innerHTML.includes('Cloudinary'))!;
     const alreadyInstalledText = within(alreadyInstalledCard).queryByText(/installed/i);
     expect(alreadyInstalledText).toBeVisible();
-
-    // Provider that's not installed
-    const notInstalledCard = screen
-      .getAllByTestId('npm-package-card')
-      .find((div) => div.innerHTML.includes('Rackspace'))!;
-    const notInstalledText = within(notInstalledCard).queryByText(/copy install command/i);
-    expect(notInstalledText).toBeVisible();
   });
 
   it('shows providers filters popover', async () => {


### PR DESCRIPTION
### What does it do?

Hides the install button for incompatible versions

### Why is it needed?

v5 plugins are entering the marketplace, and this will be the initial approach to guiding users to the correct plugin version

more updates will be coming after v5 launch to improve the experience

### How to test it?

Only compatible plugins should show the install button.

You can set up a proxy to mock the data from market-api.strapi.io or verify with some existing plugins that are out of the current version range. Which there currently aren't any, but in a few hours the marketplace cache should pick up that we've upgraded the documentation plugin to 5.0.0.

However, it's also being tested in front-end tests

### Related issue(s)/PR(s)

DX-1586

[v4 version](https://github.com/strapi/strapi/pull/21111)