### PR TITLE
Fix : 21253 [Design] Select Files tab content on the Asset

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.jsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/SelectedStep/index.jsx
@@ -12,7 +12,7 @@ export const SelectedStep = ({ selectedAssets, onSelectAsset, onReorderAsset }) 
 
   return (
     <Flex direction="column" alignItems="stretch" gap={4}>
-      <Flex gap={0}>
+      <Flex gap={0} direction="column" alignItems="start">
         <Typography variant="pi" fontWeight="bold" textColor="neutral800">
           {formatMessage(
             {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix : 21253 [Design] Select Files tab content on the Asset Folder 

### Why is it needed?

The 2 sentences should be split.

### How to test it?

- Go to an entry with a media input
- Click on Add an asset
- Go to the selected files tab
- See that there is an issue and 2 sentences should be spaced
- 

### Related issue(s)/PR(s)

#21253 