### PR TITLE
enhancement: add version param when send request to marketplace

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -90,7 +90,7 @@ const MarketplacePage = () => {
     possibleCollections,
     possibleCategories,
     pagination,
-  } = useMarketplaceData({ npmPackageType, debouncedSearch, query, tabQuery });
+  } = useMarketplaceData({ npmPackageType, debouncedSearch, query, tabQuery, strapiVersion });
 
   if (!isOnline) {
     return <OfflineLayout />;

--- a/packages/core/admin/admin/src/pages/Marketplace/hooks/useMarketplaceData.ts
+++ b/packages/core/admin/admin/src/pages/Marketplace/hooks/useMarketplaceData.ts
@@ -14,6 +14,7 @@ interface UseMarketplaceDataParams {
   debouncedSearch: string;
   query?: MarketplacePageQuery;
   tabQuery: TabQuery;
+  strapiVersion?: string | null;
 }
 
 type Collections =
@@ -101,6 +102,7 @@ function useMarketplaceData({
   debouncedSearch,
   query,
   tabQuery,
+  strapiVersion,
 }: UseMarketplaceDataParams) {
   const { notifyStatus } = useNotifyAT();
   const { formatMessage } = useIntl();
@@ -131,6 +133,7 @@ function useMarketplaceData({
     ...tabQuery.plugin,
     pagination: paginationParams,
     search: debouncedSearch,
+    version: strapiVersion,
   };
 
   const { data: pluginsResponse, status: pluginsStatus } = useQuery(
@@ -145,7 +148,6 @@ function useMarketplaceData({
         }
 
         const data = (await res.json()) as MarketplaceResponse<Plugin>;
-
         return data;
       } catch (error) {
         // silence
@@ -170,6 +172,7 @@ function useMarketplaceData({
     ...tabQuery.provider,
     pagination: paginationParams,
     search: debouncedSearch,
+    version: strapiVersion,
   };
 
   const { data: providersResponse, status: providersStatus } = useQuery(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

added a `version` parameter when sending request to market place

### Why is it needed?

Allow us to filter plugins depends on Strapi App version

more detailed description [here](https://strapi-inc.atlassian.net/browse/DX-1607)

### How to test it?

Inspect in dev tool under network tab, the payload (for both Plugins and Providers) should contain a `version` parameter when on the Marketplace page

### Related issue(s)/PR(s)

DX-1607
