### PR TITLE
feat(content-releases): add stage check to releases details page

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -146,6 +146,15 @@ const EditViewPage = () => {
   const documentTitle =
     mainField !== 'id' && document?.[mainField] ? document[mainField] : 'Untitled';
 
+  const validateSync = (values: Record<string, unknown>, options: Record<string, string>) => {
+    const yupSchema = createYupSchema(schema?.attributes, components, {
+      status,
+      ...options,
+    });
+
+    return yupSchema.validateSync(values, { abortEarly: false });
+  };
+
   return (
     <Main paddingLeft={10} paddingRight={10}>
       <Page.Title>{`${documentTitle}`}</Page.Title>
@@ -161,6 +170,7 @@ const EditViewPage = () => {
 
           return yupSchema.validate(values, { abortEarly: false });
         }}
+        initialErrors={location?.state?.forceValidation ? validateSync(initialValues, {}) : {}}
       >
         {({ resetForm }) => (
           <>

--- a/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
+++ b/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
@@ -31,7 +31,7 @@ const StyledPopoverFlex = styled(Flex)`
 
 interface EntryValidationPopoverProps {
   action: ReleaseAction['type'];
-  schema?: Struct.ContentTypeSchema & { requiredStageToPublish?: Stage };
+  schema?: Struct.ContentTypeSchema & { stageRequiredToPublish?: Stage };
   entry: ReleaseActionEntry;
   status: ReleaseAction['status'];
 }
@@ -44,105 +44,104 @@ interface ValidationStatusProps {
   entryStage?: Stage;
 }
 
-const EntryStatusTrigger = React.forwardRef<HTMLButtonElement, ValidationStatusProps>(
-  ({ action, status, hasErrors, requiredStage, entryStage }, ref) => {
-    const { formatMessage } = useIntl();
+const EntryStatusTrigger = ({
+  action,
+  status,
+  hasErrors,
+  requiredStage,
+  entryStage,
+}: ValidationStatusProps) => {
+  const { formatMessage } = useIntl();
 
-    if (action === 'publish') {
-      if (hasErrors || (requiredStage && requiredStage.id !== entryStage?.id)) {
-        return (
-          <Popover.Trigger>
-            <Button
-              variant="ghost"
-              startIcon={<CrossCircle fill="danger600" />}
-              endIcon={<CaretDown />}
-              ref={ref}
-            >
-              <Typography textColor="danger600" variant="omega" fontWeight="bold">
-                {formatMessage({
-                  id: 'content-releases.pages.ReleaseDetails.entry-validation.not-ready',
-                  defaultMessage: 'Not ready to publish',
-                })}
-              </Typography>
-            </Button>
-          </Popover.Trigger>
-        );
-      } else if (status === 'draft') {
-        return (
-          <Popover.Trigger>
-            <Button
-              variant="ghost"
-              startIcon={<CheckCircle fill="success600" />}
-              endIcon={<CaretDown />}
-              ref={ref}
-            >
-              <Typography textColor="success600" variant="omega" fontWeight="bold">
-                {formatMessage({
-                  id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
-                  defaultMessage: 'Ready to publish',
-                })}
-              </Typography>
-            </Button>
-          </Popover.Trigger>
-        );
-      } else if (status === 'modified') {
-        return (
-          <Popover.Trigger>
-            <Button
-              variant="ghost"
-              startIcon={<ArrowsCounterClockwise fill="alternative600" />}
-              endIcon={<CaretDown />}
-              ref={ref}
-            >
-              <Typography variant="omega" fontWeight="bold" textColor="alternative600">
-                {formatMessage({
-                  id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
-                  defaultMessage: 'Ready to publish changes',
-                })}
-              </Typography>
-            </Button>
-          </Popover.Trigger>
-        );
-      } else {
-        return (
-          <Popover.Trigger>
-            <Button
-              variant="ghost"
-              startIcon={<CheckCircle fill="success600" />}
-              endIcon={<CaretDown />}
-              ref={ref}
-            >
-              <Typography textColor="success600" variant="omega" fontWeight="bold">
-                {formatMessage({
-                  id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
-                  defaultMessage: 'Already published',
-                })}
-              </Typography>
-            </Button>
-          </Popover.Trigger>
-        );
-      }
-    } else {
+  if (action === 'publish') {
+    if (hasErrors || (requiredStage && requiredStage.id !== entryStage?.id)) {
       return (
         <Popover.Trigger>
           <Button
             variant="ghost"
-            startIcon={<CheckCircle fill="success600" />}
+            startIcon={<CrossCircle fill="danger600" />}
             endIcon={<CaretDown />}
-            ref={ref}
           >
-            <Typography textColor="success600" variant="omega" fontWeight="bold">
+            <Typography textColor="danger600" variant="omega" fontWeight="bold">
               {formatMessage({
-                id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
-                defaultMessage: 'Already unpublished',
+                id: 'content-releases.pages.ReleaseDetails.entry-validation.not-ready',
+                defaultMessage: 'Not ready to publish',
               })}
             </Typography>
           </Button>
         </Popover.Trigger>
       );
     }
+
+    if (status === 'draft') {
+      return (
+        <Popover.Trigger>
+          <Button
+            variant="ghost"
+            startIcon={<CheckCircle fill="success600" />}
+            endIcon={<CaretDown />}
+          >
+            <Typography textColor="success600" variant="omega" fontWeight="bold">
+              {formatMessage({
+                id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
+                defaultMessage: 'Ready to publish',
+              })}
+            </Typography>
+          </Button>
+        </Popover.Trigger>
+      );
+    }
+
+    if (status === 'modified') {
+      return (
+        <Popover.Trigger>
+          <Button
+            variant="ghost"
+            startIcon={<ArrowsCounterClockwise fill="alternative600" />}
+            endIcon={<CaretDown />}
+          >
+            <Typography variant="omega" fontWeight="bold" textColor="alternative600">
+              {formatMessage({
+                id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
+                defaultMessage: 'Ready to publish changes',
+              })}
+            </Typography>
+          </Button>
+        </Popover.Trigger>
+      );
+    }
+
+    return (
+      <Popover.Trigger>
+        <Button
+          variant="ghost"
+          startIcon={<CheckCircle fill="success600" />}
+          endIcon={<CaretDown />}
+        >
+          <Typography textColor="success600" variant="omega" fontWeight="bold">
+            {formatMessage({
+              id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
+              defaultMessage: 'Already published',
+            })}
+          </Typography>
+        </Button>
+      </Popover.Trigger>
+    );
   }
-);
+
+  return (
+    <Popover.Trigger>
+      <Button variant="ghost" startIcon={<CheckCircle fill="success600" />} endIcon={<CaretDown />}>
+        <Typography textColor="success600" variant="omega" fontWeight="bold">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
+            defaultMessage: 'Already unpublished',
+          })}
+        </Typography>
+      </Button>
+    </Popover.Trigger>
+  );
+};
 
 interface FieldsValidationProps {
   hasErrors: boolean;
@@ -174,7 +173,7 @@ const FieldsValidation = ({
         </Typography>
         {hasErrors ? <CrossCircle fill="danger600" /> : <CheckCircle fill="success600" />}
       </Flex>
-      <Typography width="100%">
+      <Typography width="100%" textColor="neutral600">
         {hasErrors
           ? formatMessage(
               {
@@ -264,15 +263,23 @@ const getReviewStageMessage = ({
       }
     );
   }
-  return formatMessage(
-    {
-      id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.ready',
-      defaultMessage: 'This entry is at the required stage for publishing. ({stageName})',
-    },
-    {
-      stageName: requiredStage?.name ?? '',
-    }
-  );
+
+  if (requiredStage && requiredStage.id === entryStage?.id) {
+    return formatMessage(
+      {
+        id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.ready',
+        defaultMessage: 'This entry is at the required stage for publishing. ({stageName})',
+      },
+      {
+        stageName: requiredStage?.name ?? '',
+      }
+    );
+  }
+
+  return formatMessage({
+    id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.stage-not-required',
+    defaultMessage: 'No required stage for publication',
+  });
 };
 
 const ReviewStageValidation = ({
@@ -303,7 +310,7 @@ const ReviewStageValidation = ({
         </Typography>
         {Icon}
       </Flex>
-      <Typography>
+      <Typography textColor="neutral600">
         {getReviewStageMessage({
           contentTypeHasReviewWorkflow,
           requiredStage,
@@ -338,7 +345,7 @@ export const EntryValidationPopover = ({
 
   // Entry stage
   const contentTypeHasReviewWorkflow = schema?.options?.reviewWorkflows ?? false;
-  const requiredStage = schema?.requiredStageToPublish;
+  const requiredStage = schema?.stageRequiredToPublish;
   const entryStage = entry.strapi_stage;
 
   if (isLoading) {

--- a/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
+++ b/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
@@ -1,0 +1,376 @@
+import * as React from 'react';
+
+import { FormErrors, FormValues } from '@strapi/admin/strapi-admin';
+import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
+import { Button, LinkButton, Flex, Typography, Popover } from '@strapi/design-system';
+import { CheckCircle, CrossCircle, ArrowsCounterClockwise, CaretDown } from '@strapi/icons';
+import { stringify } from 'qs';
+import { useIntl, MessageDescriptor } from 'react-intl';
+import { Link } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+import type {
+  ReleaseAction,
+  ReleaseActionEntry,
+  Stage,
+} from '../../../shared/contracts/release-actions';
+import type { Struct } from '@strapi/types';
+
+const StyledPopoverFlex = styled(Flex)`
+  width: 100%;
+  max-width: 256px;
+
+  & > * {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.neutral150};
+  }
+
+  & > *:last-child {
+    border-bottom: none;
+  }
+`;
+
+interface EntryValidationPopoverProps {
+  action: ReleaseAction['type'];
+  schema?: Struct.ContentTypeSchema & { requiredStageToPublish?: Stage };
+  entry: ReleaseActionEntry;
+  status: ReleaseAction['status'];
+}
+
+interface ValidationStatusProps {
+  action: ReleaseAction['type'];
+  status: ReleaseAction['status'];
+  hasErrors: boolean | null;
+  requiredStage?: Stage;
+  entryStage?: Stage;
+}
+
+const EntryStatusTrigger = React.forwardRef<HTMLButtonElement, ValidationStatusProps>(
+  ({ action, status, hasErrors, requiredStage, entryStage }, ref) => {
+    const { formatMessage } = useIntl();
+
+    if (action === 'publish') {
+      if (hasErrors || (requiredStage && requiredStage.id !== entryStage?.id)) {
+        return (
+          <Popover.Trigger>
+            <Button
+              variant="ghost"
+              startIcon={<CrossCircle fill="danger600" />}
+              endIcon={<CaretDown />}
+              ref={ref}
+            >
+              <Typography textColor="danger600" variant="omega" fontWeight="bold">
+                {formatMessage({
+                  id: 'content-releases.pages.ReleaseDetails.entry-validation.not-ready',
+                  defaultMessage: 'Not ready to publish',
+                })}
+              </Typography>
+            </Button>
+          </Popover.Trigger>
+        );
+      } else if (status === 'draft') {
+        return (
+          <Popover.Trigger>
+            <Button
+              variant="ghost"
+              startIcon={<CheckCircle fill="success600" />}
+              endIcon={<CaretDown />}
+              ref={ref}
+            >
+              <Typography textColor="success600" variant="omega" fontWeight="bold">
+                {formatMessage({
+                  id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
+                  defaultMessage: 'Ready to publish',
+                })}
+              </Typography>
+            </Button>
+          </Popover.Trigger>
+        );
+      } else if (status === 'modified') {
+        return (
+          <Popover.Trigger>
+            <Button
+              variant="ghost"
+              startIcon={<ArrowsCounterClockwise fill="alternative600" />}
+              endIcon={<CaretDown />}
+              ref={ref}
+            >
+              <Typography variant="omega" fontWeight="bold" textColor="alternative600">
+                {formatMessage({
+                  id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
+                  defaultMessage: 'Ready to publish changes',
+                })}
+              </Typography>
+            </Button>
+          </Popover.Trigger>
+        );
+      } else {
+        return (
+          <Popover.Trigger>
+            <Button
+              variant="ghost"
+              startIcon={<CheckCircle fill="success600" />}
+              endIcon={<CaretDown />}
+              ref={ref}
+            >
+              <Typography textColor="success600" variant="omega" fontWeight="bold">
+                {formatMessage({
+                  id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
+                  defaultMessage: 'Already published',
+                })}
+              </Typography>
+            </Button>
+          </Popover.Trigger>
+        );
+      }
+    } else {
+      return (
+        <Popover.Trigger>
+          <Button
+            variant="ghost"
+            startIcon={<CheckCircle fill="success600" />}
+            endIcon={<CaretDown />}
+            ref={ref}
+          >
+            <Typography textColor="success600" variant="omega" fontWeight="bold">
+              {formatMessage({
+                id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
+                defaultMessage: 'Already unpublished',
+              })}
+            </Typography>
+          </Button>
+        </Popover.Trigger>
+      );
+    }
+  }
+);
+
+interface FieldsValidationProps {
+  hasErrors: boolean;
+  errors: FormErrors<FormValues> | null;
+  kind?: string;
+  contentTypeUid?: string;
+  documentId?: string;
+  locale?: string;
+}
+
+const FieldsValidation = ({
+  hasErrors,
+  errors,
+  kind,
+  contentTypeUid,
+  documentId,
+  locale,
+}: FieldsValidationProps) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Flex direction="column" gap={1} width="100%" padding={5}>
+      <Flex gap={2} width="100%">
+        <Typography fontWeight="bold">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.fields',
+            defaultMessage: 'Fields',
+          })}
+        </Typography>
+        {hasErrors ? <CrossCircle fill="danger600" /> : <CheckCircle fill="success600" />}
+      </Flex>
+      <Typography width="100%">
+        {hasErrors
+          ? formatMessage(
+              {
+                id: 'content-releases.pages.ReleaseDetails.entry-validation.fields.error',
+                defaultMessage: '{errors} errors on fields.',
+              },
+              { errors: errors ? Object.keys(errors).length : 0 }
+            )
+          : formatMessage({
+              id: 'content-releases.pages.ReleaseDetails.entry-validation.fields.success',
+              defaultMessage: 'All fields are filled correctly.',
+            })}
+      </Typography>
+      {hasErrors && (
+        <LinkButton
+          tag={Link}
+          to={{
+            pathname: `/content-manager/${kind === 'collectionType' ? 'collection-types' : 'single-types'}/${contentTypeUid}/${documentId}`,
+            search: locale
+              ? stringify({
+                  plugins: {
+                    i18n: {
+                      locale,
+                    },
+                  },
+                })
+              : '',
+          }}
+          variant="secondary"
+          fullWidth
+          state={{ forceValidation: true }}
+        >
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.fields.see-errors',
+            defaultMessage: 'See errors',
+          })}
+        </LinkButton>
+      )}
+    </Flex>
+  );
+};
+
+const getReviewStageIcon = ({
+  contentTypeHasReviewWorkflow,
+  requiredStage,
+  entryStage,
+}: {
+  contentTypeHasReviewWorkflow: boolean;
+  requiredStage?: Stage;
+  entryStage?: Stage;
+}) => {
+  if (!contentTypeHasReviewWorkflow) {
+    return <CheckCircle fill="neutral200" />;
+  }
+  if (requiredStage && requiredStage.id !== entryStage?.id) {
+    return <CrossCircle fill="danger600" />;
+  }
+  return <CheckCircle fill="success600" />;
+};
+
+const getReviewStageMessage = ({
+  contentTypeHasReviewWorkflow,
+  requiredStage,
+  entryStage,
+  formatMessage,
+}: {
+  contentTypeHasReviewWorkflow: boolean;
+  requiredStage?: Stage;
+  entryStage?: Stage;
+  formatMessage: (messageDescriptor: MessageDescriptor, values?: Record<string, string>) => string;
+}) => {
+  if (!contentTypeHasReviewWorkflow) {
+    return formatMessage({
+      id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.not-enabled',
+      defaultMessage: 'This entry is not associated to any workflow.',
+    });
+  }
+
+  if (requiredStage && requiredStage.id !== entryStage?.id) {
+    return formatMessage(
+      {
+        id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.not-ready',
+        defaultMessage: 'This entry is not at the required stage for publishing. ({stageName})',
+      },
+      {
+        stageName: requiredStage?.name ?? '',
+      }
+    );
+  }
+  return formatMessage(
+    {
+      id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage.ready',
+      defaultMessage: 'This entry is at the required stage for publishing. ({stageName})',
+    },
+    {
+      stageName: requiredStage?.name ?? '',
+    }
+  );
+};
+
+const ReviewStageValidation = ({
+  contentTypeHasReviewWorkflow,
+  requiredStage,
+  entryStage,
+}: {
+  contentTypeHasReviewWorkflow: boolean;
+  requiredStage?: Stage;
+  entryStage?: Stage;
+}) => {
+  const { formatMessage } = useIntl();
+
+  const Icon = getReviewStageIcon({
+    contentTypeHasReviewWorkflow,
+    requiredStage,
+    entryStage,
+  });
+
+  return (
+    <Flex direction="column" gap={1} width="100%" padding={5}>
+      <Flex gap={2} width="100%">
+        <Typography fontWeight="bold">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.review-stage',
+            defaultMessage: 'Review stage',
+          })}
+        </Typography>
+        {Icon}
+      </Flex>
+      <Typography>
+        {getReviewStageMessage({
+          contentTypeHasReviewWorkflow,
+          requiredStage,
+          entryStage,
+          formatMessage,
+        })}
+      </Typography>
+    </Flex>
+  );
+};
+
+export const EntryValidationPopover = ({
+  action,
+  schema,
+  entry,
+  status,
+}: EntryValidationPopoverProps) => {
+  const { validate, isLoading } = unstable_useDocument(
+    {
+      collectionType: schema?.kind ?? '',
+      model: schema?.uid ?? '',
+    },
+    {
+      // useDocument makes a request to get more data about the entry, but we only want to have the validation function so we skip the request
+      skip: true,
+    }
+  );
+
+  // Validation errors
+  const errors = isLoading ? null : validate(entry);
+  const hasErrors = errors ? Object.keys(errors).length > 0 : false;
+
+  // Entry stage
+  const contentTypeHasReviewWorkflow = schema?.options?.reviewWorkflows ?? false;
+  const requiredStage = schema?.requiredStageToPublish;
+  const entryStage = entry.strapi_stage;
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Popover.Root>
+      <EntryStatusTrigger
+        action={action}
+        status={status}
+        hasErrors={hasErrors}
+        requiredStage={requiredStage}
+        entryStage={entryStage}
+      />
+      <Popover.Content>
+        <StyledPopoverFlex direction="column">
+          <FieldsValidation
+            hasErrors={hasErrors}
+            errors={errors}
+            contentTypeUid={schema?.uid}
+            kind={schema?.kind}
+            documentId={entry.documentId}
+            locale={entry.locale}
+          />
+          <ReviewStageValidation
+            contentTypeHasReviewWorkflow={contentTypeHasReviewWorkflow}
+            requiredStage={requiredStage}
+            entryStage={entryStage}
+          />
+        </StyledPopoverFlex>
+      </Popover.Content>
+    </Popover.Root>
+  );
+};

--- a/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
@@ -17,7 +17,7 @@ describe('EntryValidationPopover', () => {
       kind: 'collectionType',
       uid: 'api::article.article',
       options: { reviewWorkflows: true },
-      requiredStageToPublish: { id: 'stage1', name: 'Ready' },
+      stageRequiredToPublish: { id: 'stage1', name: 'Ready' },
     },
     entry: {
       documentId: '1',

--- a/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
@@ -1,0 +1,118 @@
+import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
+import { render, screen, waitFor } from '@tests/utils';
+import { IntlProvider } from 'react-intl';
+
+import { EntryValidationPopover } from '../EntryValidationPopover';
+
+jest.mock('@strapi/content-manager/strapi-admin', () => ({
+  unstable_useDocument: jest.fn(),
+}));
+
+const mockUseDocument = unstable_useDocument as jest.MockedFunction<typeof unstable_useDocument>;
+
+describe('EntryValidationPopover', () => {
+  const defaultProps = {
+    action: 'publish' as const,
+    schema: {
+      kind: 'collectionType',
+      uid: 'api::article.article',
+      options: { reviewWorkflows: true },
+      requiredStageToPublish: { id: 'stage1', name: 'Ready' },
+    },
+    entry: {
+      documentId: '1',
+      locale: 'en',
+      strapi_stage: { id: 'stage1', name: 'Ready' },
+    },
+    status: 'draft' as const,
+  };
+
+  beforeEach(() => {
+    mockUseDocument.mockReturnValue({
+      validate: jest.fn(() => ({})),
+      isLoading: false,
+    } as any);
+  });
+
+  it('renders correctly for a valid entry', async () => {
+    const { user } = render(
+      <IntlProvider locale="en" messages={{}}>
+        {/* @ts-expect-error - We only define schema props we are interested in */}
+        <EntryValidationPopover {...defaultProps} />
+      </IntlProvider>
+    );
+
+    expect(screen.getByText('Ready to publish')).toBeInTheDocument();
+
+    // Open the popover
+    await user.click(screen.getByRole('button', { name: 'Ready to publish' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fields')).toBeInTheDocument();
+    });
+    expect(screen.getByText('All fields are filled correctly.')).toBeInTheDocument();
+    expect(screen.getByText('Review stage')).toBeInTheDocument();
+    expect(
+      screen.getByText('This entry is at the required stage for publishing. (Ready)')
+    ).toBeInTheDocument();
+  });
+
+  it('renders correctly for an invalid entry', async () => {
+    mockUseDocument.mockReturnValue({
+      validate: jest.fn(() => ({ title: 'Title is required' })),
+      isLoading: false,
+    } as any);
+
+    const { user } = render(
+      <IntlProvider locale="en" messages={{}}>
+        {/* @ts-expect-error - We only define schema props we are interested in */}
+        <EntryValidationPopover {...defaultProps} />
+      </IntlProvider>
+    );
+
+    expect(screen.getByText('Not ready to publish')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Not ready to publish' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fields')).toBeInTheDocument();
+    });
+    expect(screen.getByText('1 errors on fields.')).toBeInTheDocument();
+    expect(screen.getByText('See errors')).toBeInTheDocument();
+    expect(screen.getByText('Review stage')).toBeInTheDocument();
+    expect(
+      screen.getByText('This entry is at the required stage for publishing. (Ready)')
+    ).toBeInTheDocument();
+  });
+
+  it('renders correctly for an entry not at the required stage', async () => {
+    const props = {
+      ...defaultProps,
+      entry: {
+        ...defaultProps.entry,
+        strapi_stage: { id: 'stage2', name: 'Draft' },
+      },
+    };
+
+    const { user } = render(
+      <IntlProvider locale="en" messages={{}}>
+        {/* @ts-expect-error - We only define schema props we are interested in */}
+        <EntryValidationPopover {...props} />
+      </IntlProvider>
+    );
+
+    expect(screen.getByText('Not ready to publish')).toBeInTheDocument();
+
+    // Open the popover
+    await user.click(screen.getByRole('button', { name: 'Not ready to publish' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fields')).toBeInTheDocument();
+    });
+    expect(screen.getByText('All fields are filled correctly.')).toBeInTheDocument();
+    expect(screen.getByText('Review stage')).toBeInTheDocument();
+    expect(
+      screen.getByText('This entry is not at the required stage for publishing. (Ready)')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -14,9 +14,7 @@ import {
   isFetchError,
   useStrapiApp,
   Layouts,
-  FormErrors,
 } from '@strapi/admin/strapi-admin';
-import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
 import {
   Button,
   Flex,
@@ -27,21 +25,13 @@ import {
   Badge,
   SingleSelect,
   SingleSelectOption,
-  Tooltip,
   EmptyStateLayout,
   LinkButton,
   Dialog,
   SimpleMenu,
   MenuItem,
 } from '@strapi/design-system';
-import {
-  CheckCircle,
-  More,
-  Pencil,
-  Trash,
-  CrossCircle,
-  ArrowsCounterClockwise,
-} from '@strapi/icons';
+import { More, Pencil, Trash } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import format from 'date-fns/format';
 import { utcToZonedTime } from 'date-fns-tz';
@@ -49,6 +39,7 @@ import { useIntl } from 'react-intl';
 import { useParams, useNavigate, Link as ReactRouterLink, Navigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { EntryValidationPopover } from '../components/EntryValidationPopover';
 import { RelativeTime } from '../components/RelativeTime';
 import { ReleaseActionMenu } from '../components/ReleaseActionMenu';
 import { ReleaseActionOptions } from '../components/ReleaseActionOptions';
@@ -74,9 +65,7 @@ import { getBadgeProps } from './ReleasesPage';
 import type {
   ReleaseAction,
   ReleaseActionGroupBy,
-  ReleaseActionEntry,
 } from '../../../shared/contracts/release-actions';
-import type { Struct, Internal } from '@strapi/types';
 
 /* -------------------------------------------------------------------------------------------------
  * ReleaseDetailsLayout
@@ -120,159 +109,6 @@ const TrashIcon = styled(Trash)`
   }
 `;
 
-const TypographyMaxWidth = styled(Typography)`
-  max-width: 300px;
-`;
-
-interface EntryValidationTextProps {
-  action: ReleaseAction['type'];
-  schema?: Struct.ContentTypeSchema;
-  components: { [key: Internal.UID.Component]: Struct.ComponentSchema };
-  entry: ReleaseActionEntry;
-  status: ReleaseAction['status'];
-}
-
-const EntryValidationText = ({ action, schema, entry, status }: EntryValidationTextProps) => {
-  const { formatMessage } = useIntl();
-
-  const { validate, isLoading } = unstable_useDocument(
-    {
-      collectionType: schema?.kind ?? '',
-      model: schema?.uid ?? '',
-    },
-    {
-      // useDocument makes a request to get more data about the entry, but we only want to have the validation function so we skip the request
-      skip: true,
-    }
-  );
-
-  const errorsToString = (errors: FormErrors, prefix: string = ''): string => {
-    if (Object.keys(errors).length === 0) {
-      return '';
-    }
-
-    return Object.entries(errors)
-      .map(([key, value]) => {
-        if (value === undefined || value === null) {
-          return '';
-        }
-
-        if (typeof value === 'string') {
-          return formatMessage(
-            { id: value, defaultMessage: value },
-            { field: prefix ? `${prefix}.${key}` : key }
-          );
-        }
-
-        if (
-          typeof value === 'object' &&
-          value !== null &&
-          'id' in value &&
-          'defaultMessage' in value
-        ) {
-          return formatMessage(
-            // @ts-expect-error – TODO: default message will be a string
-            { id: `${value.id}.withField`, defaultMessage: value.defaultMessage },
-            { field: prefix ? `${prefix}.${key}` : key }
-          );
-        }
-
-        return errorsToString(value as FormErrors, key);
-      })
-      .join(' ');
-  };
-
-  if (isLoading) {
-    return null;
-  }
-
-  const errors = validate(entry) ?? {};
-
-  if (action === 'publish') {
-    if (Object.keys(errors).length > 0) {
-      const validationErrorsMessages = errorsToString(errors);
-
-      return (
-        <Flex gap={2}>
-          <CrossCircle fill="danger600" />
-          <Tooltip description={validationErrorsMessages}>
-            <TypographyMaxWidth
-              textColor="danger600"
-              variant="omega"
-              fontWeight="semiBold"
-              ellipsis
-            >
-              {validationErrorsMessages}
-            </TypographyMaxWidth>
-          </Tooltip>
-        </Flex>
-      );
-    }
-
-    if (status === 'draft') {
-      return (
-        <Flex gap={2}>
-          <CheckCircle fill="success600" />
-          <Typography>
-            {formatMessage({
-              id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
-              defaultMessage: 'Ready to publish',
-            })}
-          </Typography>
-        </Flex>
-      );
-    }
-
-    if (status === 'modified') {
-      return (
-        <Flex gap={2}>
-          <ArrowsCounterClockwise fill="alternative600" />
-          <Typography>
-            {formatMessage({
-              id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
-              defaultMessage: 'Ready to publish changes',
-            })}
-          </Typography>
-        </Flex>
-      );
-    }
-
-    if (status === 'published') {
-      return (
-        <Flex gap={2}>
-          <CheckCircle fill="success600" />
-          <Typography>
-            {formatMessage({
-              id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
-              defaultMessage: 'Already published',
-            })}
-          </Typography>
-        </Flex>
-      );
-    }
-  }
-
-  return (
-    <Flex gap={2}>
-      <CheckCircle fill="success600" />
-      {!entry.publishedAt ? (
-        <Typography textColor="success600" fontWeight="bold">
-          {formatMessage({
-            id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
-            defaultMessage: 'Already unpublished',
-          })}
-        </Typography>
-      ) : (
-        <Typography>
-          {formatMessage({
-            id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-unpublish',
-            defaultMessage: 'Ready to unpublish',
-          })}
-        </Typography>
-      )}
-    </Flex>
-  );
-};
 interface ReleaseDetailsLayoutProps {
   toggleEditReleaseModal: () => void;
   toggleWarningSubmit: () => void;
@@ -843,10 +679,9 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
                         {!release.releasedAt && (
                           <>
                             <Td width="20%" minWidth="200px">
-                              <EntryValidationText
+                              <EntryValidationPopover
                                 action={type}
                                 schema={contentTypes?.[contentType.uid]}
-                                components={components}
                                 entry={entry}
                                 status={status}
                               />

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -93,5 +93,6 @@
   "pages.ReleaseDetails.entry-validation.fields.see-errors": "See errors",
   "pages.ReleaseDetails.entry-validation.review-stage.not-enabled": "This entry is not associated to any workflow.",
   "pages.ReleaseDetails.entry-validation.review-stage.not-ready": "This entry is not at the required stage for publishing. ({stageName})",
-  "pages.ReleaseDetails.entry-validation.review-stage.ready": "This entry is at the required stage for publishing. ({stageName})"
+  "pages.ReleaseDetails.entry-validation.review-stage.ready": "This entry is at the required stage for publishing. ({stageName})",
+  "pages.ReleaseDetails.entry-validation.review-stage.stage-not-required": "No required stage for publication."
 }

--- a/packages/core/content-releases/admin/src/translations/en.json
+++ b/packages/core/content-releases/admin/src/translations/en.json
@@ -78,12 +78,20 @@
   "pages.ReleaseDetails.entry-validation.modified": "Ready to publish changes",
   "pages.ReleaseDetails.entry-validation.already-unpublished": "Already unpublished",
   "pages.ReleaseDetails.entry-validation.ready-to-unpublish": "Ready to unpublish",
+  "pages.ReleaseDetails.entry-validation.not-ready": "Not ready to publish",
   "pages.ReleaseDetails.groupBy.option.content-type": "Content-Types",
   "pages.ReleaseDetails.groupBy.option.locales": "Locales",
   "pages.ReleaseDetails.groupBy.option.actions": "Actions",
   "pages.ReleaseDetails.header-subtitle.scheduled": "Scheduled for {date} at {time} ({offset})",
+  "pages.ReleaseDetails.entry-validation.fields": "Fields",
   "pages.Settings.releases.title": "Releases",
   "pages.Settings.releases.description": "Create and manage content updates",
   "pages.Settings.releases.timezone.label": "Default timezone",
-  "pages.Settings.releases.setting.default-timezone-notification-success": "Default timezone updated."
+  "pages.Settings.releases.setting.default-timezone-notification-success": "Default timezone updated.",
+  "pages.ReleaseDetails.entry-validation.fields.error": "{errors} errors on fields.",
+  "pages.ReleaseDetails.entry-validation.fields.success": "All fields are filled correctly.",
+  "pages.ReleaseDetails.entry-validation.fields.see-errors": "See errors",
+  "pages.ReleaseDetails.entry-validation.review-stage.not-enabled": "This entry is not associated to any workflow.",
+  "pages.ReleaseDetails.entry-validation.review-stage.not-ready": "This entry is not at the required stage for publishing. ({stageName})",
+  "pages.ReleaseDetails.entry-validation.review-stage.ready": "This entry is at the required stage for publishing. ({stageName})"
 }

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -65,6 +65,7 @@
     "formik": "2.4.5",
     "lodash": "4.17.21",
     "node-schedule": "2.1.1",
+    "qs": "6.11.1",
     "react-intl": "6.6.2",
     "react-redux": "8.1.3",
     "yup": "0.32.9"

--- a/packages/core/content-releases/server/src/controllers/release-action.ts
+++ b/packages/core/content-releases/server/src/controllers/release-action.ts
@@ -138,7 +138,7 @@ const releaseActionController = {
 
     const groupedData = await releaseActionService.groupActions(sanitizedResults, query.sort);
 
-    const contentTypes = releaseActionService.getContentTypeModelsFromActions(results);
+    const contentTypes = await releaseActionService.getContentTypeModelsFromActions(results);
 
     const releaseService = getService('release', { strapi });
     const components = await releaseService.getAllComponents();

--- a/packages/core/content-releases/server/src/services/release-action.ts
+++ b/packages/core/content-releases/server/src/services/release-action.ts
@@ -1,6 +1,6 @@
 import { errors, async } from '@strapi/utils';
 
-import type { Core, Internal, Struct, Modules } from '@strapi/types';
+import type { Core, Internal, Modules } from '@strapi/types';
 
 import _ from 'lodash/fp';
 
@@ -245,13 +245,9 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
 
       const workflowsService = strapi.plugin('review-workflows').service('workflows');
 
-      const contentTypeModelsMap = await contentTypeUids.reduce(
+      const contentTypeModelsMap = await async.reduce(contentTypeUids)(
         async (
-          accPromise: Promise<{
-            [key: ReleaseAction['contentType']]: Struct.ContentTypeSchema & {
-              requiredStageToPublish?: number;
-            };
-          }>,
+          accPromise: Promise<GetReleaseActions.Response['meta']['contentTypes']>,
           contentTypeUid: ReleaseAction['contentType']
         ) => {
           const acc = await accPromise;
@@ -263,12 +259,12 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
 
           acc[contentTypeUid] = {
             ...contentTypeModel,
-            requiredStageToPublish: workflow?.stageRequiredToPublish,
+            stageRequiredToPublish: workflow?.stageRequiredToPublish,
           };
 
           return acc;
         },
-        Promise.resolve({})
+        {}
       );
 
       return contentTypeModelsMap;

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -116,7 +116,7 @@ export declare namespace GetReleaseActions {
       pagination: Pagination;
       contentTypes: Record<
         Struct.ContentTypeSchema['uid'],
-        Struct.ContentTypeSchema & { requiredStageToPublish?: Stage }
+        Struct.ContentTypeSchema & { stageRequiredToPublish?: Stage }
       >;
       components: Record<Struct.ComponentSchema['uid'], Struct.ComponentSchema>;
     };

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -92,6 +92,11 @@ export declare namespace CreateManyReleaseActions {
  * GET /content-releases/:id/actions - Get all release actions
  */
 
+export interface Stage extends Entity {
+  color: string;
+  name: string;
+}
+
 export type ReleaseActionGroupBy = 'contentType' | 'action' | 'locale';
 export declare namespace GetReleaseActions {
   export interface Request {
@@ -109,7 +114,10 @@ export declare namespace GetReleaseActions {
     };
     meta: {
       pagination: Pagination;
-      contentTypes: Record<Struct.ContentTypeSchema['uid'], Struct.ContentTypeSchema>;
+      contentTypes: Record<
+        Struct.ContentTypeSchema['uid'],
+        Struct.ContentTypeSchema & { requiredStageToPublish?: Stage }
+      >;
       components: Record<Struct.ComponentSchema['uid'], Struct.ComponentSchema>;
     };
   }

--- a/tests/api/core/review-workflows/review-workflows.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows.test.api.ts
@@ -20,7 +20,7 @@ const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 const productUID = 'api::product.product';
 const model = {
   pluginOptions: {},
-  draftAndPublish: false,
+  draftAndPublish: true,
   singularName: 'product',
   pluralName: 'products',
   displayName: 'Product',
@@ -74,6 +74,13 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       url: `/content-manager/collection-types/${uid}`,
     });
     return body;
+  };
+
+  const publishEntry = async (uid, id) => {
+    return await requests.admin({
+      method: 'POST',
+      url: `/content-manager/collection-types/${uid}/${id}/actions/publish`,
+    });
   };
 
   /**
@@ -131,6 +138,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       data: {
         uid: 'workflow',
         stages: { set: [defaultStage.id, secondStage.id] },
+        stageRequiredToPublish: { set: [secondStage.id] },
       },
     });
     defaultStage = await strapi.db.query(STAGE_MODEL_UID).update({
@@ -184,7 +192,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       expect(res.status).toBe(400);
       expect(res.body.error.message).toBe('Can not create a workflow without stages');
     });
-    test('It should create a workflow with stages', async () => {
+    test('It should create a workflow with stages and required stage for publish', async () => {
       const res = await requests.admin.post('/review-workflows/workflows?populate=stages', {
         body: {
           data: {
@@ -193,6 +201,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
               { name: 'Stage 1', color: '#343434' },
               { name: 'Stage 2', color: '#141414' },
             ],
+            stageRequiredToPublishName: 'Stage 2',
           },
         },
       });
@@ -205,6 +214,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
             { name: 'Stage 1', color: '#343434' },
             { name: 'Stage 2', color: '#141414' },
           ],
+          stageRequiredToPublish: { name: 'Stage 2' },
         });
       } else {
         expect(res.status).toBe(404);
@@ -336,6 +346,44 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         expect(res.status).toBe(404);
         expect(res.body.data).toBeUndefined();
       }
+    });
+  });
+
+  describe('Publishing entries with required stage for publish', () => {
+    beforeAll(async () => {
+      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+        body: { data: { contentTypes: [productUID] } },
+      });
+    });
+
+    afterAll(async () => {
+      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+        body: { data: { contentTypes: [] } },
+      });
+    });
+
+    test('It should publish an entry if the required stage for publish is set', async () => {
+      const entry = await createEntry(productUID, { name: 'Product' });
+
+      const res = await requests.admin.put(
+        `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
+        {
+          body: { data: { id: secondStage.id } },
+        }
+      );
+
+      expect(res.status).toBe(200);
+
+      const publishRes = await publishEntry(productUID, entry.documentId);
+      expect(publishRes.status).toBe(200);
+    });
+
+    test('It should not publish an entry if the required stage for publish is not set', async () => {
+      const entry = await createEntry(productUID, { name: 'Product' });
+
+      const publishRes = await publishEntry(productUID, entry.documentId);
+
+      expect(publishRes.status).toBe(400);
     });
   });
 
