### PR TITLE
Fix Internal Plugin Resolve Path

### DIFF
--- a/packages/core/core/src/loaders/plugins/get-enabled-plugins.ts
+++ b/packages/core/core/src/loaders/plugins/get-enabled-plugins.ts
@@ -101,7 +101,7 @@ export const getEnabledPlugins = async (strapi: Core.Strapi, { client } = { clie
 
     validatePluginName(packageInfo.strapi.name);
     internalPlugins[packageInfo.strapi.name] = {
-      ...toDetailedDeclaration({ enabled: true, resolve: packagePath, isModule: client }),
+      ...toDetailedDeclaration({ enabled: true, resolve: packageModulePath, isModule: client }),
       info: packageInfo.strapi,
       packageInfo,
     };


### PR DESCRIPTION
### What does it do?

Update the plugin loader to use `packageModulePath` instead of `packagePath` when resolving plugins.

It ensures that the `toDetailedDeclaration` function gets the correct path and thus doesn't throw unwanted errors

### Why is it needed?

See #20298
### How to test it?

See https://github.com/strapi/strapi/issues/20298#issuecomment-2380550149

### Related issue(s)/PR(s)

fix #20298


---

![image](https://github.com/user-attachments/assets/9c1704fc-a28d-40b0-a762-ca475954d179)
