### PR TITLE
feat(cloud-cli): add command to link project with environment

### DIFF
--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -24,7 +24,7 @@ type PackageJson = {
 };
 
 interface CmdOptions {
-  environment?: string;
+  env?: string;
 }
 
 const QUIT_OPTION = 'Quit';
@@ -190,9 +190,9 @@ async function getTargetEnvironment(
   project: ProjectInfo,
   environments: string[]
 ): Promise<string> {
-  if (opts.environment) {
-    validateEnvironment(ctx, opts.environment, environments);
-    return opts.environment;
+  if (opts.env) {
+    validateEnvironment(ctx, opts.env, environments);
+    return opts.env;
   }
 
   if (project.targetEnvironment) {

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -7,7 +7,7 @@ import * as crypto from 'node:crypto';
 import { apiConfig } from '../config/api';
 import { compressFilesToTar } from '../utils/compress-files';
 import createProjectAction from '../create-project/action';
-import type { CLIContext, CloudApiService, CloudCliConfig, ProjectInfos } from '../types';
+import type { CLIContext, CloudApiService, CloudCliConfig, ProjectInfo } from '../types';
 import { getTmpStoragePath } from '../config/local';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { notificationServiceFactory } from '../services/notification';
@@ -59,12 +59,11 @@ async function promptForEnvironment(environments: string[]): Promise<string> {
 
 async function upload(
   ctx: CLIContext,
-  project: ProjectInfos,
+  project: ProjectInfo,
   token: string,
   maxProjectFileSize: number
 ) {
   const cloudApi = await cloudApiFactory(ctx, token);
-  // * Upload project
   try {
     const storagePath = await getTmpStoragePath();
     const projectFolder = path.resolve(process.cwd());
@@ -178,6 +177,35 @@ async function getConfig({
   }
 }
 
+function validateEnvironment(ctx: CLIContext, environment: string, environments: string[]): void {
+  if (!environments.includes(environment)) {
+    ctx.logger.error(`Environment ${environment} does not exist.`);
+    process.exit(1);
+  }
+}
+
+async function getTargetEnvironment(
+  ctx: CLIContext,
+  opts: CmdOptions,
+  project: ProjectInfo,
+  environments: string[]
+): Promise<string> {
+  if (opts.environment) {
+    validateEnvironment(ctx, opts.environment, environments);
+    return opts.environment;
+  }
+
+  if (project.targetEnvironment) {
+    return project.targetEnvironment;
+  }
+
+  if (environments.length > 1) {
+    return promptForEnvironment(environments);
+  }
+
+  return environments[0];
+}
+
 export default async (ctx: CLIContext, opts: CmdOptions) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
   const token = await getValidToken(ctx, promptLogin);
@@ -251,20 +279,7 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
     maxSize = 100000000;
   }
 
-  let targetEnvironment: string;
-
-  if (opts.environment) {
-    if (!environments.includes(opts.environment)) {
-      ctx.logger.error(`Environment ${opts.environment} does not exist.`);
-      return;
-    }
-    targetEnvironment = opts.environment;
-  } else {
-    targetEnvironment =
-      environments.length > 1 ? await promptForEnvironment(environments) : environments[0];
-  }
-
-  project.targetEnvironment = targetEnvironment;
+  project.targetEnvironment = await getTargetEnvironment(ctx, opts, project, environments);
 
   const buildId = await upload(ctx, project, token, maxSize);
 

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -288,7 +288,9 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
   }
 
   try {
-    ctx.logger.log(`🚀 Deploying project to ${chalk.cyan(project.targetEnvironment ?? `production`)} environment...`);
+    ctx.logger.log(
+      `🚀 Deploying project to ${chalk.cyan(project.targetEnvironment ?? `production`)} environment...`
+    );
     notificationService(`${apiConfig.apiBaseUrl}/notifications`, token, cliConfig);
     await buildLogsService(`${apiConfig.apiBaseUrl}/v1/logs/${buildId}`, token, cliConfig);
 

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -288,6 +288,7 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
   }
 
   try {
+    ctx.logger.log(`🚀 Deploying project to ${chalk.cyan(project.targetEnvironment ?? `production`)} environment...`);
     notificationService(`${apiConfig.apiBaseUrl}/notifications`, token, cliConfig);
     await buildLogsService(`${apiConfig.apiBaseUrl}/v1/logs/${buildId}`, token, cliConfig);
 

--- a/packages/cli/cloud/src/deploy-project/command.ts
+++ b/packages/cli/cloud/src/deploy-project/command.ts
@@ -12,7 +12,7 @@ const command: StrapiCloudCommand = ({ ctx }) => {
     .description('Deploy a Strapi Cloud project')
     .option('-d, --debug', 'Enable debugging mode with verbose logs')
     .option('-s, --silent', "Don't log anything")
-    .option('-e, --environment <name>', 'Specify the environment to deploy')
+    .option('-e, --env <name>', 'Specify the environment to deploy')
     .action((opts) => runAction('deploy', action)(ctx, opts));
 };
 

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -43,6 +43,14 @@ export default async (ctx: CLIContext) => {
   const environments = await getEnvironmentsList(ctx, cloudApiService, project);
 
   if (!environments) {
+    logger.debug(`Fetching environments failed.`);
+    return;
+  }
+
+  if (environments.length === 0) {
+    logger.log(
+      `The only available environment is already linked. You can add a new one from your project settings on the Strapi Cloud dashboard.`
+    );
     return;
   }
 

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -133,7 +133,7 @@ async function getEnvironmentsList(
       ctx.logger.warn(
         `\nThe project associated with this folder does not exist in Strapi Cloud. \nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
           'link'
-        )} command`
+        )} command.`
       );
     } else {
       spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -66,7 +66,7 @@ export default async (ctx: CLIContext) => {
   });
 
   try {
-    await local.addEnvironment(answer.targetEnvironment);
+    await local.patch({ project: { targetEnvironment: answer.targetEnvironment } });
   } catch (e) {
     await trackEvent(ctx, cloudApiService, 'didNotLinkEnvironment', {
       projectName: project.name,

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -54,7 +54,7 @@ export default async (ctx: CLIContext) => {
 
   await trackEvent(ctx, cloudApiService, 'willLinkEnvironment', {
     projectName: project.name,
-    environment: answer,
+    environmentName: answer.targetEnvironment,
   });
 
   try {
@@ -62,7 +62,7 @@ export default async (ctx: CLIContext) => {
   } catch (e) {
     await trackEvent(ctx, cloudApiService, 'didNotLinkEnvironment', {
       projectName: project.name,
-      environment: answer,
+      environmentName: answer.targetEnvironment,
     });
     logger.debug('Failed to link environment', e);
     logger.error('An error occurred while trying to link the environment.');
@@ -74,7 +74,7 @@ export default async (ctx: CLIContext) => {
   );
   await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', {
     projectName: project.name,
-    environment: answer,
+    environmentName: answer.targetEnvironment,
   });
 };
 

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -70,7 +70,7 @@ export default async (ctx: CLIContext) => {
   }
 
   logger.log(
-    `You have successfully linked your project to ${chalk.cyan(answer.targetEnvironment)}, on ${chalk.cyan(project.displayName)}, you are now able to deploy your project.`
+    `You have successfully linked your project to ${chalk.cyan(answer.targetEnvironment)}, on ${chalk.cyan(project.displayName)}. You are now able to deploy your project.`
   );
   await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', {
     projectName: project.name,

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -68,8 +68,8 @@ export default async (ctx: CLIContext) => {
     process.exit(1);
   }
 
-  logger.info(
-    `Environment ${chalk.cyan(answer)} linked successfully. Future deployments will default to this environment.`
+  logger.log(
+    `Environment ${chalk.cyan(answer.targetEnvironment)} linked successfully. Future deployments will default to this environment.`
   );
   await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', {
     projectName: project.name,

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -51,19 +51,30 @@ export default async (ctx: CLIContext) => {
     return;
   }
 
-  await trackEvent(ctx, cloudApiService, 'willLinkEnvironment', { projectName: project.name, environment: answer });
+  await trackEvent(ctx, cloudApiService, 'willLinkEnvironment', {
+    projectName: project.name,
+    environment: answer,
+  });
 
   try {
-  await local.addEnvironment(answer.targetEnvironment);
+    await local.addEnvironment(answer.targetEnvironment);
   } catch (e) {
-    await trackEvent(ctx, cloudApiService, 'didNotLinkEnvironment', { projectName: project.name, environment: answer });
+    await trackEvent(ctx, cloudApiService, 'didNotLinkEnvironment', {
+      projectName: project.name,
+      environment: answer,
+    });
     logger.debug('Failed to link environment', e);
     logger.error('An error occurred while trying to link the environment.');
     process.exit(1);
   }
 
-  logger.info(`Environment ${chalk.cyan(answer)} linked successfully. Future deployments will default to this environment.`);
-  await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', { projectName: project.name, environment: answer });
+  logger.info(
+    `Environment ${chalk.cyan(answer)} linked successfully. Future deployments will default to this environment.`
+  );
+  await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', {
+    projectName: project.name,
+    environment: answer,
+  });
 };
 
 async function promptUserForEnvironment(
@@ -94,7 +105,6 @@ async function promptUserForEnvironment(
   }
 }
 
-
 async function getEnvironmentsList(
   ctx: CLIContext,
   cloudApiService: CloudApiService,
@@ -108,11 +118,9 @@ async function getEnvironmentsList(
     } = await cloudApiService.listLinkEnvironments({ name: projectName });
     spinner.succeed();
 
-    const environments = (environmentsList as unknown as Environment[]).map((environment: Environment) => {
+    return (environmentsList as unknown as Environment[]).map((environment: Environment) => {
       return environment;
     });
-
-    return environments;
   } catch (e: any) {
     if (e.response && e.response.status === 404) {
       spinner.succeed();

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -1,0 +1,129 @@
+import chalk from 'chalk';
+import inquirer, { type Answers } from 'inquirer';
+import type { CLIContext, CloudApiService } from '../../types';
+import { cloudApiFactory, tokenServiceFactory, local } from '../../services';
+import { promptLogin } from '../../login/action';
+import { trackEvent } from '../../utils/analytics';
+import { getLocalProject } from '../../utils/get-local-config';
+
+const QUIT_OPTION = 'Quit';
+
+interface LinkEnvironmentAnswer extends Answers {
+  targetEnvironment: string;
+}
+
+interface LinkEnvironmentInput extends Answers {
+  targetEnvironment: string;
+}
+
+type Environment = {
+  name: string;
+};
+
+type EnvironmentsList = Environment[];
+
+export default async (ctx: CLIContext) => {
+  const { getValidToken } = await tokenServiceFactory(ctx);
+  const token = await getValidToken(ctx, promptLogin);
+  const { logger } = ctx;
+
+  if (!token) {
+    return;
+  }
+
+  const project = await getLocalProject(ctx);
+
+  if (!project) {
+    logger.debug(`No valid local project configuration was found.`);
+    return;
+  }
+
+  const cloudApiService = await cloudApiFactory(ctx, token);
+  const environments = await getEnvironmentsList(ctx, cloudApiService, project.name);
+
+  if (!environments) {
+    return;
+  }
+
+  const answer: LinkEnvironmentAnswer | null = await promptUserForEnvironment(ctx, environments);
+
+  if (!answer) {
+    return;
+  }
+
+  await trackEvent(ctx, cloudApiService, 'willLinkEnvironment', { projectName: project.name, environment: answer });
+
+  try {
+  await local.addEnvironment(answer.targetEnvironment);
+  } catch (e) {
+    await trackEvent(ctx, cloudApiService, 'didNotLinkEnvironment', { projectName: project.name, environment: answer });
+    logger.debug('Failed to link environment', e);
+    logger.error('An error occurred while trying to link the environment.');
+    process.exit(1);
+  }
+
+  logger.info(`Environment ${chalk.cyan(answer)} linked successfully. Future deployments will default to this environment.`);
+  await trackEvent(ctx, cloudApiService, 'didLinkEnvironment', { projectName: project.name, environment: answer });
+};
+
+async function promptUserForEnvironment(
+  ctx: CLIContext,
+  environments: EnvironmentsList
+): Promise<LinkEnvironmentAnswer | null> {
+  const { logger } = ctx;
+
+  try {
+    const answer: LinkEnvironmentInput = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'targetEnvironment',
+        message: 'Which environment do you want to link?',
+        choices: [...environments, { name: chalk.grey(`(${QUIT_OPTION})`), value: null }],
+      },
+    ]);
+
+    if (!answer.targetEnvironment) {
+      return null;
+    }
+
+    return answer;
+  } catch (e) {
+    logger.debug('Failed to get user input', e);
+    logger.error('An error occurred while trying to get your environment selection.');
+    return null;
+  }
+}
+
+
+async function getEnvironmentsList(
+  ctx: CLIContext,
+  cloudApiService: CloudApiService,
+  projectName: string
+) {
+  const spinner = ctx.logger.spinner('Fetching environments...\n').start();
+
+  try {
+    const {
+      data: { data: environmentsList },
+    } = await cloudApiService.listLinkEnvironments({ name: projectName });
+    spinner.succeed();
+
+    const environments = (environmentsList as unknown as Environment[]).map((environment: Environment) => {
+      return environment;
+    });
+
+    return environments;
+  } catch (e: any) {
+    if (e.response && e.response.status === 404) {
+      spinner.succeed();
+      ctx.logger.warn(
+        `\nThe project associated with this folder does not exist in Strapi Cloud. \nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+          'link'
+        )} command`
+      );
+    } else {
+      spinner.fail('An error occurred while fetching environments data from Strapi Cloud.');
+      ctx.logger.debug('Failed to list environments', e);
+    }
+  }
+}

--- a/packages/cli/cloud/src/environment/link/command.ts
+++ b/packages/cli/cloud/src/environment/link/command.ts
@@ -1,0 +1,17 @@
+import { type StrapiCloudCommand } from '../../types';
+import { runAction } from '../../utils/helpers';
+import action from './action';
+import { initializeEnvironmentCommand } from '../command';
+
+const command: StrapiCloudCommand = ({ command, ctx }) => {
+  const environmentCmd = initializeEnvironmentCommand(command, ctx);
+
+  environmentCmd
+    .command('link')
+    .description('Link project to a specific Strapi Cloud project environment')
+    .option('-d, --debug', 'Enable debugging mode with verbose logs')
+    .option('-s, --silent', "Don't log anything")
+    .action(() => runAction('link', action)(ctx));
+};
+
+export default command;

--- a/packages/cli/cloud/src/environment/link/index.ts
+++ b/packages/cli/cloud/src/environment/link/index.ts
@@ -1,0 +1,12 @@
+import action from './action';
+import command from './command';
+import type { StrapiCloudCommandInfo } from '../../types';
+
+export { action, command };
+
+export default {
+  name: 'link-environment',
+  description: 'Link Strapi Cloud environment to a local project',
+  action,
+  command,
+} as StrapiCloudCommandInfo;

--- a/packages/cli/cloud/src/environment/list/action.ts
+++ b/packages/cli/cloud/src/environment/list/action.ts
@@ -1,21 +1,9 @@
 import chalk from 'chalk';
 import type { CLIContext } from '../../types';
-import { cloudApiFactory, local, tokenServiceFactory } from '../../services';
+import { cloudApiFactory, tokenServiceFactory } from '../../services';
 import { promptLogin } from '../../login/action';
 import { trackEvent } from '../../utils/analytics';
-
-async function getProject(ctx: CLIContext) {
-  const { project } = await local.retrieve();
-  if (!project) {
-    ctx.logger.warn(
-      `\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
-        'link'
-      )} command`
-    );
-    process.exit(1);
-  }
-  return project;
-}
+import { getLocalProject } from '../../utils/get-local-config';
 
 export default async (ctx: CLIContext) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
@@ -26,7 +14,7 @@ export default async (ctx: CLIContext) => {
     return;
   }
 
-  const project = await getProject(ctx);
+  const project = await getLocalProject(ctx);
   if (!project) {
     ctx.logger.debug(`No valid local project configuration was found.`);
     return;

--- a/packages/cli/cloud/src/index.ts
+++ b/packages/cli/cloud/src/index.ts
@@ -7,6 +7,7 @@ import logout from './logout';
 import createProject from './create-project';
 import listProjects from './list-projects';
 import listEnvironments from './environment/list';
+import linkEnvironment from './environment/link';
 import { CLIContext } from './types';
 import { getLocalConfig, saveLocalConfig } from './config/local';
 
@@ -16,11 +17,20 @@ export const cli = {
   login,
   logout,
   createProject,
+  linkEnvironment,
   listProjects,
   listEnvironments,
 };
 
-const cloudCommands = [deployProject, link, login, logout, listProjects, listEnvironments];
+const cloudCommands = [
+  deployProject,
+  link,
+  login,
+  logout,
+  linkEnvironment,
+  listProjects,
+  listEnvironments,
+];
 
 async function initCloudCLIConfig() {
   const localConfig = await getLocalConfig();

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -9,6 +9,7 @@ import { LocalSave } from '../services/strapi-info-save';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { promptLogin } from '../login/action';
 import { trackEvent } from '../utils/analytics';
+import { getLocalConfig } from '../utils/get-local-config';
 
 const QUIT_OPTION = 'Quit';
 
@@ -38,16 +39,6 @@ type Project = {
   displayName: string;
   isMaintainer: boolean;
 };
-
-async function getExistingConfig(ctx: CLIContext) {
-  try {
-    return await local.retrieve();
-  } catch (e) {
-    ctx.logger.debug('Failed to get project config', e);
-    ctx.logger.error('An error occurred while retrieving config data from your local project.');
-    return null;
-  }
-}
 
 async function promptForRelink(
   ctx: CLIContext,
@@ -157,7 +148,7 @@ export default async (ctx: CLIContext) => {
 
   const cloudApiService = await cloudApiFactory(ctx, token);
 
-  const existingConfig: LocalSave | null = await getExistingConfig(ctx);
+  const existingConfig: LocalSave | null = await getLocalConfig(ctx);
   const shouldRelink = await promptForRelink(ctx, cloudApiService, existingConfig);
 
   if (!shouldRelink) {

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -84,7 +84,7 @@ async function getProjectsList(
     spinner.succeed();
 
     if (!Array.isArray(projectList)) {
-      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud.");
       return null;
     }
     const projects: ProjectsList = (projectList as unknown as Project[])
@@ -99,7 +99,7 @@ async function getProjectsList(
         };
       });
     if (projects.length === 0) {
-      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud");
+      ctx.logger.log("We couldn't find any projects available for linking in Strapi Cloud.");
       return null;
     }
     return projects;

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -192,7 +192,7 @@ export default async (ctx: CLIContext) => {
     }
 
     await local.save({ project: answer.linkProject });
-    logger.log(`Project ${chalk.cyan(answer.linkProject.displayName)} linked successfully.`);
+    logger.log(` You have successfully linked your project to ${chalk.cyan(answer.linkProject.displayName)}. You are now able to deploy your project.`);
     await trackEvent(ctx, cloudApiService, 'didLinkProject', {
       projectInternalName: answer.linkProject,
     });

--- a/packages/cli/cloud/src/link/action.ts
+++ b/packages/cli/cloud/src/link/action.ts
@@ -192,7 +192,9 @@ export default async (ctx: CLIContext) => {
     }
 
     await local.save({ project: answer.linkProject });
-    logger.log(` You have successfully linked your project to ${chalk.cyan(answer.linkProject.displayName)}. You are now able to deploy your project.`);
+    logger.log(
+      ` You have successfully linked your project to ${chalk.cyan(answer.linkProject.displayName)}. You are now able to deploy your project.`
+    );
     await trackEvent(ctx, cloudApiService, 'didLinkProject', {
       projectInternalName: answer.linkProject,
     });

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -53,12 +53,18 @@ export type ListLinkEnvironmentsResponse = {
   };
 };
 
+export interface Environment {
+  name: string;
+  hasLiveDeployment?: boolean;
+  hasPendingDeployment?: boolean;
+}
+
 export type GetProjectResponse = {
   data: {
     updatedAt: string;
     suspendedAt?: string;
     isTrial: boolean;
-    environments: string[];
+    environments: Environment[];
   };
   metadata: {
     dashboardUrls: {

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -9,10 +9,10 @@ import packageJson from '../../package.json';
 
 export const VERSION = 'v1';
 
-export type ProjectInfos = {
+export type ProjectInfo = {
   id: string;
   name: string;
-  selectedEnvironment?: string;
+  targetEnvironment?: string;
   displayName?: string;
   nodeVersion?: string;
   region?: string;
@@ -22,7 +22,7 @@ export type ProjectInfos = {
 
 export type EnvironmentInfo = Record<string, unknown>;
 
-export type ProjectInput = Omit<ProjectInfos, 'id'>;
+export type ProjectInput = Omit<ProjectInfo, 'id'>;
 
 export type DeployResponse = {
   build_id: string;
@@ -43,7 +43,13 @@ export type ListEnvironmentsResponse = {
 
 export type ListLinkProjectsResponse = {
   data: {
-    data: ProjectInfos[] | Record<string, never>;
+    data: ProjectInfo[] | Record<string, never>;
+  };
+};
+
+export type ListLinkEnvironmentsResponse = {
+  data: {
+    data: EnvironmentInfo[] | Record<string, never>;
   };
 };
 
@@ -89,6 +95,8 @@ export interface CloudApiService {
   listLinkProjects(): Promise<AxiosResponse<ListLinkProjectsResponse>>;
 
   listEnvironments(project: { name: string }): Promise<AxiosResponse<ListEnvironmentsResponse>>;
+
+  listLinkEnvironments(project: { name: string }): Promise<AxiosResponse<ListLinkEnvironmentsResponse>>;
 
   getProject(project: { name: string }): Promise<AxiosResponse<GetProjectResponse>>;
 
@@ -212,6 +220,23 @@ export async function cloudApiFactory(
     async listEnvironments({ name }): Promise<AxiosResponse<ListEnvironmentsResponse>> {
       try {
         const response = await axiosCloudAPI.get(`/projects/${name}/environments`);
+
+        if (response.status !== 200) {
+          throw new Error('Error fetching cloud environments from the server.');
+        }
+
+        return response;
+      } catch (error) {
+        logger.debug(
+          "🥲 Oops! Couldn't retrieve your project's environments from the server. Please try again."
+        );
+        throw error;
+      }
+    },
+
+    async listLinkEnvironments({ name }): Promise<AxiosResponse<ListLinkEnvironmentsResponse>> {
+      try {
+        const response = await axiosCloudAPI.get(`/projects/${name}/environments-linkable`);
 
         if (response.status !== 200) {
           throw new Error('Error fetching cloud environments from the server.');

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -96,7 +96,9 @@ export interface CloudApiService {
 
   listEnvironments(project: { name: string }): Promise<AxiosResponse<ListEnvironmentsResponse>>;
 
-  listLinkEnvironments(project: { name: string }): Promise<AxiosResponse<ListLinkEnvironmentsResponse>>;
+  listLinkEnvironments(project: {
+    name: string;
+  }): Promise<AxiosResponse<ListLinkEnvironmentsResponse>>;
 
   getProject(project: { name: string }): Promise<AxiosResponse<GetProjectResponse>>;
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -53,18 +53,12 @@ export type ListLinkEnvironmentsResponse = {
   };
 };
 
-export interface Environment {
-  name: string;
-  hasLiveDeployment?: boolean;
-  hasPendingDeployment?: boolean;
-}
-
 export type GetProjectResponse = {
   data: {
     updatedAt: string;
     suspendedAt?: string;
     isTrial: boolean;
-    environments: Environment[];
+    environments: string[];
   };
   metadata: {
     dashboardUrls: {

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -8,7 +8,10 @@ export type LocalSave = {
   project?: Omit<ProjectInfo, 'id'>;
 };
 
-export async function addEnvironment(targetEnvironment: string, { directoryPath }: { directoryPath?: string } = {}) {
+export async function addEnvironment(
+  targetEnvironment: string,
+  { directoryPath }: { directoryPath?: string } = {}
+) {
   const alreadyInFileData = await retrieve({ directoryPath });
   const storedData = {
     ...alreadyInFileData,

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -1,20 +1,31 @@
 import fse from 'fs-extra';
 import path from 'path';
-import type { ProjectInfos } from './cli-api';
+import type { ProjectInfo } from './cli-api';
 
 export const LOCAL_SAVE_FILENAME = '.strapi-cloud.json';
 
 export type LocalSave = {
-  project?: Omit<ProjectInfos, 'id'>;
+  project?: Omit<ProjectInfo, 'id'>;
 };
 
-export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {
+export async function addEnvironment(targetEnvironment: string, { directoryPath }: { directoryPath?: string } = {}) {
   const alreadyInFileData = await retrieve({ directoryPath });
-  const storedData = { ...alreadyInFileData, ...data };
+  const storedData = {
+    ...alreadyInFileData,
+    project: {
+      ...alreadyInFileData.project,
+      targetEnvironment,
+    },
+  };
   const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
-  // Ensure the directory exists
   await fse.ensureDir(path.dirname(pathToFile));
   await fse.writeJson(pathToFile, storedData, { encoding: 'utf8' });
+}
+
+export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {
+  const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
+  await fse.ensureDir(path.dirname(pathToFile));
+  await fse.writeJson(pathToFile, data, { encoding: 'utf8' });
 }
 
 export async function retrieve({

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -9,20 +9,21 @@ export type LocalSave = {
 };
 
 export async function addEnvironment(
-  targetEnvironment: string,
+  targetEnvironment: string | undefined,
   { directoryPath }: { directoryPath?: string } = {}
 ) {
   const alreadyInFileData = await retrieve({ directoryPath });
-  const storedData = {
+  if (!alreadyInFileData || !alreadyInFileData.project) {
+    throw new Error('No valid configuration found in the local configuration file.');
+  }
+  const dataToSave: LocalSave = {
     ...alreadyInFileData,
     project: {
       ...alreadyInFileData.project,
       targetEnvironment,
     },
   };
-  const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
-  await fse.ensureDir(path.dirname(pathToFile));
-  await fse.writeJson(pathToFile, storedData, { encoding: 'utf8' });
+  await save(dataToSave, { directoryPath });
 }
 
 export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {

--- a/packages/cli/cloud/src/services/strapi-info-save.ts
+++ b/packages/cli/cloud/src/services/strapi-info-save.ts
@@ -1,5 +1,6 @@
 import fse from 'fs-extra';
 import path from 'path';
+import { merge } from 'lodash';
 import type { ProjectInfo } from './cli-api';
 
 export const LOCAL_SAVE_FILENAME = '.strapi-cloud.json';
@@ -8,26 +9,21 @@ export type LocalSave = {
   project?: Omit<ProjectInfo, 'id'>;
 };
 
-export async function addEnvironment(
-  targetEnvironment: string | undefined,
-  { directoryPath }: { directoryPath?: string } = {}
-) {
-  const alreadyInFileData = await retrieve({ directoryPath });
-  if (!alreadyInFileData || !alreadyInFileData.project) {
-    throw new Error('No valid configuration found in the local configuration file.');
-  }
-  const dataToSave: LocalSave = {
-    ...alreadyInFileData,
-    project: {
-      ...alreadyInFileData.project,
-      targetEnvironment,
-    },
-  };
-  await save(dataToSave, { directoryPath });
-}
+// Utility type for making all properties optional recursively
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export type LocalPatch = {
+  project?: DeepPartial<Omit<ProjectInfo, 'id'>>;
+};
+
+const getFilePath = (directoryPath?: string): string =>
+  path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
 
 export async function save(data: LocalSave, { directoryPath }: { directoryPath?: string } = {}) {
-  const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
+  const pathToFile = getFilePath(directoryPath);
+  // Ensure the directory exists and creates it if not
   await fse.ensureDir(path.dirname(pathToFile));
   await fse.writeJson(pathToFile, data, { encoding: 'utf8' });
 }
@@ -35,11 +31,31 @@ export async function save(data: LocalSave, { directoryPath }: { directoryPath?:
 export async function retrieve({
   directoryPath,
 }: { directoryPath?: string } = {}): Promise<LocalSave> {
-  const pathToFile = path.join(directoryPath || process.cwd(), LOCAL_SAVE_FILENAME);
+  const pathToFile = getFilePath(directoryPath);
   const pathExists = await fse.pathExists(pathToFile);
   if (!pathExists) {
     return {};
   }
-
   return fse.readJSON(pathToFile, { encoding: 'utf8' });
+}
+
+export async function patch(
+  patchData: LocalPatch,
+  { directoryPath }: { directoryPath?: string } = {}
+) {
+  const pathToFile = getFilePath(directoryPath);
+  const existingData = await retrieve({ directoryPath });
+  if (!existingData) {
+    throw new Error('No configuration data found to patch.');
+  }
+  const newData = merge(existingData, patchData);
+  await fse.writeJson(pathToFile, newData, { encoding: 'utf8' });
+}
+
+export async function deleteConfig({ directoryPath }: { directoryPath?: string } = {}) {
+  const pathToFile = getFilePath(directoryPath);
+  const pathExists = await fse.pathExists(pathToFile);
+  if (pathExists) {
+    await fse.remove(pathToFile);
+  }
 }

--- a/packages/cli/cloud/src/utils/get-local-config.ts
+++ b/packages/cli/cloud/src/utils/get-local-config.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk';
+import type { CLIContext } from '../types';
+import { local } from '../services';
+import { LocalSave } from '../services/strapi-info-save';
+
+async function getLocalConfig(ctx: CLIContext): Promise<LocalSave | null> {
+  try {
+    return await local.retrieve();
+  } catch (e) {
+    ctx.logger.debug('Failed to get project config', e);
+    ctx.logger.error('An error occurred while retrieving config data from your local project.');
+    return null;
+  }
+}
+
+async function getLocalProject(ctx: CLIContext) {
+  const localConfig = await getLocalConfig(ctx);
+
+  if (!localConfig || !localConfig.project) {
+    ctx.logger.warn(
+      `\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
+        'link'
+      )} command`
+    );
+    process.exit(1);
+  }
+  return localConfig.project;
+}
+
+export { getLocalConfig, getLocalProject };

--- a/packages/cli/cloud/src/utils/get-local-config.ts
+++ b/packages/cli/cloud/src/utils/get-local-config.ts
@@ -20,7 +20,7 @@ async function getLocalProject(ctx: CLIContext) {
     ctx.logger.warn(
       `\nWe couldn't find a valid local project config.\nPlease link your local project to an existing Strapi Cloud project using the ${chalk.cyan(
         'link'
