### PR TITLE
fix: virtual prefix proxy path for vite middleware to work

### DIFF
--- a/packages/core/strapi/src/node/vite/watch.ts
+++ b/packages/core/strapi/src/node/vite/watch.ts
@@ -57,10 +57,21 @@ const watch = async (ctx: BuildContext): Promise<ViteWatcher> => {
 
   const viteMiddlewares: Core.MiddlewareHandler = (koaCtx, next) => {
     return new Promise((resolve, reject) => {
+      const prefix = ctx.basePath.replace(ctx.adminPath, '').replace(/\/+$/, '');
+
+      const originalPath = koaCtx.path;
+      if (!koaCtx.path.startsWith(prefix)) {
+        koaCtx.path = `${prefix}${koaCtx.path}`;
+      }
+
       vite.middlewares(koaCtx.req, koaCtx.res, (err: unknown) => {
         if (err) {
           reject(err);
         } else {
+          if (!koaCtx.res.headersSent) {
+            koaCtx.path = originalPath;
+          }
+
           resolve(next());
         }
       });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Followup on github.com/strapi/strapi/issues/21184

### Why is it needed?

when setting vite `base` it will not serve them correctly if we are rewriting the pathname 

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
