### PR TITLE
fix: Removed Unnecessary green border in the Admin Users list

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -288,15 +288,7 @@ const TABLE_HEADERS: Array<
     cellFormatter({ isActive }) {
       return (
         <Flex>
-          <Status
-            size="S"
-            borderWidth={0}
-            background="transparent"
-            color="neutral800"
-            variant={isActive ? 'success' : 'danger'}
-          >
-            <Typography>{isActive ? 'Active' : 'Inactive'}</Typography>
-          </Status>
+          <Typography>{isActive ? 'Active' : 'Inactive'}</Typography>
         </Flex>
       );
     },


### PR DESCRIPTION
### What does it do?
Removed Unnecessary green border in the Admin Users list
### Why is it needed?
To fix issue [21343](https://github.com/strapi/strapi/issues/21343) Unnecessary green border in the Admin Users list
### How to test it?
- go to Settings
- in Administration panel goto Users
- in the User Status we are getting status as Active/Inactive it was coming with border
### Related issue(s)/PR(s)
fixes [21343](https://github.com/strapi/strapi/issues/21343)