### PR TITLE
Fix 20597: Wrong Modal Height for the Component field

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -1008,7 +1008,9 @@ export const FormModal = () => {
           />
         )}
         {!isPickingAttribute && (
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit}
+           style={{overflow:'auto'}}
+          >
             <Modal.Body>
               <Tabs.Root
                 variant="simple"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added the Scroll in Modal Form.

### Why is it needed?

To fix issue 20597: Wrong Modal Height for the Component field

### How to test it?

Go to CTB
Create a CT with a component
In Component modal, check the footer

### Related issue(s)/PR(s)

#20597 