### PR TITLE
fix: stage change should not update modified status

### DIFF
--- a/packages/core/review-workflows/server/src/controllers/assignees.ts
+++ b/packages/core/review-workflows/server/src/controllers/assignees.ts
@@ -60,12 +60,7 @@ export default {
 
     await workflowService.assertContentTypeBelongsToWorkflow(model);
 
-    const updatedEntity = await assigneeService.updateEntityAssignee(
-      documentId,
-      locale || null,
-      model,
-      assigneeId
-    );
+    const updatedEntity = await assigneeService.updateEntityAssignee(entity, model, assigneeId);
 
     ctx.body = { data: await sanitizeOutput(updatedEntity) };
   },

--- a/packages/core/review-workflows/server/src/controllers/stages.ts
+++ b/packages/core/review-workflows/server/src/controllers/stages.ts
@@ -122,12 +122,7 @@ export default {
     const workflow = await workflowService.assertContentTypeBelongsToWorkflow(modelUID);
     workflowService.assertStageBelongsToWorkflow(stageId, workflow);
 
-    const updatedEntity = await stagesService.updateEntity(
-      entity.documentId,
-      entity.locale,
-      modelUID,
-      stageId
-    );
+    const updatedEntity = await stagesService.updateEntity(entity, modelUID, stageId);
 
     ctx.body = { data: await sanitizeOutput(updatedEntity) };
   },

--- a/packages/core/review-workflows/server/src/services/assignees.ts
+++ b/packages/core/review-workflows/server/src/services/assignees.ts
@@ -1,4 +1,4 @@
-import type { Core, UID } from '@strapi/types';
+import type { Core, UID, Modules } from '@strapi/types';
 import { errors } from '@strapi/utils';
 import { isNil } from 'lodash/fp';
 import { ENTITY_ASSIGNEE_ATTRIBUTE } from '../constants/workflows';
@@ -10,7 +10,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
   const metrics = getService('workflow-metrics', { strapi });
 
   return {
-    async findEntityAssigneeId(id: string, model: UID.ContentType) {
+    async findEntityAssigneeId(id: string | number, model: UID.ContentType) {
       const entity = await strapi.db.query(model).findOne({
         where: { id },
         populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
@@ -31,26 +31,25 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         updatedAt: string;
       },
       model: UID.ContentType,
-      assigneeId: string
+      assigneeId: string | null
     ) {
       const { documentId, locale } = entityToUpdate;
 
-      if (isNil(assigneeId)) {
-        return this.deleteEntityAssignee(documentId, locale, model);
+      if (!isNil(assigneeId)) {
+        const userExists = await getAdminService('user', { strapi }).exists({ id: assigneeId });
+
+        if (!userExists) {
+          throw new ApplicationError(`Selected user does not exist`);
+        }
       }
 
-      const userExists = await getAdminService('user', { strapi }).exists({ id: assigneeId });
-
-      if (!userExists) {
-        throw new ApplicationError(`Selected user does not exist`);
-      }
-
-      metrics.sendDidEditAssignee(await this.findEntityAssigneeId(documentId, model), assigneeId);
+      const oldAssigneeId = await this.findEntityAssigneeId(entityToUpdate.id, model);
+      metrics.sendDidEditAssignee(oldAssigneeId, assigneeId || null);
 
       const entity = await strapi.documents(model).update({
         documentId,
         locale,
-        data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: assigneeId },
+        data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: assigneeId || null },
         populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
         fields: [],
       });
@@ -68,18 +67,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         });
 
       return entity;
-    },
-
-    async deleteEntityAssignee(documentId: string, locale: string, model: UID.ContentType) {
-      metrics.sendDidEditAssignee(await this.findEntityAssigneeId(documentId, model), null);
-
-      return strapi.documents(model).update({
-        documentId,
-        locale,
-        data: { [ENTITY_ASSIGNEE_ATTRIBUTE]: null },
-        populate: [ENTITY_ASSIGNEE_ATTRIBUTE],
-        fields: [],
-      });
     },
   };
 };

--- a/packages/core/review-workflows/server/src/services/assignees.ts
+++ b/packages/core/review-workflows/server/src/services/assignees.ts
@@ -56,6 +56,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       });
 
       // Update the `updated_at` field of the entity, so that the `status` is not considered `Modified`
+      // NOTE: `updatedAt` is a protected attribute that can not be modified directly from the query layer
+      //        hence the knex query builder is used here.
       const { tableName } = strapi.db.metadata.get(model);
       await strapi.db
         .connection()

--- a/packages/core/review-workflows/server/src/services/assignees.ts
+++ b/packages/core/review-workflows/server/src/services/assignees.ts
@@ -59,8 +59,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       //        hence the knex query builder is used here.
       const { tableName } = strapi.db.metadata.get(model);
       await strapi.db
