### PR TITLE
test(e2e): improve efficiency of collection-type test

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -28,14 +28,6 @@ test.describe('Edit collection type', () => {
       name: ctName,
       attributes,
     });
-    await createCollectionType(page, {
-      name: 'dog',
-      attributes,
-    });
-    await createCollectionType(page, {
-      name: 'owner',
-      attributes,
-    });
 
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
@@ -47,30 +39,30 @@ test.describe('Edit collection type', () => {
   });
 
   // Tests for GH#21398
-  test('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
-    // Create dog owner relation in Content-Type Builder
-    await navToHeader(page, ['Content-Type Builder', 'Dog'], 'Dog');
+  test.only('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
+    // Create relation in Content-Type Builder
+    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
     await page.getByRole('button', { name: /add another field to this/i }).click();
     await page.getByRole('button', { name: /relation/i }).click();
     await page.getByLabel('Basic settings').getByRole('button').nth(3).click();
     await page.getByRole('button', { name: /article/i }).click();
-    await page.getByRole('menuitem', { name: /owner/i }).click();
+    await page.getByRole('menuitem', { name: /author/i }).click();
     await page.getByRole('button', { name: 'Finish' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('cell', { name: 'owner', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'author', exact: true })).toBeVisible();
 
-    // update dog owner relation in Content-Type Builder to oneToOne
-    await page.getByRole('button', { name: /edit owner/i }).click();
+    // update relation in Content-Type Builder to oneToOne
+    await page.getByRole('button', { name: /edit author/i }).click();
     await page.getByLabel('Basic settings').getByRole('button').nth(0).click();
     await page.getByRole('button', { name: 'Finish' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('cell', { name: 'owner', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'author', exact: true })).toBeVisible();
   });
 
   test('Can toggle internationalization', async ({ page }) => {
@@ -81,7 +73,7 @@ test.describe('Edit collection type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can toggle draft&publish', async ({ page }) => {
@@ -93,7 +85,7 @@ test.describe('Edit collection type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can add a field with default value', async ({ page }) => {
@@ -110,7 +102,7 @@ test.describe('Edit collection type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   /**
@@ -157,6 +149,6 @@ test.describe('Edit collection type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 });

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -39,7 +39,7 @@ test.describe('Edit collection type', () => {
   });
 
   // Tests for GH#21398
-  test.only('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
+  test('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
     // Create relation in Content-Type Builder
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
     await page.getByRole('button', { name: /add another field to this/i }).click();

--- a/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
@@ -5,7 +5,7 @@ import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
 import { clickAndWait } from '../../../utils/shared';
 
-test.describe('Create collection type', () => {
+test.describe('Create single type', () => {
   // very long timeout for these tests because they restart the server multiple times
   test.describe.configure({ timeout: 300000 });
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -46,7 +46,7 @@ test.describe('Edit single type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can toggle draft&publish', async ({ page }) => {
@@ -58,7 +58,7 @@ test.describe('Edit single type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can add a field with default value', async ({ page }) => {
@@ -74,6 +74,6 @@ test.describe('Edit single type', () => {
 
     await waitForRestart(page);
 
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

use existing content types instead of creating 2 additional types on every test (reducing server restarts by 8 🙈 )

### Why is it needed?

test is flaky because it restarts too many times and is exceptionally slow

### How to test it?

it should pass

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
