### PR TITLE
fix: preview back button behavior

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -13,6 +13,14 @@ const PreviewContent = () => {
   return (
     <Box
       src={previewUrl}
+      /**
+       * For some reason, changing an iframe's src tag causes the browser to add a new item in the
+       * history stack. This is an issue for us as it means clicking the back button will not let us
+       * go back to the edit view. To fix it, we need to trick the browser into thinking this is a
+       * different iframe when the preview URL changes. So we set a key prop to force React
+       * to mount a different node when the src changes.
+       */
+      key={previewUrl}
       title={formatMessage({
         id: 'content-manager.preview.panel.title',
         defaultMessage: 'Preview',


### PR DESCRIPTION
### What does it do?

fixes the bug where after toggling tabs multiple times in the preview page, you would need to click multiple times on the back button to get to the edit view.

### How to test it

Start from the edit view, open preview, toggle tabs a bunch of times, click on the back icon button once, you should be taken back to the preview immediately. Clicking on your browser's forward button should lead you to the preview page again.