### PR TITLE
fix: prevent submitting form on button clicks

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/components/Tokens/TokenBox.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/Tokens/TokenBox.tsx
@@ -47,6 +47,7 @@ export const TokenBox = ({ token, tokenType }: TokenBoxProps) => {
               })}
               onClick={handleClick(token)}
               variant="ghost"
+              type="button"
               style={{ padding: 0, height: '1.6rem' }}
             >
               <Duplicate />

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsButton.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/ConditionsButton.tsx
@@ -15,7 +15,7 @@ const ConditionsButtonImpl = React.forwardRef<HTMLButtonElement, ConditionsButto
 
     return (
       <ButtonContainer $hasConditions={hasConditions} className={className}>
-        <Button variant={variant} startIcon={<Cog />} onClick={onClick} ref={ref}>
+        <Button variant={variant} startIcon={<Cog />} onClick={onClick} ref={ref} type="button">
           {formatMessage({
             id: 'global.settings',
             defaultMessage: 'Settings',


### PR DESCRIPTION
### What does it do?

It prevents some forms from being submitted when a button is clicked, such as the Copy token button on the API Token page or the Settings button on the Roles form.

### Why is it needed?

The `Button` and `IconButton` components from the `@strapi/design-system` package don't specify a type for the buttons, so by default, they have `type="submit"`, which submits the form on click.

### How to test it?

This PR covers two scenarios, there might be others with the same issue.

- API Token
1. Create an API Token
2. Click on the copy button
3. It should only copy the token and nothing else

- Roles form
1. Open the Roles form
2. Click to edit an existing role
3. Open the Settings tab
4. Expand any row and click on the Settings button
5. It should open a confirm modal and nothing else

### Sanity checks

| Case | Before | After |
| -- | -- | -- |
| API Token | <video src="https://github.com/user-attachments/assets/b1c6ab05-9a88-40f5-bde0-825cac682751"> | <video src="https://github.com/user-attachments/assets/b91826ea-6e89-4450-93f6-dec642d87e14"> |
| Roles form | <video src="https://github.com/user-attachments/assets/9a0d3be4-d9c7-435a-89e4-7f1bcc8f32ed"> | <video src="https://github.com/user-attachments/assets/5e666a6a-8f41-429a-9241-76fcc78f7c8f"> |

### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/21499 and https://github.com/strapi/strapi/issues/21901
