### PR TITLE
fix: v5 migration with wrong enum values

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -15,6 +15,7 @@
 import type { UID } from '@strapi/types';
 import type { Database, Migration } from '@strapi/database';
 import { async, contentTypes } from '@strapi/utils';
+import { createDocumentService } from '../../services/document-service';
 
 type DocumentVersion = { documentId: string; locale: string };
 type Knex = Parameters<Migration['up']>[0];
@@ -168,12 +169,28 @@ const migrateUp = async (trx: Knex, db: Database) => {
    *
    * Load a batch of entries (batched to prevent loading millions of rows at once ),
    * and discard them using the document service.
+   *
+   * NOTE: This is using a custom document service without any validations,
+   *       to prevent the migration from failing if users already had invalid data in V4.
+   *       E.g. @see https://github.com/strapi/strapi/issues/21583
    */
+  const documentService = createDocumentService(strapi, {
+    // @ts-expect-error - fix this
+    validateEntityCreation(contentType: string, data: any) {
+      return data;
+    },
+    // @ts-expect-error - fix this
+    validateEntityUpdate(contentType: string, data: any) {
+      return data;
+    },
+  });
+
   for (const model of dpModels) {
     const discardDraft = async (entry: DocumentVersion) =>
-      strapi
-        .documents(model.uid as UID.ContentType)
-        .discardDraft({ documentId: entry.documentId, locale: entry.locale });
+      documentService(model.uid as UID.ContentType).discardDraft({
+        documentId: entry.documentId,
+        locale: entry.locale,
+      });
 
     for await (const batch of getBatchToDiscard({ db, trx, uid: model.uid })) {
       await async.map(batch, discardDraft, { concurrency: 10 });

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -175,13 +175,11 @@ const migrateUp = async (trx: Knex, db: Database) => {
    *       E.g. @see https://github.com/strapi/strapi/issues/21583
    */
   const documentService = createDocumentService(strapi, {
-    // @ts-expect-error - fix this
-    validateEntityCreation(contentType: string, data: any) {
+    async validateEntityCreation(_, data) {
       return data;
     },
-    // @ts-expect-error - fix this
-    validateEntityUpdate(contentType: string, data: any) {
-      return data;
+    async validateEntityUpdate(_, data, options, entity) {
+      return data as any;
     },
   });
 

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -178,7 +178,10 @@ const migrateUp = async (trx: Knex, db: Database) => {
     async validateEntityCreation(_, data) {
       return data;
     },
-    async validateEntityUpdate(_, data, options, entity) {
+    async validateEntityUpdate(_, data) {
+      // Data can be partially empty on partial updates
+      // This migration doesn't trigger any update (or partial update),
+      // so it's safe to return the data as is.
       return data as any;
     },
   });

--- a/packages/core/core/src/services/document-service/common.ts
+++ b/packages/core/core/src/services/document-service/common.ts
@@ -1,7 +1,8 @@
 import type { UID, Modules } from '@strapi/types';
 
 export type RepositoryFactoryMethod = <TContentTypeUID extends UID.ContentType>(
-  uid: TContentTypeUID
+  uid: TContentTypeUID,
+  entityValidator: Modules.EntityValidator.EntityValidator
 ) => Modules.Documents.ServiceInstance<TContentTypeUID>;
 
 export const wrapInTransaction = (fn: (...args: any) => any) => {

--- a/packages/core/core/src/services/document-service/entries.ts
+++ b/packages/core/core/src/services/document-service/entries.ts
@@ -1,4 +1,4 @@
-import type { UID } from '@strapi/types';
+import type { UID, Modules } from '@strapi/types';
 import { async } from '@strapi/utils';
 import { assoc, omit } from 'lodash/fp';
 
@@ -9,9 +9,11 @@ import { transformParamsToQuery } from './transform/query';
 import { pickSelectionParams } from './params';
 import { applyTransforms } from './attributes';
 import { transformData } from './transform/data';
-import entityValidator from '../entity-validator';
 
-const createEntriesService = (uid: UID.ContentType) => {
+const createEntriesService = (
+  uid: UID.ContentType,
+  entityValidator: Modules.EntityValidator.EntityValidator
+) => {
   const contentType = strapi.contentType(uid);
 
   async function createEntry(params = {} as any) {

--- a/packages/core/core/src/services/document-service/index.ts
+++ b/packages/core/core/src/services/document-service/index.ts
@@ -4,6 +4,8 @@ import { createMiddlewareManager, databaseErrorsMiddleware } from './middlewares
 import { createContentTypeRepository } from './repository';
 import { transformData } from './transform/data';
 
+import entityValidator from '../entity-validator';
+
 /**
  * Repository to :
  * - Access documents via actions (findMany, findOne, create, update, delete, ...)
@@ -18,7 +20,10 @@ import { transformData } from './transform/data';
  * const allArticles = strapi.documents('api::article.article').findMany(params)
  *
  */
-export const createDocumentService = (strapi: Core.Strapi): Modules.Documents.Service => {
+export const createDocumentService = (
+  strapi: Core.Strapi,
+  validator: Modules.EntityValidator.EntityValidator = entityValidator
+): Modules.Documents.Service => {
   // Cache the repositories (one per content type)
   const repositories = new Map<string, Modules.Documents.ServiceInstance>();
 
@@ -32,7 +37,7 @@ export const createDocumentService = (strapi: Core.Strapi): Modules.Documents.Se
     }
 
     const contentType = strapi.contentType(uid);
-    const repository = createContentTypeRepository(uid);
+    const repository = createContentTypeRepository(uid, validator);
 
     const instance = middlewares.wrapObject(
       repository,

--- a/packages/core/core/src/services/document-service/index.ts
+++ b/packages/core/core/src/services/document-service/index.ts
@@ -13,6 +13,7 @@ import entityValidator from '../entity-validator';
  * - Apply default parameters to document actions
  *
  * @param strapi
+ * @param validator - validator for database entries
  * @returns DocumentService
  *
  * @example Access documents

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -22,7 +22,7 @@ const { validators } = validate;
 // we have to typecast to reconcile the differences between validator and database getModel
 const getModel = ((schema: UID.Schema) => strapi.getModel(schema)) as (schema: string) => any;
 
-export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
+export const createContentTypeRepository: RepositoryFactoryMethod = (uid, validator) => {
   const contentType = strapi.contentType(uid);
   const hasDraftAndPublish = contentTypesUtils.hasDraftAndPublish(contentType);
 
@@ -49,7 +49,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (uid) => {
     return params;
   };
 
-  const entries = createEntriesService(uid);
+  const entries = createEntriesService(uid, validator);
 
   const eventManager = createEventManager(strapi, uid);
   const emitEvent = curry(eventManager.emitEvent);

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -16,13 +16,17 @@ import { transformParamsToQuery } from './transform/query';
 import { transformParamsDocumentId } from './transform/id-transform';
 import { createEventManager } from './events';
 import * as unidirectionalRelations from './utils/unidirectional-relations';
+import entityValidator from '../entity-validator';
 
 const { validators } = validate;
 
 // we have to typecast to reconcile the differences between validator and database getModel
 const getModel = ((schema: UID.Schema) => strapi.getModel(schema)) as (schema: string) => any;
 
-export const createContentTypeRepository: RepositoryFactoryMethod = (uid, validator) => {
+export const createContentTypeRepository: RepositoryFactoryMethod = (
+  uid,
+  validator = entityValidator
+) => {
   const contentType = strapi.contentType(uid);
   const hasDraftAndPublish = contentTypesUtils.hasDraftAndPublish(contentType);
 


### PR DESCRIPTION
### What does it do?

As described in https://github.com/strapi/strapi/issues/21583#issuecomment-2393242982 , trying to migrate from v4 with invalid enum values (e.g. an enum that allows red,green, blue but the stored value is "yellow") resulted in the `discard-draft` migration crashing, and so preventing the migration to happen.

example error:
```
MigrationError: Migration core::5.0.0-discard-drafts (up) failed: Original error: theme must be one of the following values: dark, light, yellow,    
       at /Users/marcroig/Documents/strapi/strapi/node_modules/umzug/lib/umzug.js:169:27    
```

We concluded that any badly formated data in v4 should be also preserved in v5 during the migration (as long as app works and data is modifiable). So the `discard-draft` migration will run without any data validation (enums, max, min, required, ...)

### Why is it needed?
So users can migrate even if there is "invalid" data.

### How to test it?

- Start with Strapi 4
- create a content type with d&p disabled
- add  an enum field
- add invalid data for that enum field in the database, for example your enum allows red, green, and blue, but you have a value in your database of yellow
- migrate to Strapi 5
- migration should not fail

### Related issue(s)/PR(s)
 
fixes #21583
