### PR TITLE
fix: handle clearing of number field to send null instead of undefined

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Number.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Number.tsx
@@ -9,7 +9,7 @@ import { InputProps } from './types';
 
 const NumberInputImpl = forwardRef<HTMLInputElement, InputProps>(
   ({ name, required, label, hint, labelAction, type, ...props }, ref) => {
-    const field = useField<number>(name);
+    const field = useField<number | null>(name);
     const fieldRef = useFocusInputField<HTMLInputElement>(name);
 
     const composedRefs = useComposedRefs(ref, fieldRef);
@@ -20,10 +20,12 @@ const NumberInputImpl = forwardRef<HTMLInputElement, InputProps>(
         <NumberInput
           ref={composedRefs}
           onValueChange={(value) => {
-            field.onChange(name, value);
+            // Convert undefined to null to store it in the form state
+            // See https://github.com/strapi/strapi/issues/22533
+            field.onChange(name, value ?? null);
           }}
           step={type === 'float' || type == 'decimal' ? 0.01 : 1}
-          value={field.value}
+          value={field.value ?? undefined}
           {...props}
         />
         <Field.Hint />

--- a/tests/api/core/content-manager/fields/integer.test.api.js
+++ b/tests/api/core/content-manager/fields/integer.test.api.js
@@ -92,4 +92,27 @@ describe('Test type integer', () => {
       field: 543,
     });
   });
+
+  test('Clearing the value should set it to null', async () => {
+    const res = await rq.post('/content-manager/collection-types/api::withinteger.withinteger', {
+      body: {
+        field: 123,
+      },
+    });
+
+    const updatedRes = await rq.put(
+      `/content-manager/collection-types/api::withinteger.withinteger/${res.body.data.documentId}`,
+      {
+        body: {
+          field: null,
+        },
+      }
+    );
+
+    expect(updatedRes.statusCode).toBe(200);
+    expect(updatedRes.body.data).toMatchObject({
+      documentId: res.body.data.documentId,
+      field: null,
+    });
+  });
 });


### PR DESCRIPTION
Ensure that when a number field is cleared, its value is explicitly set to null instead of undefined to guarantee the update is processed correctly.

### What does it do?

Fixes #22533 by explicitly setting the value to null when a number field is cleared. Previously, the value was set to undefined, which was interpreted as no change, preventing the number field from being cleared.

### Why is it needed?

This fix is necessary to enable clearing a number field. Without it, passing undefined results in no change, leaving the field uncleared.

### How to test it?

1. Navigate to the content-manager section.
2. Clear the value of a number input field.
3. Reload the page.
4. Verify that the value of the cleared field is null.

### Related issue(s)/PR(s)

Related to #22533.
