### PR TITLE
fix(chore): fix default date value bug in content type builder(#21098)

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
+++ b/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
@@ -25,6 +25,8 @@ import formatISO from 'date-fns/formatISO';
 import isEqual from 'lodash/isEqual';
 import { type MessageDescriptor, type PrimitiveType, useIntl } from 'react-intl';
 
+import { parseDateValue } from '../utils/parseDateValue';
+
 import type { Schema } from '@strapi/types';
 
 interface TranslationMessage extends MessageDescriptor {
@@ -143,7 +145,6 @@ const GenericInput = ({
   // the API always returns null, which throws an error in React,
   // therefore we cast this case to undefined
   const value = defaultValue ?? undefined;
-
   /*
    TODO: ideally we should pass in `defaultValue` and `value` for
    inputs, in order to make them controlled components. This variable
@@ -266,6 +267,7 @@ const GenericInput = ({
         );
       }
       case 'datetime': {
+        const dateValue = parseDateValue(value);
         return (
           <DateTimePicker
             clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
@@ -278,11 +280,12 @@ const GenericInput = ({
             }}
             onClear={() => onChange({ target: { name, value: null, type } })}
             placeholder={formattedPlaceholder}
-            value={value}
+            value={dateValue}
           />
         );
       }
       case 'date': {
+        const dateValue = parseDateValue(value);
         return (
           <DatePicker
             clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
@@ -298,7 +301,7 @@ const GenericInput = ({
             }}
             onClear={() => onChange({ target: { name, value: null, type } })}
             placeholder={formattedPlaceholder}
-            value={value}
+            value={dateValue}
           />
         );
       }

--- a/packages/core/content-type-builder/admin/src/utils/parseDateValue.ts
+++ b/packages/core/content-type-builder/admin/src/utils/parseDateValue.ts
@@ -1,0 +1,18 @@
+import { Schema } from '@strapi/types';
+
+export const parseDateValue = <TAttribute extends Schema.Attribute.AnyAttribute>(
+  value: Schema.Attribute.Value<TAttribute>
+): Date | undefined => {
+  if (value instanceof Date) {
+    return isValidDate(value) ? value : undefined;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return isValidDate(date) ? date : undefined;
+  }
+
+  return undefined;
+};
+
+const isValidDate = (date: Date): boolean => !isNaN(date.getTime());

--- a/packages/core/content-type-builder/admin/src/utils/tests/parseDateValue.test.ts
+++ b/packages/core/content-type-builder/admin/src/utils/tests/parseDateValue.test.ts
@@ -1,0 +1,42 @@
+import { parseDateValue } from '../parseDateValue';
+
+describe('parseDateValue', () => {
+  it('should return undefined for null, undefined', () => {
+    expect(parseDateValue(null)).toBeUndefined();
+    expect(parseDateValue(undefined)).toBeUndefined();
+  });
+
+  it('should return a valid Date object for Date input', () => {
+    const testDate = new Date('2024-09-04');
+    expect(parseDateValue(testDate)).toEqual(testDate);
+  });
+
+  it('should return undefined for invalid Date object', () => {
+    expect(parseDateValue(new Date('Invalid Date'))).toBeUndefined();
+  });
+
+  it('should return a Date object for valid string date input', () => {
+    const result = parseDateValue('2024-09-04');
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.toISOString()).toBe('2024-09-04T00:00:00.000Z');
+  });
+
+  it('should return a Date object for valid number (timestamp) input', () => {
+    const timestamp = 1725433710049;
+    const result = parseDateValue(timestamp);
+    expect(result).toBeInstanceOf(Date);
+    expect(result?.toISOString()).toBe('2024-09-04T07:08:30.049Z');
+  });
+
+  it('should return undefined for invalid string date', () => {
+    expect(parseDateValue('not-a-date')).toBeUndefined();
+  });
+
+  it('should return undefined for invalid number date', () => {
+    expect(parseDateValue(NaN)).toBeUndefined();
+  });
+
+  it('should return undefined for unexpected types', () => {
+    expect(parseDateValue({} as any)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added a helper function `parseDateValue` to convert input types into valid Date objects or undefined for invalid inputs passed to `DateTimePicker` or `DatePicker` components.

### Why is it needed?

unexpected input types (eg. boolean) had been passed as `value`,  causing errors in date handling components.

### How to test it?

- Go to content type builder
- Create a new date field in any collection
- Select type date or datetime
-  Go to advanced setting tab, select a default value from date picker
- Tada! (it works!)

### Related issue(s)/PR(s)

DX-1588
#21098 
