### PR TITLE
chore: match search between CTM menu and search

### DIFF
--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@tests/utils';
+import { render, waitFor } from '@tests/utils';
 import { useLocation } from 'react-router-dom';
 
 import { SearchInput } from '../SearchInput';
@@ -28,7 +28,7 @@ describe('SearchInput', () => {
     expect(getByRole('textbox', { name: 'Search label' })).toBeInTheDocument();
   });
 
-  it('should push value to query params', async () => {
+  it('should push value to query params after debounce delay', async () => {
     const { user, getByRole } = render(<SearchInput label="Search label" />, {
       renderOptions: {
         wrapper({ children }) {
@@ -46,13 +46,14 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
-
-    const searchString = getByRole('listitem').textContent ?? '';
-    const searchParams = new URLSearchParams(searchString);
-
-    expect(searchParams.has('_q')).toBe(true);
-    expect(searchParams.get('_q')).toBe('michka');
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
+          'michka'
+        );
+      },
+      { timeout: 600 }
+    ); // Wait for debounce (500ms) + buffer
   });
 
   it('should clear value and update query params', async () => {
@@ -73,14 +74,24 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
-
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
+          'michka'
+        );
+      },
+      { timeout: 600 }
+    );
 
     await user.click(getByRole('button', { name: 'Clear' }));
 
     expect(getByRole('textbox', { name: 'Search label' })).toHaveValue('');
 
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+      },
+      { timeout: 600 }
+    );
   });
 });


### PR DESCRIPTION
### What does it do?

Removes the need to press Enter to search on CTM by searching by typing with 500ms debounce.

### Why is it needed?

It'll match the behavior between the CTM menu and the search input, it's also a better UX IMO.

### How to test it?

1. Open CTM
2. Type something in the search input


https://github.com/user-attachments/assets/cd41b0bd-d8e8-4d6e-8880-e656bf7a2af2



### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/21358
