### PR TITLE
fix: the confirmation message of restoring a version was updated

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionHeader.tsx
@@ -78,7 +78,7 @@ export const VersionHeader = ({ headerId }: VersionHeaderProps) => {
           }),
           message: formatMessage({
             id: 'content-manager.restore.success.message',
-            defaultMessage: 'The content of the restored version is not published yet.',
+            defaultMessage: 'A past version of the content was restored.',
           }),
         });
 

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -287,7 +287,7 @@
   "history.restore.confirm.title": "Are you sure you want to restore this version?",
   "history.restore.confirm.message": "{isDraft, select, true {The restored content will override your draft.} other {The restored content won't be published, it will override the draft and be saved as pending changes. You'll be able to publish the changes at anytime.}}",
   "history.restore.success.title": "Version restored.",
-  "history.restore.success.message": "The content of the restored version is not published yet.",
+  "history.restore.success.message": "A past version of the content was restored.",
   "history.restore.error.message": "Could not restore version.",
   "validation.error": "There are validation errors in your document. Please fix them before saving.",
   "bulk-publish.edit": "Edit"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
It updates the message for the notification box after an user restores a document version.

### Why is it needed?
The message was reported as incorrect.

### How to test it?
- Edit an entry of a content-type without D&P enabled
- Go to the content history of this entry (you will need a paid license)
- Restore a past version of the entry
- See the notification saying that the version was restored on top of a published one

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/21175
