### PR TITLE
fix: update ArrayNotation type to forbid arrays of mixed types

### DIFF
--- a/packages/core/types/src/modules/documents/params/sort.ts
+++ b/packages/core/types/src/modules/documents/params/sort.ts
@@ -64,7 +64,9 @@ export type StringNotation<TSchemaUID extends UID.Schema> =
  * type E = [42]; // ❌
  * type F = 'title'; // ❌
  */
-export type ArrayNotation<TSchemaUID extends UID.Schema> = Any<TSchemaUID>[];
+export type ArrayNotation<TSchemaUID extends UID.Schema> =
+  | StringNotation<TSchemaUID>[]
+  | ObjectNotation<TSchemaUID>[];
 
 /**
  * Object notation for a sort


### PR DESCRIPTION
### What does it do?

Restrict the sort array notation to `StringNotation[] | ObjectNotation[]` to forbid arrays with mixed types.

### Why is it needed?

To make the types reflect what's happening in the internal params validation.

### How to test it?

In an example application's bootstrap file, paste the following snippet

```ts
    await strapi.documents('admin::role').findMany({
      sort: [{ createdBy: { email: 'asc' } }, 'name:asc'],
    });
```
`'name:asc'` should be highlighted as a type error (it wasn't before)

Verify you can still use the following without errors

```ts
    await strapi.documents('admin::role').findMany({
      sort: [{ createdBy: { email: 'asc' } }, { name: 'asc' }],
    });
```

or

```ts
    await strapi.documents('admin::role').findMany({
      sort: ['name:asc', 'description:desc'],
    });
```
