### PR TITLE
fix: add missing borders to widgets

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/Widget.tsx
@@ -23,6 +23,7 @@ const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
       direction="column"
       alignItems="flex-start"
       background="neutral0"
+      borderColor="neutral150"
       shadow="tableShadow"
       tag="section"
       gap={4}


### PR DESCRIPTION
### What does it do?

Adds a `borderColor` property to the `Widget` component.

### Why is it needed?

I missed it during the QA phase.

### How to test it?

Go to the homepage.