### PR TITLE
chore(docs): document traverseEntity util

### DIFF
--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -4,7 +4,6 @@ tags:
   - utils
 ---
 
-
 # Traverse Entity Utility
 
 The `traverseEntity` function is designed to recursively traverse a data entity based on its schema definition. It provides hooks to execute custom logic at each level of the traversal through the `Visitor` function.
@@ -12,11 +11,13 @@ The `traverseEntity` function is designed to recursively traverse a data entity 
 ## Overview
 
 ### Purpose
+
 The utility is used for structured data manipulation. It supports various types of attributes, such as relations, components, dynamic zones, and media, allowing seamless traversal and transformation of deeply nested entities.
 
 ## Function: `traverseEntity`
 
 ### Signature
+
 ```typescript
 async function traverseEntity(
   visitor: [Visitor](#visitoroptions),
@@ -26,35 +27,42 @@ async function traverseEntity(
 ```
 
 ### Parameters
+
 - **`visitor`**:  
   A function executed for each attribute of the entity. It provides context and utilities for modifying the entity.
 
 - **`options`**:  
   Configuration for traversal, including:
-  - `schema` *(Model)*: The schema definition of the current entity.
-  - `path` *(Path, optional)*: Tracks the current traversal path.
-  - `parent` *(Parent, optional)*: Information about the parent attribute.
-  - `getModel` *(Function)*: A function to retrieve the schema of a model by its UID.
+
+  - `schema` _(Model)_: The schema definition of the current entity.
+  - `path` _(Path, optional)_: Tracks the current traversal path.
+  - `parent` _(Parent, optional)_: Information about the parent attribute.
+  - `getModel` _(Function)_: A function to retrieve the schema of a model by its UID.
 
 - **`entity`**:  
   The data entity to be traversed.
 
 ### Returns
+
 A `Promise<Data>` that resolves with the transformed entity.
 
 ## Related Types
 
 ### Visitor
+
 ```typescript
 type Visitor = (visitorOptions: VisitorOptions, visitorUtils: VisitorUtils) => void;
 ```
-A function executed during traversal for each attribute.  
 
-**Parameters**:  
-- **`visitorOptions`** *(VisitorOptions)*: Provides details about the current state of traversal.  
-- **`visitorUtils`** *(VisitorUtils)*: Utilities for modifying the entity (e.g., `set`, `remove`).
+A function executed during traversal for each attribute.
+
+**Parameters**:
+
+- **`visitorOptions`** _(VisitorOptions)_: Provides details about the current state of traversal.
+- **`visitorUtils`** _(VisitorUtils)_: Utilities for modifying the entity (e.g., `set`, `remove`).
 
 ### VisitorOptions
+
 ```typescript
 interface VisitorOptions {
   data: Record<string, unknown>;
@@ -68,38 +76,45 @@ interface VisitorOptions {
 }
 ```
 
-- **`data`**: The current entity or its sub-section being processed.  
-- **`schema`**: The schema definition of the current entity.  
-- **`key`**: The current attribute key.  
-- **`value`**: The current attribute value.  
-- **`attribute`** *(optional)*: The schema attribute definition for the current key.  
-- **`path`**: Tracks the traversal path.  
-- **`getModel`**: Function to retrieve a schema definition by UID.  
-- **`parent`** *(optional)*: Information about the parent attribute.
+- **`data`**: The current entity or its sub-section being processed.
+- **`schema`**: The schema definition of the current entity.
+- **`key`**: The current attribute key.
+- **`value`**: The current attribute value.
+- **`attribute`** _(optional)_: The schema attribute definition for the current key.
+- **`path`**: Tracks the traversal path.
+- **`getModel`**: Function to retrieve a schema definition by UID.
+- **`parent`** _(optional)_: Information about the parent attribute.
 
 ### VisitorUtils
+
 ```typescript
 interface VisitorUtils {
   remove(key: string): void;
   set(key: string, value: Data): void;
 }
 ```
