### PR TITLE
fix: do not generate localizations links table

### DIFF
--- a/packages/core/database/src/metadata/metadata.ts
+++ b/packages/core/database/src/metadata/metadata.ts
@@ -69,6 +69,10 @@ export class Metadata extends Map<string, Meta> {
     for (const meta of this.values()) {
       for (const [attributeName, attribute] of Object.entries(meta.attributes)) {
         try {
+          if (attribute.unstable_virtual) {
+            continue;
+          }
+
           if (types.isRelationalAttribute(attribute)) {
             createRelation(attributeName, attribute, meta, this);
             continue;

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -59,9 +59,6 @@ const isOwner = (
 ): attribute is RelationalAttribute & Relation.Owner =>
   !isBidirectional(attribute) || hasInversedBy(attribute);
 
-const isVirtual = (attribute: RelationalAttribute) =>
-  'virtual' in attribute && attribute.virtual === true;
-
 const shouldUseJoinTable = (attribute: RelationalAttribute) =>
   !('useJoinTable' in attribute) || attribute.useJoinTable !== false;
 
@@ -129,7 +126,7 @@ const createOneToMany = (
       attributeName,
       meta,
     });
-  } else if (isOwner(attribute) && !isVirtual(attribute)) {
+  } else if (isOwner(attribute)) {
     throw new Error('one side of a oneToMany cannot be the owner side in a bidirectional relation');
   }
 };
@@ -382,10 +379,6 @@ const createMorphMany = (
  * Creates a join column info and add them to the attribute meta
  */
 const createJoinColumn = (metadata: Metadata, { attribute, attributeName }: JoinColumnOptions) => {
-  if (isVirtual(attribute)) {
-    return;
-  }
-
   const targetMeta = metadata.get(attribute.target);
 
   if (!targetMeta) {
@@ -424,10 +417,6 @@ const createJoinTable = (
   metadata: Metadata,
   { attributeName, attribute, meta }: JoinTableOptions
 ) => {
-  if (isVirtual(attribute)) {
-    return;
-  }
-
   if (!shouldUseJoinTable(attribute)) {
     throw new Error('Attempted to create join table when useJoinTable is false');
   }

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -419,6 +419,12 @@ const createJoinTable = (
 ) => {
   const targetMeta = metadata.get(attribute.target);
 
+  // Localizations are a "calculated" relation set in packages/plugins/i18n/server/src/register.ts
+  // we do not create an actual join table for localizations
+  if (attributeName === 'localizations') {
+    return;
+  }
+
   if (!targetMeta) {
     throw new Error(`Unknown target ${attribute.target}`);
   }

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -395,6 +395,10 @@ const createMorphMany = (
  * Creates a join column info and add them to the attribute meta
  */
 const createJoinColumn = (metadata: Metadata, { attribute, attributeName }: JoinColumnOptions) => {
+  if (attribute.virtual) {
+    return;
+  }
+
   const targetMeta = metadata.get(attribute.target);
 
   if (!targetMeta) {
@@ -433,6 +437,10 @@ const createJoinTable = (
   metadata: Metadata,
   { attributeName, attribute, meta }: JoinTableOptions
 ) => {
+  if (attribute.virtual) {
+    return;
+  }
+
   if (!shouldUseJoinTable(attribute)) {
     throw new Error('Attempted to create join table when useJoinTable is false');
   }

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -120,6 +120,10 @@ const createOneToMany = (
   meta: Meta,
   metadata: Metadata
 ) => {
+  /**
+   * Setting useJoinTable: false is a way to explicitly declare not to create a join table
+   * it is needed so that we can have self-relations with no db effects like  'localizations'
+   *  */
   if (!shouldUseJoinTable(attribute)) {
     return;
   }
@@ -194,6 +198,10 @@ const createManyToMany = (
   meta: Meta,
   metadata: Metadata
 ) => {
+  /**
+   * Setting useJoinTable: false is a way to explicitly declare not to create a join table
+   * it is needed so that we can have self-relations with no db effects like  'localizations'
+   *  */
   if (!shouldUseJoinTable(attribute)) {
     return;
   }

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -417,13 +417,11 @@ const createJoinTable = (
   metadata: Metadata,
   { attributeName, attribute, meta }: JoinTableOptions
 ) => {
-  const targetMeta = metadata.get(attribute.target);
-
-  // Localizations are a "calculated" relation set in packages/plugins/i18n/server/src/register.ts
-  // we do not create an actual join table for localizations
-  if (attributeName === 'localizations') {
+  if (!shouldUseJoinTable(attribute)) {
     return;
   }
+
+  const targetMeta = metadata.get(attribute.target);
 
   if (!targetMeta) {
     throw new Error(`Unknown target ${attribute.target}`);

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -120,6 +120,10 @@ const createOneToMany = (
   meta: Meta,
   metadata: Metadata
 ) => {
+  if (!shouldUseJoinTable(attribute)) {
+    return;
+  }
+
   if (!isBidirectional(attribute)) {
     createJoinTable(metadata, {
       attribute,
@@ -190,6 +194,10 @@ const createManyToMany = (
   meta: Meta,
   metadata: Metadata
 ) => {
+  if (!shouldUseJoinTable(attribute)) {
+    return;
+  }
+
   if (!isBidirectional(attribute) || isOwner(attribute)) {
     createJoinTable(metadata, {
       attribute,
@@ -418,7 +426,7 @@ const createJoinTable = (
   { attributeName, attribute, meta }: JoinTableOptions
 ) => {
   if (!shouldUseJoinTable(attribute)) {
-    return;
+    throw new Error('Attempted to create join table when useJoinTable is false');
   }
 
   const targetMeta = metadata.get(attribute.target);

--- a/packages/core/database/src/types/index.ts
+++ b/packages/core/database/src/types/index.ts
@@ -9,7 +9,7 @@ export interface ColumnInfo {
   notNullable?: boolean;
 }
 
-export type Attribute = ScalarAttribute | RelationalAttribute;
+export type Attribute = (ScalarAttribute | RelationalAttribute) & { unstable_virtual?: boolean };
 
 export type CountResult = { count: number };
 

--- a/packages/core/database/src/types/index.ts
+++ b/packages/core/database/src/types/index.ts
@@ -116,7 +116,6 @@ export namespace Relation {
     inversedBy?: string;
     mappedBy?: string;
     joinTable: BidirectionalAttributeJoinTable;
-    virtual?: boolean;
   };
 
   export type OneToOne = BaseBidirectional & {

--- a/packages/core/database/src/types/index.ts
+++ b/packages/core/database/src/types/index.ts
@@ -116,6 +116,7 @@ export namespace Relation {
     inversedBy?: string;
     mappedBy?: string;
     joinTable: BidirectionalAttributeJoinTable;
+    virtual?: boolean;
   };
 
   export type OneToOne = BaseBidirectional & {

--- a/packages/core/types/src/schema/attribute/definitions/relation.ts
+++ b/packages/core/types/src/schema/attribute/definitions/relation.ts
@@ -68,6 +68,7 @@ export type RelationOptions = Intersect<
     Attribute.VisibleOption,
     Attribute.RequiredOption,
     { useJoinTable?: boolean },
+    { virtual?: boolean },
   ]
 >;
 

--- a/packages/core/types/src/schema/attribute/definitions/relation.ts
+++ b/packages/core/types/src/schema/attribute/definitions/relation.ts
@@ -68,7 +68,6 @@ export type RelationOptions = Intersect<
     Attribute.VisibleOption,
     Attribute.RequiredOption,
     { useJoinTable?: boolean },
-    { virtual?: boolean },
   ]
 >;
 

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -70,6 +70,7 @@ const extendContentTypes = (strapi: Core.Strapi) => {
       private: false,
       configurable: false,
       visible: false,
+      useJoinTable: false,
       joinColumn: {
         name: 'document_id',
         referencedColumn: 'document_id',

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -71,6 +71,7 @@ const extendContentTypes = (strapi: Core.Strapi) => {
       configurable: false,
       visible: false,
       virtual: true,
+      useJoinTable: false,
       joinColumn: {
         name: 'document_id',
         referencedColumn: 'document_id',

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -70,8 +70,8 @@ const extendContentTypes = (strapi: Core.Strapi) => {
       private: false,
       configurable: false,
       visible: false,
-      virtual: true,
-      useJoinTable: false,
+      unstable_virtual: true,
+      useJoinColumn: false,
       joinColumn: {
         name: 'document_id',
         referencedColumn: 'document_id',

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -71,7 +71,6 @@ const extendContentTypes = (strapi: Core.Strapi) => {
       configurable: false,
       visible: false,
       unstable_virtual: true,
-      useJoinColumn: false,
       joinColumn: {
         name: 'document_id',
         referencedColumn: 'document_id',

--- a/packages/plugins/i18n/server/src/register.ts
+++ b/packages/plugins/i18n/server/src/register.ts
@@ -70,7 +70,7 @@ const extendContentTypes = (strapi: Core.Strapi) => {
       private: false,
       configurable: false,
       visible: false,
-      useJoinTable: false,
+      virtual: true,
       joinColumn: {
         name: 'document_id',
         referencedColumn: 'document_id',


### PR DESCRIPTION
### What does it do?

Prevents generating localizations link tables in the database, because they are a virtual relation

### Why is it needed?

Those tables shouldn't exist in Strapi 5 and it's currently wreaking havoc in a lot of areas of the code

### How to test it?

simple test: migrating from v4 to v5, migration should run fine and db should not include any `*localizations_links` or `*localizations_lnk` tables

long test: see the linked issues, this should solve all of them

### Related issue(s)/PR(s)

I believe it will fix all of the following, but I haven't confirmed yet:

fix #21189
fix #21186
another migration issue that was reported internally by @PaulBratslavsky

initial misdirected poc to fix some of the issues: https://github.com/strapi/strapi/pull/21211

DX-1604