### PR TITLE
fix: resolved the issue with search field not closing

### DIFF
--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -72,6 +72,11 @@ const SearchInput = ({
           clearLabel={formatMessage({ id: 'clearLabel', defaultMessage: 'Clear' })}
           onClear={handleClear}
           placeholder={placeholder}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+              setIsOpen(false);
+            }
+          }}
         >
           {label}
         </Searchbar>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes the issue where the search field could not be closed.

### Why is it needed?

To fix issue [21357](https://github.com/strapi/strapi/issues/21357): Impossible to close the search field if we clean it manually, the close icon disappears.

### How to test it?

1. Log in with an Super Admin profile.
2. Navigate to the Content Manager.
3. Select any collection type. In the tab, click on the search icon and try searching for any entries.
4. Once done, click anywhere outside the search field to close it. This behavior is implemented similarly to the search field functionality in the Content Manager.

### Related issue(s)/PR(s)

fixes  [21357](https://github.com/strapi/strapi/issues/21357)
