### PR TITLE
fix: send ids when connecting relations to update u&p user role

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -87,6 +87,7 @@ function useHandleDisconnect(fieldName: string, consumerName: string) {
     addFieldRow(`${fieldName}.disconnect`, {
       id: relation.id,
       apiData: {
+        id: relation.id,
         documentId: relation.documentId,
         locale: relation.locale,
       },
@@ -276,6 +277,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
       const item = {
         id: relation.id,
         apiData: {
+          id: relation.id,
           documentId: relation.documentId,
           locale: relation.locale,
         },
@@ -743,6 +745,7 @@ const RelationsList = ({
             ...relation,
             ...{
               apiData: {
+                id: relation.id,
                 documentId: relation.documentId,
                 locale: relation.locale,
                 position,

--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -17,12 +17,13 @@ const createUserBodySchema = yup.object().shape({
           .shape({
             connect: yup
               .array()
-              .of(yup.object().shape({ id: yup.strapiID().required() }))
+              // NOTE: Content Manager uses document ID to connect relation
+              .of(yup.object().shape({ documentId: yup.string().required() }))
               .min(1, 'Users must have a role')
               .required(),
           })
           .required()
-      : yup.strapiID().required()
+      : yup.string().required()
   ),
 });
 

--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -17,13 +17,12 @@ const createUserBodySchema = yup.object().shape({
           .shape({
             connect: yup
               .array()
-              // NOTE: Content Manager uses document ID to connect relation
-              .of(yup.object().shape({ documentId: yup.string().required() }))
+              .of(yup.object().shape({ id: yup.strapiID().required() }))
               .min(1, 'Users must have a role')
               .required(),
           })
           .required()
-      : yup.string().required()
+      : yup.strapiID().required()
   ),
 });
 


### PR DESCRIPTION
### What does it do?
It was not possible to create a new U&P user, or update its roles. 

U&P was expecting the role attribute to be set using the `id` attribute, but the CM was only sending the document ID.

By default, when connecting a relation, the document service [ will prioritize the documentId ](https://github.com/strapi/strapi/blob/7a6d9a2b0e029dd25100e68f71a35f20a134d3a2/packages/core/core/src/services/document-service/transform/relations/extract/data-ids.ts#L60) and transform it to the appropiate entry id.


fixes #21653
