### PR TITLE
Update upload.ts

### DIFF
--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -50,8 +50,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
   const randomSuffix = () => crypto.randomBytes(5).toString('hex');
 
   const generateFileName = (name: string) => {
+    const config = strapi.config.get<Config>('plugin::upload');
     const baseName = strings.nameToSlug(name, { separator: '_', lowercase: false });
-
+    if (config.randomSuffix === false) {
+      return baseName;
+    }
     return `${baseName}_${randomSuffix()}`;
   };
 


### PR DESCRIPTION
### What does it do?

In a couple of my projects, I really need images to not have the random suffix. This client really wants full control over the file names. I understand the suffix is created for override safety, it's good you are putting in safety mechnisms by default. But I know what I am doing and I want to override it.

### Why is it needed?

To allow my client full control over media URL's, without having random suffixes forced.

### How to test it?

set `randomSuffix: false` in the plugin options and upload something in the media library. See it didnt get a random suffix.

### Additional context

In v4 I used to run a manual override: 
```
register({ strapi }) {
    const upload = strapi.service('plugin::upload.upload');
    upload.formatFileInfo = formatFileInfo;
  },
  ```
  because the generateFileName function is not exported, i had to override the entire `formatFileInfo`. This is kindof fine at first. But somewhere between 4.20 and 4.24 the file grew to this:
  
  ```
  const path = require('path');
  const { extension } = require('mime-types');
  const {
    nameToSlug,
    errors: { ApplicationError },
    file: { bytesToKbytes },
  } = require('@strapi/utils');
  
  // the actual override:
  const generateFileName = (name) => {
    const baseName = nameToSlug(name, { separator: '-', lowercase: true });
    return baseName;
  };
  
  // https://github.com/strapi/strapi/blob/main/packages/core/upload/server/utils/index.js
  const getService = (name) => strapi.plugin('upload').service(name);
  
  // https://github.com/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js#L64
  function filenameReservedRegex() {
    // eslint-disable-next-line no-control-regex
    return /[<>:"/\\|?*\u0000-\u001F]/g;
  }
  
  // https://github.com/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js#L69
  function windowsReservedNameRegex() {
    return /^(con|prn|aux|nul|com\d|lpt\d)$/i;
  }
  
  // https://github.com/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js#L76
  function isValidFilename(string) {
    if (!string || string.length > 255) {
      return false;
    }
    if (filenameReservedRegex().test(string) || windowsReservedNameRegex().test(string)) {
      return false;
    }
    if (string === '.' || string === '..') {
      return false;
    }
    return true;
  }
  
  // https://github.com/strapi/strapi/blob/main/packages/core/upload/server/services/upload.js
  module.exports = {
    async formatFileInfo({ filename, type, size }, fileInfo = {}, metas = {}) {
      const fileService = getService('file');
  
      if (!isValidFilename(filename)) {
        throw new ApplicationError('File name contains invalid characters');
      }
  
      let ext = path.extname(filename);
      if (!ext) {
        ext = `.${extension(type)}`;
      }
  
      const usedName = (fileInfo.name || filename).normalize();
      const basename = path.basename(usedName, ext);
  
      // Prevent null characters in file name
      if (!isValidFilename(usedName)) {
        throw new ApplicationError('File name contains invalid characters');
      }
  
      const entity = {
        name: usedName,
        alternativeText: fileInfo.alternativeText,
        caption: fileInfo.caption,
        folder: fileInfo.folder,
        folderPath: await fileService.getFolderPath(fileInfo.folder),
        hash: generateFileName(basename),
        ext,
        mime: type,
        size: bytesToKbytes(size),
        sizeInBytes: size,
      };
  
      const { refId, ref, field } = metas;
  
      if (refId && ref && field) {
        entity.related = [
          {
            id: refId,
            __type: ref,
            __pivot: { field },
          },
        ];
      }
  
      if (metas.path) {
        entity.path = metas.path;
      }
  
      if (metas.tmpWorkingDirectory) {
        entity.tmpWorkingDirectory = metas.tmpWorkingDirectory;
      }
  
      return entity;
    },
  };
```
just to remove the random suffix on 1 line. I had to check every Strapi update if this service file did not get changed. It would really help me out if I could have this simple plugin option. If this is accepted I would happily add it to the docs, if you wish this to be a documented option.

Pretty please?