### PR TITLE
chore: dummy preview page on getstarted

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -22,7 +22,7 @@ module.exports = ({ env }) => ({
     enabled: env.bool('PREVIEW_ENABLED', true),
     config: {
       handler: (uid, { documentId, locale, status }) => {
-        return `/preview/${uid}/${documentId}/${locale}/${status}`;
+        return `/admin/preview/${uid}/${documentId}/${locale}/${status}`;
       },
     },
   },

--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button } from '@strapi/design-system';
 
-import Preview from './preview';
+import { registerPreviewRoute } from './preview';
 
 const config = {
   locales: ['it', 'es', 'en', 'en-GB'],
@@ -19,7 +19,7 @@ const bootstrap = (app) => {
 export default {
   config,
   register: (app) => {
-    Preview.register(app);
+    registerPreviewRoute(app);
   },
   bootstrap,
 };

--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
+
 import { Button } from '@strapi/design-system';
+
+import Preview from './preview';
 
 const config = {
   locales: ['it', 'es', 'en', 'en-GB'],
@@ -15,5 +18,8 @@ const bootstrap = (app) => {
 
 export default {
   config,
+  register: (app) => {
+    Preview.register(app);
+  },
   bootstrap,
 };

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+// @ts-ignore
+import { Page, Layouts } from '@strapi/admin/strapi-admin';
+import { Grid, Flex, Typography } from '@strapi/design-system';
+
+const PreviewComponent = () => {
+  const { uid, documentId, locale, status } = useParams();
+
+  return (
+    <Layouts.Root>
+      <Page.Main>
+        <Page.Title>{`Previewing ${uid}`}</Page.Title>
+        <Layouts.Header title={'Static Preview'} subtitle={`Dummy preview for getstarted app`} />
+        <Layouts.Content>
+          <Flex
+            direction="column"
+            alignItems="stretch"
+            gap={4}
+            hasRadius
+            background="neutral0"
+            shadow="tableShadow"
+            paddingTop={6}
+            paddingBottom={6}
+            paddingRight={7}
+            paddingLeft={7}
+          >
+            <Typography variant="delta" tag="h3">
+              Details
+            </Typography>
+
+            <Grid.Root gap={5} tag="dl">
+              <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                <Typography variant="sigma" textColor="neutral600" tag="dt">
+                  {'Content Type'}
+                </Typography>
+                <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                  <Typography>{uid}</Typography>
+                </Flex>
+              </Grid.Item>
+              <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                <Typography variant="sigma" textColor="neutral600" tag="dt">
+                  {'Document Id'}
+                </Typography>
+                <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                  <Typography>{documentId}</Typography>
+                </Flex>
+              </Grid.Item>
+              <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                <Typography variant="sigma" textColor="neutral600" tag="dt">
+                  {'Status'}
+                </Typography>
+                <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                  <Typography>{status}</Typography>
+                </Flex>
+              </Grid.Item>
+              <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                <Typography variant="sigma" textColor="neutral600" tag="dt">
+                  Locale
+                </Typography>
+                <Typography tag="dd">{locale}</Typography>
+              </Grid.Item>
+            </Grid.Root>
+          </Flex>
+        </Layouts.Content>
+      </Page.Main>
+    </Layouts.Root>
+  );
+};
+
+export { PreviewComponent };

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -41,7 +41,7 @@ const PreviewComponent = () => {
               </Grid.Item>
               <Grid.Item col={6} s={12} direction="column" alignItems="start">
                 <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  {'Document Id'}
+                  Document Id
                 </Typography>
                 <Flex gap={3} direction="column" alignItems="start" tag="dd">
                   <Typography>{documentId}</Typography>
@@ -49,7 +49,7 @@ const PreviewComponent = () => {
               </Grid.Item>
               <Grid.Item col={6} s={12} direction="column" alignItems="start">
                 <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  {'Status'}
+                  Status
                 </Typography>
                 <Flex gap={3} direction="column" alignItems="start" tag="dd">
                   <Typography>{status}</Typography>

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { lazy } from 'react';
+
+const Preview = lazy(() =>
+  // @ts-ignore
+  import('./dummy-preview').then((module) => ({
+    default: module.PreviewComponent,
+  }))
+);
+
+export default {
+  register: (app) => {
+    app.router.addRoute({
+      path: 'preview/*',
+      children: [
+        {
+          path: ':uid/:documentId/:locale/:status',
+          element: <Preview />,
+        },
+      ],
+    });
+  },
+};

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -8,16 +8,14 @@ const Preview = lazy(() =>
   }))
 );
 
-export default {
-  register: (app) => {
-    app.router.addRoute({
-      path: 'preview/*',
-      children: [
-        {
-          path: ':uid/:documentId/:locale/:status',
-          element: <Preview />,
-        },
-      ],
-    });
-  },
+export const registerPreviewRoute = (app) => {
+  app.router.addRoute({
+    path: 'preview/*',
+    children: [
+      {
+        path: ':uid/:documentId/:locale/:status',
+        element: <Preview />,
+      },
+    ],
+  });
 };


### PR DESCRIPTION
### What does it do?

Creates a dummy Preview route in the getstarted example app, so we can easily test this feature.

On preview, you will see a page with the uid, documentId, locale and status information.
![image](https://github.com/user-attachments/assets/12a90bd8-e75a-4ff0-980e-b4b5c767dd46)

I didn't find a way to hide the main sidebar 