### PR TITLE
fix: single type name not applied in the content manager

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -140,12 +140,17 @@ const EditViewPage = () => {
   };
 
   /**
-   * We look to see what the mainField is from the configuration,
-   * if it's an id we don't use it because it's a uuid format and
-   * not very user friendly. Instead in that case, we simply write "Untitled".
+   * We look to see what the mainField is from the configuration, if it's an id
+   * we don't use it because it's a uuid format and not very user friendly.
+   * Instead, we display the schema name for single-type documents
+   * or "Untitled".
    */
-  const documentTitle =
-    mainField !== 'id' && document?.[mainField] ? document[mainField] : 'Untitled';
+  let documentTitle = 'Untitled';
+  if (mainField !== 'id' && document?.[mainField]) {
+    documentTitle = document[mainField];
+  } else if (isSingleType && schema?.info.displayName) {
+    documentTitle = schema.info.displayName;
+  }
 
   return (
     <Main paddingLeft={10} paddingRight={10}>

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -423,7 +423,7 @@ test.describe('Edit View', () => {
        */
       await page.waitForURL(EDIT_URL);
 
-      await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Homepage' })).toBeVisible();
       await expect(page.getByRole('button', { name: 'More actions' })).not.toBeDisabled();
 
       /**
@@ -518,7 +518,7 @@ test.describe('Edit View', () => {
          */
         await page.waitForURL(EDIT_URL);
 
-        await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Homepage' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'More actions' })).not.toBeDisabled();
 
         /**
@@ -563,7 +563,7 @@ test.describe('Edit View', () => {
 
         // the title should update post save because it's the `mainField` of the content-type
         await expect(page.getByRole('heading', { name: 'Welcome to AFC Richmond' })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Untitled' })).not.toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Homepage' })).not.toBeVisible();
         await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
         await expect(page.getByRole('button', { name: 'Publish' })).not.toBeDisabled();
 


### PR DESCRIPTION
### What does it do?

Displays the single type schema name instead of "Untitled" if there is no relevant mainField.

### Why is it needed?

When a contributor is editing a document, it's not clear which document they are working on if the `mainField` is irrelevant.

### How to test it?

Create a single type document and switch to the content manager.

### Related issue(s)/PR(s)

Fix #20844
