### PR TITLE
fix: run discardDrafts without concurrency

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -194,7 +194,9 @@ const migrateUp = async (trx: Knex, db: Database) => {
       });
 
     for await (const batch of getBatchToDiscard({ db, trx, uid: model.uid })) {
-      await async.map(batch, discardDraft, { concurrency: 10 });
+      // NOTE: concurrency had to be disabled to prevent a race condition with self-references
+      // TODO: improve performance in a safe way
+      await async.map(batch, discardDraft, { concurrency: 1 });
     }
   }
 };


### PR DESCRIPTION
### What does it do?

Removes concurrency from the discardDrafts migration

Unfortunately that means it will run slower, but we can work on safer performance improvements later and unblock those who are stuck upgrading to Strapi 5.

### Why is it needed?

When discardDrafts is run in parallel, there is something akin to a race condition where it tries to create relations to (or from?) an entity that is being changed at the same time. When run one at a time, the problem cannot occur.

Solves https://github.com/strapi/strapi/issues/21607

### How to test it?

Experimental: 0.0.0-experimental.a13c58eec89ab119f0e381fb79c0252979e9c125

In Strapi v4, with postgres:

- Create a `destination` schema like so:
```
{
  "kind": "collectionType",
  "collectionName": "destinations",
  "info": {
    "singularName": "destination",
    "pluralName": "destinations",
    "displayName": "Destinations",
    "description": ""
  },
  "options": {
    "draftAndPublish": true
  },
  "pluginOptions": {
    "i18n": {
      "localized": true
    },
    "preview-button": {
      "listViewColumn": true
    }
  },
  "attributes": {
    "children": {
      "displayName": "children",
      "type": "component",
      "repeatable": false,
      "pluginOptions": {
        "i18n": {
          "localized": true
        }
      },
      "component": "destinations.children"
    }
  }
}
```

and children component like:

```
{
  "collectionName": "components_destinations_children",
  "info": {
    "displayName": "children",
    "description": ""
  },
  "options": {},
  "attributes": {
    "children": {
      "type": "relation",
      "relation": "oneToMany",
      "target": "api::destination.destination"
    }
  }
}
```

- add a lot of data with self-references (I don't know the exact way to cause it, but the error happens when discardDrafts is run in parallel in a transaction and references an id that is being discarded at the same time I think)
- attempt to migrate to Strapi 5 _with `develop` branch_ and and you get an error about transaction
- attempt to migrate to Strapi 5 _with this branch_, and it works

All your data should be migrated properly

### Related issue(s)/PR(s)

Solves https://github.com/strapi/strapi/issues/21607

Might relate to https://github.com/strapi/strapi/issues/21848

DX-1717