### PR TITLE
fix: change MediaLibraryInput attribute type from required to optional

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
@@ -27,7 +27,7 @@ export interface MediaLibraryInputProps {
   label?: string;
   hint?: string;
   disabled?: boolean;
-  attribute: {
+  attribute?: {
     allowedTypes?: AllowedTypes[];
     multiple?: boolean;
   };
@@ -36,7 +36,7 @@ export interface MediaLibraryInputProps {
 export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibraryInputProps>(
   (
     {
-      attribute: { allowedTypes = ['videos', 'files', 'images', 'audios'], multiple = false },
+      attribute: { allowedTypes = ['videos', 'files', 'images', 'audios'], multiple = false } = {},
       label,
       hint,
       disabled = false,
@@ -204,7 +204,7 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
 
         {step === STEPS.AssetSelect && (
           <AssetDialog
-            allowedTypes={fieldAllowedTypes}
+            allowedTypes={fieldAllowedTypes as AllowedTypes[]}
             initiallySelectedAssets={initiallySelectedAssets}
             folderId={folderId}
             onClose={() => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I changed the type of the attribute prop in the MediaLibraryInput to be optional instead of required.

### Why is it needed?

Some strapi plugins had issues with the new type definition of the component, in particular reactions and navigations

### How to test it?

- Create a new Strapi project using the experimental `npx create-strapi-app@0.0.0-experimental.fb22a8bd8745528903b2f168fdd286dfd1f5082e --quickstart`
- then install the `reactions` plugin following the instructions at this page https://market.strapi.io/plugins/strapi-plugin-reactions
- open the settings page and click the Reactions link
- create a new Reactions
- you should be able to see the modal and create the reaction

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/22258
