### PR TITLE
fix(types): attributes with defaults are not optional

### DIFF
--- a/packages/core/types/src/schema/index.ts
+++ b/packages/core/types/src/schema/index.ts
@@ -189,7 +189,11 @@ export type AttributeNamesWithTarget<TSchemaUID extends UID.Schema> = Extract<
 export type RequiredAttributeNames<TSchemaUID extends UID.Schema> = Object.KeysBy<
   Attributes<TSchemaUID>,
   Attribute.Required,
-  AttributeNames<TSchemaUID>
+  Object.KeysExcept<
+    Attributes<TSchemaUID>,
+    Attribute.DefaultTo<any>,
+    AttributeNames<TSchemaUID>
+  >
 >;
 
 /**
@@ -203,5 +207,9 @@ export type RequiredAttributeNames<TSchemaUID extends UID.Schema> = Object.KeysB
 export type OptionalAttributeNames<TSchemaUID extends UID.Schema> = Object.KeysExcept<
   Attributes<TSchemaUID>,
   Attribute.Required,
+  AttributeNames<TSchemaUID>
+> | Object.KeysBy<
+  Attributes<TSchemaUID>,
+  Attribute.DefaultTo<any>,
   AttributeNames<TSchemaUID>
 >;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Attributes/Fields which are set to required, but also have a default value, are now typed as optional (instead of required) when using the Document Service API (eg. .create()) or Types imported from "@strapi/strapi" etc.. (Fix #21803)

### Why is it needed?

Attributes should become optional when a default is given. Otherwise, omitting the value in order to use the default prompts errors. "Required" should prevent `null` values but allow `undefined` to be caught by a default value. This is also the current behavior of the REST Api. Hence, valid Api calls are wrongly highlighted.

### How to test it?

1. Create a Strapi v5 Project with a "Recipe" CollectionType
2. Add Text Fields "name", "description"
3. Set both "Required" and add a default to "description"
4. Make a test.ts file in .src with:
```typescript
import type { Core } from "@strapi/strapi";

const strapi: Core.Strapi = {} as Core.Strapi;

strapi.documents("api::recipe.recipe").create({
  data: {
    name: "Bread",
    // description: "default description"
  },
});
```
5. Typescript prompts:
Type '{ name: string; }' is not assignable to type 'Input<"api::recipe.recipe">'.   Property 'description' is missing in type '{ name: string; }' but required in type ...

### Related issue(s)/PR(s)

this is a fix idea of #21803 
