### PR TITLE
fix: unit tests for typescript types gen

### DIFF
--- a/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/attributes.test.js
@@ -680,17 +680,17 @@ describe('Attributes', () => {
           expect(definition.kind).toBe(ts.SyntaxKind.TypeLiteral);
           expect(definition.members).toHaveLength(2);
 
-          const [min, max] = definition.members;
-
-          expect(min.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-          expect(min.name.escapedText).toBe('min');
-          expect(min.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
-          expect(min.type.text).toBe('4');
+          const [max, min] = definition.members;
 
           expect(max.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
           expect(max.name.escapedText).toBe('max');
           expect(max.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
           expect(max.type.text).toBe('12');
+
+          expect(min.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+          expect(min.name.escapedText).toBe('min');
+          expect(min.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
+          expect(min.type.text).toBe('4');
 
           // Check for number keyword on the second typeArgument
           expect(typeofMinMax.kind).toBe(ts.SyntaxKind.NumberKeyword);
@@ -830,24 +830,19 @@ describe('Attributes', () => {
           expect(modifiers[0].typeArguments[0].kind).toBe(ts.SyntaxKind.TypeLiteral);
           expect(modifiers[0].typeArguments[0].members).toHaveLength(2);
 
-          // Min
-          expect(modifiers[0].typeArguments[0].members[0].kind).toBe(
-            ts.SyntaxKind.PropertyDeclaration
-          );
-          expect(modifiers[0].typeArguments[0].members[0].name.escapedText).toBe('minLength');
-          expect(modifiers[0].typeArguments[0].members[0].type.kind).toBe(
-            ts.SyntaxKind.NumericLiteral
-          );
-          expect(modifiers[0].typeArguments[0].members[0].type.text).toBe('4');
+          const [maxLength, minLength] = modifiers[0].typeArguments[0].members;
 
-          expect(modifiers[0].typeArguments[0].members[1].kind).toBe(
-            ts.SyntaxKind.PropertyDeclaration
-          );
-          expect(modifiers[0].typeArguments[0].members[1].name.escapedText).toBe('maxLength');
-          expect(modifiers[0].typeArguments[0].members[1].type.kind).toBe(
-            ts.SyntaxKind.NumericLiteral
-          );
-          expect(modifiers[0].typeArguments[0].members[1].type.text).toBe('12');
+          // Max
+          expect(maxLength.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+          expect(maxLength.name.escapedText).toBe('maxLength');
+          expect(maxLength.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
+          expect(maxLength.type.text).toBe('12');
+
+          // Min
+          expect(minLength.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+          expect(minLength.name.escapedText).toBe('minLength');
+          expect(minLength.type.kind).toBe(ts.SyntaxKind.NumericLiteral);
+          expect(minLength.type.text).toBe('4');
         });
       });
 

--- a/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
@@ -247,13 +247,13 @@ describe('Utils', () => {
       expect(objectNode.members).toHaveLength(2);
 
       expect(objectNode.members[0].kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(objectNode.members[0].name.escapedText).toBe('foo');
-      expect(objectNode.members[0].type.kind).toBe(ts.SyntaxKind.StringLiteral);
-      expect(objectNode.members[0].type.text).toBe('bar');
+      expect(objectNode.members[0].name.escapedText).toBe('bar');
+      expect(objectNode.members[0].type.kind).toBe(ts.SyntaxKind.TrueKeyword);
 
       expect(objectNode.members[1].kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(objectNode.members[1].name.escapedText).toBe('bar');
-      expect(objectNode.members[1].type.kind).toBe(ts.SyntaxKind.TrueKeyword);
+      expect(objectNode.members[1].name.escapedText).toBe('foo');
+      expect(objectNode.members[1].type.kind).toBe(ts.SyntaxKind.StringLiteral);
+      expect(objectNode.members[1].type.text).toBe('bar');
     });
 
     test('Object', () => {
@@ -262,20 +262,20 @@ describe('Utils', () => {
       expect(node.kind).toBe(ts.SyntaxKind.TypeLiteral);
       expect(node.members).toHaveLength(2);
 
-      const [firstMember, secondMember] = node.members;
+      const [barMember, fooMember] = node.members;
 
-      expect(firstMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(firstMember.name.escapedText).toBe('foo');
-      expect(firstMember.type.kind).toBe(ts.SyntaxKind.TupleType);
-      expect(firstMember.type.elements).toHaveLength(3);
-      expect(firstMember.type.elements[0].kind).toBe(ts.SyntaxKind.StringLiteral);
-      expect(firstMember.type.elements[1].kind).toBe(ts.SyntaxKind.TrueKeyword);
-      expect(firstMember.type.elements[2].kind).toBe(ts.SyntaxKind.FirstLiteralToken);
+      expect(barMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+      expect(barMember.name.escapedText).toBe('bar');
+      expect(barMember.type.kind).toBe(ts.SyntaxKind.LiteralType);
+      expect(barMember.type.literal).toBe(ts.SyntaxKind.NullKeyword);
 
-      expect(secondMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(secondMember.name.escapedText).toBe('bar');
-      expect(secondMember.type.kind).toBe(ts.SyntaxKind.LiteralType);
-      expect(secondMember.type.literal).toBe(ts.SyntaxKind.NullKeyword);
+      expect(fooMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+      expect(fooMember.name.escapedText).toBe('foo');
+      expect(fooMember.type.kind).toBe(ts.SyntaxKind.TupleType);
+      expect(fooMember.type.elements).toHaveLength(3);
+      expect(fooMember.type.elements[0].kind).toBe(ts.SyntaxKind.StringLiteral);
+      expect(fooMember.type.elements[1].kind).toBe(ts.SyntaxKind.TrueKeyword);
+      expect(fooMember.type.elements[2].kind).toBe(ts.SyntaxKind.FirstLiteralToken);
     });
 
     test('Object with complex keys', () => {
@@ -284,19 +284,19 @@ describe('Utils', () => {
       expect(node.kind).toBe(ts.SyntaxKind.TypeLiteral);
       expect(node.members).toHaveLength(2);
 
-      const [firstMember, secondMember] = node.members;
+      const [fooBar, fooDashBar] = node.members;
 
-      expect(firstMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(firstMember.name.kind).toBe(ts.SyntaxKind.StringLiteral);
-      expect(firstMember.name.text).toBe('foo-bar');
-      expect(firstMember.type.kind).toBe(ts.SyntaxKind.StringLiteral);
-      expect(firstMember.type.text).toBe('foobar');
+      expect(fooBar.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+      expect(fooBar.name.kind).toBe(ts.SyntaxKind.Identifier);
+      expect(fooBar.name.escapedText).toBe('foo');
+      expect(fooBar.type.kind).toBe(ts.SyntaxKind.StringLiteral);
+      expect(fooBar.type.text).toBe('bar');
 
-      expect(secondMember.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
-      expect(secondMember.name.kind).toBe(ts.SyntaxKind.Identifier);
-      expect(secondMember.name.escapedText).toBe('foo');
-      expect(secondMember.type.kind).toBe(ts.SyntaxKind.StringLiteral);
-      expect(secondMember.type.text).toBe('bar');
+      expect(fooDashBar.kind).toBe(ts.SyntaxKind.PropertyDeclaration);
+      expect(fooDashBar.name.kind).toBe(ts.SyntaxKind.StringLiteral);
+      expect(fooDashBar.name.text).toBe('foo-bar');
+      expect(fooDashBar.type.kind).toBe(ts.SyntaxKind.StringLiteral);
+      expect(fooDashBar.type.text).toBe('foobar');
     });
 
     test('Invalid data type supplied (function)', () => {


### PR DESCRIPTION
### What does it do?

Take into account the fact that properties are sorted within objects when generating typescript types. Fixes the unit tests.

### Why is it needed?

https://github.com/strapi/strapi/pull/21868 introduced sorting for generated types and their attributes, but didn't update the related unit tests.

For some reason, Github CI didn't seem to have an issue with that, but locally tests were failing.

### How to test it?

1. Checkout onto the branch
2. Run the unit tests, everything should work

### Related issue(s)/PR(s)

take over #22147
