### PR TITLE
ci: fix docs_build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
     name: 'docs build (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
     needs: [conditions, build]
-    if: ${{ needs.conditions.outputs.docs == 'true' }}
+    if: ${{ needs.conditions.outputs.docs == 'true' || needs.conditions.outputs.global == 'true' }}
     strategy:
       matrix:
         node: [20, 22]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
   docs_build:
     name: 'docs build (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
-    needs: [conditions]
+    needs: [conditions, build]
     if: ${{ needs.conditions.outputs.docs == 'true' }}
     strategy:
       matrix:
@@ -73,10 +73,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - name: Install docs dependencies
+        working-directory: docs
+        run: yarn install --frozen-lockfile
       - name: Run docs build
-        run: cd docs && yarn build
+        working-directory: docs
+        run: yarn build
 
   pretty:
     name: 'pretty (node: ${{ matrix.node }})'


### PR DESCRIPTION
### What does it do?

allows docs_build to run by making it dependant on build and installing its deps

### Why is it needed?

docs_build isn't actually able to run because it fails to install dependencies and build the monorepo

### How to test it?

it should run and pass here

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
