### PR TITLE
fix: single relation input allowing multiple value

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -237,6 +237,10 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       };
 
       if (ONE_WAY_RELATIONS.includes(props.attribute.relation)) {
+        // Remove the existing relation so it can be replaced with the new one
+        if (relations.length > 0) {
+          field.onChange(`${props.name}.disconnect`, relations);
+        }
         field.onChange(`${props.name}.connect`, [item]);
       } else {
         field.onChange(`${props.name}.connect`, [...(field.value?.connect ?? []), item]);


### PR DESCRIPTION
### What does it do?

Prevents the relation input from having multiple relations selected for toOne relations.

This was only a frontend issue, the backend always only accepted 1 relation.
### Why is it needed?

Describe the issue you are solving.

### How to test it?

- Create a relation field of type oneWay, oneToOne, or manyToOne
- Add one relation in that field. Then another. It should replace the 1st one, never have the 2 relations at the same time
- Save the content
- Try to add another relation. It should replace the previous one. (it's at this step that we had the bug)
- Create a relation field of type oneToMany or manyToMany. You should be free to select several relations for it.
### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21240