### PR TITLE
fix: update review workflow

### DIFF
--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -210,7 +210,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const entity = await strapi.documents(model).update({
         documentId,
         locale,
-        data: { [ENTITY_STAGE_ATTRIBUTE]: stage },
+        data: { [ENTITY_STAGE_ATTRIBUTE]: pick(['id'], stage) },
         populate: [ENTITY_STAGE_ATTRIBUTE],
       });
 

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -211,7 +211,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         documentId,
         locale,
         // Stage doesn't have DP or i18n enabled, connecting it through the `id`
-        // will be safer than relying on the `documentId` + `locale` + `status`
+        // will be safer than relying on the `documentId` + `locale` + `status` transformation
         data: { [ENTITY_STAGE_ATTRIBUTE]: pick(['id'], stage) },
         populate: [ENTITY_STAGE_ATTRIBUTE],
       });

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -210,6 +210,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const entity = await strapi.documents(model).update({
         documentId,
         locale,
+        // Stage doesn't have DP or i18n enabled, connecting it through the `id`
+        // will be safer than relying on the `documentId` + `locale` + `status`
         data: { [ENTITY_STAGE_ATTRIBUTE]: pick(['id'], stage) },
         populate: [ENTITY_STAGE_ATTRIBUTE],
       });


### PR DESCRIPTION
### What does it do?

There is an ongoing [PR](https://github.com/strapi/strapi/pull/21501) to fix non DP entries that were migrated with an empty "publishedAt" column, this issue also was breaking RW, making it imposible to change a stage. 

This will fix it asap before we merge the other PR

