### PR TITLE
feat(cli): add environment list command to cloud cli

### DIFF
--- a/packages/cli/cloud/src/cloud/command.ts
+++ b/packages/cli/cloud/src/cloud/command.ts
@@ -1,0 +1,8 @@
+import { Command } from 'commander';
+
+export function defineCloudNamespace(command: Command): Command {
+
+  return command
+    .command('cloud')
+    .description('Manage Strapi Cloud projects');
+}

--- a/packages/cli/cloud/src/cloud/command.ts
+++ b/packages/cli/cloud/src/cloud/command.ts
@@ -1,8 +1,5 @@
 import { Command } from 'commander';
 
 export function defineCloudNamespace(command: Command): Command {
-
-  return command
-    .command('cloud')
-    .description('Manage Strapi Cloud projects');
+  return command.command('cloud').description('Manage Strapi Cloud projects');
 }

--- a/packages/cli/cloud/src/environment/command.ts
+++ b/packages/cli/cloud/src/environment/command.ts
@@ -2,6 +2,6 @@ import { Command } from 'commander';
 import { defineCloudNamespace } from '../cloud/command';
 
 export function createEnvironmentCommand(command: Command): Command {
-   const cloud = defineCloudNamespace(command);
-  return cloud.command("environment").description('Manage environments for a Strapi Cloud project');
+  const cloud = defineCloudNamespace(command);
+  return cloud.command('environment').description('Manage environments for a Strapi Cloud project');
 }

--- a/packages/cli/cloud/src/environment/command.ts
+++ b/packages/cli/cloud/src/environment/command.ts
@@ -1,0 +1,7 @@
+import { Command } from 'commander';
+import { defineCloudNamespace } from '../cloud/command';
+
+export function createEnvironmentCommand(command: Command): Command {
+   const cloud = defineCloudNamespace(command);
+  return cloud.command("environment").description('Manage environments for a Strapi Cloud project');
+}

--- a/packages/cli/cloud/src/environment/list/action.ts
+++ b/packages/cli/cloud/src/environment/list/action.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+import type { CLIContext } from '../../types';
+import { cloudApiFactory, local, tokenServiceFactory } from '../../services';
+import { promptLogin } from '../../login/action';
+
+async function getProject(ctx: CLIContext) {
+  const { project } = await local.retrieve();
+  if (!project) {
+      ctx.logger.warn(`\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+    'link'
+  )} command`);
+      process.exit(1);
+  }
+  return project;
+}
+
+export default async (ctx: CLIContext) => {
+  const { getValidToken } = await tokenServiceFactory(ctx);
+  const token = await getValidToken(ctx, promptLogin);
+  const { logger } = ctx;
+
+  if (!token) {
+    return;
+  }
+
+  const project = await getProject(ctx);
+  if (!project) {
+    return;
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+  const spinner = logger.spinner('Fetching environments...').start();
+
+  try {
+    const {
+      data: { data: environmentsList },
+    } = await cloudApiService.listEnvironments({ name: project.name });
+    spinner.succeed();
+    logger.log(environmentsList);
+  } catch (e: any) {
+    if (e.response && e.response.status === 404) {
+      spinner.succeed();
+      logger.warn(`\nThe project associated with this folder does not exist in Strapi Cloud. \nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+        'link'
+      )} command`);
+
+    } else {
+    ctx.logger.debug('Failed to list environments', e);
+    spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');
+    }
+  }
+};

--- a/packages/cli/cloud/src/environment/list/action.ts
+++ b/packages/cli/cloud/src/environment/list/action.ts
@@ -6,10 +6,12 @@ import { promptLogin } from '../../login/action';
 async function getProject(ctx: CLIContext) {
   const { project } = await local.retrieve();
   if (!project) {
-      ctx.logger.warn(`\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
-    'link'
-  )} command`);
-      process.exit(1);
+    ctx.logger.warn(
+      `\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+        'link'
+      )} command`
+    );
+    process.exit(1);
   }
   return project;
 }
@@ -40,13 +42,14 @@ export default async (ctx: CLIContext) => {
   } catch (e: any) {
     if (e.response && e.response.status === 404) {
       spinner.succeed();
-      logger.warn(`\nThe project associated with this folder does not exist in Strapi Cloud. \nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
-        'link'
-      )} command`);
-
+      logger.warn(
+        `\nThe project associated with this folder does not exist in Strapi Cloud. \nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+          'link'
+        )} command`
+      );
     } else {
-    ctx.logger.debug('Failed to list environments', e);
-    spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');
+      ctx.logger.debug('Failed to list environments', e);
+      spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');
     }
   }
 };

