### PR TITLE
fix: Filter by text field with "&" symbol doesn't work #20271

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -120,7 +120,7 @@ const PopoverImpl = () => {
   }
 
   const handleSubmit = (data: FilterFormData) => {
-    const value = FILTERS_WITH_NO_VALUE.includes(data.filter) ? 'true' : data.value;
+    const value = FILTERS_WITH_NO_VALUE.includes(data.filter) ? 'true' : encodeURIComponent(data.value as string);
 
     if (!value) {
       return;

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -120,7 +120,9 @@ const PopoverImpl = () => {
   }
 
   const handleSubmit = (data: FilterFormData) => {
-    const value = FILTERS_WITH_NO_VALUE.includes(data.filter) ? 'true' : encodeURIComponent(data.value as string);
+    const value = FILTERS_WITH_NO_VALUE.includes(data.filter)
+      ? 'true'
+      : encodeURIComponent(data.value as string);
 
     if (!value) {
       return;

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -122,7 +122,7 @@ const PopoverImpl = () => {
   const handleSubmit = (data: FilterFormData) => {
     const value = FILTERS_WITH_NO_VALUE.includes(data.filter)
       ? 'true'
-      : encodeURIComponent(data.value as string);
+      : encodeURIComponent(data.value ?? '');
 
     if (!value) {
       return;

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -100,9 +100,10 @@ const ListViewPage = () => {
   });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
+  const queryString = React.useMemo(() => stringify(params, { encode: true, encodeValuesOnly: true }), [params]);
   const { data, error, isFetching } = useGetAllDocumentsQuery({
     model,
-    params,
+    queryString
   });
 
   /**
@@ -187,7 +188,7 @@ const ListViewPage = () => {
     trackUsage('willEditEntryFromList');
     navigate({
       pathname: id.toString(),
-      search: stringify({ plugins: query.plugins }),
+      search: queryString,
     });
   };
 

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -100,10 +100,21 @@ const ListViewPage = () => {
   });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
-  const queryString = React.useMemo(() => stringify(params, { encode: true, encodeValuesOnly: true }), [params]);
+  const queryString = React.useMemo(
+    () => stringify(params, { encode: true, encodeValuesOnly: true }),
+    [params]
+  );
+  const paramObject = React.useMemo(() => {
+    const pairs = queryString.split('&').map((param) => {
+      const [key, value] = param.split('=');
+      return { [key]: value };
+    });
+    return Object.assign({}, ...pairs);
+  }, [queryString]);
+
   const { data, error, isFetching } = useGetAllDocumentsQuery({
     model,
-    queryString
+    params: paramObject,
   });
 
   /**
@@ -188,7 +199,7 @@ const ListViewPage = () => {
     trackUsage('willEditEntryFromList');
     navigate({
       pathname: id.toString(),
-      search: queryString,
+      search: stringify({ plugins: query.plugins }),
     });
   };
 

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -159,18 +159,11 @@ const documentApi = contentManagerApi.injectEndpoints({
      */
     getAllDocuments: builder.query<
       Find.Response,
-      Find.Params & {
-        params?: Find.Request['query'] & {
-          [key: string]: any;
-        };
-      }
+      Find.Params & { queryString?: string; }
     >({
-      query: ({ model, params }) => ({
-        url: `/content-manager/collection-types/${model}`,
+      query: ({ model, queryString }) => ({
+        url: `/content-manager/collection-types/${model}${queryString ? `?${queryString}` : ''}`,
         method: 'GET',
-        config: {
-          params,
-        },
       }),
       providesTags: (result, _error, arg) => {
         return [

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -159,11 +159,18 @@ const documentApi = contentManagerApi.injectEndpoints({
      */
     getAllDocuments: builder.query<
       Find.Response,
-      Find.Params & { queryString?: string; }
+      Find.Params & {
+        params?: Find.Request['query'] & {
+          [key: string]: any;
+        };
+      }
     >({
-      query: ({ model, queryString }) => ({
-        url: `/content-manager/collection-types/${model}${queryString ? `?${queryString}` : ''}`,
+      query: ({ model, params }) => ({
+        url: `/content-manager/collection-types/${model}${params ? `?${params}` : ''}`,
         method: 'GET',
+        config: {
+          params,
+        },
       }),
       providesTags: (result, _error, arg) => {
         return [

--- a/packages/core/upload/admin/src/components/FilterList/index.jsx
+++ b/packages/core/upload/admin/src/components/FilterList/index.jsx
@@ -15,7 +15,7 @@ const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }) => {
     const nextFilters = appliedFilters.filter((prevFilter) => {
       const name = Object.keys(filter)[0];
       const filterType = Object.keys(filter[name])[0];
-      const value = filter[name][filterType];
+      const value = decodeURIComponent(filter[name][filterType]);
 
       return prevFilter[name]?.[filterType] !== value;
     });
@@ -29,7 +29,7 @@ const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }) => {
 
     const filterObj = filter[attributeName];
     const operator = Object.keys(filterObj)[0];
-    let value = filterObj[operator];
+    let value = decodeURIComponent(filterObj[operator]);
     let displayedOperator = operator;
 
     if (attribute.name === 'mime') {

--- a/packages/core/upload/admin/src/components/FilterList/index.jsx
+++ b/packages/core/upload/admin/src/components/FilterList/index.jsx
@@ -29,7 +29,16 @@ const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }) => {
 
     const filterObj = filter[attributeName];
     const operator = Object.keys(filterObj)[0];
-    let value = decodeURIComponent(filterObj[operator]);
+    let value = filterObj[operator];
+
+    if (Array.isArray(value)) {
+      value = value.join(', ');
+    } else if (typeof value === 'object') {
+      value = Object.values(value).join(', ');
+    } else {
+      value = decodeURIComponent(value);
+    }
+
     let displayedOperator = operator;
 
     if (attribute.name === 'mime') {

--- a/packages/core/upload/admin/src/components/FilterList/index.jsx
+++ b/packages/core/upload/admin/src/components/FilterList/index.jsx
@@ -36,7 +36,10 @@ const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }) => {
     } else if (typeof value === 'object') {
       value = Object.values(value).join(', ');
     } else {
-      value = decodeURIComponent(value);
+      value =
+        Array.isArray(value) || typeof value === 'object'
+          ? Object.values(value).join(', ')
+          : decodeURIComponent(value);
     }
 
     let displayedOperator = operator;

--- a/packages/core/upload/admin/src/components/FilterList/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/FilterList/tests/__snapshots__/index.test.js.snap
@@ -202,7 +202,7 @@ exports[`<FilterList /> renders and matches the snapshot 1`] = `
     <span
       class="c2 c3"
     >
-      type is [object Object]
+      type is image, video
     </span>
     <button
       aria-disabled="false"

--- a/packages/core/upload/admin/src/components/FilterList/tests/__snapshots__/index.test.js.snap
+++ b/packages/core/upload/admin/src/components/FilterList/tests/__snapshots__/index.test.js.snap
@@ -202,7 +202,7 @@ exports[`<FilterList /> renders and matches the snapshot 1`] = `
     <span
       class="c2 c3"
     >
-      type is not file
+      type is [object Object]
     </span>
     <button
       aria-disabled="false"

--- a/packages/core/upload/admin/src/components/FilterPopover/index.jsx
+++ b/packages/core/upload/admin/src/components/FilterPopover/index.jsx
@@ -58,7 +58,9 @@ const FilterPopover = ({ displayedFilters, filters, onSubmit, onToggle }) => {
     e.preventDefault();
     e.stopPropagation();
 
-    if (modifiedData.value) {
+    const encodedValue = encodeURIComponent(modifiedData.value);
+
+    if (encodedValue) {
       if (modifiedData.name === 'mime') {
         const alreadyAppliedFilters = filters.filter((filter) => {
           return Object.keys(filter)[0] === 'mime';
@@ -177,12 +179,12 @@ const FilterPopover = ({ displayedFilters, filters, onSubmit, onToggle }) => {
         filters.find((filter) => {
           return (
             filter[modifiedData.name] &&
-            filter[modifiedData.name]?.[modifiedData.filter] === modifiedData.value
+            filter[modifiedData.name]?.[modifiedData.filter] === encodedValue
           );
         }) !== undefined;
 
       if (!hasFilter) {
-        let filterToAdd = { [modifiedData.name]: { [modifiedData.filter]: modifiedData.value } };
+        let filterToAdd = { [modifiedData.name]: { [modifiedData.filter]: encodedValue } };
 
         const nextFilters = [...filters, filterToAdd];
 


### PR DESCRIPTION
What does it do?
Fixes a bug where filtering by text fields containing the "&" symbol fails due to improper encoding and decoding of query parameters.

Why is it needed?
Without this fix, users cannot correctly filter records by text fields containing special characters such as "&", which significantly hampers the usability of the filtering functionality.

How to test it?
Create an entity in a collection type with a text field containing the "&" symbol.
Example: Create an article titled "Test article & issue reproduce".
Go to the list of the collection type.
Use the "Filters" button to select the text field, "is" operand, and text with the "&" symbol.
Click "Add filter".
Verify that the filter is applied correctly and the appropriate records are displayed.

![image](https://github.com/user-attachments/assets/aa20c2b9-7d89-44d0-bf47-5543788cf07f)

Related issue(s)/PR(s)
#20271 