-        .connection()
-        .from(tableName)
+        .connection(tableName)
         .where({ id: entityToUpdate.id })
         .update({
           updated_at: new Date(entityToUpdate.updatedAt),

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -231,8 +231,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       //        hence the knex query builder is used here.
       const { tableName } = strapi.db.metadata.get(model);
       await strapi.db
-        .connection()
-        .from(tableName)
+        .connection(tableName)
         .where({ id: entityToUpdate.id })
         .update({
           updated_at: new Date(entityToUpdate.updatedAt),

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -227,6 +227,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       });
 
       // Update the `updated_at` field of the entity, so that the `status` is not considered `Modified`
+      // NOTE: `updatedAt` is a protected attribute that can not be modified directly from the query layer
+      //        hence the knex query builder is used here.
       const { tableName } = strapi.db.metadata.get(model);
       await strapi.db
         .connection()

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -198,8 +198,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     /**
      * Update the stage of an entity
      */
-    async updateEntity(documentId: string, locale: string, model: UID.ContentType, stageId: any) {
+    async updateEntity(
+      entityToUpdate: {
+        id: number | string;
+        documentId: string;
+        locale: string;
+        updatedAt: string;
+      },
+      model: UID.ContentType,
+      stageId: any
+    ) {
       const stage = await this.findById(stageId);
+      const { documentId, locale } = entityToUpdate;
 
       await workflowValidator.validateWorkflowCount();
 
@@ -215,6 +225,16 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         data: { [ENTITY_STAGE_ATTRIBUTE]: pick(['id'], stage) },
         populate: [ENTITY_STAGE_ATTRIBUTE],
       });
+
+      // Update the `updated_at` field of the entity, so that the `status` is not considered `Modified`
+      const { tableName } = strapi.db.metadata.get(model);
+      await strapi.db
+        .connection()
+        .from(tableName)
+        .where({ id: entityToUpdate.id })
+        .update({
+          updated_at: new Date(entityToUpdate.updatedAt),
+        });
 
       metrics.sendDidChangeEntryStage();
 

--- a/tests/api/core/review-workflows/review-workflows.test.api.ts
+++ b/tests/api/core/review-workflows/review-workflows.test.api.ts
@@ -80,6 +80,17 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   };
 
+  const updateStage = async (uid, id, stage, locale = undefined) => {
+    const { body, status } = await requests.admin({
+      method: 'PUT',
+      url: `/review-workflows/content-manager/collection-types/${uid}/${id}/stage`,
+      body: {
+        data: { id: stage.id },
+      },
+      qs: { locale },
+    });
+    return { data: body.data, status, error: body.error };
+  };
   /**
    * Create a full access token to authenticate the content API with
    */
@@ -148,358 +159,212 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   });
 
