### PR TITLE
chore: add test workflow filters for each test type

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -6,7 +6,6 @@ backend:
   - 'packages/**/strapi-server.js'
   - 'packages/{utils,generators,cli,providers}/**'
   - 'packages/core/*/{lib,bin,ee,src}/**'
-  - 'tests/api/**'
   - 'packages/core/database/**'
 frontend:
   - '.github/actions/yarn-nm-install/*.yml'
@@ -16,3 +15,9 @@ frontend:
   - 'packages/**/admin/ee/admin/**'
   - 'packages/**/strapi-admin.js'
   - 'packages/admin-test-utils/**'
+api:
+  - 'tests/api/**'
+e2e:
+  - 'tests/e2e/**'
+cli:
+  - 'tests/cli/**'

--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -49,6 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     name: 'typescript'
+    strategy:
+      matrix:
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -58,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -78,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -86,6 +89,9 @@ jobs:
     name: 'CLI Tests'
     needs: [changes, build]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -115,7 +121,7 @@ jobs:
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }})'
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 
@@ -125,7 +131,7 @@ jobs:
     name: '[CE] API Integration (mysql, node: ${{ matrix.node }})'
     strategy:
       matrix:
-        node: [18, 20]
+        node: [20, 22]
     steps:
       - run: echo "Skipped"
 

--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -16,7 +16,8 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      nonDoc: ${{ steps.filter.outputs.nonDoc }}
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,7 +29,7 @@ jobs:
           filters: .github/filters.yaml
 
   pretty:
-    name: 'pretty (node: 20)'
+    name: 'pretty (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,6 +39,17 @@ jobs:
 
   lint:
     name: 'lint (node: ${{ matrix.node }})'
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - run: echo "Skipped"
+
+  build:
+    name: 'build (node: ${{ matrix.node }})'
+    needs: [changes]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,9 +58,9 @@ jobs:
       - run: echo "Skipped"
 
   typescript:
+    name: 'typescript (node: ${{ matrix.node }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
-    needs: [build]
-    name: 'typescript'
     strategy:
       matrix:
         node: [20, 22]
@@ -57,7 +69,7 @@ jobs:
 
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
-    needs: [lint]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -67,7 +79,7 @@ jobs:
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
-    needs: [lint]
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,18 +87,30 @@ jobs:
     steps:
       - run: echo "Skipped"
 
