### PR TITLE
fix: search param being encoded twice

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -150,6 +150,15 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
     <Param = unknown>(params?: Param) =>
     (url: string) => {
       if (params) {
+        if (typeof params === 'string') {
+          return `${url}?${params}`;
+        }
+
+        /**
+         * TODO V6: Encoding should be enabled in this step
+         * So the rest of the app doesn't have to worry about it,
+         * It's considered a breaking change because it impacts any API request, including the user's custom code
+         */
         const serializedParams = qs.stringify(params, { encode: false });
         return `${url}?${serializedParams}`;
       }

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -100,21 +100,10 @@ const ListViewPage = () => {
   });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
-  const queryString = React.useMemo(
-    () => stringify(params, { encode: true, encodeValuesOnly: true }),
-    [params]
-  );
-  const paramObject = React.useMemo(() => {
-    const pairs = queryString.split('&').map((param) => {
-      const [key, value] = param.split('=');
-      return { [key]: value };
-    });
-    return Object.assign({}, ...pairs);
-  }, [queryString]);
 
   const { data, error, isFetching } = useGetAllDocumentsQuery({
     model,
-    params: paramObject,
+    params,
   });
 
   /**

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -1,6 +1,7 @@
 /**
  * Related to fetching the actual content of a collection type or single type.
  */
+import { stringify } from 'qs';
 
 import { SINGLE_TYPES } from '../constants/collections';
 
@@ -169,7 +170,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         url: `/content-manager/collection-types/${model}`,
         method: 'GET',
         config: {
-          params,
+          params: stringify(params, { encode: true }),
         },
       }),
       providesTags: (result, _error, arg) => {

--- a/packages/core/content-manager/admin/src/utils/api.ts
+++ b/packages/core/content-manager/admin/src/utils/api.ts
@@ -32,12 +32,6 @@ const buildValidParams = <TQuery extends Query>(query: TQuery): TransformedQuery
     ),
   };
 
-  if ('_q' in validQueryParams) {
-    // Encode the search query here since the paramsSerializer will not
-    // @ts-expect-error – TODO: fix this type error
-    validQueryParams._q = encodeURIComponent(validQueryParams._q);
-  }
-
   return validQueryParams;
 };
 

--- a/packages/core/content-manager/admin/src/utils/tests/api.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/api.test.ts
@@ -23,26 +23,5 @@ describe('api', () => {
         }
       `);
     });
-
-    it('should encode a search query', () => {
-      const _q = `test query`;
-      const queryParams = {
-        page: '1',
-        pageSize: '10',
-        sort: 'name:ASC',
-        _q,
-      };
-
-      const params = buildValidParams(queryParams);
-
-      expect(params).toMatchInlineSnapshot(`
-        {
-          "_q": "test%20query",
-          "page": "1",
-          "pageSize": "10",
-          "sort": "name:ASC",
-        }
-      `);
-    });
   });
 });

--- a/packages/core/review-workflows/admin/src/utils/api.ts
+++ b/packages/core/review-workflows/admin/src/utils/api.ts
@@ -38,12 +38,6 @@ const buildValidParams = <TQuery extends Query>(query: TQuery): TransformedQuery
     ),
   };
 
-  if ('_q' in validQueryParams) {
-    // Encode the search query here since the paramsSerializer will not
-    // @ts-expect-error – TODO: fix this type error
-    validQueryParams._q = encodeURIComponent(validQueryParams._q);
-  }
-
   return validQueryParams;
 };
 


### PR DESCRIPTION
### What does it do?

Searching in the List View with special characters ( * & / ...) was not working.
Characters were being encoded twice.

The solution proposes removing all encodings we had for `_q` (or any other param) , and handling the encoding inside the injected content manager endpoints.

Ideally, this should be done by the api interceptor, but doing so would be a breaking change at the moment.

### How to test it?
- Create some entries in a content-type named like `A & B` and `C & D`
- Try to search specifically for `A & B`
- The `A & B` entry should appear in the list

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/21791
