### PR TITLE
fix: loading relations without DP fails after migrating to v5

### DIFF
--- a/packages/core/core/src/services/document-service/transform/__tests__/id-map.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/id-map.test.ts
@@ -27,6 +27,9 @@ describe('Extract document ids from relation data', () => {
       db: {
         query: jest.fn((uid) => ({ findMany: findManyQueries[uid] })),
       },
+      getModel: () => ({
+        options: { draftAndPublish: true },
+      }),
     } as unknown as Core.Strapi;
   });
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
@@ -11,8 +11,11 @@ import type { Migration } from '../common';
  */
 const createPublishedAtColumn = async (db: Knex, tableName: string) => {
   await db.schema.alterTable(tableName, (table) => {
-    table.string('published_at').defaultTo(db.fn.now());
+    table.string('published_at');
   });
+
+  // Non DP content types should have their `published_at` column set to a date
+  await db(tableName).update({ published_at: new Date() });
 };
 
 export const createdPublishedAt: Migration = {

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
@@ -11,7 +11,7 @@ import type { Migration } from '../common';
  */
 const createPublishedAtColumn = async (db: Knex, tableName: string) => {
   await db.schema.alterTable(tableName, (table) => {
-    table.string('published_at').defaultTo(new Date().getTime());
+    table.string('published_at').defaultTo(db.fn.now());
   });
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
@@ -11,7 +11,7 @@ import type { Migration } from '../common';
  */
 const createPublishedAtColumn = async (db: Knex, tableName: string) => {
   await db.schema.alterTable(tableName, (table) => {
-    table.string('published_at').defaultTo(new Date());
+    table.string('published_at').defaultTo(new Date().getTime());
   });
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
@@ -11,7 +11,7 @@ import type { Migration } from '../common';
  */
 const createPublishedAtColumn = async (db: Knex, tableName: string) => {
   await db.schema.alterTable(tableName, (table) => {
-    table.string('published_at');
+    table.string('published_at').defaultTo(new Date());
   });
 };
 


### PR DESCRIPTION
### What does it do?

A migration to add the publishedAt column was not setting a default value for content types without DP. 

Resulted in non DP entries to have null values on the publishedAt column. It failed when trying to load relations to such content types with an unexpected NULL publishedAt column. 

This PR:
- Fixes the migration
- Prevents this being an issue at all. Loading relations to nonDP content types do not require filtering by the publishedAt attribute

Fixes https://github.com/strapi/strapi/issues/21166