### PR TITLE
fix: fixed the popover alighnment apper when clicking on the avatar #20782

### DIFF
--- a/packages/core/admin/admin/src/components/MainNav/NavUser.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavUser.tsx
@@ -60,7 +60,7 @@ export const NavUser = ({ children, initials, ...props }: NavUserProps) => {
   };
 
   return (
-    <Flex justifyContent="center"  {...props}>
+    <Flex justifyContent="center" {...props}>
       <Menu.Root>
         <MenuTrigger endIcon={null} fullWidth justifyContent="center">
           <Avatar.Item delayMs={0} fallback={initials} />

--- a/packages/core/admin/admin/src/components/MainNav/NavUser.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavUser.tsx
@@ -27,7 +27,7 @@ const MenuTrigger = styled(Menu.Trigger)`
 `;
 
 const MenuContent = styled(Menu.Content)`
-  left: ${({ theme }) => theme.spaces[5]};
+  left: ${({ theme }) => theme.spaces[0]};
 `;
 
 const MenuItem = styled(Menu.Item)`
@@ -60,7 +60,7 @@ export const NavUser = ({ children, initials, ...props }: NavUserProps) => {
   };
 
   return (
-    <Flex justifyContent="center" {...props}>
+    <Flex justifyContent="center"  {...props}>
       <Menu.Root>
         <MenuTrigger endIcon={null} fullWidth justifyContent="center">
           <Avatar.Item delayMs={0} fallback={initials} />


### PR DESCRIPTION
### What does it do?
fixed the popover alighnment apper when clicking on the avatar
### Why is it needed?
To fix issue [20782](https://github.com/strapi/strapi/issues/20782): [Design] A border appear when clicking on the avatar and the popover is not aligned with it
### How to test it?
- go to strapi
- click on avatar
- the popover alignment is not proper
### Related issue(s)/PR(s)
fixes  [20782](https://github.com/strapi/strapi/issues/20782)