### PR TITLE
Feat(cloud-cli): deploy command allows environment to be passed

### DIFF
--- a/packages/cli/cloud/src/cloud/command.ts
+++ b/packages/cli/cloud/src/cloud/command.ts
@@ -1,5 +1,14 @@
 import { Command } from 'commander';
+import { runAction } from '../utils/helpers';
+import listAction from '../environment/list/action';
 
-export function defineCloudNamespace(command: Command): Command {
-  return command.command('cloud').description('Manage Strapi Cloud projects');
+export function defineCloudNamespace(command: Command, ctx: unknown): Command {
+  const cloud = command.command('cloud').description('Manage Strapi Cloud projects');
+
+  // Define cloud namespace aliases:
+  cloud
+    .command('environments')
+    .description('Alias for cloud environment list')
+    .action(() => runAction('list', listAction)(ctx));
+  return cloud;
 }

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -1,4 +1,5 @@
 import fse from 'fs-extra';
+import inquirer from 'inquirer';
 import path from 'path';
 import chalk from 'chalk';
 import { AxiosError } from 'axios';
@@ -21,6 +22,40 @@ type PackageJson = {
     uuid: string;
   };
 };
+
+interface CmdOptions {
+  environment?: string;
+}
+
+const QUIT_OPTION = 'Quit';
+
+async function promptForEnvironment(environments: string[]): Promise<string> {
+  const choices = environments.map((env) => ({ name: env, value: env }));
+  const { selectedEnvironment } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'selectedEnvironment',
+      message: 'Select the environment to deploy:',
+      choices: [...choices, { name: chalk.grey(`(${QUIT_OPTION})`), value: null }],
+    },
+  ]);
+  if (selectedEnvironment === null) {
+    process.exit(1);
+  }
+
+  const { confirm } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: `Do you want to proceed with deployment to ${chalk.cyan(selectedEnvironment)}?`,
+    },
+  ]);
+
+  if (!confirm) {
+    process.exit(1);
+  }
+  return selectedEnvironment;
+}
 
 async function upload(
   ctx: CLIContext,
@@ -143,7 +178,7 @@ async function getConfig({
   }
 }
 
-export default async (ctx: CLIContext) => {
+export default async (ctx: CLIContext, opts: CmdOptions) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
   const token = await getValidToken(ctx, promptLogin);
   if (!token) {
@@ -156,6 +191,7 @@ export default async (ctx: CLIContext) => {
   }
 
   const cloudApiService = await cloudApiFactory(ctx, token);
+  let environments: string[];
 
   try {
     const {
@@ -163,6 +199,8 @@ export default async (ctx: CLIContext) => {
     } = await cloudApiService.getProject({ name: project.name });
 
     const isProjectSuspended = projectData.suspendedAt;
+    environments = projectData.environments;
+
 
     if (isProjectSuspended) {
       ctx.logger.log(
@@ -213,6 +251,24 @@ export default async (ctx: CLIContext) => {
     );
     maxSize = 100000000;
   }
+
+  let targetEnvironment: string;
+
+  if (opts.environment) {
+    if (!environments.includes(opts.environment)) {
+      ctx.logger.error(`Environment ${opts.environment} does not exist.`);
+      return;
+    }
+    targetEnvironment = opts.environment;
+  } else {
+    targetEnvironment =
+      environments.length > 1
+        ? await promptForEnvironment(environments)
+        : environments[0];
+  }
+
+  project.targetEnvironment = targetEnvironment;
+
 
   const buildId = await upload(ctx, project, token, maxSize);
 

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -201,7 +201,6 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
     const isProjectSuspended = projectData.suspendedAt;
     environments = projectData.environments;
 
-
     if (isProjectSuspended) {
       ctx.logger.log(
         '\n Oops! This project has been suspended. \n\n Please reactivate it from the dashboard to continue deploying: '
@@ -262,13 +261,10 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
     targetEnvironment = opts.environment;
   } else {
     targetEnvironment =
-      environments.length > 1
-        ? await promptForEnvironment(environments)
-        : environments[0];
+      environments.length > 1 ? await promptForEnvironment(environments) : environments[0];
   }
 
   project.targetEnvironment = targetEnvironment;
-
 
   const buildId = await upload(ctx, project, token, maxSize);
 

--- a/packages/cli/cloud/src/deploy-project/command.ts
+++ b/packages/cli/cloud/src/deploy-project/command.ts
@@ -12,7 +12,8 @@ const command: StrapiCloudCommand = ({ ctx }) => {
     .description('Deploy a Strapi Cloud project')
     .option('-d, --debug', 'Enable debugging mode with verbose logs')
     .option('-s, --silent', "Don't log anything")
-    .action(() => runAction('deploy', action)(ctx));
+    .option('-e, --environment <name>', 'Specify the environment to deploy')
+    .action((opts) => runAction('deploy', action)(ctx, opts));
 };
 
 export default command;

--- a/packages/cli/cloud/src/environment/command.ts
+++ b/packages/cli/cloud/src/environment/command.ts
@@ -3,9 +3,9 @@ import { defineCloudNamespace } from '../cloud/command';
 
 let environmentCmd: Command | null = null;
 
-export const initializeEnvironmentCommand = (command: Command): Command => {
+export const initializeEnvironmentCommand = (command: Command, ctx: unknown): Command => {
   if (!environmentCmd) {
-    const cloud = defineCloudNamespace(command);
+    const cloud = defineCloudNamespace(command, ctx);
     environmentCmd = cloud.command('environment').description('Manage environments');
   }
   return environmentCmd;

--- a/packages/cli/cloud/src/environment/command.ts
+++ b/packages/cli/cloud/src/environment/command.ts
@@ -1,7 +1,12 @@
 import { Command } from 'commander';
 import { defineCloudNamespace } from '../cloud/command';
 
-export function createEnvironmentCommand(command: Command): Command {
-  const cloud = defineCloudNamespace(command);
-  return cloud.command('environment').description('Manage environments for a Strapi Cloud project');
-}
+let environmentCmd: Command | null = null;
+
+export const getEnvironmentCommand = (command: Command): Command => {
+  if (!environmentCmd) {
+    const cloud = defineCloudNamespace(command);
+    environmentCmd = cloud.command('environment').description('Manage environments');
+  }
+  return environmentCmd;
+};

--- a/packages/cli/cloud/src/environment/command.ts
+++ b/packages/cli/cloud/src/environment/command.ts
@@ -3,7 +3,7 @@ import { defineCloudNamespace } from '../cloud/command';
 
 let environmentCmd: Command | null = null;
 
-export const getEnvironmentCommand = (command: Command): Command => {
+export const initializeEnvironmentCommand = (command: Command): Command => {
   if (!environmentCmd) {
     const cloud = defineCloudNamespace(command);
     environmentCmd = cloud.command('environment').description('Manage environments');

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -1,18 +1,17 @@
 import { type StrapiCloudCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import action from './action';
-import { initializeEnvironmentCommand }  from '../command';
+import { initializeEnvironmentCommand } from '../command';
 
 const command: StrapiCloudCommand = ({ command, ctx }) => {
-
   const environmentCmd = initializeEnvironmentCommand(command);
 
   environmentCmd
-      .command('list')
-      .description('List Strapi Cloud project environments')
-      .option('-d, --debug', 'Enable debugging mode with verbose logs')
-      .option('-s, --silent', "Don't log anything")
-      .action(() => runAction('list', action)(ctx));
+    .command('list')
+    .description('List Strapi Cloud project environments')
+    .option('-d, --debug', 'Enable debugging mode with verbose logs')
+    .option('-s, --silent', "Don't log anything")
+    .action(() => runAction('list', action)(ctx));
 };
 
 export default command;

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -1,11 +1,11 @@
 import { type StrapiCloudCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import action from './action';
-import { getEnvironmentCommand }  from '../command';
+import { initializeEnvironmentCommand }  from '../command';
 
 const command: StrapiCloudCommand = ({ command, ctx }) => {
 
-  const environmentCmd = getEnvironmentCommand(command);
+  const environmentCmd = initializeEnvironmentCommand(command);
 
   environmentCmd
       .command('list')

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -1,25 +1,18 @@
 import { type StrapiCloudCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
 import action from './action';
-import { defineCloudNamespace } from '../../cloud/command';
+import { getEnvironmentCommand }  from '../command';
 
 const command: StrapiCloudCommand = ({ command, ctx }) => {
-  const cloud = defineCloudNamespace(command);
 
-  cloud
-    .command('environments')
-    .description('Alias for cloud environment list')
-    .action(() => runAction('list', action)(ctx));
+  const environmentCmd = getEnvironmentCommand(command);
 
-  const environment = cloud
-    .command('environment')
-    .description('Manage environments for a Strapi Cloud project');
-  environment
-    .command('list')
-    .description('List Strapi Cloud project environments')
-    .option('-d, --debug', 'Enable debugging mode with verbose logs')
-    .option('-s, --silent', "Don't log anything")
-    .action(() => runAction('list', action)(ctx));
+  environmentCmd
+      .command('list')
+      .description('List Strapi Cloud project environments')
+      .option('-d, --debug', 'Enable debugging mode with verbose logs')
+      .option('-s, --silent', "Don't log anything")
+      .action(() => runAction('list', action)(ctx));
 };
 
 export default command;

--- a/packages/cli/cloud/src/environment/list/command.ts
+++ b/packages/cli/cloud/src/environment/list/command.ts
@@ -4,7 +4,7 @@ import action from './action';
 import { initializeEnvironmentCommand } from '../command';
 
 const command: StrapiCloudCommand = ({ command, ctx }) => {
-  const environmentCmd = initializeEnvironmentCommand(command);
+  const environmentCmd = initializeEnvironmentCommand(command, ctx);
 
   environmentCmd
     .command('list')

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -12,6 +12,7 @@ export const VERSION = 'v1';
 export type ProjectInfos = {
   id: string;
   name: string;
+  selectedEnvironment?: string;
   displayName?: string;
   nodeVersion?: string;
   region?: string;
@@ -51,6 +52,7 @@ export type GetProjectResponse = {
     updatedAt: string;
     suspendedAt?: string;
     isTrial: boolean;
+    environments: string[];
   };
   metadata: {
     dashboardUrls: {
@@ -64,7 +66,7 @@ export interface CloudApiService {
   deploy(
     deployInput: {
       filePath: string;
-      project: { name: string };
+      project: { name: string, targetEnvironment?: string };
     },
     {
       onUploadProgress,
@@ -122,7 +124,7 @@ export async function cloudApiFactory(
     deploy({ filePath, project }, { onUploadProgress }) {
       return axiosCloudAPI.post(
         `/deploy/${project.name}`,
-        { file: fse.createReadStream(filePath) },
+        { file: fse.createReadStream(filePath), targetEnvironment: project.targetEnvironment },
         {
           headers: {
             'Content-Type': 'multipart/form-data',

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -66,7 +66,7 @@ export interface CloudApiService {
   deploy(
     deployInput: {
       filePath: string;
-      project: { name: string, targetEnvironment?: string };
+      project: { name: string; targetEnvironment?: string };
     },
     {
       onUploadProgress,


### PR DESCRIPTION
### What does it do?

This PR introduces a feature to allow the cloud CLI deploy command to deploy to a specific cloud project environment by using a prompt selection or a flag.

- When the user runs `strapi deploy`, they would be asked to select an environment to deploy
- When the user runs `strapi deploy -e <environment> `, the deployment will be done in the specified environment

### Why is it needed?

With the introductions of Strapi Cloud multi environments, a feature to allow users to deploy to a specific environment from the CLI is needed.

### How to test it?

Pre-test: new options should be displayed on running `strapi deploy -h`:

`  -e, --environment <name>  Specify the environment to deploy`

Test Case 1: NO prompt for Environment Selection

Steps: Run strapi deploy with only 1 environment in a cloud project.
Expected: deploy should proceed as usual

Test Case 2: Prompt for Environment Selection

Steps: Run strapi deploy with multiple environments configured for the project.
Expected: 
- The user is prompted to select an environment from the available options
- All the available environments should be listed
- A quit option allows the user to cancel the deployment action

Test Case 3: Environment name invalid

Steps: Run strapi deploy -e <env-name> with an invalid environment name
Expected: command should reject with a proper log message

Test Case 4: Environment name valid

Steps: Run strapi deploy -e <env-name> with a valid environment name
Expected: 
- Deployment should start right away
- Deployment should be done to the passed environment

