### PR TITLE
fix: changed empty components wording

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -40,7 +40,7 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
             <Typography textColor="primary600" variant="pi" fontWeight="bold">
               {formatMessage({
                 id: getTranslation('components.empty-repeatable'),
-                defaultMessage: 'No entry yet. Click on the button below to add one.',
+                defaultMessage: 'No entry yet. Click to add one.',
               })}
             </Typography>
           </Flex>

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -71,7 +71,7 @@
   "components.TableEmpty.withFilters": "There are no {contentType} with the applied filters...",
   "components.TableEmpty.withSearch": "There are no {contentType} corresponding to the search ({search})...",
   "components.TableEmpty.withoutFilter": "There are no {contentType}...",
-  "components.empty-repeatable": "No entry yet. Click on the button below to add one.",
+  "components.empty-repeatable": "No entry yet. Click to add one.",
   "components.notification.info.maximum-requirement": "You have already reached the maximum number of fields",
   "components.notification.info.minimum-requirement": "A field has been added to match the minimum requirement",
   "components.repeatable.reorder.error": "An error occurred while reordering your component's field, please try again",

--- a/packages/core/content-manager/admin/src/translations/es.json
+++ b/packages/core/content-manager/admin/src/translations/es.json
@@ -49,7 +49,7 @@
   "components.TableEmpty.withFilters": "No hay {contentType} con los filtros aplicados...",
   "components.TableEmpty.withSearch": "No hay {contentType} que coincida con la búsqueda ({search})...",
   "components.TableEmpty.withoutFilter": "No hay {contentType}...",
-  "components.empty-repeatable": "Aún no hay entrada. Haga clic en el botón de abajo para agregar uno.",
+  "components.empty-repeatable": "Aún no hay entrada. Haga clic para agregar una.",
   "components.notification.info.maximum-requirement": "Ya has alcanzado el número máximo de campos",
   "components.notification.info.minimum-requirement": "Se ha agregado un campo para cumplir con el requisito mínimo",
   "components.repeatable.reorder.error": "Se produjo un error al reordenar el campo de su componente. Vuelva a intentarlo.",

--- a/packages/core/content-manager/admin/src/translations/fr.json
+++ b/packages/core/content-manager/admin/src/translations/fr.json
@@ -49,7 +49,7 @@
   "components.TableEmpty.withFilters": "Aucun {contentType} n'a été trouvé avec ces filtres...",
   "components.TableEmpty.withSearch": "Aucun {contentType} n'a été trouvé avec cette recherche ({search})...",
   "components.TableEmpty.withoutFilter": "Aucun {contentType} n'a été trouvé...",
-  "components.empty-repeatable": "Il n'a pas encore d'entrée. Cliquez sur le bouton pour en ajouter une.",
+  "components.empty-repeatable": "Il n'a pas encore d'entrée. Cliquez pour en ajouter une.",
   "components.notification.info.maximum-requirement": "Le nombre maximal de champs est atteint",
   "components.notification.info.minimum-requirement": "Un champ a été rajouté pour remplir les conditions minimales",
   "components.repeatable.reorder.error": "Une erreur s'est produite lors de la réorganisation du champ de votre composant, veuillez réessayer",

--- a/packages/core/content-manager/admin/src/translations/ja.json
+++ b/packages/core/content-manager/admin/src/translations/ja.json
@@ -49,7 +49,7 @@
   "components.TableEmpty.withFilters": "適用されたフィルタには{contentType}はありません...",
   "components.TableEmpty.withSearch": "検索に対応する{contentType}はありません（{search}）...",
   "components.TableEmpty.withoutFilter": "{contentType}はありません...",
-  "components.empty-repeatable": "No entry yet. Click on the button below to add one.",
+  "components.empty-repeatable": "No entry yet. Click to add one.",
   "components.notification.info.maximum-requirement": "You have already reached the maximum number of fields",
   "components.notification.info.minimum-requirement": "A field has been added to match the minimum requirement",
   "components.repeatable.reorder.error": "An error occurred while reordering your component's field, please try again",

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -114,13 +114,13 @@ test.describe('Uniqueness', () => {
       // testing against
 
       if (isSingle) {
-        await page.getByRole('button', { name: 'No entry yet. Click on the' }).first().click();
-        await page.getByRole('button', { name: 'No entry yet. Click on the' }).first().click();
+        await page.getByRole('button', { name: 'No entry yet. Click' }).first().click();
+        await page.getByRole('button', { name: 'No entry yet. Click' }).first().click();
       } else {
-        await page.getByRole('button', { name: 'No entry yet. Click on the' }).nth(1).click();
+        await page.getByRole('button', { name: 'No entry yet. Click' }).nth(1).click();
         await page
           .getByLabel('', { exact: true })
-          .getByRole('button', { name: 'No entry yet. Click on the' })
+          .getByRole('button', { name: 'No entry yet. Click' })
           .click();
       }
     }
@@ -190,7 +190,7 @@ test.describe('Uniqueness', () => {
         await page.getByRole('button', { name: 'Add an entry' }).click();
         await page
           .getByRole('region')
-          .getByRole('button', { name: 'No entry yet. Click on the' })
+          .getByRole('button', { name: 'No entry yet. Click' })
           .click();
         await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
 

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -188,10 +188,7 @@ test.describe('Uniqueness', () => {
         // If the field is a repeatable component field, we add an entry and fill
         // it with the same value to test uniqueness within the same entity.
         await page.getByRole('button', { name: 'Add an entry' }).click();
-        await page
-          .getByRole('region')
-          .getByRole('button', { name: 'No entry yet. Click' })
-          .click();
+        await page.getByRole('region').getByRole('button', { name: 'No entry yet. Click' }).click();
         await page.getByRole(fieldRole, { name: field.name }).fill(field.value);
 
         await clickSave(page);


### PR DESCRIPTION
### What does it do?

I changed the wording in the component and in 4 translation files (English, French, Spanish and Japanese).

### Why is it needed?

The current wording asks the user to click on a button that doesn't exist.

### How to test it?

Open an entry that has components and check their empty version.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/20798