### PR TITLE
chore: comment out getstarted log

### DIFF
--- a/examples/getstarted/src/middlewares/test-middleware.js
+++ b/examples/getstarted/src/middlewares/test-middleware.js
@@ -5,9 +5,10 @@
  */
 
 module.exports = (config, { strapi }) => {
+  // This middleware is called on every request
   // Add your own logic here.
   return async (ctx, next) => {
-    strapi.log.info('In application test-middleware middleware.');
+    // strapi.log.info('In application test-middleware middleware.');
 
     await next();
   };


### PR DESCRIPTION
### What does it do?

comments out the middleware log in getstarted

### Why is it needed?

in a normal project it would only log once, but in the monorepo it runs ptentially hundreds of times on each request because of all the live admin building done by vite

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
