### PR TITLE
fix: preview close button

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -32,18 +32,14 @@ const ClosePreviewButton = () => {
   const [{ query }] = useQueryParams();
   const { formatMessage } = useIntl();
 
-  const closePreview = () => {
-    return {
-      pathname: '..',
-      search: stringify({ plugins: query.plugins }, { encode: false }),
-    };
-  };
-
   return (
     <IconButton
       tag={Link}
       relative="path"
-      to={closePreview()}
+      to={{
+        pathname: '..',
+        search: stringify({ plugins: query.plugins }, { encode: false }),
+      }}
       label={formatMessage({
         id: 'content-manager.preview.header.close',
         defaultMessage: 'Close preview',

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -18,7 +18,7 @@ import {
 import { Cross, Link as LinkIcon } from '@strapi/icons';
 import { stringify } from 'qs';
 import { type MessageDescriptor, useIntl } from 'react-intl';
-import { Link, type To, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { getDocumentStatus } from '../../pages/EditView/EditViewPage';
@@ -30,38 +30,20 @@ import { usePreviewContext } from '../pages/Preview';
 
 const ClosePreviewButton = () => {
   const [{ query }] = useQueryParams();
-  const navigate = useNavigate();
   const { formatMessage } = useIntl();
 
-  const canGoBack = useHistory('BackButton', (state) => state.canGoBack);
-  const goBack = useHistory('BackButton', (state) => state.goBack);
-  const history = useHistory('BackButton', (state) => state.history);
-
-  const fallbackUrl: To = {
-    pathname: '..',
-    search: stringify(query, { encode: false }),
-  };
-
-  const handleClick = (e: React.MouseEvent) => {
-    /**
-     * Prevent normal link behavior. We only make it an achor for accessibility reasons.
-     * The point of this logic is to act as the browser's back button when possible, and to fallback
-     * to a link behavior to the edit view when no history is available.
-     *  */
-    e.preventDefault();
-
-    if (canGoBack) {
-      goBack();
-    } else {
-      navigate(fallbackUrl);
-    }
+  const closePreview = () => {
+    return {
+      pathname: '..',
+      search: stringify({ plugins: query.plugins }, { encode: false }),
+    };
   };
 
   return (
     <IconButton
       tag={Link}
-      to={history.at(-1) ?? fallbackUrl}
-      onClick={handleClick}
+      relative="path"
+      to={closePreview()}
       label={formatMessage({
         id: 'content-manager.preview.header.close',
         defaultMessage: 'Close preview',

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -29,7 +29,9 @@ import { usePreviewContext } from '../pages/Preview';
  * -----------------------------------------------------------------------------------------------*/
 
 const ClosePreviewButton = () => {
-  const [{ query }] = useQueryParams();
+  const [{ query }] = useQueryParams<{
+    plugins?: Record<string, unknown>;
+  }>();
   const { formatMessage } = useIntl();
 
   return (


### PR DESCRIPTION
### What does it do?

Fix preview close button redirecting to the edit view regardless of having switched to Draft & publish.

### How to test it?

Open preview, switch to publish & draft multiple times and close preview.

