### PR TITLE
 chore: make ctb tests no longer rely on test order

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -14,27 +14,27 @@ test.describe('Edit collection type', () => {
   const attributes = [{ type: 'text', name: 'testtext' }];
 
   test.beforeEach(async ({ page }) => {
+    await resetFiles();
     await sharedSetup('ctb-edit-ct', page, {
-      resetFiles: true,
       importData: 'with-admin.tar',
       login: true,
       skipTour: true,
-      afterSetup: async () => {
-        // create a collection type to be used
-        await createCollectionType(page, {
-          name: ctName,
-          attributes,
-        });
+      // Don't reset files here as it would only run once for the whole suite
+      resetFiles: false,
+    });
 
-        await createCollectionType(page, {
-          name: 'dog',
-          attributes,
-        });
-        await createCollectionType(page, {
-          name: 'owner',
-          attributes,
-        });
-      },
+    // Reset files and create the same CTs between each test to prevent side effects
+    await createCollectionType(page, {
+      name: ctName,
+      attributes,
+    });
+    await createCollectionType(page, {
+      name: 'dog',
+      attributes,
+    });
+    await createCollectionType(page, {
+      name: 'owner',
+      attributes,
     });
 
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
@@ -121,11 +121,11 @@ test.describe('Edit collection type', () => {
   test('Can configure advanced settings for multiple fields sequentially', async ({ page }) => {
     const fieldsToAdd = [
       {
-        name: 'testfield2',
+        name: 'testfield',
         defaultValue: 'mydefault',
       },
       {
-        name: 'testfield3',
+        name: 'testfield2',
         defaultValue: 'mydefault2',
       },
     ];

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -121,11 +121,11 @@ test.describe('Edit collection type', () => {
   test('Can configure advanced settings for multiple fields sequentially', async ({ page }) => {
     const fieldsToAdd = [
       {
-        name: 'testfield',
+        name: 'testfield2',
         defaultValue: 'mydefault',
       },
       {
-        name: 'testfield2',
+        name: 'testfield3',
         defaultValue: 'mydefault2',
       },
     ];

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -14,17 +14,18 @@ test.describe('Edit single type', () => {
   const attributes = [{ type: 'text', name: 'testtext' }];
 
   test.beforeEach(async ({ page }) => {
+    await resetFiles();
     await sharedSetup('ctb-edit-st', page, {
       login: true,
       skipTour: true,
-      resetFiles: true,
+      // Don't reset files here as it would only run once for the whole suite
+      resetFiles: false,
       importData: 'with-admin.tar',
-      afterSetup: async () => {
-        await createSingleType(page, {
-          name: ctName,
-          attributes,
-        });
-      },
+    });
+
+    await createSingleType(page, {
+      name: ctName,
+      attributes,
     });
 
     // Then go to our content type

--- a/tests/e2e/utils/setup.ts
+++ b/tests/e2e/utils/setup.ts
@@ -32,12 +32,11 @@ const setupRegistry: Record<string, boolean> = {};
  *
  * WARNING:
  * Using `sharedSetup` in this way introduces a risk of tests becoming dependent
- * on the order in which they are executed. Since certain setup steps run only once
- * per suite, subsequent tests may rely on the state left by previous tests.
+ * on the order in which they are executed. This could be dangerous because the execution order
+ * is not guaranteed during retries in the CI.
  *
- * This approach should primarily be used when the setup time is significant,
- * or in test suites that follow a user story flow where later tests are
- * intended to be dependent on the previous ones.
+ * This approach should primarily be used when the setup time is significant and the tests don't
+ * depend on each other's side effects.
  */
 export const sharedSetup = async (
   id: string,


### PR DESCRIPTION
### What does it do?

Updates the code in the CTB e2e tests so that it can work regardless of test order.

Our tests often rely on retries (especially on webkit), and on retries, [the execution order is no longer respected](https://playwright.dev/docs/test-retries#failures), because Playwright will only resume at the specific test that failed, the previous ones won't re-run.

For context, the PR that introduced the logic that relies on retries is #21464. I understand why, as it makes tests a lot faster. But I believe our priority should be the flakiness right now, and the extended timeouts should allow us to have slow tests that don't fail. Then I think when the tests pass reliably we can discuss the different ways to speed them up. And a test that passes means a faster CI, because fewer retries are triggered

Another possible approach would be to check if we're in a retry and only adapt the logic in that scenario, so the perf wouldn't be impacted when all goes well. But that sounds more complex to me.

Happy to discuss it!
