### PR TITLE
fix: added fix for not performing bulk actions when it is disabled

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
@@ -68,11 +68,7 @@ const BulkActionsRenderer = () => {
       >
         {(actions) =>
           actions.map((action) => {
-            return list.settings.bulkable && action?.label === 'Publish' ? (
-              <DocumentActionButton key={action.id} {...action} />
-            ) : action?.label === 'Delete' || action?.label === 'Unpublish' ? (
-              <DocumentActionButton key={action.id} {...action} />
-            ) : null;
+            return list.settings.bulkable && <DocumentActionButton key={action.id} {...action} />;
           })
         }
       </DescriptionComponentRenderer>

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
@@ -13,6 +13,7 @@ import { useIntl } from 'react-intl';
 import { useDocumentRBAC } from '../../../../features/DocumentRBAC';
 import { useDoc } from '../../../../hooks/useDocument';
 import { useDocumentActions } from '../../../../hooks/useDocumentActions';
+import { useDocumentLayout } from '../../../../hooks/useDocumentLayout';
 import { buildValidParams } from '../../../../utils/api';
 import { getTranslation } from '../../../../utils/translations';
 import {
@@ -50,6 +51,7 @@ const BulkActionsRenderer = () => {
   const plugins = useStrapiApp('BulkActionsRenderer', (state) => state.plugins);
 
   const { model, collectionType } = useDoc();
+  const { list } = useDocumentLayout(model);
   const { selectedRows } = useTable('BulkActionsRenderer', (state) => state);
 
   return (
@@ -64,7 +66,15 @@ const BulkActionsRenderer = () => {
           plugins['content-manager'].apis as ContentManagerPlugin['config']['apis']
         ).getBulkActions()}
       >
-        {(actions) => actions.map((action) => <DocumentActionButton key={action.id} {...action} />)}
+        {(actions) =>
+          actions.map((action) => {
+            return list.settings.bulkable && action?.label === 'Publish' ? (
+              <DocumentActionButton key={action.id} {...action} />
+            ) : action?.label === 'Delete' || action?.label === 'Unpublish' ? (
+              <DocumentActionButton key={action.id} {...action} />
+            ) : null;
+          })
+        }
       </DescriptionComponentRenderer>
     </Flex>
   );


### PR DESCRIPTION
### What does it do?
Made the Bulk Action to not displayed when it is disabled

### Why is it needed?
To fix issue [21173](https://github.com/strapi/strapi/issues/21173): Can perform bulk actions even if disabled

### How to test it?

1. Go to the Content Manager
2. Go to a content type's list view
3. Click on Configure the view
4. Disable Bulk actions
5. Go back to the list view
6. Select entries
7. Click on Bulk Publish, Unpublish or Delete
8. See that you can perform Bulk actions

### Related issue(s)/PR(s)
fixes [21173](https://github.com/strapi/strapi/issues/21173)