### PR TITLE
fix(blocks): various ui issues

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Code.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Code.tsx
@@ -147,7 +147,6 @@ const codeBlocks: Pick<BlocksStore, 'code'> = {
       pressEnterTwiceToExit(editor);
     },
     snippets: ['```'],
-    dragHandleTopMargin: '10px',
   },
 };
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Quote.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/Quote.tsx
@@ -36,7 +36,6 @@ const quoteBlocks: Pick<BlocksStore, 'quote'> = {
       pressEnterTwiceToExit(editor);
     },
     snippets: ['>'],
-    dragHandleTopMargin: '6px',
   },
 };
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -85,30 +85,32 @@ const DragIconButton = styled<IconButtonComponent<'div'>>(IconButton)<{
   display: flex;
   align-items: center;
   justify-content: center;
+  border: none;
   border-radius: ${({ theme }) => theme.borderRadius};
-  width: ${({ theme }) => theme.spaces[4]};
-  height: ${({ theme }) => theme.spaces[6]};
+  padding-left: ${({ theme }) => theme.spaces[0]};
+  padding-right: ${({ theme }) => theme.spaces[0]};
+  padding-top: ${({ theme }) => theme.spaces[1]};
+  padding-bottom: ${({ theme }) => theme.spaces[1]};
   visibility: hidden;
   cursor: grab;
   opacity: inherit;
   margin-top: ${(props) => props.$dragHandleTopMargin ?? 0};
 
   &:hover {
-    background: ${({ theme }) => theme.colors.neutral200};
+    background: ${({ theme }) => theme.colors.neutral100};
   }
   &:active {
     cursor: grabbing;
+    background: ${({ theme }) => theme.colors.neutral150};
   }
   &[aria-disabled='true'] {
-    cursor: not-allowed;
-    background: transparent;
+    visibility: hidden;
   }
   svg {
-    height: auto;
     min-width: ${({ theme }) => theme.spaces[3]};
 
     path {
-      fill: ${({ theme }) => theme.colors.neutral700};
+      fill: ${({ theme }) => theme.colors.neutral500};
     }
   }
 `;
@@ -591,7 +593,7 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
       background="neutral0"
       color="neutral800"
       lineHeight={6}
-      paddingRight={4}
+      paddingRight={7}
       paddingTop={6}
       paddingBottom={3}
     >

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -118,6 +118,7 @@ const ExpandIconButton = styled(IconButton)`
   position: absolute;
   bottom: 1.2rem;
   right: 1.2rem;
+  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
 `;
 
 /**

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -26,7 +26,7 @@ import { insertLink } from './utils/links';
 import { type Block, getEntries, getKeys } from './utils/types';
 
 const ToolbarWrapper = styled<FlexComponent>(Flex)`
-width: 100%;
+  width: 100%;
   &[aria-disabled='true'] {
     cursor: not-allowed;
     background: ${({ theme }) => theme.colors.neutral150};

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -26,7 +26,6 @@ import { insertLink } from './utils/links';
 import { type Block, getEntries, getKeys } from './utils/types';
 
 const ToolbarWrapper = styled<FlexComponent>(Flex)`
-  width: 100%;
   &[aria-disabled='true'] {
     cursor: not-allowed;
     background: ${({ theme }) => theme.colors.neutral150};
@@ -42,7 +41,6 @@ const Separator = styled(Toolbar.Separator)`
 const FlexButton = styled<FlexComponent<'button'>>(Flex)`
   // Inherit the not-allowed cursor from ToolbarWrapper when disabled
   &[aria-disabled] {
-    cursor: inherit;
     cursor: not-allowed;
   }
 
@@ -542,7 +540,7 @@ const BlocksToolbar = () => {
 
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
-      <ToolbarWrapper gap={2} padding={2}>
+      <ToolbarWrapper gap={2} padding={2} width="100%">
         <BlocksDropdown />
         <Separator />
         <Toolbar.ToggleGroup type="multiple" asChild>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -26,8 +26,10 @@ import { insertLink } from './utils/links';
 import { type Block, getEntries, getKeys } from './utils/types';
 
 const ToolbarWrapper = styled<FlexComponent>(Flex)`
+width: 100%;
   &[aria-disabled='true'] {
     cursor: not-allowed;
+    background: ${({ theme }) => theme.colors.neutral150};
   }
 `;
 
@@ -41,6 +43,7 @@ const FlexButton = styled<FlexComponent<'button'>>(Flex)`
   // Inherit the not-allowed cursor from ToolbarWrapper when disabled
   &[aria-disabled] {
     cursor: inherit;
+    cursor: not-allowed;
   }
 
   &[aria-disabled='false'] {


### PR DESCRIPTION
### What does it do?

- Removes the border of the `DragIconButton` in both default and disabled mode
- Changes the color and the size of the `Drag` icon because it wasn't visible enough
- Hides the `DragIconButton` when the input is disabled
- Changes the cursor to `not-allowed` for disabled modifiers
- Adds a shadow to `ExpandIconButton` to make it understandable that it is sticky
- Set the with of `ToolbarWrapper` to 100% and added a background color for its disabled state
- Thanks to the new width of `ToolbarWrapper` the input has a disabled style in expanded mode as well
- Removed `dragHandleTopMargin` for `Code` and the `Quote`
- Fixes padding issues

### Why is it needed?

Blocks is currently not aligned with the designs and its disabled states are not understandable.

### How to test it?

Open any entry that has a Blocks field. Don't forget to check the expanded mode.

### Related issue(s)/PR(s)

fix https://github.com/strapi/strapi/issues/20781