### PR TITLE
fix: history cron job breaking on mysql

### DIFF
--- a/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
@@ -97,6 +97,6 @@ describe('history lifecycles service', () => {
     await lifecyclesService.bootstrap();
 
     expect(mockScheduleJob).toHaveBeenCalledTimes(1);
-    expect(mockScheduleJob).toHaveBeenCalledWith('0 0 * * *', expect.any(Function));
+    expect(mockScheduleJob).toHaveBeenCalledWith('historyDaily', '0 0 * * *', expect.any(Function));
   });
 });

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -181,8 +181,7 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
           .deleteMany({
             where: {
               created_at: {
-                // Only keep YYYY-MM-DD from the string because mysql doesn't support ISO 8601
-                $lt: expirationDate.toISOString().split('T').at(0),
+                $lt: expirationDate,
               },
             },
           })


### PR DESCRIPTION
### What does it do?

- stops using an ISO 8601 string in the filter, because it breaks on mysql
- gives a name to the cron job (we don't use strapi.cron because we don't want the job to be disable-able)
- adds a catch clause to prevent crashing the app if other errors occur

### How to test it?

- Use different types of databases, starting with mysql
- Update the code to make the job run every second: `* * * * * *`, add a log to make sure it works, and build the content manager (or run yarn setup)
- The app should not crash
- Old history version entries should be deleted (you can make some to test with a db explorer)

### Related issue(s)/PR(s)

fixes #21613