### PR TITLE
fix: missing pointer cursor when hover top of possible relations

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/Components.tsx
+++ b/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/Components.tsx
@@ -30,6 +30,7 @@ const IconWrapper = styled<BoxComponent<'button'>>(Box)<{ $isSelected: boolean }
       fill: ${({ theme, $isSelected }) => theme.colors[$isSelected ? 'primary700' : 'neutral500']};
     }
   }
+  cursor: pointer;
   &:disabled {
     cursor: not-allowed;
   }


### PR DESCRIPTION
### What does it do?
Fix missing pointer cursor when hover top of possible relations

### Why is it needed?
To fix issue [21341](https://github.com/strapi/strapi/issues/21341) : Missing the pointer cursor when on top of a possible

### How to test it?

1. Go to CTB
2. Create relation field and hover over the possible relations.
3. Now you will not be able to see the pointer cursor.

### Related issue(s)/PR(s)
fixes [21341](https://github.com/strapi/strapi/issues/21341)