### PR TITLE
Add Back the Deprecated Shared Populate Option for Morph Links

### DIFF
--- a/packages/core/types/src/modules/documents/params/populate.ts
+++ b/packages/core/types/src/modules/documents/params/populate.ts
@@ -1,7 +1,17 @@
 import type * as Schema from '../../../schema';
 
 import type * as UID from '../../../uid';
-import type { Constants, Guard, If, And, DoesNotExtends, IsNotNever, XOR } from '../../../utils';
+import type {
+  Constants,
+  Guard,
+  If,
+  And,
+  DoesNotExtends,
+  IsNotNever,
+  XOR,
+  Intersect,
+  Extends,
+} from '../../../utils';
 
 import type { Params } from '..';
 
@@ -67,9 +77,31 @@ type PopulateClause<
   TSchemaUID extends UID.Schema,
   TKeys extends Schema.PopulatableAttributeNames<TSchemaUID>,
 > = {
-  [TKey in TKeys]?:
-    | boolean
-    | NestedParams<Schema.Attribute.Target<Schema.AttributeByName<TSchemaUID, TKey>>>;
+  [TKey in TKeys]?: Schema.Attribute.Target<
+    Schema.AttributeByName<TSchemaUID, TKey>
+  > extends infer TTarget extends UID.Schema
+    ?
+        | boolean
+        | Intersect<
+            [
+              NestedParams<TTarget>,
+              // Only add the count clause to content types links, ignore components
+              If<Extends<TTarget, UID.ContentType>, CountClause, unknown>,
+            ]
+          >
+    : never;
+};
+
+type CountClause = { count?: boolean };
+
+// TODO: Remove support in v6
+type DeprecatedSharedPopulateClauseForPolymorphicLinks = {
+  /**
+   * Allows the population of all first level links in a polymorphic link by using a wildcard.
+   *
+   * @deprecated The support is going to be dropped in Strapi v6
+   */
+  populate?: WildcardNotation;
 };
 
 /**
@@ -92,31 +124,39 @@ export type ObjectNotation<TSchemaUID extends UID.Schema> = [
       And<
         Constants.AreSchemaRegistriesExtended,
         // If TSchemaUID === UID.Schema, then ignore it and move to loose types
-        // Note: Currently, this only ignores TSchemaUID when it is equal to UID.Schema, it won't work if UID.(ContentType|Component) is passed as parameter
+        // Note: Currently, this only ignores TSchemaUID when it's equal to UID.Schema, it won't work if UID.(ContentType|Component) is passed as parameter
         DoesNotExtends<UID.Schema, TSchemaUID>
       >,
       // Populatable keys with a target
       | If<IsNotNever<TKeysWithTarget>, PopulateClause<TSchemaUID, TKeysWithTarget>>
-      // Populatable keys with either zero or multiple target(s)
+      // Populatable keys with either zero or multiple target
       | If<
           IsNotNever<TKeysWithoutTarget>,
           {
             [TKey in TKeysWithoutTarget]?:
               | boolean
-              | Fragment<
-                  Guard.Never<
-                    Schema.Attribute.MorphTargets<Schema.AttributeByName<TSchemaUID, TKey>>,
-                    UID.Schema
-                  >
+              | Intersect<
+                  [
+                    Fragment<
+                      Guard.Never<
+                        Schema.Attribute.MorphTargets<Schema.AttributeByName<TSchemaUID, TKey>>,
+                        UID.Schema
+                      >
+                    >,
+                    DeprecatedSharedPopulateClauseForPolymorphicLinks,
+                  ]
                 >;
           }
         >,
-      // Loose fallback when registries are not extended
+      // Loose fallback when registries aren't extended
       {
         [key: string]:
           | boolean
           // We can't have both populate fragments and nested params, hence the xor
-          | XOR<NestedParams<UID.Schema>, Fragment<UID.Schema>>;
+          | XOR<
+              Intersect<[NestedParams<UID.Schema>, CountClause]>,
+              Intersect<[Fragment<UID.Schema>, DeprecatedSharedPopulateClauseForPolymorphicLinks]>
+            >;
       }
     >
   : never;

--- a/packages/core/types/src/modules/documents/params/populate.ts
+++ b/packages/core/types/src/modules/documents/params/populate.ts
@@ -97,7 +97,7 @@ type CountClause = { count?: boolean };
 // TODO: Remove support in v6
 type DeprecatedSharedPopulateClauseForPolymorphicLinks = {
   /**
-   * Allows the population of all first level links in a polymorphic link by using a wildcard.
+   * Enables the population of all first-level links using a wildcard.
    *
    * @deprecated The support is going to be dropped in Strapi v6
    */

