### PR TITLE
fix: Add i18n for boolean cell values

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
@@ -10,7 +10,7 @@ interface CellValueProps {
 }
 
 const CellValue = ({ type, value }: CellValueProps) => {
-  const { formatDate, formatTime, formatNumber } = useIntl();
+  const { formatDate, formatTime, formatNumber, formatMessage } = useIntl();
   let formattedValue = value;
 
   if (type === 'date') {
@@ -39,6 +39,19 @@ const CellValue = ({ type, value }: CellValueProps) => {
       // in the design-system/NumberInput: https://github.com/strapi/design-system/blob/main/packages/strapi-design-system/src/NumberInput/NumberInput.js#L53
       maximumFractionDigits: 20,
     });
+  }
+
+  if (type === 'boolean') {
+    formattedValue = value ? 'true' : 'false';  // Default values
+    try {
+      formattedValue = formatMessage({
+        id: value ? 'app.components.ToggleCheckbox.on-label' : 'app.components.ToggleCheckbox.off-label',
+        defaultMessage: value ? 'true' : 'false'
+      });
+    } catch (error) {
+      // Fallback to default if translation is missing
+      console.warn('Missing translation for boolean value');
+    }
   }
 
   if (['integer', 'biginteger'].includes(type)) {


### PR DESCRIPTION
### What does it do?

Add a conditional boolean field types, which uses i18n.

### Why is it needed?

So users with a non-default language can see read the boolean field in their chosen language.
### How to test it?

1. Create a new content type with a boolean
2. Create an entry for that content type
3. Look at the list of entries

### Related issue(s)/PR(s)

#22281
