### PR TITLE
fix 21530: Missing description field when configuring Dynamic Zone

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
@@ -237,8 +237,8 @@ const filterFieldsBasedOnAttributeType = (type: Schema.Attribute.Kind) => (field
     case 'media':
       return field.name !== 'placeholder' && field.name !== 'mainField';
     case 'component':
-    case 'dynamiczone':
       return field.name === 'label' || field.name === 'editable';
+    case 'dynamiczone':
     case 'json':
       return field.name !== 'placeholder' && field.name !== 'mainField' && field.name !== 'size';
     case 'relation':

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/tests/EditFieldForm.test.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/tests/EditFieldForm.test.tsx
@@ -115,29 +115,27 @@ describe('EditFieldForm', () => {
       });
     });
 
-    ['component', 'dynamiczone'].forEach((type) => {
-      it(`should hide all but the label and editable fields for the attribute type: ${type}`, () => {
-        render({
-          attribute: {
-            // @ts-expect-error - ignore the error as we are testing the form for each attribute type
-            type,
-          },
-        });
-
-        expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
-        expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
-
-        expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-
-        expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
-        expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
-
-        expect(screen.queryByRole('textbox', { name: 'Description' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
+    it(`should hide all but the label and editable fields for the attribute type: component`, () => {
+      render({
+        // @ts-expect-error - ignore the error as we are testing the form for each attribute type
+        attribute: {
+          type: 'component',
+        },
       });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
+
+      expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
+
+      expect(screen.queryByRole('textbox', { name: 'Description' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
     });
 
     ['blocks', 'richtext'].forEach((type) => {
@@ -190,26 +188,29 @@ describe('EditFieldForm', () => {
       });
     });
 
-    it(`should hide the placeholder and size fields for the attribute type: json`, () => {
-      render({
-        attribute: {
-          type: 'json',
-        },
+    ['json', 'dynamiczone'].forEach((type) => {
+      it(`should hide the placeholder and size fields for the attribute type: ${type}`, () => {
+        render({
+          attribute: {
+            // @ts-expect-error - ignore the error as we are testing the form for each attribute type
+            type,
+          },
+        });
+
+        expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
+
+        expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+        expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
+
+        expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
       });
-
-      expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
-
-      expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-
-      expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
-      expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
-
-      expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
     });
 
     it("should render the mainField option for relation attributes and have a list of potential mainField attributes from it's targetModel", async () => {


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix   #21530: Missing description field when configuring Dynamic Zone

### Why is it needed?

Just as in v4 , we should be able to add a description

### How to test it?

- Go to a content-type with a dynamic zone
- Go to an entry
- Go to Configure the view
- Click on the edit icon of the dynamic zone
- See that the description field is available

### Related issue(s)/PR(s)

#21530 