--- a/packages/core/types/src/modules/documents/params/populate.ts
+++ b/packages/core/types/src/modules/documents/params/populate.ts
@@ -129,7 +129,7 @@ export type ObjectNotation<TSchemaUID extends UID.Schema> = [
       >,
       // Populatable keys with a target
       | If<IsNotNever<TKeysWithTarget>, PopulateClause<TSchemaUID, TKeysWithTarget>>
-      // Populatable keys with either zero or multiple target
+      // Populatable keys with either zero or multiple targets
       | If<
           IsNotNever<TKeysWithoutTarget>,
           {

--- a/packages/core/types/src/schema/attribute/definitions/component.ts
+++ b/packages/core/types/src/schema/attribute/definitions/component.ts
@@ -47,4 +47,4 @@ export type GetComponentValue<TAttribute extends Attribute.Attribute> =
     : never;
 
 export type ComponentTarget<TAttribute extends Attribute.Attribute> =
-  TAttribute extends Component<infer TComponentUID> ? TComponentUID : never;
+  TAttribute extends Component<infer TComponentUID, Constants.BooleanValue> ? TComponentUID : never;

--- a/packages/core/types/src/schema/attribute/definitions/media.ts
+++ b/packages/core/types/src/schema/attribute/definitions/media.ts
@@ -1,3 +1,4 @@
+import type { ContentType } from '../../../data';
 import type { Constants, If, Intersect } from '../../../utils';
 import type { Attribute } from '../..';
 
@@ -32,7 +33,6 @@ export type Media<
   ]
 >;
 
-// TODO: [TS2] Introduce a real type for the media values, remove any
 export type MediaValue<TMultiple extends Constants.BooleanValue = Constants.False> = If<
   TMultiple,
   any[],
@@ -49,6 +49,5 @@ export type GetMediaValue<TAttribute extends Attribute.Attribute> =
     ? MediaValue<TMultiple>
     : never;
 
-export type MediaTarget<TAttribute extends Attribute.Attribute> = TAttribute extends Media
-  ? MediaTargetUID
-  : never;
+export type MediaTarget<TAttribute extends Attribute.Attribute> =
+  TAttribute extends Media<MediaKind | undefined, Constants.BooleanValue> ? MediaTargetUID : never;

--- a/packages/core/types/src/schema/attribute/definitions/media.ts
+++ b/packages/core/types/src/schema/attribute/definitions/media.ts
@@ -1,4 +1,3 @@
-import type { ContentType } from '../../../data';
 import type { Constants, If, Intersect } from '../../../utils';
 import type { Attribute } from '../..';
 

--- a/packages/core/types/src/schema/attribute/definitions/media.ts
+++ b/packages/core/types/src/schema/attribute/definitions/media.ts
@@ -35,8 +35,8 @@ export type Media<
 
 export type MediaValue<TMultiple extends Constants.BooleanValue = Constants.False> = If<
   TMultiple,
-  ContentType<'plugin::upload.file'>[],
-  ContentType<'plugin::upload.file'>
+  any[],
+  any
 >;
 
 export type GetMediaValue<TAttribute extends Attribute.Attribute> =

--- a/packages/core/types/src/schema/attribute/definitions/media.ts
+++ b/packages/core/types/src/schema/attribute/definitions/media.ts
@@ -35,8 +35,8 @@ export type Media<
 
 export type MediaValue<TMultiple extends Constants.BooleanValue = Constants.False> = If<
   TMultiple,
-  any[],
-  any
+  ContentType<'plugin::upload.file'>[],
+  ContentType<'plugin::upload.file'>
 >;
 
 export type GetMediaValue<TAttribute extends Attribute.Attribute> =

--- a/packages/core/types/src/utils/expression.ts
+++ b/packages/core/types/src/utils/expression.ts
@@ -1,4 +1,4 @@
-import type { Array, Constants } from '.';
+import type { Array, Constants, Pretty } from '.';
 
 /**
  * The `IsNever` type checks if a given type {@link TValue} strictly equals to `never`.
@@ -535,5 +535,5 @@ export type Intersect<TValues extends unknown[]> = TValues extends [
   infer THead,
   ...infer TTail extends unknown[],
 ]
-  ? THead & If<Array.IsNotEmpty<TTail>, Intersect<TTail>, unknown>
+  ? Pretty<THead & If<Array.IsNotEmpty<TTail>, Intersect<TTail>, unknown>>
   : never;

--- a/packages/core/types/src/utils/index.ts
+++ b/packages/core/types/src/utils/index.ts
@@ -205,3 +205,32 @@ export type PartialWithThis<T> = Partial<T> & ThisType<T>;
  *
  */
 export type OneOf<T, U> = (T & { [K in keyof U]?: never }) | (U & { [K in keyof T]?: never });
+
+/**
+ * Enhances a given type by creating a new type from its properties using an intersection with an untyped object.
+ *
+ * This results in a cleaner and more readable type when inspected, as properties are flattened.
+ *
+ * @template T - The type to be beautified.
+ *
+ * @example
+ * Applying `Pretty` to a more complex type:
+ * ```typescript
+ * interface A {
+ *   foo: string;
+ *   bar: number;
+ * }
+ *
+ * interface B {
+ *   baz: boolean;
+ * }
+ *
+ * type C = A & B;
+ * ^ {
+ *     foo: string;
+ *     bar: number;
+ *     baz: boolean;
+ *   }
+ * ```
+ */
+export type Pretty<T> = { [K in keyof T]: T[K] } & unknown;

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -403,6 +403,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
           );
         }
 
