### PR TITLE
enhancement: disable preview link when changes are not saved

### DIFF
--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -236,6 +236,7 @@
   "popover.display-relations.label": "Display relations",
   "preview.panel.title": "Preview",
   "preview.panel.button": "Open preview",
+  "preview.panel.button-disabled-tooltip": "Please save to open the preview",
   "preview.page-title": "{contentType} preview",
   "preview.header.close": "Close preview",
   "preview.copy.label": "Copy preview link",

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -34,7 +34,17 @@ describeOnCondition(edition === 'EE')('Preview', () => {
 
     // Should go back to the edit view on close
     await clickAndWait(page, page.getByRole('link', { name: /close preview/i }));
-    await expect(page.getByRole('textbox', { name: /title/i })).toBeVisible();
+    const titleInput = page.getByRole('textbox', { name: /title/i });
+    await expect(titleInput).toBeVisible();
+
+    // Preview link should be disabled when there are unsaved changes
+    await titleInput.fill('New title');
+    const previewLink = page.getByRole('link', { name: /open preview/i });
+    await expect(previewLink).toBeDisabled();
+    await previewLink.hover();
+    await expect(
+      page.getByRole('tooltip', { name: /please save to open the preview/i })
+    ).toBeVisible();
   });
 
   test('Preview button should not appear for content types without preview config', async ({


### PR DESCRIPTION
### What does it do?

Disables preview link when there are unsaved changes in the edit view. Also adds a tooltip to explain why it's disabled

### Why is it needed?

Help users avoid losing content
### How to test it?

Make changes, don't save, button should be disabled and you should see the tooltip.

Save changes, the button should be enabled, and the tooltip should be gone

### Related issue(s)/PR(s)

replaces #22244 