--- a/packages/cli/cloud/src/environment/list/action.ts
+++ b/packages/cli/cloud/src/environment/list/action.ts
@@ -28,15 +28,15 @@ export default async (ctx: CLIContext) => {
 
   const project = await getProject(ctx);
   if (!project) {
-    ctx.logger.debug(
-      `No valid local project configuration was found.`
-    );
+    ctx.logger.debug(`No valid local project configuration was found.`);
     return;
   }
 
   const cloudApiService = await cloudApiFactory(ctx, token);
   const spinner = logger.spinner('Fetching environments...').start();
-  await trackEvent(ctx, cloudApiService, 'willListEnvironment', { projectInternalName: project.name });
+  await trackEvent(ctx, cloudApiService, 'willListEnvironment', {
+    projectInternalName: project.name,
+  });
 
   try {
     const {
@@ -44,7 +44,9 @@ export default async (ctx: CLIContext) => {
     } = await cloudApiService.listEnvironments({ name: project.name });
     spinner.succeed();
     logger.log(environmentsList);
-    await trackEvent(ctx, cloudApiService, 'didListEnvironment', { projectInternalName: project.name });
+    await trackEvent(ctx, cloudApiService, 'didListEnvironment', {
+      projectInternalName: project.name,
+    });
   } catch (e: any) {
     if (e.response && e.response.status === 404) {
       spinner.succeed();
@@ -57,6 +59,8 @@ export default async (ctx: CLIContext) => {
       spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');
       logger.debug('Failed to list environments', e);
     }
-    await trackEvent(ctx, cloudApiService, 'didNotListEnvironment', { projectInternalName: project.name });
+    await trackEvent(ctx, cloudApiService, 'didNotListEnvironment', {
+      projectInternalName: project.name,
+    });
   }
 };

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -1,0 +1,24 @@
+import { type StrapiCloudCommand } from '../../types';
+import { runAction } from '../../utils/helpers';
+import action from './action';
+import { defineCloudNamespace } from '../../cloud/command';
+
+const command: StrapiCloudCommand = ({ command, ctx }) => {
+
+  const cloud = defineCloudNamespace(command);
+
+  cloud
+    .command('environments')
+    .description('Alias for cloud environment list')
+    .action(() => runAction('list', action)(ctx));
+
+  const environment = cloud.command("environment").description('Manage environments for a Strapi Cloud project');
+  environment
+    .command('list')
+    .description('List Strapi Cloud project environments')
+    .option('-d, --debug', 'Enable debugging mode with verbose logs')
+    .option('-s, --silent', "Don't log anything")
+    .action(() => runAction('list', action)(ctx));
+};
+
+export default command;

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -4,7 +4,6 @@ import action from './action';
 import { defineCloudNamespace } from '../../cloud/command';
 
 const command: StrapiCloudCommand = ({ command, ctx }) => {
-
   const cloud = defineCloudNamespace(command);
 
   cloud
@@ -12,7 +11,9 @@ const command: StrapiCloudCommand = ({ command, ctx }) => {
     .description('Alias for cloud environment list')
     .action(() => runAction('list', action)(ctx));
 
-  const environment = cloud.command("environment").description('Manage environments for a Strapi Cloud project');
+  const environment = cloud
+    .command('environment')
+    .description('Manage environments for a Strapi Cloud project');
   environment
     .command('list')
     .description('List Strapi Cloud project environments')

--- a/packages/cli/cloud/src/environment/list/index.ts
+++ b/packages/cli/cloud/src/environment/list/index.ts
@@ -1,0 +1,12 @@
+import action from './action';
+import command from './command';
+import type { StrapiCloudCommandInfo } from '../../types';
+
+export { action, command };
+
+export default {
+  name: 'list-environments',
+  description: 'List Strapi Cloud environments',
+  action,
+  command,
+} as StrapiCloudCommandInfo;

--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -6,6 +6,7 @@ import login from './login';
 import logout from './logout';
 import createProject from './create-project';
 import listProjects from './list-projects';
+import listEnvironments from './environment/list';
 import { CLIContext } from './types';
 import { getLocalConfig, saveLocalConfig } from './config/local';
 
@@ -16,9 +17,10 @@ export const cli = {
   logout,
   createProject,
   listProjects,
+  listEnvironments
 };
 
-const cloudCommands = [deployProject, link, login, logout, listProjects];
+const cloudCommands = [deployProject, link, login, logout, listProjects, listEnvironments];
 
 async function initCloudCLIConfig() {
   const localConfig = await getLocalConfig();

--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -17,7 +17,7 @@ export const cli = {
   logout,
   createProject,
   listProjects,
-  listEnvironments
+  listEnvironments,
 };
 
 const cloudCommands = [deployProject, link, login, logout, listProjects, listEnvironments];

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -86,7 +86,7 @@ export interface CloudApiService {
 
   listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
 
-  listEnvironments(project: { name: string }): Promise<AxiosResponse<ListEnvironmentsResponse>>
+  listEnvironments(project: { name: string }): Promise<AxiosResponse<ListEnvironmentsResponse>>;
 
   getProject(project: { name: string }): Promise<AxiosResponse<GetProjectResponse>>;
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -19,6 +19,8 @@ export type ProjectInfos = {
   url?: string;
 };
 
+export type EnvironmentInfo = Record<string, unknown>;
+
 export type ProjectInput = Omit<ProjectInfos, 'id'>;
 
 export type DeployResponse = {
@@ -29,6 +31,12 @@ export type DeployResponse = {
 export type ListProjectsResponse = {
   data: {
     data: string;
+  };
+};
+
+export type ListEnvironmentsResponse = {
+  data: {
+    data: EnvironmentInfo[] | Record<string, never>;
   };
 };
 
@@ -77,6 +85,8 @@ export interface CloudApiService {
   listProjects(): Promise<AxiosResponse<ListProjectsResponse>>;
 
   listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
+
+  listEnvironments(project: { name: string }): Promise<AxiosResponse<ListEnvironmentsResponse>>
 
   getProject(project: { name: string }): Promise<AxiosResponse<GetProjectResponse>>;
 
@@ -192,6 +202,23 @@ export async function cloudApiFactory(
       } catch (error) {
         logger.debug(
           "🥲 Oops! Couldn't retrieve your project's list from the server. Please try again."
+        );
+        throw error;
+      }
+    },
+
+    async listEnvironments({ name }): Promise<AxiosResponse<ListEnvironmentsResponse>> {
+      try {
+        const response = await axiosCloudAPI.get(`/projects/${name}/environments`);
+
+        if (response.status !== 200) {
+          throw new Error('Error fetching cloud environments from the server.');
+        }
+
+        return response;
+      } catch (error) {
+        logger.debug(
+          "🥲 Oops! Couldn't retrieve your project's environments from the server. Please try again."
         );
         throw error;
       }

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -39,6 +39,10 @@ export type StrapiCloudCommand = (params: {
   ctx: CLIContext;
 }) => void | Command | Promise<Command | void>;
 
+export type StrapiCloudNamespaceCommand = (params: {
+  command: Command;
+}) => void | Command | Promise<Command | void>;
+
 export type StrapiCloudCommandInfo = {
   name: string;
   description: string;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
This PR introduces the environment list command to the Strapi Cloud CLI.

Additionally, it aligns with the General CLI Guidelines RFC by removing colons as namespace separators for commands and subcommands. To support this, two new base commands, cloud and environment, have been added to enable clearer command composition.

A future refactor of existing commands to follow this updated structure should be considered.

### Why is it needed?

With the introduction of Strapi Cloud multi environments feature, we want to allow users to list their available environments from a linked project in their CLI.

### How to test it?

An endpoint is available in CLI-API. The command can be tested against staging env checking the following scenarios:

1. Non-Strapi Project:
Running the command in a non-Strapi project should fail and return an appropriate error message.
2. Unauthenticated User:
Running the command without authentication should prompt the user to log in.
3. No Available Environments:
If no environments are available, the command should return a clear message indicating that there are no environments to list.
4. Available Environments:
When environments are present, the command should display the correct information.
5. Deleted Project:
If the command is used with a deleted project, it should return a valid error and prompt the user to link the project.
6. Corrupted strapi-config.json:
If the strapi-config.json is corrupted, the command should display an error and prompt the user to link the project.
7. Command Alias:
The alias cloud environments should function identically to the full command cloud environment list.
8. Help command
Commands and subcommands suggestions should appear running `cloud help` or `cloud environment help` commands

