### PR TITLE
enhancement: Sort Generated Content-Types and Components Definitions (#21868)

### DIFF
--- a/packages/utils/typescript/lib/generators/common/imports.js
+++ b/packages/utils/typescript/lib/generators/common/imports.js
@@ -18,9 +18,9 @@ module.exports = {
   },
 
   generateImportDefinition() {
-    const formattedImports = imports.map((key) =>
-      factory.createImportSpecifier(false, undefined, factory.createIdentifier(key))
-    );
+    const formattedImports = imports
+      .sort()
+      .map((key) => factory.createImportSpecifier(false, undefined, factory.createIdentifier(key)));
 
     return [
       factory.createImportDeclaration(

--- a/packages/utils/typescript/lib/generators/common/models/schema.js
+++ b/packages/utils/typescript/lib/generators/common/models/schema.js
@@ -22,9 +22,11 @@ const { addImport } = require('../imports');
 const generateAttributePropertySignature = (schema) => {
   const { attributes } = schema;
 
-  const properties = Object.entries(attributes).map(([attributeName, attribute]) => {
-    return attributeToPropertySignature(schema, attributeName, attribute);
-  });
+  const properties = Object.entries(attributes)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([attributeName, attribute]) => {
+      return attributeToPropertySignature(schema, attributeName, attribute);
+    });
 
   return factory.createPropertySignature(
     undefined,

--- a/packages/utils/typescript/lib/generators/common/models/utils.js
+++ b/packages/utils/typescript/lib/generators/common/models/utils.js
@@ -111,7 +111,7 @@ const toTypeLiteral = (data) => {
     throw new Error(`Cannot convert to object literal. Unknown type "${typeof data}"`);
   }
 
-  const entries = Object.entries(data);
+  const entries = Object.entries(data).sort((a, b) => a[0].localeCompare(b[0]));
 
   const props = entries.reduce((acc, [key, value]) => {
     // Handle keys such as content-type-builder & co.

--- a/packages/utils/typescript/lib/generators/components/index.js
+++ b/packages/utils/typescript/lib/generators/components/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { factory } = require('typescript');
+const { pipe, values, sortBy, map } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -18,10 +19,14 @@ const generateComponentsDefinitions = async (options = {}) => {
 
   const { components } = strapi;
 
-  const componentsDefinitions = Object.values(components).map((contentType) => ({
-    uid: contentType.uid,
-    definition: models.schema.generateSchemaDefinition(contentType),
-  }));
+  const componentsDefinitions = pipe(
+    values,
+    sortBy('uid'),
+    map((component) => ({
+      uid: component.uid,
+      definition: models.schema.generateSchemaDefinition(component),
+    }))
+  )(components);
 
   const formattedSchemasDefinitions = componentsDefinitions.reduce((acc, def) => {
     acc.push(

--- a/packages/utils/typescript/lib/generators/content-types/index.js
+++ b/packages/utils/typescript/lib/generators/content-types/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { factory } = require('typescript');
+const { values, pipe, map, sortBy } = require('lodash/fp');
 
 const { models } = require('../common');
 const { emitDefinitions, format, generateSharedExtensionDefinition } = require('../utils');
@@ -18,10 +19,14 @@ const generateContentTypesDefinitions = async (options = {}) => {
 
   const { contentTypes } = strapi;
 
-  const contentTypesDefinitions = Object.values(contentTypes).map((contentType) => ({
-    uid: contentType.uid,
-    definition: models.schema.generateSchemaDefinition(contentType),
-  }));
+  const contentTypesDefinitions = pipe(
+    values,
+    sortBy('uid'),
+    map((contentType) => ({
+      uid: contentType.uid,
+      definition: models.schema.generateSchemaDefinition(contentType),
+    }))
+  )(contentTypes);
 
   const formattedSchemasDefinitions = contentTypesDefinitions.reduce((acc, def) => {
     acc.push(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

> @Convly
> Introduces consistent sorting for generated imported definitions, schema attributes, content-types, and components.
> By ensuring a consistent order, it streamlines the generation process and prevents annoying git issues.

(cherry picked from merge commit c23fb8e on development branch, coming from pull request #21868)

### Why is it needed?
See #21208

### How to test it?
To test these changes:

1. Go to a Strapi v4 application
2. Generate TypeScript definitions using `yarn strapi ts:generate-types`
3. Verify that the imports, schema attributes, content-types, and components are consistently sorted in the generated output, even after multiple generations

### Related issue(s)/PR(s)
fixes #21208
@Convly suggested somebody made this pull request for V4 in #21208
