### PR TITLE
fix: add maximum password length validation for bcryptjs hashing

### DIFF
--- a/packages/core/admin/server/src/validation/common-validators.ts
+++ b/packages/core/admin/server/src/validation/common-validators.ts
@@ -23,6 +23,7 @@ export const username = yup.string().min(1);
 export const password = yup
   .string()
   .min(8)
+  .max(50)
   .matches(/[a-z]/, '${path} must contain at least one lowercase character')
   .matches(/[A-Z]/, '${path} must contain at least one uppercase character')
   .matches(/\d/, '${path} must contain at least one number');


### PR DESCRIPTION
### What does it do?

This PR addresses a security vulnerability in Strapi's password hashing by adding a maximum password length validation. Currently, `bcryptjs` is used for password hashing, which can securely handle passwords up to 72 bytes. Without validation, passwords longer than this limit are silently truncated, potentially creating security risks. This update ensures passwords are restricted to 72 bytes, preventing unintended truncation.

### Why is it needed?

This fix is essential to mitigate the risk of authentication bypass or predictable hashes due to password truncation. By adding this validation, users are informed if their password exceeds the secure limit, protecting against potential vulnerabilities and maintaining consistency in authentication.

### How to test it?

1. Attempt to register a new user with a password exceeding 72 bytes to verify it is rejected with an appropriate validation error.
2. Confirm that passwords within the valid length range (8–72 bytes) are accepted without issues.
3. Ensure that authentication works correctly for existing users with valid passwords.

### Related issue(s)/PR(s)

Fix #[GHSA-vj5w-qf45-pg8h](https://github.com/strapi/strapi/security/advisories/GHSA-vj5w-qf45-pg8h)