### PR TITLE
Fix on focus change on the search button; Issue #21357

### DIFF
--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -72,6 +72,7 @@ const SearchInput = ({
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onClear={handleClear}
           placeholder={placeholder}
+          onBlur={() => setIsOpen(false)}
         >
           {label}
         </Searchbar>


### PR DESCRIPTION
### What does it do?

In the file at the route: packages/core/admin/admin/src/components/SearchInput.tsx, the line 75 was added with a listener onBlur to reset the button behavior.

### Why is it needed?

When searching for a specific item containing a word, if the search field is deleted manually, it cannot be closed because the button's behavior gets "locked".
### How to test it?

To test the changes, go to any collection type, create dummy/test types, and then click the search button, write in the search bar and then delete the content of it manually. When you change focus, it resets to the search button icon.

### Related issue(s)/PR(s)

Issue #21357
