### PR TITLE
fix(DynamicComponent): inconsistent gap between fields and components

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -219,26 +219,37 @@ const DynamicComponent = ({
               <Accordion.Content>
                 <AccordionContentRadius background="neutral0">
                   <Box paddingLeft={6} paddingRight={6} paddingTop={6} paddingBottom={6}>
-                    {components[componentUid]?.layout?.map((row, rowInd) => (
-                      <Grid.Root gap={4} key={rowInd}>
-                        {row.map(({ size, ...field }) => {
-                          const fieldName = `${name}.${index}.${field.name}`;
+                    <Grid.Root gap={4}>
+                      {components[componentUid]?.layout?.map((row, rowInd) => (
+                        <Grid.Item
+                          col={12}
+                          key={rowInd}
+                          s={12}
+                          xs={12}
+                          direction="column"
+                          alignItems="stretch"
+                        >
+                          <Grid.Root gap={4}>
+                            {row.map(({ size, ...field }) => {
+                              const fieldName = `${name}.${index}.${field.name}`;
 
-                          return (
-                            <Grid.Item
-                              col={size}
-                              key={fieldName}
-                              s={12}
-                              xs={12}
-                              direction="column"
-                              alignItems="stretch"
-                            >
-                              <InputRenderer {...field} name={fieldName} />
-                            </Grid.Item>
-                          );
-                        })}
-                      </Grid.Root>
-                    ))}
+                              return (
+                                <Grid.Item
+                                  col={size}
+                                  key={fieldName}
+                                  s={12}
+                                  xs={12}
+                                  direction="column"
+                                  alignItems="stretch"
+                                >
+                                  <InputRenderer {...field} name={fieldName} />
+                                </Grid.Item>
+                              );
+                            })}
+                          </Grid.Root>
+                        </Grid.Item>
+                      ))}
+                    </Grid.Root>
                   </Box>
                 </AccordionContentRadius>
               </Accordion.Content>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fix the inconsistent gap in dynamic section between components and fields.

### Why is it needed?

Re-wrapping the grid with another Grid.Root and Grid.item

### How to test it?

1. Go to /example/getstarted
2. Add a component field into blog/test-como
3. Insert a Kitchen Sink and add the Test como component, you will now see the gap

### Related issue(s)/PR(s)

Closes #21215