### PR TITLE
fix: do not select document ids on components

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -18,6 +18,9 @@ const models = {
       title: {
         type: 'string',
       },
+      one_to_one: { type: 'relation', relation: 'oneToOne', target: 'api::dog.dog' },
+      cpa: { type: 'component', component: 'default.cpa' },
+      cpb: { type: 'component', component: 'default.cpb' },
       dz: { type: 'dynamiczone', components: ['default.cpa', 'default.cpb'] },
       morph_to_one: { type: 'relation', relation: 'morphToOne' },
       morph_to_many: { type: 'relation', relation: 'morphToMany' },
@@ -90,6 +93,34 @@ describe('convert-query-params', () => {
   test.todo('convertLimitQueryParams');
 
   describe('convertPopulateQueryParams', () => {
+    describe('Fields selection', () => {
+      test('should not select documentId when selecting fields for components', () => {
+        const populate = {
+          cpa: { fields: ['field'] },
+          cpb: { fields: ['field'] },
+        };
+
+        const newPopulate = private_convertPopulateQueryParams(populate, models['api::dog.dog']);
+
+        expect(newPopulate).toStrictEqual({
+          cpa: { select: ['id', 'field'] },
+          cpb: { select: ['id', 'field'] },
+        });
+      });
+
+      test('should select documentId for non-component populate', () => {
+        const populate = {
+          one_to_one: { fields: ['title'] },
+        };
+
+        const newPopulate = private_convertPopulateQueryParams(populate, models['api::dog.dog']);
+
+        expect(newPopulate).toStrictEqual({
+          one_to_one: { select: ['id', 'documentId', 'title'] },
+        });
+      });
+    });
+
     describe('Morph-Like Attributes', () => {
       test.each<[label: string, key: string]>([
         ['dynamic zone', 'dz'],

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -501,7 +501,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (fields) {
-      query.select = convertFieldsQueryParams(fields);
+      query.select = convertFieldsQueryParams(fields, schema);
     }
 
     if (populate) {
@@ -538,23 +538,36 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
   };
 
   // TODO: ensure field is valid in content types (will probably have to check strapi.contentTypes since it can be a string.path)
-  const convertFieldsQueryParams = (fields: FieldsParams, depth = 0): SelectQuery | undefined => {
+  const convertFieldsQueryParams = (
+    fields: FieldsParams,
+    schema?: Model,
+    depth = 0
+  ): SelectQuery | undefined => {
     if (depth === 0 && fields === '*') {
       return undefined;
     }
 
     if (typeof fields === 'string') {
       const fieldsValues = fields.split(',').map((value) => _.trim(value));
-      return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+
+      // NOTE: Only include the doc id if it's a content type
+      if (schema?.modelType === 'contentType') {
+        return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+      }
+      return _.uniq([ID_ATTRIBUTE, ...fieldsValues]);
     }
 
     if (isStringArray(fields)) {
       // map convert
       const fieldsValues = fields
-        .flatMap((value) => convertFieldsQueryParams(value, depth + 1))
+        .flatMap((value) => convertFieldsQueryParams(value, schema, depth + 1))
         .filter((v) => !isNil(v)) as string[];
 
-      return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+      // NOTE: Only include the doc id if it's a content type
+      if (schema?.modelType === 'contentType') {
+        return _.uniq([ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, ...fieldsValues]);
+      }
+      return _.uniq([ID_ATTRIBUTE, ...fieldsValues]);
     }
 
     throw new Error('Invalid fields parameter. Expected a string or an array of strings');
@@ -700,7 +713,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (!isNil(fields)) {
-      query.select = convertFieldsQueryParams(fields);
+      query.select = convertFieldsQueryParams(fields, schema);
     }
 
     if (!isNil(populate)) {


### PR DESCRIPTION
### What does it do?

When querying a CT with a compo, trying to select a field from the compo errored out.

Issue was in convertQueryParams utility, it always injected a `documentId` field inside the `fields`attribute, regardless if the populated model was a content type or a component.


### Why is it needed?

To fix the following scenario
e.g. query:
```ts
    const result = await strapi.documents('plugin::myplugin.test').findMany({
      populate: {
        compo: {
          fields: ['name']
        },
      }
    })
```

e.g error
![image](https://github.com/user-attachments/assets/d8b77349-486c-4d2e-b302-de618324db2f)


This will hopefully unblock https://github.com/strapi/strapi/pull/22273