### PR TITLE
fix: unable to create users in manager due to wrong validation

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -17,7 +17,7 @@ const createUserBodySchema = yup.object().shape({
           .shape({
             connect: yup
               .array()
-              .of(yup.object().shape({ id: yup.strapiID().required() }))
+              .of(yup.object().shape({ documentId: yup.string().required() }))
               .min(1, 'Users must have a role')
               .required(),
           })


### PR DESCRIPTION
When creating a User from Admin (Content Manager), there was a validation error as the role relationship was expecting an id, instead of the documentId the admin is sending and should be used in Strapi 5.


### What does it do?

User (from users-permissions) controller validation now expects role.connect[].documentId instead of id.

### Why is it needed?

Strapi 5 now relies on documents, and that is what the admin panel is sending. As of now, trying to create users in the panel will throw a validation error.

### How to test it?

Before: Content Manager > Users > Create. Validation error will show up.
Now: should work as expected.

### Related issue(s)/PR(s)

Couln't find any.
