### PR TITLE
fix: single type fill from locale disabled

### DIFF
--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -123,7 +123,7 @@ export default {
         permissionChecker,
         model,
         // @ts-expect-error - fix types
-        { id: document.documentId, locale, publishedAt: null },
+        { documentId: document.documentId, locale, publishedAt: null },
         { availableLocales: true, availableStatus: false }
       );
       ctx.body = { data: {}, meta };


### PR DESCRIPTION
### What does it do?

maps property to `documentId` instead of `id` so the document query is consistent for versions that are being created and the ones already created

similar issue fixed already in collection types in a different PR before, check https://github.com/strapi/strapi/pull/21009/files#r1726619948

### Why is it needed?

- fill from locale in single types is not working

### How to test it?

- fill from locale for singletypes should be working now and the button should not be disabled

### Related issue(s)/PR(s)

fixes #21178 
