### PR TITLE
fix: remove lookup param from document service

### DIFF
--- a/packages/core/core/src/services/document-service/draft-and-publish.ts
+++ b/packages/core/core/src/services/document-service/draft-and-publish.ts
@@ -70,6 +70,7 @@ const statusToLookup: TransformWithContentType = (contentType, params) => {
     return params;
   }
 
+  // @ts-expect-error: we need to create a different typing for internal params
   const lookup = params.lookup || {};
 
   switch (params?.status) {

--- a/packages/core/core/src/services/document-service/draft-and-publish.ts
+++ b/packages/core/core/src/services/document-service/draft-and-publish.ts
@@ -70,7 +70,6 @@ const statusToLookup: TransformWithContentType = (contentType, params) => {
     return params;
   }
 
-  // @ts-expect-error: we need to create a different typing for internal params
   const lookup = params.lookup || {};
 
   switch (params?.status) {

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -1,6 +1,6 @@
 import { omit, assoc, merge, curry } from 'lodash/fp';
 
-import { async, contentTypes as contentTypesUtils, validate } from '@strapi/utils';
+import { async, contentTypes as contentTypesUtils, validate, errors } from '@strapi/utils';
 
 import { UID } from '@strapi/types';
 import { wrapInTransaction, type RepositoryFactoryMethod } from './common';
@@ -47,6 +47,11 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
     await validators.validateSort(ctx, params.sort, sortValidations);
     await validators.validateFields(ctx, params.fields, fieldValidations);
     await validators.validatePopulate(ctx, params.populate, populateValidations);
+
+    // Strip lookup from params, it's only used internally
+    if (params.lookup) {
+      throw new errors.ValidationError("Invalid params: 'lookup'");
+    }
 
     // TODO: add validate status, locale, pagination
 

--- a/tests/api/core/strapi/document-service/validation/validation.test.api.ts
+++ b/tests/api/core/strapi/document-service/validation/validation.test.api.ts
@@ -250,5 +250,21 @@ describe('Document Service Validations', () => {
         ).rejects.toThrow(errors.ValidationError);
       });
     });
+
+    /**
+     * Lookup is an internal parameter used to filter by locale and status.
+     * It should not be exposed to the public API.
+     */
+    describe('lookup', () => {
+      it('should throw ValidationError', async () => {
+        await expect(
+          strapi.documents(ARTICLE_UID)[methodName]({
+            lookup: {
+              title: 'Hello World',
+            },
+          })
+        ).rejects.toThrow(errors.ValidationError);
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

remove lookup param from document service

### Why is it needed?

it's for internal use only

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
