### PR TITLE
fix: fix null value bypassing required fields

### DIFF
--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -241,11 +241,7 @@ type ValidationFn = (
   options: ValidationOptions
 ) => <TSchema extends AnySchema>(schema: TSchema) => TSchema;
 
-const addRequiredValidation: ValidationFn = (attribute, options) => (schema) => {
-  if (options.status === 'draft') {
-    return nullableSchema(schema);
-  }
-
+const addRequiredValidation: ValidationFn = (attribute) => (schema) => {
   if (
     ((attribute.type === 'component' && attribute.repeatable) ||
       attribute.type === 'dynamiczone') &&


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removed the code that allowed null values to be accepted for fields marked as required in the validation schema

### Why is it needed?

check description of issue 1 and issue 2 in #21285 

The root cause of the issues lies in the `createYupSchema` function:

- The function generates the `validationSchema` passed to the form component.
- When the `status` value is 'draft', the generated schema allows null values for all fields, including required ones.

As a result:

1. When a required text field is cleared, it becomes null.
2. The client-side validation, using the generated `ValidationSchema`, doesn't flag null value as an error.
3. The form submission bypasses client-side validation. (issue 2)
4. The null value is submitted directly to the API for the cleared required field, so the API returns the server side error directly (issue 1)

### How to test it?

For Issue 1:

Create an entry of a CT with a required field
Fill in content other than the required field
Save (this works fine)
Publish - on the required field, see the error message `this field is required`

For Issue 2:

Save and publish content with the required field filled - this works as expected
From the published entry clear the required field
Directly publish - should see the error message `this field is required` again.
### Related issue(s)/PR(s)

#21285 

DX-1616
