### PR TITLE
fix: removed the success message that appears upon clicking the settings icon

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
@@ -144,11 +144,6 @@ const EditPage = () => {
       permissionsRef.current?.setFormAfterSubmit();
 
       await refetchRole();
-
-      toggleNotification({
-        type: 'success',
-        message: formatMessage({ id: 'notification.success.saved' }),
-      });
     } catch (error) {
       toggleNotification({
         type: 'danger',


### PR DESCRIPTION
### What does it do?
It removes the 'Success' message when clicking the settings icon while editing the role.

### Why is it needed?
To fix issue [21233](https://github.com/strapi/strapi/issues/21233): [RBAC] “Success. Saved” message wrongly displayed everytime hitting Settings icon of CT permission.

### How to test it?

1. Login with Super Admin Profile
2. Go to Settings > Roles
3. Select another role than Super Admin
4. In Collection Types tab, hit Settings icon at the end of a CT line
5. Check message

### Related issue(s)/PR(s)
fixes [21233](https://github.com/strapi/strapi/issues/21233)