### PR TITLE
fix: order when loading more than 10 relations 

### DIFF
--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -67,8 +67,7 @@ const relationsApi = contentManagerApi.injectEndpoints({
              * Relations will always have unique IDs, so we can therefore assume
              * that we only need to push the new items to the cache.
              */
-
-            currentCache.results.push(...prepareTempKeys(newItems.results, currentCache.results));
+            currentCache.results = prepareTempKeys([...newItems.results, ...currentCache.results]);
             currentCache.pagination = newItems.pagination;
           } else if (newItems.pagination.page === 1) {
             /**
@@ -178,11 +177,8 @@ const relationsApi = contentManagerApi.injectEndpoints({
  * @description Adds a `__temp_key__` to each relation item. This gives us
  * a stable identifier regardless of it's ids etc. that we can then use for drag and drop.
  */
-const prepareTempKeys = (relations: RelResult[], existingRelations: RelationResult[] = []) => {
-  const [firstItem] = existingRelations.slice(0);
-
-  const keys = generateNKeysBetween(null, firstItem?.__temp_key__ ?? null, relations.length);
-
+const prepareTempKeys = (relations: RelResult[]) => {
+  const keys = generateNKeysBetween(null, null, relations.length);
   return relations.map((datum, index) => ({
     ...datum,
     __temp_key__: keys[index],

--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -66,6 +66,8 @@ const relationsApi = contentManagerApi.injectEndpoints({
             /**
              * Relations will always have unique IDs, so we can therefore assume
              * that we only need to push the new items to the cache.
+             *
+             * Push new items at the beginning as latest items are shown first
              */
             currentCache.results = prepareTempKeys([...newItems.results, ...currentCache.results]);
             currentCache.pagination = newItems.pagination;

--- a/packages/core/content-manager/admin/src/services/relations.ts
+++ b/packages/core/content-manager/admin/src/services/relations.ts
@@ -69,7 +69,10 @@ const relationsApi = contentManagerApi.injectEndpoints({
              *
              * Push new items at the beginning as latest items are shown first
              */
-            currentCache.results = prepareTempKeys([...newItems.results, ...currentCache.results]);
+            currentCache.results = [
+              ...prepareTempKeys(newItems.results, currentCache.results),
+              ...currentCache.results,
+            ];
             currentCache.pagination = newItems.pagination;
           } else if (newItems.pagination.page === 1) {
             /**
@@ -179,8 +182,10 @@ const relationsApi = contentManagerApi.injectEndpoints({
  * @description Adds a `__temp_key__` to each relation item. This gives us
  * a stable identifier regardless of it's ids etc. that we can then use for drag and drop.
  */
-const prepareTempKeys = (relations: RelResult[]) => {
-  const keys = generateNKeysBetween(null, null, relations.length);
+const prepareTempKeys = (relations: RelResult[], existingRelations: RelationResult[] = []) => {
+  const [firstItem] = existingRelations.slice(0);
+  const keys = generateNKeysBetween(null, firstItem?.__temp_key__ ?? null, relations.length);
+
   return relations.map((datum, index) => ({
     ...datum,
     __temp_key__: keys[index],


### PR DESCRIPTION
### What does it do?
Fix loading more than 2 pages of relations in the content manager. 

Relations are assigned a __temp_key__ value based on their order (a0, a1, ..., z1, z2) . Each time a page was loaded the new temp keys were based from the first temp key of the list (a0), but that same value was used to compute the temp keys for the 3rd , ... pages. So the order was messed up.


### How to test it?

Load more than 10 relations in a relational field.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/21808
