### PR TITLE
chore: set up preview e2e tests

### DIFF
--- a/tests/e2e/app-template/config/admin.js
+++ b/tests/e2e/app-template/config/admin.js
@@ -14,4 +14,16 @@ module.exports = ({ env }) => ({
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
   },
+  preview: {
+    enabled: true,
+    config: {
+      handler(uid, { documentId, locale, status }) {
+        if (uid === 'api::product.product') {
+          return null;
+        }
+
+        return `https://strapi.io/preview/${uid}/${documentId}/${locale}/${status}`;
+      },
+    },
+  },
 });

--- a/tests/e2e/app-template/config/features.js
+++ b/tests/e2e/app-template/config/features.js
@@ -1,5 +1,6 @@
 module.exports = ({ env }) => ({
   future: {
     contentReleasesScheduling: env.bool('STRAPI_FEATURES_FUTURE_RELEASES_SCHEDULING', false),
+    preview: true,
   },
 });

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, Page } from '@playwright/test';
+import { login } from '../../utils/login';
+import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
+import { clickAndWait, describeOnCondition, findAndClose, skipCtbTour } from '../../utils/shared';
+import { resetFiles } from '../../utils/file-reset';
+
+const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+describeOnCondition(edition === 'EE')('Preview', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin.tar', (cts) => cts, { coreStore: false });
+    await resetFiles();
+    await page.goto('/admin');
+    await page.evaluate(() => window.localStorage.setItem('GUIDED_TOUR_SKIPPED', 'true'));
+    await login({ page });
+    await page.waitForURL('/admin');
+  });
+
+  test('Preview button should appear for configured content types', async ({ page, context }) => {
+    // Open an edit view for a content type that has preview
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+    // Check that the preview link can be copied
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.getByRole('button', { name: /copy preview link/i }).click();
+    await findAndClose(page, 'Copied preview link');
+    const clipboardText = await page.evaluate(() => {
+      return navigator.clipboard.readText();
+    });
+    expect(clipboardText).toContain('https://strapi.io');
+
+    // Check that preview opens in a new tab
+    const newTabPromiseDraft = page.waitForEvent('popup');
+    await page.getByRole('link', { name: /open preview/i }).click();
+    const newTab = await newTabPromiseDraft;
+    expect(newTab.url()).toMatch(/^https:\/\/strapi\.io\/preview\/api::article\.article.*\/draft$/);
+
+    // Check that preview link reflects the publication status
+    await page.getByRole('button', { name: /publish/i }).click();
+    await findAndClose(page, 'Published document');
+    await page.getByRole('tab', { name: /published/i }).click();
+    const newTabPromisePublished = page.waitForEvent('popup');
+    await page.getByRole('link', { name: /open preview/i }).click();
+    const newTab2 = await newTabPromisePublished;
+    expect(newTab2.url()).toMatch(
+      /^https:\/\/strapi\.io\/preview\/api::article\.article.*\/published$/
+    );
+  });
+
+  test('Preview button should not appear for content types without preview config', async ({
+    page,
+  }) => {
+    // Open an edit view for a content type that does not have preview
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Product' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: /nike mens/i }));
+
+    await expect(page.getByRole('link', { name: /open preview/i })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds the first e2e tests for preview. They'll need to evolve as the feature grows.
