### PR TITLE
Fix Various Document Service Type Issues

### DIFF
--- a/packages/core/types/src/modules/documents/params/attributes/id.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/id.ts
@@ -1,0 +1,5 @@
+import type * as Data from '../../../../data';
+
+export type ID = Data.ID;
+
+export type DocumentID = Data.DocumentID;

--- a/packages/core/types/src/modules/documents/params/attributes/index.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/index.ts
@@ -1,8 +1,18 @@
-import type * as Schema from '../../../schema';
-import type * as Data from '../../../data';
+import type * as Schema from '../../../../schema';
 
-import type * as UID from '../../../uid';
-import type { Array, Constants, Object, If, Extends, MatchFirst, IsNotNever } from '../../../utils';
+import type * as UID from '../../../../uid';
+import type {
+  Array,
+  Constants,
+  Object,
+  If,
+  Extends,
+  MatchFirst,
+  IsNotNever,
+} from '../../../../utils';
+
+import type { ID, DocumentID } from './id';
+import type { OmitRelationsWithoutTarget, RelationInputValue } from './relations';
 
 export type NonFilterableKind = Extract<Schema.Attribute.Kind, 'password' | 'dynamiczone'>;
 export type FilterableKind = Exclude<Schema.Attribute.Kind, NonFilterableKind>;
@@ -22,8 +32,6 @@ export type GetNestedKeys<TSchemaUID extends UID.Schema> = Exclude<
   Schema.AttributeNamesWithTarget<TSchemaUID>,
   GetNonFilterableKeys<TSchemaUID>
 >;
-
-export type ID = Data.ID;
 
 export type BooleanValue = boolean | 'true' | 'false' | 't' | 'f' | '1' | '0' | 1 | 0;
 
