### PR TITLE
enhancement: prevent committing tests with only

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # Check for .only in the staged changes of test files
-if git diff --cached | grep -E '^\+\s*(test|it|describe)\.only'; then
+if git --no-pager diff --cached | grep -E '^\+\s*(test|it|describe)\.only'; then
   echo "Error: .only found in staged changes. Please remove it before committing."
   exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Check for .only in test-related functions (test.only, it.only, describe.only)
+if grep -rE '^\s*(test|it|describe)\.only' './**/*.test.*'; then
+  echo "Error: .only found in test files. Please remove it before committing."
+  exit 1
+fi
+
+# Run lint-staged if no .only is found
 yarn lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# Check for .only in test-related functions (test.only, it.only, describe.only)
-if grep -rE '^\s*(test|it|describe)\.only' './**/*.test.*'; then
-  echo "Error: .only found in test files. Please remove it before committing."
+# Check for .only in the staged changes of test files
+if git diff --cached | grep -E '^\+\s*(test|it|describe)\.only'; then
+  echo "Error: .only found in staged changes. Please remove it before committing."
   exit 1
 fi
 

--- a/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
@@ -20,31 +20,12 @@ const LoginPage = () => {
 };
 
 describe('PrivateRoute', () => {
+  // TODO: fix this, it doesn't actually clear the login between tests
   beforeEach(() => {
     window.localStorage.clear();
   });
 
-  it('Authenticated users should be able to access protected routes', async () => {
-    // Login
-    window.localStorage.setItem('jwtToken', JSON.stringify('access-token'));
-
-    render(
-      <>
-        <Route path="/auth/login" component={LoginPage} />
-        <PrivateRoute path="/">
-          <ProtectedPage />
-        </PrivateRoute>
-      </>,
-      {
-        initialEntries: ['/protected'],
-      }
-    );
-
-    // Should see the protected route
-    expect(await screen.findByText('You are authenticated'));
-  });
-
-  it.skip('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
+  it('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
     let testLocation: Location = null!;
     let testHistory: History = null!;
 
@@ -84,5 +65,25 @@ describe('PrivateRoute', () => {
     );
 
     expect(screen.getByText('Please login')).toBeInTheDocument();
+  });
+
+  it('Authenticated users should be able to access protected routes', async () => {
+    // Login
+    window.localStorage.setItem('jwtToken', JSON.stringify('access-token'));
+
+    render(
+      <>
+        <Route path="/auth/login" component={LoginPage} />
+        <PrivateRoute path="/">
+          <ProtectedPage />
+        </PrivateRoute>
+      </>,
+      {
+        initialEntries: ['/protected'],
+      }
+    );
+
+    // Should see the protected route
+    expect(await screen.findByText('You are authenticated'));
   });
 });

--- a/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/PrivateRoute.test.tsx
@@ -44,7 +44,7 @@ describe('PrivateRoute', () => {
     expect(await screen.findByText('You are authenticated'));
   });
 
-  it.only('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
+  it.skip('Unauthenticated users should not be able to access protected routes and get redirected', async () => {
     let testLocation: Location = null!;
     let testHistory: History = null!;
 

--- a/packages/core/upload/admin/src/components/AssetCard/tests/AssetCardBase.test.jsx
+++ b/packages/core/upload/admin/src/components/AssetCard/tests/AssetCardBase.test.jsx
@@ -20,7 +20,7 @@ const render = (props) => ({
 
 describe('AssetCardBase', () => {
   describe('Interaction', () => {
-    it.only('should call onSelect when the checkbox is clicked', async () => {
+    it('should call onSelect when the checkbox is clicked', async () => {
       const onSelect = jest.fn();
       const { getByRole, user } = render({
         onSelect,


### PR DESCRIPTION
### What does it do?

adds a pre-commit hook for staged changes that include `(test|it|describe).only`

### Why is it needed?

prevent us from accidentally committing a `.only()` in a test, which has happened several times in the past; we should only allow `.skip()` because then it is obvious something was intentionally skipped

### How to test it?

- after running `yarn prepare`
- try staging and committing a change with a test that includes .only left in it; you should be prevented
- having .only in your code that isn't staged should still be ok

### Related issue(s)/PR(s)

DX-1593