@@ -485,8 +533,18 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         const assigneeAttribute = 'strapi_assignee';
 
         const { status, body } = await requests.public.get(`/api/${model.pluralName}`, {
-          qs: { populate: assigneeAttribute },
+          qs: { populate: assigneeAttribute, status: 'draft' },
         });
+
+        // Assigne user to entry
+        const entry = await createEntry(productUID, { name: 'Product' });
+        const user = requests.admin.getLoggedUser();
+        await requests.admin.put(
+          `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/assignee`,
+          {
+            body: { data: { id: user.id } },
+          }
+        );
 
         expect(status).toBe(200);
         expect(body.data.length).toBeGreaterThan(0);
@@ -504,9 +562,12 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         // Assert that every assignee returned is sanitized correctly
         body.data.forEach((item) => {
           expect(item).toHaveProperty(assigneeAttribute);
-          privateUserFields.forEach((field) => {
-            expect(item[assigneeAttribute]).not.toHaveProperty(field);
-          });
+
+          if (item[assigneeAttribute]) {
+            privateUserFields.forEach((field) => {
+              expect(item[assigneeAttribute]).not.toHaveProperty(field);
+            });
+          }
         });
       });
 
@@ -537,6 +598,10 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       });
 
       test('Should not update the entity', async () => {
+        await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+          body: { data: { contentTypes: [] } },
+        });
+
         const entry = await createEntry(productUID, { name: 'Product' });
         const user = requests.admin.getLoggedUser();
 
