### PR TITLE
fix: solves username validation error

### DIFF
--- a/packages/core/admin/server/src/validation/common-validators.ts
+++ b/packages/core/admin/server/src/validation/common-validators.ts
@@ -18,7 +18,7 @@ export const firstname = yup.string().trim().min(1);
 
 export const lastname = yup.string();
 
-export const username = yup.string().min(1);
+export const username = yup.string();
 
 export const password = yup
   .string()

--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -28,8 +28,6 @@ const createUserBodySchema = yup.object().shape({
 
 const updateUserBodySchema = yup.object().shape({
   email: yup.string().email().min(1),
-
-  // change
   username: yup.string(),
   password: yup.string().min(1),
   role: yup.lazy((value) =>

--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -8,7 +8,7 @@ const deleteRoleSchema = yup.object().shape({
 
 const createUserBodySchema = yup.object().shape({
   email: yup.string().email().required(),
-  username: yup.string().min(1).required(),
+  username: yup.string().required(),
   password: yup.string().min(1).required(),
   role: yup.lazy((value) =>
     typeof value === 'object'
@@ -28,7 +28,9 @@ const createUserBodySchema = yup.object().shape({
 
 const updateUserBodySchema = yup.object().shape({
   email: yup.string().email().min(1),
-  username: yup.string().min(1),
+
+  // change
+  username: yup.string(),
   password: yup.string().min(1),
   role: yup.lazy((value) =>
     typeof value === 'object'


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Admin Users can update their data with blank usernames since username field isn't mandatory.

Video: https://www.loom.com/share/92aba52a789242798a49f1570e893136?sid=ee1c6126-b8c5-4882-a4b6-41cb00415396

### Why is it needed?

When creating a new admin user you don't normally set username and you can update other fields of the user when it's undefined but as soon as you set the username you cannot remove it (set it back to undefined) because the admin believes it's required.

### Related issue(s)/PR(s)

Fixes #20965

Let us know if this is related to any issue/pull request
