### PR TITLE
test(e2e): change playwright timeouts

### DIFF
--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -11,55 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: .github/filters.yaml
-
-  pretty:
-    name: 'pretty (node: ${{ matrix.node }})'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 22]
-    steps:
-      - run: echo "Skipped"
-
-  lint:
-    name: 'lint (node: ${{ matrix.node }})'
-    needs: [build]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 22]
-    steps:
-      - run: echo "Skipped"
-
-  build:
-    name: 'build (node: ${{ matrix.node }})'
-    needs: [changes]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 22]
-    steps:
-      - run: echo "Skipped"
-
   typescript:
     name: 'typescript (node: ${{ matrix.node }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,7 +22,6 @@ jobs:
 
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,7 +31,6 @@ jobs:
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -89,7 +40,6 @@ jobs:
 
   e2e_ce:
     name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -100,7 +50,6 @@ jobs:
 
   e2e_ee:
     name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -111,7 +60,6 @@ jobs:
 
   cli:
     name: 'CLI Tests (node: ${{ matrix.node }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -121,7 +69,6 @@ jobs:
 
   api_ce_pg:
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -132,7 +79,6 @@ jobs:
 
   api_ce_mysql:
     name: '[CE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -143,7 +89,6 @@ jobs:
 
   api_ce_sqlite:
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -154,7 +99,6 @@ jobs:
 
   api_ee_pg:
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -165,7 +109,6 @@ jobs:
 
   api_ee_mysql:
     name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -176,7 +119,6 @@ jobs:
 
   api_ee_sqlite:
     name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
-    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -31,6 +31,25 @@ jobs:
         with:
           filters: .github/filters.yaml
 
+  pretty:
+    name: 'pretty (node: ${{ matrix.node }})'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - run: echo "Skipped"
+
+  lint:
+    name: 'lint (node: ${{ matrix.node }})'
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - run: echo "Skipped"
+
   build:
     name: 'build (node: ${{ matrix.node }})'
     needs: [changes]

--- a/.github/workflows/skipped_tests.yml
+++ b/.github/workflows/skipped_tests.yml
@@ -11,8 +11,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      api: ${{ steps.filter.outputs.api }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      cli: ${{ steps.filter.outputs.cli }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/filters.yaml
+
+  build:
+    name: 'build (node: ${{ matrix.node }})'
+    needs: [changes]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - run: echo "Skipped"
+
   typescript:
     name: 'typescript (node: ${{ matrix.node }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,6 +53,7 @@ jobs:
 
   unit_back:
     name: 'unit_back (node: ${{ matrix.node }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,6 +63,7 @@ jobs:
 
   unit_front:
     name: 'unit_front (node: ${{ matrix.node }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,6 +73,7 @@ jobs:
 
   e2e_ce:
     name: '[CE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,6 +84,7 @@ jobs:
 
   e2e_ee:
     name: '[EE] e2e (browser: ${{ matrix.project }}) (shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,6 +95,7 @@ jobs:
 
   cli:
     name: 'CLI Tests (node: ${{ matrix.node }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,6 +105,7 @@ jobs:
 
   api_ce_pg:
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,6 +116,7 @@ jobs:
 
   api_ce_mysql:
     name: '[CE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -89,6 +127,7 @@ jobs:
 
   api_ce_sqlite:
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -99,6 +138,7 @@ jobs:
 
   api_ee_pg:
     name: '[EE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -109,6 +149,7 @@ jobs:
 
   api_ee_mysql:
     name: '[EE] API Integration (mysql:latest, package: mysql2, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -119,6 +160,7 @@ jobs:
 
   api_ee_sqlite:
     name: '[EE] API Integration (sqlite, client: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
+    needs: [changes, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -37,15 +37,15 @@ const getEnvBool = (envVar, defaultValue) => {
 const createConfig = ({ port, testDir, appDir }) => ({
   testDir,
 
-  /* default timeout for a jest test to 30s */
-  timeout: getEnvNum(process.env.PLAYWRIGHT_TIMEOUT, 30 * 1000),
+  /* default timeout for a jest test */
+  timeout: getEnvNum(process.env.PLAYWRIGHT_TIMEOUT, 90 * 1000),
 
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: getEnvNum(process.env.PLAYWRIGHT_EXPECT_TIMEOUT, 20 * 1000),
+    timeout: getEnvNum(process.env.PLAYWRIGHT_EXPECT_TIMEOUT, 10 * 1000),
   },
   /* Run tests in files in parallel */
   fullyParallel: false,
@@ -65,8 +65,8 @@ const createConfig = ({ port, testDir, appDir }) => ({
     /** Set timezone for consistency across any machine*/
     timezoneId: 'Europe/Paris',
 
-    /* Default time each action such as `click()` can take to 20s */
-    actionTimeout: getEnvNum(process.env.PLAYWRIGHT_ACTION_TIMEOUT, 20 * 1000),
+    /* Default time each action such as `click()` can take */
+    actionTimeout: getEnvNum(process.env.PLAYWRIGHT_ACTION_TIMEOUT, 10 * 1000),
     // Only record trace when retrying a test to optimize test performance
     trace: 'on-first-retry',
     video: getEnvBool(process.env.PLAYWRIGHT_VIDEO, false)


### PR DESCRIPTION
### What does it do?

- increase overall test timeout
- decrease action and expect timeouts
- adds missing outputs to skipped_tests.yml (update: nope, this won't change anything, but for now I'll leave it to keep it in sync with test.yml)
 
### Why is it needed?

- to reduce incidence of flaky tests while also allowing them to fail faster
- I'm hoping that fixing the outputs also fixes handling of PRs that don't trigger any tests but don't have evidence yet; if this doesn't work then I'll follow up with something else

There are currently several tests that fail because they take too long. Efforts like [this](https://github.com/strapi/strapi/pull/22079) improve them, and we should continue to write shorter and more performant tests, but right now just having a couple of servers restarts is enough to make a test flaky because the CI is so slow

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22079
