### PR TITLE
fix: preview back button behavior

### DIFF
--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -241,7 +241,6 @@ const BackButton = React.forwardRef<HTMLAnchorElement, BackButtonProps>(
     };
 
     // The link destination from the history. Undefined if there is only 1 location in the history.
-    // const historyTo = canGoBack ? history.at(-2) : undefined;
     const historyTo = canGoBack ? history.at(currentLocationIndex - 2) : undefined;
     // If no link destination from the history, use the fallback.
     const toWithFallback = historyTo ?? fallback;

--- a/packages/core/admin/admin/src/features/BackButton.tsx
+++ b/packages/core/admin/admin/src/features/BackButton.tsx
@@ -4,7 +4,7 @@ import { Link, LinkProps } from '@strapi/design-system';
 import { ArrowLeft } from '@strapi/icons';
 import { produce } from 'immer';
 import { useIntl } from 'react-intl';
-import { NavLink, type To, useLocation, useNavigate } from 'react-router-dom';
+import { NavLink, type To, useLocation, useNavigate, useNavigationType } from 'react-router-dom';
 
 import { createContext } from '../components/Context';
 
@@ -70,6 +70,7 @@ interface HistoryProviderProps {
 
 const HistoryProvider = ({ children }: HistoryProviderProps) => {
   const location = useLocation();
+  const navigationType = useNavigationType();
   const navigate = useNavigate();
   const [state, dispatch] = React.useReducer(reducer, {
     history: [],
@@ -89,8 +90,7 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
 
   const goBack: HistoryContextValue['goBack'] = React.useCallback(() => {
     /**
-     * Perform the browser back action
-     * dispatch the goBack action to keep redux in sync
+     * Perform the browser back action, dispatch the goBack action to keep the state in sync
      * and set the ref to avoid an infinite loop and incorrect state pushing
      */
     navigate(-1);
@@ -119,6 +119,12 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
   React.useLayoutEffect(() => {
     if (isGoingBack.current) {
       isGoingBack.current = false;
+    } else if (navigationType === 'REPLACE') {
+      // Prevent appending to the history when the location changes via a replace:true navigation
+      dispatch({
+        type: 'REPLACE_STATE',
+        payload: { to: location.pathname, search: location.search },
+      });
     } else {
       // this should only occur on link movements, not back/forward clicks
       dispatch({
@@ -126,7 +132,7 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
         payload: { to: location.pathname, search: location.search },
       });
     }
-  }, [dispatch, location.pathname, location.search]);
+  }, [dispatch, location.pathname, location.search, navigationType]);
 
   return (
     <Provider pushState={pushState} goBack={goBack} {...state}>
@@ -138,6 +144,13 @@ const HistoryProvider = ({ children }: HistoryProviderProps) => {
 type HistoryActions =
   | {
       type: 'PUSH_STATE';
+      payload: {
+        to: string;
+        search: string;
+      };
+    }
+  | {
+      type: 'REPLACE_STATE';
       payload: {
         to: string;
         search: string;
@@ -167,6 +180,12 @@ const reducer = (state: HistoryState, action: HistoryActions) =>
         draft.currentLocation = path;
         draft.currentLocationIndex += 1;
 
+        break;
+      }
+      case 'REPLACE_STATE': {
+        const path = `${action.payload.to}${action.payload.search}`;
+        draft.history = [...state.history.slice(0, state.currentLocationIndex - 1), path];
+        draft.currentLocation = path;
         break;
       }
       case 'GO_BACK': {
@@ -207,6 +226,7 @@ const BackButton = React.forwardRef<HTMLAnchorElement, BackButtonProps>(
     const canGoBack = useHistory('BackButton', (state) => state.canGoBack);
     const goBack = useHistory('BackButton', (state) => state.goBack);
     const history = useHistory('BackButton', (state) => state.history);
+    const currentLocationIndex = useHistory('BackButton', (state) => state.currentLocationIndex);
     const hasFallback = fallback !== '';
     const shouldBeDisabled = disabled || (!canGoBack && !hasFallback);
 
@@ -221,7 +241,8 @@ const BackButton = React.forwardRef<HTMLAnchorElement, BackButtonProps>(
     };
 
     // The link destination from the history. Undefined if there is only 1 location in the history.
-    const historyTo = canGoBack ? history.at(-1) : undefined;
+    // const historyTo = canGoBack ? history.at(-2) : undefined;
+    const historyTo = canGoBack ? history.at(currentLocationIndex - 2) : undefined;
     // If no link destination from the history, use the fallback.
     const toWithFallback = historyTo ?? fallback;
 

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
 
-import { useClipboard, useNotification, useQueryParams } from '@strapi/admin/strapi-admin';
 import {
-  Box,
-  type BoxProps,
-  Flex,
-  IconButton,
-  Tabs,
-  Typography,
-  Grid,
-} from '@strapi/design-system';
+  useClipboard,
+  useHistory,
+  useNotification,
+  useQueryParams,
+} from '@strapi/admin/strapi-admin';
+import { IconButton, Tabs, Typography, Grid } from '@strapi/design-system';
 import { Cross, Link as LinkIcon } from '@strapi/icons';
 import { stringify } from 'qs';
-import { type MessageDescriptor, useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+import { Link, type To } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { DocumentStatus } from '../../pages/EditView/components/DocumentStatus';
@@ -30,14 +27,40 @@ const ClosePreviewButton = () => {
   }>();
   const { formatMessage } = useIntl();
 
+  const canGoBack = useHistory('BackButton', (state) => state.canGoBack);
+  const goBack = useHistory('BackButton', (state) => state.goBack);
+  const history = useHistory('BackButton', (state) => state.history);
+  const locationIndex = useHistory('BackButton', (state) => state.currentLocationIndex);
+
+  /**
+   * Get the link destination from the history.
+   * Rely on a fallback (the parent edit view page) if there's no page to go back .
+   */
+  const historyTo = canGoBack ? history.at(locationIndex - 2) : undefined;
+  const fallback = {
+    pathname: '..',
+    search: stringify(query, { encode: false }),
+  } satisfies To;
+  const toWithFallback = historyTo ?? fallback;
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (canGoBack) {
+      // Prevent normal link behavior, go back in the history stack instead
+      e.preventDefault();
+      goBack();
+      return;
+    }
+
+    // Otherwise rely on native link behavior to go back to the edit view. We don't use navigate()
+    // here in order to get the relative="path" functionality from the Link component.
+  };
+
   return (
     <IconButton
       tag={Link}
       relative="path"
-      to={{
-        pathname: '..',
-        search: stringify({ plugins: query.plugins }, { encode: false }),
-      }}
+      to={toWithFallback}
+      onClick={handleClick}
       label={formatMessage({
         id: 'content-manager.preview.header.close',
         defaultMessage: 'Close preview',


### PR DESCRIPTION
### What does it do?

Updates the preview back button so it uses navigate(-1) from React Router, simulating a click on the browser's back button. It's needed because otherwise, if you go to preview, click back, and click and the edit view's back button, you're take to the preview page again.

I also fixed an issue in the shared BackButton component where the href of the link was the wrong one, it would show the URL of the current page instead of the previous one.

### How to test it?

I think it's better to let you try it and see if it does what you expect. Just avoid starting a session (or reloading) directly on the preview page, because that will rely on the fallback URL, in which case the back/previous logic cannot be managed.

FYI I noticed a bug where if you toggle the draft and publish tabs multiple times on the preview page, clicking on the back button will not do the navigation on the first try. But I'm pretty sure this is a React Router bug because of us embedding the admin inside itself. Try changing the preview URL in the config to any other URL and I think the bug should disappear.

### Related issue(s)/PR(s)

fixes #22299