### PR TITLE
Fix: Cursor pointer issue in permission checkbox settings icon

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -173,7 +173,7 @@ const ListPage = () => {
             rowCount={rowCount}
             footer={
               canCreate ? (
-                <TFooter onClick={handleNewRoleClick} icon={<Plus />}>
+                <TFooter cursor={'pointer'} onClick={handleNewRoleClick} icon={<Plus />}>
                   {formatMessage({
                     id: 'Settings.roles.list.button.add',
                     defaultMessage: 'Add new role',
@@ -221,6 +221,7 @@ const ListPage = () => {
             <Tbody>
               {roles?.map((role, index) => (
                 <RoleRow
+                  cursor={'pointer'}
                   key={role.id}
                   id={role.id}
                   name={role.name}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -173,7 +173,7 @@ const ListPage = () => {
             rowCount={rowCount}
             footer={
               canCreate ? (
-                <TFooter cursor={'pointer'} onClick={handleNewRoleClick} icon={<Plus />}>
+                <TFooter cursor='pointer' onClick={handleNewRoleClick} icon={<Plus />}>
                   {formatMessage({
                     id: 'Settings.roles.list.button.add',
                     defaultMessage: 'Add new role',

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -173,7 +173,7 @@ const ListPage = () => {
             rowCount={rowCount}
             footer={
               canCreate ? (
-                <TFooter cursor='pointer' onClick={handleNewRoleClick} icon={<Plus />}>
+                <TFooter cursor="pointer" onClick={handleNewRoleClick} icon={<Plus />}>
                   {formatMessage({
                     id: 'Settings.roles.list.button.add',
                     defaultMessage: 'Add new role',
@@ -221,7 +221,7 @@ const ListPage = () => {
             <Tbody>
               {roles?.map((role, index) => (
                 <RoleRow
-                  cursor='pointer'
+                  cursor="pointer"
                   key={role.id}
                   id={role.id}
                   name={role.name}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -221,7 +221,7 @@ const ListPage = () => {
             <Tbody>
               {roles?.map((role, index) => (
                 <RoleRow
-                  cursor={'pointer'}
+                  cursor='pointer'
                   key={role.id}
                   id={role.id}
                   name={role.name}

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/RoleRow.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/RoleRow.tsx
@@ -7,6 +7,7 @@ interface RoleRowProps extends Pick<AdminRole, 'id' | 'name' | 'description' | '
   icons: Array<Required<Pick<IconButtonProps, 'children' | 'label' | 'onClick'>>>;
   rowIndex: number;
   canUpdate?: boolean;
+  cursor?: string;
 }
 
 const RoleRow = ({
@@ -17,6 +18,7 @@ const RoleRow = ({
   icons,
   rowIndex,
   canUpdate,
+  cursor,
 }: RoleRowProps) => {
   const { formatMessage } = useIntl();
   const [, editObject] = icons;
@@ -31,6 +33,7 @@ const RoleRow = ({
 
   return (
     <Tr
+      cursor={cursor}
       aria-rowindex={rowIndex}
       key={id}
       // @ts-expect-error – the prop uses `HTMLButtonElement` but we just specify `HTMLElement`

--- a/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.jsx
+++ b/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.jsx
@@ -103,7 +103,7 @@ const SubCategory = ({ subCategory }) => {
                         }
                       )}
                     </VisuallyHidden>
-                    <Cog id="cog" cursor='pointer' />
+                    <Cog id="cog" cursor="pointer" />
                   </button>
                 </CheckboxWrapper>
               </Grid.Item>

--- a/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.jsx
+++ b/packages/plugins/users-permissions/admin/src/components/Permissions/PermissionRow/SubCategory.jsx
@@ -103,7 +103,7 @@ const SubCategory = ({ subCategory }) => {
                         }
                       )}
                     </VisuallyHidden>
-                    <Cog id="cog" />
+                    <Cog id="cog" cursor='pointer' />
                   </button>
                 </CheckboxWrapper>
               </Grid.Item>

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailTable.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailTable.jsx
@@ -52,7 +52,7 @@ const EmailTable = ({ canUpdate, onEditClick }) => {
         </Tr>
       </Thead>
       <Tbody>
-        <Tr cursor='pointer' onClick={() => onEditClick('reset_password')}>
+        <Tr cursor="pointer" onClick={() => onEditClick('reset_password')}>
           <Td>
             <Box width="3.2rem" height="3.2rem" padding="0.8rem">
               <Refresh
@@ -85,7 +85,7 @@ const EmailTable = ({ canUpdate, onEditClick }) => {
             </IconButton>
           </Td>
         </Tr>
-        <Tr cursor= 'pointer' onClick={() => onEditClick('email_confirmation')}>
+        <Tr cursor="pointer" onClick={() => onEditClick('email_confirmation')}>
           <Td>
             <Box width="3.2rem" height="3.2rem" padding="0.8rem">
               <Check

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailTable.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/components/EmailTable.jsx
@@ -52,7 +52,7 @@ const EmailTable = ({ canUpdate, onEditClick }) => {
         </Tr>
       </Thead>
       <Tbody>
-        <Tr onClick={() => onEditClick('reset_password')}>
+        <Tr cursor='pointer' onClick={() => onEditClick('reset_password')}>
           <Td>
             <Box width="3.2rem" height="3.2rem" padding="0.8rem">
               <Refresh
@@ -85,7 +85,7 @@ const EmailTable = ({ canUpdate, onEditClick }) => {
             </IconButton>
           </Td>
         </Tr>
-        <Tr onClick={() => onEditClick('email_confirmation')}>
+        <Tr cursor= 'pointer' onClick={() => onEditClick('email_confirmation')}>
           <Td>
             <Box width="3.2rem" height="3.2rem" padding="0.8rem">
               <Check

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/components/TableBody.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/components/TableBody.jsx
@@ -50,7 +50,7 @@ const TableBody = ({ sortedRoles, canDelete, canUpdate, setRoleToDelete, onDelet
   return (
     <Tbody>
       {sortedRoles?.map((role) => (
-        <Tr key={role.name} onClick={() => navigate(role.id.toString())}>
+        <Tr cursor='pointer' key={role.name} onClick={() => navigate(role.id.toString())}>
           <Td width="20%">
             <Typography>{role.name}</Typography>
           </Td>

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/components/TableBody.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/components/TableBody.jsx
@@ -50,7 +50,7 @@ const TableBody = ({ sortedRoles, canDelete, canUpdate, setRoleToDelete, onDelet
   return (
     <Tbody>
       {sortedRoles?.map((role) => (
-        <Tr cursor='pointer' key={role.name} onClick={() => navigate(role.id.toString())}>
+        <Tr cursor="pointer" key={role.name} onClick={() => navigate(role.id.toString())}>
           <Td width="20%">
             <Typography>{role.name}</Typography>
           </Td>


### PR DESCRIPTION
### What does it do?
Fixes Inconsistent cursor state for clickable elements

### Why is it needed?
To fix issue [20768](https://github.com/strapi/strapi/issues/20768) : Inconsistent cursor state for clickable elements

### How to test it?

1. Go to main menu setting.
2. Then click on Users & Permissions plugin > Roles
3. Click on any role.
4. Now if we open one of any accordion in the list and hover over the icon beside checkbox.
5. You will be able get the cursor pointer on hover. 

### Related issue(s)/PR(s)
fixes [20768](https://github.com/strapi/strapi/issues/20768) 