### PR TITLE
feat: fix filters attribute name

### DIFF
--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -152,7 +152,7 @@ describe('traverseQueryPopulate', () => {
       getModel: strapi.getModel,
     } as const;
 
-    await traverseQueryPopulate(({ key, schema, path, parent, attribute }) => {
+    await traverseQueryPopulate(({ key, parent }) => {
       switch (key) {
         case 'address':
           // top level populate should not have parent

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -152,17 +152,18 @@ describe('traverseQueryPopulate', () => {
       getModel: strapi.getModel,
     } as const;
 
-    await traverseQueryPopulate(({ key, parent }) => {
+    await traverseQueryPopulate(({ key, parent, attribute }) => {
       switch (key) {
         case 'address':
           // top level populate should not have parent
           expect(parent).toBeUndefined();
+          expect(attribute).toBeDefined();
           break;
-
         case 'filters':
           // Parent information should be available
           expect(parent.key).toBe('address');
           expect(parent.attribute).not.toBeUndefined();
+          expect(attribute).toBeDefined();
           break;
         default:
           break;

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -106,8 +106,7 @@ describe('traverseQueryPopulate', () => {
   });
 
   test('should work with filters attribute', async () => {
-    // Expect should be called 4 times
-    expect.assertions(3);
+    expect.assertions(5);
 
     const strapi = {
       getModel: jest.fn((uid) => {

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -144,11 +144,6 @@ describe('traverseQueryPopulate', () => {
           relation: 'oneToOne',
           target: 'api::address.address',
         },
-        some: {
-          type: 'relation',
-          relation: 'ManyToMany',
-          target: 'api::some.some',
-        },
       },
     } as const;
 

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -104,4 +104,80 @@ describe('traverseQueryPopulate', () => {
 
     expect(query).toEqual('address');
   });
+
+  test('should work with filters attribute', async () => {
+    // Expect should be called 4 times
+    expect.assertions(3);
+
+    const strapi = {
+      getModel: jest.fn((uid) => {
+        return {
+          uid,
+          attributes: {
+            filters: {
+              type: 'string',
+            },
+          },
+        };
+      }),
+      db: {
+        metadata: {
+          get: jest.fn(() => ({
+            columnToAttribute: {
+              address: 'address',
+            },
+          })),
+        },
+      },
+    } as any;
+
+    global.strapi = strapi;
+
+    const schema = {
+      kind: 'collectionType',
+      attributes: {
+        title: {
+          type: 'string',
+        },
+        address: {
+          type: 'relation',
+          relation: 'oneToOne',
+          target: 'api::address.address',
+        },
+        some: {
+          type: 'relation',
+          relation: 'ManyToMany',
+          target: 'api::some.some',
+        },
+      },
+    } as const;
+
+    const ctx = {
+      schema,
+      getModel: strapi.getModel,
+    } as const;
+
+    await traverseQueryPopulate(({ key, schema, path, parent, attribute }) => {
+      switch (key) {
+        case 'address':
+          // top level populate should not have parent
+          expect(parent).toBeUndefined();
+          break;
+
+        case 'filters':
+          // Parent information should be available
+          expect(parent.key).toBe('address');
+          expect(parent.attribute).not.toBeUndefined();
+          break;
+        default:
+          break;
+      }
+    }, ctx)({
+      address: {
+        filters: {
+          name: 'test',
+        },
+      },
+    });
+  });
 });

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -1,6 +1,6 @@
 import { clone, isObject, isArray, isNil, curry } from 'lodash/fp';
 
-import type { AnyAttribute, Model, Data } from './types';
+import type { Attribute, AnyAttribute, Model, Data } from './types';
 import { isRelationalAttribute, isMediaAttribute } from './content-types';
 
 export type VisitorUtils = ReturnType<typeof createVisitorUtils>;
@@ -31,10 +31,10 @@ export interface TraverseOptions {
 }
 
 export interface Parent {
+  attribute?: Attribute;
+  key: string | null;
   path: Path;
-  schema?: Model;
-  key?: string;
-  attribute?: AnyAttribute;
+  schema: Model;
 }
 
 const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity: Data) => {

--- a/packages/core/utils/src/traverse/factory.ts
+++ b/packages/core/utils/src/traverse/factory.ts
@@ -15,9 +15,17 @@ export interface Path {
   attribute: string | null;
 }
 
-export interface TraverseOptions {
-  path?: Path;
+export interface Parent {
+  attribute?: Attribute;
+  key: string | null;
+  path: Path;
   schema: Model;
+}
+
+export interface TraverseOptions {
+  schema: Model;
+  path?: Path;
+  parent?: Parent;
   getModel(uid: string): Model;
 }
 
@@ -28,6 +36,7 @@ export interface VisitorOptions {
   key: string;
   attribute?: AnyAttribute;
   path: Path;
+  parent?: Parent;
   getModel(uid: string): Model;
 }
 
@@ -91,8 +100,10 @@ interface Context<AttributeType = Attribute> {
   path: Path;
   data: unknown;
   visitor: Visitor;
+  parent?: Parent;
   getModel(uid: string): Model;
 }
+
 interface State {
   parsers: Parser[];
   interceptors: Interceptor[];
@@ -103,7 +114,7 @@ interface State {
   };
 }
 
-const DEFAULT_PATH = { raw: null, attribute: null };
+const DEFAULT_PATH = { raw: null, attribute: null } satisfies Path;
 
 export default () => {
   const state: State = {
@@ -117,7 +128,7 @@ export default () => {
   };
 
   const traverse: Traverse = async (visitor, options, data) => {
-    const { path = DEFAULT_PATH, schema, getModel } = options ?? {};
+    const { path = DEFAULT_PATH, parent, schema, getModel } = options ?? {};
 
     // interceptors
     for (const { predicate, handler } of state.interceptors) {
@@ -159,6 +170,7 @@ export default () => {
         path: newPath,
         data: out,
         getModel,
+        parent,
       };
 
       const transformUtils: TransformUtils = {
@@ -184,6 +196,7 @@ export default () => {
         data: out,
         visitor,
         getModel,
+        parent,
       });
 
       // ignore

--- a/packages/core/utils/src/traverse/query-filters.ts
+++ b/packages/core/utils/src/traverse/query-filters.ts
@@ -1,6 +1,6 @@
 import { curry, isObject, isEmpty, isArray, isNil, cloneDeep, omit } from 'lodash/fp';
 
-import traverseFactory, { Parent } from './factory';
+import traverseFactory, { type Parent } from './factory';
 
 const isObj = (value: unknown): value is Record<string, unknown> => isObject(value);
 

--- a/packages/core/utils/src/traverse/query-filters.ts
+++ b/packages/core/utils/src/traverse/query-filters.ts
@@ -1,6 +1,6 @@
 import { curry, isObject, isEmpty, isArray, isNil, cloneDeep, omit } from 'lodash/fp';
 
-import traverseFactory from './factory';
+import traverseFactory, { Parent } from './factory';
 
 const isObj = (value: unknown): value is Record<string, unknown> => isObject(value);
 
@@ -55,38 +55,61 @@ const filters = traverseFactory()
   // Recursion on operators (non attributes)
   .on(
     ({ attribute }) => isNil(attribute),
-    async ({ key, visitor, path, value, schema, getModel }, { set, recurse }) => {
-      set(key, await recurse(visitor, { schema, path, getModel }, value));
+    async ({ key, visitor, path, value, schema, getModel, attribute }, { set, recurse }) => {
+      const parent: Parent = { key, path, schema, attribute };
+
+      set(key, await recurse(visitor, { schema, path, getModel, parent }, value));
     }
   )
   // Handle relation recursion
-  .onRelation(async ({ key, attribute, visitor, path, value, getModel }, { set, recurse }) => {
-    const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+  .onRelation(
+    async ({ key, attribute, visitor, path, value, schema, getModel }, { set, recurse }) => {
+      const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
 
-    if (isMorphRelation) {
-      return;
+      if (isMorphRelation) {
+        return;
+      }
+
+      const parent: Parent = { key, path, schema, attribute };
+
+      const targetSchemaUID = attribute.target;
+      const targetSchema = getModel(targetSchemaUID!);
+
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
+
+      set(key, newValue);
     }
+  )
+  .onComponent(
+    async ({ key, attribute, visitor, path, schema, value, getModel }, { set, recurse }) => {
+      const parent: Parent = { key, path, schema, attribute };
+      const targetSchema = getModel(attribute.component);
 
-    const targetSchemaUID = attribute.target;
-    const targetSchema = getModel(targetSchemaUID!);
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
-
-    set(key, newValue);
-  })
-  .onComponent(async ({ key, attribute, visitor, path, value, getModel }, { set, recurse }) => {
-    const targetSchema = getModel(attribute.component);
-
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
-
-    set(key, newValue);
-  })
+      set(key, newValue);
+    }
+  )
   // Handle media recursion
-  .onMedia(async ({ key, visitor, path, value, getModel }, { set, recurse }) => {
+  .onMedia(async ({ key, visitor, path, schema, attribute, value, getModel }, { set, recurse }) => {
+    const parent: Parent = { key, path, schema, attribute };
+
     const targetSchemaUID = 'plugin::upload.file';
     const targetSchema = getModel(targetSchemaUID);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
+    const newValue = await recurse(
+      visitor,
+      { schema: targetSchema, path, getModel, parent },
+      value
+    );
 
     set(key, newValue);
   });

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -37,6 +37,10 @@ const isObj = (value: unknown): value is Record<string, unknown> => isObject(val
 
 const populate = traverseFactory()
   .intercept(isPopulateString, async (visitor, options, populate, { recurse }) => {
+    /**
+     * Ensure the populate clause its in the extended format ( { populate: { ... } }, and not just a string)
+     * This gives a consistent structure to track the "parent" node of each nested populate clause
+     */
     const populateObject = pathsToObjectPopulate([populate]);
     const traversedPopulate = (await recurse(visitor, options, populateObject)) as PopulateObject;
     const [result] = objectPopulateToPaths(traversedPopulate);

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -14,7 +14,7 @@ import {
   first,
 } from 'lodash/fp';
 
-import traverseFactory from './factory';
+import traverseFactory, { Parent } from './factory';
 import { Attribute } from '../types';
 import { isMorphToRelationalAttribute } from '../content-types';
 
@@ -139,34 +139,45 @@ const populate = traverseFactory()
   .on(
     // Handle recursion on populate."populate"
     isKeyword('populate'),
-    async ({ key, visitor, path, value, schema, getModel }, { set, recurse }) => {
-      const newValue = await recurse(visitor, { schema, path, getModel }, value);
+    async ({ key, visitor, path, value, schema, getModel, attribute }, { set, recurse }) => {
+      const parent: Parent = { key, path, schema, attribute };
+
+      const newValue = await recurse(visitor, { schema, path, getModel, parent }, value);
 
       set(key, newValue);
     }
   )
-  .on(isKeyword('on'), async ({ key, visitor, path, value, getModel }, { set, recurse }) => {
-    const newOn: Record<string, unknown> = {};
+  .on(
+    isKeyword('on'),
+    async ({ key, visitor, path, value, getModel, parent }, { set, recurse }) => {
+      const newOn: Record<string, unknown> = {};
 
-    if (!isObj(value)) {
-      return;
+      if (!isObj(value)) {
+        return;
+      }
+
+      for (const [uid, subPopulate] of Object.entries(value)) {
+        const model = getModel(uid);
+        const newPath = { ...path, raw: `${path.raw}[${uid}]` };
+
+        newOn[uid] = await recurse(
+          visitor,
+          { schema: model, path: newPath, getModel, parent },
+          subPopulate
+        );
+      }
+
+      set(key, newOn);
     }
-
-    for (const [uid, subPopulate] of Object.entries(value)) {
-      const model = getModel(uid);
-      const newPath = { ...path, raw: `${path.raw}[${uid}]` };
-
-      newOn[uid] = await recurse(visitor, { schema: model, path: newPath, getModel }, subPopulate);
-    }
-
-    set(key, newOn);
-  })
+  )
   // Handle populate on relation
   .onRelation(
     async ({ key, value, attribute, visitor, path, schema, getModel }, { set, recurse }) => {
       if (isNil(value)) {
         return;
       }
+
+      const parent: Parent = { key, path, schema, attribute };
 
       if (isMorphToRelationalAttribute(attribute)) {
         // Don't traverse values that cannot be parsed
@@ -175,7 +186,11 @@ const populate = traverseFactory()
         }
 
         // If there is a populate fragment defined, traverse it
-        const newValue = await recurse(visitor, { schema, path, getModel }, { on: value?.on });
+        const newValue = await recurse(
+          visitor,
+          { schema, path, getModel, parent },
+          { on: value?.on }
+        );
 
         set(key, newValue);
 
@@ -185,48 +200,70 @@ const populate = traverseFactory()
       const targetSchemaUID = attribute.target;
       const targetSchema = getModel(targetSchemaUID!);
 
-      const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
 
       set(key, newValue);
     }
   )
   // Handle populate on media
-  .onMedia(async ({ key, path, visitor, value, getModel }, { recurse, set }) => {
+  .onMedia(async ({ key, path, schema, attribute, visitor, value, getModel }, { recurse, set }) => {
     if (isNil(value)) {
       return;
     }
+
+    const parent: Parent = { key, path, schema, attribute };
 
     const targetSchemaUID = 'plugin::upload.file';
     const targetSchema = getModel(targetSchemaUID);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
+    const newValue = await recurse(
+      visitor,
+      { schema: targetSchema, path, getModel, parent },
+      value
+    );
 
     set(key, newValue);
   })
   // Handle populate on components
-  .onComponent(async ({ key, value, visitor, path, attribute, getModel }, { recurse, set }) => {
-    if (isNil(value)) {
-      return;
+  .onComponent(
+    async ({ key, value, schema, visitor, path, attribute, getModel }, { recurse, set }) => {
+      if (isNil(value)) {
+        return;
+      }
+
+      const parent: Parent = { key, path, schema, attribute };
+
+      const targetSchema = getModel(attribute.component);
+
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
+
+      set(key, newValue);
     }
-
-    const targetSchema = getModel(attribute.component);
-
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
-
-    set(key, newValue);
-  })
+  )
   // Handle populate on dynamic zones
-  .onDynamicZone(async ({ key, value, schema, visitor, path, getModel }, { set, recurse }) => {
-    if (isNil(value) || !isObject(value)) {
-      return;
-    }
+  .onDynamicZone(
+    async ({ key, value, schema, visitor, path, attribute, getModel }, { set, recurse }) => {
+      if (isNil(value) || !isObject(value)) {
+        return;
+      }
 
-    // Handle fragment syntax
-    if ('on' in value && value.on) {
-      const newOn = await recurse(visitor, { schema, path, getModel }, { on: value.on });
+      const parent: Parent = { key, path, schema, attribute };
 
-      set(key, newOn);
+      // Handle fragment syntax
+      if ('on' in value && value.on) {
+        const newOn = await recurse(visitor, { schema, path, getModel, parent }, { on: value.on });
+
+        set(key, newOn);
+      }
     }
-  });
+  );
 
 export default curry(populate.traverse);

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -14,7 +14,7 @@ import {
   first,
 } from 'lodash/fp';
 
-import traverseFactory, { Parent } from './factory';
+import traverseFactory, { type Parent } from './factory';
 import { Attribute } from '../types';
 import { isMorphToRelationalAttribute } from '../content-types';
 

--- a/packages/core/utils/src/traverse/query-sort.ts
+++ b/packages/core/utils/src/traverse/query-sort.ts
@@ -13,7 +13,7 @@ import {
   cloneDeep,
 } from 'lodash/fp';
 
-import traverseFactory, { Parent } from './factory';
+import traverseFactory, { type Parent } from './factory';
 
 const ORDERS = { asc: 'asc', desc: 'desc' };
 const ORDER_VALUES = Object.values(ORDERS);

--- a/packages/core/utils/src/traverse/query-sort.ts
+++ b/packages/core/utils/src/traverse/query-sort.ts
@@ -13,7 +13,7 @@ import {
   cloneDeep,
 } from 'lodash/fp';
 
-import traverseFactory from './factory';
+import traverseFactory, { Parent } from './factory';
 
 const ORDERS = { asc: 'asc', desc: 'desc' };
 const ORDER_VALUES = Object.values(ORDERS);
@@ -135,36 +135,58 @@ const sort = traverseFactory()
     },
   }))
   // Handle deep sort on relation
-  .onRelation(async ({ key, value, attribute, visitor, path, getModel }, { set, recurse }) => {
-    const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
+  .onRelation(
+    async ({ key, value, attribute, visitor, path, getModel, schema }, { set, recurse }) => {
+      const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
 
-    if (isMorphRelation) {
-      return;
+      if (isMorphRelation) {
+        return;
+      }
+
+      const parent: Parent = { key, path, schema, attribute };
+
+      const targetSchemaUID = attribute.target;
+      const targetSchema = getModel(targetSchemaUID!);
+
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
+
+      set(key, newValue);
     }
-
-    const targetSchemaUID = attribute.target;
-    const targetSchema = getModel(targetSchemaUID!);
-
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
-
-    set(key, newValue);
-  })
+  )
   // Handle deep sort on media
-  .onMedia(async ({ key, path, visitor, value, getModel }, { recurse, set }) => {
+  .onMedia(async ({ key, path, schema, attribute, visitor, value, getModel }, { recurse, set }) => {
+    const parent: Parent = { key, path, schema, attribute };
+
     const targetSchemaUID = 'plugin::upload.file';
     const targetSchema = getModel(targetSchemaUID);
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
+    const newValue = await recurse(
+      visitor,
+      { schema: targetSchema, path, getModel, parent },
+      value
+    );
 
     set(key, newValue);
   })
   // Handle deep sort on components
-  .onComponent(async ({ key, value, visitor, path, attribute, getModel }, { recurse, set }) => {
-    const targetSchema = getModel(attribute.component);
+  .onComponent(
+    async ({ key, value, visitor, path, schema, attribute, getModel }, { recurse, set }) => {
+      const parent: Parent = { key, path, schema, attribute };
 
-    const newValue = await recurse(visitor, { schema: targetSchema, path, getModel }, value);
+      const targetSchema = getModel(attribute.component);
 
-    set(key, newValue);
-  });
+      const newValue = await recurse(
+        visitor,
+        { schema: targetSchema, path, getModel, parent },
+        value
+      );
+
+      set(key, newValue);
+    }
+  );
 
 export default curry(sort.traverse);

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -253,6 +253,12 @@ export const validatePopulate = asyncCurry(
     functionsToApply.push(
       traverseQueryPopulate(
         async ({ key, path, value, schema, attribute, getModel, parent }, { set }) => {
+          /**
+           * NOTE: The parent check is done to support "filters" (and the rest of keys) as valid attribute names.
+           *
+           * The parent will not be an attribute when its a "populate" / "filters" / "sort" ... key.
+           * Only in those scenarios the node will be an attribute.
+           */
           if (!parent?.attribute && attribute) {
             const isPopulatableAttribute = [
               'relation',

--- a/packages/core/utils/src/validate/validators.ts
+++ b/packages/core/utils/src/validate/validators.ts
@@ -13,12 +13,18 @@ import { isOperator } from '../operators';
 import { asyncCurry, throwInvalidKey } from './utils';
 import type { Model } from '../types';
 import parseType from '../parse-type';
+import type { Parent, Path } from '../traverse/factory';
 
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE } = constants;
 
 interface Context {
   schema: Model;
   getModel: (model: string) => Model;
+}
+
+interface PopulateContext extends Context {
+  path?: Path;
+  parent?: Parent;
 }
 
 type AnyFunc = (...args: any[]) => any;
@@ -228,7 +234,7 @@ export const POPULATE_TRAVERSALS = ['nonAttributesOperators', 'private'];
 
 export const validatePopulate = asyncCurry(
   async (
-    ctx: Context,
+    ctx: PopulateContext,
     populate: unknown,
     includes: {
       fields?: (typeof FIELDS_TRAVERSALS)[number][];
@@ -366,6 +372,8 @@ export const validatePopulate = asyncCurry(
                 {
                   schema,
                   getModel,
+                  parent: { key, path, schema, attribute },
+                  path,
                 },
                 value, // pass the nested populate value
                 includes // pass down the same includes object

--- a/tests/api/core/strapi/api/populate/filtering/index.test.api.js
+++ b/tests/api/core/strapi/api/populate/filtering/index.test.api.js
@@ -44,6 +44,8 @@ const schemas = {
         pass: { type: 'password' },
         fooRef: { type: 'component', component: 'default.foo', repeatable: false },
         barRefs: { type: 'component', component: 'default.bar', repeatable: true },
+        // NOTE: Test conflicting attribute names do not cause issues with populate object
+        filters: { type: 'relation', relation: 'oneToOne', target: 'api::a.a' },
       },
     },
     b: {
@@ -221,9 +223,9 @@ describe('Populate filters', () => {
       });
     });
 
-    test.only('No filters & deep populate', async () => {
+    test('No filters & deep populate', async () => {
       const qs = {
-        populate: ['second', 'third.fooRef'],
+        populate: ['second', 'third.fooRef', 'third.filters'],
       };
       const { status, body } = await rq.get(`/${schemas.contentTypes.c.pluralName}`, { qs });
 

--- a/tests/api/core/strapi/api/populate/filtering/index.test.api.js
+++ b/tests/api/core/strapi/api/populate/filtering/index.test.api.js
@@ -19,6 +19,8 @@ const schemas = {
       attributes: {
         number: { type: 'integer' },
         field: { type: 'string' },
+        // NOTE: Test conflicting attribute names do not cause issues with populate object
+        filters: { type: 'json' },
       },
     },
     bar: {
@@ -26,6 +28,8 @@ const schemas = {
       attributes: {
         title: { type: 'string' },
         field: { type: 'password' },
+        // NOTE: Test conflicting attribute names do not cause issues with populate object
+        filters: { type: 'json' },
       },
     },
   },
@@ -217,7 +221,7 @@ describe('Populate filters', () => {
       });
     });
 
-    test('No filters & deep populate', async () => {
+    test.only('No filters & deep populate', async () => {
       const qs = {
         populate: ['second', 'third.fooRef'],
       };


### PR DESCRIPTION
### What does it do?

As seen in https://github.com/strapi/strapi/issues/21338 , attribute names called `filters` broke the populate validation.
That's cause it was confusing a "filter" inside a populate with the filters attribute name:
```ts
{
  populate: {
    foo: {
      filters: { bar: { $eq: 1 } }  // Should filter entries where bar is 1
    }
  }
}

{
  populate: {
    foo: {
      populate: {
        filters: true  //  Should populate the "filters" attribute
      }
    }
  }
}
```

The `traverseQueryPopulate` was assuming `filters` was an attribute, as it was an actual attribute of the schema. Hence the first query was always invalid.

This PR solves this by modifying the `traverseQueryPopulate` and tracking each traversed node parent. 
