### PR TITLE
Change schema validation hash generation from md5 to sha256

### DIFF
--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -52,7 +52,7 @@ export default (db: Database) => {
     },
 
     hashSchema(schema: Schema) {
-      return crypto.createHash('md5').update(JSON.stringify(schema)).digest('hex');
+      return crypto.createHash('sha256').update(JSON.stringify(schema)).digest('hex');
     },
 
     async add(schema: Schema) {


### PR DESCRIPTION
### What does it do?

When Strapi is validating the in database schema in comparison to the Strapi schema we generate a hash of the schema structure to run a quick "sanity check" before doing a more detailed comparison. 

In this case we are switching to the slightly slower sha256 by default instead of md5 and it should have very minimal impact other than generating an additional schema validation check on the next reboot of the application.

### Why is it needed?

Originally we were using md5 for ease and speed however this conflicts with certain security standards (even though we don't use this for any security itself) such as FIPS. 

Some certain automated FIPS compliance options such as the FIPS "mode" in RHEL completely disable the usage of things like md5 at the operating system level meaning any users using this option will not be able to run Strapi with this option enabled.

### How to test it?

Difficult to validate other than reviewing the stored hash in the database but requires loading up a virtual machine or container with an operating system that has the capability to enable strict FIPS security controls such as RHEL: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/security_hardening/switching-rhel-to-fips-mode_security-hardening

### Related issue(s)/PR(s)

fixes #21053 
