### PR TITLE
fix(upload): draggable element style

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/AssetCard.tsx
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCard.tsx
@@ -22,6 +22,7 @@ interface AssetCardProps {
   size?: 'S' | 'M';
   allowedTypes?: AllowedTypes[];
   alt?: string;
+  className?: string;
 }
 
 export const AssetCard = ({
@@ -32,6 +33,7 @@ export const AssetCard = ({
   onRemove,
   size = 'M',
   local = false,
+  className,
 }: AssetCardProps) => {
   const handleSelect = onSelect ? () => onSelect(asset) : undefined;
 
@@ -47,6 +49,7 @@ export const AssetCard = ({
     onRemove: onRemove ? () => onRemove(asset) : undefined,
     selected: isSelected,
     size,
+    className,
   };
 
   if (asset.mime?.includes(AssetType.Video)) {

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCardBase.tsx
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCardBase.tsx
@@ -63,6 +63,7 @@ export interface AssetCardBaseProps {
   selected?: boolean;
   subtitle?: string;
   variant: 'Image' | 'Video' | 'Audio' | 'Doc';
+  className?: string;
 }
 
 export const AssetCardBase = ({
@@ -76,6 +77,7 @@ export const AssetCardBase = ({
   selected = false,
   subtitle = '',
   variant = 'Image',
+  className,
 }: AssetCardBaseProps) => {
   const { formatMessage } = useIntl();
 
@@ -95,7 +97,13 @@ export const AssetCardBase = ({
   };
 
   return (
-    <CardContainer role="button" height="100%" tabIndex={-1} onClick={handleClick}>
+    <CardContainer
+      className={className}
+      role="button"
+      height="100%"
+      tabIndex={-1}
+      onClick={handleClick}
+    >
       <CardHeader>
         {isSelectable && (
           <CardCheckboxWrapper onClick={handlePropagationClick}>

--- a/packages/core/upload/admin/src/components/AssetCard/AssetCardBase.tsx
+++ b/packages/core/upload/admin/src/components/AssetCard/AssetCardBase.tsx
@@ -27,10 +27,15 @@ const Extension = styled.span`
 
 const CardActionsContainer = styled(CardAction)`
   opacity: 0;
+  z-index: 1;
 
   &:focus-within {
     opacity: 1;
   }
+`;
+
+const CardCheckboxWrapper = styled.div`
+  z-index: 1;
 `;
 
 const CardContainer = styled(Card)`
@@ -93,9 +98,9 @@ export const AssetCardBase = ({
     <CardContainer role="button" height="100%" tabIndex={-1} onClick={handleClick}>
       <CardHeader>
         {isSelectable && (
-          <div onClick={handlePropagationClick}>
+          <CardCheckboxWrapper onClick={handlePropagationClick}>
             <CardCheckbox checked={selected} onCheckedChange={onSelect} />
-          </div>
+          </CardCheckboxWrapper>
         )}
         {(onRemove || onEdit) && (
           <CardActionsContainer onClick={handlePropagationClick} position="end">

--- a/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
+++ b/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
@@ -1,5 +1,6 @@
 // TODO: find a better naming convention for the file that was an index file before
 import { Box, Grid, KeyboardNavigable, Typography } from '@strapi/design-system';
+import styled from 'styled-components';
 
 import { AssetCard } from '../AssetCard/AssetCard';
 
@@ -7,6 +8,16 @@ import { Draggable } from './Draggable';
 
 import type { File } from '../../../../shared/contracts/files';
 import type { AllowedTypes } from '../AssetCard/AssetCard';
+
+const DraggableAssetCard = styled(AssetCard)`
+  && {
+    cursor: move;
+  }
+
+  &:hover {
+    transform: scale(1.05);
+  }
+`;
 
 export interface AssetGridListProps {
   allowedTypes?: AllowedTypes[];
@@ -47,7 +58,7 @@ export const AssetGridList = ({
             return (
               <Grid.Item key={asset.id} col={3} height="100%">
                 <Draggable index={index} moveItem={onReorderAsset} id={asset.id}>
-                  <AssetCard
+                  <DraggableAssetCard
                     allowedTypes={allowedTypes}
                     asset={asset}
                     isSelected={isSelected}

--- a/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
+++ b/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
@@ -1,6 +1,6 @@
 // TODO: find a better naming convention for the file that was an index file before
 import { Box, Grid, KeyboardNavigable, Typography } from '@strapi/design-system';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { AssetCard } from '../AssetCard/AssetCard';
 

--- a/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
+++ b/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
@@ -11,11 +11,11 @@ import type { AllowedTypes } from '../AssetCard/AssetCard';
 
 const DraggableAssetCard = styled(AssetCard)`
   && {
-    cursor: move;
-  }
+    cursor: grab;
 
-  &:hover {
-    transform: scale(1.05);
+    &:active {
+      cursor: grabbing;
+    }
   }
 `;
 

--- a/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
+++ b/packages/core/upload/admin/src/components/AssetGridList/AssetGridList.tsx
@@ -11,11 +11,7 @@ import type { AllowedTypes } from '../AssetCard/AssetCard';
 
 const DraggableAssetCard = styled(AssetCard)`
   && {
-    cursor: grab;
-
-    &:active {
-      cursor: grabbing;
-    }
+    cursor: inherit;
   }
 `;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I have fixed some issues with upload media files for example:
* Checkbox z-index with audio file
* Edit button with audio file
* Draggable media file style

### Why is it needed?

The main problem is that it is not obvious that you can change the order of files in the field

### How to test it?

1. Create media field with multiple files
2. Upload files
3. Select "Selected files"
4. Move files and change order.
5. Check action buttons position

Fixed issue
https://github.com/user-attachments/assets/826c887a-8a5e-4b94-a599-a4b72b40ba80

Expected behavior in browse tab
https://github.com/user-attachments/assets/55d7b3c9-ae04-4ffe-ad3c-3dff22a8709c


### Related issue(s)/PR(s)

#22097 