-  describe('Get workflows', () => {
-    test("It shouldn't be available for public", async () => {
-      const res = await requests.public.get('/review-workflows/workflows');
+  describe('Workflow setup', () => {
+    describe('Get workflows', () => {
+      test("It shouldn't be available for public", async () => {
+        const res = await requests.public.get('/review-workflows/workflows');
 
-      if (hasRW) {
-        expect(res.status).toBe(401);
-      } else {
-        expect(res.status).toBe(404);
-        expect(Array.isArray(res.body)).toBeFalsy();
-      }
-    });
-
-    test('It should be available for every connected users (admin)', async () => {
-      const res = await requests.admin.get('/review-workflows/workflows');
-
-      if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(Array.isArray(res.body.data)).toBeTruthy();
-        // Why 2 workflows ? One added by the test, the other one should be the default workflow added in bootstrap
-        expect(res.body.data).toHaveLength(2);
-      } else {
-        expect(res.status).toBe(404);
-        expect(Array.isArray(res.body)).toBeFalsy();
-      }
-    });
-  });
-
-  describe('Create workflow', () => {
-    test('It should create a workflow without stages', async () => {
-      const res = await requests.admin.post('/review-workflows/workflows', {
-        body: {
-          data: {
-            name: 'testWorkflow',
-            stages: [],
-          },
-        },
+        if (hasRW) {
+          expect(res.status).toBe(401);
+        } else {
+          expect(res.status).toBe(404);
+          expect(Array.isArray(res.body)).toBeFalsy();
+        }
       });
 
-      expect(res.status).toBe(400);
-      expect(res.body.error.message).toBe('Can not create a workflow without stages');
+      test('It should be available for every connected users (admin)', async () => {
+        const res = await requests.admin.get('/review-workflows/workflows');
+
+        if (hasRW) {
+          expect(res.status).toBe(200);
+          expect(Array.isArray(res.body.data)).toBeTruthy();
+          // Why 2 workflows ? One added by the test, the other one should be the default workflow added in bootstrap
+          expect(res.body.data).toHaveLength(2);
+        } else {
+          expect(res.status).toBe(404);
+          expect(Array.isArray(res.body)).toBeFalsy();
+        }
+      });
     });
-    test('It should create a workflow with stages and required stage for publish', async () => {
-      const res = await requests.admin.post('/review-workflows/workflows?populate=stages', {
-        body: {
-          data: {
+
+    describe('Create workflow', () => {
+      test('It should create a workflow without stages', async () => {
+        const res = await requests.admin.post('/review-workflows/workflows', {
+          body: {
+            data: {
+              name: 'testWorkflow',
+              stages: [],
+            },
+          },
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error.message).toBe('Can not create a workflow without stages');
+      });
+      test('It should create a workflow with stages and required stage for publish', async () => {
+        const res = await requests.admin.post('/review-workflows/workflows?populate=stages', {
+          body: {
+            data: {
+              name: 'createdWorkflow',
+              stages: [
+                { name: 'Stage 1', color: '#343434' },
+                { name: 'Stage 2', color: '#141414' },
+              ],
+              stageRequiredToPublishName: 'Stage 2',
+            },
+          },
+        });
+
+        if (hasRW) {
+          expect(res.status).toBe(201);
+          expect(res.body.data).toMatchObject({
             name: 'createdWorkflow',
             stages: [
               { name: 'Stage 1', color: '#343434' },
               { name: 'Stage 2', color: '#141414' },
             ],
-            stageRequiredToPublishName: 'Stage 2',
-          },
-        },
-      });
+            stageRequiredToPublish: { name: 'Stage 2' },
+          });
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
 
-      if (hasRW) {
-        expect(res.status).toBe(201);
-        expect(res.body.data).toMatchObject({
-          name: 'createdWorkflow',
-          stages: [
-            { name: 'Stage 1', color: '#343434' },
-            { name: 'Stage 2', color: '#141414' },
-          ],
-          stageRequiredToPublish: { name: 'Stage 2' },
+        createdWorkflow = res.body.data;
+      });
+    });
+
+    describe('Update workflow', () => {
+      test('It should update a workflow', async () => {
+        const res = await requests.admin.put(`/review-workflows/workflows/${createdWorkflow.id}`, {
+          body: { data: { name: 'updatedWorkflow' } },
         });
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
 
-      createdWorkflow = res.body.data;
-    });
-  });
-
-  describe('Update workflow', () => {
-    test('It should update a workflow', async () => {
-      const res = await requests.admin.put(`/review-workflows/workflows/${createdWorkflow.id}`, {
-        body: { data: { name: 'updatedWorkflow' } },
+        if (hasRW) {
+          expect(res.status).toBe(200);
+          expect(res.body.data).toMatchObject({ name: 'updatedWorkflow' });
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
       });
 
-      if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(res.body.data).toMatchObject({ name: 'updatedWorkflow' });
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-
-    test('It should update a workflow with stages', async () => {
-      const res = await requests.admin.put(
-        `/review-workflows/workflows/${createdWorkflow.id}?populate=stages`,
-        {
-          body: {
-            data: {
-              name: 'updatedWorkflow',
-              stages: [
-                { id: createdWorkflow.stages[0].id, name: 'Stage 1_Updated' },
-                { name: 'Stage 2' },
-              ],
+      test('It should update a workflow with stages', async () => {
+        const res = await requests.admin.put(
+          `/review-workflows/workflows/${createdWorkflow.id}?populate=stages`,
+          {
+            body: {
+              data: {
+                name: 'updatedWorkflow',
+                stages: [
+                  { id: createdWorkflow.stages[0].id, name: 'Stage 1_Updated' },
+                  { name: 'Stage 2' },
+                ],
+              },
             },
-          },
-        }
-      );
-
-      if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(res.body.data).toMatchObject({
-          name: 'updatedWorkflow',
-          stages: [
-            { id: createdWorkflow.stages[0].id, name: 'Stage 1_Updated' },
-            { name: 'Stage 2' },
-          ],
-        });
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-  });
-
-  describe('Delete workflow', () => {
-    test('It should delete a workflow', async () => {
-      const createdRes = await requests.admin.post('/review-workflows/workflows', {
-        body: { data: { name: 'testWorkflow', stages: [{ name: 'Stage 1' }] } },
-      });
-
-      const res = await requests.admin.delete(
-        `/review-workflows/workflows/${createdRes.body.data.id}`
-      );
-
-      expect(res.status).toBe(200);
-      expect(res.body.data).toMatchObject({ name: 'testWorkflow' });
-    });
-    test("It shouldn't delete a workflow that does not exist", async () => {
-      const res = await requests.admin.delete(`/review-workflows/workflows/123456789`);
-
-      expect(res.status).toBe(404);
-      expect(res.body.data).toBeNull();
-    });
-  });
-
-  describe('Get stages', () => {
-    test("It shouldn't be available for public", async () => {
-      const res = await requests.public.get(
-        `/review-workflows/workflows/${testWorkflow.id}/stages`
-      );
-
-      if (hasRW) {
-        expect(res.status).toBe(401);
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-    test('It should be available for every connected users (admin)', async () => {
-      const res = await requests.admin.get(`/review-workflows/workflows/${testWorkflow.id}/stages`);
-
-      if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(Array.isArray(res.body.data)).toBeTruthy();
-        expect(res.body.data).toHaveLength(2);
-      } else {
-        expect(res.status).toBe(404);
-        expect(Array.isArray(res.body)).toBeFalsy();
-      }
-    });
-  });
-
-  describe('Get stage by id', () => {
-    test("It shouldn't be available for public", async () => {
-      const res = await requests.public.get(
-        `/review-workflows/workflows/${testWorkflow.id}/stages/${secondStage.id}`
-      );
-
-      if (hasRW) {
-        expect(res.status).toBe(401);
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-    test('It should be available for every connected users (admin)', async () => {
-      const res = await requests.admin.get(
-        `/review-workflows/workflows/${testWorkflow.id}/stages/${secondStage.id}`
-      );
-
-      if (hasRW) {
-        expect(res.status).toBe(200);
-        expect(res.body.data).toBeInstanceOf(Object);
-        expect(res.body.data).toEqual(secondStage);
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-  });
-
-  describe('Publishing entries with required stage for publish', () => {
-    beforeAll(async () => {
-      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-        body: { data: { contentTypes: [productUID] } },
-      });
-    });
-
-    afterAll(async () => {
-      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-        body: { data: { contentTypes: [] } },
-      });
-    });
-
-    test('It should publish an entry if the required stage for publish is set', async () => {
-      const entry = await createEntry(productUID, { name: 'Product' });
-
-      const res = await requests.admin.put(
-        `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
-        {
-          body: { data: { id: secondStage.id } },
-        }
-      );
-
-      expect(res.status).toBe(200);
-
-      const publishRes = await publishEntry(productUID, entry.documentId);
-      expect(publishRes.status).toBe(200);
-    });
-
-    test('It should not publish an entry if the required stage for publish is not set', async () => {
-      const entry = await createEntry(productUID, { name: 'Product' });
-
-      const publishRes = await publishEntry(productUID, entry.documentId);
-
-      expect(publishRes.status).toBe(400);
-    });
-  });
-
-  describe('Replace stages of a workflow', () => {
-    let stagesUpdateData;
-
-    beforeEach(() => {
-      stagesUpdateData = [
-        defaultStage,
-        { id: secondStage.id, name: 'new_name' },
-        { name: 'new stage' },
-      ];
-    });
-
-    test("It should assign a default color to stages if they don't have one", async () => {
-      const workflowRes = await requests.admin.put(
-        `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
-        {
-          body: {
-            data: {
-              stages: [
-                defaultStage,
-                { id: secondStage.id, name: secondStage.name, color: '#000000' },
-              ],
-            },
-          },
-        }
-      );
-
-      expect(workflowRes.status).toBe(200);
-      expect(workflowRes.body.data.stages[0].color).toBe('#4945FF');
-      expect(workflowRes.body.data.stages[1].color).toBe('#000000');
-    });
-    test("It shouldn't be available for public", async () => {
-      const workflowsRes = await requests.public.get(`/review-workflows/workflows?populate=*`);
-
-      if (hasRW) {
-        expect(workflowsRes.status).toBe(401);
-      } else {
-        expect(workflowsRes.status).toBe(404);
-        expect(workflowsRes.body.data).toBeUndefined();
-      }
-    });
-    test('It should be available for every connected users (admin)', async () => {
-      const workflowRes = await requests.admin.put(
-        `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
-        { body: { data: { stages: stagesUpdateData } } }
-      );
-
-      if (hasRW) {
-        expect(workflowRes.status).toBe(200);
-        expect(workflowRes.body.data).toBeInstanceOf(Object);
-        expect(workflowRes.body.data.stages).toBeInstanceOf(Array);
-        expect(workflowRes.body.data.stages[0]).toMatchObject(
-          omit(['updatedAt'], stagesUpdateData[0])
+          }
         );
-        expect(workflowRes.body.data.stages[1]).toMatchObject(
-          omit(['updatedAt'], stagesUpdateData[1])
-        );
-        expect(workflowRes.body.data.stages[2]).toMatchObject({
-          id: expect.any(Number),
-          ...omit(['updatedAt'], stagesUpdateData[2]),
-        });
-      } else {
-        expect(workflowRes.status).toBe(404);
-        expect(workflowRes.body.data).toBeUndefined();
-      }
-    });
-    test('It should throw an error if trying to delete all stages in a workflow', async () => {
-      const workflowRes = await requests.admin.put(
-        `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
-        { body: { data: { stages: [] } } }
-      );
 
-      if (hasRW) {
-        expect(workflowRes.status).toBe(400);
-        expect(workflowRes.body.error).toBeDefined();
-        expect(workflowRes.body.error.name).toEqual('ValidationError');
-      } else {
-        expect(workflowRes.status).toBe(404);
-        expect(workflowRes.body.data).toBeUndefined();
-      }
-    });
-    test('It should throw an error if trying to create stages with duplicated names', async () => {
-      const stagesRes = await requests.admin.put(
-        `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
-        {
-          body: {
-            data: {
-              stages: [{ name: 'To Do' }, { name: 'To Do' }],
-            },
-          },
+        if (hasRW) {
+          expect(res.status).toBe(200);
+          expect(res.body.data).toMatchObject({
+            name: 'updatedWorkflow',
+            stages: [
+              { id: createdWorkflow.stages[0].id, name: 'Stage 1_Updated' },
+              { name: 'Stage 2' },
+            ],
+          });
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
         }
-      );
-
-      if (hasRW) {
-        expect(stagesRes.status).toBe(400);
-        expect(stagesRes.body.error).toBeDefined();
-        expect(stagesRes.body.error.name).toEqual('ValidationError');
-        expect(stagesRes.body.error.message).toBeDefined();
-      }
+      });
     });
-    test('It should throw an error if trying to create more than 200 stages', async () => {
-      const stagesRes = await requests.admin.put(
-        `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
-        { body: { data: { stages: Array(201).fill({ name: 'new stage' }) } } }
-      );
 
-      if (hasRW) {
-        expect(stagesRes.status).toBe(400);
-        expect(stagesRes.body.error).toBeDefined();
-        expect(stagesRes.body.error.name).toEqual('ValidationError');
-        expect(stagesRes.body.error.message).toBeDefined();
-      }
+    describe('Delete workflow', () => {
+      test('It should delete a workflow', async () => {
+        const createdRes = await requests.admin.post('/review-workflows/workflows', {
+          body: { data: { name: 'testWorkflow', stages: [{ name: 'Stage 1' }] } },
+        });
+
+        const res = await requests.admin.delete(
+          `/review-workflows/workflows/${createdRes.body.data.id}`
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toMatchObject({ name: 'testWorkflow' });
+      });
+      test("It shouldn't delete a workflow that does not exist", async () => {
+        const res = await requests.admin.delete(`/review-workflows/workflows/123456789`);
+
+        expect(res.status).toBe(404);
+        expect(res.body.data).toBeNull();
+      });
     });
   });
 
-  describe('Update assignee on an entity', () => {
-    describe('Review Workflow is enabled', () => {
+  describe('Stage setup', () => {
+    describe('Get stages', () => {
+      test("It shouldn't be available for public", async () => {
+        const res = await requests.public.get(
+          `/review-workflows/workflows/${testWorkflow.id}/stages`
+        );
+
+        if (hasRW) {
+          expect(res.status).toBe(401);
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
+      });
+      test('It should be available for every connected users (admin)', async () => {
+        const res = await requests.admin.get(
+          `/review-workflows/workflows/${testWorkflow.id}/stages`
+        );
+
+        if (hasRW) {
+          expect(res.status).toBe(200);
+          expect(Array.isArray(res.body.data)).toBeTruthy();
+          expect(res.body.data).toHaveLength(2);
+        } else {
+          expect(res.status).toBe(404);
+          expect(Array.isArray(res.body)).toBeFalsy();
+        }
+      });
+    });
+
+    describe('Get stage by id', () => {
+      test("It shouldn't be available for public", async () => {
+        const res = await requests.public.get(
+          `/review-workflows/workflows/${testWorkflow.id}/stages/${secondStage.id}`
+        );
+
+        if (hasRW) {
+          expect(res.status).toBe(401);
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
+      });
+      test('It should be available for every connected users (admin)', async () => {
+        const res = await requests.admin.get(
+          `/review-workflows/workflows/${testWorkflow.id}/stages/${secondStage.id}`
+        );
+
+        if (hasRW) {
+          expect(res.status).toBe(200);
+          expect(res.body.data).toBeInstanceOf(Object);
+          expect(res.body.data).toEqual(secondStage);
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
+      });
+    });
+  });
+
+  describe('Assignee updates in Content Manager', () => {
+    describe('Can update assignee on an entity if review workflow is enabled', () => {
       beforeAll(async () => {
         // Assign Product to workflow so workflow is active on this CT
         await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
@@ -520,6 +385,7 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
           // TODO: Test with other locales
           qs: { locale: undefined },
         });
+
         expect(response.status).toBe(200);
         const assignee = response.body.data[ENTITY_ASSIGNEE_ATTRIBUTE];
         expect(assignee.id).toEqual(user.id);
@@ -586,7 +452,57 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
       });
     });
 
-    describe('Review Workflow is disabled', () => {
+    describe("Document Status should not change to 'Modified' when modifying the assignee", () => {
+      test('When updating the assignee', async () => {
+        const entry = await createEntry(productUID, { name: 'Product' });
+
+        // Update stage to make entry publishable
+        await updateStage(productUID, entry.documentId, secondStage);
+        await publishEntry(productUID, entry.documentId);
+
+        // Update the assignee of the entry
+        const user = requests.admin.getLoggedUser();
+        await requests.admin.put(
+          `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/assignee`,
+          {
+            body: { data: { id: user.id } },
+          }
+        );
+
+        // Find entity and check its status
+        const updatedEntry = await requests.admin.get(
+          `/content-manager/collection-types/${productUID}/${entry.documentId}`
+        );
+
+        expect(updatedEntry.body.data.status).toBe('published');
+      });
+
+      test('When removing the assignee', async () => {
+        const entry = await createEntry(productUID, { name: 'Product' });
+
+        // Update stage to make entry publishable
+        await updateStage(productUID, entry.documentId, secondStage);
+        await publishEntry(productUID, entry.documentId);
+
+        // Update the assignee of the entry
+        const user = requests.admin.getLoggedUser();
+        await requests.admin.put(
+          `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/assignee`,
+          {
+            body: { data: null },
+          }
+        );
+
+        // Find entity and check its status
+        const updatedEntry = await requests.admin.get(
+          `/content-manager/collection-types/${productUID}/${entry.documentId}`
+        );
+
+        expect(updatedEntry.body.data.status).toBe('published');
+      });
+    });
+
+    describe('Cannot update assignee on an entity if review workflow is disabled', () => {
       beforeAll(async () => {
         // Unassign Product to workflow so workflow is inactive on this CT
         await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
@@ -617,8 +533,348 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
     });
   });
 
-  describe('Update a stage on an entity', () => {
-    describe('Review Workflow is enabled', () => {
+  describe('Stage updates in Content Manager', () => {
+    describe('Publishing entries with required stage for publish', () => {
+      beforeAll(async () => {
+        await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+          body: { data: { contentTypes: [productUID] } },
+        });
+      });
+
+      afterAll(async () => {
+        await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+          body: { data: { contentTypes: [] } },
+        });
+      });
+
+      test('It should publish an entry if the required stage for publish is set', async () => {
+        const entry = await createEntry(productUID, { name: 'Product' });
+
+        const res = await requests.admin.put(
+          `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
+          {
+            body: { data: { id: secondStage.id } },
+          }
+        );
+
+        expect(res.status).toBe(200);
+
+        const publishRes = await publishEntry(productUID, entry.documentId);
+        expect(publishRes.status).toBe(200);
+      });
+
+      test('It should not publish an entry if the required stage for publish is not set', async () => {
+        const entry = await createEntry(productUID, { name: 'Product' });
+
+        const publishRes = await publishEntry(productUID, entry.documentId);
+
+        expect(publishRes.status).toBe(400);
+      });
+    });
+
+    describe('Replace stages of a workflow', () => {
+      let stagesUpdateData;
+
+      beforeEach(() => {
+        stagesUpdateData = [
+          defaultStage,
+          { id: secondStage.id, name: 'new_name' },
+          { name: 'new stage' },
+        ];
+      });
+
+      test("It should assign a default color to stages if they don't have one", async () => {
+        const workflowRes = await requests.admin.put(
+          `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+          {
+            body: {
+              data: {
+                stages: [
+                  defaultStage,
+                  { id: secondStage.id, name: secondStage.name, color: '#000000' },
+                ],
+              },
+            },
+          }
+        );
+
+        expect(workflowRes.status).toBe(200);
+        expect(workflowRes.body.data.stages[0].color).toBe('#4945FF');
+        expect(workflowRes.body.data.stages[1].color).toBe('#000000');
+      });
+      test("It shouldn't be available for public", async () => {
+        const workflowsRes = await requests.public.get(`/review-workflows/workflows?populate=*`);
+
+        if (hasRW) {
+          expect(workflowsRes.status).toBe(401);
+        } else {
+          expect(workflowsRes.status).toBe(404);
+          expect(workflowsRes.body.data).toBeUndefined();
+        }
+      });
+      test('It should be available for every connected users (admin)', async () => {
+        const workflowRes = await requests.admin.put(
+          `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+          { body: { data: { stages: stagesUpdateData } } }
+        );
+
+        if (hasRW) {
+          expect(workflowRes.status).toBe(200);
+          expect(workflowRes.body.data).toBeInstanceOf(Object);
+          expect(workflowRes.body.data.stages).toBeInstanceOf(Array);
+          expect(workflowRes.body.data.stages[0]).toMatchObject(
+            omit(['updatedAt'], stagesUpdateData[0])
+          );
+          expect(workflowRes.body.data.stages[1]).toMatchObject(
+            omit(['updatedAt'], stagesUpdateData[1])
+          );
+          expect(workflowRes.body.data.stages[2]).toMatchObject({
+            id: expect.any(Number),
+            ...omit(['updatedAt'], stagesUpdateData[2]),
+          });
+        } else {
+          expect(workflowRes.status).toBe(404);
+          expect(workflowRes.body.data).toBeUndefined();
+        }
+      });
+      test('It should throw an error if trying to delete all stages in a workflow', async () => {
+        const workflowRes = await requests.admin.put(
+          `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+          { body: { data: { stages: [] } } }
+        );
+
+        if (hasRW) {
+          expect(workflowRes.status).toBe(400);
+          expect(workflowRes.body.error).toBeDefined();
+          expect(workflowRes.body.error.name).toEqual('ValidationError');
+        } else {
+          expect(workflowRes.status).toBe(404);
+          expect(workflowRes.body.data).toBeUndefined();
+        }
+      });
+      test('It should throw an error if trying to create stages with duplicated names', async () => {
+        const stagesRes = await requests.admin.put(
+          `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+          {
+            body: {
+              data: {
+                stages: [{ name: 'To Do' }, { name: 'To Do' }],
+              },
+            },
+          }
+        );
+
+        if (hasRW) {
+          expect(stagesRes.status).toBe(400);
+          expect(stagesRes.body.error).toBeDefined();
+          expect(stagesRes.body.error.name).toEqual('ValidationError');
+          expect(stagesRes.body.error.message).toBeDefined();
+        }
+      });
+      test('It should throw an error if trying to create more than 200 stages', async () => {
+        const stagesRes = await requests.admin.put(
+          `/review-workflows/workflows/${testWorkflow.id}?populate=*`,
+          { body: { data: { stages: Array(201).fill({ name: 'new stage' }) } } }
+        );
+
+        if (hasRW) {
+          expect(stagesRes.status).toBe(400);
+          expect(stagesRes.body.error).toBeDefined();
+          expect(stagesRes.body.error.name).toEqual('ValidationError');
+          expect(stagesRes.body.error.message).toBeDefined();
+        }
+      });
+    });
+
+    describe('Update a stage on an entity', () => {
+      describe('Review Workflow is enabled', () => {
+        beforeAll(async () => {
+          // Update workflow to assign content type
+          await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+            body: { data: { contentTypes: [productUID] } },
+          });
+        });
+
+        test('Should update the accordingly on an entity', async () => {
+          const entry = await createEntry(productUID, { name: 'Product' });
+
+          const { status, data } = await updateStage(
+            productUID,
+            entry.documentId,
+            secondStage,
+            entry.locale
+          );
+
+          expect(status).toBe(200);
+          expect(data[ENTITY_STAGE_ATTRIBUTE]).toEqual(
+            expect.objectContaining({ id: secondStage.id })
+          );
+        });
+
+        test('Should throw an error if stage does not belong to the workflow', async () => {
+          const entry = await createEntry(productUID, { name: 'Product' });
+
+          const { status, error } = await updateStage(
+            productUID,
+            entry.documentId,
+            { id: 1234 },
+            entry.locale
+          );
+
+          expect(status).toBe(400);
+          expect(error).toBeDefined();
+          expect(error.name).toEqual('ApplicationError');
+          expect(error.message).toEqual('Stage does not belong to workflow "workflow"');
+        });
+
+        test('Should return entity stage information to the content API', async () => {
+          const stageAttribute = 'strapi_stage';
+
+          const { status, body } = await requests.public.get(`/api/${model.pluralName}`, {
+            qs: { populate: stageAttribute, status: 'draft' },
+          });
+
+          expect(status).toBe(200);
+          expect(body.data.length).toBeGreaterThan(0);
+
+          body.data.forEach((item) => {
+            expect(item).toHaveProperty(stageAttribute);
+            expect(item[stageAttribute]).not.toBeNull();
+            expect(item[stageAttribute]).toHaveProperty('name');
+          });
+        });
+      });
+
+      describe('Review Workflow is disabled', () => {
+        beforeAll(async () => {
+          // Update workflow to unassign content type
+          await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+            body: { data: { contentTypes: [] } },
+          });
+        });
+        test('Should not update the entity', async () => {
+          const entry = await createEntry(productUID, { name: 'Product' });
+
+          const { status, error } = await updateStage(
+            productUID,
+            entry.documentId,
+            secondStage,
+            entry.locale
+          );
+
+          expect(status).toBe(400);
+          expect(error).toBeDefined();
+          expect(error.name).toBe('ApplicationError');
+        });
+      });
+    });
+
+    describe('Listing available stages for transition', () => {
+      const endpoint = (id) =>
+        `/review-workflows/content-manager/collection-types/${productUID}/${id}/stages`;
+
+      let utils;
+      let entry;
+      let restrictedRequest;
+      let restrictedUser;
+      let restrictedRole;
+
+      const deleteFixtures = async () => {
+        await utils.deleteUserById(restrictedUser.id);
+        await utils.deleteRolesById([restrictedRole.id]);
+      };
+
+      beforeAll(async () => {
+        // Update workflow to assign content type
+        await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
+          body: { data: { contentTypes: [productUID] } },
+        });
+
+        entry = await createEntry(productUID, { name: 'Product' });
+
+        utils = createUtils(strapi);
+        const role = await utils.createRole({
+          name: 'restricted-role',
+          description: '',
+        });
+        restrictedRole = role;
+
+        const restrictedUserInfo = {
+          email: 'restricted@user.io',
+          password: 'Restricted123',
+        };
+
+        restrictedUser = await utils.createUserIfNotExists({
+          ...restrictedUserInfo,
+          roles: [role.id],
+        });
+
+        // @ts-expect-error - We don't have the type for this
+        restrictedRequest = await createAuthRequest({ strapi, userInfo: restrictedUserInfo });
+      });
+
+      afterAll(async () => {
+        await deleteFixtures();
+      });
+
+      test("It shouldn't be available for public", async () => {
+        const res = await requests.public.get(endpoint(entry.documentId));
+
+        if (hasRW) {
+          expect(res.status).toBe(401);
+        } else {
+          expect(res.status).toBe(404);
+          expect(res.body.data).toBeUndefined();
+        }
+      });
+
+      test('It should return available stages for an admin user', async () => {
+        const res = await requests.admin.get(endpoint(entry.documentId));
+
+        expect(res.body.data).toHaveLength(1);
+        expect(res.body.data[0]).toMatchObject(secondStage);
+      });
+
+      test('It should be forbidden when the user cannot read the content type', async () => {
+        const res = await restrictedRequest.get(endpoint(entry.documentId));
+
+        expect(res.status).toBe(403);
+      });
+
+      test('It should return an empty list when a user does not have the permission to transition the current stage', async () => {
+        const permission = {
+          action: 'plugin::content-manager.explorer.read',
+          subject: productUID,
+          fields: null,
+          conditions: [],
+        };
+        await utils.assignPermissionsToRole(restrictedRole.id, [permission]);
+
+        const res = await restrictedRequest.get(endpoint(entry.documentId));
+
+        expect(res.body.data).toHaveLength(0);
+      });
+    });
+
+    test('Document Status should not change to "Modified" when updating the stage', async () => {
+      const entry = await createEntry(productUID, { name: 'Product-stage-status' });
+
+      // Update the stage of the entry so the entry its publishable
+      await updateStage(productUID, entry.documentId, secondStage);
+      await publishEntry(productUID, entry.documentId);
+
+      // Update the stage of the entry again
+      await updateStage(productUID, entry.documentId, defaultStage);
+
+      // Document status should be unchanged (published)
+      const updatedEntry = await requests.admin.get(
+        `/content-manager/collection-types/${productUID}/${entry.documentId}`
+      );
+
+      expect(updatedEntry.body.data.status).toBe('published');
+    });
+
+    describe('Deleting a stage when content already exists', () => {
       beforeAll(async () => {
         // Update workflow to assign content type
         await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
@@ -626,205 +882,28 @@ describeOnCondition(edition === 'EE')('Review workflows', () => {
         });
       });
 
-      test('Should update the accordingly on an entity', async () => {
-        const entry = await createEntry(productUID, { name: 'Product' });
+      test('When content exists in a review stage and this stage is deleted, the content should be moved to the nearest available stage', async () => {
+        const products = await findAll(productUID);
 
-        const response = await requests.admin({
-          method: 'PUT',
-          url: `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
-          body: {
-            data: { id: secondStage.id },
-          },
-          // TODO: Test with other locales
-          qs: { locale: entry.locale },
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.body.data[ENTITY_STAGE_ATTRIBUTE]).toEqual(
-          expect.objectContaining({ id: secondStage.id })
+        // Move half of the entries to the last stage,
+        // and the other half to the first stage
+        await async.map(products.results, async (entity) =>
+          updateEntry(productUID, entity.id, {
+            [ENTITY_STAGE_ATTRIBUTE]: entity.id % 2 ? defaultStage.id : secondStage.id,
+          })
         );
-      });
 
-      test('Should throw an error if stage does not belong to the workflow', async () => {
-        const entry = await createEntry(productUID, { name: 'Product' });
-
-        const response = await requests.admin({
-          method: 'PUT',
-          url: `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
-          body: {
-            data: { id: 1234 },
-          },
-          // TODO: Test with other locales
-          qs: { locale: entry.locale },
-        });
-
-        expect(response.status).toBe(400);
-        expect(response.body.error).toBeDefined();
-        expect(response.body.error.name).toEqual('ApplicationError');
-        expect(response.body.error.message).toEqual('Stage does not belong to workflow "workflow"');
-      });
-
-      test('Should return entity stage information to the content API', async () => {
-        const stageAttribute = 'strapi_stage';
-
-        const { status, body } = await requests.public.get(`/api/${model.pluralName}`, {
-          qs: { populate: stageAttribute, status: 'draft' },
-        });
-
-        expect(status).toBe(200);
-        expect(body.data.length).toBeGreaterThan(0);
-
-        body.data.forEach((item) => {
-          expect(item).toHaveProperty(stageAttribute);
-          expect(item[stageAttribute]).not.toBeNull();
-          expect(item[stageAttribute]).toHaveProperty('name');
-        });
-      });
-    });
-
-    describe('Review Workflow is disabled', () => {
-      beforeAll(async () => {
-        // Update workflow to unassign content type
+        // Delete last stage stage of the default workflow
         await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-          body: { data: { contentTypes: [] } },
-        });
-      });
-      test('Should not update the entity', async () => {
-        const entry = await createEntry(productUID, { name: 'Product' });
-
-        const response = await requests.admin({
-          method: 'PUT',
-          url: `/review-workflows/content-manager/collection-types/${productUID}/${entry.documentId}/stage`,
-          body: {
-            data: { id: secondStage.id },
-          },
-          // TODO: Test with other locales
-          qs: { locale: entry.locale },
+          body: { data: { stages: [defaultStage] } },
         });
 
-        expect(response.status).toBe(400);
-        expect(response.body.error).toBeDefined();
-        expect(response.body.error.name).toBe('ApplicationError');
+        // Expect the content in these stages to be moved to the nearest available stage
+        const productsAfter = await findAll(productUID);
+        for (const entry of productsAfter.results) {
+          expect(entry[ENTITY_STAGE_ATTRIBUTE].name).toEqual(defaultStage.name);
+        }
       });
-    });
-  });
-
-  describe('Listing available stages for transition', () => {
-    const endpoint = (id) =>
-      `/review-workflows/content-manager/collection-types/${productUID}/${id}/stages`;
-
-    let utils;
-    let entry;
-    let restrictedRequest;
-    let restrictedUser;
-    let restrictedRole;
-
-    const deleteFixtures = async () => {
-      await utils.deleteUserById(restrictedUser.id);
-      await utils.deleteRolesById([restrictedRole.id]);
-    };
-
-    beforeAll(async () => {
-      // Update workflow to assign content type
-      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-        body: { data: { contentTypes: [productUID] } },
-      });
-
-      entry = await createEntry(productUID, { name: 'Product' });
-
-      utils = createUtils(strapi);
-      const role = await utils.createRole({
-        name: 'restricted-role',
-        description: '',
-      });
-      restrictedRole = role;
-
-      const restrictedUserInfo = {
-        email: 'restricted@user.io',
-        password: 'Restricted123',
-      };
-
-      restrictedUser = await utils.createUserIfNotExists({
-        ...restrictedUserInfo,
-        roles: [role.id],
-      });
-
-      // @ts-expect-error - We don't have the type for this
-      restrictedRequest = await createAuthRequest({ strapi, userInfo: restrictedUserInfo });
-    });
-
-    afterAll(async () => {
-      await deleteFixtures();
-    });
-
-    test("It shouldn't be available for public", async () => {
-      const res = await requests.public.get(endpoint(entry.documentId));
-
-      if (hasRW) {
-        expect(res.status).toBe(401);
-      } else {
-        expect(res.status).toBe(404);
-        expect(res.body.data).toBeUndefined();
-      }
-    });
-
-    test('It should return available stages for an admin user', async () => {
-      const res = await requests.admin.get(endpoint(entry.documentId));
-
-      expect(res.body.data).toHaveLength(1);
-      expect(res.body.data[0]).toMatchObject(secondStage);
-    });
-
-    test('It should be forbidden when the user cannot read the content type', async () => {
-      const res = await restrictedRequest.get(endpoint(entry.documentId));
-
-      expect(res.status).toBe(403);
-    });
-
-    test('It should return an empty list when a user does not have the permission to transition the current stage', async () => {
-      const permission = {
-        action: 'plugin::content-manager.explorer.read',
-        subject: productUID,
-        fields: null,
-        conditions: [],
-      };
-      await utils.assignPermissionsToRole(restrictedRole.id, [permission]);
-
-      const res = await restrictedRequest.get(endpoint(entry.documentId));
-
-      expect(res.body.data).toHaveLength(0);
-    });
-  });
-
-  describe('Deleting a stage when content already exists', () => {
-    beforeAll(async () => {
-      // Update workflow to assign content type
-      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-        body: { data: { contentTypes: [productUID] } },
-      });
-    });
-
-    test('When content exists in a review stage and this stage is deleted, the content should be moved to the nearest available stage', async () => {
-      const products = await findAll(productUID);
-
-      // Move half of the entries to the last stage,
-      // and the other half to the first stage
-      await async.map(products.results, async (entity) =>
-        updateEntry(productUID, entity.id, {
-          [ENTITY_STAGE_ATTRIBUTE]: entity.id % 2 ? defaultStage.id : secondStage.id,
-        })
-      );
-
-      // Delete last stage stage of the default workflow
-      await requests.admin.put(`/review-workflows/workflows/${testWorkflow.id}?populate=*`, {
-        body: { data: { stages: [defaultStage] } },
-      });
-
-      // Expect the content in these stages to be moved to the nearest available stage
-      const productsAfter = await findAll(productUID);
-      for (const entry of productsAfter.results) {
-        expect(entry[ENTITY_STAGE_ATTRIBUTE].name).toEqual(defaultStage.name);
-      }
     });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Changing the stage/assignee attribute made the document status go from publshed to modifed, confusing the users.

This PR ensures changhing those values will not change the publicaton status of the document, by keeping the same updated at value when making the update on the entry.


### Why is it needed?

Describe the issue you are solving.

### How to test it?

Go to the Content Manager
Go to a content type with a review workflow assigned (you will need a paid license)
Go to an entry with a published state
Change the stage of this entry
You will see the state not changed from Published to Modified


### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/21429
