### PR TITLE
fix: accessing graphql playground without users-permissions plugin

### DIFF
--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -118,6 +118,17 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
       },
     };
 
+    const isPlaygroundRequest =
+      ctx.request.method === 'GET' &&
+      ctx.request.url === path && // Matches the GraphQL endpoint
+      playgroundEnabled && // Only allow if the Playground is enabled
+      ctx.request.header.accept?.includes('text/html'); // Specific to Playground UI loading
+
+    // Skip authentication for the GraphQL Playground UI
+    if (isPlaygroundRequest) {
+      return next();
+    }
+
     return strapi.auth.authenticate(ctx, next);
   });
 


### PR DESCRIPTION
### What does it do?

- skips the authenticate request for the graphql playground

### Why is it needed?

- So we are able to load graphql playground without users-permissions

### How to test it?

- remove users-permissions and try to access graphql playground the UI should work
- `GET` queries on graphql should be authenticated

### Related issue(s)/PR(s)

#21977 
fixes #21915 
