### PR TITLE
ci: use correct fetch-depth

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ permissions:
   contents: read # to fetch code (actions/checkout)
   actions: read
 
+# IMPORTANT
+# Jobs using `nx affected` require nrwl/nx-set-shas, which in turn requires actions/checkout fetch-depth:0 (meaning unlimited)
+
 jobs:
   conditions:
     runs-on: ubuntu-latest
@@ -70,7 +73,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Run docs build
@@ -87,7 +89,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Run lint
@@ -102,6 +103,8 @@ jobs:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for nx-set-shas
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -123,6 +126,8 @@ jobs:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for nx-set-shas
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -150,6 +155,8 @@ jobs:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for nx-set-shas
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -172,6 +179,8 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for nx-set-shas
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.tsx.snap
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.tsx.snap
@@ -226,6 +226,10 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
   color: #7b79ff;
 }
 
+.c8:hover svg path {
+  fill: #7b79ff;
+}
+
 .c8:active {
   color: #271fe0;
 }

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.tsx.snap
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/components/tests/__snapshots__/Header.test.tsx.snap
@@ -166,6 +166,10 @@ exports[`Header renders 1`] = `
   color: #7b79ff;
 }
 
+.c4:hover svg path {
+  fill: #7b79ff;
+}
+
 .c4:active {
   color: #271fe0;
 }


### PR DESCRIPTION
### What does it do?

uses the correct fetch-depth for jobs with `nx affected`

### Why is it needed?

they weren't being checked out deep enough to run `nx affected`

### How to test it?

this workflow should run; actually check the "details" of unit_front and unit_back to ensure they ran and didn't just pass even though there was an error

### Related issue(s)/PR(s)

