### PR TITLE
fix(content-manager): non-unique keys for Dynamic Zone add above/below menu items

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -180,7 +180,7 @@ const DynamicComponent = ({
                 <React.Fragment key={category}>
                   <Menu.Label>{category}</Menu.Label>
                   {components.map(({ displayName, uid }) => (
-                    <Menu.Item key={componentUid} onSelect={() => onAddComponent(uid, index)}>
+                    <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index)}>
                       {displayName}
                     </Menu.Item>
                   ))}
@@ -200,7 +200,7 @@ const DynamicComponent = ({
                 <React.Fragment key={category}>
                   <Menu.Label>{category}</Menu.Label>
                   {components.map(({ displayName, uid }) => (
-                    <Menu.Item key={componentUid} onSelect={() => onAddComponent(uid, index + 1)}>
+                    <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index + 1)}>
                       {displayName}
                     </Menu.Item>
                   ))}


### PR DESCRIPTION
### What does it do?

Fixes a `Encountered two children with the same keys` React warning in the Content editor.
This error occurs when expanding the `Add component above` / `Add component below` menu items in Dynamic Zone fields.

### Why is it needed?

This error is displayed in the developer console:

```
Warning: Encountered two children with the same key, `content.text`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

### How to test it?

1. Add a Dynamic Zone field to a content type.
2. Add/edit a document with this type.
3. Add an entry to the field.
4. Open the browser console.
5. Open the `Add component above` / `Add component below` menu items.

![image](https://github.com/user-attachments/assets/2130e672-e788-4aac-8401-00555ccff9c1)

(The buttons themselves don't work in v5.2.0, but that is a different issue.)