### PR TITLE
fix: Changed the color of the titles of the panels

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/Panels.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Panels.tsx
@@ -151,7 +151,7 @@ const Panel = React.forwardRef<any, PanelProps>(({ children, title }, ref) => {
       justifyContent="stretch"
       alignItems="flex-start"
     >
-      <Typography tag="h2" variant="sigma" textTransform="uppercase">
+      <Typography tag="h2" variant="sigma" textTransform="uppercase" textColor={"neutral600"}>
         {title}
       </Typography>
       {children}


### PR DESCRIPTION
### What does it do?

Changed the color of the titles in the panels of the sidebar (in the edit view).

### Why is it needed?

To bring back the color we had in v4.

### How to test it?

You'll simply need to go to the edit view of any entry.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20788