### PR TITLE
feat(content-releases): considered review stage when getting the action status

### DIFF
--- a/examples/getstarted/src/api/category/content-types/category/schema.json
+++ b/examples/getstarted/src/api/category/content-types/category/schema.json
@@ -9,7 +9,6 @@
     "name": "Category"
   },
   "options": {
-    "reviewWorkflows": true,
     "draftAndPublish": true
   },
   "pluginOptions": {

--- a/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
+++ b/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
@@ -31,7 +31,10 @@ const StyledPopoverFlex = styled(Flex)`
 
 interface EntryValidationPopoverProps {
   action: ReleaseAction['type'];
-  schema?: Struct.ContentTypeSchema & { stageRequiredToPublish?: Stage };
+  schema?: Struct.ContentTypeSchema & {
+    hasReviewWorkflow: boolean;
+    stageRequiredToPublish?: Stage;
+  };
   entry: ReleaseActionEntry;
   status: ReleaseAction['status'];
 }
@@ -323,10 +326,10 @@ const ReviewStageValidation = ({
 };
 
 export const EntryValidationPopover = ({
-  action,
   schema,
   entry,
   status,
+  action,
 }: EntryValidationPopoverProps) => {
   const { validate, isLoading } = unstable_useDocument(
     {
@@ -344,7 +347,7 @@ export const EntryValidationPopover = ({
   const hasErrors = errors ? Object.keys(errors).length > 0 : false;
 
   // Entry stage
-  const contentTypeHasReviewWorkflow = schema?.options?.reviewWorkflows ?? false;
+  const contentTypeHasReviewWorkflow = schema?.hasReviewWorkflow ?? false;
   const requiredStage = schema?.stageRequiredToPublish;
   const entryStage = entry.strapi_stage;
 

--- a/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/EntryValidationPopover.test.tsx
@@ -16,7 +16,7 @@ describe('EntryValidationPopover', () => {
     schema: {
       kind: 'collectionType',
       uid: 'api::article.article',
-      options: { reviewWorkflows: true },
+      hasReviewWorkflow: true,
       stageRequiredToPublish: { id: 'stage1', name: 'Ready' },
     },
     entry: {

--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -105,6 +105,24 @@ const releaseApi = adminApi
           { type: 'ReleaseAction', id: 'LIST' },
         ]);
       },
+      createWorkflow(endpoint: AnyEndpointDefinition) {
+        extendInvalidatesTags(endpoint, [
+          { type: 'Release', id: 'LIST' },
+          { type: 'ReleaseAction', id: 'LIST' },
+        ]);
+      },
+      updateWorkflow(endpoint: AnyEndpointDefinition) {
+        extendInvalidatesTags(endpoint, [
+          { type: 'Release', id: 'LIST' },
+          { type: 'ReleaseAction', id: 'LIST' },
+        ]);
+      },
+      deleteWorkflow(endpoint: AnyEndpointDefinition) {
+        extendInvalidatesTags(endpoint, [
+          { type: 'Release', id: 'LIST' },
+          { type: 'ReleaseAction', id: 'LIST' },
+        ]);
+      },
     },
   })
   .injectEndpoints({

--- a/packages/core/content-releases/server/src/middlewares/documents.ts
+++ b/packages/core/content-releases/server/src/middlewares/documents.ts
@@ -17,6 +17,7 @@ const updateActionsStatusAndUpdateReleaseStatus = async (
 ) => {
   const releases = await strapi.db.query(RELEASE_MODEL_UID).findMany({
     where: {
+      releasedAt: null,
       actions: {
         contentType,
         entryDocumentId: entry.documentId,
@@ -27,7 +28,7 @@ const updateActionsStatusAndUpdateReleaseStatus = async (
 
   const entryStatus = await isEntryValid(contentType, entry, { strapi });
 
-  await strapi.db.query(RELEASE_ACTION_MODEL_UID).update({
+  await strapi.db.query(RELEASE_ACTION_MODEL_UID).updateMany({
     where: {
       contentType,
       entryDocumentId: entry.documentId,

--- a/packages/core/content-releases/server/src/services/release-action.ts
+++ b/packages/core/content-releases/server/src/services/release-action.ts
@@ -1,6 +1,6 @@
 import { errors, async } from '@strapi/utils';
 
-import type { Core, Internal, Modules } from '@strapi/types';
+import type { Core, Internal, Modules, UID, Data } from '@strapi/types';
 
 import _ from 'lodash/fp';
 
@@ -361,6 +361,61 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
       getService('release', { strapi }).updateReleaseStatus(releaseId);
 
       return deletedAction;
+    },
+
+    async validateActionsByContentTypes(contentTypeUids: UID.ContentType[]) {
+      const actions = await strapi.db.query(RELEASE_ACTION_MODEL_UID).findMany({
+        where: {
+          contentType: {
+            $in: contentTypeUids,
+          },
+          // We only want to validate actions that are going to be published
+          type: 'publish',
+          release: {
+            releasedAt: {
+              $null: true,
+            },
+          },
+        },
+        populate: { release: true },
+      });
+
+      const releasesUpdated: Data.ID[] = [];
+
+      await async.map(actions, async (action: ReleaseAction) => {
+        const isValid = await getDraftEntryValidStatus(
+          {
+            contentType: action.contentType,
+            documentId: action.entryDocumentId,
+            locale: action.locale,
+          },
+          { strapi }
+        );
+
+        await strapi.db.query(RELEASE_ACTION_MODEL_UID).update({
+          where: {
+            id: action.id,
+          },
+          data: {
+            isEntryValid: isValid,
+          },
+        });
+
+        if (!releasesUpdated.includes(action.release.id)) {
+          releasesUpdated.push(action.release.id);
+        }
+
+        return {
+          id: action.id,
+          isEntryValid: isValid,
+        };
+      });
+
+      if (releasesUpdated.length > 0) {
+        await async.map(releasesUpdated, async (releaseId: number) => {
+          await getService('release', { strapi }).updateReleaseStatus(releaseId);
+        });
+      }
     },
   };
 };

--- a/packages/core/content-releases/server/src/services/release-action.ts
+++ b/packages/core/content-releases/server/src/services/release-action.ts
@@ -259,6 +259,7 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
 
           acc[contentTypeUid] = {
             ...contentTypeModel,
+            hasReviewWorkflow: !!workflow,
             stageRequiredToPublish: workflow?.stageRequiredToPublish,
           };
 

--- a/packages/core/content-releases/server/src/utils/index.ts
+++ b/packages/core/content-releases/server/src/utils/index.ts
@@ -54,6 +54,15 @@ export const isEntryValid = async (
       entry
     );
 
+    const workflowsService = strapi.plugin('review-workflows').service('workflows');
+    const workflow = await workflowsService.getAssignedWorkflow(contentTypeUid, {
+      populate: 'stageRequiredToPublish',
+    });
+
+    if (workflow?.stageRequiredToPublish) {
+      return entry.strapi_stage.id === workflow.stageRequiredToPublish.id;
+    }
+
     return true;
   } catch {
     return false;

--- a/packages/core/content-releases/shared/contracts/release-actions.ts
+++ b/packages/core/content-releases/shared/contracts/release-actions.ts
@@ -116,7 +116,7 @@ export declare namespace GetReleaseActions {
       pagination: Pagination;
       contentTypes: Record<
         Struct.ContentTypeSchema['uid'],
-        Struct.ContentTypeSchema & { stageRequiredToPublish?: Stage }
+        Struct.ContentTypeSchema & { hasReviewWorkflow: boolean; stageRequiredToPublish?: Stage }
       >;
       components: Record<Struct.ComponentSchema['uid'], Struct.ComponentSchema>;
     };

--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -190,20 +190,16 @@ export const FormModal = () => {
 
       // Edit content type
       if (modalType === 'contentType' && actionType === 'edit') {
-        const {
-          displayName,
-          draftAndPublish,
-          kind,
-          pluginOptions,
-          pluralName,
-          reviewWorkflows,
-          singularName,
-        } = get(allDataSchema, [...pathToSchema, 'schema'], {
-          displayName: null,
-          pluginOptions: {},
-          singularName: null,
-          pluralName: null,
-        });
+        const { displayName, draftAndPublish, kind, pluginOptions, pluralName, singularName } = get(
+          allDataSchema,
+          [...pathToSchema, 'schema'],
+          {
+            displayName: null,
+            pluginOptions: {},
+            singularName: null,
+            pluralName: null,
+          }
+        );
 
         dispatch({
           type: SET_DATA_TO_EDIT,
@@ -215,10 +211,6 @@ export const FormModal = () => {
             kind,
             pluginOptions,
             pluralName,
-            // because review-workflows is an EE feature the attribute does
-            // not always exist, but the component prop-types expect a boolean,
-            // so we have to ensure undefined is casted to false
-            reviewWorkflows: reviewWorkflows ?? false,
             singularName,
           },
         });

--- a/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/contentType/createContentTypeSchema.ts
@@ -190,7 +190,6 @@ export const createContentTypeSchema = ({
       .required(errorsTrads.required.id),
     draftAndPublish: yup.boolean(),
     kind: yup.string().oneOf(['singleType', 'collectionType']),
-    reviewWorkflows: yup.boolean(),
   };
 
   return yup.object(shape);

--- a/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/model-schema.ts
@@ -26,7 +26,6 @@ export const createSchema = (
     pluginOptions: yup.object(),
     collectionName: yup.string().nullable().test(isValidCollectionName),
     attributes: createAttributesValidator({ types, relations, modelType }),
-    reviewWorkflows: yup.boolean(),
     draftAndPublish: yup.boolean(),
   } as any;
 

--- a/packages/core/review-workflows/server/src/services/workflows.ts
+++ b/packages/core/review-workflows/server/src/services/workflows.ts
@@ -197,7 +197,10 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         await strapi
           .plugin('content-releases')
           .service('release-action')
-          .validateActionsByContentTypes([...workflow.contentTypes, ...opts.data.contentTypes]);
+          .validateActionsByContentTypes([
+            ...workflow.contentTypes,
+            ...(opts.data.contentTypes || []),
+          ]);
 
         return updatedWorkflow;
       });

--- a/packages/core/review-workflows/server/src/services/workflows.ts
+++ b/packages/core/review-workflows/server/src/services/workflows.ts
@@ -109,9 +109,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         metrics.sendDidCreateWorkflow();
 
         // Create Workflow
-        return strapi.db
+        const createdWorkflow = await strapi.db
           .query(WORKFLOW_MODEL_UID)
           .create(strapi.get('query-params').transform(WORKFLOW_MODEL_UID, createOpts));
+
+        if (opts.data.stageRequiredToPublishName) {
+          await strapi
+            .plugin('content-releases')
+            .service('release-action')
+            .validateActionsByContentTypes(opts.data.contentTypes);
+        }
+
+        return createdWorkflow;
       });
     },
 
@@ -180,10 +189,17 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         const query = strapi.get('query-params').transform(WORKFLOW_MODEL_UID, updateOpts);
 
         // Update Workflow
-        return strapi.db.query(WORKFLOW_MODEL_UID).update({
+        const updatedWorkflow = await strapi.db.query(WORKFLOW_MODEL_UID).update({
           ...query,
           where: { id: workflow.id },
         });
+
+        await strapi
+          .plugin('content-releases')
+          .service('release-action')
+          .validateActionsByContentTypes([...workflow.contentTypes, ...opts.data.contentTypes]);
+
+        return updatedWorkflow;
       });
     },
 
@@ -214,11 +230,19 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         });
 
         const query = strapi.get('query-params').transform(WORKFLOW_MODEL_UID, opts);
+
         // Delete Workflow
-        return strapi.db.query(WORKFLOW_MODEL_UID).delete({
+        const deletedWorkflow = await strapi.db.query(WORKFLOW_MODEL_UID).delete({
           ...query,
           where: { id: workflow.id },
         });
+
+        await strapi
+          .plugin('content-releases')
+          .service('release-action')
+          .validateActionsByContentTypes(workflow.contentTypes);
+
+        return deletedWorkflow;
       });
     },
     /**

--- a/tests/api/core/review-workflows/review-workflows-stage-permissions.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows-stage-permissions.test.api.ts
@@ -18,9 +18,6 @@ const model = {
       type: 'string',
     },
   },
-  options: {
-    reviewWorkflows: true,
-  },
 };
 
 const baseWorkflow = {

--- a/tests/api/core/review-workflows/review-workflows-webhooks.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows-webhooks.test.api.ts
@@ -26,9 +26,6 @@ const model = {
       type: 'string',
     },
   },
-  options: {
-    reviewWorkflows: true,
-  },
 };
 
 describeOnCondition(edition === 'EE')('Review workflows', () => {

--- a/tests/api/core/review-workflows/review-workflows.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows.test.api.ts
@@ -30,9 +30,6 @@ const model = {
       type: 'string',
     },
   },
-  options: {
-    reviewWorkflows: true,
-  },
 };
 
 describeOnCondition(edition === 'EE')('Review workflows', () => {


### PR DESCRIPTION
### What does it do?

Releases' status depends on the validation status of attached entries. Now these status could change based on changes on Review Workflows (if one content type is added to a Review Workflow for example)

### How to test it?

Tests that all the following actions cause the required changes on releases's status:

- Changing the review stage of one entry inside a release.
- Creating a new Workflow with one content type that has entries inside a release.
- Update a Workflow with content types that has entries inside a release.
- Remove a workflow with content types that has entries inside a release.
