### PR TITLE
fix(strapi/types): add Attribute column type

### DIFF
--- a/packages/core/types/src/schema/attribute/base.ts
+++ b/packages/core/types/src/schema/attribute/base.ts
@@ -64,6 +64,27 @@ export interface Attribute<TKind extends Kind = Kind> {
    * Meaning that, if it's set to 'true', the attribute would be considered while performing a search operation.
    */
   searchable?: boolean;
+
+  /**
+   * Database validations and settings
+   * https://docs.strapi.io/dev-docs/backend-customization/models#database-validations-and-settings
+   *
+   * @experimental
+   * @deprecated The column property is experimental and can be deprecated/changed at any time in the future.
+   */
+  column?: Partial<Column>;
+}
+
+// NOTE: Copied directly from @strapi/database package
+export interface Column {
+  type?: string;
+  name?: string;
+  args?: unknown[];
+  defaultTo?: unknown;
+  notNullable?: boolean;
+  unsigned?: boolean;
+  unique?: boolean;
+  primary?: boolean;
 }
 
 /**


### PR DESCRIPTION
### What does it do?

Types the `Attribute.column` for Strapi v5

### Why is it needed?

Missing `column` type when create schema attributes

### Related issue(s)/PR(s)

#21577 #21580

cc @Convly 