### PR TITLE
fix: allow cross origin sources when cropping images

### DIFF
--- a/packages/core/upload/admin/src/hooks/useCropImg.ts
+++ b/packages/core/upload/admin/src/hooks/useCropImg.ts
@@ -45,6 +45,7 @@ export const useCropImg = () => {
         zoomable: false,
         cropBoxResizable: true,
         background: false,
+        checkCrossOrigin: false,
         crop: handleResize,
       });
 


### PR DESCRIPTION
### What does it do?
Images uploaded using AWS could not be cropped.

We use Cropperjs to crop images, the library exposes a Cross Origin config param to only allow images from the same source. It was enabled by default, this PR disables it so whe


### How to test it?

Using an AWS provider:

1. Update `/config/plugins.js`
```ts
  upload: {
    config: {
      provider: 'aws-s3',
      providerOptions: {
        credentials: {
          accessKeyId: env('AWS_ACCESS_KEY_ID'),
          secretAccessKey: env('AWS_ACCESS_SECRET'),
        },
        region: env('AWS_REGION'),
        params: {
          // ACL: 'private', 
          // signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 15 * 60),
          Bucket: env('AWS_BUCKET'),
        },
      },
      actionOptions: {
        upload: {},
        uploadStream: {},
        delete: {},
      },
    },
  },
```

2. Update `config/middlewares.js`:
```ts
{
    name: 'strapi::security',
    config: {
      contentSecurityPolicy: {
        useDefaults: true,
        directives: {
          'img-src': [
            "'self'",
            'data:',
            'blob:',
            'XXXX', // <==== ADD YOUR AWS DOMAIN HERE
          ],
          'media-src': [
            "'self'",
            'data:',
            'blob:',
            'XXXX', // <==== ADD YOUR AWS DOMAIN HERE
          ],
        },
      },
    },
  },
```

3. Update your env variables with AWS_ACCESS_KEY_ID, AWS_ACCESS_SECRET, AWS_BUCKET, AWS_REGION

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/19696
