### PR TITLE
fix(rw): check transition permission to change assignee

### DIFF
--- a/packages/core/review-workflows/server/src/controllers/stages.ts
+++ b/packages/core/review-workflows/server/src/controllers/stages.ts
@@ -159,10 +159,9 @@ export default {
     }
 
     // Load entity
-    const locale = await validateLocale(query?.locale);
+    const locale = (await validateLocale(query?.locale)) ?? undefined;
     const entity = await strapi.documents(modelUID).findOne({
       documentId,
-      // @ts-expect-error - locale should be also null in the doc service types
       locale,
       populate: [ENTITY_STAGE_ATTRIBUTE],
     });

--- a/packages/core/review-workflows/server/src/routes/review-workflows.ts
+++ b/packages/core/review-workflows/server/src/routes/review-workflows.ts
@@ -135,7 +135,7 @@ export default {
           {
             name: 'admin::hasPermissions',
             config: {
-              actions: ['admin::users.read', 'admin::review-workflows.read'],
+              actions: ['admin::users.read'],
             },
           },
         ],


### PR DESCRIPTION
### What does it do?

fixes https://github.com/strapi/strapi/issues/21292

Basically we were checking for the "view review workflows settings" permission to update the stage, which was wrong.

So I removed it, and after [checking with Yannis](https://strapihq.slack.com/archives/C051PLC9CF7/p1726562903262239), I added a check to only allow a user to change the assignee if they have the permission to change the current stage

Note that this is only a backend fix, the field is not disabled in the frontend, but you should see the error message in the field if you don't have the permission.

### How to test it?

Follow the steps listed in Yannis' issue: https://github.com/strapi/strapi/issues/21292
