### PR TITLE
[FIX] Auth providers username handling

### DIFF
--- a/packages/plugins/users-permissions/server/services/providers-registry.js
+++ b/packages/plugins/users-permissions/server/services/providers-registry.js
@@ -3,6 +3,7 @@
 const { strict: assert } = require('assert');
 const jwt = require('jsonwebtoken');
 const urljoin = require('url-join');
+const { v4: uuidv4 } = require('uuid');
 const jwkToPem = require('jwk-to-pem');
 
 const getCognitoPayload = async ({ idToken, jwksUrl, purest }) => {
@@ -46,487 +47,482 @@ const getCognitoPayload = async ({ idToken, jwksUrl, purest }) => {
   }
 };
 
-const initProviders = ({ baseURL, purest }) => ({
-  email: {
-    enabled: true,
-    icon: 'envelope',
-    grantConfig: {},
-  },
-  discord: {
-    enabled: false,
-    icon: 'discord',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/discord/callback`,
-      scope: ['identify', 'email'],
-    },
-    async authCallback({ accessToken }) {
-      const discord = purest({ provider: 'discord' });
+const initProviders = ({ baseURL, purest }) => {
+  const uuid = uuidv4();
 
-      return discord
-        .get('users/@me')
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => {
-          // Combine username and discriminator (if discriminator exists and not equal to 0)
-          const username =
-            body.discriminator && body.discriminator !== '0'
-              ? `${body.username}#${body.discriminator}`
-              : body.username;
-          return {
-            username,
+  return ({
+    email: {
+      enabled: true,
+      icon: 'envelope',
+      grantConfig: {},
+    },
+    discord: {
+      enabled: false,
+      icon: 'discord',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/discord/callback`,
+        scope: ['identify', 'email'],
+      },
+      async authCallback({ accessToken }) {
+        const discord = purest({ provider: 'discord' });
+
+        return discord
+          .get('users/@me')
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => {
+            return {
+              username: uuid,
+              email: body.email,
+            };
+          });
+      },
+    },
+    facebook: {
+      enabled: false,
+      icon: 'facebook-square',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/facebook/callback`,
+        scope: ['email'],
+      },
+      async authCallback({ accessToken }) {
+        const facebook = purest({ provider: 'facebook' });
+
+        return facebook
+          .get('me')
+          .auth(accessToken)
+          .qs({ fields: 'name,email' })
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
             email: body.email,
-          };
-        });
+          }));
+      },
     },
-  },
-  facebook: {
-    enabled: false,
-    icon: 'facebook-square',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/facebook/callback`,
-      scope: ['email'],
-    },
-    async authCallback({ accessToken }) {
-      const facebook = purest({ provider: 'facebook' });
+    google: {
+      enabled: false,
+      icon: 'google',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/google/callback`,
+        scope: ['email'],
+      },
+      async authCallback({ accessToken }) {
+        const google = purest({ provider: 'google' });
 
-      return facebook
-        .get('me')
-        .auth(accessToken)
-        .qs({ fields: 'name,email' })
-        .request()
-        .then(({ body }) => ({
-          username: body.name,
-          email: body.email,
-        }));
+        return google
+          .query('oauth')
+          .get('tokeninfo')
+          .qs({ accessToken })
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: body.email,
+          }));
+      },
     },
