### PR TITLE
chore(telemetry): smooth event rate limiting

### DIFF
--- a/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
@@ -1,6 +1,12 @@
 import createMiddleware from '../middleware';
 
 describe('Metrics middleware', () => {
+  const originalDateNow = Date.now;
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
   test('Ignores request with extension in them', async () => {
     const sendEvent = jest.fn();
 
@@ -54,5 +60,38 @@ describe('Metrics middleware', () => {
     }
 
     expect(sendEvent).toHaveBeenCalledTimes(1000);
+  });
+
+  test('Resets counter after 24 hours', async () => {
+    const sendEvent = jest.fn();
+    Date.now = () => new Date('2021-01-01T00:00:00Z').getTime();
+
+    const middleware = createMiddleware({ sendEvent });
+
+    for (let i = 0; i < 2000; i += 1) {
+      await middleware(
+        {
+          request: {
+            method: 'GET',
+            url: '/some-api',
+          },
+        } as any,
+        jest.fn()
+      );
+    }
+
+    Date.now = () => new Date('2021-01-02T00:01:00Z').getTime(); // 1 day and 1 minute later.
+
+    await middleware(
+      {
+        request: {
+          method: 'GET',
+          url: '/some-api',
+        },
+      } as any,
+      jest.fn()
+    );
+
+    expect(sendEvent).toHaveBeenCalledTimes(1001);
   });
 });

--- a/packages/core/core/src/services/metrics/__tests__/rate-limiter.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/rate-limiter.test.ts
@@ -1,6 +1,12 @@
 import wrapWithRateLimiter from '../rate-limiter';
 
 describe('Telemetry daily RateLimiter', () => {
+  const originalDateNow = Date.now;
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
   test('Passes event and payload to sender', async () => {
     const sender = jest.fn(() => Promise.resolve(true));
 
@@ -44,5 +50,27 @@ describe('Telemetry daily RateLimiter', () => {
     await send('restrictedEvent');
 
     expect(sender).toHaveBeenCalledTimes(1);
+  });
+
+  test('Calls the sender again after 24 hours for restricted events', async () => {
+    const sender = jest.fn(() => Promise.resolve(true));
+
+    Date.now = () => new Date('2021-01-01T00:00:00Z').getTime();
+
+    const send = wrapWithRateLimiter(sender, { limitedEvents: ['restrictedEvent'] });
+
+    await send('restrictedEvent');
+    await send('restrictedEvent');
+    await send('restrictedEvent');
+
+    expect(sender).toHaveBeenCalledTimes(1);
+
+    Date.now = () => new Date('2021-01-02T00:01:00Z').getTime(); // 1 day and 1 minute later.
+
+    await send('restrictedEvent');
+    await send('restrictedEvent');
+    await send('restrictedEvent');
+
+    expect(sender).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/core/src/services/metrics/middleware.ts
+++ b/packages/core/core/src/services/metrics/middleware.ts
@@ -2,13 +2,17 @@ import type { Core } from '@strapi/types';
 import type { Sender } from './sender';
 
 interface State {
-  currentDay: number | null;
+  expires: number;
   counter: number;
+}
+
+function nextResetDate(): number {
+  return Date.now() + 24 * 60 * 60 * 1000; // Now + 24 hours.
 }
 
 const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
   const state: State = {
-    currentDay: null,
+    expires: nextResetDate(),
     counter: 0,
   };
 
@@ -16,10 +20,8 @@ const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
     const { url, method } = ctx.request;
 
     if (!url.includes('.') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
-      const dayOfMonth = new Date().getDate();
-
-      if (dayOfMonth !== state.currentDay) {
-        state.currentDay = dayOfMonth;
+      if (Date.now() > state.expires) {
+        state.expires = nextResetDate();
         state.counter = 0;
       }
 


### PR DESCRIPTION
### What does it do?

Rate limited events now resets 24h after the last event (or process start), instead of each day at midnight.


### Why is it needed?

It will smooth the sending of events, and avoid receiving a burst of events at midnight on the telemetry server.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
