### PR TITLE
test: use correct blocks page header

### DIFF
--- a/tests/e2e/tests/content-manager/blocks.spec.ts
+++ b/tests/e2e/tests/content-manager/blocks.spec.ts
@@ -15,7 +15,7 @@ test.describe('Blocks editor', () => {
   test('adds a code block and specifies the language', async ({ page, browserName }) => {
     // Write some text into a blocks editor
     const code = 'const problems = 99';
-    await navToHeader(page, ['Content Manager', 'Homepage'], 'Untitled');
+    await navToHeader(page, ['Content Manager', 'Homepage'], 'Homepage');
     await expect(page.getByRole('link', { name: 'Back' })).toBeVisible();
     const textbox = page.getByRole('textbox').nth(1);
     await expect(textbox).toBeVisible();


### PR DESCRIPTION
### What does it do?

fixes the header from 'untitled' to 'homepage' 

### Why is it needed?

there may have previously been a bug with the header causing the test to fail that has now been fixed, but not entirely sure

### How to test it?

e2e tests should pass, particularly the blocks test

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
