### PR TITLE
fix(content-releases): invalidate documents when release is published

### DIFF
--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -79,7 +79,7 @@ const extendInvalidatesTags = (
 
 const releaseApi = adminApi
   .enhanceEndpoints({
-    addTagTypes: ['Release', 'ReleaseAction', 'EntriesInRelease', 'ReleaseSettings'],
+    addTagTypes: ['Release', 'ReleaseAction', 'EntriesInRelease', 'ReleaseSettings', 'Document'],
     endpoints: {
       updateDocument(endpoint: AnyEndpointDefinition) {
         extendInvalidatesTags(endpoint, [
@@ -330,7 +330,10 @@ const releaseApi = adminApi
               method: 'POST',
             };
           },
-          invalidatesTags: (result, error, arg) => [{ type: 'Release', id: arg.id }],
+          invalidatesTags: (result, error, arg) => [
+            { type: 'Release', id: arg.id },
+            { type: 'Document', id: `ALL_LIST` },
+          ],
         }),
         deleteRelease: build.mutation<DeleteRelease.Response, DeleteRelease.Request['params']>({
           query({ id }) {


### PR DESCRIPTION
### What does it do?

Invalidate documents list from CM when a Release is published.

### How to test it?

1. Create a release and add some entries in-draft to it.
2. Publish the release and go to the content-manager
3. Entries status should be updated 

