### PR TITLE
fix: fixed the caching issue in media-lib new folder

### DIFF
--- a/packages/core/upload/admin/src/hooks/useEditFolder.ts
+++ b/packages/core/upload/admin/src/hooks/useEditFolder.ts
@@ -29,9 +29,9 @@ export const useEditFolder = () => {
     UpdateFolder.Response['error'] | CreateFolders.Response['error'],
     EditFolderRequestParams
   >((...args) => editFolderRequest(put, post, ...args), {
-    onSuccess() {
-      queryClient.refetchQueries([pluginId, 'folders'], { active: true });
-      queryClient.refetchQueries([pluginId, 'folder', 'structure'], { active: true });
+    async onSuccess() {
+      await queryClient.refetchQueries([pluginId, 'folders'], { active: true });
+      await queryClient.refetchQueries([pluginId, 'folder', 'structure'], { active: true });
     },
   });
 


### PR DESCRIPTION
### What does it do?
Fixed the new folder not getting displayed when we try to move the asset in media-lib.

### Why is it needed?
To fix issue [21367](https://github.com/strapi/strapi/issues/21367) : Caching issue media-lib new folder

### How to test it?

- Start with 0 folders
- Upload a few images
- Try to move a file from the list view and see there is no sub folder to move to
- click “creat folder” fill and save the form
- try to move the same file again
- The select is still empty
- Refresh the page
- do the same operation and the select is now filled correctly

### Related issue(s)/PR(s)
fixes [21367](https://github.com/strapi/strapi/issues/21367)