### PR TITLE
fix: <svg> attribute width="<N>rem" & height="<N>rem" errors in Safari

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -778,7 +778,7 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
               defaultMessage: 'Confirmation',
             })}
           </Dialog.Header>
-          <Dialog.Body icon={<WarningCircle width="24px" height="24px" fill="danger600" />}>
+          <Dialog.Body icon={<WarningCircle width="24" height="24" fill="danger600" />}>
             {formatMessage({
               id: 'global.prompt.unsaved',
               defaultMessage: 'You have unsaved changes, are you sure you want to leave?',

--- a/packages/core/admin/admin/src/components/GuidedTour/Ornaments.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Ornaments.tsx
@@ -24,7 +24,7 @@ const Number = ({ children, state, ...props }: NumberProps) => {
       {...props}
     >
       {state === STATES.IS_DONE ? (
-        <Check aria-hidden width={`1.6rem`} fill="neutral0" />
+        <Check aria-hidden width={`16`} fill="neutral0" />
       ) : (
         <Typography fontWeight="semiBold" textColor="neutral0">
           {children}

--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -115,7 +115,7 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                         <NavLinkBadgeCounter
                           label={badgeContentNumeric}
                           backgroundColor="primary600"
-                          width="2.3rem"
+                          width="23"
                           color="neutral0"
                         >
                           {badgeContentNumeric}

--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -76,7 +76,7 @@ const Error = (props: ErrorProps) => {
     <PageMain height="100%">
       <Flex alignItems="center" height="100%" justifyContent="center">
         <EmptyStateLayout
-          icon={<WarningCircle width="16rem" />}
+          icon={<WarningCircle width="160" />}
           content={formatMessage({
             id: 'anErrorOccurred',
             defaultMessage: 'Woops! Something went wrong. Please, try again.',
@@ -108,7 +108,7 @@ const NoPermissions = (props: NoPermissionsProps) => {
       <Flex alignItems="center" height="100%" justifyContent="center">
         <Box minWidth="50%">
           <EmptyStateLayout
-            icon={<EmptyPermissions width="16rem" />}
+            icon={<EmptyPermissions width="160" />}
             content={formatMessage({
               id: 'app.components.EmptyStateLayout.content-permissions',
               defaultMessage: "You don't have the permissions to access that content",
@@ -141,7 +141,7 @@ const NoData = (props: NoDataProps) => {
       <Flex alignItems="center" height="100%" width="100%" justifyContent="center">
         <Box minWidth="50%">
           <EmptyStateLayout
-            icon={<EmptyDocuments width="16rem" />}
+            icon={<EmptyDocuments width="160" />}
             action={props.action}
             content={formatMessage({
               id: 'app.components.EmptyStateLayout.content-document',

--- a/packages/core/admin/admin/src/components/Table.tsx
+++ b/packages/core/admin/admin/src/components/Table.tsx
@@ -325,7 +325,7 @@ const Empty = (props: Table.EmptyProps) => {
               defaultMessage: 'No content found',
             })}
             hasRadius
-            icon={<EmptyDocuments width="16rem" />}
+            icon={<EmptyDocuments width="160" />}
             {...props}
           />
         </Td>

--- a/packages/core/admin/admin/src/components/tests/ContentBox.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/ContentBox.test.tsx
@@ -16,8 +16,8 @@ describe('ContentBox', () => {
           <ExternalLink
             data-testid="end-action-icon"
             color="neutral600"
-            width="1.2rem"
-            height="1.2rem"
+            width="12"
+            height="12"
             style={{
               marginLeft: '0.8rem',
             }}

--- a/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
+++ b/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
@@ -41,7 +41,7 @@ export const InternalErrorPage = () => {
             defaultMessage: 'An error occured',
           })}
           hasRadius
-          icon={<EmptyPictures width="16rem" />}
+          icon={<EmptyPictures width="160" />}
           shadow="tableShadow"
         />
       </Layouts.Content>

--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -266,8 +266,8 @@ const MarketplacePage = () => {
                   endAction={
                     <ExternalLink
                       fill="neutral600"
-                      width="1.2rem"
-                      height="1.2rem"
+                      width="12"
+                      height="12"
                       style={{ marginLeft: '0.8rem' }}
                     />
                   }

--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -217,7 +217,7 @@ const InstallPluginButton = ({
   if (isInstalled) {
     return (
       <Flex gap={2} paddingLeft={4}>
-        <Check width="1.2rem" height="1.2rem" color="success600" />
+        <Check width="12" height="12" color="success600" />
         <Typography variant="omega" textColor="success600" fontWeight="bold">
           {formatMessage({
             id: 'admin.pages.MarketPlacePage.plugin.installed',
@@ -327,8 +327,8 @@ const PackageStats = ({ githubStars = 0, npmDownloads = 0, npmPackageType }: Pac
     <Flex gap={1}>
       {!!githubStars && (
         <>
-          <GitHub height="1.2rem" width="1.2rem" aria-hidden />
-          <Star height="1.2rem" width="1.2rem" fill="warning500" aria-hidden />
+          <GitHub height="12" width="12" aria-hidden />
+          <Star height="12" width="12" fill="warning500" aria-hidden />
           <p
             aria-label={formatMessage(
               {
@@ -348,7 +348,7 @@ const PackageStats = ({ githubStars = 0, npmDownloads = 0, npmPackageType }: Pac
           <VerticalDivider />
         </>
       )}
-      <Download height="1.2rem" width="1.2rem" aria-hidden />
+      <Download height="12" width="12" aria-hidden />
       <p
         aria-label={formatMessage(
           {

--- a/packages/core/admin/admin/src/pages/NotFoundPage.tsx
+++ b/packages/core/admin/admin/src/pages/NotFoundPage.tsx
@@ -40,7 +40,7 @@ export const NotFoundPage = () => {
             defaultMessage: "Oops! We can't seem to find the page you're looging for...",
           })}
           hasRadius
-          icon={<EmptyPictures width="16rem" />}
+          icon={<EmptyPictures width="160" />}
           shadow="tableShadow"
         />
       </Layouts.Content>

--- a/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
@@ -83,7 +83,7 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
                   position="relative"
                 >
                   {formatMessage(link.intlLabel)}
-                  {link?.licenseOnly && <CustomIcon width="1.5rem" height="1.5rem" />}
+                  {link?.licenseOnly && <CustomIcon width="15" height="15" />}
                 </Link>
               );
             })}

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
@@ -184,7 +184,7 @@ export const ListView = () => {
             )}
             {canCreate && apiTokens.length === 0 ? (
               <EmptyStateLayout
-                icon={<EmptyDocuments width="16rem" />}
+                icon={<EmptyDocuments width="160" />}
                 content={formatMessage({
                   id: 'Settings.apiTokens.addFirstToken',
                   defaultMessage: 'Add your first API Token',
@@ -206,7 +206,7 @@ export const ListView = () => {
             ) : null}
             {!canCreate && apiTokens.length === 0 ? (
               <EmptyStateLayout
-                icon={<EmptyDocuments width="16rem" />}
+                icon={<EmptyDocuments width="160" />}
                 content={formatMessage({
                   id: 'Settings.apiTokens.emptyStateLayout',
                   defaultMessage: 'You don’t have any content yet...',

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/components/LogoInput.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/components/LogoInput.tsx
@@ -369,7 +369,7 @@ const ComputerForm = () => {
                 onDragEnter={handleDragEnter}
                 onDragLeave={handleDragLeave}
               >
-                <PlusCircle fill="primary600" width="6rem" height="6rem" aria-hidden />
+                <PlusCircle fill="primary600" width="60" height="60" aria-hidden />
                 <Box paddingTop={3} paddingBottom={5}>
                   <Typography variant="delta" tag="label" htmlFor={id}>
                     {formatMessage({

--- a/packages/core/admin/admin/src/pages/Settings/pages/PurchaseAuditLogs.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/PurchaseAuditLogs.tsx
@@ -20,7 +20,7 @@ const PurchaseAuditLogs = () => {
         />
         <Box paddingLeft={10} paddingRight={10}>
           <EmptyStateLayout
-            icon={<EmptyPermissions width="16rem" />}
+            icon={<EmptyPermissions width="160" />}
             content={formatMessage({
               id: 'Settings.permissions.auditLogs.not-available',
               defaultMessage:

--- a/packages/core/admin/admin/src/pages/Settings/pages/PurchaseSingleSignOn.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/PurchaseSingleSignOn.tsx
@@ -23,7 +23,7 @@ const PurchaseSingleSignOn = () => {
         />
         <Box paddingLeft={10} paddingRight={10}>
           <EmptyStateLayout
-            icon={<EmptyPermissions width="16rem" />}
+            icon={<EmptyPermissions width="160" />}
             content={formatMessage({
               id: 'Settings.sso.not-available',
               defaultMessage:

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
@@ -211,7 +211,7 @@ const ListView = () => {
                     })}
                   </LinkButton>
                 }
-                icon={<EmptyDocuments width="16rem" />}
+                icon={<EmptyDocuments width="160" />}
                 content={formatMessage({
                   id: 'Settings.transferTokens.addFirstToken',
                   defaultMessage: 'Add your first Transfer Token',
@@ -220,7 +220,7 @@ const ListView = () => {
             ) : null}
             {!canCreate && transferTokens.length === 0 ? (
               <EmptyStateLayout
-                icon={<EmptyDocuments width="16rem" />}
+                icon={<EmptyDocuments width="160" />}
                 content={formatMessage({
                   id: 'Settings.transferTokens.emptyStateLayout',
                   defaultMessage: 'You don’t have any content yet...',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/HeadersInput.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/HeadersInput.tsx
@@ -84,8 +84,8 @@ const HeadersInput = () => {
                     />
                   </Box>
                   <IconButton
-                    width="4rem"
-                    height="4rem"
+                    width="40"
+                    height="40"
                     onClick={() => removeRow(index)}
                     color="primary600"
                     label={formatMessage(
@@ -97,7 +97,7 @@ const HeadersInput = () => {
                     )}
                     type="button"
                   >
-                    <Minus width="0.8rem" />
+                    <Minus width="8" />
                   </IconButton>
                 </Flex>
               </Grid.Item>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/TriggerContainer.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/TriggerContainer.tsx
@@ -45,7 +45,7 @@ const TriggerContainer = ({ isPending, onCancel, response }: TriggerContainerPro
                       defaultMessage: 'cancel',
                     })}
                   </Typography>
-                  <Cross fill="neutral400" height="1.2rem" width="1.2rem" />
+                  <Cross fill="neutral400" height="12" width="12" />
                 </Flex>
               </button>
             </Flex>
@@ -71,7 +71,7 @@ const Status = ({ isPending, statusCode }: StatusProps) => {
   if (isPending || !statusCode) {
     return (
       <Flex gap={2} alignItems="center">
-        <Loader height="1.2rem" width="1.2rem" />
+        <Loader height="12" width="12" />
         <Typography>
           {formatMessage({ id: 'Settings.webhooks.trigger.pending', defaultMessage: 'pending' })}
         </Typography>
@@ -82,7 +82,7 @@ const Status = ({ isPending, statusCode }: StatusProps) => {
   if (statusCode >= 200 && statusCode < 300) {
     return (
       <Flex gap={2} alignItems="center">
-        <Check fill="success700" height="1.2rem" width="1.2rem" />
+        <Check fill="success700" height="12" width="12" />
         <Typography>
           {formatMessage({ id: 'Settings.webhooks.trigger.success', defaultMessage: 'success' })}
         </Typography>
@@ -93,7 +93,7 @@ const Status = ({ isPending, statusCode }: StatusProps) => {
   if (statusCode >= 300) {
     return (
       <Flex gap={2} alignItems="center">
-        <Cross fill="danger700" height="1.2rem" width="1.2rem" />
+        <Cross fill="danger700" height="12" width="12" />
         <Typography>
           {formatMessage({ id: 'Settings.error', defaultMessage: 'error' })} {statusCode}
         </Typography>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
@@ -81,7 +81,7 @@ export const AdminSeatInfoEE = () => {
               defaultMessage: 'At limit: add seats to invite more users',
             })}
           >
-            <WarningCircle width="1.4rem" height="1.4rem" fill="danger500" />
+            <WarningCircle width="14" height="14" fill="danger500" />
           </Tooltip>
         )}
       </Flex>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/Users/components/CreateActionEE.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/Users/components/CreateActionEE.tsx
@@ -30,7 +30,7 @@ export const CreateActionEE = React.forwardRef<HTMLButtonElement, CreateActionCE
             })}
             side="left"
           >
-            <WarningCircle width="1.4rem" height="1.4rem" fill="danger500" />
+            <WarningCircle width="14" height="14" fill="danger500" />
           </Tooltip>
         )}
         <Button

--- a/packages/core/content-manager/admin/src/components/ComponentIcon.tsx
+++ b/packages/core/content-manager/admin/src/components/ComponentIcon.tsx
@@ -29,7 +29,7 @@ const ComponentIcon = ({
       borderRadius={showBackground ? '50%' : 0}
       {...props}
     >
-      <Icon height="2rem" width="2rem" />
+      <Icon height="20" width="20" />
     </Flex>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/ListConfiguration/components/DraggableCard.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListConfiguration/components/DraggableCard.tsx
@@ -123,7 +123,7 @@ const DraggableCard = ({
                   )}
                   type="button"
                 >
-                  <Pencil width="1.2rem" height="1.2rem" />
+                  <Pencil width="12" height="12" />
                 </ActionButton>
               </Modal.Trigger>
               <EditFieldForm
@@ -146,7 +146,7 @@ const DraggableCard = ({
               )}
               type="button"
             >
-              <Cross width="1.2rem" height="1.2rem" />
+              <Cross width="12" height="12" />
             </ActionButton>
           </Flex>
         </FieldContainer>

--- a/packages/core/content-manager/admin/src/pages/ListView/components/AutoCloneFailureModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/AutoCloneFailureModal.tsx
@@ -61,8 +61,8 @@ const AutoCloneFailureModalBody = ({ prohibitedFields }: AutoCloneFailureModalBo
                   {index !== fieldPath.length - 1 && (
                     <ChevronRight
                       fill="neutral500"
-                      height="0.8rem"
-                      width="0.8rem"
+                      height="8"
+                      width="8"
                       style={{ margin: '0 0.8rem' }}
                     />
                   )}

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -264,7 +264,7 @@ const SelectedEntriesTableContent = ({
                   marginLeft="auto"
                   variant="ghost"
                 >
-                  <Pencil width={'1.6rem'} height={'1.6rem'} />
+                  <Pencil width={'16'} height={'16'} />
                 </IconButton>
               </Flex>
             </Table.Cell>

--- a/packages/core/content-manager/admin/src/pages/NoContentTypePage.tsx
+++ b/packages/core/content-manager/admin/src/pages/NoContentTypePage.tsx
@@ -39,7 +39,7 @@ const NoContentType = () => {
               "You don't have any content yet, we recommend you to create your first Content-Type.",
           })}
           hasRadius
-          icon={<EmptyDocuments width="16rem" />}
+          icon={<EmptyDocuments width="160" />}
           shadow="tableShadow"
         />
       </Layouts.Content>

--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -104,7 +104,7 @@ const DeleteReleaseActionItem = ({ releaseId, actionId }: DeleteReleaseActionIte
   return (
     <StyledMenuItem $variant="danger" onSelect={handleDeleteAction}>
       <Flex gap={2}>
-        <Cross width="1.6rem" height="1.6rem" />
+        <Cross width="16" height="16" />
         <Typography textColor="danger600" variant="omega">
           {formatMessage({
             id: 'content-releases.content-manager-edit-view.remove-from-release',
@@ -174,7 +174,7 @@ const ReleaseActionEntryLinkItem = ({
       }}
     >
       <Flex gap={2}>
-        <Pencil width="1.6rem" height="1.6rem" />
+        <Pencil width="16" height="16" />
         <Typography variant="omega">
           {formatMessage({
             id: 'content-releases.content-manager-edit-view.edit-entry',
@@ -200,7 +200,7 @@ const EditReleaseItem = ({ releaseId }: EditReleaseItemProps) => {
     /* @ts-expect-error inference isn't working in DS */
     <StyledMenuItem tag={NavLink} isLink to={`/plugins/content-releases/${releaseId}`}>
       <Flex gap={2}>
-        <Pencil width="1.6rem" height="1.6rem" />
+        <Pencil width="16" height="16" />
         <Typography textColor="neutral800" variant="omega">
           {formatMessage({
             id: 'content-releases.content-manager-edit-view.edit-release',

--- a/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
@@ -67,7 +67,7 @@ export const NoReleases = () => {
   const { formatMessage } = useIntl();
   return (
     <EmptyStateLayout
-      icon={<EmptyDocuments width="16rem" />}
+      icon={<EmptyDocuments width="160" />}
       content={formatMessage({
         id: 'content-releases.content-manager-edit-view.add-to-release.no-releases-message',
         defaultMessage:

--- a/packages/core/content-releases/admin/src/components/ReleaseListCell.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseListCell.tsx
@@ -94,7 +94,7 @@ const ReleaseListCell = ({ documentId, model }: ReleaseListCellProps) => {
           variant="ghost"
           onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
           // TODO: find a way in the DS to define the widht and height of the icon
-          endIcon={releases.length > 0 ? <CaretDown width="1.2rem" height="1.2rem" /> : null}
+          endIcon={releases.length > 0 ? <CaretDown width="12" height="12" /> : null}
         >
           <Typography
             style={{ maxWidth: '252px', cursor: 'pointer' }}

--- a/packages/core/content-releases/admin/src/pages/PurchaseContentReleases.tsx
+++ b/packages/core/content-releases/admin/src/pages/PurchaseContentReleases.tsx
@@ -22,7 +22,7 @@ const PurchaseContentReleases = () => {
         />
         <Box paddingLeft={10} paddingRight={10}>
           <EmptyStateLayout
-            icon={<EmptyPermissions width="16rem" />}
+            icon={<EmptyPermissions width="160" />}
             content={formatMessage({
               id: 'content-releases.pages.PurchaseRelease.not-available',
               defaultMessage:

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -702,7 +702,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
               })}
             </LinkButton>
           }
-          icon={<EmptyDocuments width="16rem" />}
+          icon={<EmptyDocuments width="160" />}
           content={formatMessage({
             id: 'content-releases.pages.Details.tab.emptyEntries',
             defaultMessage:

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -110,7 +110,7 @@ const ReleasesGrid = ({ sectionTitle, releases = [], isError = false }: Releases
             target: sectionTitle,
           }
         )}
-        icon={<EmptyDocuments width="16rem" />}
+        icon={<EmptyDocuments width="160" />}
       />
     );
   }

--- a/packages/core/content-type-builder/admin/src/components/AttributeIcon.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AttributeIcon.tsx
@@ -88,7 +88,7 @@ export const AttributeIcon = ({ type, customField = null, ...rest }: AttributeIc
   }
 
   return (
-    <IconBox width="3.2rem" shrink={0} {...rest} aria-hidden>
+    <IconBox width="32" shrink={0} {...rest} aria-hidden>
       <Box tag={Compo} />
     </IconBox>
   );

--- a/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AttributeOptions/AttributeOption.tsx
@@ -19,7 +19,7 @@ const newAttributes: string[] = [];
 const NewBadge = () => (
   <Flex grow={1} justifyContent="flex-end">
     <Flex gap={1} hasRadius background="alternative100" padding={`0.2rem 0.4rem`}>
-      <Sparkle width={`1rem`} height={`1rem`} fill="alternative600" />
+      <Sparkle width={`10`} height={`10`} fill="alternative600" />
       <Typography textColor="alternative600" variant="sigma">
         New
       </Typography>

--- a/packages/core/content-type-builder/admin/src/components/ComponentCard/ComponentIcon/ComponentIcon.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ComponentCard/ComponentIcon/ComponentIcon.tsx
@@ -19,7 +19,7 @@ export const ComponentIcon = ({ isActive = false, icon = 'dashboard' }: Componen
       width={8}
       borderRadius="50%"
     >
-      <Icon height="2rem" width="2rem" />
+      <Icon height="20" width="20" />
     </Flex>
   );
 };

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/ContentTypeBuilderNav.tsx
@@ -103,7 +103,7 @@ export const ContentTypeBuilderNav = () => {
               <Box paddingLeft={7}>
                 <TextButton
                   onClick={section.customLink.onClick}
-                  startIcon={<Plus width="0.8rem" height="0.8rem" />}
+                  startIcon={<Plus width="8" height="8" />}
                   marginTop={2}
                   cursor="pointer"
                 >

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -485,7 +485,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       height="16"
                       style="transform: rotateX(0deg);"
                       viewBox="0 0 32 32"
-                      width="1.2rem"
+                      width="12"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -559,9 +559,9 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
               >
                 <svg
                   fill="currentColor"
-                  height="0.8rem"
+                  height="8"
                   viewBox="0 0 32 32"
-                  width="0.8rem"
+                  width="8"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -606,7 +606,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       height="16"
                       style="transform: rotateX(0deg);"
                       viewBox="0 0 32 32"
-                      width="1.2rem"
+                      width="12"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -660,9 +660,9 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
               >
                 <svg
                   fill="currentColor"
-                  height="0.8rem"
+                  height="8"
                   viewBox="0 0 32 32"
-                  width="0.8rem"
+                  width="8"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -707,7 +707,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                       height="16"
                       style="transform: rotateX(0deg);"
                       viewBox="0 0 32 32"
-                      width="1.2rem"
+                      width="12"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
@@ -747,10 +747,10 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                           <svg
                             aria-hidden="true"
                             fill="#4a4a6a"
-                            height="1.2rem"
+                            height="12"
                             style="transform: rotateX(0deg);"
                             viewBox="0 0 32 32"
-                            width="1.2rem"
+                            width="12"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
@@ -813,10 +813,10 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                           <svg
                             aria-hidden="true"
                             fill="#4a4a6a"
-                            height="1.2rem"
+                            height="12"
                             style="transform: rotateX(0deg);"
                             viewBox="0 0 32 32"
-                            width="1.2rem"
+                            width="12"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
@@ -893,9 +893,9 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
               >
                 <svg
                   fill="currentColor"
-                  height="0.8rem"
+                  height="8"
                   viewBox="0 0 32 32"
-                  width="0.8rem"
+                  width="8"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path

--- a/packages/core/content-type-builder/admin/src/components/List.tsx
+++ b/packages/core/content-type-builder/admin/src/components/List.tsx
@@ -94,7 +94,7 @@ export const List = ({
                   defaultMessage: 'Create your first Collection-Type',
                 })}
                 hasRadius
-                icon={<EmptyDocuments width="16rem" />}
+                icon={<EmptyDocuments width="160" />}
               />
             </Td>
           </Tr>

--- a/packages/core/review-workflows/admin/src/routes/settings/components/AddStage.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/AddStage.tsx
@@ -17,7 +17,7 @@ export const AddStage = ({ children, ...props }: ButtonProps) => {
     >
       <Typography variant="pi" fontWeight="bold">
         <Flex tag="span" gap={2}>
-          <PlusCircle width="2.4rem" height="2.4rem" aria-hidden />
+          <PlusCircle width="24" height="24" aria-hidden />
           {children}
         </Flex>
       </Typography>

--- a/packages/core/review-workflows/admin/src/routes/settings/components/StageDragPreview.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/StageDragPreview.tsx
@@ -26,7 +26,7 @@ const StageDragPreview = ({ name }: StageDragPreviewType) => {
         justifyContent="center"
         width={6}
       >
-        <CaretDown width="0.8rem" fill="neutral600" />
+        <CaretDown width="8" fill="neutral600" />
       </Flex>
 
       <Typography fontWeight="bold">{name}</Typography>

--- a/packages/core/review-workflows/admin/src/routes/settings/components/tests/__snapshots__/AddStage.test.tsx.snap
+++ b/packages/core/review-workflows/admin/src/routes/settings/components/tests/__snapshots__/AddStage.test.tsx.snap
@@ -83,9 +83,9 @@ exports[`AddStage should render a list of stages 1`] = `
         <svg
           aria-hidden="true"
           fill="currentColor"
-          height="2.4rem"
+          height="24"
           viewBox="0 0 32 32"
-          width="2.4rem"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/tests/__snapshots__/index.test.tsx.snap
@@ -897,9 +897,9 @@ exports[`BrowseStep renders and match snapshot 1`] = `
                 <svg
                   class="c47"
                   fill="currentColor"
-                  height="2.4rem"
+                  height="24"
                   viewBox="0 0 32 32"
-                  width="2.4rem"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path

--- a/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.tsx
+++ b/packages/core/upload/admin/src/components/FolderCard/FolderCard/FolderCard.tsx
@@ -102,7 +102,7 @@ export const FolderCard = React.forwardRef(
               paddingRight={3}
               paddingTop={2}
             >
-              <StyledFolder width="2.4rem" height="2.4rem" />
+              <StyledFolder width="24" height="24" />
             </Box>
 
             {children}

--- a/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/FolderCard/tests/__snapshots__/FolderCard.test.tsx.snap
@@ -190,9 +190,9 @@ exports[`FolderCard has all required ids set when rendering a start action 1`] =
         <svg
           class="c7"
           fill="currentColor"
-          height="2.4rem"
+          height="24"
           viewBox="0 0 32 32"
-          width="2.4rem"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -389,9 +389,9 @@ exports[`FolderCard renders and matches the snapshot 1`] = `
         <svg
           class="c5"
           fill="currentColor"
-          height="2.4rem"
+          height="24"
           viewBox="0 0 32 32"
-          width="2.4rem"
+          width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/EmptyStateAsset.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/EmptyStateAsset.tsx
@@ -90,8 +90,8 @@ export const EmptyStateAsset = ({
     >
       <PicturePlus
         aria-hidden
-        width="3.2rem"
-        height="3.2rem"
+        width="32"
+        height="32"
         fill={disabled ? 'neutral400' : 'primary600'}
       />
       <TextAlignTypography

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/tests/MediaLibraryInput.test.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/tests/MediaLibraryInput.test.tsx
@@ -48,9 +48,9 @@ describe('<MediaLibraryInput />', () => {
         <svg
           aria-hidden="true"
           fill="#4945ff"
-          height="3.2rem"
+          height="32"
           viewBox="0 0 32 32"
-          width="3.2rem"
+          width="32"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path

--- a/packages/core/upload/admin/src/components/SelectTree/Option.tsx
+++ b/packages/core/upload/admin/src/components/SelectTree/Option.tsx
@@ -68,7 +68,7 @@ const Option = ({ children, data, selectProps, ...props }: OptionProps) => {
               onOptionToggle(value);
             }}
           >
-            <Icon width="1.4rem" fill="neutral500" />
+            <Icon width="14" fill="neutral500" />
           </ToggleButton>
         )}
       </Flex>

--- a/packages/core/upload/admin/src/components/TableList/PreviewCell.tsx
+++ b/packages/core/upload/admin/src/components/TableList/PreviewCell.tsx
@@ -38,7 +38,7 @@ export const PreviewCell = ({ type, content }: PreviewCellProps) => {
         height="3.2rem"
         borderRadius="50%"
       >
-        <Folder fill="secondary500" width="1.6rem" height="1.6rem" />
+        <Folder fill="secondary500" width="16" height="16" />
       </Flex>
     );
   }

--- a/packages/core/upload/admin/src/components/TableList/tests/__snapshots__/CellContent.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/TableList/tests/__snapshots__/CellContent.test.tsx.snap
@@ -280,9 +280,9 @@ exports[`TableList | CellContent should render image cell type when element type
   >
     <svg
       fill="#66b7f1"
-      height="1.6rem"
+      height="16"
       viewBox="0 0 32 32"
-      width="1.6rem"
+      width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromComputerForm.tsx
@@ -126,7 +126,7 @@ export const FromComputerForm = ({
             <Flex justifyContent="center">
               <Wrapper>
                 <IconWrapper>
-                  <PicturePlus aria-hidden width="3.2rem" height="3.2rem" />
+                  <PicturePlus aria-hidden width="32" height="32" />
                 </IconWrapper>
 
                 <Box paddingTop={3} paddingBottom={5}>

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/tests/__snapshots__/FromComputerForm.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/tests/__snapshots__/FromComputerForm.test.tsx.snap
@@ -214,9 +214,9 @@ exports[`FromComputerForm snapshots the component 1`] = `
                 <svg
                   aria-hidden="true"
                   fill="currentColor"
-                  height="3.2rem"
+                  height="32"
                   viewBox="0 0 32 32"
-                  width="3.2rem"
+                  width="32"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -693,7 +693,7 @@ const BulkLocaleAction: DocumentActionComponent = ({
         }),
         content: (
           <Flex direction="column" alignItems="center" gap={2}>
-            <WarningCircle width="2.4rem" height="2.4rem" fill="danger600" />
+            <WarningCircle width="24" height="24" fill="danger600" />
             <Typography textAlign="center">
               {formatMessage({
                 id: getTranslation('CMEditViewBulkLocale.draft-relation-warning'),

--- a/packages/plugins/i18n/admin/src/components/LocaleListCell.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocaleListCell.tsx
@@ -70,7 +70,7 @@ const LocaleListCell = ({
               {localesForDocument.join(', ')}
             </Typography>
             <Flex>
-              <CaretDown width="1.2rem" height="1.2rem" />
+              <CaretDown width="12" height="12" />
             </Flex>
           </Flex>
         </Button>


### PR DESCRIPTION
The width and height attributes with the value <code>\<N\>rem</code> have been changed in the components.
Rem was leading to the error message <code>Error: Invalid value for attribute width="rem"</code> in the Safari browser.

What does it do?

The width and height values for all svg files used in components have been changed.

 It was changed from <code>\<N\>rem</code> to <code>\<N*10\></code>.

Why is it needed?

Rem was leading to the error message <code>Error: Invalid value for attribute width="\<N\>rem"</code> in the safari browser.

How to test it?

Run new project in dev mode, open admin panel (Content Manager) in Safari browser, open console and watch errors.
Click Create New Entry button in collection-type with assets field and watch errors in console.
