### PR TITLE
security(deps): bump nanoid to 3.3.8 in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24125,11 +24125,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.6, nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Dependabot bumped it for docs, for some reason was unable to create the PR for root

### Why is it needed?

CVE-2024-55565

### How to test it?

id generation of all kinds should still work, and that's all covered by the existing tests

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22389
