### PR TITLE
feat: add workflowId & hasRequiredStageToPublish to workflows metrics

### DIFF
--- a/packages/core/review-workflows/server/src/services/metrics/index.ts
+++ b/packages/core/review-workflows/server/src/services/metrics/index.ts
@@ -16,12 +16,18 @@ export const sendDidChangeEntryStage = async () => {
   strapi.telemetry.send('didChangeEntryStage', {});
 };
 
-export const sendDidCreateWorkflow = async () => {
-  strapi.telemetry.send('didCreateWorkflow', {});
+export const sendDidCreateWorkflow = async (
+  workflowId: string,
+  hasRequiredStageToPublish: boolean
+) => {
+  strapi.telemetry.send('didCreateWorkflow', { workflowId, hasRequiredStageToPublish });
 };
 
-export const sendDidEditWorkflow = async () => {
-  strapi.telemetry.send('didEditWorkflow', {});
+export const sendDidEditWorkflow = async (
+  workflowId: string,
+  hasRequiredStageToPublish: boolean
+) => {
+  strapi.telemetry.send('didEditWorkflow', { workflowId, hasRequiredStageToPublish });
 };
 
 export const sendDidEditAssignee = async (fromId: any, toId: any) => {

--- a/packages/core/review-workflows/server/src/services/workflows.ts
+++ b/packages/core/review-workflows/server/src/services/workflows.ts
@@ -106,12 +106,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           });
         }
 
-        metrics.sendDidCreateWorkflow();
-
         // Create Workflow
         const createdWorkflow = await strapi.db
           .query(WORKFLOW_MODEL_UID)
           .create(strapi.get('query-params').transform(WORKFLOW_MODEL_UID, createOpts));
+
+        metrics.sendDidCreateWorkflow(createdWorkflow.id, !!opts.data.stageRequiredToPublishName);
 
         if (opts.data.stageRequiredToPublishName) {
           await strapi
@@ -184,7 +184,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
           });
         }
 
-        metrics.sendDidEditWorkflow();
+        metrics.sendDidEditWorkflow(workflow.id, !!opts.data.stageRequiredToPublishName);
 
         const query = strapi.get('query-params').transform(WORKFLOW_MODEL_UID, updateOpts);
 


### PR DESCRIPTION
### What does it do?

We need the workflowId and is stage required to publish has been enabled so we can use this data to get a total of workflows with required stage to publish set. 