### PR TITLE
feat(cloud-cli): display warning when using deploy command

### DIFF
--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@strapi/utils": "5.4.0",
     "axios": "1.7.4",
+    "boxen": "5.1.2",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",
     "commander": "8.3.0",

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -1,5 +1,6 @@
 import fse from 'fs-extra';
 import inquirer from 'inquirer';
+import boxen from 'boxen';
 import path from 'path';
 import chalk from 'chalk';
 import { AxiosError } from 'axios';
@@ -7,7 +8,13 @@ import * as crypto from 'node:crypto';
 import { apiConfig } from '../config/api';
 import { compressFilesToTar } from '../utils/compress-files';
 import createProjectAction from '../create-project/action';
-import type { CLIContext, CloudApiService, CloudCliConfig, ProjectInfo } from '../types';
+import type {
+  CLIContext,
+  CloudApiService,
+  CloudCliConfig,
+  EnvironmentDetails,
+  ProjectInfo,
+} from '../types';
 import { getTmpStoragePath } from '../config/local';
 import { cloudApiFactory, tokenServiceFactory, local } from '../services';
 import { notificationServiceFactory } from '../services/notification';
@@ -25,7 +32,16 @@ type PackageJson = {
 
 interface CmdOptions {
   env?: string;
+  force?: boolean;
 }
+
+const boxenOptions: boxen.Options = {
+  padding: 1,
+  margin: 1,
+  align: 'center',
+  borderColor: 'yellow',
+  borderStyle: 'round',
+};
 
 const QUIT_OPTION = 'Quit';
 
@@ -43,17 +59,6 @@ async function promptForEnvironment(environments: string[]): Promise<string> {
     process.exit(1);
   }
 
-  const { confirm } = await inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'confirm',
-      message: `Do you want to proceed with deployment to ${chalk.cyan(selectedEnvironment)}?`,
-    },
-  ]);
-
-  if (!confirm) {
-    process.exit(1);
-  }
   return selectedEnvironment;
 }
 
@@ -206,6 +211,17 @@ async function getTargetEnvironment(
   return environments[0];
 }
 
+async function hasPendingOrLiveDeployment(
+  environments: EnvironmentDetails[],
+  targetEnvironment: string
+): Promise<boolean> {
+  const environment = environments.find((env) => env.name === targetEnvironment);
+  if (!environment) {
+    throw new Error(`Environment details ${targetEnvironment} not found.`);
+  }
+  return environment.hasPendingDeployment || environment.hasLiveDeployment || false;
+}
+
 export default async (ctx: CLIContext, opts: CmdOptions) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
   const token = await getValidToken(ctx, promptLogin);
@@ -219,15 +235,18 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
   }
 
   const cloudApiService = await cloudApiFactory(ctx, token);
+  let projectData;
   let environments: string[];
+  let environmentsDetails: EnvironmentDetails[];
 
   try {
     const {
-      data: { data: projectData, metadata },
+      data: { data, metadata },
     } = await cloudApiService.getProject({ name: project.name });
-
-    const isProjectSuspended = projectData.suspendedAt;
+    projectData = data;
     environments = projectData.environments;
+    environmentsDetails = projectData.environmentsDetails;
+    const isProjectSuspended = projectData.suspendedAt;
 
     if (isProjectSuspended) {
       ctx.logger.log(
@@ -280,6 +299,26 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
   }
 
   project.targetEnvironment = await getTargetEnvironment(ctx, opts, project, environments);
+
+  if (!opts.force) {
+    const shouldDisplayWarning = await hasPendingOrLiveDeployment(
+      environmentsDetails,
+      project.targetEnvironment
+    );
+    if (shouldDisplayWarning) {
+      ctx.logger.log(boxen(cliConfig.projectDeployment.confirmationText, boxenOptions));
+      const { confirm } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirm',
+          message: `Do you want to proceed with deployment to ${chalk.cyan(projectData.displayName)} on ${chalk.cyan(project.targetEnvironment)} environment?`,
+        },
+      ]);
+      if (!confirm) {
+        process.exit(1);
+      }
+    }
+  }
 
   const buildId = await upload(ctx, project, token, maxSize);
 

--- a/packages/cli/cloud/src/deploy-project/action.ts
+++ b/packages/cli/cloud/src/deploy-project/action.ts
@@ -211,10 +211,10 @@ async function getTargetEnvironment(
   return environments[0];
 }
 
