### PR TITLE
Fix 21344: fixed the Media Library's missing cursor pointers on the filters

### DIFF
--- a/packages/core/upload/admin/src/components/SortPicker/index.jsx
+++ b/packages/core/upload/admin/src/components/SortPicker/index.jsx
@@ -1,35 +1,44 @@
 import React from 'react';
 
-import { SingleSelect, SingleSelectOption } from '@strapi/design-system';
+import { SingleSelect, SingleSelectOption, Box } from '@strapi/design-system';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import styled from 'styled-components';
 
 import { sortOptions } from '../../constants';
 import { getTrad } from '../../utils';
+
+const SingleSelectWrapper = styled(Box)`
+  div[role='combobox'] {
+    cursor: pointer;
+  }
+`;
 
 const SortPicker = ({ onChangeSort, value }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <SingleSelect
-      size="S"
-      value={value}
-      onChange={(value) => onChangeSort(value)}
-      aria-label={formatMessage({
-        id: getTrad('sort.label'),
-        defaultMessage: 'Sort by',
-      })}
-      placeholder={formatMessage({
-        id: getTrad('sort.label'),
-        defaultMessage: 'Sort by',
-      })}
-    >
-      {sortOptions.map((filter) => (
-        <SingleSelectOption key={filter.key} value={filter.value}>
-          {formatMessage({ id: getTrad(filter.key), defaultMessage: `${filter.value}` })}
-        </SingleSelectOption>
-      ))}
-    </SingleSelect>
+   <SingleSelectWrapper>
+      <SingleSelect
+        size="S"
+        value={value}
+        onChange={(value) => onChangeSort(value)}
+        aria-label={formatMessage({
+          id: getTrad('sort.label'),
+          defaultMessage: 'Sort by',
+        })}
+        placeholder={formatMessage({
+          id: getTrad('sort.label'),
+          defaultMessage: 'Sort by',
+        })}
+      >
+        {sortOptions.map((filter) => (
+          <SingleSelectOption key={filter.key} value={filter.value}>
+            {formatMessage({ id: getTrad(filter.key), defaultMessage: `${filter.value}` })}
+          </SingleSelectOption>
+        ))}
+      </SingleSelect>
+    </SingleSelectWrapper>
   );
 };
 

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/index.jsx
@@ -55,6 +55,7 @@ const BoxWithHeight = styled(Box)`
   height: 3.2rem;
   display: flex;
   align-items: center;
+  cursor: pointer
 `;
 
 const TypographyMaxWidth = styled(Typography)`
@@ -235,7 +236,7 @@ export const MediaLibrary = () => {
                   paddingRight={2}
                   background="neutral0"
                   hasRadius
-                  borderColor="neutral200"
+                  borderColor="neutral200"                  
                 >
                   <Checkbox
                     aria-label={formatMessage({
@@ -249,6 +250,7 @@ export const MediaLibrary = () => {
                           selected.length === assetCount + folderCount
                     }
                     onCheckedChange={(e) => handleBulkSelect(e, [...assets, ...folders])}
+                    style={{cursor: 'pointer'}}
                   />
                 </BoxWithHeight>
               )}


### PR DESCRIPTION
What does it do?
Fixed the Media Library's missing cursor pointers issue on the filters

Why is it needed?
To fix issue https://github.com/strapi/design-system/issues/1791: Media Library missing cursor pointers on the filters

How to test it?

- Open the Media Library
- Hover over the filters, it should show the cursor pointers.

Related issue(s)/PR(s)
https://github.com/strapi/design-system/issues/1791