### PR TITLE
test(e2e): fix flaky ctb tests

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -9,9 +9,8 @@ test.describe('Edit collection type', () => {
   // very long timeout for these tests because they restart the server multiple times
   test.describe.configure({ timeout: 300000 });
 
-  // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
-  const ctName = 'Secret Document';
-  const attributes = [{ type: 'text', name: 'testtext' }];
+  // use existing type to avoid extra resets and flakiness
+  const ctName = 'Article';
 
   test.beforeEach(async ({ page }) => {
     await resetFiles();
@@ -19,14 +18,7 @@ test.describe('Edit collection type', () => {
       importData: 'with-admin.tar',
       login: true,
       skipTour: true,
-      // Don't reset files here as it would only run once for the whole suite
-      resetFiles: false,
-    });
-
-    // Reset files and create the same CTs between each test to prevent side effects
-    await createCollectionType(page, {
-      name: ctName,
-      attributes,
+      resetFiles: true,
     });
 
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
@@ -34,7 +26,7 @@ test.describe('Edit collection type', () => {
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await resetFiles();
   });
 
@@ -42,49 +34,72 @@ test.describe('Edit collection type', () => {
   test('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
     // Create relation in Content-Type Builder
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
-    await page.getByRole('button', { name: /add another field to this/i }).click();
+    await page.getByRole('button', { name: /add another field to this collection type/i }).click();
     await page.getByRole('button', { name: /relation/i }).click();
     await page.getByLabel('Basic settings').getByRole('button').nth(3).click();
     await page.getByRole('button', { name: /article/i }).click();
-    await page.getByRole('menuitem', { name: /author/i }).click();
+    await page.getByRole('menuitem', { name: /product/i }).click();
     await page.getByRole('button', { name: 'Finish' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
 
+    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
+    // Fix the bug then remove this
     await waitForRestart(page);
 
-    await expect(page.getByRole('cell', { name: 'author', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
 
     // update relation in Content-Type Builder to oneToOne
-    await page.getByRole('button', { name: /edit author/i }).click();
+    await page.getByRole('button', { name: /edit product/i }).click();
     await page.getByLabel('Basic settings').getByRole('button').nth(0).click();
     await page.getByRole('button', { name: 'Finish' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
-
     await waitForRestart(page);
-
-    await expect(page.getByRole('cell', { name: 'author', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
   });
 
   test('Can toggle internationalization', async ({ page }) => {
+    // toggle off
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Internationalization').click();
+    await page.getByRole('button', { name: 'Yes, disable' }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
+    // Fix the bug then remove this
+    await page.reload();
+
+    // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Finish' }).click();
-
     await waitForRestart(page);
-
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can toggle draft&publish', async ({ page }) => {
+    // toggle off
     await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
     await page.getByRole('button', { name: 'Finish' }).click();
-
     await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
+    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
+    // Fix the bug then remove this
+    await page.reload();
+
+    // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Draft & publish').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -9,23 +9,15 @@ test.describe('Edit single type', () => {
   // very long timeout for these tests because they restart the server multiple times
   test.describe.configure({ timeout: 300000 });
 
-  // use a name with a capital and a space to ensure we also test the kebab-casing conversion for api ids
-  const ctName = 'Secret Document';
-  const attributes = [{ type: 'text', name: 'testtext' }];
+  // Use the existing single-type from our test data
+  const ctName = 'Homepage';
 
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
     await sharedSetup('ctb-edit-st', page, {
       login: true,
       skipTour: true,
-      // Don't reset files here as it would only run once for the whole suite
-      resetFiles: false,
+      resetFiles: true,
       importData: 'with-admin.tar',
-    });
-
-    await createSingleType(page, {
-      name: ctName,
-      attributes,
     });
 
     // Then go to our content type
@@ -34,30 +26,53 @@ test.describe('Edit single type', () => {
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterAll(async () => {
+  test.afterEach(async ({ page }) => {
     await resetFiles();
   });
 
   test('Can toggle internationalization', async ({ page }) => {
+    // toggle off
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Internationalization').click();
+    await page.getByRole('button', { name: 'Yes, disable' }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
+    // Fix the bug then remove this
+    await page.reload();
+
+    // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Finish' }).click();
-
     await waitForRestart(page);
-
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 
   test('Can toggle draft&publish', async ({ page }) => {
+    // toggle off
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
     await page.getByRole('button', { name: 'Finish' }).click();
-
     await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
+    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
+    // Fix the bug then remove this
+    await page.reload();
+
+    // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Draft & publish').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 


### PR DESCRIPTION
### What does it do?

for both single-type and collection-type:

- use an existing content type to add attributes to instead of creating one
- add tests for toggles in both directions
- add fix / workaround with comment for bug where after server restart the UI still uses the old schema settings for the modal data

no longer tests creating a content type with spaces in the 'edit' tests, but they are still created in the 'create' tests, so no coverage is actually lost

### Why is it needed?

flaky and/or broken tests

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