-      )} command`
+      )} command.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
### What does it do?

This PR adds a command for Cloud CLI users to link their local project to a specific cloud environment.

With strapi environment link, users can select an environment from their available options to set as the default for deploying their local project.

If a user runs strapi deploy without a linked environment or an `-e / --env` flag, they will be prompted to choose an environment.
Once an environment is linked, the strapi deploy command will use it automatically, without further prompts.

**Additional changes**

- Duplicated configuration retrieval functions have been consolidated in a utils file.
- Type names have been updated for consistency.

### Why is it needed?

With the introduction of Strapi Cloud multi-environments, users need a way to deploy to specific environments via the CLI. This command completes the essential environment features, allowing users to deploy to a selected environment by either choosing it manually, using a flag, or setting a default environment.


### How to test it?

---

**Pretest 1** 
- New options should be displayed on running `strapi cloud environment -h:`

```
  Manage environments

Options:
  -h, --help      Display help for command

Commands:
  link [options]  Link project to a specific Strapi Cloud project environment
  list [options]  List Strapi Cloud project environments
  help [command]  Display help for command
```

**Pretest 2**  
- Using any command without being logged in should prompt to login.

----
**Test Case 1: No Project in Local Config** 

- Steps: Clear the project from the local config (`$ rm .strapi-cloud.json`) and run `strapi cloud environment link`.
- Expected: Reject with an error about no project configured:
`[WARN] `
`We couldn't find a valid local project config.`
`Please link your local project to an existing Strapi Cloud project using the link command.`

