### PR TITLE
fix: test CI/CD building repo 2 times

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        shard: [1/2, 2/2]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -221,7 +221,7 @@ jobs:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+        shard: [1/2, 2/2]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+        shard: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -221,7 +221,7 @@ jobs:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+        shard: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,13 +171,13 @@ jobs:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     timeout-minutes: 60
     needs: [changes, build]
-    name: '[CE] e2e (browser: ${{ matrix.project }})'
+    name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/2, 2/2]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -213,7 +213,7 @@ jobs:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     timeout-minutes: 60
     needs: [changes, build]
-    name: '[EE] e2e (browser: ${{ matrix.project }})'
+    name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
     runs-on: ubuntu-latest
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
@@ -221,7 +221,7 @@ jobs:
       fail-fast: false # remove once tests aren't flaky
       matrix:
         project: ['chromium', 'webkit', 'firefox']
-        shard: [1/2, 2/2]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
 
   lint:
     name: 'lint (node: ${{ matrix.node }})'
+    needs: [build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -94,7 +95,7 @@ jobs:
 
   typescript:
     name: 'typescript (node: ${{ matrix.node }})'
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -121,7 +122,7 @@ jobs:
   unit_back:
     if: needs.changes.outputs.backend == 'true'
     name: 'unit_back (node: ${{ matrix.node }})'
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     env:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
@@ -145,7 +146,7 @@ jobs:
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # remove once tests aren't flaky
@@ -169,7 +170,7 @@ jobs:
   e2e_ce:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     timeout-minutes: 60
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[CE] e2e (browser: ${{ matrix.project }})'
     runs-on: ubuntu-latest
     strategy:
@@ -211,7 +212,7 @@ jobs:
   e2e_ee:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     timeout-minutes: 60
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[EE] e2e (browser: ${{ matrix.project }})'
     runs-on: ubuntu-latest
     env:
@@ -256,7 +257,7 @@ jobs:
   cli:
     if: needs.changes.outputs.backend == 'true'
     timeout-minutes: 60
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: 'CLI Tests (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
     strategy:
@@ -283,7 +284,7 @@ jobs:
   api_ce_pg:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
       matrix:
@@ -323,7 +324,7 @@ jobs:
   api_ce_mysql:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[CE] API Integration (mysql:latest, package: mysql2}, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
       matrix:
@@ -362,7 +363,7 @@ jobs:
   api_ce_sqlite:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
       matrix:
@@ -385,7 +386,7 @@ jobs:
   # EE
   api_ee_pg:
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
@@ -428,7 +429,7 @@ jobs:
 
   api_ee_mysql:
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
@@ -470,7 +471,7 @@ jobs:
 
   api_ee_sqlite:
     runs-on: ubuntu-latest
-    needs: [changes, lint, pretty, build]
+    needs: [changes, build]
     name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:


### PR DESCRIPTION
### What does it do?
Moved lint to second strage since it requires build stap
Removed pretty as a requirement to run second stage tests (Final test will still fail but we atleast want to know if the code passes) 
increase E2E shards 
### Why is it needed?
1  to not build 2 times
2 To make the tests run if prettier fails so that we can still check if there are any code issues or only prettier issues
3 so that the time it takes for the tests to run goos down from 21 to 15
### How to test it?

If all test pass it should be fine 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
 https://github.com/strapi/strapi/pull/21467
 
 
 2 shards https://github.com/strapi/strapi/actions/runs/11256802614
 5 shards https://github.com/strapi/strapi/actions/runs/11257246445/job/31301300364?pr=21740
 7 shards https://github.com/strapi/strapi/actions/runs/11257753134?pr=21740
 
 aka sharding here does not help since all the log tests happen in shard 1 aka to make it go down form taking 10 minutes we need Playwright Orchestration so that it is split more fairly
 
 From my research only 2 exist 
 https://github.com/alyaothman14/playwright-smart-orchestration-js/tree/main
 Second one is propertery
 https://docs.currents.dev/guides/parallelization-guide/pw-parallelization/playwright-orchestration