### PR TITLE
fix: replaced translation id for the save button of the edit view

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -773,7 +773,7 @@ const UpdateAction: DocumentActionComponent = ({
      */
     disabled: isSubmitting || (!modified && !isCloning) || activeTab === 'published',
     label: formatMessage({
-      id: 'content-manager.containers.Edit.save',
+      id: 'global.save',
       defaultMessage: 'Save',
     }),
     onClick: async () => {


### PR DESCRIPTION
### What does it do?

I replaced the translation `id` for the "Save" button of the edit view.

### Why is it needed?

The save button is never translated in any language because the `id` is not the right one.

### How to test it?

1. Go to the profile settings
2. Change the language to anything else than english
3. Go to any entry
4. Check the "Save" button

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/22192