### PR TITLE
Sort Generated Content-Types and Components Definitions

### DIFF
--- a/packages/utils/typescript/lib/generators/common/imports.js
+++ b/packages/utils/typescript/lib/generators/common/imports.js
@@ -18,9 +18,9 @@ module.exports = {
   },
 
   generateImportDefinition() {
-    const formattedImports = imports.map((key) =>
-      factory.createImportSpecifier(false, undefined, factory.createIdentifier(key))
-    );
+    const formattedImports = imports
+      .sort()
+      .map((key) => factory.createImportSpecifier(false, undefined, factory.createIdentifier(key)));
 
     return [
       factory.createImportDeclaration(

--- a/packages/utils/typescript/lib/generators/common/models/schema.js
+++ b/packages/utils/typescript/lib/generators/common/models/schema.js
@@ -22,9 +22,11 @@ const { addImport } = require('../imports');
 const generateAttributePropertySignature = (schema) => {
   const { attributes } = schema;
 
-  const properties = Object.entries(attributes).map(([attributeName, attribute]) => {
-    return attributeToPropertySignature(schema, attributeName, attribute);
-  });
+  const properties = Object.entries(attributes)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([attributeName, attribute]) => {
+      return attributeToPropertySignature(schema, attributeName, attribute);
+    });
 
   return factory.createPropertySignature(
     undefined,

--- a/packages/utils/typescript/lib/generators/common/models/utils.js
+++ b/packages/utils/typescript/lib/generators/common/models/utils.js
@@ -111,7 +111,7 @@ const toTypeLiteral = (data) => {
     throw new Error(`Cannot convert to object literal. Unknown type "${typeof data}"`);
   }
 
-  const entries = Object.entries(data);
+  const entries = Object.entries(data).sort((a, b) => a[0].localeCompare(b[0]));
 
   const props = entries.reduce((acc, [key, value]) => {
     // Handle keys such as content-type-builder & co.

--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { factory } = require('typescript');
+const { pipe, values, sortBy, map } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -23,10 +24,14 @@ const generateComponentsDefinitions = async (options = {}) => {
 
   const { components } = strapi;
 
-  const componentsDefinitions = Object.values(components).map((contentType) => ({
-    uid: contentType.uid,
-    definition: models.schema.generateSchemaDefinition(contentType),
-  }));
+  const componentsDefinitions = pipe(
+    values,
+    sortBy('uid'),
+    map((component) => ({
+      uid: component.uid,
+      definition: models.schema.generateSchemaDefinition(component),
+    }))
+  )(components);
 
   options.logger.debug(`Found ${componentsDefinitions.length} components.`);
 

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { factory } = require('typescript');
+const { values, pipe, map, sortBy } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -23,10 +24,14 @@ const generateContentTypesDefinitions = async (options = {}) => {
 
   const { contentTypes } = strapi;
 
-  const contentTypesDefinitions = Object.values(contentTypes).map((contentType) => ({
-    uid: contentType.uid,
-    definition: models.schema.generateSchemaDefinition(contentType),
-  }));
+  const contentTypesDefinitions = pipe(
+    values,
+    sortBy('uid'),
+    map((contentType) => ({
+      uid: contentType.uid,
+      definition: models.schema.generateSchemaDefinition(contentType),
+    }))
+  )(contentTypes);
 
   options.logger.debug(`Found ${contentTypesDefinitions.length} content-types.`);
 


### PR DESCRIPTION
### What does it do?

Introduces consistent sorting for generated imported definitions, schema attributes, content-types, and components.

By ensuring a consistent order, it streamlines the generation process and prevents annoying git issues.

### Why is it needed?

See https://github.com/strapi/strapi/issues/21208

### How to test it?

To test these changes:
1. Go to a Strapi v5 application
1. Generate TypeScript definitions using `yarn strapi ts:generate-types`
2. Verify that the imports, schema attributes, content-types, and components are consistently sorted in the generated output, even after multiple generations

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/21208