### PR TITLE
fix: add component button style

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
@@ -30,13 +30,13 @@ const AddComponentButton = ({
     >
       <Flex tag="span" gap={2}>
         <StyledAddIcon aria-hidden $isOpen={isOpen} $hasError={hasError && !isOpen} />
-        <AddComponentTitle
+        <Typography
           variant="pi"
           fontWeight="bold"
-          textColor={hasError && !isOpen ? 'danger600' : 'neutral500'}
+          textColor={hasError && !isOpen ? 'danger600' : 'neutral600'}
         >
           {children}
-        </AddComponentTitle>
+        </Typography>
       </Flex>
     </StyledButton>
   );
@@ -55,10 +55,6 @@ const StyledAddIcon = styled(PlusCircle)<{ $isOpen?: boolean; $hasError?: boolea
     fill: ${({ theme, $hasError }) =>
       $hasError ? theme.colors.danger600 : theme.colors.neutral500};
   }
-`;
-
-const AddComponentTitle = styled<TypographyComponent>(Typography)`
-  color: ${({ theme }) => theme.colors.neutral600};
 `;
 
 const StyledButton = styled(Button)`

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
@@ -42,18 +42,18 @@ const AddComponentButton = ({
   );
 };
 
-const StyledAddIcon = styled(PlusCircle) <{ $isOpen?: boolean; $hasError?: boolean }>`
+const StyledAddIcon = styled(PlusCircle)<{ $isOpen?: boolean; $hasError?: boolean }>`
   height: ${({ theme }) => theme.spaces[6]};
   width: ${({ theme }) => theme.spaces[6]};
   transform: ${({ $isOpen }) => ($isOpen ? 'rotate(45deg)' : 'rotate(0deg)')};
 
   > circle {
     fill: ${({ theme, $hasError }) =>
-    $hasError ? theme.colors.danger200 : theme.colors.neutral150};
+      $hasError ? theme.colors.danger200 : theme.colors.neutral150};
   }
   > path {
     fill: ${({ theme, $hasError }) =>
-    $hasError ? theme.colors.danger600 : theme.colors.neutral500};
+      $hasError ? theme.colors.danger600 : theme.colors.neutral500};
   }
 `;
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/AddComponentButton.tsx
@@ -42,56 +42,30 @@ const AddComponentButton = ({
   );
 };
 
-const StyledAddIcon = styled(PlusCircle)<{ $isOpen?: boolean; $hasError?: boolean }>`
+const StyledAddIcon = styled(PlusCircle) <{ $isOpen?: boolean; $hasError?: boolean }>`
   height: ${({ theme }) => theme.spaces[6]};
   width: ${({ theme }) => theme.spaces[6]};
   transform: ${({ $isOpen }) => ($isOpen ? 'rotate(45deg)' : 'rotate(0deg)')};
 
   > circle {
     fill: ${({ theme, $hasError }) =>
-      $hasError ? theme.colors.danger200 : theme.colors.neutral150};
+    $hasError ? theme.colors.danger200 : theme.colors.neutral150};
   }
   > path {
     fill: ${({ theme, $hasError }) =>
-      $hasError ? theme.colors.danger600 : theme.colors.neutral600};
+    $hasError ? theme.colors.danger600 : theme.colors.neutral500};
   }
 `;
 
-const AddComponentTitle = styled<TypographyComponent>(Typography)``;
+const AddComponentTitle = styled<TypographyComponent>(Typography)`
+  color: ${({ theme }) => theme.colors.neutral600};
+`;
 
 const StyledButton = styled(Button)`
+  padding-left: ${({ theme }) => theme.spaces[3]};
   border-radius: 26px;
-  border-color: ${({ theme }) => theme.colors.neutral150};
   box-shadow: ${({ theme }) => theme.shadows.filterShadow};
   height: 5rem;
-
-  &:hover {
-    ${AddComponentTitle} {
-      color: ${({ theme }) => theme.colors.primary600};
-    }
-
-    ${StyledAddIcon} {
-      > circle {
-        fill: ${({ theme }) => theme.colors.primary600};
-      }
-      > path {
-        fill: ${({ theme }) => theme.colors.primary600};
-      }
-    }
-  }
-  &:active {
-    ${AddComponentTitle} {
-      color: ${({ theme }) => theme.colors.primary600};
-    }
-    ${StyledAddIcon} {
-      > circle {
-        fill: ${({ theme }) => theme.colors.primary600};
-      }
-      > path {
-        fill: ${({ theme }) => theme.colors.neutral100};
-      }
-    }
-  }
 `;
 
 export { AddComponentButton };


### PR DESCRIPTION
### What does it do?

- Simplifies `AddComponentButton` by using its styles inherited from `Button`
- Removes the unnecessary styles change on hover when disabled
- Changes the padding left to better fit the icon shape

### Why is it needed?

The current version is not in sync with the design and makes users think that they can click on the button even if it's disabled. It will improve the UX of the disabled Dynamic Zones in the "Published" tab and in Content History.

#### Before

https://github.com/user-attachments/assets/c9d987d1-e66d-492d-939e-28ba27cfd34f

#### After

https://github.com/user-attachments/assets/e19ad3c6-859a-47fb-a629-c35acc1e98c9

### How to test it?

Open any entry with a Dynamic Zone and check its disabled version.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
