### PR TITLE
chore: v4-to-v5 warning on changed packages

### DIFF
--- a/packages/cli/create-strapi-starter/README.md
+++ b/packages/cli/create-strapi-starter/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Create strapi starter
 
 This package includes the `create-strapi-starter` CLI to simplify creating a Strapi project using starters and templates

--- a/packages/core/content-manager/README.md
+++ b/packages/core/content-manager/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Strapi Content Manager
 
 ## Description

--- a/packages/core/content-type-builder/README.md
+++ b/packages/core/content-type-builder/README.md
@@ -1,1 +1,5 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Strapi plugin

--- a/packages/core/email/README.md
+++ b/packages/core/email/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Strapi plugin
 
 > :warning: The Shipper Email may also need to be changed in the `Email Templates` tab on the admin panel for emails to send properly

--- a/packages/core/helper-plugin/README.md
+++ b/packages/core/helper-plugin/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Strapi Helper Plugin
 
 ## Description

--- a/packages/core/upload/README.md
+++ b/packages/core/upload/README.md
@@ -1,1 +1,5 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # strapi-plugin-upload

--- a/packages/plugins/i18n/README.md
+++ b/packages/plugins/i18n/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> This package is only compatible with Strapi v4 version <br/>
+> i18N is now a core feature of Strapi 5 and doesn't need to be installed <br/>
+> The most recent versions of Strapi packages can be found at [https://github.com/strapi/strapi](https://github.com/strapi/strapi)
+
 # Strapi plugin i18n
 
 The Internationalization (i18n) plugin allows Strapi users to create, manage and distribute localized content in different languages, called "locales". For more information about the concept of internationalization, please refer to the [W3C definition](https://www.w3.org/International/questions/qa-i18n.en#i18n).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add warning banners to be published during next v4 release