### PR TITLE
feat: DTS assert count of items sent and received is equal

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -6,11 +6,18 @@ import type { Struct, Utils } from '@strapi/types';
 
 import { createDispatcher, connectToWebsocket, trimTrailingSlash } from '../utils';
 
-import type { IDestinationProvider, IMetadata, ProviderType, IAsset } from '../../../../types';
+import type {
+  IDestinationProvider,
+  IMetadata,
+  ProviderType,
+  IAsset,
+  TransferStage,
+} from '../../../../types';
 import type { Client, Server, Auth } from '../../../../types/remote/protocol';
 import type { ILocalStrapiDestinationProviderOptions } from '../local-destination';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
+import { TransferAssetFlow } from '../../../../types/remote/protocol/client';
 
 export interface IRemoteStrapiDestinationProviderOptions
   extends Pick<ILocalStrapiDestinationProviderOptions, 'restore' | 'strategy'> {
@@ -37,11 +44,24 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
 
   transferID: string | null;
 
+  stats!: { [TStage in Exclude<TransferStage, 'schemas'>]: { count: 0 } };
+
   constructor(options: IRemoteStrapiDestinationProviderOptions) {
     this.options = options;
     this.ws = null;
     this.dispatcher = null;
     this.transferID = null;
+
+    this.resetStats();
+  }
+
+  private resetStats() {
+    this.stats = {
+      assets: { count: 0 },
+      entities: { count: 0 },
+      links: { count: 0 },
+      configuration: { count: 0 },
+    };
   }
 
   async initTransfer(): Promise<string> {
@@ -56,6 +76,9 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
     if (!res?.transferID) {
       throw new ProviderTransferError('Init failed, invalid response from the server');
     }
+
+    this.resetStats();
+
     return res.transferID;
   }
 
@@ -78,33 +101,48 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
       return new ProviderTransferError('Unexpected error');
     }
 
+    this.stats[step] = { count: 0 };
+
     return null;
   }
 
   async #endStep<T extends Client.TransferPushStep>(step: T) {
     try {
-      await this.dispatcher?.dispatchTransferStep({ action: 'end', step });
+      const res = await this.dispatcher?.dispatchTransferStep<{
+        ok: boolean;
+        stats: { started: number; finished: number };
+      }>({
+        action: 'end',
+        step,
+      });
+
+      return { stats: res?.stats, error: null };
     } catch (e) {
       if (e instanceof Error) {
-        return e;
+        return { stats: null, error: e };
       }
 
       if (typeof e === 'string') {
-        return new ProviderTransferError(e);
+        return { stats: null, error: new ProviderTransferError(e) };
       }
 
-      return new ProviderTransferError('Unexpected error');
+      return { stats: null, error: new ProviderTransferError('Unexpected error') };
     }
-
-    return null;
   }
 
   async #streamStep<T extends Client.TransferPushStep>(
     step: T,
-    data: Client.GetTransferPushStreamData<T>
+    message: Client.GetTransferPushStreamData<T>
   ) {
     try {
-      await this.dispatcher?.dispatchTransferStep({ action: 'stream', step, data });
+      if (step === 'assets') {
+        const assetMessage = message as TransferAssetFlow[];
+        this.stats[step].count += assetMessage.filter((data) => data.action === 'start').length;
+      } else {
+        this.stats[step].count += message.length;
+      }
+
+      await this.dispatcher?.dispatchTransferStep({ action: 'stream', step, data: message });
     } catch (e) {
       if (e instanceof Error) {
         return e;
@@ -143,9 +181,20 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
             return callback(streamError);
           }
         }
-        const e = await this.#endStep(step);
+        const { error, stats } = await this.#endStep(step);
 
-        callback(e);
+        if (
+          stats &&
+          (stats.started !== this.stats[step].count || stats.finished !== this.stats[step].count)
+        ) {
+          callback(
+            new Error(
+              `Data missing: sent ${this.stats[step].count} ${step}, recieved ${stats.started} and added ${stats.finished} ${step}`
+            )
+          );
+        }
+
+        callback(error);
       },
 
       write: async (chunk, _encoding, callback) => {
@@ -316,7 +365,7 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
         }
 
         if (hasStarted) {
-          const endStepError = await this.#endStep('assets');
+          const { error: endStepError } = await this.#endStep('assets');
 
           if (endStepError) {
             return callback(endStepError);

--- a/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-destination/index.ts
@@ -116,7 +116,7 @@ class RemoteStrapiDestinationProvider implements IDestinationProvider {
         step,
       });
 
-      return { stats: res?.stats, error: null };
+      return { stats: res?.stats ?? null, error: null };
     } catch (e) {
       if (e instanceof Error) {
         return { stats: null, error: e };

--- a/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
@@ -36,10 +36,7 @@ export interface PushHandler extends Handler {
   streams?: { [stage in TransferStage]?: Writable };
 
   stats: {
-    [stage in Exclude<TransferStage, 'schemas'>]: {
-      started: number;
-      finished: number;
-    };
+    [stage in Exclude<TransferStage, 'schemas'>]: Protocol.Client.Stats;
   };
 
   /**

--- a/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
@@ -35,6 +35,13 @@ export interface PushHandler extends Handler {
    */
   streams?: { [stage in TransferStage]?: Writable };
 
+  stats: {
+    [stage in Exclude<TransferStage, 'schemas'>]: {
+      started: number;
+      finished: number;
+    };
+  };
+
   /**
    * Holds all the transferred assets for the current transfer handler (one registry per connection)
    */
@@ -313,6 +320,8 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
 
       await this.createWritableStreamForStep(stage);
 
+      this.stats[stage] = { started: 0, finished: 0 };
+
       return { ok: true };
     }
 
@@ -332,7 +341,13 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
       }
 
       // For all other steps
-      await Promise.all(msg.data.map((item) => writeAsync(stream, item)));
+      await Promise.all(
+        msg.data.map(async (item) => {
+          this.stats[stage].started += 1;
+          await writeAsync(stream, item);
+          this.stats[stage].finished += 1;
+        })
+      );
     }
 
     if (msg.action === 'end') {
@@ -348,7 +363,7 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
 
       delete this.streams?.[stage];
 
-      return { ok: true };
+      return { ok: true, stats: this.stats[stage] };
     }
   },
 
