### PR TITLE
feat(core/config): export Shared types

### DIFF
--- a/packages/core/types/src/core/config/index.ts
+++ b/packages/core/types/src/core/config/index.ts
@@ -1,3 +1,4 @@
+export type * as Shared from './shared';
 export type { Server } from './server';
 export type { Admin } from './admin';
 export type { Api } from './api';


### PR DESCRIPTION
### What does it do?

Export the `Shared` types namespace for Core.Config

### Why is it needed?

With this exported, Strapi users are able to type their config files.

```ts
import type { Core } from "@strapi/strapi";

type AdminConfig = Core.Config.Shared.ConfigFunction<Core.Config.Admin>;

const config: AdminConfig = ({ env }) => {
	return {
		apiToken: { salt: env("API_TOKEN_SALT") },
		transfer: { token: { salt: env("TRANSFER_TOKEN_SALT") } },
		auth: { secret: env("ADMIN_JWT_SECRET") },
	};
};

export default config;
```

> [!NOTE]
> This `shared.ts` file seems to have been created for this but was never exported and is not used inside Strapi code also.
