### PR TITLE
test(e2e): add update and delete content type tests

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -166,4 +166,36 @@ test.describe('Edit collection type', () => {
 
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
+
+  test('Can change type name', async ({ page }) => {
+    const newname = 'New name';
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    await page.getByRole('textbox', { name: 'Display name' }).fill(newname);
+
+    await page.getByRole('button', { name: 'Finish', exact: true }).click();
+
+    await waitForRestart(page);
+
+    // TODO: fix bug that requires a page refresh to see that content types have been updated
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: newname })).toBeVisible();
+  });
+
+  test('Can delete type', async ({ page }) => {
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    // need to accept the browser modal
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await waitForRestart(page);
+
+    // TODO: fix bug that requires a page refresh to see that content types have been updated
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
+  });
 });

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -91,4 +91,36 @@ test.describe('Edit single type', () => {
 
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
+
+  test('Can change type name', async ({ page }) => {
+    const newname = 'New name';
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    await page.getByRole('textbox', { name: 'Display name' }).fill(newname);
+
+    await page.getByRole('button', { name: 'Finish', exact: true }).click();
+
+    await waitForRestart(page);
+
+    // TODO: fix bug that requires a page refresh to see that content types have been updated
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: newname })).toBeVisible();
+  });
+
+  test('Can delete type', async ({ page }) => {
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    // need to accept the browser modal
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await waitForRestart(page);
+
+    // TODO: fix bug that requires a page refresh to see that content types have been updated
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
### What does it do?

adds tests for update and delete collection type and single type

Note: there is a bug that the CTB does not update the schemas until after a page refresh, which has been noted in a TODO

### Why is it needed?

tests didn't exist

### How to test it?

they should pass

### Related issue(s)/PR(s)

DX-1468
DX-1650
