### PR TITLE
chore: add json data to dummy preview

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -22,7 +22,9 @@ module.exports = ({ env }) => ({
     enabled: env.bool('PREVIEW_ENABLED', true),
     config: {
       handler: (uid, { documentId, locale, status }) => {
-        return `/admin/preview/${uid}/${documentId}/${locale}/${status}`;
+        const kind =
+          strapi.contentType(uid).kind === 'collectionType' ? 'collection-types' : 'single-types';
+        return `/admin/preview/${kind}/${uid}/${documentId}/${locale}/${status}`;
       },
     },
   },

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -3,15 +3,22 @@ import { useParams } from 'react-router-dom';
 
 // @ts-ignore
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
-import { Grid, Flex, Typography } from '@strapi/design-system';
+import { unstable_useDocument as useDocument } from '@strapi/content-manager/strapi-admin';
+import { Grid, Flex, Typography, JSONInput } from '@strapi/design-system';
 
 const PreviewComponent = () => {
-  const { uid, documentId, locale, status } = useParams();
+  const { uid: model, documentId, locale, status, collectionType } = useParams();
+  const { document } = useDocument({
+    model,
+    documentId,
+    params: { locale, status },
+    collectionType,
+  });
 
   return (
     <Layouts.Root>
       <Page.Main>
-        <Page.Title>{`Previewing ${uid}`}</Page.Title>
+        <Page.Title>{`Previewing ${model}`}</Page.Title>
         <Layouts.Header title="Static Preview" subtitle="Dummy preview for getstarted app" />
         <Layouts.Content>
           <Flex
@@ -36,7 +43,7 @@ const PreviewComponent = () => {
                   Content Type
                 </Typography>
                 <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{uid}</Typography>
+                  <Typography>{model}</Typography>
                 </Flex>
               </Grid.Item>
               <Grid.Item col={6} s={12} direction="column" alignItems="start">
@@ -62,6 +69,7 @@ const PreviewComponent = () => {
                 <Typography tag="dd">{locale}</Typography>
               </Grid.Item>
             </Grid.Root>
+            {document && <JSONInput value={JSON.stringify(document, null, 2)} disabled />}
           </Flex>
         </Layouts.Content>
       </Page.Main>

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -13,7 +13,7 @@ export const registerPreviewRoute = (app) => {
     path: 'preview/*',
     children: [
       {
-        path: ':uid/:documentId/:locale/:status',
+        path: ':collectionType/:uid/:documentId/:locale/:status',
         element: <Preview />,
       },
     ],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a JSON input with the raw document data to the internal dummy preview page

![screenshot 2024-11-22 at 10 24 22@2x](https://github.com/user-attachments/assets/3feff403-824a-4672-986b-436ecd19f8e0)


### Why is it needed?

it's more like a real preview that actually queries the content. It was handy for me in another PR where I want to make sure content updates are saved by the time I open the preview