@@ -606,7 +671,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         const stageAttribute = 'strapi_stage';
 
         const { status, body } = await requests.public.get(`/api/${model.pluralName}`, {
-          qs: { populate: stageAttribute },
+          qs: { populate: stageAttribute, status: 'draft' },
         });
 
         expect(status).toBe(200);

--- a/tests/e2e/tests/content-releases/release-details-page.spec.ts
+++ b/tests/e2e/tests/content-releases/release-details-page.spec.ts
@@ -38,38 +38,36 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await page.waitForURL('/admin/plugins/content-releases/*');
   });
 
-  test.fixme(
-    'A user should be able to add collection-type and single-type entries to a release and publish the release',
-    async ({ page }) => {
-      // Add a collection-type entry to the release
-      await page.getByRole('link', { name: 'Content Manager' }).click();
-      await page.getByRole('link', { name: 'Author' }).click();
-      await page.getByRole('gridcell', { name: 'Led Tasso' }).click();
-      await page.waitForURL('**/content-manager/collection-types/api::author.author/**');
-      await addEntryToRelease({ page, releaseName });
+  test('A user should be able to add collection-type and single-type entries to a release and publish the release', async ({
+    page,
+  }) => {
+    // Add a collection-type entry to the release
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+    await page.getByRole('link', { name: 'Author' }).click();
+    await page.getByRole('gridcell', { name: 'Led Tasso' }).click();
+    await page.waitForURL('**/content-manager/collection-types/api::author.author/**');
+    await addEntryToRelease({ page, releaseName });
 
-      // Add a single-type entry to the release
-      await page.getByRole('link', { name: 'Content Manager' }).click();
-      await page.getByRole('link', { name: 'Upcoming Matches' }).click();
-      await page.waitForURL('**/content-manager/single-types/api::upcoming-match.upcoming-match**');
-      // Open the add to release dialog
-      await addEntryToRelease({ page, releaseName });
+    // Add a single-type entry to the release
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+    await page.getByRole('link', { name: 'Upcoming Matches' }).click();
+    await page.waitForURL('**/content-manager/single-types/api::upcoming-match.upcoming-match**');
+    // Open the add to release dialog
+    await addEntryToRelease({ page, releaseName });
 
-      // Publish the release
-      await page.getByRole('link', { name: 'Releases' }).click();
-      await page.getByRole('link', { name: `${releaseName}` }).click();
-      await page.getByRole('button', { name: 'Publish' }).click();
-      expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Publish' })).not.toBeVisible();
-      await expect(
-        page.getByRole('button', { name: 'Release edit and delete menu' })
-      ).not.toBeVisible();
-      await expect(page.getByRole('gridcell', { name: 'publish unpublish' })).not.toBeVisible();
-      await expect(
-        page.getByRole('gridcell', { name: 'This entry was published.' }).first()
-      ).toBeVisible();
-    }
-  );
+    // Publish the release
+    await page.getByRole('link', { name: 'Releases' }).click();
+    await page.getByRole('link', { name: `${releaseName}` }).click();
+    await page.getByRole('button', { name: 'Publish' }).click();
+    expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Publish' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Release edit and delete menu' })).toHaveCount(0);
+    await expect(page.getByRole('gridcell', { name: 'publish unpublish' })).toHaveCount(0);
+    await expect(
+      page.getByRole('gridcell', { name: 'This entry was published.' }).first()
+    ).toBeVisible();
+  });
 
   test('A user should be able to edit and delete a release', async ({ page }) => {
     // Edit the release
@@ -90,6 +88,7 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await expect(page.getByRole('link', { name: `${editedEntryName}` })).not.toBeVisible();
   });
 