-Utility functions to modify the entity:  
-- **`remove(key)`**: Deletes an attribute from the entity.  
+
+Utility functions to modify the entity:
+
+- **`remove(key)`**: Deletes an attribute from the entity.
 - **`set(key, value)`**: Sets or updates an attribute on the entity.
 
 ### Path
+
 ```typescript
 interface Path {
   raw: string | null;
   attribute: string | null;
 }
 ```
+
 Tracks the traversal path:
+
 - **`raw`**: The traversal path on the entity
 - **`attribute`**: The same traversal path on the schema if the attibute exists
 
 ### Parent
+
 ```typescript
 interface Parent {
   attribute?: Attribute;
@@ -108,10 +123,11 @@ interface Parent {
   schema: Model;
 }
 ```
+
 Tracks parent information for the current attribute.
 
-
 ### TraverseOptions
+
 ```typescript
 interface TraverseOptions {
   schema: Model;
@@ -120,8 +136,10 @@ interface TraverseOptions {
   getModel(uid: string): Model;
 }
 ```
+
 Configuration for the traversal:
-- **`schema`**: The schema definition of the current entity.  
-- **`path`** *(optional)*: Tracks the current traversal path.  
-- **`parent`** *(optional)*: Information about the parent attribute.  
+
+- **`schema`**: The schema definition of the current entity.
+- **`path`** _(optional)_: Tracks the current traversal path.
+- **`parent`** _(optional)_: Information about the parent attribute.
 - **`getModel`**: Function to retrieve a schema definition by UID.

