### PR TITLE
Add Placeholders for Empty Artifacts in Type Generation

### DIFF
--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -6,7 +6,7 @@ const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
 
 const NO_COMPONENT_PLACEHOLDER_COMMENT = `/*
- * The app doesn't have any component yet.
+ * The app doesn't have any components yet.
  */
 `;
 

--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -5,6 +5,11 @@ const { factory } = require('typescript');
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
 
+const NO_COMPONENT_PLACEHOLDER_COMMENT = `/*
+ * The app doesn't have any component yet.
+ */
+`;
+
 /**
  * Generate type definitions for Strapi Components
  *
@@ -22,6 +27,12 @@ const generateComponentsDefinitions = async (options = {}) => {
     uid: contentType.uid,
     definition: models.schema.generateSchemaDefinition(contentType),
   }));
+
+  options.logger.debug(`Found ${componentsDefinitions.length} components.`);
+
+  if (componentsDefinitions.length === 0) {
+    return { output: NO_COMPONENT_PLACEHOLDER_COMMENT, stats: {} };
+  }
 
   const formattedSchemasDefinitions = componentsDefinitions.reduce((acc, def) => {
     acc.push(

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -6,7 +6,7 @@ const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
 
 const NO_CONTENT_TYPE_PLACEHOLDER_COMMENT = `/*
- * The app doesn't have any content-type yet.
+ * The app doesn't have any content-types yet.
  */
 `;
 

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -5,6 +5,11 @@ const { factory } = require('typescript');
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
 
+const NO_CONTENT_TYPE_PLACEHOLDER_COMMENT = `/*
+ * The app doesn't have any content-type yet.
+ */
+`;
+
 /**
  * Generate type definitions for Strapi Content-Types
  *
@@ -22,6 +27,12 @@ const generateContentTypesDefinitions = async (options = {}) => {
     uid: contentType.uid,
     definition: models.schema.generateSchemaDefinition(contentType),
   }));
+
+  options.logger.debug(`Found ${contentTypesDefinitions.length} content-types.`);
+
+  if (contentTypesDefinitions.length === 0) {
+    return { output: NO_CONTENT_TYPE_PLACEHOLDER_COMMENT, stats: {} };
+  }
 
   const formattedSchemasDefinitions = contentTypesDefinitions.reduce((acc, def) => {
     acc.push(


### PR DESCRIPTION
### What does it do?

Do not generate the module augmentation for empty artifact collections (content-types, components).

Instead, add a comment to explain why the file is empty.

### Why is it needed?

When no components (or content-types) exist in an app, we still try to do the module augmentation which can lead to unexpected behavior in the type system.

### How to test it?

- `cd examples/kitchensink-ts`
- `yarn strapi ts:generate-types -d`
- open `types/generated/components.d.ts`
- The file should only contain a single comment

- `cd examples/kitchensink-ts`
- `yarn strapi ts:generate-types -d`
- open `types/generated/components.d.ts`
- The file should contain all the components' type definitions + the module augmentation

### Related issue(s)/PR(s)

take over #19883