### PR TITLE
fix(e2e): use clickAndWait to ensure the page is ready

### DIFF
--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -30,7 +30,7 @@ const goToHistoryPage = async (page: Page) => {
 
   // TODO find out why the history button sometimes doesn't appear. Reloading shouldn't be necessary
   if (await historyButton.isVisible()) {
-    await historyButton.click();
+    await clickAndWait(page, historyButton);
   } else {
     await page.reload();
     await goToHistoryPage(page);
@@ -229,9 +229,9 @@ describeOnCondition(edition === 'EE')('History', () => {
       await page.getByRole('menuitem', { name: /delete entry/i }).click();
       await page.getByRole('button', { name: /confirm/i }).click();
 
-      // Go to the the article's history page
+      // Go to the history page
       await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
-      await page.getByRole('gridcell', { name: 'Zava retires' }).click();
+      await clickAndWait(page, page.getByRole('gridcell', { name: 'Zava retires' }));
       await page.waitForURL(ARTICLE_EDIT_URL);
       await goToHistoryPage(page);
       await page.waitForURL(ARTICLE_HISTORY_URL);
@@ -432,9 +432,7 @@ describeOnCondition(edition === 'EE')('History', () => {
 
       // Create new author
       await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-      // await page.waitForSelector('text=Author');
       await clickAndWait(page, page.getByRole('link', { name: 'Author' }));
-      // await page.waitForSelector('text=Create new entry');
       await clickAndWait(page, page.getByRole('link', { name: /Create new entry/, exact: true }));
       await page.waitForURL(AUTHOR_CREATE_URL);
       await page.getByRole('textbox', { name: 'name' }).fill('Will Kitman');
@@ -457,11 +455,11 @@ describeOnCondition(edition === 'EE')('History', () => {
       await page.getByRole('menuitem', { name: /delete entry/i }).click();
       await page.getByRole('button', { name: /confirm/i }).click();
 
-      // Go to the the article's history page
+      // Go to the history page
       await clickAndWait(page, page.getByRole('link', { name: 'Homepage' }));
       await page.waitForURL(HOMEPAGE_EDIT_URL);
       await page.getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /content history/i }).click();
+      await clickAndWait(page, page.getByRole('menuitem', { name: /content history/i }));
       await page.waitForURL(HOMEPAGE_HISTORY_URL);
 
       // Assert that the unknown relation alert is displayed

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -80,10 +80,7 @@ export const skipCtbTour = async (page: Page) => {
  */
 export const clickAndWait = async (page: Page, locator: Locator) => {
   await locator.click();
-
-  if (page.context().browser()?.browserType().name() === 'webkit') {
-    await page.waitForLoadState('networkidle');
-  }
+  await page.waitForLoadState('networkidle');
 };
 
 /**


### PR DESCRIPTION
### What does it do?

- Removes condition in order to `waitForLoadState` on every browser
- Uses clickAndWait when navigating from page to page

### Why is it needed?

- The test is flaky often failing to find the first locator after page navigation
- It fails for webkit and firefox 

### How to test it?

The CI should pass
