### PR TITLE
fix(e2e): enable tests for release-details-page.spec.ts

### DIFF
--- a/packages/core/content-releases/server/src/bootstrap.ts
+++ b/packages/core/content-releases/server/src/bootstrap.ts
@@ -49,8 +49,8 @@ export const bootstrap = async ({ strapi }: { strapi: Core.Strapi }) => {
 
             deleteReleasesActionsAndUpdateReleaseStatus({
               contentType: model.uid,
-              locale: where.locale ?? null,
-              ...(where.documentId && { entryDocumentId: where.documentId }),
+              locale: where?.locale ?? null,
+              ...(where?.documentId && { entryDocumentId: where.documentId }),
             });
           }
         } catch (error) {

--- a/packages/core/content-releases/server/src/utils/index.ts
+++ b/packages/core/content-releases/server/src/utils/index.ts
@@ -71,7 +71,19 @@ export const getEntry = async (
   { strapi }: { strapi: Core.Strapi }
 ) => {
   if (documentId) {
-    return strapi.documents(contentType).findOne({ documentId, locale, populate, status });
+    // Try to get an existing draft or published document
+    const entry = await strapi
+      .documents(contentType)
+      .findOne({ documentId, locale, populate, status });
+
+    // The document isn't published yet, but the action is to publish it, fetch the draft
+    if (status === 'published' && !entry) {
+      return strapi
+        .documents(contentType)
+        .findOne({ documentId, locale, populate, status: 'draft' });
+    }
+
+    return entry;
   }
 
   return strapi.documents(contentType).findFirst({ locale, populate, status });

--- a/tests/e2e/tests/content-releases/release-details-page.spec.ts
+++ b/tests/e2e/tests/content-releases/release-details-page.spec.ts
@@ -38,38 +38,37 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await page.waitForURL('/admin/plugins/content-releases/*');
   });
 
-  test.fixme(
-    'A user should be able to add collection-type and single-type entries to a release and publish the release',
-    async ({ page }) => {
-      // Add a collection-type entry to the release
-      await page.getByRole('link', { name: 'Content Manager' }).click();
-      await page.getByRole('link', { name: 'Author' }).click();
-      await page.getByRole('gridcell', { name: 'Led Tasso' }).click();
-      await page.waitForURL('**/content-manager/collection-types/api::author.author/**');
-      await addEntryToRelease({ page, releaseName });
+  test('A user should be able to add collection-type and single-type entries to a release and publish the release', async ({
+    page,
+  }) => {
+    // Add a collection-type entry to the release
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+    await page.getByRole('link', { name: 'Author' }).click();
+    await page.getByRole('gridcell', { name: 'Led Tasso' }).click();
+    await page.waitForURL('**/content-manager/collection-types/api::author.author/**');
+    await addEntryToRelease({ page, releaseName });
 
-      // Add a single-type entry to the release
-      await page.getByRole('link', { name: 'Content Manager' }).click();
-      await page.getByRole('link', { name: 'Upcoming Matches' }).click();
-      await page.waitForURL('**/content-manager/single-types/api::upcoming-match.upcoming-match**');
-      // Open the add to release dialog
-      await addEntryToRelease({ page, releaseName });
+    // Add a single-type entry to the release
+    await page.getByRole('link', { name: 'Content Manager' }).click();
+    await page.getByRole('link', { name: 'Upcoming Matches' }).click();
+    await page.waitForURL('**/content-manager/single-types/api::upcoming-match.upcoming-match**');
+    // Open the add to release dialog
+    await addEntryToRelease({ page, releaseName });
 
-      // Publish the release
-      await page.getByRole('link', { name: 'Releases' }).click();
-      await page.getByRole('link', { name: `${releaseName}` }).click();
-      await page.getByRole('button', { name: 'Publish' }).click();
-      expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Publish' })).not.toBeVisible();
-      await expect(
-        page.getByRole('button', { name: 'Release edit and delete menu' })
-      ).not.toBeVisible();
-      await expect(page.getByRole('gridcell', { name: 'publish unpublish' })).not.toBeVisible();
-      await expect(
-        page.getByRole('gridcell', { name: 'This entry was published.' }).first()
-      ).toBeVisible();
-    }
-  );
+    // Publish the release
+    await page.getByRole('link', { name: 'Releases' }).click();
+    await page.getByRole('link', { name: `${releaseName}` }).click();
+    await page.getByRole('button', { name: 'Publish' }).click();
+    expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Publish' })).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Release edit and delete menu' })
+    ).not.toBeVisible();
+    await expect(page.getByRole('gridcell', { name: 'publish unpublish' })).not.toBeVisible();
+    await expect(
+      page.getByRole('gridcell', { name: 'This entry was published.' }).first()
+    ).toBeVisible();
+  });
 
   test('A user should be able to edit and delete a release', async ({ page }) => {
     // Edit the release
@@ -90,51 +89,48 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await expect(page.getByRole('link', { name: `${editedEntryName}` })).not.toBeVisible();
   });
 
