### PR TITLE
fix: review workflow persist data

### DIFF
--- a/packages/core/admin/ee/server/src/bootstrap.ts
+++ b/packages/core/admin/ee/server/src/bootstrap.ts
@@ -1,10 +1,11 @@
 import executeCEBootstrap from '../../../server/src/bootstrap';
-import { getService } from '../../server/src/utils';
+import { getService } from './utils';
 import actions from './config/admin-actions';
-import { persistTablesWithPrefix } from './utils/persisted-tables';
 
 export default async (args: any) => {
   const { actionProvider } = getService('permission');
+  const { persistTablesWithPrefix } = getService('persist-tables');
+
   if (strapi.ee.features.isEnabled('sso')) {
     await actionProvider.registerMany(actions.sso);
   }

--- a/packages/core/admin/ee/server/src/services/__tests__/persisted-tables.test.ts
+++ b/packages/core/admin/ee/server/src/services/__tests__/persisted-tables.test.ts
@@ -1,4 +1,4 @@
-import { findTables } from '../persisted-tables';
+import { findTables } from '../persist-tables';
 
 const strapiMock = {
   db: {

--- a/packages/core/admin/ee/server/src/services/index.ts
+++ b/packages/core/admin/ee/server/src/services/index.ts
@@ -4,6 +4,7 @@ import role from './role';
 import user from './user';
 import metrics from './metrics';
 import seatEnforcement from './seat-enforcement';
+import persistTables from './persist-tables';
 
 export default {
   auth,
@@ -12,4 +13,5 @@ export default {
   user,
   metrics,
   'seat-enforcement': seatEnforcement,
+  'persist-tables': persistTables,
 };

--- a/packages/core/admin/ee/server/src/services/persist-tables.ts
+++ b/packages/core/admin/ee/server/src/services/persist-tables.ts
@@ -1,7 +1,7 @@
 import type { Core } from '@strapi/types';
 import { differenceWith, isEqual } from 'lodash/fp';
 
-interface PersistedTable {
+export interface PersistedTable {
   name: string;
   dependsOn?: Array<{ name: string }>;
 }

--- a/packages/core/review-workflows/server/src/register.ts
+++ b/packages/core/review-workflows/server/src/register.ts
@@ -1,8 +1,8 @@
-import { defaultsDeep } from 'lodash/fp';
+import { defaultsDeep, filter, pipe, map } from 'lodash/fp';
 
 import type { Core } from '@strapi/types';
 
-import { getService } from './utils';
+import { getService, getAdminService } from './utils';
 import migrateStageAttribute from './migrations/shorten-stage-attribute';
 import migrateReviewWorkflowStagesColor from './migrations/set-stages-default-color';
 import migrateReviewWorkflowStagesRoles from './migrations/set-stages-roles';
@@ -11,7 +11,7 @@ import migrateWorkflowsContentTypes from './migrations/multiple-workflows';
 import migrateDeletedCTInWorkflows from './migrations/handle-deleted-ct-in-workflows';
 import reviewWorkflowsMiddlewares from './middlewares/review-workflows';
 
-import { getVisibleContentTypesUID } from './utils/review-workflows';
+import { getVisibleContentTypesUID, hasStageAttribute } from './utils/review-workflows';
 
 import {
   ENTITY_STAGE_ATTRIBUTE,
@@ -20,8 +20,6 @@ import {
   MAX_WORKFLOWS,
   MAX_STAGES_PER_WORKFLOW,
 } from './constants/workflows';
-
-// import { persistTables, removePersistedTablesWithSuffix } from '../../utils/persisted-tables';
 
 const setRelation = (attributeName: any, target: any, contentType: any) => {
   Object.assign(contentType.attributes, {
@@ -56,33 +54,38 @@ function extendReviewWorkflowContentTypes({ strapi }: { strapi: Core.Strapi }) {
   }
 }
 
-// TODO: V5
-// function persistStagesJoinTables({ strapi }: { strapi: Core.LoadedStrapi }) {
-//   return async ({ contentTypes }: any) => {
-//     const getStageTableToPersist = (contentTypeUID: any) => {
-//       // Persist the stage join table
-//       const { attributes, tableName } = strapi.db.metadata.get(contentTypeUID) as any;
-//       const joinTableName = attributes[ENTITY_STAGE_ATTRIBUTE].joinTable.name;
-//       return {
-//         name: joinTableName,
-//         dependsOn: [{ name: tableName }],
-//       };
-//     };
+// TODO: V6 - Instead of persisting the join tables, always create the stage & assignee attributes, even in CE mode
+//            It was decided in V4 & V5 to not expose them (as they pollute the CTs) but it's not worth given the complexity this needs
+function persistStagesJoinTables({ strapi }: { strapi: Core.Strapi }) {
+  const { removePersistedTablesWithSuffix, persistTables } = getAdminService('persist-tables');
 
-//     const joinTablesToPersist = pipe([
-//       getVisibleContentTypesUID,
-//       filter((uid: any) => hasStageAttribute(contentTypes[uid])),
-//       map(getStageTableToPersist),
-//     ])(contentTypes);
+  return async ({ contentTypes }: any) => {
+    const getStageTableToPersist = (contentTypeUID: any) => {
+      // Persist the stage join table
+      const { attributes, tableName } = strapi.db.metadata.get(contentTypeUID) as any;
+      const joinTableName = attributes[ENTITY_STAGE_ATTRIBUTE].joinTable.name;
+      return {
+        name: joinTableName,
+        dependsOn: [{ name: tableName }],
+      };
+    };
 
-// await removePersistedTablesWithSuffix('_strapi_stage_links');
-// await persistTables(joinTablesToPersist);
-// };
-// }
+    const joinTablesToPersist = pipe([
+      getVisibleContentTypesUID,
+      filter((uid: any) => hasStageAttribute(contentTypes[uid])),
+      map(getStageTableToPersist),
+    ])(contentTypes);
+
+    // Remove previously created join tables and persist the new ones
+    await removePersistedTablesWithSuffix('_strapi_stage_links');
+    await persistTables(joinTablesToPersist);
+  };
+}
 
 export default async ({ strapi }: { strapi: Core.Strapi }) => {
   // Data Migrations
   strapi.hook('strapi::content-types.beforeSync').register(migrateStageAttribute);
+  strapi.hook('strapi::content-types.afterSync').register(persistStagesJoinTables({ strapi }));
   strapi
     .hook('strapi::content-types.afterSync')
     .register(migrateReviewWorkflowStagesColor)

--- a/packages/core/review-workflows/server/src/register.ts
+++ b/packages/core/review-workflows/server/src/register.ts
@@ -54,8 +54,12 @@ function extendReviewWorkflowContentTypes({ strapi }: { strapi: Core.Strapi }) {
   }
 }
 
-// TODO: V6 - Instead of persisting the join tables, always create the stage & assignee attributes, even in CE mode
-//            It was decided in V4 & V5 to not expose them in CE (as they pollute the CTs) but it's not worth given the complexity this needs
+/**
+ * Persist the stage & assignee attributes so they are not removed when downgrading to CE.
+ *
+ * TODO: V6 - Instead of persisting the join tables, always create the stage & assignee attributes, even in CE mode
+ *            It was decided in V4 & V5 to not expose them in CE (as they pollute the CTs) but it's not worth given the complexity this needs
+ */
 function persistRWOnDowngrade({ strapi }: { strapi: Core.Strapi }) {
   const { removePersistedTablesWithSuffix, persistTables } = getAdminService('persist-tables');
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Review workflows adds two additional attributes to content types, strapi_assignee and strapi_stage . Those are the values displayed in the content manager edit view.

As RW is an EE feature, it was decided for those attributes to not exist on the Comunity Edition. But at the same time if a user filled those values in EE and they downgrade, we want to keep the data there.

In v4 we were using a persist_table logic, to persist those join tables even if the attribute didn't exist. At some point we discussed doing otherwise, but eventually this was forgotten.

This PR reintroduces the persisted table logic we had in in v4.
