### PR TITLE
enhancement(home): add recently published widget

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -8,7 +8,7 @@ import { Page } from '../../components/PageHelpers';
 import { useEnterprise } from '../../ee';
 import { useAuth } from '../../features/Auth';
 
-import { LastEditedWidget } from './components/ContentManagerWidgets';
+import { LastEditedWidget, LastPublishedWidget } from './components/ContentManagerWidgets';
 import { GuidedTour } from './components/GuidedTour';
 
 /* -------------------------------------------------------------------------------------------------
@@ -41,6 +41,9 @@ const HomePageCE = () => {
           <Grid.Root gap={5}>
             <Grid.Item col={6} s={12}>
               <LastEditedWidget />
+            </Grid.Item>
+            <Grid.Item col={6} s={12}>
+              <LastPublishedWidget />
             </Grid.Item>
           </Grid.Root>
         </Flex>

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -36,7 +36,7 @@ const HomePageCE = () => {
         })}
       />
       <Layouts.Content>
-        <Flex direction="column" alignItems="stretch" gap={5}>
+        <Flex direction="column" alignItems="stretch" gap={8} paddingBottom={10}>
           <GuidedTour />
           <Grid.Root gap={5}>
             <Grid.Item col={6} s={12}>

--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -62,7 +62,7 @@ const WidgetContent = ({ document }: { document: RecentDocument }) => {
   return (
     <Tr onClick={handleRowClick(document)} key={document.documentId}>
       <Td>
-        <CellTypography variant="omega" textColor="neutral800">
+        <CellTypography title={document.documentId} variant="omega" textColor="neutral800">
           {document.title}
         </CellTypography>
       </Td>
@@ -73,8 +73,10 @@ const WidgetContent = ({ document }: { document: RecentDocument }) => {
                 id: 'content-manager.widget.last-edited.single-type',
                 defaultMessage: 'Single-Type',
               })
-            : // TODO check how to localize display name
-              document.contentTypeDisplayName}
+            : formatMessage({
+                id: document.contentTypeDisplayName,
+                defaultMessage: document.contentTypeDisplayName,
+              })}
         </CellTypography>
       </Td>
       <Td>
@@ -128,7 +130,7 @@ const LastEditedWidget = () => {
       <Widget.NoData>
         {formatMessage({
           id: 'content-manager.widget.last-edited.no-data',
-          defaultMessage: 'No edited entry',
+          defaultMessage: 'No edited entries',
         })}
       </Widget.NoData>
     );

--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, Status, Table, Tbody, Td, Tr, Typography } from '@strapi/design-system';
-import { Pencil } from '@strapi/icons';
+import { CheckCircle, Pencil } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { Link, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -48,14 +48,71 @@ const DocumentStatus = ({ status = 'draft' }: DocumentStatusProps) => {
   );
 };
 
+const WidgetContent = ({ document }: { document: RecentDocument }) => {
+  const { formatMessage } = useIntl();
+  const { trackUsage } = useTracking();
+  const navigate = useNavigate();
+
+  const handleRowClick = (document: RecentDocument) => () => {
+    trackUsage('willEditEntryFromHome');
+    const link = getEditViewLink(document);
+    navigate(link);
+  };
+
+  return (
+    <Tr onClick={handleRowClick(document)} key={document.documentId}>
+      <Td>
+        <CellTypography variant="omega" textColor="neutral800">
+          {document.title}
+        </CellTypography>
+      </Td>
+      <Td>
+        <CellTypography variant="omega" textColor="neutral600">
+          {document.kind === 'singleType'
+            ? formatMessage({
+                id: 'content-manager.widget.last-edited.single-type',
+                defaultMessage: 'Single-Type',
+              })
+            : // TODO check how to localize display name
+              document.contentTypeDisplayName}
+        </CellTypography>
+      </Td>
+      <Td>
+        <Box display="inline-block">
+          <DocumentStatus status={document.status} />
+        </Box>
+      </Td>
+      <Td>
+        <Typography textColor="neutral600">
+          <RelativeTime timestamp={new Date(document.updatedAt)} />
+        </Typography>
+      </Td>
+      <Td onClick={(e) => e.stopPropagation()}>
+        <Box display="inline-block">
+          <IconButton
+            tag={Link}
+            to={getEditViewLink(document)}
+            onClick={() => trackUsage('willEditEntryFromHome')}
+            label={formatMessage({
+              id: 'content-manager.actions.edit.label',
+              defaultMessage: 'Edit',
+            })}
+            variant="ghost"
+          >
+            <Pencil />
+          </IconButton>
+        </Box>
+      </Td>
+    </Tr>
+  );
+};
+
 /* -------------------------------------------------------------------------------------------------
  * LastEditedWidget
  * -----------------------------------------------------------------------------------------------*/
 
-const LastEditedContent = () => {
+const LastEditedWidget = () => {
   const { formatMessage } = useIntl();
-  const { trackUsage } = useTracking();
-  const navigate = useNavigate();
   const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'update' });
 
   if (isLoading) {
@@ -77,67 +134,6 @@ const LastEditedContent = () => {
     );
   }
 
