### PR TITLE
fix: renable the basic relations test

### DIFF
--- a/tests/api/core/content-manager/api/basic-relations.test.api.js
+++ b/tests/api/core/content-manager/api/basic-relations.test.api.js
@@ -113,8 +113,7 @@ const collectorFixtures = ({ stamp }) => [
 const getCollectorByName = (collectors, name) => collectors.find((c) => c.name === name);
 const getStampByName = (stamps, name) => stamps.find((s) => s.name === name);
 
-// TODO: Fix relations
-describe.skip('CM API', () => {
+describe('CM API', () => {
   describe.each([{ populateRelations: false }, { populateRelations: true }])(
     `populate relations in webhooks ($populateRelations)`,
     ({ populateRelations }) => {
@@ -213,11 +212,11 @@ describe.skip('CM API', () => {
         test('findOne', async () => {
           const res = await rq({
             method: 'GET',
-            url: `/content-manager/collection-types/api::collector.collector/${data.collectors[0].id}`,
+            url: `/content-manager/collection-types/api::collector.collector/${data.collectors[0].documentId}`,
           });
 
           expect(res.statusCode).toBe(200);
-          expect(res.body).toMatchObject({
+          expect(res.body.data).toMatchObject({
             age: 25,
             id: 1,
             name: 'Bernard',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove the skip to the api test and replace the id with documentId and the correct response object

### Why is it needed?

The test was disabled during the implementation of v5

### How to test it?

- from the root run the api test
`yarn test:api tests/api/core/content-manager/api/basic-relations.test.api.js`

### Related issue(s)/PR(s)

CS-1193