### PR TITLE
feat: adding info diagnostics to data-transfer providers

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -604,8 +604,8 @@ class TransferEngine<
    */
   async bootstrap(): Promise<void> {
     const results = await Promise.allSettled([
-      this.sourceProvider.bootstrap?.(),
-      this.destinationProvider.bootstrap?.(),
+      this.sourceProvider.bootstrap?.(this.diagnostics),
+      this.destinationProvider.bootstrap?.(this.diagnostics),
     ]);
 
     results.forEach((result) => {

--- a/packages/core/data-transfer/types/providers.d.ts
+++ b/packages/core/data-transfer/types/providers.d.ts
@@ -6,6 +6,7 @@ import type {
   MaybePromise,
 } from './utils';
 import type { IMetadata } from './common-entities';
+import type { IDiagnosticReporter } from '../src/engine/diagnostic';
 
 export type ProviderType = 'source' | 'destination';
 
@@ -18,7 +19,7 @@ export interface IProvider {
    * bootstrap() is called during transfer engine bootstrap
    * It is used for initialization operations such as making a database connection, opening a file, checking authorization, etc
    */
-  bootstrap?(): MaybePromise<void>;
+  bootstrap?(diagnostics?: IDiagnosticReporter): MaybePromise<void>;
   close?(): MaybePromise<void>; // called during transfer engine close
 
   getMetadata(): MaybePromise<IMetadata | null>; // returns the transfer metadata to be used for version validation


### PR DESCRIPTION
### What does it do?

- Adds diagnostics to the providers of data-transfer so we can have logs and a log file with information for debugging issues

### Why is it needed?

- To make debugging DTS easier

### How to test it?

