### PR TITLE
add documentId to `me` graphql query

### DIFF
--- a/packages/plugins/users-permissions/server/graphql/types/me.js
+++ b/packages/plugins/users-permissions/server/graphql/types/me.js
@@ -6,6 +6,7 @@ module.exports = ({ nexus }) => {
 
     definition(t) {
       t.nonNull.id('id');
+      t.nonNull.id('documentId');
       t.nonNull.string('username');
       t.string('email');
       t.boolean('confirmed');


### PR DESCRIPTION
Since I need the documentId to do other graphql queries to the user, I really want to get it from the `me`.


### What does it do?

Add `documentId` to the `me` schema.

### Why is it needed?

To allow to fetch the `documentId` in graphql queries
