### PR TITLE
fix: remove link to open a new issue directly

### DIFF
--- a/packages/core/admin/admin/src/components/ErrorElement.tsx
+++ b/packages/core/admin/admin/src/components/ErrorElement.tsx
@@ -68,7 +68,7 @@ ${error.stack}
                         isExternal
                         // hack to get rid of the current endIcon, which should be removable by using `null`.
                         endIcon
-                        href="https://github.com/strapi/strapi/issues/new?assignees=&labels=&projects=&template=BUG_REPORT.md"
+                        href="https://github.com/strapi/strapi/issues"
                       >{`Strapi's GitHub`}</Link>
                     ),
                   }


### PR DESCRIPTION
### What does it do?

Alters the link to open up a new bug report issue when encountering the error page to just point to issues directly

### Why is it needed?

Too many people opening bug reports and not filling out the template properly
https://github.com/strapi/strapi/issues?q=is%3Aissue+label%3A%22flag%3A+invalid+template%22+is%3Aclosed

### How to test it?

Hit the error and click the button

### Related issue(s)/PR(s)

N/A
