### PR TITLE
fix: Pages can be scrolled when hovering sticky navs

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -88,6 +88,11 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
       mainNavElement.addEventListener('mouseenter', handleMouseEnter);
       mainNavElement.addEventListener('mouseleave', handleMouseLeave);
 
+      const isCursorOverMainNav = mainNavElement.matches(':hover');
+      if (isCursorOverMainNav) {
+        toggleScroll(true);
+      }
+
       return () => {
         mainNavElement.removeEventListener('mouseenter', handleMouseEnter);
         mainNavElement.removeEventListener('mouseleave', handleMouseLeave);

--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -71,6 +71,31 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
   );
   const listLinks = sortLinks(listLinksAlphabeticallySorted);
 
+  // Prevent scrolling the page when the cursor hovers over the MainNav
+  React.useEffect(() => {
+    const preventScroll = (event: WheelEvent) => event.preventDefault();
+    const toggleScroll = (enable: boolean) => {
+      window[enable ? 'addEventListener' : 'removeEventListener']('wheel', preventScroll, {
+        passive: false,
+      });
+    };
+
+    const mainNavElement = document.querySelector('nav');
+    if (mainNavElement) {
+      const handleMouseEnter = () => toggleScroll(true);
+      const handleMouseLeave = () => toggleScroll(false);
+
+      mainNavElement.addEventListener('mouseenter', handleMouseEnter);
+      mainNavElement.addEventListener('mouseleave', handleMouseLeave);
+
+      return () => {
+        mainNavElement.removeEventListener('mouseenter', handleMouseEnter);
+        mainNavElement.removeEventListener('mouseleave', handleMouseLeave);
+        toggleScroll(false);
+      };
+    }
+  }, [pathname]);
+
   return (
     <MainNav>
       <NavBrand />


### PR DESCRIPTION
### What does it do?

This PR introduces a change to the `LeftMenu` component to prevent the page from scrolling when the cursor hovers over the `MainNav` component. The implementation uses `useEffect` to add and remove event listeners for the `wheel` event, effectively toggling the scroll behavior based on the cursor's position.

### Why is it needed?

This change addresses an issue where users could inadvertently scroll the entire page when interacting with the sticky navigation bar (`MainNav`). 

### How to test it?

Go to any page and hover over the left navbar and try to scroll.

### Related issue(s)/PR(s)

Fixes #22408