-  },
-  google: {
-    enabled: false,
-    icon: 'google',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/google/callback`,
-      scope: ['email'],
-    },
-    async authCallback({ accessToken }) {
-      const google = purest({ provider: 'google' });
-
-      return google
-        .query('oauth')
-        .get('tokeninfo')
-        .qs({ accessToken })
-        .request()
-        .then(({ body }) => ({
-          username: body.email.split('@')[0],
-          email: body.email,
-        }));
-    },
-  },
-  github: {
-    enabled: false,
-    icon: 'github',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/github/callback`,
-      scope: ['user', 'user:email'],
-    },
-    async authCallback({ accessToken }) {
-      const github = purest({
-        provider: 'github',
-        defaults: {
-          headers: {
-            'user-agent': 'strapi',
+    github: {
+      enabled: false,
+      icon: 'github',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/github/callback`,
+        scope: ['user', 'user:email'],
+      },
+      async authCallback({ accessToken }) {
+        const github = purest({
+          provider: 'github',
+          defaults: {
+            headers: {
+              'user-agent': 'strapi',
+            },
           },
-        },
-      });
+        });
 
-      const { body: userBody } = await github.get('user').auth(accessToken).request();
+        const { body: userBody } = await github.get('user').auth(accessToken).request();
 
-      // This is the public email on the github profile
-      if (userBody.email) {
+        // This is the public email on the github profile
+        if (userBody.email) {
+          return {
+            username: uuid,
+            email: userBody.email,
+          };
+        }
+        // Get the email with Github's user/emails API
+        const { body: emailBody } = await github.get('user/emails').auth(accessToken).request();
+
         return {
           username: userBody.login,
-          email: userBody.email,
+          email: Array.isArray(emailBody)
+            ? emailBody.find((email) => email.primary === true).email
+            : null,
         };
-      }
-      // Get the email with Github's user/emails API
-      const { body: emailBody } = await github.get('user/emails').auth(accessToken).request();
+      },
+    },
+    microsoft: {
+      enabled: false,
+      icon: 'windows',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/microsoft/callback`,
+        scope: ['user.read'],
+      },
+      async authCallback({ accessToken }) {
+        const microsoft = purest({ provider: 'microsoft' });
 
-      return {
-        username: userBody.login,
-        email: Array.isArray(emailBody)
-          ? emailBody.find((email) => email.primary === true).email
-          : null,
-      };
+        return microsoft
+          .get('me')
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: body.userPrincipalName,
+          }));
+      },
     },
-  },
-  microsoft: {
-    enabled: false,
-    icon: 'windows',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/microsoft/callback`,
-      scope: ['user.read'],
-    },
-    async authCallback({ accessToken }) {
-      const microsoft = purest({ provider: 'microsoft' });
 
-      return microsoft
-        .get('me')
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => ({
-          username: body.userPrincipalName,
-          email: body.userPrincipalName,
-        }));
-    },
-  },
-
-  twitter: {
-    enabled: false,
-    icon: 'twitter',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/twitter/callback`,
-    },
-    async authCallback({ accessToken, query, providers }) {
-      const twitter = purest({
-        provider: 'twitter',
-        defaults: {
-          oauth: {
-            consumer_key: providers.twitter.key,
-            consumer_secret: providers.twitter.secret,
-          },
-        },
-      });
-
-      return twitter
-        .get('account/verify_credentials')
-        .auth(accessToken, query.access_secret)
-        .qs({ screen_name: query['raw[screen_name]'], include_email: 'true' })
-        .request()
-        .then(({ body }) => ({
-          username: body.screen_name,
-          email: body.email,
-        }));
-    },
-  },
-  instagram: {
-    enabled: false,
-    icon: 'instagram',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/instagram/callback`,
-      scope: ['user_profile'],
-    },
-    async authCallback({ accessToken }) {
-      const instagram = purest({ provider: 'instagram' });
-
-      return instagram
-        .get('me')
-        .auth(accessToken)
-        .qs({ fields: 'id,username' })
-        .request()
-        .then(({ body }) => ({
-          username: body.username,
-          email: `${body.username}@strapi.io`, // dummy email as Instagram does not provide user email
-        }));
-    },
-  },
-  vk: {
-    enabled: false,
-    icon: 'vk',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/vk/callback`,
-      scope: ['email'],
-    },
-    async authCallback({ accessToken, query }) {
-      const vk = purest({ provider: 'vk' });
-
-      return vk
-        .get('users')
-        .auth(accessToken)
-        .qs({ id: query.raw.user_id, v: '5.122' })
-        .request()
-        .then(({ body }) => ({
-          username: `${body.response[0].last_name} ${body.response[0].first_name}`,
-          email: query.raw.email,
-        }));
-    },
-  },
-
-  twitch: {
-    enabled: false,
-    icon: 'twitch',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/twitch/callback`,
-      scope: ['user:read:email'],
-    },
-    async authCallback({ accessToken, providers }) {
-      const twitch = purest({
-        provider: 'twitch',
-        config: {
-          twitch: {
-            default: {
-              origin: 'https://api.twitch.tv',
-              path: 'helix/{path}',
-              headers: {
-                Authorization: 'Bearer {auth}',
-                'Client-Id': '{auth}',
-              },
+    twitter: {
+      enabled: false,
+      icon: 'twitter',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/twitter/callback`,
+      },
+      async authCallback({ accessToken, query, providers }) {
+        const twitter = purest({
+          provider: 'twitter',
+          defaults: {
+            oauth: {
+              consumer_key: providers.twitter.key,
+              consumer_secret: providers.twitter.secret,
             },
           },
-        },
-      });
-
-      return twitch
-        .get('users')
-        .auth(accessToken, providers.twitch.key)
-        .request()
-        .then(({ body }) => ({
-          username: body.data[0].login,
-          email: body.data[0].email,
-        }));
-    },
-  },
-
-  linkedin: {
-    enabled: false,
-    icon: 'linkedin',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callbackUrl: `${baseURL}/linkedin/callback`,
-      scope: ['r_liteprofile', 'r_emailaddress'],
-    },
-    async authCallback({ accessToken }) {
-      const linkedIn = purest({ provider: 'linkedin' });
-      const {
-        body: { localizedFirstName },
-      } = await linkedIn.get('me').auth(accessToken).request();
-      const {
-        body: { elements },
-      } = await linkedIn
-        .get('emailAddress?q=members&projection=(elements*(handle~))')
-        .auth(accessToken)
-        .request();
-
-      const email = elements[0]['handle~'];
-
-      return {
-        username: localizedFirstName,
-        email: email.emailAddress,
-      };
-    },
-  },
-
-  cognito: {
-    enabled: false,
-    icon: 'aws',
-    grantConfig: {
-      key: '',
-      secret: '',
-      subdomain: 'my.subdomain.com',
-      callback: `${baseURL}/cognito/callback`,
-      scope: ['email', 'openid', 'profile'],
-    },
-    async authCallback({ query, providers }) {
-      const jwksUrl = new URL(providers.cognito.jwksurl);
-      const idToken = query.id_token;
-      const tokenPayload = await getCognitoPayload({ idToken, jwksUrl, purest });
-      return {
-        username: tokenPayload['cognito:username'],
-        email: tokenPayload.email,
-      };
-    },
-  },
-
-  reddit: {
-    enabled: false,
-    icon: 'reddit',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callback: `${baseURL}/reddit/callback`,
-      scope: ['identity'],
-    },
-    async authCallback({ accessToken }) {
-      const reddit = purest({
-        provider: 'reddit',
-        config: {
-          reddit: {
-            default: {
-              origin: 'https://oauth.reddit.com',
-              path: 'api/{version}/{path}',
-              version: 'v1',
-              headers: {
-                Authorization: 'Bearer {auth}',
-                'user-agent': 'strapi',
-              },
-            },
-          },
-        },
-      });
-
-      return reddit
-        .get('me')
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => ({
-          username: body.name,
-          email: `${body.name}@strapi.io`, // dummy email as Reddit does not provide user email
-        }));
-    },
-  },
-
-  auth0: {
-    enabled: false,
-    icon: '',
-    grantConfig: {
-      key: '',
-      secret: '',
-      subdomain: 'my-tenant.eu',
-      callback: `${baseURL}/auth0/callback`,
-      scope: ['openid', 'email', 'profile'],
-    },
-    async authCallback({ accessToken, providers }) {
-      const auth0 = purest({ provider: 'auth0' });
-
-      return auth0
-        .get('userinfo')
-        .subdomain(providers.auth0.subdomain)
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => {
-          const username = body.username || body.nickname || body.name || body.email.split('@')[0];
-          const email = body.email || `${username.replace(/\s+/g, '.')}@strapi.io`;
-
-          return {
-            username,
-            email,
-          };
         });
-    },
-  },
 
