### PR TITLE
fix: add condition to basePath (v5)

### DIFF
--- a/packages/core/strapi/src/node/create-build-context.ts
+++ b/packages/core/strapi/src/node/create-build-context.ts
@@ -135,10 +135,11 @@ const createBuildContext = async <TOptions extends BaseOptions>({
   const features = strapiInstance.config.get('features', undefined);
 
   const { bundler = 'vite', ...restOptions } = options;
+  const serveAdminPanel = strapiInstance.config.get('admin.serveAdminPanel', true);
 
   const buildContext = {
     appDir,
-    basePath: `${adminPath}/`,
+    basePath: serveAdminPanel ? `${adminPath}/` : '/',
     bundler,
     customisations,
     cwd,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

setting root path to `/` when serve the admin build folder on a separate server


### Why is it needed?

fixes #22284 

### How to test it?

- create a new strapi app with `npx create-strapi-app@0.0.0-experimental.0588b9a4effba287cf26bd50e23baa14cdaf1616`
- add `url: 'http://localhost:1337'`, to ./config/server.js
- add `url: 'http://localhost:3000'`, and `serverAdminPanel: false` to ./config/admin.js([more info here](https://docs.strapi.io/dev-docs/admin-panel-customization/deployment))
- run yarn build
- copy and move the build folder outside of the strapi project
- `cd` to build folder, run ` npx serve -l 3000`
- admin panel should be accessible at `http://localhost:3000` without any errors shown 

### Related issue(s)/PR(s)

#22284 
DX-1768
