### PR TITLE
fix(homepage): make back button work when document has a locale

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -16,8 +16,9 @@ import type { RecentDocument } from '../../../../../shared/contracts/homepage';
 const getEditViewLink = (document: RecentDocument): string => {
   // TODO: import the constants for this once the code is moved to the CM package
   const kindPath = document.kind === 'singleType' ? 'single-types' : 'collection-types';
+  const queryParams = document.locale ? `?plugins[i18n][locale]=${document.locale}` : '';
 
-  return `/content-manager/${kindPath}/${document.contentTypeUid}/${document.documentId}`;
+  return `/content-manager/${kindPath}/${document.contentTypeUid}/${document.documentId}${queryParams}`;
 };
 
 const CellTypography = styled(Typography).attrs({ maxWidth: '14.4rem', display: 'inline-block' })`


### PR DESCRIPTION
### What does it do?

Appends the i18n params when a recent document has a locale

### Why is it needed?

The back button is broken for documents that have entries in several locales

### How to test it?

Create a document in one locale, then create another version of the document in a different locale
Go to the homepage and click the edit link on the recent document
Once in the CM click the back button
You should go back to the homepage

### Related issue(s)/PR(s)

fixes: https://github.com/strapi/strapi/issues/22427
