### PR TITLE
fix: use dynamic pkg.json import to get write pkg version during install

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -3,10 +3,10 @@ import os from 'node:os';
 import chalk from 'chalk';
 import commander from 'commander';
 import crypto from 'crypto';
+import fse from 'fs-extra';
 
 import * as prompts from './prompts';
 import { handleCloudLogin } from './cloud';
-import { version } from '../package.json';
 import { createStrapi } from './create-strapi';
 import { checkNodeRequirements } from './utils/check-requirements';
 import { checkInstallPath } from './utils/check-install-path';
@@ -16,6 +16,8 @@ import { addDatabaseDependencies, getDatabaseInfos } from './utils/database';
 
 import type { Options, Scope } from './types';
 import { logger } from './utils/logger';
+
+const { version } = fse.readJSONSync(join(__dirname, '..', 'package.json'));
 
 const command = new commander.Command('create-strapi-app')
   .version(version)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- fix: use dynamic pkg.json import to get write pkg version during install

