### PR TITLE
fix(content-manager): ensure plugin::users-permissions.user is redire…

### DIFF
--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -87,6 +87,24 @@ const documentApi = contentManagerApi.injectEndpoints({
         'Relations',
         { type: 'UidAvailability', id: model },
       ],
+      transformResponse: (response: Create.Response, meta, arg): Create.Response => {
+        /**
+         * TODO v6
+         * Adapt plugin:users-permissions.user to return the same response
+         * shape as all other requests. The error is returned as expected.
+         */
+        if (!('data' in response) && arg.model === 'plugin::users-permissions.user') {
+          return {
+            data: response,
+            meta: {
+              availableStatus: [],
+              availableLocales: [],
+            },
+          };
+        }
+
+        return response;
+      },
     }),
     deleteDocument: builder.mutation<
       Delete.Response,


### PR DESCRIPTION
### What does it do?

I believe changing the shape in the plugin would be a breaking change so using RTK query transformResponse to return the correct response shape for request to `plugin::users-permissions.user`

### Why is it needed?

The shape returned is not the same as our usual response shape with a data key, instead it's just returning the document

### The bug

When creating a User in the content manager we are stuck on the create page after saving

https://github.com/user-attachments/assets/1c653518-0705-4816-b368-93d4337e0aa6

### How to test it?


- Go to the content manager
- Click the User content-type
- Create a new user
- When you save, it should navigate you from `...<path>/create` to `...<path>/<documentId>`

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22409
