### PR TITLE
fix: do not display fill from locales if i18n no enabled

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -279,7 +279,7 @@ const FillFromAnotherLocaleAction = ({
     onClose();
   };
 
-  if (!hasI18n || !Array.isArray(locales) || locales.length === 0) {
+  if (!hasI18n) {
     return null;
   }
 

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -241,6 +241,7 @@ const FillFromAnotherLocaleAction = ({
 }: HeaderActionProps) => {
   const { formatMessage } = useIntl();
   const [{ query }] = useQueryParams<I18nBaseQuery>();
+  const { hasI18n } = useI18n();
   const currentDesiredLocale = query.plugins?.i18n?.locale;
   const [localeSelected, setLocaleSelected] = React.useState<string | null>(null);
   const setValues = useForm('FillFromAnotherLocale', (state) => state.setValues);
@@ -277,6 +278,10 @@ const FillFromAnotherLocaleAction = ({
 
     onClose();
   };
+
+  if (!hasI18n || !Array.isArray(locales) || locales.length === 0) {
+    return null;
+  }
 
   return {
     type: 'icon',


### PR DESCRIPTION
### What does it do?

Do not display the "Fill from locale" button if i18n is not enabled or there is not more than one locale.

fixes #21203