### PR TITLE
ci: run backend tests on server json file changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,7 +1,7 @@
 # This file determines when jobs should run or skipped based on which files were modified
 
 backend:
-  - 'packages/**/server/**/*.(js|ts)'
+  - 'packages/**/server/**/*.(js|ts|json)'
   - 'packages/**/strapi-server.js'
   - 'packages/{utils,generators,cli,providers}/**'
   - 'packages/core/*/{lib,bin,ee,src}/**'


### PR DESCRIPTION
### What does it do?

Makes sure the backend tests run in the CI when JSON files change in the server part of a package

### Why is it needed?

i18n locales config can break snapshots with JSON data. We need the CI to run to catch that.

For example this PR: https://github.com/strapi/strapi/pull/21881
That required this change: https://github.com/strapi/strapi/pull/22347
