### PR TITLE
Add an environment variable for disabling /_health log

### DIFF
--- a/packages/core/core/src/middlewares/logger.ts
+++ b/packages/core/core/src/middlewares/logger.ts
@@ -6,6 +6,10 @@ export const logger: Core.MiddlewareFactory = (_, { strapi }) => {
     await next();
     const delta = Math.ceil(Date.now() - start);
 
-    strapi.log.http(`${ctx.method} ${ctx.url} (${delta} ms) ${ctx.status}`);
+    if (process.env.LOG_HEALTH === 'false' && ctx.url === '/_health') {
+      return;
+    } else {
+      strapi.log.http(`${ctx.method} ${ctx.url} (${delta} ms) ${ctx.status}`);
+    }
   };
 };


### PR DESCRIPTION
### What does it do?

Adds a conditional statement to look for an environment variable called `LOG_HEALTH` and specifically looks for this value to be set false (it will obviously be set to undefined by default) and checks to see if the route to be logged is the `/_health`

If both of these conditionals pass then the request won't be logged to the console

### Why is it needed?

Since we transitioned Strapi Cloud to use an HTTP healthcheck rather and a TCP port check all Strapi Cloud runtime logs are constantly spammed by us checking the status of the running project as you can see below:

![image](https://github.com/user-attachments/assets/d5c4c0e4-c355-4434-8559-469a3392d062)

This is obviously quite annoying to users that are looking at the runtime logs within the Strapi Cloud dashboard but also increases the size of the log file and slows down the real time logs rendering within Strapi Cloud

### How to test it?

Using one of the example projects within the repo:

- Run Strapi normally with `yarn develop`
- Execute a `GET /_health`
- See that the request is properly logged to the server console

- Run Strapi with the following environment variable `LOG_HEALTH=false yarn develop`
- Execute a `GET /_health`
- See that the request is no longer logged to the server console

### Related issue(s)/PR(s)

N/A
