### PR TITLE
fix: changed active state background color

### DIFF
--- a/packages/core/admin/admin/src/components/MainNav/NavLink.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavLink.tsx
@@ -24,25 +24,18 @@ const MainNavLinkWrapper = styled(RouterLink)`
   padding-block: 0.6rem;
   padding-inline: 0.6rem;
 
-  &:hover,
-  &.active {
-    background: ${({ theme }) => theme.colors.neutral100};
-  }
-
   &:hover {
     svg path {
       fill: ${({ theme }) => theme.colors.neutral600};
     }
-    color: ${({ theme }) => theme.colors.neutral700};
+    background: ${({ theme }) => theme.colors.neutral100};
   }
 
   &.active {
     svg path {
       fill: ${({ theme }) => theme.colors.primary600};
     }
-
-    color: ${({ theme }) => theme.colors.primary600};
-    font-weight: 500;
+    background: ${({ theme }) => theme.colors.primary100};
   }
 `;
 


### PR DESCRIPTION
### What does it do?

- Changes the `background` of an active link to `primary100` instead of `neutral100`
- Removes the text-related properties (`color` and `font-weight`) since links are now only icons

### Why is it needed?

The current version is not aligned with the designs.

### How to test it?

You can check it on any page since it's the main navigation.
