### PR TITLE
fix: add conditional rendering of password prompt

### DIFF
--- a/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
+++ b/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
@@ -75,7 +75,12 @@ export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
         setFieldValue,
         setFieldError,
         dirty,
+        initialValues,
       }) => {
+        // Check if restrictedAccess has changed from its initial value
+        const hasRestrictedAccessChanged = 
+          values.restrictedAccess !== initialValues.restrictedAccess;
+
         return (
           <Form noValidate onSubmit={handleSubmit}>
             <Layouts.Header
@@ -149,7 +154,7 @@ export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
                         <Field.Hint />
                       </Field.Root>
                     </Grid.Item>
-                    {values.restrictedAccess && (
+                    {hasRestrictedAccessChanged && (
                       <Grid.Item col={6} s={12} direction="column" alignItems="stretch">
                         <Field.Root
                           name="password"


### PR DESCRIPTION
### What does it do?

In the original version the password prompt is only rendered when the state is equal to ON.
This leads to the problem described in #22295, when turning the restricted OFF no password is being passed to the endpoint, which results in restricted access being ON forever.
### Why is it needed?

To solve #22295

### How to test it?

1. Open http://localhost:1337/admin/settings/documentation
2. Turn the Restricted access ON
3. Save
4. Turn the Restricted access OFF
4. Save
5. Be happy!

### Related issue(s)/PR(s)

#22295
