### PR TITLE
feat: preview allowed origins config

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -22,7 +22,7 @@ module.exports = ({ env }) => ({
     enabled: env.bool('PREVIEW_ENABLED', true),
     config: {
       handler: (uid, { documentId, locale, status }) => {
-        return `/preview/${uid}/${documentId}/${locale}/${status}`;
+        return `/admin/preview/${uid}/${documentId}/${locale}/${status}`;
       },
     },
   },

--- a/packages/core/content-manager/server/src/preview/index.ts
+++ b/packages/core/content-manager/server/src/preview/index.ts
@@ -21,13 +21,12 @@ const getFeature = (): Partial<Plugin.LoadedPlugin> => {
   // }
 
   return {
-    bootstrap() {
-      // eslint-disable-next-line no-console -- TODO remove when we have real functionality
-      console.log('Bootstrapping preview server');
-
+    register() {
       const config = getService(strapi, 'preview-config');
       config.validate();
+      config.register();
     },
+    bootstrap() {},
     routes,
     controllers,
     services,

--- a/packages/core/content-manager/server/src/preview/services/preview-config.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview-config.ts
@@ -33,14 +33,17 @@ const extendMiddlewareConfiguration = (middleware = { name: '', config: {} }) =>
     // @ts-expect-error - currentMiddleware is not a string
     if (currentMiddleware.name === middleware.name) {
       // Deep merge (+ concat arrays) the new config with the current middleware config
-      // @ts-expect-error - fix
-      return mergeWith(currentMiddleware, middleware, (objValue, srcValue) => {
-        if (Array.isArray(objValue)) {
-          return objValue.concat(srcValue);
-        }
+      return mergeWith(
+        (objValue, srcValue) => {
+          if (Array.isArray(objValue)) {
+            return objValue.concat(srcValue);
+          }
 
-        return objValue;
-      });
+          return undefined;
+        },
+        currentMiddleware,
+        middleware
+      );
     }
 
     return currentMiddleware;

--- a/packages/core/content-manager/server/src/preview/services/preview-config.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview-config.ts
@@ -1,3 +1,5 @@
+import { mergeWith } from 'lodash/fp';
+
 import type { Core, UID } from '@strapi/types';
 import { errors } from '@strapi/utils';
 
@@ -10,15 +12,70 @@ export type HandlerParams = {
 export interface PreviewConfig {
   enabled: boolean;
   config: {
+    // List of CSP allowed origins. This is a shortcut to setting it up inside `config/middlewares.js`
+    allowedOrigins: string[];
     handler: (uid: UID.Schema, params: HandlerParams) => string | undefined;
   };
 }
+
+/**
+ * Utility to extend Strapi configuration middlewares. Mainly used to extend the CSP directives from the security middleware.
+ */
+const extendMiddlewareConfiguration = (middleware = { name: '', config: {} }) => {
+  const middlewares = strapi.config.get('middlewares') as (string | object)[];
+
+  const configuredMiddlewares = middlewares.map((currentMiddleware) => {
+    if (currentMiddleware === middleware.name) {
+      // Use the new config object if the middleware has no config property yet
+      return middleware;
+    }
+
+    // @ts-expect-error - currentMiddleware is not a string
+    if (currentMiddleware.name === middleware.name) {
+      // Deep merge (+ concat arrays) the new config with the current middleware config
+      // @ts-expect-error - fix
+      return mergeWith(currentMiddleware, middleware, (objValue, srcValue) => {
+        if (Array.isArray(objValue)) {
+          return objValue.concat(srcValue);
+        }
+
+        return objValue;
+      });
+    }
+
+    return currentMiddleware;
+  });
+
+  strapi.config.set('middlewares', configuredMiddlewares);
+};
 
 /**
  * Read configuration for static preview
  */
 const createPreviewConfigService = ({ strapi }: { strapi: Core.Strapi }) => {
   return {
+    register() {
+      if (!this.isEnabled()) {
+        return;
+      }
+
+      const config = strapi.config.get('admin.preview') as PreviewConfig;
+
+      /**
+       * Register the allowed origins for CSP, so the preview URL can be displayed
+       */
+      extendMiddlewareConfiguration({
+        name: 'strapi::security',
+        config: {
+          contentSecurityPolicy: {
+            directives: {
+              'frame-src': config.config.allowedOrigins,
+            },
+          },
+        },
+      });
+    },
+
     isEnabled() {
       const config = strapi.config.get('admin.preview') as PreviewConfig;
 

--- a/packages/core/content-manager/server/src/preview/services/preview-config.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview-config.ts
@@ -64,16 +64,18 @@ const createPreviewConfigService = ({ strapi }: { strapi: Core.Strapi }) => {
       /**
        * Register the allowed origins for CSP, so the preview URL can be displayed
        */
-      extendMiddlewareConfiguration({
-        name: 'strapi::security',
-        config: {
-          contentSecurityPolicy: {
-            directives: {
-              'frame-src': config.config.allowedOrigins,
+      if (config.config?.allowedOrigins) {
+        extendMiddlewareConfiguration({
+          name: 'strapi::security',
+          config: {
+            contentSecurityPolicy: {
+              directives: {
+                'frame-src': config.config.allowedOrigins,
+              },
             },
           },
-        },
-      });
+        });
+      }
     },
 
     isEnabled() {

--- a/packages/core/content-manager/server/src/register.ts
+++ b/packages/core/content-manager/server/src/register.ts
@@ -1,8 +1,10 @@
 import type { Plugin } from '@strapi/types';
 import history from './history';
+import preview from './preview';
 
 const register: Plugin.LoadedPlugin['register'] = async ({ strapi }) => {
   await history.register?.({ strapi });
+  await preview.register?.({ strapi });
 };
 
 export default register;


### PR DESCRIPTION
### What does it do?

Introduces a new `allowedOrigins` preview config, so all the necessary configuration for Preview is in the same place.

Until now, it was required to set up the preview URL in the `config/middlewares.js` security middleware. It was tedious and just another step that made preview config more complicated. 

Now you can do the same by configuring it in `config/admin.js`:

```ts
  preview: {
    enabled: env.bool('PREVIEW_ENABLED', true),
    config: {
      allowedOrigins: ['docs.strapi.io'],
      handler: (uid, { documentId, locale, status }) => {
        if (status === 'published') {
          return 'https://docs.strapi.io/';
        }

        return 'https://docs.strapi.io/dev-docs/intro';
      },
    },
  },
``` 

There is no need to update the `config/middlewares.js` file anymore.
