### PR TITLE
chore(homepage): move guided tour

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -8,6 +8,8 @@ import { Page } from '../../components/PageHelpers';
 import { useEnterprise } from '../../ee';
 import { useAuth } from '../../features/Auth';
 
+import { GuidedTour } from './components/GuidedTour';
+
 /* -------------------------------------------------------------------------------------------------
  * HomePageCE
  * -----------------------------------------------------------------------------------------------*/
@@ -32,6 +34,9 @@ const HomePageCE = () => {
           defaultMessage: 'Welcome to your administration panel',
         })}
       />
+      <Layouts.Content>
+        <GuidedTour />
+      </Layouts.Content>
     </Main>
   );
 };

--- a/packages/core/admin/admin/src/pages/Home/components/GuidedTour.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/GuidedTour.tsx
@@ -1,0 +1,20 @@
+import { GuidedTourHomepage } from '../../../components/GuidedTour/Homepage';
+import { useGuidedTour } from '../../../components/GuidedTour/Provider';
+
+export const GuidedTour = () => {
+  const guidedTourState = useGuidedTour('HomePage', (state) => state.guidedTourState);
+  const isGuidedTourVisible = useGuidedTour('HomePage', (state) => state.isGuidedTourVisible);
+  const isSkipped = useGuidedTour('HomePage', (state) => state.isSkipped);
+  const showGuidedTour =
+    !Object.values(guidedTourState).every((section) =>
+      Object.values(section).every((step) => step)
+    ) &&
+    isGuidedTourVisible &&
+    !isSkipped;
+
+  if (!showGuidedTour) {
+    return null;
+  }
+
+  return <GuidedTourHomepage />;
+};

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -10,8 +10,10 @@ test.describe('Home', () => {
     await login({ page });
   });
 
-  test('a user should be greeted by their name', async ({ page }) => {
-    // "test" is the user fist name in the database
+  test('a user should have a personalized homepage', async ({ page }) => {
+    /**
+     * Assert the user is greeted with their name
+     */
     await expect(page.getByText('Hello test')).toBeVisible();
     await expect(page).toHaveTitle(/homepage/i);
 
@@ -22,5 +24,17 @@ test.describe('Home', () => {
     await page.getByRole('button', { name: /save/i }).click();
     await clickAndWait(page, page.getByRole('link', { name: 'Home' }));
     await expect(page.getByText('Hello Rebecca')).toBeVisible();
+
+    /**
+     * Assert the user can see and dismiss the guided tour
+     */
+    const skipTheTourButton = page.getByRole('button', { name: 'Skip the tour' });
+    await expect(skipTheTourButton).toBeVisible();
+
+    await skipTheTourButton.click();
+    await expect(skipTheTourButton).not.toBeVisible();
+    // Reload to ensure the update persisted
+    await page.reload();
+    await expect(skipTheTourButton).not.toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

Create pages/comonents/GuidedTour.tsx which now handles the logic to return the existing GuidedTourHomepage component.

### Why is it needed?

- For the homepage feature

### How to test it?

- Go to the new homepage
- You should see the gudied tour
- Skip the tour, you should now longer see it (reset local storage to get it back)
- Otherwise the GuidedTour should behave as usual


