### PR TITLE
fix 22026 : Enum difference v4/v5 - "Choose here" as null value

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Enumeration.tsx
@@ -11,7 +11,7 @@ const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
   ({ name, required, label, hint, labelAction, options = [], ...props }, ref) => {
     const field = useField(name);
     const fieldRef = useFocusInputField<HTMLDivElement>(name);
-
+    options = [{ label: 'Choose here', value: '' }, ...options];
     const composedRefs = useComposedRefs(ref, fieldRef);
 
     return (
@@ -20,7 +20,7 @@ const EnumerationInput = forwardRef<HTMLDivElement, EnumerationProps>(
         <SingleSelect
           ref={composedRefs}
           onChange={(value) => {
-            field.onChange(name, value);
+            field.onChange(name, value || null);
           }}
           value={field.value}
           {...props}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix #22026 : Enum difference v4/v5 - "Choose here" as null value

### Why is it needed?

In Strapi v4 a user could create an enum - a content editor could select values but could also select "Choose here" as a null value.


### How to test it?

Create an enum on Strapi v5 - check content editor experience (no choose here option)

### Related issue(s)/PR(s)

#22026 