### PR TITLE
fix: allow morphToMany relation ordering in sanitize and validate

### DIFF
--- a/packages/core/utils/src/__tests__/morph.test.ts
+++ b/packages/core/utils/src/__tests__/morph.test.ts
@@ -15,7 +15,7 @@ describe('restricted relations', () => {
       target: 'admin::user',
     };
 
-    // we don't care about actual relation permissions here, only that the properties are not removed
+    // we don't care about actual relation permissions here, only that the properties are sanitized and validated correctly
     global.strapi = {
       auth: {
         verify(_config, auth) {

--- a/packages/core/utils/src/__tests__/morph.test.ts
+++ b/packages/core/utils/src/__tests__/morph.test.ts
@@ -15,7 +15,7 @@ describe('restricted relations', () => {
       target: 'admin::user',
     };
 
-    // we don't care about actual relations here, only that the properties are not removed
+    // we don't care about actual relation permissions here, only that the properties are not removed
     global.strapi = {
       auth: {
         verify(_config, auth) {

--- a/packages/core/utils/src/__tests__/morph.test.ts
+++ b/packages/core/utils/src/__tests__/morph.test.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from 'yup';
+import { ValidationError } from '../errors';
 import * as sanitizeVisitors from '../sanitize/visitors';
 import * as validateVisitors from '../validate/visitors';
 

--- a/packages/core/utils/src/__tests__/morph.test.ts
+++ b/packages/core/utils/src/__tests__/morph.test.ts
@@ -1,0 +1,307 @@
+import { ValidationError } from 'yup';
+import * as sanitizeVisitors from '../sanitize/visitors';
+import * as validateVisitors from '../validate/visitors';
+
+describe('restricted relations', () => {
+  describe('polymorphic relations', () => {
+    const auth = {};
+    const morphKeys = ['morph'];
+    const removeRestrictedRelationsFn = sanitizeVisitors.removeRestrictedRelations(auth);
+    const throwRestrictedRelationsFn = validateVisitors.throwRestrictedRelations(auth);
+
+    const attribute = {
+      type: 'relation',
+      relation: 'morphToMany',
+      target: 'admin::user',
+    };
+
+    // we don't care about actual relations here, only that the properties are not removed
+    global.strapi = {
+      auth: {
+        verify(one, two, three) {
+          console.log(one, two, three);
+          if (two.scope === 'undefined.find') {
+            throw new Error('no permissions');
+          }
+
+          return true;
+        },
+      },
+    };
+
+    test('sanitizes morph relations connect, set, disconnect, and options', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      const promises = morphKeys.map(async (key) => {
+        return removeRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: [
+                  { __type: 'api::admin:morphtest', id: 1 },
+                  'invalid', // to be removed
+                ],
+                set: [
+                  { __type: 'api::admin:morphtest', id: 1 },
+                  'invalid', // to be removed
+                ],
+                disconnect: [
+                  { __type: 'api::admin:morphtest', id: 1 },
+                  'invalid', // to be removed
+                ],
+                options: {
+                  strict: false,
+                  fakeOption: { fake: 'string' }, // to be removed
+                },
+                fakeProp: 'asdf', // to be removed
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+      await Promise.all(promises);
+
+      expect(remove).toHaveBeenCalledTimes(0);
+      expect(set).toBeCalledTimes(1);
+      expect(set).toHaveBeenCalledWith('morph', {
+        connect: [{ __type: 'api::admin:morphtest', id: 1 }],
+        disconnect: [{ __type: 'api::admin:morphtest', id: 1 }],
+        options: { strict: false },
+        set: [{ __type: 'api::admin:morphtest', id: 1 }],
+      });
+    });
+    test('validates valid morph relations connect, set, disconnect, and options', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      // as long as it doesn't throw is the main test
+      const promises = morphKeys.map(async (key) => {
+        return throwRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                set: [{ __type: 'api::admin:morphtest', id: 1 }],
+                disconnect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                options: {
+                  strict: false,
+                },
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+
+      await expect(Promise.all(promises)).resolves.not.toThrow();
+
+      expect(remove).toHaveBeenCalledTimes(0);
+      expect(set).toBeCalledTimes(0);
+    });
+
+    test('throws an error for invalid morph relations option', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      const promises = morphKeys.map(async (key) => {
+        return throwRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                set: [{ __type: 'api::admin:morphtest', id: 1 }],
+                disconnect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                options: {
+                  invalidoption: true, // Invalid
+                },
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+      await expect(Promise.all(promises)).rejects.toThrow(
+        new ValidationError('Invalid key invalidoption')
+      );
+    });
+
+    test('throws an error for invalid morph relations connect', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      const promises = morphKeys.map(async (key) => {
+        return throwRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: ['invalidString'], // Invalid
+                set: [{ __type: 'api::admin:morphtest', id: 1 }],
+                disconnect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                options: {},
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+
+      await expect(Promise.all(promises)).rejects.toThrow(new ValidationError('Invalid key morph'));
+    });
+
+    test('throws an error for invalid morph relations set', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      const promises = morphKeys.map(async (key) => {
+        return throwRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                set: ['invalidString'], // Invalid
+                disconnect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                options: {},
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+
+      await expect(Promise.all(promises)).rejects.toThrow(new ValidationError('Invalid key morph'));
+    });
+
+    test('throws an error for invalid morph relations disconnect', async () => {
+      const remove = jest.fn();
+      const set = jest.fn();
+
+      const promises = morphKeys.map(async (key) => {
+        return throwRestrictedRelationsFn(
+          {
+            data: {
+              morph: {
+                connect: [{ __type: 'api::admin:morphtest', id: 1 }],
+                set: [{ __type: 'api::admin:morphtest', id: 1 }],
+                disconnect: ['invalidString'], // Invalid
+                options: {},
+              },
+            },
+            key,
+            attribute,
+            schema: {
+              kind: 'collectionType',
+              info: {
+                singularName: 'test',
+                pluralName: 'tests',
+              },
+              options: { populateCreatorFields: true },
+              attributes: {
+                morph: attribute,
+              },
+            },
+            value: {},
+            path: {
+              attribute: null,
+              raw: null,
+            },
+          },
+          { remove, set }
+        );
+      });
+
+      await expect(Promise.all(promises)).rejects.toThrow(new ValidationError('Invalid key morph'));
+    });
+  });
+});

--- a/packages/core/utils/src/__tests__/morph.test.ts
+++ b/packages/core/utils/src/__tests__/morph.test.ts
@@ -18,9 +18,8 @@ describe('restricted relations', () => {
     // we don't care about actual relations here, only that the properties are not removed
     global.strapi = {
       auth: {
-        verify(one, two, three) {
-          console.log(one, two, three);
-          if (two.scope === 'undefined.find') {
+        verify(_config, auth) {
+          if (auth.scope === 'undefined.find') {
             throw new Error('no permissions');
           }
 

--- a/packages/core/utils/src/relations.ts
+++ b/packages/core/utils/src/relations.ts
@@ -1,3 +1,4 @@
+import { isBoolean } from 'lodash/fp';
 import type { Attribute, Model } from './types';
 
 import { isRelationalAttribute } from './content-types';
@@ -21,6 +22,10 @@ const isAnyToMany = (attribute: Attribute) =>
 
 export const constants = {
   MANY_RELATIONS,
+};
+
+export const VALID_RELATION_ORDERING_KEYS: { [key: string]: (value: any) => boolean } = {
+  strict: isBoolean,
 };
 
 export { getRelationalFields, isOneToAny, isManyToAny, isAnyToOne, isAnyToMany };

--- a/packages/core/utils/src/relations.ts
+++ b/packages/core/utils/src/relations.ts
@@ -24,6 +24,8 @@ export const constants = {
   MANY_RELATIONS,
 };
 
+// Valid keys in the `options` property of relations reordering
+// The value for each key must be a function that returns true if it is a valid value
 export const VALID_RELATION_ORDERING_KEYS: { [key: string]: (value: any) => boolean } = {
   strict: isBoolean,
 };

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -1,5 +1,7 @@
 import * as contentTypeUtils from '../../content-types';
 import type { Visitor } from '../../traverse/factory';
+import { RelationOrderingOptions } from '../../types';
+import { VALID_RELATION_ORDERING_KEYS } from '../../relations';
 
 const ACTIONS_TO_VERIFY = ['find'];
 const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = contentTypeUtils.constants;
@@ -19,23 +21,76 @@ export default (auth: unknown): Visitor =>
     }
 
     const handleMorphRelation = async () => {
-      const newMorphValue: Record<string, unknown>[] = [];
+      const elements: any = (data as Record<string, MorphArray>)[key];
 
-      for (const element of (data as Record<string, MorphArray>)[key]) {
+      if ('connect' in elements || 'set' in elements || 'disconnect' in elements) {
+        const newValue: Record<string, unknown> = {};
+
+        const connect = await handleMorphElements(elements.connect || []);
+        const relSet = await handleMorphElements(elements.set || []);
+        const disconnect = await handleMorphElements(elements.disconnect || []);
+
+        if (connect.length > 0) {
+          newValue.connect = connect;
+        }
+
+        if (relSet.length > 0) {
+          newValue.set = relSet;
+        }
+
+        if (disconnect.length > 0) {
+          newValue.disconnect = disconnect;
+        }
+
+        if (
+          'options' in elements &&
+          typeof elements.options === 'object' &&
+          elements.options !== null
+        ) {
+          const filteredOptions: RelationOrderingOptions = {};
+
+          // Iterate through the keys of elements.options
+          Object.keys(elements.options).forEach((key) => {
+            const validator = VALID_RELATION_ORDERING_KEYS[key as keyof RelationOrderingOptions];
+
+            // Ensure the key exists in VALID_RELATION_ORDERING_KEYS and the validator is defined before calling it
+            if (validator && validator(elements.options[key])) {
+              filteredOptions[key as keyof RelationOrderingOptions] = elements.options[key];
+            }
+          });
+
+          // Assign the filtered options back to newValue
+          newValue.options = filteredOptions;
+        } else {
+          newValue.options = {};
+        }
+
+        set(key, newValue);
+      } else {
+        const newMorphValue = await handleMorphElements(elements);
+
+        // If the new value is empty, remove the relation completely
+        if (newMorphValue.length === 0) {
+          remove(key);
+        } else {
+          set(key, newMorphValue);
+        }
+      }
+    };
+
+    const handleMorphElements = async (elements: any[]) => {
+      const allowedElements: Record<string, unknown>[] = [];
+
+      for (const element of elements) {
         const scopes = ACTIONS_TO_VERIFY.map((action) => `${element.__type}.${action}`);
         const isAllowed = await hasAccessToSomeScopes(scopes, auth);
 
         if (isAllowed) {
-          newMorphValue.push(element);
+          allowedElements.push(element);
         }
       }
 
-      // If the new value is empty, remove the relation completely
-      if (newMorphValue.length === 0) {
-        remove(key);
-      } else {
-        set(key, newMorphValue);
-      }
+      return allowedElements;
     };
 
     const handleRegularRelation = async () => {

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -42,6 +42,7 @@ export default (auth: unknown): Visitor =>
           newValue.disconnect = disconnect;
         }
 
+        // TODO: this should technically be in its own visitor to check morph options, but for now we'll handle it here
         if (
           'options' in elements &&
           typeof elements.options === 'object' &&

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -61,8 +61,6 @@ export default (auth: unknown): Visitor =>
 
           // Assign the filtered options back to newValue
           newValue.options = filteredOptions;
-        } else {
-          newValue.options = {};
         }
 
         set(key, newValue);

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -1,3 +1,4 @@
+import { isArray, isObject } from 'lodash/fp';
 import * as contentTypeUtils from '../../content-types';
 import type { Visitor } from '../../traverse/factory';
 import { RelationOrderingOptions } from '../../types';
@@ -80,7 +81,15 @@ export default (auth: unknown): Visitor =>
     const handleMorphElements = async (elements: any[]) => {
       const allowedElements: Record<string, unknown>[] = [];
 
+      if (!isArray(elements)) {
+        return allowedElements;
+      }
+
       for (const element of elements) {
+        if (!isObject(element) || !('__type' in element)) {
+          continue;
+        }
+
         const scopes = ACTIONS_TO_VERIFY.map((action) => `${element.__type}.${action}`);
         const isAllowed = await hasAccessToSomeScopes(scopes, auth);
 

--- a/packages/core/utils/src/types.ts
+++ b/packages/core/utils/src/types.ts
@@ -12,6 +12,10 @@ export type Data = {
 
 export type Config = Record<string, unknown>;
 
+export interface RelationOrderingOptions {
+  strict?: boolean;
+}
+
 export interface Attribute {
   type: string;
   writable?: boolean;

--- a/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
+++ b/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
@@ -1,6 +1,7 @@
 import * as contentTypeUtils from '../../content-types';
 import { throwInvalidKey } from '../utils';
 import type { Visitor } from '../../traverse/factory';
+import { VALID_RELATION_ORDERING_KEYS } from '../../relations';
 
 const ACTIONS_TO_VERIFY = ['find'];
 const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = contentTypeUtils.constants;
@@ -20,7 +21,41 @@ export default (auth: unknown): Visitor =>
     }
 
     const handleMorphRelation = async () => {
-      for (const element of (data as Record<string, MorphArray>)[key]) {
+      const elements: any = (data as Record<string, MorphArray>)[key];
+
+      if ('connect' in elements || 'set' in elements || 'disconnect' in elements) {
+        await handleMorphElements(elements.connect || []);
+        await handleMorphElements(elements.set || []);
+        await handleMorphElements(elements.disconnect || []);
+
+        if ('options' in elements) {
+          if (elements.options === null || elements.options === undefined) {
+            return;
+          }
+
+          if (typeof elements.options !== 'object') {
+            throwInvalidKey({ key, path: path.attribute });
+          }
+
+          const optionKeys = Object.keys(elements.options);
+
+          // Validate each key based on its validator function
+          for (const key of optionKeys) {
+            if (!(key in VALID_RELATION_ORDERING_KEYS)) {
+              throwInvalidKey({ key, path: path.attribute });
+            }
+            if (!VALID_RELATION_ORDERING_KEYS[key](elements.options[key])) {
+              throwInvalidKey({ key, path: path.attribute });
+            }
+          }
+        }
+      } else {
+        await handleMorphElements(elements);
+      }
+    };
+
+    const handleMorphElements = async (elements: any[]) => {
+      for (const element of elements) {
         const scopes = ACTIONS_TO_VERIFY.map((action) => `${element.__type}.${action}`);
         const isAllowed = await hasAccessToSomeScopes(scopes, auth);
 

--- a/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
+++ b/packages/core/utils/src/validate/visitors/throw-restricted-relations.ts
@@ -28,6 +28,7 @@ export default (auth: unknown): Visitor =>
         await handleMorphElements(elements.set || []);
         await handleMorphElements(elements.disconnect || []);
 
+        // TODO: this should technically be in its own visitor to check morph options, but for now we'll handle it here
         if ('options' in elements) {
           if (elements.options === null || elements.options === undefined) {
             return;

--- a/tests/api/core/strapi/api/relations.test.api.js
+++ b/tests/api/core/strapi/api/relations.test.api.js
@@ -223,7 +223,8 @@ const updateShop = async (
       //   id: shop?.myCompo?.id,
       //   compo_products_ow: { [relAction]: anyToOneRel },
       //   compo_products_mw: { options: { strict }, [relAction]: anyToManyRel },
-      // },      ...data,
+      // },
+      ...data,
     },
     populate || populateShop
   );

--- a/tests/api/core/strapi/api/relations.test.api.js
+++ b/tests/api/core/strapi/api/relations.test.api.js
@@ -217,7 +217,13 @@ const updateShop = async (
           };
         }),
       },
-      ...data,
+      // TODO V5: Discuss component id update, updating a draft component
+      //          with a published component id will fail
+      // myCompo: {
+      //   id: shop?.myCompo?.id,
+      //   compo_products_ow: { [relAction]: anyToOneRel },
+      //   compo_products_mw: { options: { strict }, [relAction]: anyToManyRel },
+      // },      ...data,
     },
     populate || populateShop
   );

--- a/tests/api/core/strapi/api/relations.test.api.js
+++ b/tests/api/core/strapi/api/relations.test.api.js
@@ -15,16 +15,22 @@ let id1;
 let id2;
 let id3;
 
-const populateShop = [
-  'products_ow',
-  'products_oo',
-  'products_mo',
-  'products_om',
-  'products_mm',
-  'products_mw',
-  'myCompo.compo_products_ow',
-  'myCompo.compo_products_mw',
-];
+const populateShop = {
+  products_ow: true,
+  products_oo: true,
+  products_mo: true,
+  products_om: true,
+  products_mm: true,
+  products_mw: true,
+  products_morphtomany: {
+    on: {
+      'api::product.product': true,
+    },
+  },
+  myCompo: {
+    populate: ['compo_products_ow', 'compo_products_mw'],
+  },
+};
 
 const compo = (withRelations = false) => ({
   displayName: 'compo',
@@ -102,6 +108,10 @@ const shopModel = {
       relation: 'oneToMany',
       target: 'api::product.product',
     },
+    products_morphtomany: {
+      type: 'relation',
+      relation: 'morphToMany',
+    },
     myCompo: {
       type: 'component',
       repeatable: false,
@@ -153,6 +163,16 @@ const createShop = async ({
       products_om: { options, connect: anyToManyRel },
       products_mm: { options, connect: anyToManyRel },
       products_mw: { options, connect: anyToManyRel },
+      products_morphtomany: {
+        options,
+        connect: anyToManyRel.map((rel) => {
+          return {
+            id: rel.documentId ? rel.documentId : rel,
+            __type: 'api::product.product',
+            position: rel?.position || undefined,
+          };
+        }),
+      },
       myCompo: {
         compo_products_ow: { connect: anyToOneRel },
         compo_products_mw: { options, connect: anyToManyRel },
@@ -187,13 +207,16 @@ const updateShop = async (
       products_om: { options: { strict }, [relAction]: anyToManyRel },
       products_mm: { options: { strict }, [relAction]: anyToManyRel },
       products_mw: { options: { strict }, [relAction]: anyToManyRel },
-      // TODO V5: Discuss component id update, updating a draft component
-      //          with a published component id will fail
-      // myCompo: {
-      //   id: shop?.myCompo?.id,
-      //   compo_products_ow: { [relAction]: anyToOneRel },
-      //   compo_products_mw: { options: { strict }, [relAction]: anyToManyRel },
-      // },
+      products_morphtomany: {
+        options: { strict },
+        [relAction]: anyToManyRel.map((rel) => {
+          return {
+            id: rel.documentId ? rel.documentId : rel,
+            __type: 'api::product.product',
+            position: rel?.position || undefined,
+          };
+        }),
+      },
       ...data,
     },
     populate || populateShop
@@ -870,6 +893,120 @@ describe('Relations', () => {
       });
 
       expect(updatedShop.error).toMatchObject({ status: 400, name: 'ValidationError' });
+    });
+
+    test('Create relations using invalid key in morphToMany returns error', async () => {
+      const result = await createEntry(
+        'shops',
+        {
+          name: 'Cazotte Shop',
+          products_morphtomany: {
+            options: { strict: true, invalid: true },
+            connect: [
+              {
+                id: id1,
+                __type: 'api::product.product',
+                position: 'end',
+              },
+            ],
+            invalid: 'fake',
+          },
+        },
+        populateShop
+      );
+
+      expect(result.error).toMatchObject({ status: 400, name: 'ValidationError' });
+    });
+
+    test('Create relations using invalid options for morphToMany returns error', async () => {
+      const result = await createEntry(
+        'shops',
+        {
+          name: 'Cazotte Shop',
+          products_morphtomany: {
+            options: { strict: true, invalid: true },
+            connect: [
+              {
+                id: id1,
+                __type: 'api::product.product',
+                position: 'end',
+              },
+            ],
+          },
+        },
+        populateShop
+      );
+
+      expect(result.error).toMatchObject({ status: 400, name: 'ValidationError' });
+    });
+
+    test('Create relations using invalid connect for morphToMany returns error', async () => {
+      const result = await createEntry(
+        'shops',
+        {
+          name: 'Cazotte Shop',
+          products_morphtomany: {
+            options: { strict: true },
+            connect: [
+              {
+                id: id1,
+                __type: 'api::product.product',
+                position: 'end',
+              },
+              'invalid',
+            ],
+          },
+        },
+        populateShop
+      );
+
+      expect(result.error).toMatchObject({ status: 400, name: 'ValidationError' });
+    });
+
+    test('Create relations using invalid disconnect for morphToMany returns error', async () => {
+      const result = await createEntry(
+        'shops',
+        {
+          name: 'Cazotte Shop',
+          products_morphtomany: {
+            options: { strict: true, invalid: true },
+            disconnect: [
+              {
+                id: id1,
+                __type: 'api::product.product',
+                position: 'end',
+              },
+              'invalid',
+            ],
+          },
+        },
+        populateShop
+      );
+
+      expect(result.error).toMatchObject({ status: 400, name: 'ValidationError' });
+    });
+
+    test('Create relations using invalid set for morphToMany returns error', async () => {
+      const result = await createEntry(
+        'shops',
+        {
+          name: 'Cazotte Shop',
+          products_morphtomany: {
+            options: { strict: true, invalid: true },
+            set: [
+              {
+                id: id1,
+                __type: 'api::product.product',
+                position: 'end',
+              },
+              'invalid',
+            ],
+          },
+        },
+        populateShop
+      );
+
+      expect(result.error).toMatchObject({ status: 400, name: 'ValidationError' });
     });
 
     test('Update relations with invalid connect array in strict mode', async () => {

--- a/tests/api/core/upload/content-api/upload.test.api.js
+++ b/tests/api/core/upload/content-api/upload.test.api.js
@@ -22,6 +22,10 @@ const dogModel = {
     profilePicture: {
       type: 'media',
     },
+    relatedMedia: {
+      type: 'media',
+      multiple: true,
+    },
   },
 };
 
@@ -397,6 +401,167 @@ describe('Upload plugin', () => {
       });
 
       expect(res.body.data.length).toBe(0);
+    });
+
+    describe('Media relations', () => {
+      test('connect returns the right status code', async () => {
+        // upload images
+        const images = await rq({
+          method: 'POST',
+          url: '/upload',
+          formData: {
+            files: [
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+            ],
+          },
+        });
+        const imageIds = images.body.map((item) => item.id);
+
+        // create entity with just the first image
+        const res = await rq({
+          method: 'POST',
+          url: `/dogs/?populate=*`,
+          body: {
+            data: {
+              relatedMedia: [imageIds[0]],
+            },
+          },
+        });
+
+        const documentId = res.body.data.documentId;
+
+        // connect the second image
+        const connectRes = await rq({
+          method: 'PUT',
+          url: `/dogs/${documentId}?populate=*`,
+          body: JSON.stringify({
+            data: {
+              relatedMedia: {
+                connect: [imageIds[0]],
+              },
+            },
+          }),
+        });
+
+        expect(connectRes.status).toBe(200);
+
+        // TODO: once Github issue 20961 is fixed, uncomment these lines to test results and update this test name to "works"
+        // expect(connectRes.body.data.relatedMedia).toHaveLength(1);
+
+        // expect(connectRes.body.data.relatedMedia[1]).toEqual(
+        //   expect.objectContaining({
+        //     id: images.body[1].id,
+        //   })
+        // );
+      });
+
+      test('disconnect returns the right status code', async () => {
+        // upload images
+        const images = await rq({
+          method: 'POST',
+          url: '/upload',
+          formData: {
+            files: [
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+            ],
+          },
+        });
+        const imageIds = images.body.map((item) => item.id);
+
+        // create entity with just the first image
+        const res = await rq({
+          method: 'POST',
+          url: `/dogs/?populate=*`,
+          body: {
+            data: {
+              relatedMedia: [imageIds[0]],
+            },
+          },
+        });
+
+        const documentId = res.body.data.documentId;
+
+        // connect the second image
+        const connectRes = await rq({
+          method: 'PUT',
+          url: `/dogs/${documentId}?populate=*`,
+          body: JSON.stringify({
+            data: {
+              relatedMedia: {
+                disconnect: [imageIds[0]],
+              },
+            },
+          }),
+        });
+
+        expect(connectRes.status).toBe(200);
+
+        // TODO: once Github issue 20961 is fixed, uncomment these lines to test results and update this test name to "works"
+        // expect(connectRes.body.data.relatedMedia).toHaveLength(1);
+
+        // expect(connectRes.body.data.relatedMedia[1]).toEqual(
+        //   expect.objectContaining({
+        //     id: images.body[1].id,
+        //   })
+        // );
+      });
+
+      test('set works', async () => {
+        // upload images
+        const images = await rq({
+          method: 'POST',
+          url: '/upload',
+          formData: {
+            files: [
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+              fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+            ],
+          },
+        });
+        const imageIds = images.body.map((item) => item.id);
+
+        // create entity with just the first image
+        const res = await rq({
+          method: 'POST',
+          url: `/dogs/?populate=*`,
+          body: {
+            data: {
+              relatedMedia: [imageIds[0]],
+            },
+          },
+        });
+
+        const documentId = res.body.data.documentId;
+
+        // connect the second image
+        const connectRes = await rq({
+          method: 'PUT',
+          url: `/dogs/${documentId}?populate=*`,
+          body: JSON.stringify({
+            data: {
+              relatedMedia: {
+                set: [imageIds[0], imageIds[1]],
+              },
+            },
+          }),
+        });
+
+        expect(connectRes.status).toBe(200);
+
+        expect(connectRes.body.data.relatedMedia).toHaveLength(2);
+        expect(connectRes.body.data.relatedMedia[0]).toEqual(
+          expect.objectContaining({
+            id: images.body[0].id,
+          })
+        );
+        expect(connectRes.body.data.relatedMedia[1]).toEqual(
+          expect.objectContaining({
+            id: images.body[1].id,
+          })
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
### What does it do?

- allows morph relations set, connect, disconnect, and options properties to validate/sanitize correctly

### Why is it needed?

This PR is necessary for v5 stable to allow polymorphic relations input to validate/sanitize properly

It came from https://github.com/strapi/strapi/pull/21135 but that PR has too many potential side effects to merge into v5 this close to release, so only this critical part is being added for now

### How to test it?

- verify that polymorphic relations can set/disconnect/connect through validation -- beware that they may not actually work correctly due to [this bug](https://github.com/strapi/strapi/issues/20961), the thing to test is that it makes it through validation
- ensure that it properly sanitizes and validates connect, disconnect, set, and options and doesn't allow bad values to pass through

Automated tests have been added for every positive and negative case (though it's missing results testing on the api tests because results would be wrong)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/21135