-  build:
-    name: 'build (node: ${{ matrix.node }})'
-    needs: [changes, lint, unit_front]
+  e2e_ce:
+    name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        project: ['chromium', 'webkit', 'firefox']
+        shard: [1/2, 2/2]
+    steps:
+      - run: echo "Skipped"
+
+  e2e_ee:
+    name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
+    needs: [changes, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: ['chromium', 'webkit', 'firefox']
+        shard: [1/2, 2/2]
     steps:
       - run: echo "Skipped"
 
   cli:
-    name: 'CLI Tests'
+    name: 'CLI Tests (node: ${{ matrix.node }})'
     needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
@@ -95,49 +119,93 @@ jobs:
     steps:
       - run: echo "Skipped"
 
-  e2e_ce:
-    runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[CE] e2e (browser: ${{ matrix.project }})'
-    strategy:
-      matrix:
-        project: ['chromium', 'webkit', 'firefox']
-    steps:
-      - run: echo "Skipped"
-
-  e2e_ee:
-    runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[EE] e2e (browser: ${{ matrix.project }})'
-    strategy:
-      matrix:
-        project: ['chromium', 'webkit', 'firefox']
-    steps:
-      - run: echo "Skipped"
-
   api_ce_pg:
+    name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[CE] API Integration (postgres, node: ${{ matrix.node }})'
     strategy:
       matrix:
         node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       - run: echo "Skipped"
 
   api_ce_mysql:
+    name: '[CE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[CE] API Integration (mysql, node: ${{ matrix.node }})'
     strategy:
       matrix:
         node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       - run: echo "Skipped"
 
   api_ce_sqlite:
+    name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
-    needs: [lint, unit_back, unit_front]
-    name: '[CE] API Integration (sqlite: ${{ matrix.sqlite_pkg }}, node: ${{ matrix.node }})'
+    strategy:
+      matrix:
+        node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    steps:
+      - run: echo "Skipped"
+
+  api_ee_pg:
+    name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    steps:
+      - run: echo "Skipped"
+
+  api_ee_mysql:
+    name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    steps:
+      - run: echo "Skipped"
+
+  api_ee_sqlite:
+    name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+        shard: [1/5, 2/5, 3/5, 4/5, 5/5]
+    steps:
+      - run: echo "Skipped"
+
+  test_result:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: aggregate_test_result
+    needs:
+      [
+        pretty,
+        lint,
+        build,
+        typescript,
+        unit_back,
+        unit_front,
+        e2e_ce,
+        e2e_ee,
+        cli,
+        api_ce_pg,
+        api_ce_mysql,
+        api_ce_sqlite,
+        api_ee_pg,
+        api_ee_mysql,
+        api_ee_sqlite,
+      ]
     steps:
       - run: echo "Skipped"

--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -184,28 +184,3 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       - run: echo "Skipped"
-
-  test_result:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: aggregate_test_result
-    needs:
-      [
-        pretty,
-        lint,
-        build,
-        typescript,
-        unit_back,
-        unit_front,
-        e2e_ce,
-        e2e_ee,
-        cli,
-        api_ce_pg,
-        api_ce_mysql,
-        api_ce_sqlite,
-        api_ee_pg,
-        api_ee_mysql,
-        api_ee_sqlite,
-      ]
-    steps:
-      - run: echo "Skipped"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,7 @@ jobs:
         run: yarn nx affected --target=test:unit --nx-ignore-cycles
 
   unit_front:
+    if: needs.changes.outputs.frontend == 'true'
     name: 'unit_front (node: ${{ matrix.node }})'
     needs: [changes, build]
     runs-on: ubuntu-latest
@@ -168,7 +169,7 @@ jobs:
         run: yarn nx affected --target=test:front --nx-ignore-cycles -- --runInBand
 
   e2e_ce:
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.e2e == 'true'
     timeout-minutes: 60
     needs: [changes, build]
     name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
@@ -210,7 +211,7 @@ jobs:
           retention-days: 1
 
   e2e_ee:
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.e2e == 'true'
     timeout-minutes: 60
     needs: [changes, build]
     name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
@@ -255,7 +256,7 @@ jobs:
           retention-days: 1
 
   cli:
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.cli == 'true'
     timeout-minutes: 60
     needs: [changes, build]
     name: 'CLI Tests (node: ${{ matrix.node }})'
@@ -282,7 +283,7 @@ jobs:
         run: yarn test:cli
 
   api_ce_pg:
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -322,7 +323,7 @@ jobs:
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_mysql:
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[CE] API Integration (mysql:latest, package: mysql2}, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -361,7 +362,7 @@ jobs:
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_sqlite:
-    if: needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
@@ -388,7 +389,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+    if: (needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true') && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
@@ -431,7 +432,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+    if: (needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true') && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
@@ -473,7 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, build]
     name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    if: needs.changes.outputs.backend == 'true' && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
+    if: (needs.changes.outputs.backend == 'true' || needs.changes.outputs.api == 'true') && github.event.pull_request.head.repo.full_name == github.repository && !(github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      api: ${{ steps.filter.outputs.api }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      cli: ${{ steps.filter.outputs.cli }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### What does it do?

implements filters specific for each type of integration/e2e tests so we run exactly what is necessary

### Why is it needed?

e2e tests are currently not running when e2e tests are changed, because we were piggybacking on the setup for api tests. now all the test types should just track themselves

### How to test it?

CI should run exactly what it needs to. For example:
- a change to a backend file will trigger runs for api, cli, e2e, and unit:back
- a change to a frontend file will trigger runs for unit:front and e2e
- a change to an api test or utility will trigger runs only for api
- a change to an e2e test or utility will trigger runs only for e2e
- a change to a cli test or utility will trigger runs only for cli
- a change to github workflows will trigger all tests (this is a trade-off; the test results themselves will never be affected by a workflow change, however, workflow changes are difficult to test if they don't trigger tests to run)
- any skipped runs should not prevent test_aggregate from passing

I'm not sure, but I think if you branch from this PR and target it in github it will follow the workflows from this PR, that would be one way to test it if that's true

### Related issue(s)/PR(s)

DX-1699
