### PR TITLE
ci: enable dependabot for security upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
 
       jest:
         patterns:
+          - '@swc/jest'
           - 'jest'
           - 'jest-*'
           - 'supertest'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,9 @@ updates:
           - '@babel/*'
           - 'babel-*'
 
-      eslint:
+      eslint-prettier:
         patterns:
+          - 'prettier'
           - 'eslint'
           - 'eslint-*'
           - '@eslint/*'
@@ -23,12 +24,6 @@ updates:
       playwright:
         patterns:
           - '@playwright/*'
-
-      prettier:
-        patterns:
-          - 'prettier'
-          - 'eslint-config-prettier'
-          - 'eslint-plugin-prettier'
 
       react:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,17 +12,30 @@ updates:
         patterns:
           - 'eslint'
           - 'eslint-*'
-          - '@typescript-eslint/*'
+          - '@eslint/*'
 
       jest:
         patterns:
           - 'jest'
           - 'jest-*'
+          - 'supertest'
+
+      playwright:
+        patterns:
+          - '@playwright/*'
+
+      prettier:
+        patterns:
+          - 'prettier'
+          - 'eslint-config-prettier'
+          - 'eslint-plugin-prettier'
 
       react:
         patterns:
           - 'react'
           - 'react-dom'
+          - 'react-router'
+          - 'react-router-dom'
 
       react-dnd:
         patterns:
@@ -43,16 +56,31 @@ updates:
         patterns:
           - 'storybook'
           - '@storybook/*'
+          - '@storybook/addon-*'
+
+      swc:
+        patterns:
+          - '@swc/*'
+        exclude-patterns:
+          - '@swc/jest'
 
       testing-library:
         patterns:
           - '@testing-library/*'
+
+      typescript:
+        patterns:
+          - 'typescript'
+          - 'ts-jest'
+          - '@typescript-eslint/*'
 
       webpack:
         patterns:
           - 'webpack'
           - 'webpack-cli'
           - 'webpack-dev-server'
+          - 'html-webpack-plugin'
+          - 'webpack-bundle-analyzer'
 
     commit-message:
       prefix: 'chore'
@@ -61,18 +89,14 @@ updates:
       interval: weekly
       day: sunday
       time: '22:00'
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     ignore:
-      # Only allow patch as minor babel versions need to be upgraded all together
-      - dependency-name: '@babel/*'
-        update-types:
-          - 'version-update:semver-major'
-          - 'version-update:semver-minor'
-
+      # only accept security updates
       - dependency-name: '*'
         update-types:
           - 'version-update:semver-patch'
+          - 'version-update:semver-minor'
           - 'version-update:semver-major'
 
     labels:
@@ -80,7 +104,7 @@ updates:
       - 'pr: chore'
 
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
     directory: /
     commit-message:
       prefix: 'chore'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,12 +88,11 @@ updates:
     open-pull-requests-limit: 5
     versioning-strategy: increase
     ignore:
-      # only accept security updates
-      - dependency-name: '*'
+      # Only allow patch as minor babel versions need to be upgraded all together
+      - dependency-name: '@babel/*'
         update-types:
-          - 'version-update:semver-patch'
-          - 'version-update:semver-minor'
           - 'version-update:semver-major'
+          - 'version-update:semver-minor'
 
     labels:
       - 'source: dependencies'


### PR DESCRIPTION
### What does it do?

- allows dependabot to start opening PRs again (every Sunday)
- updates package groups
- for now, ignore all updates except security updates
  - later we can revisit if we want to allow non-security upgrades, but generally in the past it has caused more effort and instability than usefulness

### Why is it needed?

- saves time and effort and improves response time in patching security issues in dependencies

### How to test it?

Can't easily test it until it's merged and we see that dependabot starts submitting PR

### Related issue(s)/PR(s)

DX-1798