### PR TITLE
fix: resolve search encoding issue in content manager

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -107,7 +107,7 @@ const ListViewPage = () => {
   const paramObject = React.useMemo(() => {
     const pairs = queryString.split('&').map((param) => {
       const [key, value] = param.split('=');
-      return { [key]: value };
+      return { [key]: decodeURIComponent(value) };
     });
     return Object.assign({}, ...pairs);
   }, [queryString]);


### PR DESCRIPTION
What does it do?
This PR fixes an issue with search encoding in the content manager. It prevents double-encoding of search query parameters and ensures proper decoding of URL-encoded values before sending them to the backend.
Why is it needed?
When searching for entries in the content manager, spaces and special characters were being incorrectly encoded, leading to inaccurate search results. For example, searching for "test 1" would result in the space being encoded to "%20" and then escaped in the database query, making it impossible to find the correct entries.

How to test it?
1. Create some entries in a content-type, e.g., "test 1" and "test 2"
2. In the content manager, try to search specifically for "test 1"
3. Verify that the search returns only "test 1" and not "test 2"
4. Check the REST query logs and database query logs to ensure that the space is not being encoded into "%20" and that
the "%" is not being escaped in the database query

![image](https://github.com/user-attachments/assets/7913a766-96ff-4cd8-b35c-05a15e470cad)

Related issue(s)/PR(s)
Fixes #21791 