### PR TITLE
Fixed issue 20843 : Wrong numbers are displayed media library

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/BulkActions.jsx
@@ -12,7 +12,9 @@ import { BulkMoveButton } from './BulkMoveButton';
 
 export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
   const { formatMessage } = useIntl();
-
+  const numberAssets = selected.reduce(function(_this, val) {
+    return val?.type === 'folder' ? _this + val.files.count : _this + 1;
+}, 0);
   return (
     <Flex gap={2} paddingBottom={5}>
       <Typography variant="epsilon" textColor="neutral600">
@@ -24,7 +26,7 @@ export const BulkActions = ({ selected, onSuccess, currentFolder }) => {
           },
           {
             numberFolders: selected.filter(({ type }) => type === 'folder').length,
-            numberAssets: selected.filter(({ type }) => type === 'asset').length,
+            numberAssets: numberAssets,
           }
         )}
       </Typography>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixed  https://github.com/strapi/strapi/issues/20843 : Wrong numbers are displayed media library

### Why is it needed?
Currently, it only displays folder count not considering assets in it.
e.g.
It should display “2 folders - 2 assets”, not “2 folders - 0 assets”



### How to test it?

- Go to media library
- create folder 
- Add Some assets in folder
- Select that folder
- You will get Proper msg "folder_count folders - assets_count assets" . it will not like " folder_count folders - 0 assets"
 

### Related issue(s)/PR(s)

#20843 