### PR TITLE
fix(preview): page title and disabled link

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -1,18 +1,10 @@
 import * as React from 'react';
 
 import { useClipboard, useNotification, useQueryParams } from '@strapi/admin/strapi-admin';
-import {
-  Box,
-  type BoxProps,
-  Flex,
-  IconButton,
-  Tabs,
-  Typography,
-  Grid,
-} from '@strapi/design-system';
+import { IconButton, Tabs, Typography, Grid } from '@strapi/design-system';
 import { Cross, Link as LinkIcon } from '@strapi/icons';
 import { stringify } from 'qs';
-import { type MessageDescriptor, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
@@ -156,7 +148,7 @@ const PreviewHeader = () => {
       {/* Title and status */}
       <Grid.Item xs={1} paddingTop={2} paddingBottom={2} gap={3}>
         <ClosePreviewButton />
-        <PreviewTitle tag="h1" fontWeight={600} fontSize={2} maxWidth="200px">
+        <PreviewTitle tag="h1" fontWeight={600} fontSize={2} maxWidth="200px" title={title}>
           {title}
         </PreviewTitle>
         <Status />

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -118,7 +118,20 @@ const PreviewHeader = () => {
   // Get main field
   const mainField = usePreviewContext('PreviewHeader', (state) => state.mainField);
   const document = usePreviewContext('PreviewHeader', (state) => state.document);
-  const title = document[mainField];
+  const schema = usePreviewContext('PreviewHeader', (state) => state.schema);
+
+  /**
+   * We look to see what the mainField is from the configuration, if it's an id
+   * we don't use it because it's a uuid format and not very user friendly.
+   * Instead, we display the schema name for single-type documents
+   * or "Untitled".
+   */
+  let documentTitle = 'Untitled';
+  if (mainField !== 'id' && document?.[mainField]) {
+    documentTitle = document[mainField];
+  } else if (schema.kind === 'singleType' && schema?.info.displayName) {
+    documentTitle = schema.info.displayName;
+  }
 
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -148,8 +161,8 @@ const PreviewHeader = () => {
       {/* Title and status */}
       <Grid.Item xs={1} paddingTop={2} paddingBottom={2} gap={3}>
         <ClosePreviewButton />
-        <PreviewTitle tag="h1" fontWeight={600} fontSize={2} maxWidth="200px" title={title}>
-          {title}
+        <PreviewTitle tag="h1" fontWeight={600} fontSize={2} maxWidth="200px" title={documentTitle}>
+          {documentTitle}
         </PreviewTitle>
         <Status />
       </Grid.Item>

--- a/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
@@ -58,8 +58,6 @@ const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
     trackUsage('willNavigate', { from: pathname, to: destinationPathname });
   };
 
-  const isDisabled = isModified;
-
   return {
     title: formatMessage({ id: 'content-manager.preview.panel.title', defaultMessage: 'Preview' }),
     content: (
@@ -78,9 +76,9 @@ const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
               to={{ pathname: 'preview', search: stringify(query, { encode: false }) }}
               onClick={trackNavigation}
               width="100%"
-              disabled={isDisabled}
-              pointerEvents={isDisabled ? 'none' : undefined}
-              tabIndex={isDisabled ? -1 : undefined}
+              disabled={isModified}
+              pointerEvents={isModified ? 'none' : undefined}
+              tabIndex={isModified ? -1 : undefined}
             >
               {formatMessage({
                 id: 'content-manager.preview.panel.button',

--- a/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
@@ -61,33 +61,31 @@ const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
   return {
     title: formatMessage({ id: 'content-manager.preview.panel.title', defaultMessage: 'Preview' }),
     content: (
-      <Flex gap={2} width="100%">
-        <ConditionalTooltip
-          label={formatMessage({
-            id: 'content-manager.preview.panel.button-disabled-tooltip',
-            defaultMessage: 'Please save to open the preview',
-          })}
-          isShown={isModified}
-        >
-          <Box cursor="not-allowed" flex="auto">
-            <Button
-              variant="tertiary"
-              tag={Link}
-              to={{ pathname: 'preview', search: stringify(query, { encode: false }) }}
-              onClick={trackNavigation}
-              width="100%"
-              disabled={isModified}
-              pointerEvents={isModified ? 'none' : undefined}
-              tabIndex={isModified ? -1 : undefined}
-            >
-              {formatMessage({
-                id: 'content-manager.preview.panel.button',
-                defaultMessage: 'Open preview',
-              })}
-            </Button>
-          </Box>
-        </ConditionalTooltip>
-      </Flex>
+      <ConditionalTooltip
+        label={formatMessage({
+          id: 'content-manager.preview.panel.button-disabled-tooltip',
+          defaultMessage: 'Please save to open the preview',
+        })}
+        isShown={isModified}
+      >
+        <Box cursor="not-allowed" width="100%">
+          <Button
+            variant="tertiary"
+            tag={Link}
+            to={{ pathname: 'preview', search: stringify(query, { encode: false }) }}
+            onClick={trackNavigation}
+            width="100%"
+            disabled={isModified}
+            pointerEvents={isModified ? 'none' : undefined}
+            tabIndex={isModified ? -1 : undefined}
+          >
+            {formatMessage({
+              id: 'content-manager.preview.panel.button',
+              defaultMessage: 'Open preview',
+            })}
+          </Button>
+        </Box>
+      </ConditionalTooltip>
     ),
   };
 };

--- a/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewSidePanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useQueryParams, useTracking, useForm } from '@strapi/admin/strapi-admin';
-import { Button, Flex, Tooltip, type TooltipProps } from '@strapi/design-system';
+import { Box, Button, Flex, Tooltip, type TooltipProps } from '@strapi/design-system';
 import { UID } from '@strapi/types';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
@@ -58,6 +58,8 @@ const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
     trackUsage('willNavigate', { from: pathname, to: destinationPathname });
   };
 
+  const isDisabled = isModified;
+
   return {
     title: formatMessage({ id: 'content-manager.preview.panel.title', defaultMessage: 'Preview' }),
     content: (
@@ -69,19 +71,23 @@ const PreviewSidePanel: PanelComponent = ({ model, documentId, document }) => {
           })}
           isShown={isModified}
         >
-          <Button
-            variant="tertiary"
-            tag={Link}
-            to={{ pathname: 'preview', search: stringify(query, { encode: false }) }}
-            onClick={trackNavigation}
-            flex="auto"
-            disabled={isModified}
-          >
-            {formatMessage({
-              id: 'content-manager.preview.panel.button',
-              defaultMessage: 'Open preview',
-            })}
-          </Button>
+          <Box cursor="not-allowed" flex="auto">
+            <Button
+              variant="tertiary"
+              tag={Link}
+              to={{ pathname: 'preview', search: stringify(query, { encode: false }) }}
+              onClick={trackNavigation}
+              width="100%"
+              disabled={isDisabled}
+              pointerEvents={isDisabled ? 'none' : undefined}
+              tabIndex={isDisabled ? -1 : undefined}
+            >
+              {formatMessage({
+                id: 'content-manager.preview.panel.button',
+                defaultMessage: 'Open preview',
+              })}
+            </Button>
+          </Box>
         </ConditionalTooltip>
       </Flex>
     ),

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -98,16 +98,15 @@ describeOnCondition(edition === 'EE')('Preview', () => {
     expect(iframe).not.toBeNull();
 
     // Check if the iframe is loading the correct URL
-    const src = await iframe.getAttribute('src');
-    expect(src).toContain('/preview/api::article.article/');
-    expect(src).toContain('/en/draft');
+    await expect(iframe).toHaveAttribute('src', /\/preview\/api::article\.article\/.+\/en\/draft$/);
 
     // Navigate to the published tab
     await clickAndWait(page, page.getByRole('tab', { name: /^Published$/ }));
 
     const updatedIframe = page.getByTitle('Preview');
-    const srcPublished = await updatedIframe.getAttribute('src');
-    expect(srcPublished).toContain('/preview/api::article.article/');
-    expect(srcPublished).toContain('/en/published');
+    await expect(updatedIframe).toHaveAttribute(
+      'src',
+      /\/preview\/api::article\.article\/.+\/en\/published$/
+    );
   });
 });

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -41,7 +41,8 @@ describeOnCondition(edition === 'EE')('Preview', () => {
     await titleInput.fill('New title');
     const previewLink = page.getByRole('link', { name: /open preview/i });
     await expect(previewLink).toBeDisabled();
-    await previewLink.hover();
+    // Can't hover the link directly because of pointer-events:none, so hover the div parent
+    await previewLink.locator('..').hover();
     await expect(
       page.getByRole('tooltip', { name: /please save to open the preview/i })
     ).toBeVisible();

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -93,7 +93,7 @@ describeOnCondition(edition === 'EE')('Preview', () => {
     await clickAndWait(page, page.getByRole('link', { name: /open preview/i }));
 
     // Check if the iframe is present
-    const iframe = await page.getByTitle('Preview');
+    const iframe = page.getByTitle('Preview');
     expect(iframe).not.toBeNull();
 
     // Check if the iframe is loading the correct URL
@@ -104,7 +104,7 @@ describeOnCondition(edition === 'EE')('Preview', () => {
     // Navigate to the published tab
     await clickAndWait(page, page.getByRole('tab', { name: /^Published$/ }));
 
-    const updatedIframe = await page.getByTitle('Preview');
+    const updatedIframe = page.getByTitle('Preview');
     const srcPublished = await updatedIframe.getAttribute('src');
     expect(srcPublished).toContain('/preview/api::article.article/');
     expect(srcPublished).toContain('/en/published');


### PR DESCRIPTION
### What does it do?

Adds 3 fixes related the the preview page header title, reported in the blitz:

- adds a tooltip, so we have a way to see the full title when it's cropped because it's too long. I rely on the native HTML title to trigger the browser's default tooltip. I checked with @lucasboilly and he approved it, our DS tooltip isn't great at handling long content over multiple lines. It's also much simpler to implement.
- makes sure the title is the same as the one from the edit view by copying the logic from there
- properly disables the link. TIL the disabled tag does nothing for anchors! so I combined [this workaround](https://stackoverflow.com/questions/13955667/disabled-href-tag#comment119178426_27057625) with [this one](https://stackoverflow.com/a/46665946/3661792) for the not allowed cursor

### How to test it?

- write long content in the main field, open preview, the title is truncated. Hover it and you'll see the full title in the browser's tooltip
- make sure the preview page shows the same header title as the edit view:
  - collection type with non-id main field: main field
  - collection type with id main field: "Untitled"
  - single type with non-id main field: main field
  - single type with id main field: content type display name
- make a change in the edit view and don't save. This preview button should be disabled with 🚫 cursor. Click it, nothing should happen. Save and it's enabled again
 
### Related issue(s)/PR(s)

- fixes #22300
- fixes #22298