### PR TITLE
Revise database/index to skip .withSchema when no tableName passed to strapi.db.getConnection()

### DIFF
--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -166,6 +166,7 @@ class Database {
   getConnection(): Knex;
   getConnection(tableName?: string): Knex.QueryBuilder;
   getConnection(tableName?: string): Knex | Knex.QueryBuilder {
+    if (!tableName) return this.connection;
     const schema = this.getSchemaName();
     const connection = tableName ? this.connection(tableName) : this.connection;
     return schema ? connection.withSchema(schema) : connection;


### PR DESCRIPTION
This was breaking in unidrectional-relations.js, returning a QueryBuilder object instead of a Knex object.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Skips the connection.withSchema directive if tableName is NOT provided. Otherwise, strapi.db.getConnection() returns a QueryBuilder instance instead of a Knex instance.

### Why is it needed?

unidrectional-relations.js was breaking on Publish of a saved entry with:
```
TypeError: con.batchInsert is not a function
    at .../server/node_modules/@strapi/core/dist/services/document-service/utils/unidirectional-relations.js:69:17
```


### How to test it?

Save an entry with unidrectional relationship to another object. Publish it. Then try to update, save, Publish.

**Result:**
<img width="710" alt="image" src="https://github.com/user-attachments/assets/a198adaf-34a1-4b80-a408-99c1704cc728">

**After revision** to return Knex object instead of QueryBuilder, the Publish function works:
<img width="563" alt="image" src="https://github.com/user-attachments/assets/83f96b60-3993-4177-8de2-b2f487e1c53d">



