### PR TITLE
Fix error with onChange on input of color picker

### DIFF
--- a/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
+++ b/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
@@ -143,7 +143,7 @@ export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerI
                     style={{ textTransform: 'uppercase' }}
                     value={value}
                     placeholder="#000000"
-                    onChange={onChange}
+                    onChange={(e) => onChange(name, e.target.value)}
                   />
                 </Field.Root>
               </Flex>


### PR DESCRIPTION
### What does it do?

The onChange function of the input to change the hex colors wasn't getting the right parameters

### Why is it needed?

The color picker custom field in Strapi 5 does not allow editing or pasting a hex code in the text box

### How to test it?

In can be done in any hex input, I tested using the hex input of the route "/admin/content-manager/collection-types/api::kitchensink.kitchensink/create" that is in examples/getstarted

### Related issue(s)/PR(s)

Fixed #21838
