### PR TITLE
fix: copy button shown on v4 plugins

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -275,28 +275,17 @@ const CardButton = ({
       return (
         <Tooltip
           data-testid={`tooltip-${pluginName}`}
-          label={
-            !versionRange
-              ? formatMessage(
-                  {
-                    id: 'admin.pages.MarketPlacePage.plugin.version.null',
-                    defaultMessage:
-                      'Unable to verify compatibility with your Strapi version: "{strapiAppVersion}"',
-                  },
-                  { strapiAppVersion }
-                )
-              : formatMessage(
-                  {
-                    id: 'admin.pages.MarketPlacePage.plugin.version',
-                    defaultMessage:
-                      'Update your Strapi version: "{strapiAppVersion}" to: "{versionRange}"',
-                  },
-                  {
-                    strapiAppVersion,
-                    versionRange,
-                  }
-                )
-          }
+          label={formatMessage(
+            {
+              id: 'admin.pages.MarketPlacePage.plugin.version',
+              defaultMessage:
+                'Update your Strapi version: "{strapiAppVersion}" to: "{versionRange}"',
+            },
+            {
+              strapiAppVersion,
+              versionRange,
+            }
+          )}
         >
           <span>
             <Button

--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -66,7 +66,10 @@ const NpmPackageCard = ({
   }`;
 
   const versionRange = semver.validRange(attributes.strapiVersion);
-  const isCompatible = semver.satisfies(strapiAppVersion ?? '', versionRange ?? '');
+
+  const isCompatible = versionRange
+    ? semver.satisfies(strapiAppVersion ?? '', versionRange)
+    : false;
 
   return (
     <Flex

--- a/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/tests/MarketplacePage.test.tsx
@@ -62,25 +62,17 @@ describe('Marketplace page - layout', () => {
     expect(button).not.toBeInTheDocument();
   });
 
-  it('shows compatibility tooltip message when no version provided', async () => {
-    const { findByTestId, findAllByTestId, user } = render();
+  it('Does not show (copy install command) button', async () => {
+    const { findAllByTestId } = render();
 
     const alreadyInstalledCard = (await findAllByTestId('npm-package-card')).find((div) =>
       div.innerHTML.includes('Config Sync')
     )!;
 
-    const button = within(alreadyInstalledCard)
-      .getByText(/copy install command/i)
-      .closest('button')!;
+    const button = within(alreadyInstalledCard).queryByText(/copy install command/i);
 
-    await user.hover(button);
-    const tooltip = await findByTestId(`tooltip-Config Sync`);
-
-    expect(button).toBeEnabled();
-    expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveTextContent(
-      'Unable to verify compatibility with your Strapi version: "4.1.0"'
-    );
+    // Assert that the button does not show
+    expect(button).not.toBeInTheDocument();
   });
 
   it('handles production environment', async () => {


### PR DESCRIPTION
### What does it do?

insures that  a plugin is considered incompatible if versionRange is not valid

### Why is it needed?

copy install button is showing on invalid plugins for v5

### How to test it?

- plugins like “BigBluebutton” or “Cloudflare pages” shouldn’t be shown with the “Copy install command” button

