### PR TITLE
enhancement(homepage): create recently edited documents endpoint

### DIFF
--- a/packages/core/admin/ee/server/src/controllers/index.ts
+++ b/packages/core/admin/ee/server/src/controllers/index.ts
@@ -1,5 +1,3 @@
-import type {} from 'koa-body';
-
 import authentication from './authentication';
 import role from './role';
 import user from './user';

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -1,0 +1,31 @@
+import type { Core } from '@strapi/types';
+import * as yup from 'yup';
+import { errors } from '@strapi/utils';
+import { getService } from '../utils';
+
+const recentDocumentParamsSchema = yup.object().shape({
+  action: yup.mixed<'update'>().oneOf(['update']).required(),
+});
+
+const createHomepageController = ({ strapi }: { strapi: Core.Strapi }) => {
+  return {
+    async getRecentDocuments(ctx) {
+      let action;
+
+      try {
+        action = (await recentDocumentParamsSchema.validate(ctx.query)).action;
+      } catch (error) {
+        if (error instanceof yup.ValidationError) {
+          throw new errors.ValidationError(error.message);
+        }
+        throw error;
+      }
+
+      if (action === 'update') {
+        return getService('homepage').getRecentUpdates();
+      }
+    },
+  } satisfies Core.Controller;
+};
+
+export { createHomepageController };

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -2,16 +2,17 @@ import type { Core } from '@strapi/types';
 import * as yup from 'yup';
 import { errors } from '@strapi/utils';
 import { getService } from '../utils';