--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -77,8 +77,6 @@ interface VisitorOptions {
 - **`getModel`**: Function to retrieve a schema definition by UID.  
 - **`parent`** *(optional)*: Information about the parent attribute.
 
----
-
 ### VisitorUtils
 ```typescript
 interface VisitorUtils {
@@ -89,8 +87,6 @@ interface VisitorUtils {
 Utility functions to modify the entity:  
 - **`remove(key)`**: Deletes an attribute from the entity.  
 - **`set(key, value)`**: Sets or updates an attribute on the entity.
-
----
 
 ### Path
 ```typescript
@@ -103,8 +99,6 @@ Tracks the traversal path:
 - **`raw`**: The traversal path on the entity
 - **`attribute`**: The same traversal path on the schema if the attibute exists
 
----
-
 ### Parent
 ```typescript
 interface Parent {
@@ -116,7 +110,6 @@ interface Parent {
 ```
 Tracks parent information for the current attribute.
 
----
 
 ### TraverseOptions
 ```typescript

--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -1,0 +1,142 @@
+---
+title: traverseEntity
+tags:
+  - utils
+---
+
+
+# Traverse Entity Utility
+
+The `traverseEntity` function is designed to recursively traverse a data entity based on its schema definition. It provides hooks to execute custom logic at each level of the traversal through the `Visitor` function.
+
+---
+
+## Overview
+
+### Purpose
+The utility is used for structured data manipulation. It supports various types of attributes, such as relations, components, dynamic zones, and media, allowing seamless traversal and transformation of deeply nested entities.
+
+---
+
+## Function: `traverseEntity`
+
+### Signature
+```typescript
+async function traverseEntity(
+  visitor: [Visitor](#visitoroptions),
+  options: TraverseOptions,
+  entity: Data
+): Promise<Data>;
+```
+
+### Parameters
+- **`visitor`**:  
+  A function executed for each attribute of the entity. It provides context and utilities for modifying the entity.
+
+- **`options`**:  
+  Configuration for traversal, including:
+  - `schema` *(Model)*: The schema definition of the current entity.
+  - `path` *(Path, optional)*: Tracks the current traversal path.
+  - `parent` *(Parent, optional)*: Information about the parent attribute.
+  - `getModel` *(Function)*: A function to retrieve the schema of a model by its UID.
+
+- **`entity`**:  
+  The data entity to be traversed.
+
+### Returns
+A `Promise<Data>` that resolves with the transformed entity.
+
+---
+
+## Related Types
+
+### Visitor
+```typescript
+type Visitor = (visitorOptions: VisitorOptions, visitorUtils: VisitorUtils) => void;
+```
+A function executed during traversal for each attribute.  
+
+**Parameters**:  
+- **`visitorOptions`** *(VisitorOptions)*: Provides details about the current state of traversal.  
+- **`visitorUtils`** *(VisitorUtils)*: Utilities for modifying the entity (e.g., `set`, `remove`).
+
+---
+
+### VisitorOptions
+```typescript
+interface VisitorOptions {
+  data: Record<string, unknown>;
+  schema: Model;
+  key: string;
+  value: Data[keyof Data];
+  attribute?: AnyAttribute;
+  path: Path;
+  getModel(uid: string): Model;
+  parent?: Parent;
+}
+```
+
+- **`data`**: The current entity or its sub-section being processed.  
+- **`schema`**: The schema definition of the current entity.  
+- **`key`**: The current attribute key.  
+- **`value`**: The current attribute value.  
+- **`attribute`** *(optional)*: The schema attribute definition for the current key.  
+- **`path`**: Tracks the traversal path.  
+- **`getModel`**: Function to retrieve a schema definition by UID.  
+- **`parent`** *(optional)*: Information about the parent attribute.
+
+---
+
+### VisitorUtils
+```typescript
+interface VisitorUtils {
+  remove(key: string): void;
+  set(key: string, value: Data): void;
+}
+```
+Utility functions to modify the entity:  
+- **`remove(key)`**: Deletes an attribute from the entity.  
+- **`set(key, value)`**: Sets or updates an attribute on the entity.
+
+---
+
+### Path
+```typescript
+interface Path {
+  raw: string | null;
+  attribute: string | null;
+}
+```
+Tracks the traversal path:
+- **`raw`**: The raw path of the current attribute in the entity.  
+- **`attribute`**: The schema-defined attribute path.
+
+---
+
+### Parent
+```typescript
+interface Parent {
+  attribute?: Attribute;
+  key: string | null;
+  path: Path;
+  schema: Model;
+}
+```
+Tracks parent information for the current attribute.
+
+---
+
+### TraverseOptions
+```typescript
+interface TraverseOptions {
+  schema: Model;
+  path?: Path;
+  parent?: Parent;
+  getModel(uid: string): Model;
+}
+```
+Configuration for the traversal:
+- **`schema`**: The schema definition of the current entity.  
+- **`path`** *(optional)*: Tracks the current traversal path.  
+- **`parent`** *(optional)*: Information about the parent attribute.  
+- **`getModel`**: Function to retrieve a schema definition by UID.

--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -100,8 +100,8 @@ interface Path {
 }
 ```
 Tracks the traversal path:
-- **`raw`**: The raw path of the current attribute in the entity.  
-- **`attribute`**: The schema-defined attribute path.
+- **`raw`**: The traversal path on the entity
+- **`attribute`**: The same traversal path on the schema if the attibute exists
 
 ---
 

--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -9,14 +9,10 @@ tags:
 
 The `traverseEntity` function is designed to recursively traverse a data entity based on its schema definition. It provides hooks to execute custom logic at each level of the traversal through the `Visitor` function.
 
----
-
 ## Overview
 
 ### Purpose
 The utility is used for structured data manipulation. It supports various types of attributes, such as relations, components, dynamic zones, and media, allowing seamless traversal and transformation of deeply nested entities.
-
----
 
 ## Function: `traverseEntity`
 
@@ -46,8 +42,6 @@ async function traverseEntity(
 ### Returns
 A `Promise<Data>` that resolves with the transformed entity.
 
----
-
 ## Related Types
 
 ### Visitor
@@ -59,8 +53,6 @@ A function executed during traversal for each attribute.
 **Parameters**:  
 - **`visitorOptions`** *(VisitorOptions)*: Provides details about the current state of traversal.  
 - **`visitorUtils`** *(VisitorUtils)*: Utilities for modifying the entity (e.g., `set`, `remove`).
-
----
 
 ### VisitorOptions
 ```typescript


### PR DESCRIPTION
### What does it do?

Adds documentation for the `traverseEntity` utility

### Why is it needed?

So it is easier for everyone to understand and use the utility

### How to test it?

Read it 

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22278

p.s.

ChatGPT did a good job IMO
