### PR TITLE
fix(content-releases): delete from release

### DIFF
--- a/packages/core/content-releases/server/src/controllers/release.ts
+++ b/packages/core/content-releases/server/src/controllers/release.ts
@@ -64,9 +64,15 @@ const releaseController = {
         populate: {
           actions: {
             fields: ['type'],
+            filters: {
+              contentType,
+              entryDocumentId: entryDocumentId ?? null,
+              locale: locale ?? null,
+            },
           },
         },
       });
+
       ctx.body = { data: releases };
     } else {
       const relatedReleases = await releaseService.findMany({


### PR DESCRIPTION
### What does it do?

Find releases with one entry attached was returning all the actions on the release and not only the action we are. With this change we only return the action with the entry.

### How to test it?

1. Create a release and add multiple entries to it
2. Try to delete from the release one of the last entries
3. It should delete the right entry

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21291
