### PR TITLE
FIX 21368: fixed the pagination showing for less assets

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.jsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/index.jsx
@@ -374,7 +374,7 @@ export const BrowseStep = ({
         </>
       )}
 
-      {pagination.pageCount > 0 && (
+      {pagination.total > pagination.pageSize && (
         <Flex justifyContent="space-between" paddingTop={4}>
           <PageSize pageSize={queryObject.pageSize} onChangePageSize={onChangePageSize} />
           <PaginationFooter
@@ -420,6 +420,10 @@ BrowseStep.propTypes = {
     sort: PropTypes.string,
     folder: PropTypes.number,
   }).isRequired,
-  pagination: PropTypes.shape({ pageCount: PropTypes.number.isRequired }).isRequired,
+  pagination: PropTypes.shape({
+    pageCount: PropTypes.number.isRequired,
+    pageSize: PropTypes.number,
+    total: PropTypes.number,
+  }).isRequired,
   selectedAssets: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };


### PR DESCRIPTION
### What does it do?

Fixed the pagination showing for less number of Assets

### Why is it needed?

To fix issue [21368](https://github.com/strapi/strapi/issues/21368): When the number of assets is lower than the amount that should be displayed, the pagination shouldn’t be visible


### How to test it?

1. Open the Content Manager.
2. Select a collection type or single type that allows you to add an image.
3. Add an image; pagination should appear if the asset count exceeds the page size.

### Related issue(s)/PR(s)

[#21368](https://github.com/strapi/strapi/issues/21368)
