### PR TITLE
fix: unable to type color value using keyboard

### DIFF
--- a/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
+++ b/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
@@ -10,7 +10,7 @@ import {
   useComposedRefs,
 } from '@strapi/design-system';
 import { CaretDown } from '@strapi/icons';
-import { useField, type InputProps, type FieldValue } from '@strapi/strapi/admin';
+import { type InputProps, type FieldValue } from '@strapi/strapi/admin';
 import { HexColorPicker } from 'react-colorful';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -143,7 +143,7 @@ export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerI
                     style={{ textTransform: 'uppercase' }}
                     value={value}
                     placeholder="#000000"
-                    onChange={onChange}
+                    onChange={(e) => onChange(name, e.target.value)}
                   />
                 </Field.Root>
               </Flex>

--- a/packages/plugins/color-picker/admin/src/components/tests/ColorPickerInput.test.tsx
+++ b/packages/plugins/color-picker/admin/src/components/tests/ColorPickerInput.test.tsx
@@ -6,7 +6,7 @@ import { IntlProvider } from 'react-intl';
 
 import { ColorPickerInput } from '../ColorPickerInput';
 
-const render = () => ({
+const render = (onChange = () => {}) => ({
   ...renderRTL(
     <ColorPickerInput
       name="color"
@@ -14,7 +14,7 @@ const render = () => ({
       type="string"
       initialValue=""
       value=""
-      onChange={() => {}}
+      onChange={onChange}
     />,
     {
       wrapper: ({ children }) => {
@@ -49,5 +49,19 @@ describe('<ColorPickerInput />', () => {
     expect(getByRole('slider', { name: 'Color' })).toBeVisible();
     expect(getByRole('slider', { name: 'Hue' })).toBeVisible();
     expect(getByRole('textbox', { name: 'Color picker input' })).toBeVisible();
+  });
+
+  it('calls onChange when value is entered into the input field', async () => {
+    const handleChange = jest.fn();
+    const { user, getByRole } = render(handleChange);
+    await user.click(getByRole('button', { name: 'Color picker toggle' }));
+
+    const colorInput = getByRole('textbox', { name: 'Color picker input' });
+    await user.clear(colorInput);
+    await user.click(colorInput);
+    await user.paste('#ff5733');
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith('color', '#ff5733');
   });
 });


### PR DESCRIPTION
### What does it do?

I updated the onChange function call in the color picker plugin to pass the name as the argument

### Why is it needed?

User was unable to type the hex color value using keyboard

### How to test it?

Assign a color picker component to some single type component and try to edit the color value using keyboard

### Related issue(s)/PR(s)

fixes: https://github.com/strapi/strapi/issues/21838