@@ -390,6 +405,7 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
       }
 
       if (action === 'start') {
+        this.stats.assets.started += 1;
         this.assets[assetID] = { ...item.data, stream: new PassThrough() };
         writeAsync(assetsStream, this.assets[assetID]);
       }
@@ -407,6 +423,7 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
           const { stream: assetStream } = this.assets[assetID];
           assetStream
             .on('close', () => {
+              this.stats.assets.finished += 1;
               delete this.assets[assetID];
               resolve();
             })
@@ -443,6 +460,12 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
 
     this.assets = {};
     this.streams = {};
+    this.stats = {
+      assets: { started: 0, finished: 0 },
+      configuration: { started: 0, finished: 0 },
+      entities: { started: 0, finished: 0 },
+      links: { started: 0, finished: 0 },
+    };
 
     this.flow = createFlow(DEFAULT_TRANSFER_FLOW);
 

--- a/packages/core/data-transfer/types/remote/protocol/client/transfer/push.d.ts
+++ b/packages/core/data-transfer/types/remote/protocol/client/transfer/push.d.ts
@@ -25,3 +25,5 @@ export type TransferPushStep = TransferPushMessage['step'];
 type TransferStepCommands<T extends string, U> = { step: T } & TransferStepFlow<U>;
 
 type TransferStepFlow<U> = { action: 'start' } | { action: 'stream'; data: U } | { action: 'end' };
+
+export type Stats = { started: number; finished: number };

--- a/packages/core/data-transfer/types/remote/protocol/client/transfer/push.d.ts
+++ b/packages/core/data-transfer/types/remote/protocol/client/transfer/push.d.ts
@@ -6,7 +6,7 @@ export type TransferPushMessage = CreateTransferMessage<
   | TransferStepCommands<'entities', IEntity[]>
   | TransferStepCommands<'links', ILink[]>
   | TransferStepCommands<'configuration', IConfiguration[]>
-  | TransferStepCommands<'assets', TransferAssetFlow[] | null>
+  | TransferStepCommands<'assets', TransferAssetFlow[]>
 >;
 
 export type GetTransferPushStreamData<T extends TransferPushStep> = {
@@ -15,7 +15,9 @@ export type GetTransferPushStreamData<T extends TransferPushStep> = {
     step: key;
   } & TransferPushMessage;
 }[T] extends { data: infer U }
-  ? U
+  ? U extends any[] // Check if U is already an array
+    ? U // If U is an array, keep it as-is
+    : U[] // Otherwise, wrap it in an array
   : never;
 
 export type TransferPushStep = TransferPushMessage['step'];


### PR DESCRIPTION
### What does it do?

- Adds counters to the remote transfers, so we know how much data is sent, received and successfully added
- does a comparison and throws and error incase of a mismatch

### Why is it needed?

- Throw and error and rollback to prevent data loss during transfers

### How to test it?

- Transfers should work just fine