### PR TITLE
fix: Resolve naming conflict in the v5 `document_id` migration

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -33,8 +33,8 @@ const QUERIES = {
     SELECT :tableName:.id as id, string_agg(DISTINCT :inverseJoinColumn:::character varying, ',') as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
-    GROUP BY :tableName:.id, :joinColumn:
+    WHERE :tableName:.document_id IS NULL
+    GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
     LIMIT 1;
   `,
       params
@@ -48,8 +48,8 @@ const QUERIES = {
     SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
-    GROUP BY :tableName:.id, :joinColumn:
+    WHERE :tableName:.document_id IS NULL
+    GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
     LIMIT 1;
   `,
       params
@@ -63,8 +63,8 @@ const QUERIES = {
     SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
-    GROUP BY :joinColumn:
+    WHERE :tableName:.document_id IS NULL
+    GROUP BY :joinTableName:.:joinColumn:
     LIMIT 1;
     `,
       params


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes the migration that adds `document_id` column to existing content type tables. 

The original issue was reported here and mistakenly closed as a duplicate:

Fix #21899 

### Why is it needed?

This takes care of a potential naming conflict that happens when you have a content type with a singular name "document", which seems to be a common naming pattern for Strapi installations in the wild.

### How to test it?

- Start with the latest v4 and prepare it for the v5 migration
- Start the server, all the migrations should pass
- Do this on postgres, sqlite and mysql

_Important: I only have managed to test the postgres migration, and people in the original issue have confirmed this works for sqlite._ 

### Related issue(s)/PR(s)

#21899