### PR TITLE
fix: resolve naming conflict in the v5 `document_id` migration

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -33,7 +33,7 @@ const QUERIES = {
     SELECT :tableName:.id as id, string_agg(DISTINCT :inverseJoinColumn:::character varying, ',') as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
+    WHERE :tableName:.document_id IS NULL
     GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
     LIMIT 1;
   `,
@@ -48,7 +48,7 @@ const QUERIES = {
     SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
+    WHERE :tableName:.document_id IS NULL
     GROUP BY :tableName:.id, :joinTableName:.:joinColumn:
     LIMIT 1;
   `,
@@ -63,7 +63,7 @@ const QUERIES = {
     SELECT :tableName:.id as id, group_concat(DISTINCT :inverseJoinColumn:) as other_ids
     FROM :tableName:
     LEFT JOIN :joinTableName: ON :tableName:.id = :joinTableName:.:joinColumn:
-    WHERE document_id IS NULL
+    WHERE :tableName:.document_id IS NULL
     GROUP BY :joinTableName:.:joinColumn:
     LIMIT 1;
     `,


### PR DESCRIPTION
### What does it do?

This PR fixes the migration that adds `document_id` column to existing content type tables. 

The original issue was reported here and mistakenly closed as a duplicate:

Fix #21899 

A follow-up PR (#22049) was also closed unmerged in favour of #21596, but as @innerdvations mentioned, #21596 doesn't fully resolve the issue with content types named "Document".

### Why is it needed?

This takes care of a potential naming conflict that happens when you have a content type with a singular name "document", which seems to be a common naming pattern for Strapi installations in the wild.

### How to test it?

- Start with the latest v4 and prepare it for the v5 migration
- Start the server, all the migrations should pass
- Do this on postgres, sqlite and mysql

_Important: I only have managed to test the postgres migration, and people in the original issue have confirmed this works for sqlite._ 

### Related issue(s)/PR(s)

#21899
#21596
#22049 