**Test Case 2: Invalid Project in Cloud API** 

- Steps: Set an invalid project name (change it in .strapi-cloud.json file), run `strapi cloud environment link`.
- Expected: Reject with an error about an invalid project: 
`[WARN]`
`The project associated with this folder does not exist in Strapi Cloud.`
`Please link your local project to an existing Strapi Cloud project using the link command.`

**Test Case 3: Environment Selection** 

- Steps: Running `strapi cloud environment link` with >1 environment should prompt to select one environment:
- Expected: 
 	- All environments available in strapi cloud project should be displayed
 	- Selecting `Quit` option should cancel the operation.
 	- Selecting one env save the selected environment to the local config.
 	- Succesful operation should log:
 	`You have successfully linked your project to <environment>, on <project>. You are now able to deploy your project`

**Test Case 4: Default Environment in Deploy** 

- Steps: Set a default environment, run the deploy command.
- Expected: CLI should use the default environment to deploy and no question about the environment should be displayed.


**Test Case 5: Default Environment in and flag** 

- Steps: Set a default environment, run the deploy command with a flag `--env` to deploy to a different env than the default environment.
- Expected: CLI should NOT use the default environment to deploy but the environment passed with the flag
- repeat the test with using the short flag `-e`

**Test Case 6: Clear Environment on Relink** 

- Steps: Set a default environment and then re-link the project to a different strapi cloud project.
- Expected: target environment should be removed from `.strapi-config.json` file

**Test Case 7: Only environment linked** 

- Steps: In a project with only production environment, link production environment and then use the link command again
- Expected: Rejected operation with log ` The only available environment is already linked. You can add a new one from your project settings on the Strapi Cloud dashboard.`
