### PR TITLE
fix: Enumeration add "Choose here" as empty value

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, memo } from 'react';
 
 import { SingleSelect, SingleSelectOption, useComposedRefs, Field } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
 
 import { useFocusInputField } from '../../hooks/useFocusInputField';
 import { useField } from '../Form';
@@ -9,6 +10,7 @@ import { EnumerationProps } from './types';
 
 const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
   ({ name, required, label, hint, labelAction, options = [], ...props }, ref) => {
+    const { formatMessage } = useIntl();
     const field = useField(name);
     const fieldRef = useFocusInputField<HTMLDivElement>(name);
 
@@ -25,6 +27,12 @@ const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
           value={field.value}
           {...props}
         >
+          <SingleSelectOption value="" disabled={required} hidden={required}>
+            {formatMessage({
+              id: 'components.InputSelect.option.placeholder',
+              defaultMessage: 'Choose here',
+            })}
+          </SingleSelectOption>
           {options.map(({ value, label, disabled, hidden }) => {
             return (
               <SingleSelectOption key={value} value={value} disabled={disabled} hidden={hidden}>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds again in the Enumeration field the "Choose here" as the empty option, to reflect the behavior we had in v4 

### Why is it needed?

Because otherwise there is no possibility to set to empty an enumeration field when filled. In the case the field is required the "Choose here" option is not selectable like it was in v4

### How to test it?

- Create an enum on Strapi v5 
-  set the field as not required
- then create a new instance of the enum field and try to select an option
- Save
- then edit the entry and choose the "Choose here" option to save the empty value and save

test the required field case
- go to a collection and add an enum field required
- then create a new instance of the Collection and try to save the enum empty
- then try to publish the entry (an error message needs to show up for the enumeration field)
- then select an option in the enumeration and save the instance
- try to select the "Choose here" option (you can't do it)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/22026
