### PR TITLE
fix: preview title overflow

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -156,9 +156,9 @@ const PreviewHeader = () => {
       {/* Title and status */}
       <Grid.Item xs={1} paddingTop={2} paddingBottom={2} gap={3}>
         <ClosePreviewButton />
-        <Typography tag="h1" fontWeight={600} fontSize={2} maxWidth="200px">
+        <PreviewTitle tag="h1" fontWeight={600} fontSize={2} maxWidth="200px">
           {title}
-        </Typography>
+        </PreviewTitle>
         <Status />
       </Grid.Item>
       {/* Tabs */}
@@ -181,6 +181,12 @@ const PreviewHeader = () => {
     </Grid.Root>
   );
 };
+
+const PreviewTitle = styled(Typography)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
 
 const StatusTab = styled(Tabs.Trigger)`
   text-transform: uppercase;


### PR DESCRIPTION
## What does it do?

Handle long title names for static preview:

![image](https://github.com/user-attachments/assets/7638d7a8-0a9f-412f-8eaf-16b119b9df20)

Before , the title was being wrapped and made the header higher.



### How to test it?

- Create an entry with a long title
- Open Preview and see the title being cropped to fit maximum 200px

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/22158
