### PR TITLE
chore: fix mysql workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -361,7 +361,7 @@ jobs:
         uses: ./.github/actions/run-build
       - uses: ./.github/actions/run-api-tests
         with:
-          dbOptions: '--dbclient=${{ matrix.db_client }} --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
+          dbOptions: '--dbclient=mysql --dbhost=localhost --dbport=3306 --dbname=strapi_test --dbusername=strapi --dbpassword=strapi'
           jestOptions: '--shard=${{ matrix.shard }}'
 
   api_ce_sqlite:


### PR DESCRIPTION
### What does it do?

use mysql for dbclient in api_ce_mysql workflow

### Why is it needed?

api_ce_mysql tests are not receiving a dbclient value and are probably currently running with sqlite

### How to test it?

CI should work

### Related issue(s)/PR(s)

