### PR TITLE
fix(e2e): update accessible name for flaky webkit test in history.spec.ts 

### DIFF
--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -252,7 +252,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       await clickAndWait(page, page.getByRole('link', { name: /Create new entry/, exact: true }));
       await page.waitForURL(ARTICLE_CREATE_URL);
       await page.getByRole('textbox', { name: 'title' }).fill('Being from Kansas');
-      await page.getByRole('textbox', { name: 'slug' }).fill('being-from-kansas');
+      await page.getByRole('textbox', { name: 'slug This value is unique for the selected locale' }).fill('being-from-kansas');
       await page.getByRole('button', { name: 'Save' }).click();
       await page.waitForURL(ARTICLE_EDIT_URL);
 

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -252,7 +252,9 @@ describeOnCondition(edition === 'EE')('History', () => {
       await clickAndWait(page, page.getByRole('link', { name: /Create new entry/, exact: true }));
       await page.waitForURL(ARTICLE_CREATE_URL);
       await page.getByRole('textbox', { name: 'title' }).fill('Being from Kansas');
-      await page.getByRole('textbox', { name: 'slug This value is unique for the selected locale' }).fill('being-from-kansas');
+      await page
+        .getByRole('textbox', { name: 'slug This value is unique for the selected locale' })
+        .fill('being-from-kansas');
       await page.getByRole('button', { name: 'Save' }).click();
       await page.waitForURL(ARTICLE_EDIT_URL);
 


### PR DESCRIPTION
### What does it do?

Update the accessible name to be the same as what is in the Dom

### Why is it needed?

The webkit test is flaky

### How to test it?

The e2e tests should pass


