### PR TITLE
fix: locales in localpicker component not order alphabetically

### DIFF
--- a/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocalePicker.tsx
@@ -53,18 +53,30 @@ const LocalePicker = () => {
     }
   }, [hasI18n, handleChange, locales, query.plugins?.i18n?.locale]);
 
+  const sortedLocaleOptions = React.useMemo(() => {
+    const displayedLocales = Array.isArray(locales)
+      ? locales.filter((locale) => {
+          /**
+           * If you can create or read we allow you to see the locale exists
+           * this is because in the ListView, you may be able to create a new entry
+           * in a locale you can't read.
+           */
+          return canCreate.includes(locale.code) || canRead.includes(locale.code);
+        })
+      : [];
+
+    return displayedLocales
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((locale) => (
+        <SingleSelectOption key={locale.id} value={locale.code}>
+          {locale.name}
+        </SingleSelectOption>
+      ));
+  }, [locales, canCreate, canRead]);
+
   if (!hasI18n || !Array.isArray(locales) || locales.length === 0) {
     return null;
   }
-
-  const displayedLocales = locales.filter((locale) => {
-    /**
-     * If you can create or read we allow you to see the locale exists
-     * this is because in the ListView, you may be able to create a new entry
-     * in a locale you can't read.
-     */
-    return canCreate.includes(locale.code) || canRead.includes(locale.code);
-  });
 
   return (
     <SingleSelect
@@ -77,13 +89,7 @@ const LocalePicker = () => {
       // @ts-expect-error – This can be removed in V2 of the DS.
       onChange={handleChange}
     >
-      {displayedLocales
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((locale) => (
-          <SingleSelectOption key={locale.id} value={locale.code}>
-            {locale.name}
-          </SingleSelectOption>
-        ))}
+      {sortedLocaleOptions}
     </SingleSelect>
   );
 };


### PR DESCRIPTION
### What does it do?
Locales in LocalePicker Component Not Ordered Alphabetically

### Why is it needed?
To fix issue [20895](https://github.com/strapi/strapi/issues/20895) : [Strapi v5 RC] Locales in LocalePicker Component Not Ordered Alphabetically

### How to test it?

1. Navigate to any content type having localisation enabled.
2. Observe the order of the locales in the LocalePicker dropdown top of the content listings (just before the setting icon).

### Related issue(s)/PR(s)
fixes [20895](https://github.com/strapi/strapi/issues/20895) 