### PR TITLE
fix: dynamic zones breaking layout logic

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/useDocument.test.tsx
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocument.test.tsx
@@ -202,6 +202,12 @@ describe('useDocument', () => {
             "visible": false,
             "writable": false,
           },
+          "dz": {
+            "components": [
+              "blog.test-como",
+            ],
+            "type": "dynamiczone",
+          },
           "id": {
             "type": "string",
           },

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -75,6 +75,32 @@ describe('useDocumentLayout', () => {
           [
             {
               "attribute": {
+                "components": [
+                  "blog.test-como",
+                ],
+                "type": "dynamiczone",
+              },
+              "disabled": false,
+              "hint": "",
+              "label": "dz",
+              "mainField": {
+                "name": "name",
+                "type": "string",
+              },
+              "name": "dz",
+              "placeholder": "",
+              "required": false,
+              "size": 12,
+              "type": "dynamiczone",
+              "unique": false,
+              "visible": true,
+            },
+          ],
+        ],
+        [
+          [
+            {
+              "attribute": {
                 "type": "uid",
               },
               "disabled": false,
@@ -90,6 +116,8 @@ describe('useDocumentLayout', () => {
               "visible": true,
             },
           ],
+        ],
+        [
           [
             {
               "attribute": {

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -250,9 +250,10 @@ const formatEditLayout = (
       currentPanelIndex += 2;
     } else {
       if (!panels[currentPanelIndex]) {
-        panels.push([]);
+        panels.push([row]);
+      } else {
+        panels[currentPanelIndex].push(row);
       }
-      panels[currentPanelIndex].push(row);
     }
 
     return panels;

--- a/packages/core/content-manager/admin/tests/mockData.ts
+++ b/packages/core/content-manager/admin/tests/mockData.ts
@@ -398,6 +398,10 @@ const CM_CONTENT_TYPE_MOCK_DATA = [
         allowedTypes: ['images'],
         pluginOptions: {},
       },
+      dz: {
+        type: 'dynamiczone',
+        components: ['blog.test-como'],
+      },
       city: {
         type: 'string',
         required: true,
@@ -718,6 +722,22 @@ const CM_COLLECTION_TYPE_LAYOUT_MOCK_DATA = {
           mainField: 'name',
         },
       },
+      dz: {
+        edit: {
+          label: 'dz',
+          description: '',
+          placeholder: '',
+          visible: true,
+          editable: true,
+          mainField: 'name',
+        },
+        list: {
+          label: 'dz',
+          searchable: false,
+          sortable: false,
+          mainField: 'name',
+        },
+      },
       cover: {
         edit: {
           label: 'cover',
@@ -894,6 +914,7 @@ const CM_COLLECTION_TYPE_LAYOUT_MOCK_DATA = {
     layouts: {
       list: ['id', 'categories', 'cover', 'postal_code'],
       edit: [
+        [{ name: 'dz', size: 12 }],
         [
           {
             name: 'slug',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes https://github.com/strapi/strapi/issues/21267

I narrowed down the problem to when a dynamic zone is the first field in the edit view layout, and there's one or more fields after.

I updated the tests so they would get the bug with the previous version of the `useDocumentLayout` code (by adding a dynamic zone at the start of the layout).

### How to test it?

Test the flow that would break before:
- create a new content type
- add a dynamic zone field first
- then add a text field (or anything else)
- then open the edit view for that content type, or the configure the view page

I think we also need some random QA to try various combinations: DZ after DZ, DZ then field then DZ, field then DZ...

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21267