### PR TITLE
fix(content-releases): get entryDocumentId when entry is singleType

### DIFF
--- a/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
@@ -165,6 +165,7 @@ const AddActionToReleaseModal = ({
 
 const ReleaseActionModalForm: DocumentActionComponent = ({
   documentId,
+  document,
   model,
   collectionType,
 }: DocumentActionProps) => {
@@ -257,6 +258,8 @@ const ReleaseActionModalForm: DocumentActionComponent = ({
       defaultMessage: 'Add to release',
     }),
     icon: <PaperPlane />,
+    // Entry is creating so we don't want to allow adding it to a release
+    disabled: !document,
     position: ['panel', 'table-row'],
     dialog: {
       type: 'modal',

--- a/packages/core/content-releases/admin/src/components/ReleasesPanel.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleasesPanel.tsx
@@ -11,7 +11,12 @@ import { ReleaseActionMenu } from './ReleaseActionMenu';
 
 import type { PanelComponent, PanelComponentProps } from '@strapi/content-manager/strapi-admin';
 
-const Panel: PanelComponent = ({ model, documentId, collectionType }: PanelComponentProps) => {
+const Panel: PanelComponent = ({
+  model,
+  document,
+  documentId,
+  collectionType,
+}: PanelComponentProps) => {
   const [{ query }] = useQueryParams<{ plugins: { i18n: { locale: string } } }>();
   const locale = query.plugins?.i18n?.locale;
 
@@ -23,12 +28,17 @@ const Panel: PanelComponent = ({ model, documentId, collectionType }: PanelCompo
   const { allowedActions } = useRBAC(PERMISSIONS);
   const { canRead, canDeleteAction } = allowedActions;
 
-  const response = useGetReleasesForEntryQuery({
-    contentType: model,
-    entryDocumentId: documentId,
-    locale,
-    hasEntryAttached: true,
-  });
+  const response = useGetReleasesForEntryQuery(
+    {
+      contentType: model,
+      entryDocumentId: documentId,
+      locale,
+      hasEntryAttached: true,
+    },
+    {
+      skip: !document,
+    }
+  );
   const releases = response.data?.data;
 
   const getReleaseColorVariant = (
@@ -51,7 +61,7 @@ const Panel: PanelComponent = ({ model, documentId, collectionType }: PanelCompo
     return null;
   }
 
-  if (releases && releases.length === 0) {
+  if (!releases || releases.length === 0) {
     return null;
   }
 

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -1,6 +1,6 @@
 import type Koa from 'koa';
 
-import { errors, async } from '@strapi/utils';
+import { async } from '@strapi/utils';
 import {
   validateReleaseAction,
   validateReleaseActionUpdateSchema,
@@ -23,20 +23,6 @@ const releaseActionController = {
     const releaseActionArgs = ctx.request.body as CreateReleaseAction.Request['body'];
 
     await validateReleaseAction(releaseActionArgs);
-
-    // If we are adding a singleType, we need to append the documentId of that singleType
-    const model = strapi.getModel(releaseActionArgs.contentType);
-    if (model.kind === 'singleType') {
-      const document = await strapi.db.query(model.uid).findOne({ select: ['documentId'] });
-
-      if (!document) {
-        throw new errors.NotFoundError(
-          `No entry found for contentType ${releaseActionArgs.contentType}`
-        );
-      }
-
-      releaseActionArgs.entryDocumentId = document.documentId;
-    }
 
     const releaseActionService = getService('release-action', { strapi });
     const releaseAction = await releaseActionService.create(releaseId, releaseActionArgs);

--- a/packages/core/content-releases/server/src/controllers/release.ts
+++ b/packages/core/content-releases/server/src/controllers/release.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../shared/contracts/releases';
 import type { UserInfo } from '../../../shared/types';
 import { getService } from '../utils';
+import type { Schema } from '@strapi/types';
 
 type ReleaseWithPopulatedActions = Release & { actions: { count: number } };
 
@@ -34,7 +35,19 @@ const releaseController = {
 
     await validatefindByDocumentAttachedParams(query);
 
-    const { contentType, entryDocumentId, hasEntryAttached, locale } = query;
+    // If entry is a singleType, we need to manually add the entryDocumentId to the query
+    const model = strapi.getModel(query.contentType) as Schema.ContentType;
+    if (model.kind && model.kind === 'singleType') {
+      const document = await strapi.db.query(model.uid).findOne({ select: ['documentId'] });
+
+      if (!document) {
+        throw new errors.NotFoundError(`No entry found for contentType ${query.contentType}`);
+      }
+
+      query.entryDocumentId = document.documentId;
+    }
+
+    const { contentType, hasEntryAttached, entryDocumentId, locale } = query;
     const isEntryAttached =
       typeof hasEntryAttached === 'string' ? Boolean(JSON.parse(hasEntryAttached)) : false;
 

--- a/packages/core/content-releases/server/src/controllers/release.ts
+++ b/packages/core/content-releases/server/src/controllers/release.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import { errors } from '@strapi/utils';
+import type { Schema } from '@strapi/types';
 import { RELEASE_MODEL_UID } from '../constants';
 import { validateRelease, validatefindByDocumentAttachedParams } from './validation/release';
 import type {
@@ -14,7 +15,6 @@ import type {
 } from '../../../shared/contracts/releases';
 import type { UserInfo } from '../../../shared/types';
 import { getService } from '../utils';
-import type { Schema } from '@strapi/types';
 
 type ReleaseWithPopulatedActions = Release & { actions: { count: number } };
 

--- a/packages/core/content-releases/server/src/services/__tests__/release-action.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release-action.test.ts
@@ -87,6 +87,18 @@ const baseStrapiMock = {
 
     return map[contentType];
   }),
+  contentType: jest.fn((contentType: string) => {
+    const map: Record<string, any> = {
+      'api::contentTypeA.contentTypeA': {
+        kind: 'collectionType',
+      },
+      'api::contentTypeB.contentTypeB': {
+        kind: 'collectionType',
+      },
+    };
+
+    return map[contentType];
+  }),
   documents: jest.fn().mockReturnValue({
     findOne: jest.fn().mockReturnValue({ documentId: 'id', name: 'test' }),
     findFirst: jest.fn().mockReturnValue({ documentId: 'id', name: 'test' }),
@@ -129,7 +141,7 @@ describe('Release Action service', () => {
           query: jest.fn().mockReturnValue({
             create: jest.fn().mockReturnValue({
               type: 'publish',
-              entry: { id: 1, contentType: 'api::contentType.contentType' },
+              entry: { id: 1, contentType: 'api::contentTypeA.contentTypeA' },
             }),
             findOne: jest.fn().mockReturnValue({ id: 1, name: 'test' }),
             count: jest.fn(),
@@ -144,14 +156,14 @@ describe('Release Action service', () => {
       const mockActionArgs = {
         type: 'publish' as const,
         entryDocumentId: '1',
-        contentType: 'api::contentType.contentType' as const,
+        contentType: 'api::contentTypeA.contentTypeA' as const,
       };
 
       const action = await releaseActionService.create(1, mockActionArgs);
 
       expect(action).toEqual({
         type: 'publish',
-        entry: { id: 1, contentType: 'api::contentType.contentType' },
+        entry: { id: 1, contentType: 'api::contentTypeA.contentTypeA' },
       });
     });
 
@@ -170,7 +182,7 @@ describe('Release Action service', () => {
       const mockActionArgs = {
         type: 'publish' as const,
         entryDocumentId: '1',
-        contentType: 'api::contentType.contentType' as const,
+        contentType: 'api::contentTypeA.contentTypeA' as const,
       };
 
       expect(() => releaseActionService.create(1, mockActionArgs)).rejects.toThrow(
@@ -194,7 +206,7 @@ describe('Release Action service', () => {
       const mockActionArgs = {
         type: 'publish' as const,
         entryDocumentId: '1',
-        contentType: 'api::contentType.contentType' as const,
+        contentType: 'api::contentTypeA.contentTypeA' as const,
       };
 
       expect(() => releaseActionService.create(1, mockActionArgs)).rejects.toThrow(

--- a/packages/core/content-releases/server/src/services/release-action.ts
+++ b/packages/core/content-releases/server/src/services/release-action.ts
@@ -93,6 +93,18 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
         validateUniqueEntry(releaseId, action),
       ]);
 
+      // If we are adding a singleType, we need to append the documentId of that singleType
+      const model = strapi.contentType(action.contentType);
+      if (model.kind === 'singleType') {
+        const document = await strapi.db.query(model.uid).findOne({ select: ['documentId'] });
+
+        if (!document) {
+          throw new errors.NotFoundError(`No entry found for contentType ${action.contentType}`);
+        }
+
+        action.entryDocumentId = document.documentId;
+      }
+
       const release = await strapi.db
         .query(RELEASE_MODEL_UID)
         .findOne({ where: { id: releaseId } });


### PR DESCRIPTION
### What does it do?

This PR fix multiple errors on Releases when you add a Single Type entry. SingleTypes have documentId but we don't have them on the frontend so we don't send it to the releases' endpoints. With this PR we append the documentId when content type is a Single Type. 

### How to test it?

Follow all the Releases flow (adding an entry, edit the entry, remove it, publish, etc...) with singleType entries.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21177
