### PR TITLE
fix(admin): don't redirect if token is set

### DIFF
--- a/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
@@ -37,24 +37,17 @@ const AuthPage = () => {
 
   const { token } = useAuth('AuthPage', (auth) => auth);
 
-  const searchParams = new URLSearchParams(search);
-  const redirectTo = searchParams.get('redirectTo');
-
   if (!authType || !forms) {
     return <Navigate to="/" />;
   }
 
   const Component = forms[authType as keyof FormDictionary];
 
-  if (token && redirectTo) {
-    return <Navigate to={redirectTo} />;
-  }
-
   // Redirect the user to the login page if
   // the endpoint does not exist or
   // there is already an admin user oo
   // the user is already logged in
-  if (!Component || (hasAdmin && authType === 'register-admin') || (token && !redirectTo)) {
+  if (!Component || (hasAdmin && authType === 'register-admin' && token)) {
     return <Navigate to="/" />;
   }
 

--- a/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
@@ -37,17 +37,24 @@ const AuthPage = () => {
 
   const { token } = useAuth('AuthPage', (auth) => auth);
 
+  const searchParams = new URLSearchParams(search);
+  const redirectTo = searchParams.get('redirectTo');
+
   if (!authType || !forms) {
     return <Navigate to="/" />;
   }
 
   const Component = forms[authType as keyof FormDictionary];
 
+  if (token && redirectTo) {
+    return <Navigate to={redirectTo} />;
+  }
+
   // Redirect the user to the login page if
   // the endpoint does not exist or
   // there is already an admin user oo
   // the user is already logged in
-  if (!Component || (hasAdmin && authType === 'register-admin') || token) {
+  if (!Component || (hasAdmin && authType === 'register-admin') || (token && !redirectTo)) {
     return <Navigate to="/" />;
   }
 

--- a/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx
@@ -44,10 +44,18 @@ const AuthPage = () => {
   const Component = forms[authType as keyof FormDictionary];
 
   // Redirect the user to the login page if
-  // the endpoint does not exist or
+  // the endpoint does not exists
+  if (!Component) {
+    return <Navigate to="/" />;
+  }
+
+  // User is already logged in
+  if (authType !== 'register-admin' && authType !== 'register' && token) {
+    return <Navigate to="/" />;
+  }
+
   // there is already an admin user oo
-  // the user is already logged in
-  if (!Component || (hasAdmin && authType === 'register-admin' && token)) {
+  if (hasAdmin && authType === 'register-admin' && token) {
     return <Navigate to="/" />;
   }
 

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -223,8 +223,8 @@ const Register = ({ hasAdmin }: RegisterProps) => {
         setNpsSurveySettings((s) => ({ ...s, enabled: true }));
 
         navigate({
-          pathname: '/auth/register-admin',
-          search: `?redirectTo=${encodeURIComponent('/usecase')}&hasAdmin=${true}`,
+          pathname: '/usecase',
+          search: `?hasAdmin=${true}`,
         });
       } else {
         navigate('/');
@@ -257,8 +257,8 @@ const Register = ({ hasAdmin }: RegisterProps) => {
         setNpsSurveySettings((s) => ({ ...s, enabled: true }));
 
         navigate({
-          pathname: '/auth/register',
-          search: `?redirectTo=${encodeURIComponent('/usecase')}&hasAdmin=${hasAdmin}`,
+          pathname: '/usecase',
+          search: `?hasAdmin=${hasAdmin}`,
         });
       } else {
         navigate('/');

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -223,8 +223,8 @@ const Register = ({ hasAdmin }: RegisterProps) => {
         setNpsSurveySettings((s) => ({ ...s, enabled: true }));
 
         navigate({
-          pathname: '/usecase',
-          search: `?hasAdmin=${true}`,
+          pathname: '/auth/register-admin',
+          search: `?redirectTo=${encodeURIComponent('/usecase')}&hasAdmin=${true}`,
         });
       } else {
         navigate('/');
@@ -257,8 +257,8 @@ const Register = ({ hasAdmin }: RegisterProps) => {
         setNpsSurveySettings((s) => ({ ...s, enabled: true }));
 
         navigate({
-          pathname: '/usecase',
-          search: `?hasAdmin=${hasAdmin}`,
+          pathname: '/auth/register',
+          search: `?redirectTo=${encodeURIComponent('/usecase')}&hasAdmin=${hasAdmin}`,
         });
       } else {
         navigate('/');

--- a/tests/e2e/tests/admin/signup.spec.ts
+++ b/tests/e2e/tests/admin/signup.spec.ts
@@ -100,4 +100,19 @@ test.describe('Sign Up', () => {
 
     await expect(page).toHaveTitle(TITLE_HOME);
   });
+
+  test('a user should be redirected to /usecase page if they mark news as true', async ({
+    page,
+  }) => {
+    await page.getByLabel(/Keep me updated/).check();
+    await page.getByRole('button', { name: "Let's start" }).click();
+
+    // Wait for navigation to complete
+    await page.waitForURL('**/usecase**');
+
+    // Assert that we're on the /usecase page
+    expect(page.url()).toContain('/usecase');
+
+    await expect(page.getByText('Tell us a bit more about yourself')).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Current problem

When user mark "news" checkbox during registration they should be redirected to `/usecase` page before going to the admin panel. Right now they are being redirected to the admin panel instead.

This was happening because on `Register` component, on Register function (exactly [here](https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/pages/Auth/components/Register.tsx#L156)) we set the user's token. This cause `AuthPage` ([here](https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/pages/Auth/AuthPage.tsx)) to rerender because token has changed, that cause users to being redirected to the admin panel instead of `/usecase` because now token is not empty

### Solution

Solution is very simple, we really don't need to redirect users to admin if token is set at AuthPage level. I removed that check and instead I added it to the Login component. 
