### PR TITLE
fix: updating admin user without having a last name

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/utils/validation.ts
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/utils/validation.ts
@@ -10,7 +10,7 @@ const COMMON_USER_SCHEMA = {
     id: translatedErrors.required.id,
     defaultMessage: 'This field is required',
   }),
-  lastname: yup.string(),
+  lastname: yup.string().nullable(),
   email: yup.string().email(translatedErrors.email).lowercase().required({
     id: translatedErrors.required.id,
     defaultMessage: 'This field is required',


### PR DESCRIPTION
fix #21856
fix #19633

### What does it do?

It enables to update admin user without having a last name

### Why is it needed?

The last name field for admin user and other users is not a mandatory field, This PR will enable users to update profile without last name

### How to test it?

1. Have an admin user with no last name
2. In the Strapi admin panel, settings, edit that user
3. save

### Related issue(s)/PR(s)

#19633

Let us know if this is related to any issue/pull request


https://github.com/user-attachments/assets/f64fffee-79ac-4b05-9d03-ea7149fb8f28


