### PR TITLE
fix: added fix for i18n tooltips are not working

### DIFF
--- a/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
-import { Flex, VisuallyHidden } from '@strapi/design-system';
+import { Flex, Tooltip, VisuallyHidden } from '@strapi/design-system';
 import { Earth, EarthStriked } from '@strapi/icons';
 import { MessageDescriptor, useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -101,10 +101,12 @@ const LabelAction = ({ title, icon }: LabelActionProps) => {
   return (
     <Span tag="span">
       <VisuallyHidden tag="span">{formatMessage(title)}</VisuallyHidden>
-      {React.cloneElement(icon as React.ReactElement, {
-        'aria-hidden': true,
-        focusable: false, // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
-      })}
+      <Tooltip label={formatMessage(title)}>
+        {React.cloneElement(icon as React.ReactElement, {
+          'aria-hidden': true,
+          focusable: false, // See: https://allyjs.io/tutorials/focusing-in-svg.html#making-svg-elements-focusable
+        })}
+      </Tooltip>
     </Span>
   );
 };
@@ -115,7 +117,7 @@ const Span = styled(Flex)`
     height: 12px;
 
     fill: ${({ theme }) => theme.colors.neutral500};
-
+    cursor: pointer;
     path {
       fill: ${({ theme }) => theme.colors.neutral500};
     }


### PR DESCRIPTION
### What does it do?
It fixes the issue of the tooltip not showing when we hover over the globe icon.

### Why is it needed?
To fix issue [21336](https://github.com/strapi/strapi/issues/21336) : I18n tooltips are not working

### How to test it?

1. Go to the edit view of an entry from a content type with i18n enabled
2. Try hovering over the globe icon of any field
3. See that there are no tooltips to explain what it is

### Related issue(s)/PR(s)
fixes [21336](https://github.com/strapi/strapi/issues/21336)