### PR TITLE
Fix: lookup dependencies in devDeps as well

### DIFF
--- a/packages/core/strapi/src/node/core/dependencies.ts
+++ b/packages/core/strapi/src/node/core/dependencies.ts
@@ -77,7 +77,7 @@ const checkRequiredDependencies = async ({
         throw new Error(`Could not find dependencies in package.json at path: ${cwd}`);
       }
 
-      const declaredVersion = pkg.packageJson.dependencies[name];
+      const declaredVersion = pkg.packageJson.dependencies[name] ?? pkg.packageJson.devDependencies[name];
 
       if (!declaredVersion) {
         acc.install.push({


### PR DESCRIPTION
### What does it do?

When checking if the peer deps are installed it now checks in devDeps as well

### Why is it needed?

Because those peerDeps are only need to **build** the strapi admin, on the end user project they should be in devDeps and not on a production server, without this change strapi does not find the deps even if they are already installed

And so it will run multiple times the install command

[INFO] The Strapi admin needs to install the following dependencies:
@freshpress/strapi:build:    - react@^18.0.0
@freshpress/strapi:build:   - react-dom@^18.0.0
@freshpress/strapi:build:   - react-router-dom@^6.0.0
@freshpress/strapi:build:   - styled-components@^6.0.0
@freshpress/strapi:build: [INFO] Running 'npm install --legacy-peer-deps --save react@^18.0.0 react-dom@^18.0.0 react-router-dom@^6.0.0 styled-components@^6.0.0'


### How to test it?

An example package.json
```
{
  "name": "strapi",
  "version": "0.1.0",
  "private": true,
  "description": "A Strapi application",
  "scripts": {
    "build": "strapi build",
    "deploy": "strapi deploy",
    "serve": "strapi develop",
    "seed:example": "node ./scripts/seed.js",
    "strapi": "strapi",
  },
  "dependencies": {
    "@strapi/core": "^5.3.0",
    "@strapi/plugin-users-permissions": "5.3.0",
    "fs-extra": "^11.2.0",
    "mime-types": "^2.1.35",
    "mysql2": "3.11.4"
  },
  "devDependencies": {
    "@strapi/pack-up": "^5.0.2",
    "@strapi/strapi": "5.3.0",
    "@types/node": "^22",
    "@types/react": "^18",
    "@types/react-dom": "^18",
    "react": "^18.3.1",
    "react-dom": "^18.3.1",
    "react-router-dom": "^6.28.0",
    "styled-components": "^6.1.13",
    "typescript": "^5"
  },
  "engines": {
    "node": ">=18.0.0 <=20.x.x",
    "npm": ">=6.0.0"
  },
  "strapi": {
    "uuid": "30c1208e-7af8-4b35-a99c-6c13a7c02d8e"
  }
}
```

This is only a first step because right now the strapi core includes the build command and so lists a [lot of build deps](https://github.com/strapi/strapi/blob/b0db56479de441dfe8feb37a43c7f6f6fecf75c1/packages/core/strapi/package.json#L132) as it's dependencies

Ideally the build part should be moved to a subpackage and become an optional peerDep of strapi core so that we don't need to have all those build tools like typescript, vite and all that on a production deployment

