### PR TITLE
enhancement(homepage): get recent publish activity

### DIFF
--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -27,7 +27,11 @@ const createHomepageController = () => {
         throw error;
       }
 
-      return { data: await homepageService.getActivityForAction(action) };
+      if (action === 'publish') {
+        return { data: await homepageService.getRecentlyPublishedDocuments() };
+      }
+
+      return { data: await homepageService.getRecentlyUpdatedDocuments() };
     },
   } satisfies Core.Controller;
 };

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -8,7 +8,10 @@ const createHomepageController = () => {
   const homepageService = getService('homepage');
 
   const recentDocumentParamsSchema = yup.object().shape({
-    action: yup.mixed<GetRecentDocuments.Request['query']['action']>().oneOf(['update']).required(),
+    action: yup
+      .mixed<GetRecentDocuments.Request['query']['action']>()
+      .oneOf(['update', 'publish'])
+      .required(),
   });
 
   return {
@@ -24,12 +27,7 @@ const createHomepageController = () => {
         throw error;
       }
 
-      if (action === 'update') {
-        return { data: await homepageService.getRecentUpdates() };
-      }
-
-      // Just making TS happy until we manage the other actions here
-      return { data: [] };
+      return { data: await homepageService.getActivityForAction(action) };
     },
   } satisfies Core.Controller;
 };

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -94,20 +94,14 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
   const formatDocuments = (documents: Modules.Documents.AnyDocument[], meta: DocumentMeta) => {
     return documents.map((document) => {
-      /**
-       * Save the main field value before deleting it so we can use the common
-       * title key instead across all content types. Use the delete operator instead of
-       * destructuring or lodash omit for better type inference.
-       */
-      const mainFieldValue = document[meta.mainField ?? 'documentId'];
-      delete document[meta.mainField];
+      const { mainField, ...restDocument } = document;
 
       return {
         data: {
-          ...document,
-          ...(document.publishedAt && { publishedAt: new Date(document.publishedAt) }),
+          ...restDocument,
+          ...(restDocument.publishedAt && { publishedAt: new Date(restDocument.publishedAt) }),
           updatedAt: new Date(document.updatedAt),
-          title: mainFieldValue,
+          title: document[meta.mainField ?? 'documentId'],
         },
         meta: {
           model: meta.uid,

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -171,6 +171,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
       return addStatusToDocuments(overallRecentDocuments);
     },
+
     async getRecentlyUpdatedDocuments(): Promise<GetRecentDocuments.Response['data']> {
       const allowedContentTypeUids = await getPermittedContentTypes();
       // Fetch the configuration for each content type in a single query

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -16,8 +16,7 @@ export declare namespace GetRecentDocuments {
   export interface Request {
     body: {};
     query: {
-      // TODO union with "publish"
-      action: 'update';
+      action: 'update' | 'publish';
     };
   }
 

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -4,7 +4,7 @@ import type { Struct, UID } from '@strapi/types';
 // Export required to avoid "cannot be named" TS build error
 export interface RecentDocument {
   kind: Struct.ContentTypeKind;
-  model: UID.ContentType;
+  contentTypeUid: UID.ContentType;
   documentId: string;
   locale?: string;
   status?: 'draft' | 'published' | 'modified';

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -10,6 +10,7 @@ export interface RecentDocument {
   status?: 'draft' | 'published' | 'modified';
   title: string;
   updatedAt: Date;
+  publishedAt?: Date | null;
 }
 
 export declare namespace GetRecentDocuments {

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -232,7 +232,7 @@ describe('Homepage API', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body.data).toHaveLength(2);
-    expect(response.body.data.every((doc) => doc.hasDraftAndPublish)).toBe(true);
+    expect(response.body.data.every((doc) => doc.publishedAt)).not.toBe(null);
     expect(response.body.data[0].title).toBe('Tag 1');
     expect(response.body.data[0].status).toBe('published');
     // Assert the data is the published data, but the status should be modified

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -38,6 +38,32 @@ const articleModel = {
   },
 };
 
+const authorUid = 'api::author.author';
+const authorModel = {
+  kind: 'collectionType',
+  collectionName: 'authors',
+  singularName: 'author',
+  pluralName: 'authors',
+  displayName: 'Author',
+  description: '',
+  draftAndPublish: false,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    name: {
+      type: 'string',
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
+    },
+  },
+};
+
 const tagUid = 'api::tag.tag';
 const tagModel = {
   kind: 'collectionType',
@@ -80,7 +106,7 @@ describe('Homepage API', () => {
   let rq;
 
   beforeAll(async () => {
-    await builder.addContentTypes([articleModel, globalModel, tagModel]).build();
+    await builder.addContentTypes([articleModel, globalModel, tagModel, authorModel]).build();
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
   });
@@ -104,7 +130,7 @@ describe('Homepage API', () => {
     });
   });
 
-  it('finds the most recent updates', async () => {
+  it('finds the most recently updated documents', async () => {
     // Create a global document so we can update it later
     const globalDoc = await strapi.documents(globalUid).create({
       data: {
@@ -156,5 +182,61 @@ describe('Homepage API', () => {
     expect(response.body.data[2].model).toBe('api::article.article');
     expect(response.body.data[3].title).toBe('tag-5');
     expect(response.body.data[3].model).toBe('api::tag.tag');
+  });
+
+  it('finds the most recently published documents', async () => {
+    // Create draft and publish documents
+    const article = await strapi.documents(articleUid).create({
+      data: {
+        title: 'The Paperback Writer',
+      },
+    });
+    const tag = await strapi.documents(tagUid).create({
+      data: {
+        slug: 'Tag 1',
+      },
+    });
+    // Create non raft and publish document
+    const author = await strapi.documents(authorUid).create({
+      data: {
+        name: 'Paul McCartney',
+      },
+    });
+
+    // Publish the article
+    await strapi.documents(articleUid).publish({
+      documentId: article.documentId,
+    });
+    // Update published document to create a 'modified' status
+    await strapi.documents(articleUid).update({
+      documentId: article.documentId,
+      data: {
+        title: 'Paperback Writer',
+      },
+    });
+    await strapi.documents(tagUid).publish({
+      documentId: tag.documentId,
+    });
+    // Update the author (won't be included in the response)
+    await strapi.documents(authorUid).update({
+      documentId: author.documentId,
+      data: {
+        name: `John Lennon`,
+      },
+    });
+
+    const response = await rq({
+      method: 'GET',
+      url: '/admin/homepage/recent-documents?action=publish',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.data).toHaveLength(2);
+    expect(response.body.data.every((doc) => doc.hasDraftAndPublish)).toBe(true);
+    expect(response.body.data[0].title).toBe('Tag 1');
+    expect(response.body.data[0].status).toBe('published');
+    // Assert the data is the published data, but the status should be modified
+    expect(response.body.data[1].title).toBe('The Paperback Writer');
+    expect(response.body.data[1].status).toBe('modified');
   });
 });

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -175,13 +175,13 @@ describe('Homepage API', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body.data).toHaveLength(4);
     expect(response.body.data[0].title).toBe('tag-8');
-    expect(response.body.data[0].model).toBe('api::tag.tag');
+    expect(response.body.data[0].contentTypeUid).toBe('api::tag.tag');
     expect(response.body.data[1].title).toBe('global-7');
-    expect(response.body.data[1].model).toBe('api::global.global');
+    expect(response.body.data[1].contentTypeUid).toBe('api::global.global');
     expect(response.body.data[2].title).toBe('Article 6');
-    expect(response.body.data[2].model).toBe('api::article.article');
+    expect(response.body.data[2].contentTypeUid).toBe('api::article.article');
     expect(response.body.data[3].title).toBe('tag-5');
-    expect(response.body.data[3].model).toBe('api::tag.tag');
+    expect(response.body.data[3].contentTypeUid).toBe('api::tag.tag');
   });
 
   it('finds the most recently published documents', async () => {


### PR DESCRIPTION
### What does it do?

- Refactors the service to extract functions to be shared 
- Updates homepage service to get recent publishing activity

### Why is it needed?

- To display publish activity

### How to test it?

- Publish some stuff, update a published document to get a modified state, and make some updates to documents that don't have draft and publish
- Make an authenticated GET to `http://localhost:1337/admin/homepage/recent-documents?action=publish` 
- You should see only documents with draft and published, only the published data, and the correct status (published or modified)


