### PR TITLE
fix: fix default time formatting issue

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
+++ b/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
@@ -420,8 +420,8 @@ const GenericInput = ({
           <TimePicker
             clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
             disabled={disabled}
-            onChange={(time) => handleTimeChangeEvent(time, onChange, name, type)}
-            onClear={() => handleTimeChangeEvent(undefined, onChange, name, type)}
+            onChange={(time) => handleTimeChangeEvent(onChange, name, type, time)}
+            onClear={() => handleTimeChangeEvent(onChange, name, type, undefined)}
             value={formattedValue}
           />
         );

--- a/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
+++ b/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
@@ -26,6 +26,7 @@ import isEqual from 'lodash/isEqual';
 import { type MessageDescriptor, type PrimitiveType, useIntl } from 'react-intl';
 
 import { parseDateValue } from '../utils/parseDateValue';
+import { handleTimeChange, handleTimeChangeEvent } from '../utils/timeFormat';
 
 import type { Schema } from '@strapi/types';
 
@@ -413,26 +414,15 @@ const GenericInput = ({
         );
       }
       case 'time': {
-        let time = value;
-
-        // The backend send a value which has the following format: '00:45:00.000'
-        // or the time picker only supports hours & minutes so we need to mutate the value
-        if (typeof value === 'string' && value.split(':').length > 2) {
-          const [hour, minute] = value.split(':');
-          time = `${hour}:${minute}`;
-        }
+        const formattedValue = handleTimeChange({ value, onChange, name, type });
 
         return (
           <TimePicker
             clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
             disabled={disabled}
-            onChange={(time) => {
-              onChange({ target: { name, value: `${time}`, type } });
-            }}
-            onClear={() => {
-              onChange({ target: { name, value: null, type } });
-            }}
-            value={time}
+            onChange={(time) => handleTimeChangeEvent(time, onChange, name, type)}
+            onClear={() => handleTimeChangeEvent(undefined, onChange, name, type)}
+            value={formattedValue}
           />
         );
       }

--- a/packages/core/content-type-builder/admin/src/utils/tests/timeFormat.test.ts
+++ b/packages/core/content-type-builder/admin/src/utils/tests/timeFormat.test.ts
@@ -36,7 +36,7 @@ describe('Time Logic', () => {
   describe('handleTimeChangeEvent', () => {
     it('should add seconds and milliseconds to time string', () => {
       const onChange = jest.fn();
-      handleTimeChangeEvent('14:30', onChange, 'timeField', 'time');
+      handleTimeChangeEvent(onChange, 'timeField', 'time', '14:30');
       expect(onChange).toHaveBeenCalledWith({
         target: { name: 'timeField', value: '14:30:00.000', type: 'time' },
       });
@@ -44,7 +44,7 @@ describe('Time Logic', () => {
 
     it('should not modify time string with seconds and milliseconds', () => {
       const onChange = jest.fn();
-      handleTimeChangeEvent('14:30:00.000', onChange, 'timeField', 'time');
+      handleTimeChangeEvent(onChange, 'timeField', 'time', '14:30:00.000');
       expect(onChange).toHaveBeenCalledWith({
         target: { name: 'timeField', value: '14:30:00.000', type: 'time' },
       });
@@ -52,7 +52,7 @@ describe('Time Logic', () => {
 
     it('should handle undefined input', () => {
       const onChange = jest.fn();
-      handleTimeChangeEvent(undefined, onChange, 'timeField', 'time');
+      handleTimeChangeEvent(onChange, 'timeField', 'time', undefined);
       expect(onChange).toHaveBeenCalledWith({
         target: { name: 'timeField', value: undefined, type: 'time' },
       });

--- a/packages/core/content-type-builder/admin/src/utils/tests/timeFormat.test.ts
+++ b/packages/core/content-type-builder/admin/src/utils/tests/timeFormat.test.ts
@@ -1,0 +1,61 @@
+import { handleTimeChange, handleTimeChangeEvent } from '../timeFormat';
+
+describe('Time Logic', () => {
+  describe('handleTimeChange', () => {
+    it('should remove seconds from time string', () => {
+      const result = handleTimeChange({
+        value: '14:30:45.000',
+        onChange: jest.fn(),
+        name: 'timeField',
+        type: 'time',
+      });
+      expect(result).toBe('14:30');
+    });
+
+    it('should not modify time string without seconds', () => {
+      const result = handleTimeChange({
+        value: '14:30',
+        onChange: jest.fn(),
+        name: 'timeField',
+        type: 'time',
+      });
+      expect(result).toBe('14:30');
+    });
+
+    it('should return undefined for undefined input', () => {
+      const result = handleTimeChange({
+        value: undefined,
+        onChange: jest.fn(),
+        name: 'timeField',
+        type: 'time',
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('handleTimeChangeEvent', () => {
+    it('should add seconds and milliseconds to time string', () => {
+      const onChange = jest.fn();
+      handleTimeChangeEvent('14:30', onChange, 'timeField', 'time');
+      expect(onChange).toHaveBeenCalledWith({
+        target: { name: 'timeField', value: '14:30:00.000', type: 'time' },
+      });
+    });
+
+    it('should not modify time string with seconds and milliseconds', () => {
+      const onChange = jest.fn();
+      handleTimeChangeEvent('14:30:00.000', onChange, 'timeField', 'time');
+      expect(onChange).toHaveBeenCalledWith({
+        target: { name: 'timeField', value: '14:30:00.000', type: 'time' },
+      });
+    });
+
+    it('should handle undefined input', () => {
+      const onChange = jest.fn();
+      handleTimeChangeEvent(undefined, onChange, 'timeField', 'time');
+      expect(onChange).toHaveBeenCalledWith({
+        target: { name: 'timeField', value: undefined, type: 'time' },
+      });
+    });
+  });
+});

--- a/packages/core/content-type-builder/admin/src/utils/timeFormat.ts
+++ b/packages/core/content-type-builder/admin/src/utils/timeFormat.ts
@@ -3,14 +3,14 @@ type TimeChangeHandler = (params: {
 }) => void;
 
 type TimeChangeParams = {
-  value: string | undefined;
+  value?: string;
   onChange: TimeChangeHandler;
   name: string;
   type: string;
 };
 
-// The backend send a value which has the following format: '00:45:00.000'
-// or the time picker only supports hours & minutes so we need to mutate the value
+// The backend sends a value which has the following format: '00:45:00.000'
+// but the time picker only supports hours & minutes so we need to mutate the value
 const removeSeconds = (time: string): string => {
   const [hours, minutes] = time.split(':');
   return `${hours}:${minutes}`;
@@ -21,12 +21,12 @@ const addSecondsAndMilliseconds = (time: string): string => {
   return time.split(':').length === 2 ? `${time}:00.000` : time;
 };
 
-const formatTimeForInput = (value: string | undefined): string | undefined => {
-  if (!value) return undefined;
+const formatTimeForInput = (value?: string): string | undefined => {
+  if (!value) return;
   return value.split(':').length > 2 ? removeSeconds(value) : value;
 };
 
-const formatTimeForOutput = (value: string | undefined): string | undefined => {
+const formatTimeForOutput = (value?: string): string | undefined => {
   if (!value) return undefined;
   return addSecondsAndMilliseconds(value);
 };
@@ -38,10 +38,10 @@ export const handleTimeChange = ({ value }: TimeChangeParams): string | undefine
 };
 
 export const handleTimeChangeEvent = (
-  time: string | undefined,
   onChange: TimeChangeHandler,
   name: string,
-  type: string
+  type: string,
+  time?: string
 ): void => {
   const formattedOutputTime = formatTimeForOutput(time);
 

--- a/packages/core/content-type-builder/admin/src/utils/timeFormat.ts
+++ b/packages/core/content-type-builder/admin/src/utils/timeFormat.ts
@@ -1,0 +1,55 @@
+type TimeChangeHandler = (params: {
+  target: { name: string; value: string | undefined; type: string };
+}) => void;
+
+type TimeChangeParams = {
+  value: string | undefined;
+  onChange: TimeChangeHandler;
+  name: string;
+  type: string;
+};
+
+// The backend send a value which has the following format: '00:45:00.000'
+// or the time picker only supports hours & minutes so we need to mutate the value
+const removeSeconds = (time: string): string => {
+  const [hours, minutes] = time.split(':');
+  return `${hours}:${minutes}`;
+};
+
+// we need to send back the value with the same '00:45:00.000' format
+const addSecondsAndMilliseconds = (time: string): string => {
+  return time.split(':').length === 2 ? `${time}:00.000` : time;
+};
+
+const formatTimeForInput = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  return value.split(':').length > 2 ? removeSeconds(value) : value;
+};
+
+const formatTimeForOutput = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  return addSecondsAndMilliseconds(value);
+};
+
+export const handleTimeChange = ({ value }: TimeChangeParams): string | undefined => {
+  const formattedInputTime = formatTimeForInput(value);
+
+  return formattedInputTime;
+};
+
+export const handleTimeChangeEvent = (
+  time: string | undefined,
+  onChange: TimeChangeHandler,
+  name: string,
+  type: string
+): void => {
+  const formattedOutputTime = formatTimeForOutput(time);
+
+  onChange({
+    target: {
+      name,
+      value: formattedOutputTime,
+      type,
+    },
+  });
+};


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

add `handleTimeChange` function to format time when needed.

### Why is it needed?

Input (Display) Format:

The`TimePicker` only supports the time format "HH:MM" (hours and minutes).
The default value set in the Content-Type Builder (CTB) comes in the format `HH:mm:ss.SSS`
To display the default value correctly, we need to convert it from `HH:mm:ss.SSS` to `HH:MM`.

Output (Submission) Format:

When a user selects or changes a time in the `TimePicker`, it provides the time in `HH:MM` format.
However, the backend expects to receive the time in the full `HH:mm:ss.SSS` format.
Therefore, we need to convert the user-selected time from `HH:MM` back to `HH:mm:ss.SSS` before sending it to the backend.

In summary:

For display: Convert `HH:mm:ss.SSS` → `HH:MM`
For submission: Convert `HH:MM` → `HH:mm:ss.SSS`

### How to test it?

Manually: 
- Create a `Date` field with type `time` in any collection in the Content type builder
- Go to advanced settings and select a `default value`
- Save
- Go to Content Manager, create a new entry with the default value
- There should be no errors

Unit test:

`cd strapi/packages/core/content-type-builder`
run `yarn test:front `

### Related issue(s)/PR(s)

#20875 

DX-1592
