### PR TITLE
fix: make ctb loader truly round

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
@@ -144,7 +144,7 @@ const Blocker = ({ displayedIcon, description, title, isOpen }: BlockerProps) =>
           </Flex>
           {displayedIcon === 'reload' && (
             <IconBox padding={6} background="primary100" borderColor="primary200">
-              <LoaderReload width="3.6rem" height="3.6rem" />
+              <LoaderReload width="4rem" height="4rem" />
             </IconBox>
           )}
           {displayedIcon === 'time' && (
@@ -209,6 +209,9 @@ const Overlay = styled(Flex)`
 
 const IconBox = styled(Box)`
   border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   svg {
     > path {
       fill: ${({ theme }) => theme.colors.primary600} !important;


### PR DESCRIPTION
### What does it do?

- Makes the CTB loader round
- Harmonizes the icons sizes between the 2 states

### Why is it needed?

It's currently not the case.

#### Before

https://github.com/user-attachments/assets/451077b7-6ca9-4e5b-921d-adf55c20205b

#### After

https://github.com/user-attachments/assets/e6a0d05a-cf35-4612-a8e1-d4a57766cd35

### How to test it?

Create or update any content type.

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/21349