### PR TITLE
fix: reset createdAt field when duplicating entry

### DIFF
--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -184,7 +184,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       entriesToClone,
       async.pipe(
         validateParams,
-        omit('id'),
+        omit(['id', 'createdAt']),
         // assign new documentId
         assoc('documentId', createDocumentId()),
         // Merge new data into it

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -184,7 +184,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       entriesToClone,
       async.pipe(
         validateParams,
-        omit(['id', 'createdAt']),
+        omit(['id', 'createdAt', 'updatedAt']),
         // assign new documentId
         assoc('documentId', createDocumentId()),
         // Merge new data into it


### PR DESCRIPTION
### What does it do?

Resets the `createdAt` field when duplicating entries instead of duplicating the existing value.

### Why is it needed?

According to #21593, this is important to sort on the createdAt field for duplicated entries, and also to keep it consistent with v4.

### How to test it?

1. Duplicate an entry
2. Compare the `createdAt` value, it shouldn't be the same as the original value


```js
{
    "results": [
        // current state
        {
            "id": 4,
            "documentId": "e7c3l7w9o791ovxwovds8ugs",
            "name": "A",
            "createdAt": "2024-10-25T21:44:19.832Z",
            "updatedAt": "2024-10-25T21:26:09.221Z",
            "publishedAt": "2024-10-25T21:26:09.220Z",
        },
        {
            "id": 5,
            "documentId": "wxntm8myw7pbe58p338tifwx",
            "name": "A",
            "createdAt": "2024-10-25T21:44:19.832Z",
            "updatedAt": "2024-10-25T21:26:09.221Z",
            "publishedAt": "2024-10-25T21:26:09.220Z",
        },
        // with this change
        {
            "id": 6,
            "documentId": "yf5bs4cl79t9z9j5ra4fhs2t",
            "name": "A",
            "createdAt": "2024-10-25T21:53:57.213Z",
            "updatedAt": "2024-10-25T21:26:09.221Z",
            "publishedAt": "2024-10-25T21:26:09.220Z",
        },
    ],
}
```


### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/21593