### PR TITLE
fix: update openapi params definition

### DIFF
--- a/packages/plugins/documentation/server/src/services/helpers/utils/query-params.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/query-params.ts
@@ -8,7 +8,7 @@ const params: OpenAPIV3.ParameterObject[] = [
     deprecated: false,
     required: false,
     schema: {
-      type: 'string',
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
     },
   },
   {
@@ -68,7 +68,7 @@ const params: OpenAPIV3.ParameterObject[] = [
     deprecated: false,
     required: false,
     schema: {
-      type: 'string',
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
     },
   },
   {
@@ -78,7 +78,11 @@ const params: OpenAPIV3.ParameterObject[] = [
     deprecated: false,
     required: false,
     schema: {
-      type: 'string',
+      oneOf: [
+        { type: 'string' },
+        { type: 'boolean' },
+        { type: 'object', additionalProperties: true },
+      ],
     },
   },
   {


### PR DESCRIPTION
### What does it do?
Describe the technical changes you did.

### Why is it needed?
The `documentation` plugin doesn't emit all allowed types for the `fields`, `populate`, and `sort` parameters.  This PR simply updates the definition of those fields so they're properly typed.

### How to test it?
Verify the spec for `sort` and `fields` supports `string[]` and that `populate` allows objects.  The `src/extensions/documentation/documentation/1.0.0/full_documentation.json` file contains the generated API specs.

### Related issue(s)/PR(s)
None
