### PR TITLE
fix graphql playground

### DIFF
--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@apollo/server": "4.11.0",
-    "@as-integrations/koa": "1.1.1",
     "@graphql-tools/schema": "10.0.3",
     "@graphql-tools/utils": "^10.1.3",
     "@koa/cors": "5.0.0",

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -4,7 +4,6 @@ import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault,
 } from '@apollo/server/plugin/landingPage/default';
-import { koaMiddleware } from '@as-integrations/koa';
 import depthLimit from 'graphql-depth-limit';
 import bodyParser from 'koa-bodyparser';
 import cors from '@koa/cors';
@@ -12,6 +11,7 @@ import cors from '@koa/cors';
 import type { Core } from '@strapi/types';
 import type { BaseContext, DefaultContextExtends, DefaultStateExtends } from 'koa';
 
+import { koaMiddleware } from './middlewares/koaMiddleware';
 import { formatGraphqlError } from './format-graphql-error';
 
 const merge = mergeWith((a, b) => {

--- a/packages/plugins/graphql/server/src/middlewares/koaMiddleware.ts
+++ b/packages/plugins/graphql/server/src/middlewares/koaMiddleware.ts
@@ -1,0 +1,127 @@
+/**
+ * Patched version of @as-integrations/koa.
+ */
+import { Readable } from 'node:stream';
+import { parse } from 'node:url';
+import type { WithRequired } from '@apollo/utils.withrequired';
+import {
+  type ApolloServer,
+  type BaseContext,
+  type ContextFunction,
+  type HTTPGraphQLRequest,
+  HeaderMap,
+} from '@apollo/server';
+import type Koa from 'koa';
+
+export interface KoaContextFunctionArgument<
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+> {
+  ctx: Koa.ParameterizedContext<StateT, ContextT>;
+}
+
+interface KoaMiddlewareOptions<TContext extends BaseContext, StateT, ContextT> {
+  context?: ContextFunction<[KoaContextFunctionArgument<StateT, ContextT>], TContext>;
+}
+
+export function koaMiddleware<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
+  server: ApolloServer<BaseContext>,
+  options?: KoaMiddlewareOptions<BaseContext, StateT, ContextT>
+): Koa.Middleware<StateT, ContextT>;
+export function koaMiddleware<
+  TContext extends BaseContext,
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+>(
+  server: ApolloServer<TContext>,
+  options: WithRequired<KoaMiddlewareOptions<TContext, StateT, ContextT>, 'context'>
+): Koa.Middleware<StateT, ContextT>;
+export function koaMiddleware<
+  TContext extends BaseContext,
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+>(
+  server: ApolloServer<TContext>,
+  options?: KoaMiddlewareOptions<TContext, StateT, ContextT>
+): Koa.Middleware<StateT, ContextT> {
+  server.assertStarted('koaMiddleware()');
+
+  // This `any` is safe because the overload above shows that context can
+  // only be left out if you're using BaseContext as your context, and {} is a
+  // valid BaseContext.
+  const defaultContext: ContextFunction<
+    [KoaContextFunctionArgument<StateT, ContextT>],
+    any
+  > = async () => ({});
+
+  const context: ContextFunction<[KoaContextFunctionArgument<StateT, ContextT>], TContext> =
+    options?.context ?? defaultContext;
+
+  return async (ctx, next) => {
+    if (!ctx.request.body) {
+      // The json koa-bodyparser *always* sets ctx.request.body to {} if it's unset (even
+      // if the Content-Type doesn't match), so if it isn't set, you probably
+      // forgot to set up koa-bodyparser.
+      ctx.status = 500;
+      ctx.body =
+        '`ctx.request.body` is not set; this probably means you forgot to set up the ' +
+        '`koa-bodyparser` middleware before the Apollo Server middleware.';
+      return;
+    }
+
+    const incomingHeaders = new HeaderMap();
+    for (const [key, value] of Object.entries(ctx.headers)) {
+      if (value !== undefined) {
+        // Node/Koa headers can be an array or a single value. We join
+        // multi-valued headers with `, ` just like the Fetch API's `Headers`
+        // does. We assume that keys are already lower-cased (as per the Node
+        // docs on IncomingMessage.headers) and so we don't bother to lower-case
+        // them or combine across multiple keys that would lower-case to the
+        // same value.
+        incomingHeaders.set(key, Array.isArray(value) ? value.join(', ') : value);
+      }
+    }
+
+    const httpGraphQLRequest: HTTPGraphQLRequest = {
+      method: ctx.method.toUpperCase(),
+      headers: incomingHeaders,
+      search: parse(ctx.url).search ?? '',
+      body: ctx.request.body,
+    };
+
+    const { body, headers, status } = await server.executeHTTPGraphQLRequest({
+      httpGraphQLRequest,
+      context: () => context({ ctx }),
+    });
+
+    if (body.kind === 'complete') {
+      ctx.body = body.string;
+    } else if (body.kind === 'chunked') {
+      ctx.body = Readable.from(
+        (async function* () {
+          for await (const chunk of body.asyncIterator) {
+            yield chunk;
+            if (typeof ctx.body.flush === 'function') {
+              // If this response has been piped to a writable compression stream then `flush` after
+              // each chunk.
+              // This is identical to the Express integration:
+              // https://github.com/apollographql/apollo-server/blob/a69580565dadad69de701da84092e89d0fddfa00/packages/server/src/express4/index.ts#L96-L105
+              ctx.body.flush();
+            }
+          }
+        })()
+      );
+    } else {
+      throw Error(`Delivery method ${(body as any).kind} not implemented`);
+    }
+
+    if (status !== undefined) {
+      ctx.status = status;
+    }
+    for (const [key, value] of headers) {
+      ctx.set(key, value);
+    }
+
+    return next();
+  };
+}

--- a/tests/api/plugins/graphql/playground.test.api.js
+++ b/tests/api/plugins/graphql/playground.test.api.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+let strapi;
+let rq;
+
+describe('Test GraphQL Playground End to End', () => {
+  beforeAll(async () => {
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  test('Playground is accessible', async () => {
+    const res = await rq({
+      url: '/graphql',
+      method: 'POST',
+      body: {
+        query:
+          'query IntrospectionQuery {\n  __schema {\n    description\n    queryType {\n      name\n    }\n    mutationType {\n      name\n    }\n    subscriptionType {\n      name\n    }\n    types {\n      ...FullType\n    }\n    directives {\n      name\n      description\n      locations\n      args {\n        ...InputValue\n      }\n    }\n  }\n}\n\nfragment FullType on __Type {\n  kind\n  name\n  description\n  fields(includeDeprecated: true) {\n    name\n    description\n    args {\n      ...InputValue\n    }\n    type {\n      ...TypeRef\n    }\n    isDeprecated\n    deprecationReason\n  }\n  inputFields {\n    ...InputValue\n  }\n  interfaces {\n    ...TypeRef\n  }\n  enumValues(includeDeprecated: true) {\n    name\n    description\n    isDeprecated\n    deprecationReason\n  }\n  possibleTypes {\n    ...TypeRef\n  }\n}\n\nfragment InputValue on __InputValue {\n  name\n  description\n  type {\n    ...TypeRef\n  }\n  defaultValue\n}\n\nfragment TypeRef on __Type {\n  kind\n  name\n  ofType {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType {\n                kind\n                name\n                ofType {\n                  kind\n                  name\n                  ofType {\n                    kind\n                    name\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}',
+        operationName: 'IntrospectionQuery',
+        extensions: {},
+      },
+    });
+
+    expect(res.body.errors).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,16 +303,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@as-integrations/koa@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@as-integrations/koa@npm:1.1.1"
-  peerDependencies:
-    "@apollo/server": ^4.0.0
-    koa: ^2.0.0
-  checksum: 10c0/ffabb8d3e3073fa39cfb00493ee6e2a0bc5076e003db720341b33805f247ee9eae8987e727cd7d39fa00b1efbcda19a661e93bfc99c8f80bb07dbcddc1ce223c
-  languageName: node
-  linkType: hard
-
 "@aws-crypto/crc32@npm:3.0.0":
   version: 3.0.0
   resolution: "@aws-crypto/crc32@npm:3.0.0"
@@ -8866,7 +8856,6 @@ __metadata:
   resolution: "@strapi/plugin-graphql@workspace:packages/plugins/graphql"
   dependencies:
     "@apollo/server": "npm:4.11.0"
-    "@as-integrations/koa": "npm:1.1.1"
     "@graphql-tools/schema": "npm:10.0.3"
     "@graphql-tools/utils": "npm:^10.1.3"
     "@koa/cors": "npm:5.0.0"


### PR DESCRIPTION
### What does it do?

Makes the GraphQL playground accessible on V5 by postponing the auth middleware check. With the current implementation, the auth middleware is called before we can check the route config (`auth: false`), causing it to throw 401.

### Why is it needed?

GraphQL playground is not accessible at all without the user-permissions plugin.

### How to test it?

1. Create vanilla project
2. Remove the @strapi/plugin-users-permissions from dependencies
3. Add @strapi/plugin-graphql and its plugin configuration
4. Start project and open the graphql endpoint in browser, it should display the Apollo playground;

### Sanity checks

| Before | After |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/1ba31c7b-9a51-40f2-bcb6-3b2bad346fde"> | <video src="https://github.com/user-attachments/assets/2bbccecc-a48d-4284-b0c9-c5427e8ce7cb"> |

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/21915