### PR TITLE
enhancement: allow to add custom languages and replace existing langu…

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -42,6 +42,7 @@ interface StrapiAppConstructorArgs extends Partial<Pick<StrapiApp, 'appPlugins'>
     auth?: { logo: string };
     head?: { favicon: string };
     locales?: string[];
+    languageNativeNames?: Record<string, string>;
     menu?: { logo: string };
     notifications?: { releases: boolean };
     theme?: { light: DefaultTheme; dark: DefaultTheme };
@@ -101,6 +102,7 @@ class StrapiApp {
     authLogo: Logo,
     head: { favicon: '' },
     locales: ['en'],
+    languageNativeNames: languageNativeNames,
     menuLogo: Logo,
     notifications: { releases: true },
     themes: { light: lightTheme, dark: darkTheme },
@@ -291,6 +293,13 @@ class StrapiApp {
     if (customConfig.tutorials !== undefined) {
       this.configurations.tutorials = customConfig.tutorials;
     }
+
+    if (customConfig.languageNativeNames !== undefined) {
+      this.configurations.languageNativeNames = {
+        ...languageNativeNames,
+        ...customConfig.languageNativeNames,
+      }
+    }
   };
 
   createHook = (name: string) => {
@@ -432,7 +441,7 @@ class StrapiApp {
   runHookParallel = (name: string) => this.hooksDict[name].runParallel();
 
   render() {
-    const localeNames = pick(languageNativeNames, this.configurations.locales || []);
+    const localeNames = pick(this.configurations.languageNativeNames || languageNativeNames, this.configurations.locales || []);
     const locale = (localStorage.getItem(LANGUAGE_LOCAL_STORAGE_KEY) ||
       'en') as keyof typeof localeNames;
 


### PR DESCRIPTION
### What does it do?
Allows to add custom languages and replace existing language native names in app.ts

### Why is it needed?
It allows to add custom translations for not yet supported languages. At the moment it is not possible to add new language. It also allows to change existing languages' native names displayed in language switch dropdown in admin panel.

### How to test it?
Put the following to app.ts or app.js:
```
const config = {
  locales: ['it', 'es', 'en', 'en-GB', 'lv'],
  languageNativeNames: {
    lv: 'Latviešu',
    es: "Spanish"
  }
};
```
It will add `Latviešu` language option and replace `Español` with `Spanish`. Translations for added languages could be provided in same way as extensions for existing languages by adding file `lv.json` or `config.translations` https://docs.strapi.io/dev-docs/admin-panel-customization/options#extending-translations
