### PR TITLE
fix(history): handle nested component images

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
@@ -204,6 +204,7 @@ const VersionContent = () => {
       (schemaAttributes: Schema.Attributes, components: ComponentsDictionary = {}) =>
       (document: Omit<Document, 'id'>) => {
         const schema = { attributes: schemaAttributes };
+
         const transformations = pipe(
           removeFieldsThatDontExistOnSchema(schema),
           prepareTempKeys(schema, components)

--- a/packages/core/content-manager/server/src/history/controllers/history-version.ts
+++ b/packages/core/content-manager/server/src/history/controllers/history-version.ts
@@ -3,8 +3,8 @@ import type { Core, UID } from '@strapi/types';
 import { pick } from 'lodash/fp';
 import { getService as getContentManagerService } from '../../utils';
 import { getService } from '../utils';
-import { HistoryVersions } from '../../../../shared/contracts';
-import { RestoreHistoryVersion } from '../../../../shared/contracts/history-versions';
+import type { HistoryVersions } from '../../../../shared/contracts';
+import type { RestoreHistoryVersion } from '../../../../shared/contracts/history-versions';
 import { validateRestoreVersion } from './validation/history-version';
 
 /**

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -8,7 +8,7 @@ import { scheduleJob } from 'node-schedule';
 import { getService } from '../utils';
 import { FIELDS_TO_IGNORE, HISTORY_VERSION_UID } from '../constants';
 
-import { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
+import type { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
 import { createServiceUtils } from './utils';
 
 /**

--- a/packages/core/content-manager/server/src/history/services/utils.ts
+++ b/packages/core/content-manager/server/src/history/services/utils.ts
@@ -1,11 +1,11 @@
 import { difference, omit } from 'lodash/fp';
-import type { Struct, UID } from '@strapi/types';
-import { Core, Data, Modules, Schema } from '@strapi/types';
+
+import type { Core, Data, Modules, Schema, Struct, UID } from '@strapi/types';
 import { contentTypes } from '@strapi/utils';
-import { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
+import type { CreateHistoryVersion } from '../../../../shared/contracts/history-versions';
 import { FIELDS_TO_IGNORE } from '../constants';
-import { HistoryVersions } from '../../../../shared/contracts';
-import { RelationResult } from '../../../../shared/contracts/relations';
+import type { HistoryVersions } from '../../../../shared/contracts';
+import type { RelationResult } from '../../../../shared/contracts/relations';
 
 const DEFAULT_RETENTION_DAYS = 90;
 


### PR DESCRIPTION
### What does it do?

- Handle possible null values on the frontend
- Update the backend to handle images inside components

These changes resolve the related issue and should display images at an infinite level of nesting

### Why is it needed?

Describe the issue you are solving.

### How to test it?

- Create a component that has an image, and another component inside it that also has an image. (note: I think self nesting is broken so please don't try to use the same component inside itself)
- Add this component to a content type
- Also add a sibling component that has an image
- Now go to your content type and add images to all your components
- Save, go to content history

You should see all your images at every level at nesting:

<img width="400" alt="Screenshot 2024-11-26 at 14 23 25" src="https://github.com/user-attachments/assets/ccd8d959-701b-4f12-8bd0-cf5545cc852d">


### Related issue(s)/PR(s)

resolves https://github.com/strapi/strapi/issues/22060

--- 

## Help Wanted!

Unfortunately I am unable to restore a history version with components that have images.

The document service is throwing the following errors when [it calls update](https://github.com/strapi/strapi/blob/7d575f66bf2575073780538336ccfcdbe1eaca19/packages/core/content-manager/server/src/history/services/history.ts#L273-L278)

<img width="1504" alt="Screenshot 2024-11-26 at 14 29 55" src="https://github.com/user-attachments/assets/e9fac395-69e6-47b3-8d6e-e06a78dd810a">
