### PR TITLE
enhancement: add customField parameter to extendFields

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/forms/forms.ts
@@ -98,6 +98,7 @@ export const forms = {
           data,
           type: customField.type,
           step,
+          customField,
           ...rest,
         });
 
@@ -168,6 +169,7 @@ export const forms = {
             data,
             type,
             step,
+            customField: null,
             ...rest,
           });
 


### PR DESCRIPTION
enhancement: add customField parameter to args in app.getPlugin('content-type-builder').apis.forms.extendFields(..., {form: {advanced(args) => {...}}})

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds customField argument that can be used in plugin bootstrap in `app.getPlugin('content-type-builder').apis.forms.extendFields(..., {form: {advanced(args) => {...}}})`. Example with slightly modified i18n/admin/src/index.ts :
<details>
<summary>Example with slightly modified i18n/admin/src/index.ts</summary>
<img src="https://github.com/user-attachments/assets/3d6be1e7-e2e7-4b6e-9aa5-e1db9f19aaa3" />
</details>

### Why is it needed?

The solution allows plugin developers to have more flexibility when designing custom fields. When writing code in `advanced(args) => {...}`, at the moment there is no way to know whether current field is custom or built-in, even name of the field is unknown. Using customField argument along with contentTypeSchema (already there) allows to know what the current field exactly is.\
It is useful in case if there are few custom 'json' field types created and when creating content type, each field needs it's own configuration.
