### PR TITLE
chore: Harmonized all button sizes in settings

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
@@ -11,6 +11,7 @@ import {
   TextInput,
   Typography,
 } from '@strapi/design-system';
+import { Check } from '@strapi/icons';
 import { format } from 'date-fns';
 import { Formik, Form, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
@@ -197,14 +198,13 @@ const CreatePage = () => {
                         handleReset();
                         permissionsRef.current?.resetForm();
                       }}
-                      size="L"
                     >
                       {formatMessage({
                         id: 'app.components.Button.reset',
                         defaultMessage: 'Reset',
                       })}
                     </Button>
-                    <Button type="submit" loading={isSubmitting} size="L">
+                    <Button type="submit" loading={isSubmitting} startIcon={<Check />}>
                       {formatMessage({
                         id: 'global.save',
                         defaultMessage: 'Save',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Box, Button, Flex, Main } from '@strapi/design-system';
+import { Check } from '@strapi/icons';
 import { Formik, FormikHelpers } from 'formik';
 import { useIntl } from 'react-intl';
 import { Navigate, useMatch } from 'react-router-dom';
@@ -191,9 +192,9 @@ const EditPage = () => {
                 <Flex gap={2}>
                   <Button
                     type="submit"
+                    startIcon={<Check />}
                     disabled={role.code === 'strapi-super-admin'}
                     loading={isSubmitting}
-                    size="L"
                   >
                     {formatMessage({
                       id: 'global.save',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
@@ -191,7 +191,6 @@ const EditPage = () => {
                     startIcon={<Check />}
                     loading={isSubmitting}
                     type="submit"
-                    size="L"
                   >
                     {formatMessage({ id: 'global.save', defaultMessage: 'Save' })}
                   </Button>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
@@ -98,7 +98,6 @@ const WebhookForm = ({
                   variant="tertiary"
                   startIcon={<Publish />}
                   disabled={isCreating || isTriggering}
-                  size="L"
                 >
                   {formatMessage({
                     id: 'Settings.webhooks.trigger',
@@ -108,7 +107,6 @@ const WebhookForm = ({
                 <Button
                   startIcon={<Check />}
                   type="submit"
-                  size="L"
                   disabled={!modified}
                   loading={isSubmitting}
                 >

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
@@ -144,7 +144,6 @@ export const SingleSignOnPage = () => {
                     loading={isSubmitting}
                     startIcon={<Check />}
                     type="submit"
-                    size="L"
                   >
                     {formatMessage({
                       id: 'global.save',

--- a/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/:id.tsx
@@ -335,7 +335,6 @@ const EditPage = () => {
                   <Button
                     startIcon={<Check />}
                     type="submit"
-                    size="M"
                     disabled={!modified || isSubmitting || values.stages.length === 0}
                     // if the confirm dialog is open the loading state is on
                     // the confirm button already


### PR DESCRIPTION
### What does it do?

I removed the `size="L"` and `size="M"` properties of the buttons that had them in the settings. I also added a `<Check />` icon to the "Save" button of the admin role page.

### Why is it needed?

A few pages in the settings had buttons that had a `size="L"` or a `size="M"`, but it's not supposed to be the case. All the other pages from the settings have a `size="S"`. I changed it so we have a consistent design across all pages of the settings. I added the `<Check />` icon for the same reasons.

### How to test it?

You'll need to go to the following pages:
- Settings > Review Workflow > Open any workflow
- Settings > Review Workflow > Create new workflow
- Settings > Single Sign-On
- Settings > Webhooks > Open any webhook
- Settings > Webhooks > Create new webhook
- Settings > Roles (admin panel) > Open any role
- Settings > Roles (admin panel) > Create new role
- Settings > Users > Open any user

### Related issue(s)/PR(s)

No related issue.