### PR TITLE
fix: fixed cancel and publish button from dialog modal of bulk publish

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/ConfirmBulkActionDialog.tsx
@@ -50,7 +50,7 @@ const ConfirmBulkActionDialog = ({
         </Dialog.Body>
         <Dialog.Footer>
           <Dialog.Cancel>
-            <Button fullWidth onClick={onToggleDialog} variant="tertiary">
+            <Button width={'50%'} onClick={onToggleDialog} variant="tertiary">
               {formatMessage({
                 id: 'app.components.Button.cancel',
                 defaultMessage: 'Cancel',
@@ -173,6 +173,7 @@ const ConfirmDialogPublishAll = ({
       }
       endAction={
         <Button
+          width={'50%'}
           onClick={onConfirm}
           variant="secondary"
           startIcon={<Check />}


### PR DESCRIPTION
### What does it do?
Fixed cancel and publish button from dialog modal of bulk publish
### Why is it needed?
To fix issue [20809](https://github.com/strapi/strapi/issues/20809): [Design] Missing overlay and oversized “Cancel” button for the Dialog modal of Bulk Publish
### How to test it?
- go to CM
- select any one collection type then
- add more than one entries then select all and click on publish button
- one popup will be open with details then click on Publish we will get confirmation popup 
- in that popup cancel button is in fullwidth 
### Related issue(s)/PR(s)
fixes [20809](https://github.com/strapi/strapi/issues/20809)