### PR TITLE
fix:  color of the links in the Rich text (Blocks) field is not the right one

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Link.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BaseLink, Button, Field, Flex, Popover, useComposedRefs } from '@strapi/design-system';
+import { Box, Button, Field, Flex, Popover, useComposedRefs } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { Editor, Path, Range, Transforms } from 'slate';
 import { type RenderElementProps, ReactEditor } from 'slate-react';
@@ -10,7 +10,7 @@ import { type BlocksStore, useBlocksEditorContext } from '../BlocksEditor';
 import { editLink, removeLink } from '../utils/links';
 import { isLinkNode, type Block } from '../utils/types';
 
-const StyledBaseLink = styled(BaseLink)`
+const StyledLink = styled(Box)`
   text-decoration: none;
 `;
 
@@ -90,15 +90,16 @@ const LinkContent = React.forwardRef<HTMLAnchorElement, LinkContentProps>(
     return (
       <Popover.Root open={popoverOpen}>
         <Popover.Trigger>
-          <StyledBaseLink
+          <StyledLink
             {...attributes}
+            tag="a"
             ref={forwardedRef}
             href={link.url}
             onClick={() => setPopoverOpen(true)}
             color="primary600"
           >
             {children}
-          </StyledBaseLink>
+          </StyledLink>
         </Popover.Trigger>
         <Popover.Content onPointerDownOutside={handleClose}>
           <Flex padding={4} direction="column" gap={4}>


### PR DESCRIPTION
### Before

![Screenshot 2024-12-04 233042](https://github.com/user-attachments/assets/5c36c42b-c503-49fb-b19c-9e2291da88ca)

![Screenshot 2024-12-04 233054](https://github.com/user-attachments/assets/645d128c-0fd2-440c-af12-c9a6c9d355bd)


### Now


![Screenshot 2024-12-04 230708](https://github.com/user-attachments/assets/8f872aec-49bc-4472-a9e0-52c3eaade08b)

![Screenshot 2024-12-04 231724](https://github.com/user-attachments/assets/028bcc86-0d0f-4c1a-9158-3e888b4fc975)
