### PR TITLE
fix: add status to removed fields when cleaning data

### DIFF
--- a/packages/plugins/i18n/admin/src/utils/clean.ts
+++ b/packages/plugins/i18n/admin/src/utils/clean.ts
@@ -18,6 +18,7 @@ const cleanData = (
     'strapi_stage',
     'strapi_assignee',
     'locale',
+    'status',
   ]);
 
   const cleanedDataWithoutPasswordAndRelation = recursiveRemoveFieldTypes(


### PR DESCRIPTION
### What does it do?

Remove status field from added fields fields when filling from another locale

### Why is it needed?

look at issue #21179 
status field shouldn't be filled from another locale

### How to test it?

Try to fill from another locale (when the other locale is in `modified` status) and then save it should work with no errors
you can check #21179 for reproduction

### Related issue(s)/PR(s)

fixes #21179 
