### PR TITLE
fix: entries always showing up as "Draft"

### DIFF
--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -158,13 +158,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const status = documents[0].publishedAt !== null ? 'published' : 'draft';
     const locales = documents.map((d) => d.locale).filter(Boolean);
 
+    const where: Record<string, any> = {
+      documentId: { $in: documents.map((d) => d.documentId).filter(Boolean) },
+      publishedAt: { $null: status === 'published' },
+    };
+
+    // If there is any locale to filter (if i18n is enabled)
+    if (locales.length) {
+      where.locale = { $in: locales };
+    }
+
     return strapi.query(uid).findMany({
-      where: {
-        documentId: { $in: documents.map((d) => d.documentId).filter(Boolean) },
-        // NOTE: find the "opposite" status
-        publishedAt: { $null: status === 'published' },
-        locale: { $in: locales },
-      },
+      where,
       select: ['id', 'documentId', 'locale', 'updatedAt', 'createdAt', 'publishedAt'],
     });
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Entries were displayed as Draft even if they were published in the list view.

When populating the published version of a draft, we were always filtering by locale even for non i18n content types.

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/22470
