### PR TITLE
fix(ts): use correct koa-body types for request.body

### DIFF
--- a/packages/core/admin/ee/server/src/controllers/index.ts
+++ b/packages/core/admin/ee/server/src/controllers/index.ts
@@ -1,4 +1,4 @@
-import 'koa-bodyparser';
+import 'koa-body';
 
 import authentication from './authentication';
 import role from './role';

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -113,7 +113,7 @@
     "js-cookie": "2.2.1",
     "jsonwebtoken": "9.0.0",
     "koa": "2.13.4",
-    "koa-bodyparser": "4.4.1",
+    "koa-body": "4.2.0",
     "koa-compose": "4.1.0",
     "koa-passport": "5.0.0",
     "koa-static": "5.0.0",

--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -26,16 +26,6 @@ import type {
 
 const { isUsingTypeScript } = tsUtils;
 
-/* TODO extend the request in this way once Replace is available
-  type FileRequest = Context['request'] & { file: unknown };
-  type FileContext = Replace<Context, { request: FileRequest }>;
-*/
-declare module 'koa' {
-  interface Request {
-    files: unknown;
-  }
-}
-
 /**
  * A set of functions called "actions" for `Admin`
  */

--- a/packages/core/admin/server/src/controllers/index.ts
+++ b/packages/core/admin/server/src/controllers/index.ts
@@ -1,4 +1,4 @@
-import 'koa-bodyparser';
+import 'koa-body';
 
 import admin from './admin';
 import apiToken from './api-token';

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -52,7 +52,6 @@
     "@strapi/types": "4.25.17",
     "@strapi/utils": "4.25.17",
     "koa": "2.13.4",
-    "koa-bodyparser": "4.4.1",
     "lodash": "4.17.21",
     "qs": "6.11.1"
   },

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -65,7 +65,7 @@
     "@strapi/utils": "4.25.17",
     "fs-extra": "10.0.0",
     "immer": "9.0.19",
-    "koa-bodyparser": "4.4.1",
+    "koa-body": "4.2.0",
     "lodash": "4.17.21",
     "pluralize": "8.0.0",
     "prop-types": "^15.8.1",

--- a/packages/core/content-type-builder/server/src/controllers/content-types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/content-types.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import type { Context } from 'koa';
-import 'koa-bodyparser';
+import 'koa-body';
 
 import { contentTypes } from '@strapi/utils';
 import type { UID } from '@strapi/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8248,7 +8248,7 @@ __metadata:
     js-cookie: "npm:2.2.1"
     jsonwebtoken: "npm:9.0.0"
     koa: "npm:2.13.4"
-    koa-bodyparser: "npm:4.4.1"
+    koa-body: "npm:4.2.0"
     koa-compose: "npm:4.1.0"
     koa-passport: "npm:5.0.0"
     koa-static: "npm:5.0.0"
@@ -8742,7 +8742,6 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/lodash": "npm:^4.14.191"
     koa: "npm:2.13.4"
-    koa-bodyparser: "npm:4.4.1"
     lodash: "npm:4.17.21"
     qs: "npm:6.11.1"
   languageName: unknown
@@ -8771,7 +8770,7 @@ __metadata:
     history: "npm:^4.9.0"
     immer: "npm:9.0.19"
     koa: "npm:2.13.4"
-    koa-bodyparser: "npm:4.4.1"
+    koa-body: "npm:4.2.0"
     lodash: "npm:4.17.21"
     pluralize: "npm:8.0.0"
     prop-types: "npm:^15.8.1"
@@ -21922,7 +21921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa-bodyparser@npm:4.4.1, koa-bodyparser@npm:^4.3.0":
+"koa-bodyparser@npm:^4.3.0":
   version: 4.4.1
   resolution: "koa-bodyparser@npm:4.4.1"
   dependencies:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Uses the correct type definitions for `Koa.Context['request']['body']`

### Why is it needed?

`koa-bodyparser` is used only by `apollo-server-koa`

### How to test it?

```bash
npm run test:ts
```

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/18526#issuecomment-2547788666
- https://github.com/strapi/strapi/blob/v4/packages/core/strapi/src/middlewares/body.ts#L3
- https://github.com/koajs/koa-body/blob/v4.2.0/index.d.ts#L4-L9
- https://github.com/apollographql/apollo-server/blob/release-3.10.0/packages/apollo-server-koa/src/ApolloServer.ts#L4C25-L4C39
