### PR TITLE
fix: added fix for the last draft displaying NaN

### DIFF
--- a/packages/core/content-manager/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-manager/admin/src/components/RelativeTime.tsx
@@ -43,9 +43,10 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
       // see https://github.com/date-fns/date-fns/issues/2891 – No idea why it's all partial it returns it every time.
     }) as Required<Duration>;
 
-    const unit = intervals.find((intervalUnit) => {
-      return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
-    })!;
+    const unit =
+      intervals.find((intervalUnit) => {
+        return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
+      }) ?? 'seconds';
 
     const relativeTime = isPast(timestamp) ? -interval[unit] : interval[unit];
 

--- a/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
@@ -44,4 +44,13 @@ describe('RelativeTime', () => {
     expect(screen.getByRole('time')).toHaveTextContent('5 minutes ago');
     // expect(getByText('5 minutes ago')).toBeInTheDocument();
   });
+
+  it('handles when timestamp is exactly now', () => {
+    const now = new Date('2015-10-01 08:00:00').getTime();
+    spiedDateNow = setDateNow(now);
+
+    render(<RelativeTime timestamp={new Date(now)} />);
+
+    expect(screen.getByRole('time')).toHaveTextContent('now');
+  });
 });


### PR DESCRIPTION
### What does it do?

It fixes the 'NaN' issue when you open the see more of a content you edited less than 1 second ago.

### Why is it needed?

To fix issue [20756](https://github.com/strapi/strapi/issues/20756) : Last draft NaN value for a content

### How to test it?

1. Go To CM
2. Click on any collection type.
3. Edit the a field and Save it.
4. try to see the Updated in the top right ellipses menu. (Note: Please try to see within 1 sec of the content edited and saved) 

### Related issue(s)/PR(s)

fixes [20756](https://github.com/strapi/strapi/issues/20756)
