### PR TITLE
fix: the disabled components don’t look like they are disabled inside content history

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -23,10 +23,10 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
     width: 2.4rem;
     height: 2.4rem;
     > circle {
-      fill: ${({ theme }) => (!disabled ? theme.colors.neutral600 : theme.colors.primary200)};
+      fill: ${({ theme }) => (!disabled ? theme.colors.neutral400 : theme.colors.primary200)};
     }
     > path {
-      fill: ${({ theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
+      fill: ${({ theme }) => (disabled ? theme.colors.neutral400 : theme.colors.primary600)};
     }
   `;
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -50,7 +50,6 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
             </Typography>
           </Flex>
         </Flex>
-        ;
       </Box>
     </>
   );

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -55,7 +55,5 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
   );
 };
 
-<div>test</div>;
-
 export { Initializer };
 export type { InitializerProps };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -23,7 +23,7 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
     <>
       <Box
         tag="button"
-        background="neutral100"
+        background={disabled ? 'neutral150' : 'neutral100'}
         borderColor={field.error ? 'danger600' : 'neutral200'}
         hasRadius
         disabled={disabled}
@@ -34,12 +34,12 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
         style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
       >
         <Flex direction="column" gap={2}>
-          <Flex justifyContent="center" color={disabled ? 'neutral400' : 'primary600'}>
+          <Flex justifyContent="center" color={disabled ? 'neutral500' : 'primary600'}>
             <PlusCircle width="3.2rem" height="3.2rem" />
           </Flex>
           <Flex justifyContent="center">
             <Typography
-              textColor={disabled ? 'neutral400' : 'primary600'}
+              textColor={disabled ? 'neutral600' : 'primary600'}
               variant="pi"
               fontWeight="bold"
             >

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -19,17 +19,6 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
 
   const field = useField(name);
 
-  const CircleIcon = styled(PlusCircle)`
-    width: 2.4rem;
-    height: 2.4rem;
-    > circle {
-      fill: ${({ theme }) => (!disabled ? theme.colors.neutral400 : theme.colors.primary200)};
-    }
-    > path {
-      fill: ${({ theme }) => (disabled ? theme.colors.neutral400 : theme.colors.primary600)};
-    }
-  `;
-
   return (
     <>
       <Box
@@ -45,7 +34,7 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
       >
         <Flex direction="column" gap={2}>
           <Flex justifyContent="center">
-            <CircleIcon />
+            <CircleIconWrapper disabled={disabled} />
           </Flex>
           <Flex justifyContent="center">
             <Typography
@@ -63,6 +52,20 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
       </Box>
     </>
   );
+};
+
+export const CircleIconWrapper = ({ disabled }: { disabled?: boolean }) => {
+  const CircleIcon = styled(PlusCircle)`
+    width: 3.2rem;
+    height: 3.2rem;
+    > circle {
+      fill: ${({ theme }) => (!disabled ? theme.colors.neutral400 : theme.colors.primary200)};
+    }
+    > path {
+      fill: ${({ theme }) => (disabled ? theme.colors.neutral400 : theme.colors.primary600)};
+    }
+  `;
+  return <CircleIcon />;
 };
 
 export { Initializer };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -55,6 +55,20 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
   );
 };
 
+{/* <Flex direction="column" gap={2}>
+  <Flex justifyContent="center" color={disabled ? 'neutral400' : 'primary600'}>
+    <PlusCircle width="2.4rem" height="2.4rem" />
+  </Flex>
+  <Flex justifyContent="center">
+    <Typography textColor={disabled ? 'neutral400' : 'primary600'} variant="pi" fontWeight="bold">
+      {formatMessage({
+        id: getTranslation('components.empty-repeatable'),
+        defaultMessage: 'No entry yet. Click to add one.',
+      })}
+    </Typography>
+  </Flex>
+</Flex>; */}
+
 export const CircleIconWrapper = ({ disabled }: { disabled?: boolean }) => {
   const CircleIcon = styled(PlusCircle)`
     width: 3.2rem;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -19,6 +19,17 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
 
   const field = useField(name);
 
+  const CircleIcon = styled(PlusCircle)`
+    width: 2.4rem;
+    height: 2.4rem;
+    > circle {
+      fill: ${({ theme }) => (!disabled ? theme.colors.neutral600 : theme.colors.primary200)};
+    }
+    > path {
+      fill: ${({ theme }) => (disabled ? theme.colors.neutral600 : theme.colors.primary600)};
+    }
+  `;
+
   return (
     <>
       <Box
@@ -37,7 +48,11 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
             <CircleIcon />
           </Flex>
           <Flex justifyContent="center">
-            <Typography textColor="primary600" variant="pi" fontWeight="bold">
+            <Typography
+              textColor={disabled ? `neutral600` : `primary600`}
+              variant="pi"
+              fontWeight="bold"
+            >
               {formatMessage({
                 id: getTranslation('components.empty-repeatable'),
                 defaultMessage: 'No entry yet. Click to add one.',
@@ -49,17 +64,6 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
     </>
   );
 };
-
-const CircleIcon = styled(PlusCircle)`
-  width: 2.4rem;
-  height: 2.4rem;
-  > circle {
-    fill: ${({ theme }) => theme.colors.primary200};
-  }
-  > path {
-    fill: ${({ theme }) => theme.colors.primary600};
-  }
-`;
 
 export { Initializer };
 export type { InitializerProps };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -34,12 +34,12 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
         style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
       >
         <Flex direction="column" gap={2}>
-          <Flex justifyContent="center">
-            <CircleIconWrapper disabled={disabled} />
+          <Flex justifyContent="center" color={disabled ? 'neutral400' : 'primary600'}>
+            <PlusCircle width="3.2rem" height="3.2rem" />
           </Flex>
           <Flex justifyContent="center">
             <Typography
-              textColor={disabled ? `neutral600` : `primary600`}
+              textColor={disabled ? 'neutral400' : 'primary600'}
               variant="pi"
               fontWeight="bold"
             >
@@ -50,37 +50,10 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
             </Typography>
           </Flex>
         </Flex>
+        ;
       </Box>
     </>
   );
-};
-
-{/* <Flex direction="column" gap={2}>
-  <Flex justifyContent="center" color={disabled ? 'neutral400' : 'primary600'}>
-    <PlusCircle width="2.4rem" height="2.4rem" />
-  </Flex>
-  <Flex justifyContent="center">
-    <Typography textColor={disabled ? 'neutral400' : 'primary600'} variant="pi" fontWeight="bold">
-      {formatMessage({
-        id: getTranslation('components.empty-repeatable'),
-        defaultMessage: 'No entry yet. Click to add one.',
-      })}
-    </Typography>
-  </Flex>
-</Flex>; */}
-
-export const CircleIconWrapper = ({ disabled }: { disabled?: boolean }) => {
-  const CircleIcon = styled(PlusCircle)`
-    width: 3.2rem;
-    height: 3.2rem;
-    > circle {
-      fill: ${({ theme }) => (!disabled ? theme.colors.neutral400 : theme.colors.primary200)};
-    }
-    > path {
-      fill: ${({ theme }) => (disabled ? theme.colors.neutral400 : theme.colors.primary600)};
-    }
-  `;
-  return <CircleIcon />;
 };
 
 export { Initializer };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -31,6 +31,7 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
         paddingTop={9}
         paddingBottom={9}
         type="button"
+        style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
       >
         <Flex direction="column" gap={2}>
           <Flex justifyContent="center">

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Initializer.tsx
@@ -55,5 +55,7 @@ const Initializer = ({ disabled, name, onClick }: InitializerProps) => {
   );
 };
 
+<div>test</div>;
+
 export { Initializer };
 export type { InitializerProps };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
I have fixed a component cosmetic issue where inside the Content History page it was showing as not disabled.
Eventually I chose to pass props at the level of the component and remove the styled component all together.
The <Flex> component supports passing down the current color prop. Also the <PlusCircle> icon supports pasing down props such as width and height.

### Why is it needed?
The disabled components don’t look like they are disabled. It makes it hard to understand that the fields in Content History are not editable.

### How to test it?
Steps to reproduce:
- Go to an entry with a component
- Click on the 3 dots
- Click on Content History (you will need a paid license)
- The Components should appear as disabled (grey text instead of blue).

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/20796

