### PR TITLE
fix(home): replace title documentId with document title

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -62,7 +62,7 @@ const WidgetContent = ({ document }: { document: RecentDocument }) => {
   return (
     <Tr onClick={handleRowClick(document)} key={document.documentId}>
       <Td>
-        <CellTypography title={document.documentId} variant="omega" textColor="neutral800">
+        <CellTypography title={document.title} variant="omega" textColor="neutral800">
           {document.title}
         </CellTypography>
       </Td>


### PR DESCRIPTION
### What does it do?

Replace documentId with title

### Why is it needed?

It was a mistake

### How to test it?

Hover over the titles in the widgets and you should see the title not the documentId

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