-  cas: {
-    enabled: false,
-    icon: 'book',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callback: `${baseURL}/cas/callback`,
-      scope: ['openid email'], // scopes should be space delimited
-      subdomain: 'my.subdomain.com/cas',
-    },
-    async authCallback({ accessToken, providers }) {
-      const cas = purest({ provider: 'cas' });
-
-      return cas
-        .get('oidc/profile')
-        .subdomain(providers.cas.subdomain)
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => {
-          // CAS attribute may be in body.attributes or "FLAT", depending on CAS config
-          const username = body.attributes
-            ? body.attributes.strapiusername || body.id || body.sub
-            : body.strapiusername || body.id || body.sub;
-          const email = body.attributes
-            ? body.attributes.strapiemail || body.attributes.email
-            : body.strapiemail || body.email;
-          if (!username || !email) {
-            strapi.log.warn(
-              `CAS Response Body did not contain required attributes: ${JSON.stringify(body)}`
-            );
-          }
-          return {
-            username,
-            email,
-          };
-        });
-    },
-  },
-
-  patreon: {
-    enabled: false,
-    icon: '',
-    grantConfig: {
-      key: '',
-      secret: '',
-      callback: `${baseURL}/patreon/callback`,
-      scope: ['identity', 'identity[email]'],
-    },
-    async authCallback({ accessToken }) {
-      const patreon = purest({
-        provider: 'patreon',
-        config: {
-          patreon: {
-            default: {
-              origin: 'https://www.patreon.com',
-              path: 'api/oauth2/{path}',
-              headers: {
-                authorization: 'Bearer {auth}',
-              },
-            },
-          },
-        },
-      });
-
-      return patreon
-        .get('v2/identity')
-        .auth(accessToken)
-        .qs(new URLSearchParams({ 'fields[user]': 'full_name,email' }).toString())
-        .request()
-        .then(({ body }) => {
-          const patreonData = body.data.attributes;
-          return {
-            username: patreonData.full_name,
-            email: patreonData.email,
-          };
-        });
-    },
-  },
-  keycloak: {
-    enabled: false,
-    icon: '',
-    grantConfig: {
-      key: '',
-      secret: '',
-      subdomain: 'myKeycloakProvider.com/realms/myrealm',
-      callback: `${baseURL}/keycloak/callback`,
-      scope: ['openid', 'email', 'profile'],
-    },
-    async authCallback({ accessToken, providers }) {
-      const keycloak = purest({ provider: 'keycloak' });
-
-      return keycloak
-        .subdomain(providers.keycloak.subdomain)
-        .get('protocol/openid-connect/userinfo')
-        .auth(accessToken)
-        .request()
-        .then(({ body }) => {
-          return {
-            username: body.preferred_username,
+        return twitter
+          .get('account/verify_credentials')
+          .auth(accessToken, query.access_secret)
+          .qs({ screen_name: query['raw[screen_name]'], include_email: 'true' })
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
             email: body.email,
-          };
-        });
+          }));
+      },
     },