+        // TODO: Remove the possibility to have multiple properties at the same time (on/count/populate)
         const newSubPopulate = {};
 
         // case: { populate: '*' }

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -394,9 +394,6 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
          * Validate nested population queries in the context of a polymorphic attribute (dynamic zone, morph relation).
          *
          * If 'populate' exists in subPopulate, its value should be constrained to a wildcard ('*').
-         *
-         * TODO: This approach should be marked as deprecated and replaced with a more robust solution in future versions.
-         *       e.g. Using glob patterns in the fragment API.
          */
         if ('populate' in subPopulate && subPopulate.populate !== '*') {
           throw new Error(

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -5,29 +5,29 @@
  * You can read more here: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#filters
  */
 
+import _ from 'lodash';
 import {
-  isNil,
-  toNumber,
-  isInteger,
-  isEmpty,
-  isObject,
   cloneDeep,
   get,
   isArray,
+  isEmpty,
+  isInteger,
+  isNil,
+  isObject,
   isString,
+  toNumber,
 } from 'lodash/fp';
-import _ from 'lodash';
-
-import parseType from './parse-type';
-import { PaginationError } from './errors';
 import {
-  isDynamicZoneAttribute,
-  isMorphToRelationalAttribute,
   constants,
   hasDraftAndPublish,
+  isDynamicZoneAttribute,
+  isMorphToRelationalAttribute,
 } from './content-types';
-import { Model } from './types';
+import { PaginationError } from './errors';
 import { isOperator } from './operators';
+
+import parseType from './parse-type';
+import { Model } from './types';
 
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, PUBLISHED_AT_ATTRIBUTE } = constants;
 
@@ -40,6 +40,7 @@ export interface SortMap {
 export interface SortParamsObject {
   [key: string]: SortOrder | SortParamsObject;
 }
+
 type SortParams = string | string[] | SortParamsObject | SortParamsObject[];
 type FieldsParams = string | string[];
 
@@ -48,6 +49,7 @@ type FiltersParams = unknown;
 export interface PopulateAttributesParams {
   [key: string]: boolean | PopulateObjectParams;
 }
+
 export interface PopulateObjectParams {
   sort?: SortParams;
   fields?: FieldsParams;
@@ -83,6 +85,7 @@ export interface Params {
 type FiltersQuery = (options: { meta: Model }) => WhereQuery | undefined;
 type OrderByQuery = SortMap | SortMap[];
 type SelectQuery = string | string[];
+
 export interface WhereQuery {
   [key: string]: any;
 }
@@ -116,6 +119,7 @@ class InvalidOrderError extends Error {
     this.message = 'Invalid order. order can only be one of asc|desc|ASC|DESC';
   }
 }
+
 class InvalidSortError extends Error {
   constructor() {
     super();
@@ -220,7 +224,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
    * Start query parser
    */
   const convertStartQueryParams = (startQuery: unknown): number => {
-    const startAsANumber = _.toNumber(startQuery);
+    const startAsANumber = toNumber(startQuery);
 
     if (!_.isInteger(startAsANumber) || startAsANumber < 0) {
       throw new Error(`convertStartQueryParams expected a positive integer got ${startAsANumber}`);
@@ -233,7 +237,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
    * Limit query parser
    */
   const convertLimitQueryParams = (limitQuery: unknown): number | undefined => {
-    const limitAsANumber = _.toNumber(limitQuery);
+    const limitAsANumber = toNumber(limitQuery);
 
     if (!_.isInteger(limitAsANumber) || (limitAsANumber !== -1 && limitAsANumber < 0)) {
       throw new Error(`convertLimitQueryParams expected a positive integer got ${limitAsANumber}`);
@@ -354,7 +358,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
         try {
           const subPopulateAsBoolean = parseType({ type: 'boolean', value: subPopulate });
           // Only true is accepted as a boolean populate value
-          return subPopulateAsBoolean === true ? { ...acc, [key]: true } : acc;
+          return subPopulateAsBoolean ? { ...acc, [key]: true } : acc;
         } catch {
           // ignore
         }
@@ -377,7 +381,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
       if (isMorphLikeRelationalAttribute) {
         const hasInvalidProperties = Object.keys(subPopulate).some(
-          (key) => !['on', 'count'].includes(key)
+          (key) => !['populate', 'on', 'count'].includes(key)
         );
 
         if (hasInvalidProperties) {
@@ -386,11 +390,33 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
           );
         }
 
+        /**
+         * Validate nested population queries in the context of a polymorphic attribute (dynamic zone, morph relation).
+         *
+         * If 'populate' exists in subPopulate, its value should be constrained to a wildcard ('*').
+         *
+         * TODO: This approach should be marked as deprecated and replaced with a more robust solution in future versions.
+         *       e.g. Using glob patterns in the fragment API.
+         */
+        if ('populate' in subPopulate && subPopulate['populate'] !== '*') {
+          throw new Error(
+            `Invalid nested population query detected. When using 'populate' within polymorphic structures, ` +
+              `its value must be '*' to indicate all second level links. Specific field targeting is not supported here. ` +
+              `Consider using the fragment API for more granular population control.`
+          );
+        }
+
         const newSubPopulate = {};
 
-        // { on: { ... } }
+        // case: { populate: '*' }
+        if ('populate' in subPopulate) {
+          Object.assign(newSubPopulate, { populate: true });
+        }
+
+        // case: { on: { <clauses> } }
         if (hasPopulateFragmentDefined(subPopulate)) {
-          // transform the fragment and assign it to the new sub-populate object
+          // If the fragment API is used, it applies the transformation to every
+          // sub-populate, then assign the result to the new sub-populate
           Object.assign(newSubPopulate, {
             on: Object.entries(subPopulate.on).reduce(
               (acc, [type, typeSubPopulate]) => ({
@@ -402,7 +428,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
           });
         }
 
-        // { count: true | false }
+        // case: { count: true | false }
         if (hasCountDefined(subPopulate)) {
           Object.assign(newSubPopulate, { count: subPopulate.count });
         }

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -398,7 +398,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
          * TODO: This approach should be marked as deprecated and replaced with a more robust solution in future versions.
          *       e.g. Using glob patterns in the fragment API.
          */
-        if ('populate' in subPopulate && subPopulate['populate'] !== '*') {
+        if ('populate' in subPopulate && subPopulate.populate !== '*') {
           throw new Error(
             `Invalid nested population query detected. When using 'populate' within polymorphic structures, ` +
               `its value must be '*' to indicate all second level links. Specific field targeting is not supported here. ` +


### PR DESCRIPTION
### What does it do?
Introduces (add back) a deprecated method for populating second-level links in polymorphic structures using a shared `populate`.

It also includes:
- the addition of the `CountClause` type
- updates for handling nested population queries more robustly
- introduces the `Pretty` type for enhancing readability of complex type intersections

### Why is it needed?

Ease the migration to v5 while we work on a better solution to allow pattern matching during populate ops.

Allow developers to populate polymorphic links' relations using a wildcard (`'*'`), although this method will be deprecated in the next major.

### How to test it?
- Verify that the deprecated `populate` method works with polymorphic links using a wildcard.
- Ensure that the `CountClause` type is applied correctly in populate clauses (should only be there for regular relations or medias, not components & morphs)
- Check that nested population queries within polymorphic attributes are validated properly.
