### PR TITLE
Fix: logging data-transfer and adding verbose

### DIFF
--- a/packages/core/data-transfer/src/commands/export/action.ts
+++ b/packages/core/data-transfer/src/commands/export/action.ts
@@ -32,6 +32,7 @@ const BYTES_IN_MB = 1024 * 1024;
 interface CmdOptions {
   file?: string;
   encrypt?: boolean;
+  verbose?: boolean;
   key?: string;
   compress?: boolean;
   only?: (keyof TransferGroupFilter)[];
@@ -85,7 +86,7 @@ export default async (opts: CmdOptions) => {
     },
   });
 
-  engine.diagnostics.onDiagnostic(formatDiagnostic('export'));
+  engine.diagnostics.onDiagnostic(formatDiagnostic('export', opts.verbose));
 
   const progress = engine.progress.stream;
 

--- a/packages/core/data-transfer/src/commands/export/command.ts
+++ b/packages/core/data-transfer/src/commands/export/command.ts
@@ -19,6 +19,7 @@ const command = ({ command }: { command: Command }) => {
     .addOption(
       new Option('--no-compress', 'Disables gzip compression of output file').default(true)
     )
+    .addOption(new Option('--verbose', 'Enable verbose logs'))
     .addOption(
       new Option(
         '-k, --key <string>',

--- a/packages/core/data-transfer/src/commands/import/action.ts
+++ b/packages/core/data-transfer/src/commands/import/action.ts
@@ -34,6 +34,7 @@ interface CmdOptions {
   file?: string;
   decompress?: boolean;
   decrypt?: boolean;
+  verbose?: boolean;
   key?: string;
   conflictStrategy?: 'restore';
   force?: boolean;
@@ -109,7 +110,7 @@ export default async (opts: CmdOptions) => {
 
   const engine = createTransferEngine(source, destination, engineOptions);
 
-  engine.diagnostics.onDiagnostic(formatDiagnostic('import'));
+  engine.diagnostics.onDiagnostic(formatDiagnostic('import', opts.verbose));
 
   const progress = engine.progress.stream;
 

--- a/packages/core/data-transfer/src/commands/import/command.ts
+++ b/packages/core/data-transfer/src/commands/import/command.ts
@@ -24,6 +24,7 @@ const command = ({ command }: { command: Command }) => {
         'Provide encryption key in command instead of using the prompt'
       )
     )
+    .addOption(new Option('--verbose', 'Enable verbose logs'))
     .addOption(forceOption)
     .addOption(excludeOption)
     .addOption(onlyOption)

--- a/packages/core/data-transfer/src/commands/transfer/action.ts
+++ b/packages/core/data-transfer/src/commands/transfer/action.ts
@@ -33,6 +33,7 @@ interface CmdOptions {
   fromToken: string;
   to: URL;
   toToken: string;
+  verbose?: boolean;
   only?: (keyof engineDatatransfer.TransferGroupFilter)[];
   exclude?: (keyof engineDatatransfer.TransferGroupFilter)[];
   throttle?: number;
@@ -135,7 +136,7 @@ export default async (opts: CmdOptions) => {
     },
   });
 
-  engine.diagnostics.onDiagnostic(formatDiagnostic('transfer'));
+  engine.diagnostics.onDiagnostic(formatDiagnostic('transfer', opts.verbose));
 
   const progress = engine.progress.stream;
 

--- a/packages/core/data-transfer/src/commands/transfer/command.ts
+++ b/packages/core/data-transfer/src/commands/transfer/command.ts
@@ -27,6 +27,7 @@ const command = ({ command }: { command: Command }) => {
       ).argParser(parseURL)
     )
     .addOption(new Option('--to-token <token>', `Transfer token for the remote Strapi destination`))
+    .addOption(new Option('--verbose', 'Enable verbose logs'))
     .addOption(forceOption)
     .addOption(excludeOption)
     .addOption(onlyOption)

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -40,7 +40,7 @@ import {
   createDiagnosticReporter,
   IDiagnosticReporter,
   ErrorDiagnosticSeverity,
-} from './diagnostic';
+} from '../utils/diagnostic';
 import { DataTransferError } from '../errors';
 import * as utils from '../utils';
 import { ProviderTransferError } from '../errors/providers';
@@ -199,7 +199,7 @@ class TransferEngine<
   reportInfo(message: string, params?: unknown) {
     this.diagnostics.report({
       kind: 'info',
-      details: { createdAt: new Date(), message, params },
+      details: { createdAt: new Date(), message, params, origin: 'engine' },
     });
   }
 
@@ -603,8 +603,8 @@ class TransferEngine<
    */
   async bootstrap(): Promise<void> {
     const results = await Promise.allSettled([
-      this.sourceProvider.bootstrap?.(),
-      this.destinationProvider.bootstrap?.(),
+      this.sourceProvider.bootstrap?.(this.diagnostics),
+      this.destinationProvider.bootstrap?.(this.diagnostics),
     ]);
 
     results.forEach((result) => {

--- a/packages/core/data-transfer/src/errors/constants.ts
+++ b/packages/core/data-transfer/src/errors/constants.ts
@@ -1,4 +1,4 @@
-import { ErrorDiagnosticSeverity } from '../engine/diagnostic';
+import { ErrorDiagnosticSeverity } from '../utils/diagnostic';
 
 export const SeverityKind: Record<string, ErrorDiagnosticSeverity> = {
   FATAL: 'fatal',

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -11,6 +11,7 @@ import type {
   ProviderType,
   Transaction,
 } from '../../../../types';
+import type { IDiagnosticReporter } from '../../../utils/diagnostic';
 
 import { restore } from './strategies';
 import * as utils from '../../../utils';
@@ -47,6 +48,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
   onWarning?: ((message: string) => void) | undefined;
 
+  #diagnostics?: IDiagnosticReporter;
+
   /**
    * The entities mapper is used to map old entities to their new IDs
    */
@@ -58,7 +61,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     this.uploadsBackupDirectoryName = `uploads_backup_${Date.now()}`;
   }
 
-  async bootstrap(): Promise<void> {
+  async bootstrap(diagnostics?: IDiagnosticReporter): Promise<void> {
+    this.#diagnostics = diagnostics;
     this.#validateOptions();
     this.strapi = await this.options.getStrapi();
     if (!this.strapi) {
@@ -84,6 +88,17 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     return !excluded && !notIncluded;
   };
 
+  #reportInfo(message: string) {
+    this.#diagnostics?.report({
+      details: {
+        createdAt: new Date(),
+        message,
+        origin: 'local-destination-provider',
+      },
+      kind: 'info',
+    });
+  }
+
   async close(): Promise<void> {
     const { autoDestroy } = this.options;
     this.transaction?.end();
@@ -95,6 +110,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
   }
 
   #validateOptions() {
+    this.#reportInfo('validating options');
     if (!VALID_CONFLICT_STRATEGIES.includes(this.options.strategy)) {
       throw new ProviderValidationError(`Invalid strategy ${this.options.strategy}`, {
         check: 'strategy',
@@ -114,12 +130,13 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     if (!this.options.restore) {
       throw new ProviderValidationError('Missing restore options');
     }
+    this.#reportInfo('deleting record');
     return restore.deleteRecords(this.strapi, this.options.restore);
   }
 
   async #deleteAllAssets(trx?: Knex.Transaction) {
     assertValidStrapi(this.strapi);
-
+    this.#reportInfo('deleting all assets');
     // if we're not restoring files, don't touch the files
     if (!this.#areAssetsIncluded()) {
       return;
@@ -144,10 +161,14 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
         }
       }
     }
+
+    this.#reportInfo('deleted all assets');
   }
 
   async rollback() {
+    this.#reportInfo('Rolling back transaction');
     await this.transaction?.rollback();
+    this.#reportInfo('Rolled back transaction');
   }
 
   async beforeTransfer() {
@@ -169,6 +190,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
   }
 
   getMetadata(): IMetadata {
+    this.#reportInfo('getting metadata');
     assertValidStrapi(this.strapi, 'Not able to get Schemas');
     const strapiVersion = this.strapi.config.get<string>('info.strapi');
     const createdAt = new Date().toISOString();
@@ -182,6 +204,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
   }
 
   getSchemas() {
+    this.#reportInfo('getting schema');
     assertValidStrapi(this.strapi, 'Not able to get Schemas');
     const schemas = {
       ...this.strapi.contentTypes,
@@ -193,6 +216,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
   createEntitiesWriteStream(): Writable {
     assertValidStrapi(this.strapi, 'Not able to import entities');
+    this.#reportInfo('creating entities stream');
     const { strategy } = this.options;
 
     const updateMappingTable = (type: string, oldID: number, newID: number) => {
@@ -227,6 +251,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     }
 
     if (this.strapi.config.get<{ provider: string }>('plugin.upload').provider === 'local') {
+      this.#reportInfo('creating assets backup directory');
       const assetsDirectory = path.join(this.strapi.dirs.static.public, 'uploads');
       const backupDirectory = path.join(
         this.strapi.dirs.static.public,
@@ -247,6 +272,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
         await fse.mkdir(assetsDirectory);
         // Create a .gitkeep file to ensure the directory is not empty
         await fse.outputFile(path.join(assetsDirectory, '.gitkeep'), '');
+        this.#reportInfo(`created assets backup directory ${backupDirectory}`);
       } catch (err) {
         throw new ProviderTransferError(
           'The backup folder for the assets could not be created inside the public folder. Please ensure Strapi has write permissions on the public directory',
@@ -268,19 +294,21 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
     // TODO: this should catch all thrown errors and bubble it up to engine so it can be reported as a non-fatal diagnostic message telling the user they may need to manually delete assets
     if (this.strapi.config.get<{ provider: string }>('plugin.upload').provider === 'local') {
+      this.#reportInfo('removing assets backup');
       assertValidStrapi(this.strapi);
       const backupDirectory = path.join(
         this.strapi.dirs.static.public,
         this.uploadsBackupDirectoryName
       );
       await fse.rm(backupDirectory, { recursive: true, force: true });
+      this.#reportInfo('successfully removed assets backup');
     }
   }
 
   // TODO: Move this logic to the restore strategy
   async createAssetsWriteStream(): Promise<Writable> {
     assertValidStrapi(this.strapi, 'Not able to stream Assets');
-
+    this.#reportInfo('creating assets write stream');
     if (!this.#areAssetsIncluded()) {
       throw new ProviderTransferError(
         'Attempting to transfer assets when `assets` is not set in restore options'
@@ -399,7 +427,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
 
   async createConfigurationWriteStream(): Promise<Writable> {
     assertValidStrapi(this.strapi, 'Not able to stream Configurations');
-
+    this.#reportInfo('creating configuration write stream');
     const { strategy } = this.options;
 
     if (strategy === 'restore') {
@@ -414,6 +442,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
   }
 
   async createLinksWriteStream(): Promise<Writable> {
+    this.#reportInfo('creating links write stream');
     if (!this.strapi) {
       throw new Error('Not able to stream links. Strapi instance not found');
     }

--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -3,6 +3,7 @@ import { chain } from 'stream-chain';
 import type { LoadedStrapi } from '@strapi/types';
 
 import type { IMetadata, ISourceProvider, ProviderType } from '../../../../types';
+import type { IDiagnosticReporter } from '../../../utils/diagnostic';
 import { createEntitiesStream, createEntitiesTransformStream } from './entities';
 import { createLinksStream } from './links';
 import { createConfigurationStream } from './configuration';
@@ -29,12 +30,26 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   strapi?: LoadedStrapi;
 
+  #diagnostics?: IDiagnosticReporter;
+
   constructor(options: ILocalStrapiSourceProviderOptions) {
     this.options = options;
   }
 
-  async bootstrap(): Promise<void> {
+  async bootstrap(diagnostics?: IDiagnosticReporter): Promise<void> {
+    this.#diagnostics = diagnostics;
     this.strapi = await this.options.getStrapi();
+  }
+
+  #reportInfo(message: string) {
+    this.#diagnostics?.report({
+      details: {
+        createdAt: new Date(),
+        message,
+        origin: 'local-source-provider',
+      },
+      kind: 'info',
+    });
   }
 
   async close(): Promise<void> {
@@ -47,6 +62,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   }
 
   getMetadata(): IMetadata {
+    this.#reportInfo('getting metadata');
     const strapiVersion = strapi.config.get<string>('info.strapi');
     const createdAt = new Date().toISOString();
 
@@ -60,7 +76,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   async createEntitiesReadStream(): Promise<Readable> {
     assertValidStrapi(this.strapi, 'Not able to stream entities');
-
+    this.#reportInfo('creating entities read stream');
     return chain([
       // Entities stream
       createEntitiesStream(this.strapi),
@@ -72,19 +88,20 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   createLinksReadStream(): Readable {
     assertValidStrapi(this.strapi, 'Not able to stream links');
+    this.#reportInfo('creating links read stream');
 
     return createLinksStream(this.strapi);
   }
 
   createConfigurationReadStream(): Readable {
     assertValidStrapi(this.strapi, 'Not able to stream configuration');
-
+    this.#reportInfo('creating configuration read stream');
     return createConfigurationStream(this.strapi);
   }
 
   getSchemas() {
     assertValidStrapi(this.strapi, 'Not able to get Schemas');
-
+    this.#reportInfo('getting schemas');
     const schemas = {
       ...this.strapi.contentTypes,
       ...this.strapi.components,
@@ -99,7 +116,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   createAssetsReadStream(): Readable {
     assertValidStrapi(this.strapi, 'Not able to stream assets');
-
+    this.#reportInfo('creating assets read stream');
     return createAssetsStream(this.strapi);
   }
 }

--- a/packages/core/data-transfer/src/strapi/providers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/providers/utils.ts
@@ -10,6 +10,7 @@ import {
   ProviderValidationError,
   ProviderErrorDetails,
 } from '../../errors/providers';
+import { IDiagnosticReporter } from '../../utils/diagnostic';
 
 interface IDispatcherState {
   transfer?: { kind: Client.TransferKind; id: string };
@@ -26,7 +27,8 @@ export const createDispatcher = (
   retryMessageOptions = {
     retryMessageMaxRetries: 5,
     retryMessageTimeout: 30000,
-  }
+  },
+  reportInfo?: (message: string) => void
 ) => {
   const state: IDispatcherState = {};
 
@@ -49,6 +51,20 @@ export const createDispatcher = (
         Object.assign(payload, { transferID: state.transfer?.id });
       }
 
+      if (message.type === 'command') {
+        reportInfo?.(
+          `dispatching message command:${
+            (message as Client.CommandMessage).command
+          } uuid:${uuid} sent:${numberOfTimesMessageWasSent}`
+        );
+      } else if (message.type === 'transfer') {
+        const messageToSend = message as Client.TransferMessage;
+        reportInfo?.(
+          `dispatching message action:${messageToSend.action} ${
+            messageToSend.kind === 'step' ? `step:${messageToSend.step}` : ''
+          } uuid:${uuid} sent:${numberOfTimesMessageWasSent}`
+        );
+      }
       const stringifiedPayload = JSON.stringify(payload);
       ws.send(stringifiedPayload, (error) => {
         if (error) {
@@ -72,6 +88,20 @@ export const createDispatcher = (
 
       const onResponse = (raw: RawData) => {
         const response: Server.Message<U> = JSON.parse(raw.toString());
+        if (message.type === 'command') {
+          reportInfo?.(
+            `received response to message command: ${
+              (message as Client.CommandMessage).command
+            } uuid: ${uuid} sent: ${numberOfTimesMessageWasSent}`
+          );
+        } else if (message.type === 'transfer') {
+          const messageToSend = message as Client.TransferMessage;
+          reportInfo?.(
+            `received response to message action:${messageToSend.action} ${
+              messageToSend.kind === 'step' ? `step:${messageToSend.step}` : ''
+            } uuid:${uuid} sent:${numberOfTimesMessageWasSent}`
+          );
+        }
         if (response.uuid === uuid) {
           clearInterval(interval);
           if (response.error) {
@@ -161,7 +191,11 @@ type WebsocketParams = ConstructorParameters<typeof WebSocket>;
 type Address = WebsocketParams[0];
 type Options = WebsocketParams[2];
 
-export const connectToWebsocket = (address: Address, options?: Options): Promise<WebSocket> => {
+export const connectToWebsocket = (
+  address: Address,
+  options?: Options,
+  diagnostics?: IDiagnosticReporter
+): Promise<WebSocket> => {
   return new Promise((resolve, reject) => {
     const server = new WebSocket(address, options);
     server.once('open', () => {
@@ -198,6 +232,15 @@ export const connectToWebsocket = (address: Address, options?: Options): Promise
           `Failed to initialize the connection: Unexpected server response ${res.statusCode}`
         )
       );
+    });
+
+    server.on('message', (raw: RawData) => {
+      const response: Server.Message = JSON.parse(raw.toString());
+      if (response.diagnostic) {
+        diagnostics?.report({
+          ...response.diagnostic,
+        });
+      }
     });
 
     server.once('error', (err) => {

--- a/packages/core/data-transfer/src/strapi/remote/handlers/abstract.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/abstract.ts
@@ -2,6 +2,7 @@ import type { WebSocket, RawData } from 'ws';
 
 import type { ValidTransferCommand } from './constants';
 import type { TransferMethod } from '../constants';
+import type { IDiagnosticReporter } from '../../../utils/diagnostic';
 
 type BufferLike = Parameters<WebSocket['send']>[0];
 
@@ -26,6 +27,8 @@ export interface Handler {
 
   get response(): TransferState['response'];
   set response(response: TransferState['response']);
+
+  get diagnostics(): IDiagnosticReporter;
 
   // Add message UUIDs
   addUUID(uuid: string): void;
@@ -98,4 +101,6 @@ export interface Handler {
   onMessage(message: RawData, isBinary: boolean): Promise<void> | void;
   onClose(code: number, reason: Buffer): Promise<void> | void;
   onError(err: Error): Promise<void> | void;
+  onInfo(message: string): Promise<void> | void;
+  onWarning(message: string): Promise<void> | void;
 }

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -9,6 +9,7 @@ import type { Protocol } from '../../../../types';
 import { ProviderError, ProviderTransferError } from '../../../errors/providers';
 import { VALID_TRANSFER_COMMANDS, ValidTransferCommand } from './constants';
 import { TransferMethod } from '../constants';
+import { createDiagnosticReporter } from '../../../utils/diagnostic';
 
 type WSCallback = (client: WebSocket, request: IncomingMessage) => void;
 
@@ -149,6 +150,7 @@ export const handlerControllerFactory =
       const cb: WSCallback = (ws) => {
         const state: TransferState = { id: undefined };
         const messageUUIDs = new Set<string>();
+        const diagnostics = createDiagnosticReporter();
 
         const cannotRespondHandler = (err: unknown) => {
           strapi?.log?.error(
@@ -188,6 +190,10 @@ export const handlerControllerFactory =
 
           set response(response) {
             state.response = response;
+          },
+
+          get diagnostics() {
+            return diagnostics;
           },
 
           addUUID(uuid) {
@@ -326,6 +332,8 @@ export const handlerControllerFactory =
           onMessage() {},
           onError() {},
           onClose() {},
+          onInfo() {},
+          onWarning() {},
         };
 
         const handler: Handler = Object.assign(Object.create(prototype), implementation(prototype));
@@ -359,6 +367,16 @@ export const handlerControllerFactory =
             strapi?.log?.error(err);
             cannotRespondHandler(err);
           }
+        });
+
+        diagnostics.onDiagnostic((diagnostic) => {
+          const uuid = randomUUID();
+          const payload = JSON.stringify({
+            diagnostic,
+            uuid,
+          });
+
+          handler.send(payload);
         });
       };
 

--- a/packages/core/data-transfer/src/utils/diagnostic.ts
+++ b/packages/core/data-transfer/src/utils/diagnostic.ts
@@ -51,6 +51,7 @@ export type WarningDiagnostic = GenericDiagnostic<
 export type InfoDiagnostic<T = unknown> = GenericDiagnostic<
   'info',
   {
+    origin?: string;
     params?: T;
   }
 >;

--- a/packages/core/data-transfer/types/providers.d.ts
+++ b/packages/core/data-transfer/types/providers.d.ts
@@ -19,7 +19,7 @@ export interface IProvider {
    * bootstrap() is called during transfer engine bootstrap
    * It is used for initialization operations such as making a database connection, opening a file, checking authorization, etc
    */
-  bootstrap?(): MaybePromise<void>;
+  bootstrap?(diagnostics?: IDiagnosticReporter): MaybePromise<void>;
   close?(): MaybePromise<void>; // called during transfer engine close
 
   getMetadata(): MaybePromise<IMetadata | null>; // returns the transfer metadata to be used for version validation

--- a/packages/core/data-transfer/types/remote/protocol/server/messaging.d.ts
+++ b/packages/core/data-transfer/types/remote/protocol/server/messaging.d.ts
@@ -5,6 +5,7 @@ export type Message<T = unknown> = {
   uuid?: string;
   data?: T | null;
   error?: ServerError | null;
+  diagnostic?: Diagnostic;
 };
 
 // Successful

--- a/packages/utils/logger/src/configs/output-file-configuration.ts
+++ b/packages/utils/logger/src/configs/output-file-configuration.ts
@@ -3,14 +3,22 @@ import { transports, LoggerOptions } from 'winston';
 import { LEVEL_LABEL, LEVELS } from '../constants';
 import { prettyPrint, excludeColors } from '../formats';
 
-export default (filename: string): LoggerOptions => {
+export default (
+  filename: string,
+  fileTransportOptions: transports.FileTransportOptions = {}
+): LoggerOptions => {
   return {
     level: LEVEL_LABEL,
     levels: LEVELS,
     format: prettyPrint(),
     transports: [
       new transports.Console(),
-      new transports.File({ level: 'error', filename, format: excludeColors }),
+      new transports.File({
+        level: 'error',
+        filename,
+        format: excludeColors,
+        ...fileTransportOptions,
+      }),
     ],
   };
 };

--- a/packages/utils/logger/src/formats/detailed-log.ts
+++ b/packages/utils/logger/src/formats/detailed-log.ts
@@ -1,0 +1,19 @@
+import { format } from 'winston';
+
+/**
+ * This will remove the chalk color codes from the message provided.
+ * It's used to log plain text in the log file
+ */
+export default format.printf(({ message, level, timestamp }) => {
+  if (typeof message !== 'string') {
+    return message;
+  }
+
+  const newMessage = `[${timestamp as string}] ${level}: ${message as string}`;
+
+  return newMessage.replace(
+    // eslint-disable-next-line no-control-regex
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    ''
+  );
+});

--- a/packages/utils/logger/src/formats/index.ts
+++ b/packages/utils/logger/src/formats/index.ts
@@ -2,3 +2,4 @@ export { default as prettyPrint } from './pretty-print';
 export type { PrettyPrintOptions } from './pretty-print';
 export { default as levelFilter } from './level-filter';
 export { default as excludeColors } from './exclude-colors';
+export { default as detailedLogs } from './detailed-log';


### PR DESCRIPTION
### What does it do?

Backporting the dts enhancement recently added for data-transfer in V5 to have `--verbose` option
fixing logging a file during a transfer

### Why is it needed?

- `--verbose` option is need for v4 projects

### How to test it?

- Add `--verbose` to transfer or import or export commands it should log a file with information about the transfer

### Related issue(s)/PR(s)

#22085 #22214 