### PR TITLE
fix: adjust polymorphic relation encoding and index mapping

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -601,11 +601,11 @@ export const createEntityManager = (db: Database): EntityManager => {
           )
             .connect(
               // Merge id & __type to get a single id key
-              dataset.map(encodePolymorphicRelation({ idColumn: 'id', typeColumn: '__type' }))
+              dataset.map(encodePolymorphicRelation({ idColumn: 'id', typeColumn: typeField }))
             )
             .get()
             // set the order based on the order of the ids
-            .reduce((acc, rel, idx) => ({ ...acc, [rel.id]: idx }), {} as Record<ID, number>);
+            .reduce((acc, rel, idx) => ({ ...acc, [rel.id]: idx + 1 }), {} as Record<ID, number>);
 
           rows.forEach((row: Record<string, unknown>) => {
             const rowId = row[morphColumn.idColumn.name] as ID;


### PR DESCRIPTION
### What does it do?

Fix the components' reordering by passing the relation's type field (_`__type` for relations and `__component` for dynamic zones' components_) instead of hard-coding `__type`.

Additionally, start the value of the order property at `1` instead of `0` to maintain consistency with the rest of the code.

### Why is it needed?

This was causing issues on entries' creation as components would not be ordered correctly (_`encodePolymorphicRelation` was returning `1::undefined`-like IDs since `__type` doesn't exist in component data_)

### How to test it?

See reproduction steps in related issues and PRs.

### Related issue(s)/PR(s)

fix #22170
fix #22228
fix #22250


### TODO

- [ ] Add e2e tests