### PR TITLE
fix: validation message errors

### DIFF
--- a/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
+++ b/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
@@ -132,6 +132,25 @@ const EntryStatusTrigger = ({
     );
   }
 
+  if (status === 'published') {
+    return (
+      <Popover.Trigger>
+        <Button
+          variant="ghost"
+          startIcon={<CheckCircle fill="success600" />}
+          endIcon={<CaretDown />}
+        >
+          <Typography textColor="success600" variant="omega" fontWeight="bold">
+            {formatMessage({
+              id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-unpublish',
+              defaultMessage: 'Ready to unpublish',
+            })}
+          </Typography>
+        </Button>
+      </Popover.Trigger>
+    );
+  }
+
   return (
     <Popover.Trigger>
       <Button variant="ghost" startIcon={<CheckCircle fill="success600" />} endIcon={<CaretDown />}>


### PR DESCRIPTION
### What does it do?

If status of entry is published and the action is not publish (means that actions is unpublish) we want to show the right message: "Ready to publish", this PR handle that case.

### How to test it?

1. Create an entry and publish it
2. Assign it to a Release for unpublish
3. The message should say "Ready to unpublish", before was showing "Ready to publish" 
