### PR TITLE
fix(e2e): enable e2e bulk action tests in listview.spec.ts

### DIFF
--- a/tests/e2e/tests/content-manager/listview.spec.ts
+++ b/tests/e2e/tests/content-manager/listview.spec.ts
@@ -46,8 +46,7 @@ test.describe('List View', () => {
     await expect(page.getByRole('link', { name: 'Next page' })).toBeDisabled();
   });
 
-  // Should be enabled once bulk publish is in action
-  test.fixme('A user should be able to perform bulk actions on entries', async ({ page }) => {
+  test('A user should be able to perform bulk actions on entries', async ({ page }) => {
     await test.step('bulk publish', async () => {
       await page.getByRole('link', { name: 'Content Manager' }).click();
       // Select all entries to publish


### PR DESCRIPTION
### What does it do?

Enables the bulk action tests in listview.spec.ts

### Why is it needed?

To test the feature

### How to test it?

The tests should pass here in the CI