@@ -69,7 +77,8 @@ export type ScalarValues = GetValue<
  */
 export type GetValues<TSchemaUID extends UID.Schema> = {
   id?: ID;
-} & OmitRelationWithoutTarget<
+  documentId?: TSchemaUID;
+} & OmitRelationsWithoutTarget<
   TSchemaUID,
   {
     [TKey in Schema.OptionalAttributeNames<TSchemaUID>]?: GetValue<
@@ -80,14 +89,6 @@ export type GetValues<TSchemaUID extends UID.Schema> = {
       Schema.AttributeByName<TSchemaUID, TKey>
     >;
   }
->;
-
-export type OmitRelationWithoutTarget<TSchemaUID extends UID.Schema, TValue> = Omit<
-  TValue,
-  Exclude<
-    Schema.AttributeNamesByType<TSchemaUID, 'relation'>,
-    Schema.AttributeNamesWithTarget<TSchemaUID>
-  >
 >;
 
 /**
@@ -102,8 +103,8 @@ export type GetValue<TAttribute extends Schema.Attribute.Attribute> = If<
       // Relation
       [
         Extends<TAttribute, Schema.Attribute.OfType<'relation'>>,
-        TAttribute extends Schema.Attribute.Relation<infer TRelationKind, infer TTarget>
-          ? If<IsNotNever<TTarget>, Schema.Attribute.RelationPluralityModifier<TRelationKind, ID>>
+        TAttribute extends Schema.Attribute.RelationWithTarget
+          ? RelationInputValue<TAttribute['relation']>
           : never,
       ],
       // DynamicZone
@@ -156,3 +157,7 @@ export type GetValue<TAttribute extends Schema.Attribute.Attribute> = If<
   >,
   unknown
 >;
+
+// Re-export useful types
+
+export type { ID, DocumentID };

--- a/packages/core/types/src/modules/documents/params/attributes/relations.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/relations.ts
@@ -1,0 +1,46 @@
+import type * as Schema from '../../../../schema';
+
+import type * as UID from '../../../../uid';
+import type { If } from '../../../../utils';
+
+import type { ID, DocumentID } from './id';
+
+type ShortHand = ID;
+type LongHandEntity = { id: ID };
+type LongHandDocument = { documentId: DocumentID; locale?: string };
+type LongHand = LongHandEntity | LongHandDocument;
+
+interface PositionalArguments {
+  before?: ID;
+  after?: ID;
+  start?: boolean;
+  end?: boolean;
+}
+
+type WithPositionArguments<T> = T & { position?: PositionalArguments };
+
+type Set = { set: ShortHand[] | LongHand[] | null };
+type Connect = { connect: ShortHand[] | WithPositionArguments<LongHand>[] };
+type Disconnect = { disconnect: ShortHand[] | LongHand[] };
+
+type FullUpdate = Set;
+type PartialUpdate = Partial<Connect & Disconnect>;
+
+type XOneInput = ShortHand | LongHand | null;
+type XManyInput = ShortHand[] | LongHand[] | null | PartialUpdate | FullUpdate;
+
+export type RelationInputValue<TRelationKind extends Schema.Attribute.RelationKind.Any> = If<
+  Schema.Attribute.IsManyRelation<TRelationKind>,
+  XManyInput,
+  XOneInput
+>;
+
+type RelationsKeysWithoutTarget<TSchemaUID extends UID.Schema> = Exclude<
+  Schema.AttributeNamesByType<TSchemaUID, 'relation'>,
+  Schema.AttributeNamesWithTarget<TSchemaUID>
+>;
+
+export type OmitRelationsWithoutTarget<TSchemaUID extends UID.Schema, TValue> = Omit<
+  TValue,
+  RelationsKeysWithoutTarget<TSchemaUID>
+>;

--- a/packages/core/types/src/modules/documents/params/filters/index.ts
+++ b/packages/core/types/src/modules/documents/params/filters/index.ts
@@ -10,6 +10,7 @@ import type * as Params from '..';
 export { Operator };
 
 type IDKey = 'id';
+type DocumentIDKey = 'documentId';
 
 /**
  * Filter representation for nested attributes
@@ -29,12 +30,13 @@ type NestedAttributeCondition<
  */
 type AttributeCondition<
   TSchemaUID extends UID.Schema,
-  TAttributeName extends IDKey | Schema.AttributeNames<TSchemaUID>,
+  TAttributeName extends IDKey | DocumentIDKey | Schema.AttributeNames<TSchemaUID>,
 > =
   MatchFirst<
     [
       // Special catch for manually added ID attributes
       [StrictEqual<TAttributeName, IDKey>, Params.Attribute.ID],
+      [StrictEqual<TAttributeName, DocumentIDKey>, Params.Attribute.DocumentID],
       [
         IsNotNever<TAttributeName>,
         // Get the filter attribute value for the given attribute
@@ -83,7 +85,7 @@ export type ObjectNotation<TSchemaUID extends UID.Schema> = {
         And<IsNotNever<TScalarKeys>, IsNotNever<TNestedKeys>>,
         // Strongly typed representation of the filter object tree
         {
-          [TIter in IDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
+          [TIter in IDKey | DocumentIDKey | TScalarKeys]?: AttributeCondition<TSchemaUID, TIter>;
         } & {
           [TIter in TNestedKeys]?: NestedAttributeCondition<TSchemaUID, TIter>;
         },

--- a/packages/core/types/src/public/shared.ts
+++ b/packages/core/types/src/public/shared.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
 /**
  * The `DocumentServicePluginParams` interface represents the various document-service's plugin parameters where the key is the parameter, and the value is the related type.
  *

--- a/packages/core/types/src/schema/attribute/definitions/relation.ts
+++ b/packages/core/types/src/schema/attribute/definitions/relation.ts
@@ -34,7 +34,7 @@ export type RelationWithTarget<
   morphMany: MorphMany<TTargetUID>;
 }[TRelationKind];
 
-type RelationWithoutTarget<
+export type RelationWithoutTarget<
   TRelationKind extends RelationKind.WithoutTarget = RelationKind.WithoutTarget,
 > = {
   // Morph Owner (morphToOne, morphToMany)


### PR DESCRIPTION
### What does it do?

- Add the possibility to filter on `documentId` (root and nested filters)
- Added back the support for the relation re-ordering API in create/update data payloads

_I've also split the attribute utils (document service's params) into different files to make it less bloated._

### Why is it needed?

Fix incorrect behaviors in the document service types

### How to test it?

Reproduce the queries from https://github.com/strapi/strapi/issues/20735#issuecomment-2380452010 using any application and similar content types

### Related issue(s)/PR(s)

fix #20735