### PR TITLE
fix: api state not cleared on logout

### DIFF
--- a/packages/core/admin/admin/src/features/Auth.tsx
+++ b/packages/core/admin/admin/src/features/Auth.tsx
@@ -7,6 +7,7 @@ import { Login } from '../../../shared/contracts/authentication';
 import { createContext } from '../components/Context';
 import { useTypedDispatch } from '../core/store/hooks';
 import { setLocale } from '../reducer';
+import { adminApi } from '../services/api';
 import {
   useGetMeQuery,
   useLoginMutation,
@@ -154,10 +155,11 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
   );
 
   const logout = React.useCallback(async () => {
+    dispatch(adminApi.util.resetApiState());
     await logoutMutation();
     clearStorage();
     push('/auth/login');
-  }, [clearStorage, logoutMutation, push]);
+  }, [clearStorage, logoutMutation, push, dispatch]);
 
   return (
     <Provider token={token} user={user} login={login} logout={logout} setToken={setToken}>


### PR DESCRIPTION
### What does it do?

Fixes an issue where the app's local cache wasn't cleared when you logged out.

### Why is it needed?

Prevent one user's data from leaking to the next user to log in via the same browser

### How to test it?

Have 2 users users:
- one is a super admin with full permissions
- one is an "author" without permissions to read a specific field

You should be able to do this in the same tab without refreshing:
- login as the author user
- open the edit/create view where you removed the permissions for a field. You shouldn't see that field.
- logout
- login as super admin
- go to the same edit/create view. You should see the field

### Related issue(s)/PR(s)

fixes #20344
