### PR TITLE
fix: display issue while scrolling on roles view

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -35,7 +35,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
           background="neutral0"
           shadow="tableShadow"
           width={`${width}px`}
-          zIndex={1}
+          zIndex={2}
           data-strapi-header-sticky
         >
           <Flex justifyContent="space-between">


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It updates the z-index of the fixed header to 2.

### Why is it needed?

To make the scroll better without hindering the top header view.

### How to test it?

- Navigate to Roles in admin
- Try to edit any role
- Scroll through the rows

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/21346