+import type { GetRecentDocuments } from '../../../shared/contracts/homepage';
 
 const createHomepageController = () => {
   const homepageService = getService('homepage');
 
   const recentDocumentParamsSchema = yup.object().shape({
-    action: yup.mixed<'update'>().oneOf(['update']).required(),
+    action: yup.mixed<GetRecentDocuments.Request['query']['action']>().oneOf(['update']).required(),
   });
 
   return {
-    async getRecentDocuments(ctx) {
+    async getRecentDocuments(ctx): Promise<GetRecentDocuments.Response> {
       let action;
 
       try {
@@ -26,6 +27,9 @@ const createHomepageController = () => {
       if (action === 'update') {
         return { data: await homepageService.getRecentUpdates() };
       }
+
+      // Just making TS happy until we manage the other actions here
+      return { data: [] };
     },
   } satisfies Core.Controller;
 };

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -3,11 +3,13 @@ import * as yup from 'yup';
 import { errors } from '@strapi/utils';
 import { getService } from '../utils';
 
-const recentDocumentParamsSchema = yup.object().shape({
-  action: yup.mixed<'update'>().oneOf(['update']).required(),
-});
+const createHomepageController = () => {
+  const homepageService = getService('homepage');
 
-const createHomepageController = ({ strapi }: { strapi: Core.Strapi }) => {
+  const recentDocumentParamsSchema = yup.object().shape({
+    action: yup.mixed<'update'>().oneOf(['update']).required(),
+  });
+
   return {
     async getRecentDocuments(ctx) {
       let action;
@@ -22,7 +24,7 @@ const createHomepageController = ({ strapi }: { strapi: Core.Strapi }) => {
       }
 
       if (action === 'update') {
-        return getService('homepage').getRecentUpdates();
+        return { data: await homepageService.getRecentUpdates() };
       }
     },
   } satisfies Core.Controller;

--- a/packages/core/admin/server/src/controllers/index.ts
+++ b/packages/core/admin/server/src/controllers/index.ts
@@ -10,6 +10,7 @@ import transfer from './transfer';
 import user from './user';
 import webhooks from './webhooks';
 import contentApi from './content-api';
+import { createHomepageController } from './homepage';
 
 export default {
   admin,
@@ -22,4 +23,5 @@ export default {
   user,
   webhooks,
   'content-api': contentApi,
+  homepage: createHomepageController,
 };

--- a/packages/core/admin/server/src/routes/homepage.ts
+++ b/packages/core/admin/server/src/routes/homepage.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from '@strapi/types';
+
+const info = { pluginName: 'admin', type: 'admin' };
+
+export default [
+  {
+    method: 'GET',
+    info,
+    path: '/homepage/recent-documents',
+    handler: 'homepage.getRecentDocuments',
+    config: {
+      policies: ['admin::isAuthenticatedAdmin'],
+    },
+  },
+] satisfies Plugin.LoadedPlugin['routes'][string]['routes'];

--- a/packages/core/admin/server/src/routes/index.ts
+++ b/packages/core/admin/server/src/routes/index.ts
@@ -7,6 +7,7 @@ import webhooks from './webhooks';
 import apiTokens from './api-tokens';
 import contentApi from './content-api';
 import transfer from './transfer';
+import homepage from './homepage';
 
 const routes = {
   admin: {
@@ -21,6 +22,7 @@ const routes = {
       ...apiTokens,
       ...contentApi,
       ...transfer,
+      ...homepage,
     ],
   },
 };

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -1,0 +1,11 @@
+import type { Core } from '@strapi/types';
+
+const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
+  return {
+    async getRecentUpdates() {
+      return 'recent updates';
+    },
+  };
+};
+
+export { createHomepageService };

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -1,9 +1,119 @@
-import type { Core } from '@strapi/types';
+import type { Core, UID } from '@strapi/types';
+import { contentTypes } from '@strapi/utils';
+import { omit } from 'lodash/fp';
 
 const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
+  const MAX_DOCUMENTS = 4;
+
+  const metadataService = strapi.plugin('content-manager').service('document-metadata');
+  const permissionService = strapi.admin.services.permission as typeof import('./permission');
+
+  /**
+   * Don't use the strapi.store util because we need to make
+   * more precise queries than exact key matches, in order to make as few queries as possible.
+   */
+  const coreStore = strapi.db.query('strapi::core-store');
+
   return {
     async getRecentUpdates() {
-      return 'recent updates';
+      // Get all the content types the user has permissions to read
+      const readPermissions = await permissionService.findMany({
+        where: {
+          role: { users: { id: strapi.requestContext.get()?.state?.user.id } },
+          action: 'plugin::content-manager.explorer.read',
+        },
+      });
+      const allowedContentTypeNames = readPermissions
+        .map((permission) => permission.subject)
+        .filter(Boolean) as UID.ContentType[];
+
+      // Fetch the configuration for each content type in a single query
+      const rawConfigurations = await coreStore.findMany({
+        where: {
+          key: {
+            $in: allowedContentTypeNames.map(
+              (contentType) => `plugin_content_manager_configuration_content_types::${contentType}`
+            ),
+          },
+        },
+      });
+      const configurations = rawConfigurations.map((rawConfiguration) => {
+        return JSON.parse(rawConfiguration.value);
+      });
+
+      const recentDocuments = await Promise.all(
+        allowedContentTypeNames.map(async (contentTypeName) => {
+          const configuration = configurations.find((config) => config.uid === contentTypeName);
+          const contentType = strapi.contentType(contentTypeName);
+          const fields = ['documentId', 'updatedAt'];
+
+          // Add fields required to get the status if D&P is enabled
+          const hasDraftAndPublish = contentTypes.hasDraftAndPublish(contentType);
+          if (hasDraftAndPublish) {
+            fields.push('publishedAt');
+          }
+
+          // Only add the main field if it's defined
+          const { mainField } = configuration.settings;
+          if (mainField) {
+            fields.push(mainField);
+          }
+
+          // Only add locale if it's localized
+          const isLocalized = (contentType.pluginOptions?.i18n as any)?.localized;
+          if (isLocalized) {
+            fields.push('locale');
+          }
+
+          const documents = await strapi.documents(contentTypeName).findMany({
+            limit: MAX_DOCUMENTS,
+            sort: 'updatedAt:desc',
+            fields,
+          });
+
+          return documents.map((document) => ({
+            data: {
+              ...omit(mainField ? [mainField] : [], document),
+              title: document[mainField ?? 'documentId'],
+            },
+            meta: {
+              model: contentTypeName,
+              kind: contentType.kind,
+              hasDraftAndPublish,
+            },
+          }));
+        })
+      );
+
+      const overallRecentDocuments = recentDocuments
+        .flat()
+        // @ts-expect-error document service does not infer updatedAt
+        .sort((a, b) => new Date(b.data.updatedAt) - new Date(a.data.updatedAt))
+        .slice(0, MAX_DOCUMENTS);
+
+      return Promise.all(
+        overallRecentDocuments.map(async (document) => {
+          /**
+           * Tries to query the other version of the document if draft and publish is enabled,
+           * so that we know when to give the "modified" status.
+           */
+          const { availableStatus } = await metadataService.getMetadata(
+            document.meta.model,
+            document.data,
+            {
+              availableStatus: document.meta.hasDraftAndPublish,
+              availableLocales: false,
+            }
+          );
+          const status = metadataService.getStatus(document.data, availableStatus);
+
+          return {
+            ...document.data,
+            ...document.meta,
+            status,
+          };
+        })
+      );
     },
   };
 };

--- a/packages/core/admin/server/src/services/index.ts
+++ b/packages/core/admin/server/src/services/index.ts
@@ -13,6 +13,7 @@ import * as action from './action';
 import * as apiToken from './api-token';
 import * as transfer from './transfer';
 import * as projectSettings from './project-settings';
+import { createHomepageService } from './homepage';
 
 // TODO: TS - Export services one by one as this export is cjs
 export default {
@@ -30,4 +31,5 @@ export default {
   'api-token': apiToken,
   transfer,
   'project-settings': projectSettings,
+  homepage: createHomepageService,
 };

--- a/packages/core/admin/server/src/utils/index.d.ts
+++ b/packages/core/admin/server/src/utils/index.d.ts
@@ -9,6 +9,7 @@ import * as token from '../services/token';
 import * as apiToken from '../services/api-token';
 import * as projectSettings from '../services/project-settings';
 import * as transfer from '../services/transfer';
+import { createHomepageService } from '../services/homepage';
 
 type S = {
   role: typeof role;
@@ -22,6 +23,7 @@ type S = {
   'api-token': typeof apiToken;
   'project-settings': typeof projectSettings;
   transfer: typeof transfer;
+  homepage: ReturnType<typeof createHomepageService>;
 };
 
 type Resolve<T> = T extends (...args: unknown[]) => unknown ? T : { [K in keyof T]: T[K] };

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -1,7 +1,8 @@
 import type { errors } from '@strapi/utils';
 import type { Struct, UID } from '@strapi/types';
 
-interface RecentDocument {
+// Export required to avoid "cannot be named" TS build error
+export interface RecentDocument {
   kind: Struct.ContentTypeKind;
   model: UID.ContentType;
   documentId: string;

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -1,0 +1,27 @@
+import type { errors } from '@strapi/utils';
+import type { Struct, UID } from '@strapi/types';
+
+interface RecentDocument {
+  kind: Struct.ContentTypeKind;
+  model: UID.ContentType;
+  documentId: string;
+  locale?: string;
+  status?: 'draft' | 'published' | 'modified';
+  title: string;
+  updatedAt: Date;
+}
+
+export declare namespace GetRecentDocuments {
+  export interface Request {
+    body: {};
+    query: {
+      // TODO union with "publish"
+      action: 'update';
+    };
+  }
+
+  export interface Response {
+    data: RecentDocument[];
+    error?: errors.ApplicationError;
+  }
+}

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -1,0 +1,160 @@
+'use strict';
+
+import { createTestBuilder } from 'api-tests/builder';
+import { createAuthRequest } from 'api-tests/request';
+import { createStrapiInstance } from 'api-tests/strapi';
+
+const articleUid = 'api::article.article';
+const articleModel = {
+  kind: 'collectionType',
+  collectionName: 'articles',
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  description: '',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    title: {
+      type: 'string',
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
+    },
+    content: {
+      type: 'blocks',
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
+    },
+  },
+};
+
+const tagUid = 'api::tag.tag';
+const tagModel = {
+  kind: 'collectionType',
+  collectionName: 'tags',
+  singularName: 'tag',
+  pluralName: 'tags',
+  displayName: 'Tag',
+  description: '',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    slug: {
+      type: 'string',
+    },
+  },
+};
+
+const globalUid = 'api::global.global';
+const globalModel = {
+  kind: 'singleType',
+  collectionName: 'globals',
+  singularName: 'global',
+  pluralName: 'globals',
+  displayName: 'Global',
+  description: '',
+  attributes: {
+    siteName: {
+      type: 'string',
+    },
+  },
+};
+
+describe('Homepage API', () => {
+  const builder = createTestBuilder();
+  let strapi;
+  let rq;
+
+  beforeAll(async () => {
+    await builder.addContentTypes([articleModel, globalModel, tagModel]).build();
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  it('requires action param', async () => {
+    const response = await rq({
+      method: 'GET',
+      url: '/admin/homepage/recent-documents',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toMatchObject({
+      error: {
+        message: 'action is a required field',
+      },
+    });
+  });
+
+  it('finds the most recent updates', async () => {
+    // Create a global document so we can update it later
+    const globalDoc = await strapi.documents(globalUid).create({
+      data: {
+        siteName: 'a cool site name',
+      },
+    });
+
+    /**
+     * Create content in different content types. Use a loop with the modulo operator to alternate
+     * actions of different kinds, so we can then make sure that the list of recent documents
+     * has them all in the right order.
+     **/
+    for (let i = 0; i < 9; i++) {
+      if (i % 3 === 0) {
+        await strapi.documents(articleUid).create({
+          data: {
+            title: `Article ${i}`,
+            content: [{ type: 'paragraph', children: [{ type: 'text', text: 'Hello world' }] }],
+          },
+        });
+      } else if (i % 3 === 1) {
+        await strapi.documents(globalUid).update({
+          documentId: globalDoc.documentId,
+          data: {
+            siteName: `global-${i}`,
+          },
+        });
+      } else {
+        await strapi.documents(tagUid).create({
+          data: {
+            slug: `tag-${i}`,
+          },
+        });
+      }
+    }
+
+    const response = await rq({
+      method: 'GET',
+      url: '/admin/homepage/recent-documents?action=update',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data).toHaveLength(4);
+    expect(response.body.data[0].title).toBe('tag-8');
+    expect(response.body.data[0].model).toBe('api::tag.tag');
+    expect(response.body.data[1].title).toBe('global-7');
+    expect(response.body.data[1].model).toBe('api::global.global');
+    expect(response.body.data[2].title).toBe('Article 6');
+    expect(response.body.data[2].model).toBe('api::article.article');
+    expect(response.body.data[3].title).toBe('tag-5');
+    expect(response.body.data[3].model).toBe('api::tag.tag');
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds a `/admin/homepage/recent-documents` endpoint in the admin package.

I haven't extracted many utils or anything, because this PR blocks the frontend work, so ideally we'd merge it soon. I think we can look at the abstractions to create when we work on the recently published documents ticket.

### Why is it needed?

For the "recently edited" widget on the new homepage

### How to test it?

Make updates in Strapi. Then make a GET `/admin/homepage/recent-documents?action=update`, while being authenticated. You should see the most recent documents you have updated across all content types. Each should have a "title" field that is the main field (or the documentId if there's no main field)
