### PR TITLE
fix: change name of id param in content api routes

### DIFF
--- a/packages/core/core/src/core-api/routes/index.ts
+++ b/packages/core/core/src/core-api/routes/index.ts
@@ -42,7 +42,7 @@ const getCollectionTypeRoutes = ({ uid, info }: Schema.ContentType) => {
     },
     findOne: {
       method: 'GET',
-      path: `/${info.pluralName}/:id`,
+      path: `/${info.pluralName}/:documentId`,
       handler: `${uid}.findOne`,
       config: {},
     },
@@ -54,13 +54,13 @@ const getCollectionTypeRoutes = ({ uid, info }: Schema.ContentType) => {
     },
     update: {
       method: 'PUT',
-      path: `/${info.pluralName}/:id`,
+      path: `/${info.pluralName}/:documentId`,
       handler: `${uid}.update`,
       config: {},
     },
     delete: {
       method: 'DELETE',
-      path: `/${info.pluralName}/:id`,
+      path: `/${info.pluralName}/:documentId`,
       handler: `${uid}.delete`,
       config: {},
     },


### PR DESCRIPTION
### What does it do?

Rename content api route param name to :documentId (was :id before), this was specially confusing in the content api permissions UI

Before: 
<img width="267" alt="image" src="https://github.com/user-attachments/assets/ee7edcb2-df54-4b46-bc6f-956a6fa894ca">

After:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/72e16688-3f73-405c-8222-540b15d48246">


### Why is it needed?

To make it clear which parameter users should use.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/21852
