### PR TITLE
chore: ui issues and french translations

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
@@ -17,7 +17,7 @@ import type { HistoryVersions } from '../../../../shared/contracts';
  * -----------------------------------------------------------------------------------------------*/
 
 const BlueText = (children: React.ReactNode) => (
-  <Typography textColor="primary600">{children}</Typography>
+  <Typography textColor="primary600" variant='pi'>{children}</Typography>
 );
 
 /* -------------------------------------------------------------------------------------------------
@@ -89,10 +89,7 @@ const VersionCard = ({ version, isCurrent }: VersionCardProps) => {
       borderStyle="solid"
       borderColor={isActive ? 'primary600' : 'neutral200'}
       color="neutral800"
-      paddingTop={4}
-      paddingBottom={4}
-      paddingLeft={5}
-      paddingRight={5}
+      padding={5}
       tag={Link}
       to={`?${stringify({ ...query, id: version.id })}`}
       style={{ textDecoration: 'none' }}
@@ -229,10 +226,7 @@ const VersionsList = () => {
         <Flex
           direction="column"
           gap={3}
-          paddingTop={5}
-          paddingBottom={5}
-          paddingLeft={4}
-          paddingRight={4}
+          padding={4}
           tag="ul"
           alignItems="stretch"
         >
@@ -249,7 +243,7 @@ const VersionsList = () => {
           ))}
         </Flex>
         {versions.meta.pagination.page < versions.meta.pagination.pageCount && (
-          <Box paddingBottom={5} textAlign="center">
+          <Box paddingBottom={4} textAlign="center">
             <PaginationButton page={page + 1}>
               {formatMessage({
                 id: 'content-manager.history.sidebar.show-older',

--- a/packages/core/content-manager/admin/src/translations/fr.json
+++ b/packages/core/content-manager/admin/src/translations/fr.json
@@ -192,5 +192,15 @@
   "apiError.This attribute must be unique": "Le champ {field} doit être unique",
   "popUpWarning.warning.publish-question": "Êtes-vous sûr de vouloir le publier ?",
   "popUpwarning.warning.has-draft-relations.button-confirm": "Oui, publier",
-  "popUpwarning.warning.has-draft-relations.message": "<b>{count, plural, =0 { des relations de votre contenu n'est} one { des relations de votre contenu n'est} other { des relations de votre contenu ne sont}}</b> pas publié actuellement.<br></br>Cela peut engendrer des liens cassés ou des erreurs dans votre projet."
+  "popUpwarning.warning.has-draft-relations.message": "<b>{count, plural, =0 { des relations de votre contenu n'est} one { des relations de votre contenu n'est} other { des relations de votre contenu ne sont}}</b> pas publié actuellement.<br></br>Cela peut engendrer des liens cassés ou des erreurs dans votre projet.",  
+  "history.sidebar.show-newer": "Voir les versions récentes",
+  "history.sidebar.show-older": "Voir les anciennes versions",
+  "history.content.new-field.message": "Ce champ n'existait pas lorsque cette version a été sauvegardée. Si vous restaurez cette version, il sera vide.",
+  "history.content.unknown-fields.message": "Ces champs ont été supprimés ou renommés dans le Content-Type Builder. <b>Ces champs ne seront pas restaurés.</b>",
+  "history.content.no-relations": "Aucune relation.",
+  "history.restore.confirm.button": "Restaurer",
+  "history.restore.confirm.title": "Êtes-vous sûr de vouloir restaurer cette version ?",
+  "history.restore.confirm.message": "{isDraft, select, true {The restored content will override your draft.} other {Le contenu restauré ne sera pas publié, il écrasera le brouillon et sera sauvegardé en tant que changement en attente de publication. Vous pourrez publier les changements à tout moment.}}",
+  "history.restore.success.title": "Version restaurée.",
+  "history.restore.success.message": "Le contenu de la version restaurée n'a pas encore été publié."
 }


### PR DESCRIPTION
### What does it do?

Changed a few paddings and a text style. I also added a few translations in French.

### Why is it needed?

The new text style will reduce the risk that the "X minutes/months/years ago by Y" text has to be displayed in 2 lines on small screens. The rest is purely UI enhancements in order to better match the mockups.

### How to test it?

Open the Content History page from any entry.

### Related issue(s)/PR(s)

No related issue or PR.