-  const handleRowClick = (document: RecentDocument) => () => {
-    trackUsage('willEditEntryFromHome');
-    const link = getEditViewLink(document);
-    navigate(link);
-  };
-
-  return (
-    <Table colCount={5} rowCount={data?.length ?? 0}>
-      <Tbody>
-        {data?.map((document) => (
-          <Tr onClick={handleRowClick(document)} key={document.documentId}>
-            <Td>
-              <CellTypography variant="omega" textColor="neutral800">
-                {document.title}
-              </CellTypography>
-            </Td>
-            <Td>
-              <CellTypography variant="omega" textColor="neutral600">
-                {document.kind === 'singleType'
-                  ? formatMessage({
-                      id: 'content-manager.widget.last-edited.single-type',
-                      defaultMessage: 'Single-Type',
-                    })
-                  : // TODO check how to localize display name
-                    document.contentTypeDisplayName}
-              </CellTypography>
-            </Td>
-            <Td>
-              <Box display="inline-block">
-                <DocumentStatus status={document.status} />
-              </Box>
-            </Td>
-            <Td>
-              <Typography textColor="neutral600">
-                <RelativeTime timestamp={new Date(document.updatedAt)} />
-              </Typography>
-            </Td>
-            <Td onClick={(e) => e.stopPropagation()}>
-              <Box display="inline-block">
-                <IconButton
-                  tag={Link}
-                  to={getEditViewLink(document)}
-                  onClick={() => trackUsage('willEditEntryFromHome')}
-                  label={formatMessage({
-                    id: 'content-manager.actions.edit.label',
-                    defaultMessage: 'Edit',
-                  })}
-                  variant="ghost"
-                >
-                  <Pencil />
-                </IconButton>
-              </Box>
-            </Td>
-          </Tr>
-        ))}
-      </Tbody>
-    </Table>
-  );
-};
-
-const LastEditedWidget = () => {
   return (
     <Widget.Root
       title={{
@@ -146,9 +142,57 @@ const LastEditedWidget = () => {
       }}
       icon={Pencil}
     >
-      <LastEditedContent />
+      <Table colCount={5} rowCount={data?.length ?? 0}>
+        <Tbody>
+          {data?.map((document) => <WidgetContent key={document.documentId} document={document} />)}
+        </Tbody>
+      </Table>
     </Widget.Root>
   );
 };
 
-export { LastEditedWidget };
+/* -------------------------------------------------------------------------------------------------
+ * LastPublishedWidget
+ * -----------------------------------------------------------------------------------------------*/
+
+const LastPublishedWidget = () => {
+  const { formatMessage } = useIntl();
+  const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'publish' });
+
+  if (isLoading) {
+    return <Widget.Loading />;
+  }
+
+  if (error) {
+    return <Widget.Error />;
+  }
+
+  if (data?.length === 0) {
+    return (
+      <Widget.NoData>
+        {formatMessage({
+          id: 'content-manager.widget.last-published.no-data',
+          defaultMessage: 'No published entries',
+        })}
+      </Widget.NoData>
+    );
+  }
+
+  return (
+    <Widget.Root
+      title={{
+        id: 'content-manager.widget.last-published.title',
+        defaultMessage: 'Last published entries',
+      }}
+      icon={CheckCircle}
+    >
+      <Table colCount={5} rowCount={data?.length ?? 0}>
+        <Tbody>
+          {data?.map((document) => <WidgetContent key={document.documentId} document={document} />)}
+        </Tbody>
+      </Table>
+    </Widget.Root>
+  );
+};
+
+export { LastEditedWidget, LastPublishedWidget };

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -294,5 +294,7 @@
   "bulk-publish.edit": "Edit",
   "widget.last-edited.title": "Last edited entries",
   "widget.last-edited.single-type": "Single-Type",
-  "widget.last-edited.no-data": "No edited entry"
+  "widget.last-edited.no-data": "No edited entries",
+  "widget.last-published.title": "Last published entries",
+  "widget.last-published.no-data": "No published entries"
 }

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -58,4 +58,43 @@ test.describe('Home', () => {
       mostRecentEntry.getByRole('gridcell', { name: /nike mens newer!/i })
     ).toBeVisible();
   });
+
+  test('a user should see the last published entries', async ({ page }) => {
+    const recentlyPublishedWidget = page.getByLabel(/last published entries/i);
+    await expect(recentlyPublishedWidget).toBeVisible();
+
+    // Make content update in the CM
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await page.getByRole('button', { name: /publish/i }).click();
+    await findAndClose(page, 'Published document');
+
+    // Go back to the home page, the published entry should be the first in the table with published status
+    await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
+    const mostRecentPublishedEntry = recentlyPublishedWidget.getByRole('row').nth(0);
+    await expect(mostRecentPublishedEntry).toBeVisible();
+    await expect(
+      mostRecentPublishedEntry.getByRole('gridcell', { name: 'West Ham post match analysis' })
+    ).toBeVisible();
+    await expect(
+      mostRecentPublishedEntry.getByRole('gridcell', { name: 'Published' })
+    ).toBeVisible();
+
+    // Now go modify the published entry
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    const title = page.getByLabel(/title/i);
+    await title.fill('West Ham pre match pep talk');
+    await page.getByRole('button', { name: /save/i }).click();
+    await findAndClose(page, 'Saved document');
+
+    // Go back to the home page, the published entry should be the first in the table with modified status
+    await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
+    const mostRecentModifiedEntry = recentlyPublishedWidget.getByRole('row').nth(0);
+    await expect(
+      // It should still be the published data, not the modified draft data
+      mostRecentModifiedEntry.getByRole('gridcell', { name: 'West Ham post match analysis' })
+    ).toBeVisible();
+    await expect(mostRecentModifiedEntry.getByRole('gridcell', { name: 'Modified' })).toBeVisible();
+  });
 });


### PR DESCRIPTION
### What does it do?

- Add new `LastPublishedWidget`
- Refactor the `LastEditContent` component to support the `LastPublishedWidget`

### Why is it needed?

To show recently published documents

### How to test it?

- Go to the CM and publish some stuff
- Go to Home, you should see the new widget with the documents you just published
- Go edit one of those published documents
- You should now see the document in the widget with the modified status, but the data will still be the published data

