### PR TITLE
feat(review-workflows): check entry stage before publish

### DIFF
--- a/packages/core/review-workflows/server/src/bootstrap.ts
+++ b/packages/core/review-workflows/server/src/bootstrap.ts
@@ -54,4 +54,5 @@ export default async (args: any) => {
   const docsMiddlewares = getService('document-service-middlewares');
   strapi.documents.use(docsMiddlewares.assignStageOnCreate);
   strapi.documents.use(docsMiddlewares.handleStageOnUpdate);
+  strapi.documents.use(docsMiddlewares.checkStageBeforePublish);
 };

--- a/tests/e2e/tests/review-workflows/settings.spec.ts
+++ b/tests/e2e/tests/review-workflows/settings.spec.ts
@@ -100,32 +100,65 @@ describeOnCondition(edition === 'EE')('settings', () => {
   test('as a user I want to be able to set a required stage for publishing', async ({ page }) => {
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByRole('link', { name: 'Review Workflows' }).click();
+    await page.getByRole('link', { name: 'Create new workflow' }).click();
 
-    // Click on the existing workflow
-    await page.getByRole('link', { name: 'Default' }).click();
+    /**
+     * Create the dummy workflow
+     */
+    await page.getByRole('textbox', { name: 'Workflow Name' }).fill('Publish Workflow');
+    await page.getByRole('combobox', { name: 'Associated to' }).click();
+    await page.getByRole('option', { name: 'Author' }).click();
+    await page.keyboard.press('Escape');
 
-    // Add a new stage
-    await page.getByRole('button', { name: 'Add new stage' }).click();
-    await page
-      .getByRole('region', { name: '', exact: true })
-      .getByLabel('Stage name*')
-      .fill('Required Stage');
-    await page.getByRole('region', { name: 'Required Stage' }).getByLabel('Color').click();
-    await page.getByRole('option', { name: 'Yellow', exact: true }).click();
+    for (const stage of [
+      { name: 'Draft', color: 'Blue' },
+      { name: 'Review', color: 'Lilac' },
+      { name: 'Done', color: 'Green' },
+    ]) {
+      await page.getByRole('button', { name: 'Add new stage' }).click();
+      await page
+        .getByRole('region', { name: '', exact: true })
+        .getByLabel('Stage name*')
+        .fill(stage.name);
+      await page.getByRole('region', { name: stage.name }).getByLabel('Color').click();
+      await page.getByRole('option', { name: stage.color, exact: true }).click();
+    }
 
-    // Set the new stage as required for publishing
+    // Set a stage as required for publishing
     await page.getByRole('combobox', { name: 'Required stage for publishing' }).click();
-    await page.getByRole('option', { name: 'Required Stage' }).click();
+    await page.getByRole('option', { name: 'Done' }).click();
 
-    // Save changes
+    // Save workflow
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Updated Workflow');
+    await findAndClose(page, 'Created workflow');
 
     // Verify changes
     const requiredStageCombobox = page.getByRole('combobox', {
       name: 'Required stage for publishing',
     });
     await expect(requiredStageCombobox).toBeVisible();
-    await expect(requiredStageCombobox.locator('span').first()).toHaveText('Required Stage');
+    await expect(requiredStageCombobox.locator('span').first()).toHaveText('Done');
+
+    // Navigate to Content Manager to check validation is working
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+
+    // Go to the entry
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+    await page.getByRole('link', { name: 'Author' }).click();
+    await page.getByRole('gridcell', { name: 'Ted Lasso' }).click();
+    await page.getByRole('textbox', { name: 'Name' }).fill('Ted Laso');
+
+    // Try to publish without reaching the required stage
+    await page.getByRole('button', { name: 'Publish' }).click();
+    await expect(page.getByText('Entry is not at the required stage to publish')).toBeVisible();
+
+    // Change the stage to the required one & publish
+    await page.getByRole('combobox', { name: 'Review stage' }).click();
+    await page.getByRole('option', { name: 'Done' }).click();
+    await findAndClose(page, 'Review stage updated');
+
+    await page.getByRole('button', { name: 'Publish' }).click();
+
+    await expect(page.getByText('Published document')).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

Add validation when ContentType is related to one RW with required stage for publish. Entry only will be published if the entry is at the right stage.

### How to test it?

1. Create one RW with a required stage for publish and assign it to one Content Type.
2. Create or go to an already existing entry of that Content Type and put it in a wrong stage
3. Try to publish, it should throw an error
4. Change entry's stage for the required one and try to publish
5. It should publish with no errors
