### PR TITLE
fix: change the value format on change for date and datetime

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -25,7 +25,7 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(date) => {
-            field.onChange(name, date ? convertLocalDateToUTCDate(date) : null);
+            field.onChange(name, date ? convertLocalDateToUTCDate(date).toISOString() : null);
           }}
           onClear={() => field.onChange(name, null)}
           value={value ? convertLocalDateToUTCDate(value) : value}

--- a/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/DateTime.tsx
@@ -11,7 +11,7 @@ import { InputProps } from './types';
 const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const { formatMessage } = useIntl();
-    const field = useField<Date | null>(name);
+    const field = useField<string | null>(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);
 
     const composedRefs = useComposedRefs(ref, fieldRef);
@@ -24,7 +24,8 @@ const DateTimeInput = forwardRef<HTMLInputElement, InputProps>(
           ref={composedRefs}
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onChange={(date) => {
-            field.onChange(name, date ? date : null);
+            // Store ISO string in the field, but Date object in the component value
+            field.onChange(name, date ? date.toISOString() : null);
           }}
           onClear={() => field.onChange(name, null)}
           value={value}

--- a/packages/core/review-workflows/server/src/controllers/stages.ts
+++ b/packages/core/review-workflows/server/src/controllers/stages.ts
@@ -174,12 +174,14 @@ export default {
     const entityStageId = entity[ENTITY_STAGE_ATTRIBUTE]?.id;
     const canTransition = stagePermissions.can(STAGE_TRANSITION_UID, entityStageId);
 
-    const [workflowCount, { stages: workflowStages }] = await Promise.all([
+    const [workflowCount, workflowResult] = await Promise.all([
       workflowService.count(),
       workflowService.getAssignedWorkflow(modelUID, {
         populate: 'stages',
       }),
     ]);
+
+    const workflowStages = workflowResult ? workflowResult.stages : [];
 
     const meta = {
       stageCount: workflowStages.length,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It solves the infinite loop in the devTool when we save a date or a date time on the CM Edit view

### Why is it needed?

Because RTK doesn't allow non serializable values so we want to serialize the value when we change it
In addiction I have fixed a small issue we had when we call the review workflow controller and we try to destructure stages even if the value is null

### How to test it?

1. Go to 'Content Manager'
2. Click on Any collection that has a date field with `date` or `datetime` type, create a new entry.
3. entry is now correctly created,
4.  right click to check the console in browser, try to update the date or time value
5. we don't have errors anymore

Please test carefully every single value with different locales and timezones, thanks

### Related issue(s)/PR(s)

CS-1088
https://github.com/strapi/strapi/issues/21157
