### PR TITLE
fix(homepage): add missing styles for error, loading, and empty states

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -48,10 +48,11 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
 
   const getEditViewLink = (document: RecentDocument): string => {
     // TODO: import the constants for this once the code is moved to the CM package
-    const kindPath = document.kind === 'singleType' ? 'single-types' : 'collection-types';
+    const isSingleType = document.kind === 'singleType';
+    const kindPath = isSingleType ? 'single-types' : 'collection-types';
     const queryParams = document.locale ? `?plugins[i18n][locale]=${document.locale}` : '';
 
-    return `/content-manager/${kindPath}/${document.contentTypeUid}/${document.documentId}${queryParams}`;
+    return `/content-manager/${kindPath}/${document.contentTypeUid}${isSingleType ? '' : '/' + document.documentId}${queryParams}`;
   };
 
   const handleRowClick = (document: RecentDocument) => () => {

--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -118,21 +118,49 @@ const LastEditedWidget = () => {
   const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'update' });
 
   if (isLoading) {
-    return <Widget.Loading />;
+    return (
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-edited.title',
+          defaultMessage: 'Last edited entries',
+        }}
+        icon={Pencil}
+      >
+        <Widget.Loading />
+      </Widget.Root>
+    );
   }
 
   if (error) {
-    return <Widget.Error />;
+    return (
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-edited.title',
+          defaultMessage: 'Last edited entries',
+        }}
+        icon={Pencil}
+      >
+        <Widget.Error />
+      </Widget.Root>
+    );
   }
 
   if (data?.length === 0) {
     return (
-      <Widget.NoData>
-        {formatMessage({
-          id: 'content-manager.widget.last-edited.no-data',
-          defaultMessage: 'No edited entries',
-        })}
-      </Widget.NoData>
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-edited.title',
+          defaultMessage: 'Last edited entries',
+        }}
+        icon={Pencil}
+      >
+        <Widget.NoData>
+          {formatMessage({
+            id: 'content-manager.widget.last-edited.no-data',
+            defaultMessage: 'No edited entries',
+          })}
+        </Widget.NoData>
+      </Widget.Root>
     );
   }
 
@@ -162,21 +190,49 @@ const LastPublishedWidget = () => {
   const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'publish' });
 
   if (isLoading) {
-    return <Widget.Loading />;
+    return (
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-published.title',
+          defaultMessage: 'Last published entries',
+        }}
+        icon={CheckCircle}
+      >
+        <Widget.Loading />
+      </Widget.Root>
+    );
   }
 
   if (error) {
-    return <Widget.Error />;
+    return (
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-published.title',
+          defaultMessage: 'Last published entries',
+        }}
+        icon={CheckCircle}
+      >
+        <Widget.Error />
+      </Widget.Root>
+    );
   }
 
   if (data?.length === 0) {
     return (
-      <Widget.NoData>
-        {formatMessage({
-          id: 'content-manager.widget.last-published.no-data',
-          defaultMessage: 'No published entries',
-        })}
-      </Widget.NoData>
+      <Widget.Root
+        title={{
+          id: 'content-manager.widget.last-published.title',
+          defaultMessage: 'Last published entries',
+        }}
+        icon={CheckCircle}
+      >
+        <Widget.NoData>
+          {formatMessage({
+            id: 'content-manager.widget.last-published.no-data',
+            defaultMessage: 'No published entries',
+          })}
+        </Widget.NoData>
+      </Widget.Root>
     );
   }
 

--- a/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
@@ -5,25 +5,6 @@ import { PuzzlePiece, WarningCircle } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { type MessageDescriptor, useIntl } from 'react-intl';
 
-const WidgetCard = (props: FlexProps) => {
-  return (
-    <Flex
-      hasRadius
-      direction="column"
-      alignItems="flex-start"
-      width="100%"
-      background="neutral0"
-      shadow="tableShadow"
-      tag="section"
-      gap={4}
-      padding={6}
-      {...props}
-    >
-      {props.children}
-    </Flex>
-  );
-};
-
 interface RootProps {
   title: MessageDescriptor;
   icon?: typeof import('@strapi/icons').PuzzlePiece;
@@ -36,7 +17,18 @@ const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
   const Icon = icon;
 
   return (
-    <WidgetCard aria-labelledby={id}>
+    <Flex
+      width="100%"
+      hasRadius
+      direction="column"
+      alignItems="flex-start"
+      background="neutral0"
+      shadow="tableShadow"
+      tag="section"
+      gap={4}
+      padding={6}
+      aria-labelledby={id}
+    >
       <Flex direction="row" alignItems="center" gap={2} tag="header">
         <Icon fill="neutral500" aria-hidden />
         <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
@@ -46,7 +38,7 @@ const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
       <Box width="100%" height="261px" overflow="auto" tag="main">
         {children}
       </Box>
-    </WidgetCard>
+    </Flex>
   );
 };
 
@@ -58,7 +50,7 @@ const Loading = ({ children }: LoadingProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <WidgetCard height="100%" justifyContent="center" alignItems="center">
+    <Flex height="100%" justifyContent="center" alignItems="center">
       <Loader>
         {children ??
           formatMessage({
@@ -66,7 +58,7 @@ const Loading = ({ children }: LoadingProps) => {
             defaultMessage: 'Loading widget content',
           })}
       </Loader>
-    </WidgetCard>
+    </Flex>
   );
 };
 
