### PR TITLE
fix: search by numeric numbers in a relation

### DIFF
--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -451,7 +451,7 @@ const applyWhere = (qb: Knex.QueryBuilder, where: Where) => {
 
 const fieldLowerFn = (qb: Knex.QueryBuilder) => {
   // Postgres requires string to be passed
-  if (qb.client.config.client === 'postgres') {
+  if (qb.client.dialect === 'postgresql') {
     return 'LOWER(CAST(?? AS VARCHAR))';
   }
 


### PR DESCRIPTION
### What does it do?

we were using the config client name before, which could be postgres / pg / pg-native depending on the pg driver that was instaled. This now uses the dialect name, which should be postgresql for any of the knexjs supported pg drivers.

