### PR TITLE
fix: repeatable components should not load relations when creating a new entry

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -177,9 +177,10 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
     /**
      * We'll always have a documentId in a created entry, so we look for a componentId first.
      * Same with `uid` and `documentModel`.
+     * The componentId is empty when adding a new component in a repeatable. Let it be null to skip isRelatedToCurrentDocument
      */
     const model = component ? component.uid : currentDocumentMeta.model;
-    const id = component && componentId ? componentId.toString() : documentId;
+    const id = component ? componentId?.toString() : documentId;
 
     /**
      * The `name` prop is a complete path to the field, e.g. `field1.field2.field3`.


### PR DESCRIPTION
### What does it do?

When pressing "add an entry" on a repeatable component, the RelationsFields starts looking for the selected relation with the component id. Which doesn't exist yet. So it falls back to the documentId of the parent document this component is inside of. This is wrong and returns a `404`.

### Why is it needed?

Making sure the incorrect API call is not triggered.

### How to test it?

The example project in the Strapi repo contains a `Menu Section` contentType that contains a repeatable component with a relation inside called `categories`. If you press "add an entry" here, an incorrect API call is triggered. This PR fixes this. It should not trigger the `useGetRelationsQuery` . (note: it does trigger `useLazySearchRelationsQuery` which is correct and looks alike)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/21354
