### PR TITLE
feat: add static preview (remove future flag)

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -14,5 +14,4 @@ runs:
       env:
         RUN_EE: ${{ inputs.runEE }}
         JEST_OPTIONS: ${{ inputs.jestOptions }}
-        STRAPI_FEATURES_FUTURE_RELEASES_SCHEDULING: ${{ inputs.enableFutureFeatures }}
       shell: bash

--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,5 +1,1 @@
-module.exports = ({ env }) => ({
-  future: {
-    preview: env.bool('STRAPI_FUTURE_PREVIEW', false),
-  },
-});
+module.exports = ({ env }) => ({});

--- a/packages/core/content-manager/admin/src/preview/constants.ts
+++ b/packages/core/content-manager/admin/src/preview/constants.ts
@@ -1,1 +1,0 @@
-export const FEATURE_ID = 'preview';

--- a/packages/core/content-manager/admin/src/preview/index.ts
+++ b/packages/core/content-manager/admin/src/preview/index.ts
@@ -1,18 +1,12 @@
 /* eslint-disable check-file/no-index */
 
 import { PreviewSidePanel } from './components/PreviewSidePanel';
-import { FEATURE_ID } from './constants';
 
 import type { ContentManagerPlugin } from '../content-manager';
 import type { PluginDefinition } from '@strapi/admin/strapi-admin';
 
 const previewAdmin = {
   bootstrap(app) {
-    // TODO: Add license registry check when it's available
-    if (!window.strapi.future.isEnabled(FEATURE_ID)) {
-      return;
-    }
-
     const contentManagerPluginApis = app.getPlugin('content-manager')
       .apis as ContentManagerPlugin['config']['apis'];
 

--- a/packages/core/content-manager/server/src/preview/constants.ts
+++ b/packages/core/content-manager/server/src/preview/constants.ts
@@ -1,1 +1,0 @@
-export const FEATURE_ID = 'preview';

--- a/packages/core/content-manager/server/src/preview/index.ts
+++ b/packages/core/content-manager/server/src/preview/index.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from '@strapi/types';
 
-import { FEATURE_ID } from './constants';
 import { routes } from './routes';
 import { controllers } from './controllers';
 import { services } from './services';
@@ -11,15 +10,6 @@ import { getService } from './utils';
  * so that we can assume it is enabled in the other files.
  */
 const getFeature = (): Partial<Plugin.LoadedPlugin> => {
-  if (!strapi.features.future.isEnabled(FEATURE_ID)) {
-    return {};
-  }
-
-  // TODO: Add license registry check when it's available
-  // if (!strapi.ee.features.isEnabled('cms-content-preview')) {
-  //   return {};
-  // }
-
   return {
     register() {
       const config = getService(strapi, 'preview-config');

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,7 +1,5 @@
 export interface FeaturesConfig {
-  future?: {
-    preview?: boolean;
-  };
+  future?: object;
 }
 
 export interface FeaturesService {

--- a/tests/api/core/content-manager/preview/preview.test.api.ts
+++ b/tests/api/core/content-manager/preview/preview.test.api.ts
@@ -1,6 +1,5 @@
 import { createStrapiInstance } from 'api-tests/strapi';
 import { createAuthRequest } from 'api-tests/request';
-import { describeOnCondition } from 'api-tests/utils';
 import { createTestBuilder } from 'api-tests/builder';
 
 const collectionTypeUid = 'api::product.product';
@@ -41,11 +40,7 @@ const singleTypeModel = {
   },
 };
 
-const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
-
-// TODO: Remove skip when future flag is removed
-// describeOnCondition(edition === 'EE')('Preview', () => {
-describeOnCondition(false)('Preview', () => {
+describe('Preview', () => {
   const builder = createTestBuilder();
   let strapi;
   let rq;

--- a/tests/e2e/app-template/config/features.js
+++ b/tests/e2e/app-template/config/features.js
@@ -1,6 +1,3 @@
 module.exports = ({ env }) => ({
-  future: {
-    contentReleasesScheduling: env.bool('STRAPI_FEATURES_FUTURE_RELEASES_SCHEDULING', false),
-    preview: true,
-  },
+  future: {},
 });

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -1,12 +1,10 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { clickAndWait, describeOnCondition, findAndClose, skipCtbTour } from '../../utils/shared';
+import { clickAndWait, findAndClose, skipCtbTour } from '../../utils/shared';
 import { resetFiles } from '../../utils/file-reset';
 
-const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
-
-describeOnCondition(edition === 'EE')('Preview', () => {
+test.describe('Preview', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin.tar', (cts) => cts, { coreStore: false });
     await resetFiles();


### PR DESCRIPTION
### What does it do?

Removes the future flag to make Static Preview available to everyone

### Why is it needed?

So folks can use it! Docs should be live in time for next week's release
