### PR TITLE
The install button in "market.strapi.io" website for any plugin doesn't work

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,3 +26,4 @@ Provide information about the environment and the path to verify the behaviour.
 ### Related issue(s)/PR(s)
 
 Let us know if this is related to any issue/pull request
+  


### PR DESCRIPTION
The install button in "market.strapi.io" website for any plugin doesn't work

### What does it do?
There's no changes on the files, I just a space change to create a pull request

### Why is it needed?
The install button doesn't have any action ad it redirect the user to a 404 error

### How to test it?

Provide information about the environment and the path to verify the behaviour.
visit "market.strapi.io" for any plugin

### Related issue(s)/PR(s)
No

