### PR TITLE
enhancement: change all internal cron tasks to named tasks

### DIFF
--- a/packages/core/admin/ee/server/src/services/metrics.ts
+++ b/packages/core/admin/ee/server/src/services/metrics.ts
@@ -49,7 +49,10 @@ const sendUpdateProjectInformation = async (strapi: Core.Strapi) => {
 
 const startCron = (strapi: Core.Strapi) => {
   strapi.cron.add({
-    '0 0 0 * * *': () => sendUpdateProjectInformation(strapi),
+    sendProjectInformation: {
+      task: () => sendUpdateProjectInformation(strapi),
+      options: '0 0 0 * * *',
+    },
   });
 };
 

--- a/packages/core/admin/server/src/services/metrics.ts
+++ b/packages/core/admin/server/src/services/metrics.ts
@@ -30,7 +30,10 @@ const sendUpdateProjectInformation = async (strapi: Core.Strapi) => {
 
 const startCron = (strapi: Core.Strapi) => {
   strapi.cron.add({
-    '0 0 0 * * *': () => sendUpdateProjectInformation(strapi),
+    sendProjectInformation: {
+      task: () => sendUpdateProjectInformation(strapi),
+      options: '0 0 0 * * *',
+    },
   });
 };
 

--- a/packages/core/core/src/ee/index.ts
+++ b/packages/core/core/src/ee/index.ts
@@ -205,7 +205,13 @@ const checkLicense = async ({ strapi }: { strapi: Core.Strapi }) => {
 
   if (!shouldStayOffline) {
     await onlineUpdate({ strapi });
-    strapi.cron.add({ [shiftCronExpression('0 0 */12 * * *')]: onlineUpdate });
+
+    strapi.cron.add({
+      onlineUpdate: {
+        task: () => onlineUpdate({ strapi }),
+        options: shiftCronExpression('0 0 */12 * * *'),
+      },
+    });
   } else {
     if (!ee.licenseInfo.expireAt) {
       return disable('Your license does not have offline support.');

--- a/packages/core/review-workflows/server/src/services/metrics/weekly-metrics.ts
+++ b/packages/core/review-workflows/server/src/services/metrics/weekly-metrics.ts
@@ -70,7 +70,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     async registerCron() {
       const weeklySchedule = await this.ensureWeeklyStoredCronSchedule();
 
-      strapi.cron.add({ [weeklySchedule]: this.sendMetrics.bind(this) });
+      strapi.cron.add({
+        reviewWorkflowsWeekly: {
+          task: this.sendMetrics.bind(this),
+          options: weeklySchedule,
+        },
+      });
     },
   };
 };

--- a/packages/core/upload/server/src/services/weekly-metrics.ts
+++ b/packages/core/upload/server/src/services/weekly-metrics.ts
@@ -129,6 +129,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async registerCron() {
     const weeklySchedule = await this.ensureWeeklyStoredCronSchedule();
 
-    strapi.cron.add({ [weeklySchedule]: this.sendMetrics.bind(this) });
+    strapi.cron.add({
+      uploadWeekly: {
+        task: this.sendMetrics.bind(this),
+        options: weeklySchedule,
+      },
+    });
   },
 });


### PR DESCRIPTION
## What this does

Previously all of our built-in metrics based cron tasks were using the simplified format:

```js
cron.add({
  '*/1 * * * *': () => console.log('A minute has passed.'),
});
```

And they have been changed to use the named format

```js
cron.add({
  myTask: {
    task,
    options: '*/5 * * * *', // Executes every 5 minutes.
  },
});
```

## Why this change

As the maintainer of the Strapi Redis Plugin and with the new changes coming in my plugin for Strapi 5 I'm integrating the Redlock package which automatically forces all cron-tasks to use red-locks to prevent clustered environments from running the same task at the same time.

In essence what this could do is help prevent duplicate data being sent to the telemetry system from the same project running in a horizontal or vertical cluster mode.

## How to test it

Simply run Strapi in console mode and review the output of `strapi.cron.jobs` and see that all of the built in cron-tasks now have a specified name instead of being anonymous tasks 