### PR TITLE
fix: cm relations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ As of September 2024 (and until this document is updated), only the v4.x.x and v
 **Note**: The v4.x.x LTS version will only receive high/critical severity fixes until April 2026. Any Medium/Low severity issues will not be fixed unless specific exceptions are made.
 
 | Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes                          |
-|---------|-------------|----------------|----------------|------------------------|--------------------------------|
+| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------------------------ |
 | 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS                            |
 | 5.x.x   | RC          | N/A            | September 2024 | N/A                    | Not Supported                  |
 | 5.x.x   | Beta        | N/A            | N/A            | N/A                    | Not Supported                  |

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -120,6 +120,7 @@ const EditViewPage = () => {
 
     return transformDocument(schema, components)(form);
   }, [document, isCreatingDocument, isSingleType, schema, components]);
+
   if (hasError) {
     return <Page.Error />;
   }

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -19,9 +19,10 @@ import {
   ButtonProps,
 } from '@strapi/design-system';
 import { Cross, More, WarningCircle } from '@strapi/icons';
+import mapValues from 'lodash/fp/mapValues';
 import { useIntl } from 'react-intl';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { styled, DefaultTheme } from 'styled-components';
+import { DefaultTheme } from 'styled-components';
 
 import { PUBLISHED_AT_ATTRIBUTE_NAME } from '../../../constants/attributes';
 import { SINGLE_TYPES } from '../../../constants/collections';
@@ -35,6 +36,7 @@ import { getTranslation } from '../../../utils/translations';
 
 import type { RelationsFormValue } from './FormInputs/Relations';
 import type { DocumentActionComponent } from '../../../content-manager';
+
 /* -------------------------------------------------------------------------------------------------
  * Types
  * -----------------------------------------------------------------------------------------------*/
@@ -493,6 +495,22 @@ const DocumentActionModal = ({
   );
 };
 
+const transformData = (data: Record<string, any>): any => {
+  if (Array.isArray(data)) {
+    return data.map(transformData);
+  }
+
+  if (typeof data === 'object' && data !== null) {
+    if ('api_data' in data) {
+      return data.api_data;
+    }
+
+    return mapValues(transformData)(data);
+  }
+
+  return data;
+};
+
 /* -------------------------------------------------------------------------------------------------
  * DocumentActionComponents
  * -----------------------------------------------------------------------------------------------*/
