### PR TITLE
fix: delete document actions labels

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -491,13 +491,17 @@ const DeleteAction: DocumentActionComponent = ({ documentId, model, collectionTy
   const { delete: deleteAction } = useDocumentActions();
   const { toggleNotification } = useNotification();
   const setSubmitting = useForm('DeleteAction', (state) => state.setSubmitting);
+  const isLocalized = document?.locale != null;
 
   return {
     disabled: !canDelete || !document,
-    label: formatMessage({
-      id: 'content-manager.actions.delete.label',
-      defaultMessage: 'Delete document',
-    }),
+    label: formatMessage(
+      {
+        id: 'content-manager.actions.delete.label',
+        defaultMessage: 'Delete entry{isLocalized, select, true { (all locales)} other {}}',
+      },
+      { isLocalized }
+    ),
     icon: <Trash />,
     dialog: {
       type: 'dialog',

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -4,7 +4,7 @@
   "actions.clone.label": "Duplicate",
   "actions.delete.dialog.body": "Are you sure you want to delete this document? This action is irreversible.",
   "actions.delete.error": "An error occurred while trying to delete the document.",
-  "actions.delete.label": "Delete document",
+  "actions.delete.label": "Delete entry{isLocalized, select, true { (all locales)} other {}}",
   "actions.discard.label": "Discard changes",
   "actions.discard.dialog.body": "Are you sure you want to discard the changes? This action is irreversible.",
   "actions.edit.error": "An error occurred while trying to edit the document.",

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -318,6 +318,13 @@ const DeleteLocaleAction: DocumentActionComponent = ({
   const { delete: deleteAction } = useDocumentActions();
   const { hasI18n, canDelete } = useI18n();
 
+  // Get the current locale object, using the URL instead of document so it works while creating
+  const [{ query }] = useQueryParams<I18nBaseQuery>();
+  const { data: locales = [] } = useGetLocalesQuery();
+  const currentDesiredLocale = query.plugins?.i18n?.locale;
+  const locale = !('error' in locales) && locales.find((loc) => loc.code === currentDesiredLocale);
+  console.log(locales);
+
   if (!hasI18n) {
     return null;
   }
@@ -326,10 +333,13 @@ const DeleteLocaleAction: DocumentActionComponent = ({
     disabled:
       (document?.locale && !canDelete.includes(document.locale)) || !document || !document.id,
     position: ['header', 'table-row'],
-    label: formatMessage({
-      id: getTranslation('actions.delete.label'),
-      defaultMessage: 'Delete locale',
-    }),
+    label: formatMessage(
+      {
+        id: getTranslation('actions.delete.label'),
+        defaultMessage: 'Delete entry ({locale})',
+      },
+      { locale: locale && locale.name }
+    ),
     icon: <StyledTrash />,
     variant: 'danger',
     dialog: {

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -323,7 +323,6 @@ const DeleteLocaleAction: DocumentActionComponent = ({
   const { data: locales = [] } = useGetLocalesQuery();
   const currentDesiredLocale = query.plugins?.i18n?.locale;
   const locale = !('error' in locales) && locales.find((loc) => loc.code === currentDesiredLocale);
-  console.log(locales);
 
   if (!hasI18n) {
     return null;

--- a/packages/plugins/i18n/admin/src/translations/en.json
+++ b/packages/plugins/i18n/admin/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "actions.delete.label": "Delete locale",
+  "actions.delete.label": "Delete entry ({locale})",
   "actions.delete.dialog.title": "Confirmation",
   "actions.delete.dialog.body": "Are you sure you want to delete this locale?",
   "actions.delete.error": "An error occurred while trying to delete the document locale.",

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -358,7 +358,7 @@ test.describe('Edit View', () => {
       await page.getByRole('gridcell', { name: 'West Ham post match analysis' }).click();
 
       await page.getByRole('button', { name: 'More actions' }).click();
-      await page.getByRole('menuitem', { name: 'Delete document' }).click();
+      await page.getByRole('menuitem', { name: 'Delete entry (all locales)' }).click();
       await page.getByRole('button', { name: 'Confirm' }).click();
 
       await findAndClose(page, 'Deleted Document');

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -227,7 +227,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       await page.getByRole('link', { name: 'Will Kitman' }).click();
       await page.waitForURL(AUTHOR_EDIT_URL);
       await page.getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /delete document/i }).click();
+      await page.getByRole('menuitem', { name: /delete entry/i }).click();
       await page.getByRole('button', { name: /confirm/i }).click();
 
       // Go to the the article's history page
@@ -461,7 +461,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       await page.getByRole('link', { name: 'Will Kitman' }).click();
       await page.waitForURL(AUTHOR_EDIT_URL);
       await page.getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /delete document/i }).click();
+      await page.getByRole('menuitem', { name: /delete entry/i }).click();
       await page.getByRole('button', { name: /confirm/i }).click();
 
       // Go to the the article's history page

--- a/tests/e2e/tests/i18n/settings.spec.ts
+++ b/tests/e2e/tests/i18n/settings.spec.ts
@@ -71,7 +71,9 @@ test.describe('Settings', () => {
       await expect(page.getByRole('menuitem', { name: 'Edit the model' })).toBeEnabled();
       await expect(page.getByRole('menuitem', { name: 'Configure the view' })).toBeEnabled();
       await expect(page.getByRole('menuitem', { name: 'Delete locale' })).toBeDisabled();
-      await expect(page.getByRole('menuitem', { name: 'Delete document' })).toBeEnabled();
+      await expect(
+        page.getByRole('menuitem', { name: 'Delete entry (all locales)' })
+      ).toBeEnabled();
       await page.keyboard.press('Escape');
 
       /**


### PR DESCRIPTION
### What does it do?

Fix the labels of document actions to match [the designs](https://www.figma.com/design/Tt8uHuQezEP0CsWunbulb5/Draft-%26-Publish?node-id=3189-207205&node-type=FRAME&t=MyrsKiYZY6SfTvTN-0):

- "delete document" => "delete entry" with i18n, "delete entry (all locales)" without i18n
- "delete locale" => "delete entry (locale name)"

### How to test it?

check the action with i18n enabled, disabled, as well as while creating a new locale before it's saved