-  test.fixme(
-    "A user should be able to change the entry groupings, update an entry's action, remove an entry from a release, and navigate to the entry in the content manager",
-    async ({ page }) => {
-      // Change the entry groupings
-      await expect(page.getByRole('separator', { name: 'Article' })).toBeVisible();
-      await expect(page.getByRole('separator', { name: 'Author' })).toBeVisible();
-      await page.getByLabel('Group by').click();
-      await page.getByRole('option', { name: 'Actions' }).click();
-      await expect(page.getByRole('separator', { name: 'publish', exact: true })).toBeVisible();
-      await expect(page.getByRole('separator', { name: 'unpublish' })).toBeVisible();
+  test("A user should be able to change the entry groupings, update an entry's action, remove an entry from a release, and navigate to the entry in the content manager", async ({
+    page,
+  }) => {
+    // Change the entry groupings
+    await expect(page.getByRole('separator', { name: 'Article' })).toBeVisible();
+    await expect(page.getByRole('separator', { name: 'Author' })).toBeVisible();
+    await page.getByLabel('Group by').click();
+    await page.getByRole('option', { name: 'Actions' }).click();
+    await expect(page.getByRole('separator', { name: 'publish', exact: true })).toBeVisible();
+    await expect(page.getByRole('separator', { name: 'unpublish' })).toBeVisible();
 
-      // Change the entry grouping
-      const row = await page.getByRole('row').filter({ hasText: 'West Ham post match analysis' });
-      // The first row after the header is NOT the one we will update
-      await expect(
-        page
-          .getByRole('row')
-          .nth(1)
-          .getByRole('gridcell', { name: 'Analyse post-match contre West Ham' })
-      ).toBeVisible();
-      // Update a given row's action
-      await expect(row.getByRole('radio').first()).not.toBeChecked();
-      row.locator('label').first().click();
-      await expect(row.getByRole('radio').first()).toBeChecked();
-      // The updated is now the first row after the header
-      await expect(
-        page.getByRole('row').nth(1).getByRole('gridcell', { name: 'West Ham post match analysis' })
-      ).toBeVisible();
+    // Change the entry grouping
+    const row = await page.getByRole('row').filter({ hasText: 'West Ham post match analysis' });
+    // The first row after the header is NOT the one we will update
+    await expect(
+      page
+        .getByRole('row')
+        .nth(1)
+        .getByRole('gridcell', { name: 'Analyse post-match contre West Ham' })
+    ).toBeVisible();
+    // Update a given row's action
+    await expect(row.getByRole('radio').first()).not.toBeChecked();
+    row.locator('label').first().click();
+    await expect(row.getByRole('radio').first()).toBeChecked();
+    // The updated is now the first row after the header
+    await expect(
+      page.getByRole('row').nth(1).getByRole('gridcell', { name: 'West Ham post match analysis' })
+    ).toBeVisible();
 
-      // Navigate to a given row's entry in the content-manager
-      await row.getByRole('button', { name: 'Release action options' }).click();
-      await page.getByRole('menuitem', { name: 'Edit entry' }).click();
-      await page.waitForURL('**/content-manager/collection-types/api::article.article/**');
-      await expect(
-        page.getByRole('heading', { name: 'West Ham post match analysis' })
-      ).toBeVisible();
+    // Navigate to a given row's entry in the content-manager
+    await row.getByRole('button', { name: 'Release action options' }).click();
+    await page.getByRole('menuitem', { name: 'Edit entry' }).click();
+    await page.waitForURL('**/content-manager/collection-types/api::article.article/**');
+    await expect(page.getByRole('heading', { name: 'West Ham post match analysis' })).toBeVisible();
 
-      // Return to release page
-      await page.goBack();
-      await page.waitForURL('/admin/plugins/content-releases/*');
+    // Return to release page
+    await page.goBack();
+    await page.waitForURL('/admin/plugins/content-releases/*');
 
-      // Remove a given row's entry from the release
-      await row.getByRole('button', { name: 'Release action options' }).click();
-      await page.getByRole('menuitem', { name: 'Remove from release' }).click();
-      await expect(row).not.toBeVisible();
-    }
-  );
+    // Remove a given row's entry from the release
+    await row.getByRole('button', { name: 'Release action options' }).click();
+    await page.getByRole('menuitem', { name: 'Remove from release' }).click();
+    await expect(row).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
### What does it do?

- Updates the dataset to remove duplicate release actions
- Returns the draft entry for a release action targeting a document that hasn't been published yet
- Handles a null case throwing errors when trying to delete many release actions in bootstrap

### Why is it needed?

- To test the feature

