### PR TITLE
fix: prevent password reset email to unconfirmed accounts

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -244,7 +244,7 @@ module.exports = ({ strapi }) => ({
       .query('plugin::users-permissions.user')
       .findOne({ where: { email: email.toLowerCase() } });
 
-    if (!user || user.blocked) {
+    if (!user || user.blocked || !user.confirmed) {
       return ctx.send({ ok: true });
     }
 


### PR DESCRIPTION
 <!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Prevents sending password reset emails to unconfirmed user accounts when email confirmation is enabled.

### Why is it needed?

- To prevent misuse of the password reset feature

### How to test it?

- Enable email confirmation in the admin panel.
- Register a new user without confirming their email address.
- Attempt to initiate the password reset process for the unconfirmed user.
- Verify that no password reset email is sent to the unconfirmed email address.

### Related issue(s)/PR(s)

- Fixes #14613
- Pr #14615 (discussions)
