### PR TITLE
enhancement: add preview panel button

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import { Button } from '@strapi/design-system';
+import { UID } from '@strapi/types';
+import { useIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
+
+import { useGetPreviewUrlQuery } from '../services/preview';
+
+import type { PanelComponent } from '@strapi/content-manager/strapi-admin';
+
+const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
+  const { formatMessage } = useIntl();
+  const { data, error } = useGetPreviewUrlQuery({
+    params: {
+      contentType: model as UID.ContentType,
+    },
+    query: {
+      documentId,
+      locale: document?.locale,
+      status: document?.status,
+    },
+  });
+
+  if (!data?.data?.url || error) {
+    return null;
+  }
+
+  return {
+    title: formatMessage({ id: 'content-manager.preview.panel.title', defaultMessage: 'Preview' }),
+    content: (
+      <Button variant="tertiary" fullWidth tag={Link} to={data.data.url} target="_blank">
+        {formatMessage({
+          id: 'content-manager.preview.panel.button',
+          defaultMessage: 'Open preview',
+        })}
+      </Button>
+    ),
+  };
+};
+
+export { PreviewSidePanel };

--- a/packages/core/content-manager/admin/src/preview/index.ts
+++ b/packages/core/content-manager/admin/src/preview/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable check-file/no-index */
 
+import { PreviewSidePanel } from './components/PreviewSidePanel';
 import { FEATURE_ID } from './constants';
 
 import type { PluginDefinition } from '@strapi/admin/strapi-admin';
@@ -8,10 +9,17 @@ const previewAdmin = {
   bootstrap(app) {
     // TODO: Add license registry check when it's available
     if (!window.strapi.future.isEnabled(FEATURE_ID)) {
-      return {};
+      return;
     }
-    // eslint-disable-next-line no-console -- TODO remove when we have real functionality
-    console.log('Bootstrapping preview admin');
+
+    const contentManagerPluginApis = app.getPlugin('content-manager').apis;
+
+    if (
+      'addEditViewSidePanel' in contentManagerPluginApis &&
+      typeof contentManagerPluginApis.addEditViewSidePanel === 'function'
+    ) {
+      contentManagerPluginApis.addEditViewSidePanel([PreviewSidePanel]);
+    }
   },
 } satisfies Partial<PluginDefinition>;
 

--- a/packages/core/content-manager/admin/src/preview/services/preview.ts
+++ b/packages/core/content-manager/admin/src/preview/services/preview.ts
@@ -1,0 +1,22 @@
+import { GetPreviewUrl } from '../../../../shared/contracts/preview';
+import { contentManagerApi } from '../../services/api';
+
+const previewApi = contentManagerApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getPreviewUrl: builder.query<GetPreviewUrl.Response, GetPreviewUrl.Request>({
+      query({ query, params }) {
+        return {
+          url: `/content-manager/preview/url/${params.contentType}`,
+          method: 'GET',
+          config: {
+            params: query,
+          },
+        };
+      },
+    }),
+  }),
+});
+
+const { useGetPreviewUrlQuery } = previewApi;
+
+export { useGetPreviewUrlQuery };

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -231,6 +231,8 @@
   "popUpWarning.warning.unpublish-question": "Are you sure you don't want to publish it?",
   "popUpWarning.warning.updateAllSettings": "This will modify all your settings",
   "popover.display-relations.label": "Display relations",
+  "preview.panel.title": "Preview",
+  "preview.panel.button": "Open preview",
   "relation.add": "Add relation",
   "relation.disconnect": "Remove",
   "relation.error-adding-relation": "An error occurred while trying to add the relation.",


### PR DESCRIPTION
### What does it do?

Adds an external link button to the preview URL.

No tests here as unit tests wouldn't add real value, and this will be covered by end to end tests soon.

### How to test it?

Open any edit view page, you should see the preview panel on the right sidebar, clicking should take you to the (fake) preview URL in a new tab