### PR TITLE
feat: add i18n.localized for fields inside a component

### DIFF
--- a/packages/plugins/i18n/admin/src/index.ts
+++ b/packages/plugins/i18n/admin/src/index.ts
@@ -163,21 +163,25 @@ export default {
         }),
         form: {
           advanced({ contentTypeSchema, forTarget, type, step }: any) {
-            if (!['contentType', 'component'].includes(forTarget)) {
+            // A top level as well as a nested components inside a repeatable should be able to be localized
+            if (!['contentType', 'component', 'components'].includes(forTarget)) {
               return [];
             }
 
-            const hasI18nEnabled = get(
-              contentTypeSchema,
-              ['schema', 'pluginOptions', 'i18n', 'localized'],
-              false
-            );
+            if (forTarget === 'contentType') {
+              const hasI18nEnabled = get(
+                contentTypeSchema,
+                ['schema', 'pluginOptions', 'i18n', 'localized'],
+                false
+              );
 
-            if (!hasI18nEnabled && forTarget === 'contentType') {
-              return [];
+              if (!hasI18nEnabled) {
+                return [];
+              }
             }
 
-            if (type === 'component' && step === '1') {
+            // Keep this condition but keep it for contentType as components can be nested
+            if (type === 'component' && step === '1' && forTarget === 'contentType') {
               return [];
             }
 

--- a/packages/plugins/i18n/admin/src/index.ts
+++ b/packages/plugins/i18n/admin/src/index.ts
@@ -163,7 +163,7 @@ export default {
         }),
         form: {
           advanced({ contentTypeSchema, forTarget, type, step }: any) {
-            if (forTarget !== 'contentType') {
+            if (!['contentType', 'component'].includes(forTarget)) {
               return [];
             }
 
@@ -173,7 +173,7 @@ export default {
               false
             );
 
-            if (!hasI18nEnabled) {
+            if (!hasI18nEnabled && forTarget === 'contentType') {
               return [];
             }
 


### PR DESCRIPTION

Hello 👋 


I tried to follow https://github.com/strapi/strapi/blob/develop/CONTRIBUTING.md to test the plugin but didn't manage to make it. I tested it on my own instance, but I wasn't even able to see a console.log here :/ How can we test changes from a plugin? 


### What does it do?

Today we can add `i18n.localized=true` at a `contentType` level only cf https://github.com/strapi/strapi/blob/develop/packages/plugins/i18n/admin/src/index.ts#L166


```ts
  if (forTarget !== 'contentType') {
    return [];
  }

  const hasI18nEnabled = get(
    contentTypeSchema,
    ['schema', 'pluginOptions', 'i18n', 'localized'],
    false
  );
```


With this small change it's now possible to see the option when we add a new field to a component too, and it doesn't create an issue for the API cf:

URL: GET http://localhost:1337/content-type-builder/components
```json
  "pedro": {
      "type": "string",
      "maxLength": 150,
      "pluginOptions": {
          "i18n": {
              "localized": true
          }
      }
  }
```

It's also possible to add a value there from the UI, and of course if you save the value it works.



### Why is it needed?

Today it's possible to say the whole component is going to be translated. But then it creates an issue:
- How do we know the value to translate?

While it's kind of easy to filter our quite a few types such as boolean, for string values it's complex. 

We may create a field `href`, while we do want to translate the label/title associated, we do not want to tag the href itself as a string to translate.
With this fix, we can set the whole component to be localized and we can isolate fields.


### How to test it?

1. Create a component with the fix and go to advanced settings

<img width="1119" alt="Screenshot 2024-10-10 at 10 49 24" src="https://github.com/user-attachments/assets/29bc91fa-dfb0-4ed4-b29e-9f20762c8d07">

2. Apply the fix, redo the action


<img width="1119" alt="Screenshot 2024-10-10 at 10 49 41" src="https://github.com/user-attachments/assets/7deed242-1bcf-4036-a8e3-ceb7f3736133">



### Limitations

Arguments from `advanced`
```json
{
    "contentTypeSchema": {},
    "forTarget": "component",
    "type": "text",
    "step": null,
    "props": {
        "data": {
            "type": "string"
        },
        "actionType": "create",
        "attributes": [
            {
                "type": "text",
                "name": "href"
            },
            {
                "type": "boolean",
                "default": true,
                "name": "blank"
            },
            {
                "type": "string",
                "maxLength": 150,
                "pluginOptions": {
                    "i18n": {
                        "localized": true
                    }
                },
                "name": "pedro"
            }
        ]
    }
}
```

Today the `advanced` method doesn't provide enough elements to hide this option if the parent is not localized.
> Maybe also set `checked` (_is it possible?_) to the input if we know the parent is already translated and the type makes sense