@@ -78,7 +70,7 @@ const Error = ({ children }: ErrorProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <WidgetCard height="100%" justifyContent="center" alignItems="center" gap={2}>
+    <Flex height="100%" direction="column" justifyContent="center" alignItems="center" gap={2}>
       <WarningCircle width="3.2rem" height="3.2rem" fill="danger600" />
       <Typography variant="delta">
         {formatMessage({
@@ -93,7 +85,7 @@ const Error = ({ children }: ErrorProps) => {
             defaultMessage: "Couldn't load widget content.",
           })}
       </Typography>
-    </WidgetCard>
+    </Flex>
   );
 };
 
@@ -105,7 +97,7 @@ const NoData = ({ children }: NoDataProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <WidgetCard height="100%" justifyContent="center" alignItems="center" gap={6}>
+    <Flex height="100%" direction="column" justifyContent="center" alignItems="center" gap={6}>
       <EmptyDocuments width="16rem" height="8.8rem" />
       <Typography textColor="neutral600">
         {children ??
@@ -114,7 +106,7 @@ const NoData = ({ children }: NoDataProps) => {
             defaultMessage: 'No content found.',
           })}
       </Typography>
-    </WidgetCard>
+    </Flex>
   );
 };
 

--- a/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
@@ -1,9 +1,28 @@
 import * as React from 'react';
 
-import { Box, Flex, Loader, Typography } from '@strapi/design-system';
+import { Box, Flex, type FlexProps, Loader, Typography } from '@strapi/design-system';
 import { PuzzlePiece, WarningCircle } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { type MessageDescriptor, useIntl } from 'react-intl';
+
+const WidgetCard = (props: FlexProps) => {
+  return (
+    <Flex
+      hasRadius
+      direction="column"
+      alignItems="flex-start"
+      width="100%"
+      background="neutral0"
+      shadow="tableShadow"
+      tag="section"
+      gap={4}
+      padding={6}
+      {...props}
+    >
+      {props.children}
+    </Flex>
+  );
+};
 
 interface RootProps {
   title: MessageDescriptor;
@@ -17,18 +36,7 @@ const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
   const Icon = icon;
 
   return (
-    <Flex
-      direction="column"
-      alignItems="flex-start"
-      gap={4}
-      background="neutral0"
-      padding={6}
-      shadow="tableShadow"
-      hasRadius
-      width="100%"
-      tag="section"
-      aria-labelledby={id}
-    >
+    <WidgetCard aria-labelledby={id}>
       <Flex direction="row" alignItems="center" gap={2} tag="header">
         <Icon fill="neutral500" aria-hidden />
         <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
@@ -38,7 +46,7 @@ const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
       <Box width="100%" height="261px" overflow="auto" tag="main">
         {children}
       </Box>
-    </Flex>
+    </WidgetCard>
   );
 };
 
@@ -50,7 +58,7 @@ const Loading = ({ children }: LoadingProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Flex direction="column" height="100%" justifyContent="center" alignItems="center">
+    <WidgetCard height="100%" justifyContent="center" alignItems="center">
       <Loader>
         {children ??
           formatMessage({
@@ -58,7 +66,7 @@ const Loading = ({ children }: LoadingProps) => {
             defaultMessage: 'Loading widget content',
           })}
       </Loader>
-    </Flex>
+    </WidgetCard>
   );
 };
 
@@ -70,7 +78,7 @@ const Error = ({ children }: ErrorProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Flex direction="column" height="100%" justifyContent="center" alignItems="center" gap={2}>
+    <WidgetCard height="100%" justifyContent="center" alignItems="center" gap={2}>
       <WarningCircle width="3.2rem" height="3.2rem" fill="danger600" />
       <Typography variant="delta">
         {formatMessage({
@@ -85,7 +93,7 @@ const Error = ({ children }: ErrorProps) => {
             defaultMessage: "Couldn't load widget content.",
           })}
       </Typography>
-    </Flex>
+    </WidgetCard>
   );
 };
 
@@ -97,7 +105,7 @@ const NoData = ({ children }: NoDataProps) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Flex direction="column" height="100%" justifyContent="center" alignItems="center" gap={6}>
+    <WidgetCard height="100%" justifyContent="center" alignItems="center" gap={6}>
       <EmptyDocuments width="16rem" height="8.8rem" />
       <Typography textColor="neutral600">
         {children ??
@@ -106,7 +114,7 @@ const NoData = ({ children }: NoDataProps) => {
             defaultMessage: 'No content found.',
           })}
       </Typography>
-    </Flex>
+    </WidgetCard>
   );
 };
 


### PR DESCRIPTION
### What does it do?

- Refactors the root component to handle every state

### Why is it needed?

To match the designs

### How to test it?

Check the designs

<img width="670" alt="Screenshot 2024-12-16 at 11 49 47" src="https://github.com/user-attachments/assets/c24ec37a-7aa9-46ac-b053-6f7274fddaa8" />
<img width="695" alt="Screenshot 2024-12-16 at 11 49 33" src="https://github.com/user-attachments/assets/15cec4f6-f8c5-44dd-be44-b83fffe899f4" />
<img width="681" alt="Screenshot 2024-12-16 at 11 49 24" src="https://github.com/user-attachments/assets/30bf12f5-14ac-4931-8c5f-4da0a87c741b" />


### Related issue(s)/PR(s)

resolves https://github.com/strapi/strapi/issues/22426
