### PR TITLE
fix: correct spelling of keycloak provider

### DIFF
--- a/packages/plugins/users-permissions/server/services/providers-registry.js
+++ b/packages/plugins/users-permissions/server/services/providers-registry.js
@@ -500,7 +500,7 @@ const initProviders = ({ baseURL, purest }) => ({
         });
     },
   },
-  keycloack: {
+  keycloak: {
     enabled: false,
     icon: '',
     grantConfig: {


### PR DESCRIPTION
Corrected TYPO in keycloak provider

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes issue #21391 

### Why is it needed?

Default configuration of keycloak provider does not work.

### How to test it?

Configure the provider according to https://docs.strapi.io/dev-docs/plugins/users-permissions#keycloak-config

### Related issue(s)/PR(s)

No related issues