+  // @TODO: Looks like release data at with-admin.tar is corrupted. We need to fix that first before running this test
   test.fixme(
     "A user should be able to change the entry groupings, update an entry's action, remove an entry from a release, and navigate to the entry in the content manager",
     async ({ page }) => {
@@ -101,7 +100,6 @@ describeOnCondition(edition === 'EE')('Release page', () => {
       await expect(page.getByRole('separator', { name: 'publish', exact: true })).toBeVisible();
       await expect(page.getByRole('separator', { name: 'unpublish' })).toBeVisible();
 
-      // Change the entry grouping
       const row = await page.getByRole('row').filter({ hasText: 'West Ham post match analysis' });
       // The first row after the header is NOT the one we will update
       await expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8625,6 +8625,7 @@ __metadata:
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
     node-schedule: "npm:2.1.1"
+    qs: "npm:6.11.1"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-intl: "npm:6.6.2"


### PR DESCRIPTION
### What does it do?

This PR refactors the Status column on Releases details page to add a Popover where we show both: fields validations & stage validation of each entry inside a release.

### How to test it?

1. Create a release and a Review Workflow with a required stage to publish
2. Add multiple entries to your release.
3. Check the status column is showing the expected information

### Known issue

- Icon colors are not okay. I will add a following PR on the DS for this. 
<img width="290" alt="Screenshot 2024-09-27 at 13 53 43" src="https://github.com/user-attachments/assets/21229ec7-47a1-4407-aca2-421d7a967fed">
