### PR TITLE
chore: reuse DocumentStatus in history and preview

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionsList.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
 import { useQueryParams } from '@strapi/admin/strapi-admin';
-import { Box, Flex, Typography, type BoxProps } from '@strapi/design-system';
+import { Box, Flex, Typography } from '@strapi/design-system';
 import { stringify } from 'qs';
-import { type MessageDescriptor, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { RelativeTime } from '../../components/RelativeTime';
+import { DocumentStatus } from '../../pages/EditView/components/DocumentStatus';
 import { getDisplayName } from '../../utils/users';
 import { useHistoryContext } from '../pages/History';
 
@@ -26,13 +27,6 @@ const BlueText = (children: React.ReactNode) => (
  * VersionCard
  * -----------------------------------------------------------------------------------------------*/
 
-interface StatusData {
-  background: BoxProps['background'];
-  border: BoxProps['borderColor'];
-  text: BoxProps['color'];
-  message: MessageDescriptor;
-}
-
 interface VersionCardProps {
   version: HistoryVersions.HistoryVersionDataResponse;
   isCurrent: boolean;
@@ -41,42 +35,6 @@ interface VersionCardProps {
 const VersionCard = ({ version, isCurrent }: VersionCardProps) => {
   const { formatDate, formatMessage } = useIntl();
   const [{ query }] = useQueryParams<{ id?: string }>();
-
-  const statusData = ((): StatusData => {
-    switch (version.status) {
-      case 'draft':
-        return {
-          background: 'secondary100',
-          border: 'secondary200',
-          text: 'secondary700',
-          message: {
-            id: 'content-manager.containers.List.draft',
-            defaultMessage: 'Draft',
-          },
-        };
-      case 'modified':
-        return {
-          background: 'alternative100',
-          border: 'alternative200',
-          text: 'alternative700',
-          message: {
-            id: 'content-manager.containers.List.modified',
-            defaultMessage: 'Modified',
-          },
-        };
-      case 'published':
-      default:
-        return {
-          background: 'success100',
-          border: 'success200',
-          text: 'success700',
-          message: {
-            id: 'content-manager.containers.List.published',
-            defaultMessage: 'Published',
-          },
-        };
-    }
-  })();
   const isActive = query.id === version.id.toString();
   const author = version.createdBy && getDisplayName(version.createdBy);
 
@@ -122,23 +80,7 @@ const VersionCard = ({ version, isCurrent }: VersionCardProps) => {
           )}
         </Typography>
       </Flex>
-      {version.status && (
-        <Box
-          background={statusData.background}
-          borderStyle="solid"
-          borderWidth="1px"
-          borderColor={statusData.border}
-          hasRadius
-          paddingLeft="6px"
-          paddingRight="6px"
-          paddingTop="2px"
-          paddingBottom="2px"
-        >
-          <Typography variant="pi" fontWeight="bold" textColor={statusData.text}>
-            {formatMessage(statusData.message)}
-          </Typography>
-        </Box>
-      )}
+      {version.status && <DocumentStatus status={version.status} size="XS" />}
     </Flex>
   );
 };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 
 import { capitalise } from '../../../utils/strings';
 
-interface DocumentStatusProps extends Omit<StatusProps, 'children' | 'size' | 'variant'> {
+interface DocumentStatusProps extends Omit<StatusProps, 'children' | 'variant'> {
   /**
    * The status of the document (draft, published, etc.)
    * @default 'draft'
@@ -16,14 +16,14 @@ interface DocumentStatusProps extends Omit<StatusProps, 'children' | 'size' | 'v
  * @description Displays the status of a document (draft, published, etc.)
  * and automatically calculates the appropriate variant for the status.
  */
-const DocumentStatus = ({ status = 'draft', ...restProps }: DocumentStatusProps) => {
+const DocumentStatus = ({ status = 'draft', size = 'S', ...restProps }: DocumentStatusProps) => {
   const statusVariant =
     status === 'draft' ? 'secondary' : status === 'published' ? 'success' : 'alternative';
 
   const { formatMessage } = useIntl();
 
   return (
-    <Status {...restProps} size={'S'} variant={statusVariant}>
+    <Status {...restProps} size={size} variant={statusVariant}>
       <Typography tag="span" variant="omega" fontWeight="bold">
         {formatMessage({
           id: `content-manager.containers.List.${status}`,

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -6,12 +6,13 @@ import {
   useNotification,
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
-import { Box, type BoxProps, Flex, IconButton, Typography } from '@strapi/design-system';
+import { Flex, IconButton, Typography } from '@strapi/design-system';
 import { Cross, Link as LinkIcon } from '@strapi/icons';
 import { stringify } from 'qs';
-import { type MessageDescriptor, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link, type To, useNavigate } from 'react-router-dom';
 
+import { DocumentStatus } from '../../pages/EditView/components/DocumentStatus';
 import { getDocumentStatus } from '../../pages/EditView/EditViewPage';
 import { usePreviewContext } from '../pages/Preview';
 
@@ -64,91 +65,23 @@ const ClosePreviewButton = () => {
 };
 
 /* -------------------------------------------------------------------------------------------------
- * DocumentStatus
+ * Status
  * -----------------------------------------------------------------------------------------------*/
 
-interface StatusData {
-  background: BoxProps['background'];
-  border: BoxProps['borderColor'];
-  text: BoxProps['color'];
-  message: MessageDescriptor;
-}
-
-const getStatusData = (status: ReturnType<typeof getDocumentStatus>): StatusData => {
-  switch (status) {
-    case 'draft':
-      return {
-        background: 'secondary100',
-        border: 'secondary200',
-        text: 'secondary700',
-        message: {
-          id: 'content-manager.containers.List.draft',
-          defaultMessage: 'Draft',
-        },
-      };
-    case 'modified':
-      return {
-        background: 'alternative100',
-        border: 'alternative200',
-        text: 'alternative700',
-        message: {
-          id: 'content-manager.containers.List.modified',
-          defaultMessage: 'Modified',
-        },
-      };
-    case 'published':
-    default:
-      return {
-        background: 'success100',
-        border: 'success200',
-        text: 'success700',
-        message: {
-          id: 'content-manager.containers.List.published',
-          defaultMessage: 'Published',
-        },
-      };
-  }
-};
-
-const DocumentStatus = () => {
-  const { formatMessage } = useIntl();
-
+const Status = () => {
   // Get status
   const document = usePreviewContext('PreviewHeader', (state) => state.document);
   const schema = usePreviewContext('PreviewHeader', (state) => state.schema);
   const meta = usePreviewContext('PreviewHeader', (state) => state.meta);
   const hasDraftAndPublished = schema?.options?.draftAndPublish ?? false;
-  const status = getDocumentStatus(document, meta);
-
-  const statusData = getStatusData(status);
 
   if (!hasDraftAndPublished) {
     return null;
   }
 
-  /**
-   * TODO: Add an XS size to the Status component from the design system so that we can add
-   * a variant to the VersionsList component.
-   * Then we could reuse it both here and in history's VersionCard component.
-   */
+  const status = getDocumentStatus(document, meta);
 
-  return (
-    <Box
-      background={statusData.background}
-      borderStyle="solid"
-      borderWidth="1px"
-      borderColor={statusData.border}
-      hasRadius
-      paddingLeft="6px"
-      paddingRight="6px"
-      paddingTop="2px"
-      paddingBottom="2px"
-    >
-      <Typography variant="pi" fontWeight="bold" textColor={statusData.text}>
-        {formatMessage(statusData.message)}
-      </Typography>
-    </Box>
-  );
+  return <DocumentStatus status={status} size="XS" />;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -189,7 +122,7 @@ const PreviewHeader = () => {
         <Typography tag="h1" fontWeight={600} fontSize={2}>
           {title}
         </Typography>
-        <DocumentStatus />
+        <Status />
       </Flex>
       <IconButton
         type="button"


### PR DESCRIPTION
### What does it do?

Reuses the CM's DocumentStatus component in History and Preview. It wasn't possible before because it didn't have an XS size variant, but now it does thanks to the last RC and [this PR](https://github.com/strapi/design-system/pull/1801)

### Why is it needed?

Love deleting code

### How to test it?

Check the status in the history sidebar and in the preview header. Nothing should have changed.