### PR TITLE
test(front): run front-end tests with runInBand

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -8,6 +8,7 @@ backend:
   - 'packages/core/*/{lib,bin,ee,src}/**'
   - 'packages/core/database/**'
   - 'yarn.lock'
+  - 'package.json'
 frontend:
   - '.github/actions/yarn-nm-install/*.yml'
   - '.github/workflows/**'
@@ -17,6 +18,7 @@ frontend:
   - 'packages/**/strapi-admin.js'
   - 'packages/admin-test-utils/**'
   - 'yarn.lock'
+  - 'package.json'
 api:
   - 'tests/api/**'
 e2e:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
       - name: Run tests
-        run: yarn nx affected --target=test:front --nx-ignore-cycles -- --runInBand
+        run: yarn nx affected --target=test:front --nx-ignore-cycles
 
   e2e_ce:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.e2e == 'true'

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:cli:debug": "node tests/scripts/run-cli-tests.js --debug",
     "test:e2e": "node tests/scripts/run-e2e-tests.js",
     "test:e2e:clean": "node tests/scripts/run-e2e-tests.js clean",
-    "test:front": "cross-env IS_EE=true jest --config jest.config.front.js --run-in-band",
+    "test:front": "cross-env IS_EE=true jest --config jest.config.front.js --runInBand",
     "test:front:all": "cross-env IS_EE=true nx run-many --target=test:front --nx-ignore-cycles",
     "test:front:all:ce": "cross-env IS_EE=false nx run-many --target=test:front:ce --nx-ignore-cycles",
     "test:front:ce": "cross-env IS_EE=false run test:front",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:cli:debug": "node tests/scripts/run-cli-tests.js --debug",
     "test:e2e": "node tests/scripts/run-e2e-tests.js",
     "test:e2e:clean": "node tests/scripts/run-e2e-tests.js clean",
-    "test:front": "cross-env IS_EE=true jest --config jest.config.front.js",
+    "test:front": "cross-env IS_EE=true jest --config jest.config.front.js --run-in-band",
     "test:front:all": "cross-env IS_EE=true nx run-many --target=test:front --nx-ignore-cycles",
     "test:front:all:ce": "cross-env IS_EE=false nx run-many --target=test:front:ce --nx-ignore-cycles",
     "test:front:ce": "cross-env IS_EE=false run test:front",


### PR DESCRIPTION
### What does it do?

use `--run-in-band` to run test:front

### Why is it needed?

front-end tests quite consistently fail without it, probably due to race conditions

it's essentially a requirement for running front end test, CI was already using it, this just makes it so it's also used locally

### How to test it?

try running front-end unit tests locally and they should pass

without this PR it's very likely that some of them fail

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
