### PR TITLE
fix: modified and published both entries are displayed in relation fi…

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -507,7 +507,7 @@ const RelationsInput = ({
 
   const hasNextPage = data?.pagination ? data.pagination.page < data.pagination.pageCount : false;
 
-  const options = data?.results ?? [];
+  const options = data?.results?.filter((opt) => opt.status === 'published') ?? [];
 
   const handleChange = (relationId?: string) => {
     if (!relationId) {


### PR DESCRIPTION
### What does it do?
Fixes the modified and published both entries are displayed in relation field selection dropdown

### Why is it needed?
To fix issue [21359](https://github.com/strapi/strapi/issues/21359) : Both Modified and Published entries are displayed in my Relation field

### How to test it?

1. Create multiple entries with Daft/Modified/Published statuses of a collection type
2. Map that collection type into another collection type as 1:1 or 1:N relation
3. Now if you open the relation field dropdown ton select you will get all states of same entries

### Related issue(s)/PR(s)
fixes [21359](https://github.com/strapi/strapi/issues/21359) 