### PR TITLE
enhancement: add didRestoreHistoryVersion and willNavigate to history

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -148,6 +148,7 @@ interface EventWithoutProperties {
     | 'didSelectContentTypeFieldSettings'
     | 'didSelectContentTypeSettings'
     | 'didEditAuthenticationProvider'
+    | 'didRestoreHistoryVersion'
     | 'hasClickedCTBAddFieldBanner'
     | 'removeComponentFromDynamicZone'
     | 'willAddMoreFieldToContentType'

--- a/packages/core/content-manager/admin/src/history/components/HistoryAction.tsx
+++ b/packages/core/content-manager/admin/src/history/components/HistoryAction.tsx
@@ -1,8 +1,8 @@
-import { useQueryParams } from '@strapi/admin/strapi-admin';
+import { useQueryParams, useTracking } from '@strapi/admin/strapi-admin';
 import { ClockCounterClockwise } from '@strapi/icons';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 import type { DocumentActionComponent } from '../../content-manager';
 
@@ -10,11 +10,22 @@ const HistoryAction: DocumentActionComponent = ({ model, document }) => {
   const { formatMessage } = useIntl();
   const [{ query }] = useQueryParams<{ plugins?: Record<string, unknown> }>();
   const navigate = useNavigate();
+  const { trackUsage } = useTracking();
+  const { pathname } = useLocation();
   const pluginsQueryParams = stringify({ plugins: query.plugins }, { encode: false });
 
   if (!window.strapi.features.isEnabled('cms-content-history')) {
     return null;
   }
+
+  const handleOnClick = () => {
+    const destination = { pathname: 'history', search: pluginsQueryParams };
+    trackUsage('willNavigate', {
+      from: pathname,
+      to: `${pathname}/${destination.pathname}?${destination.search}`,
+    });
+    navigate(destination);
+  };
 
   return {
     icon: <ClockCounterClockwise />,
@@ -22,7 +33,7 @@ const HistoryAction: DocumentActionComponent = ({ model, document }) => {
       id: 'content-manager.history.document-action',
       defaultMessage: 'Content History',
     }),
-    onClick: () => navigate({ pathname: 'history', search: pluginsQueryParams }),
+    onClick: handleOnClick,
     disabled:
       /**
        * The user is creating a new document.

--- a/packages/core/content-manager/admin/src/history/components/HistoryAction.tsx
+++ b/packages/core/content-manager/admin/src/history/components/HistoryAction.tsx
@@ -22,7 +22,7 @@ const HistoryAction: DocumentActionComponent = ({ model, document }) => {
     const destination = { pathname: 'history', search: pluginsQueryParams };
     trackUsage('willNavigate', {
       from: pathname,
-      to: `${pathname}/${destination.pathname}?${destination.search}`,
+      to: `${pathname}/${destination.pathname}`,
     });
     navigate(destination);
   };

--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -4,6 +4,7 @@ import {
   ConfirmDialog,
   useNotification,
   useQueryParams,
+  useTracking,
   useRBAC,
   Layouts,
 } from '@strapi/admin/strapi-admin';
@@ -26,6 +27,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = React.useState(false);
   const navigate = useNavigate();
   const { formatMessage, formatDate } = useIntl();
+  const { trackUsage } = useTracking();
   const { toggleNotification } = useNotification();
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
@@ -79,6 +81,8 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
             defaultMessage: 'The content of the restored version is not published yet.',
           }),
         });
+
+        trackUsage('didRestoreHistoryVersion');
       }
 
       if ('error' in response) {


### PR DESCRIPTION
### What does it do?

We added the track for:
 - the number of times users go to the Content History page: we’ll need to implement the willNavigate event for that
 - the number of times users restore a history version: we’ll need to implement the didRestoreHistoryVersion event

### Why is it needed?

To have some metrics regarding the use of the Content History feature

### How to test it?

- add some entries to a Collection and try to modify them and save
- click on the "Content History" button in the Edit view 
- check the Network tab in the DevTool, a new POST track call will be triggered with the event "willNavigate"
- now in the History page try to select an old version and click on the Restore button (it needs to be enabled)
- in the Confirmation dialog click Restore
- check the Network tab in the DevTool, a new POST track call will be triggered with the event "didRestoreHistoryVersion"

### Related issue(s)/PR(s)

CS-1206
