### PR TITLE
fix(content-releases): validation and cache releases

### DIFF
--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -114,7 +114,7 @@ const createYupSchema = (
                       // an array of objects with {id} properties, representing the related entities.
                       return yup.array().of(
                         yup.object().shape({
-                          id: yup.string().required(),
+                          id: yup.number().required(),
                         })
                       );
                     } else if (typeof value === 'object') {

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -187,7 +187,10 @@ const releaseApi = adminApi
               method: 'GET',
             };
           },
-          providesTags: (result, error, arg) => [{ type: 'Release' as const, id: arg.id }],
+          providesTags: (result, error, arg) => [
+            { type: 'Release', id: 'LIST' },
+            { type: 'Release' as const, id: arg.id },
+          ],
         }),
         getReleaseActions: build.query<
           GetReleaseActions.Response,


### PR DESCRIPTION
### What does it do?

Fix two bugs that were affecting content releases.
* When validating relations to many entries that are required we want to validate id is a number, not a string
* We need to invalidate cache data of release when entries are added to a release

### How to test it?

1. Add one entry to a release with "hasMany" relation, validation should work 

1. Create a release
2. Add one entry to that release and move to the release page
3. Release status should be ready and publish button enabled

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21227
