### PR TITLE
fix: fixed the margin issue for displayed field list in collection types setting

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/ViewSettingsMenu.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/ViewSettingsMenu.tsx
@@ -155,6 +155,7 @@ const FieldPicker = ({ headers = [], resetHeaders, setHeaders }: FieldPickerProp
               background={isActive ? 'primary100' : 'transparent'}
               hasRadius
               padding={2}
+              margin={1}
               key={header.name}
             >
               <Checkbox


### PR DESCRIPTION
### What does it do?

Fixes the spacing issue in Collection types setting in the Displayed fields list

### Why is it needed?

To fix issue [21347](https://github.com/strapi/strapi/issues/21347): Too much spacing and missing white top border between selected item in the Displayed fields list

### How to test it?

- go to CM
- select any one collection type
- click on setting icon we will get configure the view section
- in the section we have displayed field list
- when we check 1st & 2nd fields then we will see the space issue

### Related issue(s)/PR(s)

fixes [21347](https://github.com/strapi/strapi/issues/21347)