-  },
-});
+    instagram: {
+      enabled: false,
+      icon: 'instagram',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/instagram/callback`,
+        scope: ['user_profile'],
+      },
+      async authCallback({ accessToken }) {
+        const instagram = purest({ provider: 'instagram' });
+
+        return instagram
+          .get('me')
+          .auth(accessToken)
+          .qs({ fields: 'id,username' })
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: `${body.username}@strapi.io`, // dummy email as Instagram does not provide user email
+          }));
+      },
+    },
+    vk: {
+      enabled: false,
+      icon: 'vk',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/vk/callback`,
+        scope: ['email'],
+      },
+      async authCallback({ accessToken, query }) {
+        const vk = purest({ provider: 'vk' });
+
+        return vk
+          .get('users')
+          .auth(accessToken)
+          .qs({ id: query.raw.user_id, v: '5.122' })
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: query.raw.email,
+          }));
+      },
+    },
+
+    twitch: {
+      enabled: false,
+      icon: 'twitch',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/twitch/callback`,
+        scope: ['user:read:email'],
+      },
+      async authCallback({ accessToken, providers }) {
+        const twitch = purest({
+          provider: 'twitch',
+          config: {
+            twitch: {
+              default: {
+                origin: 'https://api.twitch.tv',
+                path: 'helix/{path}',
+                headers: {
+                  Authorization: 'Bearer {auth}',
+                  'Client-Id': '{auth}',
+                },
+              },
+            },
+          },
+        });
+
+        return twitch
+          .get('users')
+          .auth(accessToken, providers.twitch.key)
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: body.data[0].email,
+          }));
+      },
+    },
+
+    linkedin: {
+      enabled: false,
+      icon: 'linkedin',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callbackUrl: `${baseURL}/linkedin/callback`,
+        scope: ['r_liteprofile', 'r_emailaddress'],
+      },
+      async authCallback({ accessToken }) {
+        const linkedIn = purest({ provider: 'linkedin' });
+
+        const {
+          body: { elements },
+        } = await linkedIn
+          .get('emailAddress?q=members&projection=(elements*(handle~))')
+          .auth(accessToken)
+          .request();
+
+        const email = elements[0]['handle~'];
+
+        return {
+          username: uuid,
+          email: email.emailAddress,
+        };
+      },
+    },
+
+    cognito: {
+      enabled: false,
+      icon: 'aws',
+      grantConfig: {
+        key: '',
+        secret: '',
+        subdomain: 'my.subdomain.com',
+        callback: `${baseURL}/cognito/callback`,
+        scope: ['email', 'openid', 'profile'],
+      },
+      async authCallback({ query, providers }) {
+        const jwksUrl = new URL(providers.cognito.jwksurl);
+        const idToken = query.id_token;
+        const tokenPayload = await getCognitoPayload({ idToken, jwksUrl, purest });
+        return {
+          username: uuid,
+          email: tokenPayload.email,
+        };
+      },
+    },
+
+    reddit: {
+      enabled: false,
+      icon: 'reddit',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callback: `${baseURL}/reddit/callback`,
+        scope: ['identity'],
+      },
+      async authCallback({ accessToken }) {
+        const reddit = purest({
+          provider: 'reddit',
+          config: {
+            reddit: {
+              default: {
+                origin: 'https://oauth.reddit.com',
+                path: 'api/{version}/{path}',
+                version: 'v1',
+                headers: {
+                  Authorization: 'Bearer {auth}',
+                  'user-agent': 'strapi',
+                },
+              },
+            },
+          },
+        });
+
+        return reddit
+          .get('me')
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => ({
+            username: uuid,
+            email: `${body.name}@strapi.io`, // dummy email as Reddit does not provide user email
+          }));
+      },
+    },
+
+    auth0: {
+      enabled: false,
+      icon: '',
+      grantConfig: {
+        key: '',
+        secret: '',
+        subdomain: 'my-tenant.eu',
+        callback: `${baseURL}/auth0/callback`,
+        scope: ['openid', 'email', 'profile'],
+      },
+      async authCallback({ accessToken, providers }) {
+        const auth0 = purest({ provider: 'auth0' });
+
+        return auth0
+          .get('userinfo')
+          .subdomain(providers.auth0.subdomain)
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => {
+            const username = uuid;
+            const email = body.email || `${username.replace(/\s+/g, '.')}@strapi.io`;
+
+            return {
+              username,
+              email,
+            };
+          });
+      },
+    },
+
+    cas: {
+      enabled: false,
+      icon: 'book',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callback: `${baseURL}/cas/callback`,
+        scope: ['openid email'], // scopes should be space delimited
+        subdomain: 'my.subdomain.com/cas',
+      },
+      async authCallback({ accessToken, providers }) {
+        const cas = purest({ provider: 'cas' });
+
+        return cas
+          .get('oidc/profile')
+          .subdomain(providers.cas.subdomain)
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => {
+            // CAS attribute may be in body.attributes or "FLAT", depending on CAS config
+            const username = uuid;
+            const email = body.attributes
+              ? body.attributes.strapiemail || body.attributes.email
+              : body.strapiemail || body.email;
+            if (!username || !email) {
+              strapi.log.warn(
+                `CAS Response Body did not contain required attributes: ${JSON.stringify(body)}`
+              );
+            }
+            return {
+              username,
+              email,
+            };
+          });
+      },
+    },
+
+    patreon: {
+      enabled: false,
+      icon: '',
+      grantConfig: {
+        key: '',
+        secret: '',
+        callback: `${baseURL}/patreon/callback`,
+        scope: ['identity', 'identity[email]'],
+      },
+      async authCallback({ accessToken }) {
+        const patreon = purest({
+          provider: 'patreon',
+          config: {
+            patreon: {
+              default: {
+                origin: 'https://www.patreon.com',
+                path: 'api/oauth2/{path}',
+                headers: {
+                  authorization: 'Bearer {auth}',
+                },
+              },
+            },
+          },
+        });
+
+        return patreon
+          .get('v2/identity')
+          .auth(accessToken)
+          .qs(new URLSearchParams({ 'fields[user]': 'full_name,email' }).toString())
+          .request()
+          .then(({ body }) => {
+            const patreonData = body.data.attributes;
+            return {
+              username: uuid,
+              email: patreonData.email,
+            };
+          });
+      },
+    },
+    keycloak: {
+      enabled: false,
+      icon: '',
+      grantConfig: {
+        key: '',
+        secret: '',
+        subdomain: 'myKeycloakProvider.com/realms/myrealm',
+        callback: `${baseURL}/keycloak/callback`,
+        scope: ['openid', 'email', 'profile'],
+      },
+      async authCallback({ accessToken, providers }) {
+        const keycloak = purest({ provider: 'keycloak' });
+
+        return keycloak
+          .subdomain(providers.keycloak.subdomain)
+          .get('protocol/openid-connect/userinfo')
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => {
+            return {
+              username: uuid,
+              email: body.email,
+            };
+          });
+      },
+    },
+  })
+};
 
 module.exports = () => {
   const purest = require('purest');


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This change sets all of the username values with UUIDs, instead of the current specific handling for each platform.

### Why is it needed?

Generally speaking, people who use providers to login on applications, don't then use the username to login next time, they still use the same provider login. The username is not needed, and if it is people are able to add manual changes to the username themselves. This change is motivated by a bug I incountered in my application. Registering normally, with a username `joe`, after which trying to register with `joe@gmail.com` or any other provider, due to the current handling of usernames, allowed the user to be created with the username `joe` again. Leaving us with 2 users with the same username. This is a breaking issue, that needs to be looked at. I think it is best to have unique IDs using UUIDv4, and if anyone wants to handle usernames differently they can add that. Also we achieve consistency with this approach.

### How to test it?

Register using a username that you have a username on google with, ex. `joe` and email `joe@random.com`. It is important not to use the google account here. After this implement the google auth provider, and register with the google account `joe@google.com`. A user with username `joe` will be created. Leaving us with two same usernames..
