### PR TITLE
fix: show Page Error on the EditView if you have errors in the useDoc…

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocument.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocument.ts
@@ -60,6 +60,7 @@ type UseDocument = (
   schema?: Schema;
   schemas?: Schema[];
   validate: (document: Document) => null | FormErrors;
+  hasError?: boolean;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -154,12 +155,14 @@ const useDocument: UseDocument = (args, opts) => {
   );
 
   const isLoading = isLoadingDocument || isFetchingDocument || isLoadingSchema;
+  const hasError = !!error;
 
   return {
     components,
     document: data?.data,
     meta: data?.meta,
     isLoading,
+    hasError,
     schema,
     schemas,
     validate,

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -55,6 +55,7 @@ const EditViewPage = () => {
     collectionType,
     id,
     model,
+    hasError,
   } = useDoc();
 
   const hasDraftAndPublished = schema?.options?.draftAndPublish ?? false;
@@ -119,6 +120,9 @@ const EditViewPage = () => {
 
     return transformDocument(schema, components)(form);
   }, [document, isCreatingDocument, isSingleType, schema, components]);
+  if (hasError) {
+    return <Page.Error />;
+  }
 
   if (isLoading && !document?.documentId) {
     return <Page.Loading />;


### PR DESCRIPTION
### What does it do?

it shows the Page.Error component in the case you have an error coming from the useDocument hook in the Edit view.

### Why is it needed?

It happens, in single types pages, for some roles, to have a Forbidden error when we try to see the Edit view of the single collection with a cascade of Notification errors, to avoid it we decided, at the moment, to show a Page Error

### How to test it?

 - Add a new user to the Author role
 - Access as an author
 - Access the existing single types
 - See the error page with just one notification error
 
### Related issue(s)/PR(s)
CS-1115
https://github.com/strapi/strapi/issues/21213