### PR TITLE
feat: preview content in an iframe

### DIFF
--- a/examples/getstarted/config/middlewares.js
+++ b/examples/getstarted/config/middlewares.js
@@ -5,7 +5,17 @@ const responseHandlers = require('./src/response-handlers');
 module.exports = [
   'strapi::logger',
   'strapi::errors',
-  'strapi::security',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'frame-src': ["'self'"], // URLs that will be loaded in an iframe (e.g. Content Preview)
+        },
+      },
+    },
+  },
   'strapi::cors',
   'strapi::poweredBy',
   'strapi::query',

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -1,19 +1,28 @@
 import * as React from 'react';
 
+import { Box } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+
 import { usePreviewContext } from '../pages/Preview';
 
 const PreviewContent = () => {
   const previewUrl = usePreviewContext('PreviewContent', (state) => state.url);
 
+  const { formatMessage } = useIntl();
+
   return (
-    <iframe
+    <Box
       src={previewUrl}
-      title="Content Preview"
+      title={formatMessage({
+        id: 'content-manager.preview.panel.title',
+        defaultMessage: 'Preview',
+      })}
+      width="100%"
+      height="100%"
       style={{
-        width: '100%',
-        height: '100%',
         border: 'none',
       }}
+      tag="iframe"
     />
   );
 };

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -19,9 +19,7 @@ const PreviewContent = () => {
       })}
       width="100%"
       height="100%"
-      style={{
-        border: 'none',
-      }}
+      borderWidth={0}
       tag="iframe"
     />
   );

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { Page } from '@strapi/admin/strapi-admin';
+
+import { usePreviewContext } from '../pages/Preview';
+
+const PreviewContent = () => {
+  const previewUrl = usePreviewContext('PreviewIframe', (state) => state.url);
+
+  if (!previewUrl) {
+    return <Page.Loading />;
+  }
+
+  return (
+    <iframe
+      src={previewUrl}
+      title="Content Preview"
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+      }}
+    />
+  );
+};
+
+export { PreviewContent };

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 
-import { Page } from '@strapi/admin/strapi-admin';
-
 import { usePreviewContext } from '../pages/Preview';
 
 const PreviewContent = () => {
-  const previewUrl = usePreviewContext('PreviewIframe', (state) => state.url);
-
-  if (!previewUrl) {
-    return <Page.Loading />;
-  }
+  const previewUrl = usePreviewContext('PreviewContent', (state) => state.url);
 
   return (
     <iframe

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Page, useQueryParams, useRBAC, createContext } from '@strapi/admin/strapi-admin';
-import { Box, FocusTrap, Portal } from '@strapi/design-system';
+import { Box, Flex, FocusTrap, Portal } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 
@@ -11,6 +11,7 @@ import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { type UseDocument, useDocument } from '../../hooks/useDocument';
 import { useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { buildValidParams } from '../../utils/api';
+import { PreviewContent } from '../components/PreviewContent';
 import { PreviewHeader } from '../components/PreviewHeader';
 import { useGetPreviewUrlQuery } from '../services/preview';
 
@@ -127,7 +128,10 @@ const PreviewPage = () => {
         meta={documentResponse.meta}
         schema={documentResponse.schema}
       >
-        <PreviewHeader />
+        <Flex direction="column" height="100%" alignItems={'stretch'}>
+          <PreviewHeader />
+          <PreviewContent />
+        </Flex>
       </PreviewProvider>
     </>
   );


### PR DESCRIPTION
### What does it do?

Renders the preview url content inside an iframe.

> [!WARNING]  
> To render external URLs users will need to set that url into the CSP directives
```ts
// config/middlewares.js
module.exports = [
  // ...
  {
    name: 'strapi::security',
    config: {
      contentSecurityPolicy: {
        useDefaults: true,
        directives: {
          'frame-src': ["'self'", 'https://docs.strapi.io'], // e.g render strapi.io docs
        },
      },
    },
  },
  // ...
];

```