### PR TITLE
test(e2e): add content search test suite

### DIFF
--- a/tests/e2e/tests/search/content-type.spec.ts
+++ b/tests/e2e/tests/search/content-type.spec.ts
@@ -9,10 +9,22 @@ test.describe('Search', () => {
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
     await page.goto('/admin');
     await login({ page });
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
   });
 
-  test('Searching without a space works', async ({ page }) => {
+  // TODO: Extremely long search string
+
+  // TODO: Clearing the search box
+
+  test('ASCII (no spaces)', async ({ page }) => {
     const searchTerm = 'Nike';
+
+    // create doc that shouldn't be found
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill('Product 1');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
 
     // search for searchTerm
     await navToHeader(page, ['Content Manager', 'Products'], 'Products');
@@ -26,9 +38,13 @@ test.describe('Search', () => {
     await expect(rows).toHaveCount(2);
   });
 
-  // TODO: This is currently skipped because of an actual bug that needs to be fixed before this is enabled
-  test.fixme('Searching with a space works', async ({ page }) => {
-    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+  //
+  // TODO: The tests below here are currently skipped because of an actual bug that needs to be fixed regarding url encoding params
+  //
+
+  test.fixme('ASCII (spaces)', async ({ page }) => {
+    // space tests that url encoding is done correctly
+    const searchTerm = 'Product 2';
 
     // create first doc
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
@@ -40,17 +56,14 @@ test.describe('Search', () => {
     // create second doc
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
     await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
-    await page.getByRole('textbox', { name: 'name' }).fill('Product 2');
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
 
-    // TODO: remove this, for some reason playwright trace only shows white screen without this even though it works
-    await page.reload();
-
-    // search for 'Product 2' (the space is important because it tests character encoding for _q param)
+    // search for searchTerm
     await navToHeader(page, ['Content Manager', 'Products'], 'Products');
     await page.getByRole('button', { name: 'Search', exact: true }).click();
-    await page.fill('input[name="search"]', 'Product');
+    await page.fill('input[name="search"]', searchTerm);
     await page.locator('input[name="search"]').press('Enter');
 
     const tableWithProduct = page.locator('table:has-text("Product")');
@@ -58,5 +71,116 @@ test.describe('Search', () => {
     await expect(rows).toHaveCount(2);
 
     await page.getByRole('link', { name: 'asdfasdfasdfas' }).click();
+  });
+
+  test.fixme('extended ASCII', async ({ page }) => {
+    const searchTerm = 'Café';
+
+    // Create document
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // Search
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // Assert
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+  });
+
+  // Unicode Search Test
+  test.fixme('Unicode', async ({ page }) => {
+    const searchTerm = '商品';
+
+    // Create document
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // Search
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // Assert
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+  });
+
+  test.fixme('emojis', async ({ page }) => {
+    const searchTerm = '🎉🎉🎉';
+
+    // Create document
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // Search
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // Assert
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+  });
+
+  test.fixme('Special characters', async ({ page }) => {
+    const searchTerm = 'Product & = + # Test';
+
+    // Create document
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // Search
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // Assert
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+  });
+
+  test.fixme('Mixed encoding', async ({ page }) => {
+    const searchTerm = '商品 🎉 Café & # 1';
+
+    // Create document
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill(searchTerm);
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // Search
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // Assert
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
   });
 });

--- a/tests/e2e/tests/search/content-type.spec.ts
+++ b/tests/e2e/tests/search/content-type.spec.ts
@@ -22,7 +22,7 @@ function createSearchTest(testFunction, description, searchTerm) {
     const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
     const rows = tableWithProduct.locator('tr');
 
-    // Note that there is already an item in there, so if search didn't work this would be 3
+    // Note that there is already an item in there, so if search didn't filter this would be 3 or more
     await expect(rows).toHaveCount(2);
   });
 }
@@ -35,9 +35,11 @@ test.describe('Search', () => {
     await navToHeader(page, ['Content Manager', 'Products'], 'Products');
   });
 
+  // TODO: Test clearing the search box
+
+  // The testFn is necessary so that we can skip tests
   const testCases = [
-    // TODO: Extremely long search string
-    // TODO: Clearing the search box
+    // TODO: Test extremely long search string
     { testFn: test, description: 'ASCII (no spaces)', searchTerm: 'TestMe' },
     { testFn: test.fixme, description: 'ASCII (spaces)', searchTerm: 'Product 2' },
     { testFn: test.fixme, description: 'extended ASCII', searchTerm: 'Café' },

--- a/tests/e2e/tests/search/content-type.spec.ts
+++ b/tests/e2e/tests/search/content-type.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
+import { login } from '../../utils/login';
+import { clickAndWait, navToHeader } from '../../utils/shared';
+
+test.describe('Search', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin.tar');
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('Searching without a space works', async ({ page }) => {
+    const searchTerm = 'Nike';
+
+    // search for searchTerm
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', searchTerm);
+    await page.locator('input[name="search"]').press('Enter');
+
+    // check that only expected results are found
+    const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+  });
+
+  // TODO: This is currently skipped because of an actual bug that needs to be fixed before this is enabled
+  test.fixme('Searching with a space works', async ({ page }) => {
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+
+    // create first doc
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill('Product 1');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // create second doc
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'name' }).fill('Product 2');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    // TODO: remove this, for some reason playwright trace only shows white screen without this even though it works
+    await page.reload();
+
+    // search for 'Product 2' (the space is important because it tests character encoding for _q param)
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
+    await page.fill('input[name="search"]', 'Product');
+    await page.locator('input[name="search"]').press('Enter');
+
+    const tableWithProduct = page.locator('table:has-text("Product")');
+    const rows = tableWithProduct.locator('tr');
+    await expect(rows).toHaveCount(2);
+
+    await page.getByRole('link', { name: 'asdfasdfasdfas' }).click();
+  });
+});


### PR DESCRIPTION
### What does it do?

adds an e2e test suite for the content-type search box

### Why is it needed?

it was missing

specifically, to provide a (skipped) tests for the eventual resolution of https://github.com/strapi/strapi/issues/21791

### How to test it?

it should pass

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21791
