### PR TITLE
fix: <svg> attribute width="<N>rem" errors in Safari

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -100,7 +100,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                       aria-label={labelValue}
                     >
                       <NavLink.Icon label={labelValue}>
-                        <LinkIcon width="20px" height="20px" fill="neutral500" />
+                        <LinkIcon width="20" height="20" fill="neutral500" />
                       </NavLink.Icon>
                       {badgeContentLock ? (
                         <NavLinkBadgeLock

--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -100,7 +100,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                       aria-label={labelValue}
                     >
                       <NavLink.Icon label={labelValue}>
-                        <LinkIcon width="2rem" height="2rem" fill="neutral500" />
+                        <LinkIcon width="20px" height="20px" fill="neutral500" />
                       </NavLink.Icon>
                       {badgeContentLock ? (
                         <NavLinkBadgeLock

--- a/packages/core/admin/admin/src/components/Onboarding.tsx
+++ b/packages/core/admin/admin/src/components/Onboarding.tsx
@@ -112,7 +112,7 @@ const Onboarding = () => {
                   width={6}
                   height={6}
                 >
-                  <Play fill="buttonNeutral0" width="12px" height="12px" />
+                  <Play fill="buttonNeutral0" width="12" height="12" />
                 </IconWrapper>
               </Box>
               <Flex direction="column" alignItems="start" paddingLeft={4}>

--- a/packages/core/admin/admin/src/components/Onboarding.tsx
+++ b/packages/core/admin/admin/src/components/Onboarding.tsx
@@ -112,7 +112,7 @@ const Onboarding = () => {
                   width={6}
                   height={6}
                 >
-                  <Play fill="buttonNeutral0" width="1.2rem" height="1.2rem" />
+                  <Play fill="buttonNeutral0" width="12px" height="12px" />
                 </IconWrapper>
               </Box>
               <Flex direction="column" alignItems="start" paddingLeft={4}>


### PR DESCRIPTION
Сhanged the with and height value for all svgs used in the LeftMenu & Onboarding. It was changed from <N>rem to <N*10>px. Rem was leading to the error message Error: Invalid value for <svg> attribute width="<N>rem" in the safari browser.

### What does it do?

Changed the with and height value for all svgs used in the packages/core/admin/admin/src/components/LeftMenu.tsx LinkIcon component. It was changed from 2rem to 20px.
Changed the with and height value for all svgs used in the packages/core/admin/admin/src/components/Onboarding.tsx Play component. It was changed from 1.2rem to 12px.

### Why is it needed?

Rem was leading to the error message Error: Invalid value for <svg> attribute width="<N>rem" in the safari browser.

### How to test it?

Run new project in dev mode, open admin panel (Home page) in Safari browser, open console and watch errors.
Click Help button and watch errors in console.