@@ -643,7 +661,7 @@ const PublishAction: DocumentActionComponent = ({
           documentId,
           params,
         },
-        formValues
+        transformData(formValues)
       );
 
       if ('data' in res && collectionType !== SINGLE_TYPES) {
@@ -797,7 +815,7 @@ const UpdateAction: DocumentActionComponent = ({
               documentId: cloneMatch.params.origin!,
               params,
             },
-            document
+            transformData(document)
           );
 
           if ('data' in res) {
@@ -823,7 +841,7 @@ const UpdateAction: DocumentActionComponent = ({
               documentId,
               params,
             },
-            document
+            transformData(document)
           );
 
           if (
@@ -841,7 +859,7 @@ const UpdateAction: DocumentActionComponent = ({
               model,
               params,
             },
-            document
+            transformData(document)
           );
 
           if ('data' in res && collectionType !== SINGLE_TYPES) {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -501,8 +501,8 @@ const transformData = (data: Record<string, any>): any => {
   }
 
   if (typeof data === 'object' && data !== null) {
-    if ('api_data' in data) {
-      return data.api_data;
+    if ('apiData' in data) {
+      return data.apiData;
     }
 
     return mapValues(transformData)(data);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -208,6 +208,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
 
     const realServerRelationsCount =
       'pagination' in data && data.pagination ? data.pagination.total : 0;
+
     /**
      * Items that are already connected, but reordered would be in
      * this list, so to get an accurate figure, we remove them.

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -86,7 +86,7 @@ function useHandleDisconnect(fieldName: string, consumerName: string) {
 
     addFieldRow(`${fieldName}.disconnect`, {
       id: relation.id,
-      api_data: {
+      apiData: {
         documentId: relation.documentId,
       },
     });
@@ -150,10 +150,10 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
     const isMorph = props.attribute.relation.toLowerCase().includes('morph');
     const isDisabled = isMorph || disabled;
 
-    const { id: componentId, uid: componentUID } = useComponent(
-      'RelationsField',
-      ({ uid, id }) => ({ id, uid })
-    );
+    const { componentId, componentUID } = useComponent('RelationsField', ({ uid, id }) => ({
+      componentId: id,
+      componentUID: uid,
+    }));
 
     /**
      * We'll always have a documentId in a created entry, so we look for a componentId first.
@@ -267,7 +267,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
 
       const item = {
         id: relation.id,
-        api_data: {
+        apiData: {
           documentId: relation.documentId,
           locale: relation.locale,
         },

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -88,6 +88,7 @@ function useHandleDisconnect(fieldName: string, consumerName: string) {
       id: relation.id,
       apiData: {
         documentId: relation.documentId,
+        locale: relation.locale,
       },
     });
   };

--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -67,11 +67,8 @@ const relationsApi = contentManagerApi.injectEndpoints({
              * Relations will always have unique IDs, so we can therefore assume
              * that we only need to push the new items to the cache.
              */
-            const existingIds = currentCache.results.map((item) => item.documentId);
-            const uniqueNewItems = newItems.results.filter(
-              (item) => !existingIds.includes(item.documentId)
-            );
-            currentCache.results.push(...prepareTempKeys(uniqueNewItems, currentCache.results));
+
+            currentCache.results.push(...prepareTempKeys(newItems.results, currentCache.results));
             currentCache.pagination = newItems.pagination;
           } else if (newItems.pagination.page === 1) {
             /**

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -460,15 +460,7 @@ export default {
 
     const relationsUnion = uniqBy(
       (res: any) => {
-        // return `${res.documentId}-${res.locale}`;
-
-        // if (sourceModelType === 'component') {
-        //   return res.id;
-        // }
-
-        return res.locale
-          ? `${res.documentId}-${res.locale}`
-          : `${res.documentId}-`;
+        return res.locale ? `${res.documentId}-${res.locale}` : `${res.documentId}`;
       },
 
       concat(sanitizedRes.results, res.results)

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -459,7 +459,18 @@ export default {
     });
 
     const relationsUnion = uniqBy(
-      (res: any) => `${res.documentId}-${res.locale}`,
+      (res: any) => {
+        // return `${res.documentId}-${res.locale}`;
+
+        // if (sourceModelType === 'component') {
+        //   return res.id;
+        // }
+
+        return res.locale
+          ? `${res.documentId}-${res.locale}`
+          : `${res.documentId}-`;
+      },
+
       concat(sanitizedRes.results, res.results)
     );
 

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -458,7 +458,10 @@ export default {
       ordering: 'desc',
     });
 
-    const relationsUnion = uniqBy('documentId', concat(sanitizedRes.results, res.results));
+    const relationsUnion = uniqBy(
+      (res: any) => `${res.documentId}-${res.locale}`,
+      concat(sanitizedRes.results, res.results)
+    );
 
     ctx.body = {
       pagination: res.pagination || {

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -458,7 +458,7 @@ export default {
       ordering: 'desc',
     });
 
-    const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));
+    const relationsUnion = uniqBy('documentId', concat(sanitizedRes.results, res.results));
 
     ctx.body = {
       pagination: res.pagination || {

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -7,11 +7,11 @@ import type { DocumentMetadata } from '../../../shared/contracts/collection-type
 import { getValidatableFieldsPopulate } from './utils/populate';
 
 export interface DocumentVersion {
-  id: number;
+  id: string | number;
   documentId: Modules.Documents.ID;
-  locale: string;
-  updatedAt: string | null | Date;
-  publishedAt: string | null | Date;
+  locale?: string;
+  updatedAt?: string | null | Date;
+  publishedAt?: string | null | Date;
 }
 
 const AVAILABLE_STATUS_FIELDS = [
@@ -86,7 +86,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const versionsByLocale = groupBy('locale', allVersions);
 
     // Delete the current locale
-    delete versionsByLocale[version.locale];
+    if (version.locale) {
+      delete versionsByLocale[version.locale];
+    }
 
     // For each locale, get the ones with the same status
     // There will not be a draft and a version counterpart if the content

--- a/packages/core/content-manager/server/src/utils/index.ts
+++ b/packages/core/content-manager/server/src/utils/index.ts
@@ -1,8 +1,11 @@
 import '@strapi/types';
+
 import { DocumentManagerService } from 'src/services/document-manager';
+import DocumentMetadata from 'src/services/document-metadata';
 
 type Services = {
   'document-manager': DocumentManagerService;
+  'document-metadata': typeof DocumentMetadata;
   [key: string]: any;
 };
 

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -292,8 +292,8 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
 
     // Load any unidirectional relation targetting the old published entries
     const relationsToSync = await unidirectionalRelations.load(uid, {
-      draftVersions: draftsToPublish,
-      publishedVersions: oldPublishedVersions,
+      newVersions: draftsToPublish,
+      oldVersions: oldPublishedVersions,
     });
 
     // Delete old published versions
@@ -366,8 +366,8 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
 
     // Load any unidirectional relation targeting the old drafts
     const relationsToSync = await unidirectionalRelations.load(uid, {
-      draftVersions: [],
-      publishedVersions: oldDrafts,
+      newVersions: versionsToDraft,
+      oldVersions: oldDrafts,
     });
 
     // Delete old drafts
@@ -379,7 +379,11 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     );
 
     // Sync unidirectional relations with the new draft entries
-    await unidirectionalRelations.sync(oldDrafts, draftEntries, relationsToSync);
+    await unidirectionalRelations.sync(
+      [...oldDrafts, ...versionsToDraft],
+      draftEntries,
+      relationsToSync
+    );
 
     draftEntries.forEach(emitEvent('entry.draft-discard'));
     return { documentId, entries: draftEntries };

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -291,7 +291,10 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     ]);
 
     // Load any unidirectional relation targetting the old published entries
-    const relationsToSync = await unidirectionalRelations.load(uid, oldPublishedVersions);
+    const relationsToSync = await unidirectionalRelations.load(uid, {
+      draftVersions: draftsToPublish,
+      publishedVersions: oldPublishedVersions,
+    });
 
     // Delete old published versions
     await async.map(oldPublishedVersions, (entry: any) => entries.delete(entry.id));
@@ -302,7 +305,11 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     );
 
     // Sync unidirectional relations with the new published entries
-    await unidirectionalRelations.sync(oldPublishedVersions, publishedEntries, relationsToSync);
+    await unidirectionalRelations.sync(
+      [...oldPublishedVersions, ...draftsToPublish],
+      publishedEntries,
+      relationsToSync
+    );
 
     publishedEntries.forEach(emitEvent('entry.publish'));
 
@@ -358,7 +365,10 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     ]);
 
     // Load any unidirectional relation targeting the old drafts
-    const relationsToSync = await unidirectionalRelations.load(uid, oldDrafts);
+    const relationsToSync = await unidirectionalRelations.load(uid, {
+      draftVersions: [],
+      publishedVersions: oldDrafts,
+    });
 
     // Delete old drafts
     await async.map(oldDrafts, (entry: any) => entries.delete(entry.id));

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -100,7 +100,7 @@ const load = async (uid: UID.ContentType, { publishedVersions, draftVersions }: 
 const sync = async (
   oldEntries: { id: string; locale: string }[],
   newEntries: { id: string; locale: string }[],
-  oldRelations: { joinTable: any; relations: any[]; replace?: boolean }[]
+  oldRelations: { joinTable: any; relations: any[] }[]
 ) => {
   /**
    * Create a map of old entry ids to new entry ids

--- a/tests/api/core/content-manager/api/relations-permissions.test.api.js
+++ b/tests/api/core/content-manager/api/relations-permissions.test.api.js
@@ -138,7 +138,7 @@ describe('Relation permissions', () => {
 
     const shopEntry = await createEntry(
       'api::shop.shop',
-      { name: 'Shop', products: [product.id] },
+      { name: 'Shop', products: [product.documentId] },
       populateShop
     );
     shop = shopEntry.data;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Fix https://github.com/strapi/strapi/issues/21355
- Fix https://github.com/strapi/strapi/issues/21382

Replacement for https://github.com/strapi/strapi/pull/21390


### Details

- Fixes findExisting returning both draft & published entries when non DP relations are present
- Fixes UI not sending the documentId & locale as part of relations infos
- Fixes Relation links not including the locale & redirecting to the defaultLocale instaed (will need refactoring later)
- When a DP doc is published and is targeted by a non DP source with a unidirectional relation, the relation should point to both Draft & Published
- v4 to v5 migration doesn't create links to both published & drafts when running discardDraft

### Others issues to fix in another PR


- RTK query cache is messing up with the UX

