### PR TITLE
fix(home): make locale defined or null to get the correct status

### DIFF
--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -96,7 +96,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     return documents.map((document) => {
       return {
         documentId: document.documentId,
-        locale: document.locale,
+        locale: document.locale ?? null,
         updatedAt: new Date(document.updatedAt),
         title: document[meta.mainField ?? 'documentId'],
         publishedAt:

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -7,7 +7,7 @@ export interface RecentDocument {
   contentTypeUid: UID.ContentType;
   contentTypeDisplayName: string;
   documentId: string;
-  locale?: string;
+  locale: string | null;
   status?: 'draft' | 'published' | 'modified';
   title: string;
   updatedAt: Date;

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -149,6 +149,7 @@ describe('Homepage API', () => {
      **/
     for (let i = 0; i < 9; i++) {
       if (i % 3 === 0) {
+        // When index is 0, 3, 6
         await strapi.documents(articleUid).create({
           data: {
             title: `Article ${i}`,
@@ -156,6 +157,7 @@ describe('Homepage API', () => {
           },
         });
       } else if (i % 3 === 1) {
+        // When index is 1, 4, 7
         await strapi.documents(globalUid).update({
           documentId: globalDoc.documentId,
           status: 'draft',
@@ -164,6 +166,7 @@ describe('Homepage API', () => {
           },
         });
       } else {
+        // When index is 2, 5, 8
         await strapi.documents(tagUid).create({
           data: {
             slug: `tag-${i}`,
@@ -183,7 +186,8 @@ describe('Homepage API', () => {
     expect(response.body.data[0].contentTypeUid).toBe('api::tag.tag');
     expect(response.body.data[1].title).toBe('global-7');
     expect(response.body.data[1].contentTypeUid).toBe('api::global.global');
-    expect(response.body.data[1].status).toBe('draft');
+    // Document with globalUid was published and then updated, assert the modified status
+    expect(response.body.data[1].status).toBe('modified');
     expect(response.body.data[2].title).toBe('Article 6');
     expect(response.body.data[2].contentTypeUid).toBe('api::article.article');
     expect(response.body.data[3].title).toBe('tag-5');


### PR DESCRIPTION
### What does it do?

Ensures locale is defined or null when getting a status

### Why is it needed?

Otherwise the status is incorrect

### How to test it?

Edit some content in draft and published 
Verify the correct status show up on the homepage

NOTE: A content-type without d&p will still show draft. This is another bug....I think?
