### PR TITLE
fix: replaced the Code icon with CodeBlock icon

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Code.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Code.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Box, SingleSelect, SingleSelectOption } from '@strapi/design-system';
-import { Code } from '@strapi/icons';
+import { CodeBlock as CodeBlockIcon } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { Editor, Transforms } from 'slate';
 import { useSelected, type RenderElementProps, useFocused, ReactEditor } from 'slate-react';
@@ -95,7 +95,7 @@ const CodeEditor = (props: RenderElementProps) => {
 const codeBlocks: Pick<BlocksStore, 'code'> = {
   code: {
     renderElement: (props) => <CodeEditor {...props} />,
-    icon: Code,
+    icon: CodeBlockIcon,
     label: {
       id: 'components.Blocks.blocks.code',
       defaultMessage: 'Code block',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Replaced the Code icon with CodeBlock icon inside the block editor.

### Why is it needed?
Users were confusing them. One is a code block modifier and the other is simply a inline block modifier.

### How to test it?
Create a collection with a block editor field. Click the dropdown and see at the bottom where it says Code Block.
The icon should be now different than the inline code on the Toolbar.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/22058
