### PR TITLE
feat(plugins/i18n): add missing locale for Luxembourgish (lb-LU)

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -1472,6 +1472,14 @@
     "name": "Lithuanian (Lithuania) (lt-LT)"
   },
   {
+    "code": "lb",
+    "name": "Luxembourgish (lb)"
+  },
+  {
+    "code": "lb-LU",
+    "name": "Luxembourgish (Luxembourg) (lb-LU)"
+  },
+  {
     "code": "lu",
     "name": "Luba-Katanga (lu)"
   },


### PR DESCRIPTION
Adds the possibility to select Luxembourgish when adding a new locale in the internationalization settings.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds the ISO 639-1 code for Luxembourgish and the regional variation of Luxembourgish for Luxembourg, using the ISO 3166-1 alpha-2 country code in the `iso-locales.json`.

This makes Luxembourgish available in the settings for the Internationalization plugin

### Why is it needed?

Luxembourgish is not available in the settings right now, so there's no proper option to provide Luxembourgish translations.

### How to test it?

Go to admin/settings/internationalization, add new locale, select Luxembourgish.

Then in the content manager, on a collection type with internationalization enabled, ensure you can create entries using the new locale.

### Related issue(s)/PR(s)

No related issue / PR