-async function hasPendingOrLiveDeployment(
+function hasPendingOrLiveDeployment(
   environments: EnvironmentDetails[],
   targetEnvironment: string
-): Promise<boolean> {
+): boolean {
   const environment = environments.find((env) => env.name === targetEnvironment);
   if (!environment) {
     throw new Error(`Environment details ${targetEnvironment} not found.`);
@@ -301,7 +301,7 @@ export default async (ctx: CLIContext, opts: CmdOptions) => {
   project.targetEnvironment = await getTargetEnvironment(ctx, opts, project, environments);
 
   if (!opts.force) {
-    const shouldDisplayWarning = await hasPendingOrLiveDeployment(
+    const shouldDisplayWarning = hasPendingOrLiveDeployment(
       environmentsDetails,
       project.targetEnvironment
     );

--- a/packages/cli/cloud/src/deploy-project/command.ts
+++ b/packages/cli/cloud/src/deploy-project/command.ts
@@ -12,6 +12,7 @@ const command: StrapiCloudCommand = ({ ctx }) => {
     .description('Deploy a Strapi Cloud project')
     .option('-d, --debug', 'Enable debugging mode with verbose logs')
     .option('-s, --silent', "Don't log anything")
+    .option('-f, --force', 'Skip confirmation to deploy')
     .option('-e, --env <name>', 'Specify the environment to deploy')
     .action((opts) => runAction('deploy', action)(ctx, opts));
 };

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import inquirer, { type Answers } from 'inquirer';
-import { ProjectInput } from '../../services/cli-api';
+import { EnvironmentDetails, ProjectInput } from '../../services/cli-api';
 import type { CLIContext, CloudApiService } from '../../types';
 import { cloudApiFactory, tokenServiceFactory, local } from '../../services';
 import { promptLogin } from '../../login/action';
@@ -17,13 +17,7 @@ interface LinkEnvironmentInput extends Answers {
   targetEnvironment: string;
 }
 
-export type Environment = {
-  name: string;
-  hasLiveDeployment: boolean;
-  hasPendingDeployment: boolean;
-};
-
-type EnvironmentsList = Environment[];
+type EnvironmentsList = EnvironmentDetails[];
 
 export default async (ctx: CLIContext) => {
   const { getValidToken } = await tokenServiceFactory(ctx);
@@ -135,7 +129,7 @@ async function getEnvironmentsList(
     }
     spinner.succeed();
     return environmentsList.filter(
-      (environment: Environment) => environment.name !== project.targetEnvironment
+      (environment: EnvironmentDetails) => environment.name !== project.targetEnvironment
     );
   } catch (e: any) {
     if (e.response && e.response.status === 404) {

--- a/packages/cli/cloud/src/environment/link/action.ts
+++ b/packages/cli/cloud/src/environment/link/action.ts
@@ -17,8 +17,10 @@ interface LinkEnvironmentInput extends Answers {
   targetEnvironment: string;
 }
 
-type Environment = {
+export type Environment = {
   name: string;
+  hasLiveDeployment: boolean;
+  hasPendingDeployment: boolean;
 };
 
 type EnvironmentsList = Environment[];

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -55,7 +55,7 @@ export type ListLinkProjectsResponse = {
 
 export type ListLinkEnvironmentsResponse = {
   data: {
-    data: EnvironmentInfo[] | Record<string, never>;
+    data: EnvironmentDetails[] | Record<string, never>;
   };
 };
 

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -22,6 +22,12 @@ export type ProjectInfo = {
 
 export type EnvironmentInfo = Record<string, unknown>;
 
+export type EnvironmentDetails = {
+  name: string;
+  hasLiveDeployment: boolean;
+  hasPendingDeployment: boolean;
+};
+
 export type ProjectInput = Omit<ProjectInfo, 'id'>;
 
 export type DeployResponse = {
@@ -55,10 +61,12 @@ export type ListLinkEnvironmentsResponse = {
 
 export type GetProjectResponse = {
   data: {
+    displayName: string;
     updatedAt: string;
     suspendedAt?: string;
     isTrial: boolean;
     environments: string[];
+    environmentsDetails: EnvironmentDetails[];
   };
   metadata: {
     dashboardUrls: {

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -22,6 +22,9 @@ export type CloudCliConfig = {
     defaults: Partial<ProjectAnswers>;
     introText: string;
   };
+  projectDeployment: {
+    confirmationText: string;
+  };
   buildLogsConnectionTimeout: string;
   buildLogsMaxRetries: string;
   notificationsConnectionTimeout: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7176,6 +7176,7 @@ __metadata:
     "@types/eventsource": "npm:1.1.15"
     "@types/lodash": "npm:^4.14.191"
     axios: "npm:1.7.4"
+    boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
     commander: "npm:8.3.0"


### PR DESCRIPTION
### What does it do?

We add a warning message to be displayed when the deploy command is used and the target environment has already a deployment done or is in progress.

At the same time, a `-f / --force` flag to skip the warning and confirmation prompt has been introduced.

### Why is it needed?

Deploying a local project with a different db state will incur in data loss. We need to warn users that deploying is a also a destructive operation. 

### How to test it?
----
**Pretest** 

**Verify Deployment Commands**

- Steps: Run the `strapi deploy -h` command.
Confirm the help output includes the following commands and options:

```
Deploy a Strapi Cloud project

Options:
  -d, --debug       Enable debugging mode with verbose logs
  -s, --silent      Don't log anything
  -f, --force       Skip confirmation to deploy
  -e, --env <name>  Specify the environment to deploy
  -h, --help        display help for command
```

**Tests**

You would need an environment with a deployment done and another without. To achieve the second, you can create a new environment and cancel the build process.

You should test all ways to deploy a project:

- `deploy` command
- `deploy -e <environment>`
- `deploy --env <environment>`
- deploy with default environment set (`cloud environment link `→ select an environment)

You should at least test one case with a deployment in course and one with a finished successful deployment.

**1. Project with no deployments:**

A project with no deployments should not display a warning on deploy in any case

**2. Project with deployments in course or done:**

- A project with a deployment should always display warning and ask for confirmation to deploy

- When using `deploy -f` / `deploy --force` the warning should not be displayed and the deployment should be done straightaway

- `deploy -e <environment> -f` should deploy straightaway without warning.

- Warning should look like in the screenshot:

![Screenshot 2024-11-14 at 11 52 01](https://github.com/user-attachments/assets/c292f665-6f60-47f9-9d20-d107ca894115)
