### PR TITLE
fix: hide doc status when no d&p

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -81,7 +81,11 @@ const WidgetContent = ({ document }: { document: RecentDocument }) => {
       </Td>
       <Td>
         <Box display="inline-block">
-          {document.status && <DocumentStatus status={document.status} />}
+          {document.status ? (
+            <DocumentStatus status={document.status} />
+          ) : (
+            <Typography aria-hidden>-</Typography>
+          )}
         </Box>
       </Td>
       <Td>

--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -81,7 +81,7 @@ const WidgetContent = ({ document }: { document: RecentDocument }) => {
       </Td>
       <Td>
         <Box display="inline-block">
-          <DocumentStatus status={document.status} />
+          {document.status && <DocumentStatus status={document.status} />}
         </Box>
       </Td>
       <Td>

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -133,7 +133,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
         return {
           ...recentDocument,
-          status,
+          status: hasDraftAndPublish ? status : undefined,
         };
       })
     );

--- a/tests/api/core/admin/admin-homepage.test.api.ts
+++ b/tests/api/core/admin/admin-homepage.test.api.ts
@@ -167,9 +167,9 @@ describe('Homepage API', () => {
         });
       } else {
         // When index is 2, 5, 8
-        await strapi.documents(tagUid).create({
+        await strapi.documents(authorUid).create({
           data: {
-            slug: `tag-${i}`,
+            name: `author-${i}`,
           },
         });
       }
@@ -180,18 +180,24 @@ describe('Homepage API', () => {
       url: '/admin/homepage/recent-documents?action=update',
     });
 
+    // Assert the response
     expect(response.statusCode).toBe(200);
     expect(response.body.data).toHaveLength(4);
-    expect(response.body.data[0].title).toBe('tag-8');
-    expect(response.body.data[0].contentTypeUid).toBe('api::tag.tag');
+    // Assert the document titles
+    expect(response.body.data[0].title).toBe('author-8');
     expect(response.body.data[1].title).toBe('global-7');
-    expect(response.body.data[1].contentTypeUid).toBe('api::global.global');
-    // Document with globalUid was published and then updated, assert the modified status
-    expect(response.body.data[1].status).toBe('modified');
     expect(response.body.data[2].title).toBe('Article 6');
+    expect(response.body.data[3].title).toBe('author-5');
+    // Assert the document content type uids
+    expect(response.body.data[0].contentTypeUid).toBe('api::author.author');
+    expect(response.body.data[1].contentTypeUid).toBe('api::global.global');
     expect(response.body.data[2].contentTypeUid).toBe('api::article.article');
-    expect(response.body.data[3].title).toBe('tag-5');
-    expect(response.body.data[3].contentTypeUid).toBe('api::tag.tag');
+    expect(response.body.data[3].contentTypeUid).toBe('api::author.author');
+    // Assert the document statuses
+    expect(response.body.data[0].status).toBe(undefined);
+    expect(response.body.data[1].status).toBe('modified');
+    expect(response.body.data[2].status).toBe('draft');
+    expect(response.body.data[3].status).toBe(undefined);
   });
 
   it('finds the most recently published documents', async () => {

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -57,6 +57,7 @@ test.describe('Home', () => {
     await expect(
       mostRecentEntry.getByRole('gridcell', { name: /nike mens newer!/i })
     ).toBeVisible();
+    await expect(mostRecentEntry.getByRole('gridcell', { name: /draft/i })).toBeVisible();
   });
 
   test('a user should see the last published entries', async ({ page }) => {


### PR DESCRIPTION
### What does it do?

- [Backend] Return undefined locale if the CT doesn't have D&P
- [Backend] Update API tests 
- [Frontend] Hide the status for documents undefined locale
- [e2e] TODO: Looking into it in the related PR, but there is already a published product in the DB that isn't present in the CMS in the e2e test instance.

### Why is it needed?

Only d&p documents should have a status

### How to test it?

Make changes to documents with and without draft and publish
Check the statuses are correct for draft and published (draft, published, modified)
Check there is no status for no draft and published (empty grid cell)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22407
