### PR TITLE
chore: remove duplicate dependency

### DIFF
--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -69,7 +69,6 @@
     "@strapi/content-manager": "workspace:*",
     "@strapi/pack-up": "5.0.2",
     "@strapi/types": "workspace:*",
-    "@strapi/utils": "workspace:*",
     "@testing-library/react": "15.0.7",
     "msw": "1.3.0",
     "react": "18.3.1",


### PR DESCRIPTION
### What does it do?

- we have a duplicated dependency `@strapi/utils` 

### Why is it needed?

- allows nx releases to resolve the versioning issue in this package

