### PR TITLE
fix(i18n): allow unique + un localized fields on i18n content types

### DIFF
--- a/packages/plugins/i18n/admin/src/index.ts
+++ b/packages/plugins/i18n/admin/src/index.ts
@@ -139,28 +139,6 @@ export default {
       });
 
       ctbFormsAPI.extendFields(LOCALIZED_FIELDS, {
-        validator: (args: any) => ({
-          i18n: yup.object().shape({
-            localized: yup.bool().test({
-              name: 'ensure-unique-localization',
-              message: getTranslation('plugin.schema.i18n.ensure-unique-localization'),
-              test(value) {
-                if (value === undefined || value) {
-                  return true;
-                }
-
-                const unique = get(args, ['3', 'modifiedData', 'unique'], null);
-
-                // Unique fields must be localized
-                if (unique && !value) {
-                  return false;
-                }
-
-                return true;
-              },
-            }),
-          }),
-        }),
         form: {
           advanced({ contentTypeSchema, forTarget, type, step }: any) {
             if (forTarget !== 'contentType') {

--- a/packages/plugins/i18n/admin/src/translations/de.json
+++ b/packages/plugins/i18n/admin/src/translations/de.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Dieses Plugin ermöglicht es, Inhalte in verschiedenen Sprachen zu erstellen, zu lesen und zu aktualisieren, sowohl über das Admin-Panel als auch über die API",
   "plugin.description.short": "Dieses Plugin ermöglicht es, Inhalte in verschiedenen Sprachen zu erstellen, zu lesen und zu aktualisieren, sowohl über das Admin-Panel als auch über die API",
   "plugin.name": "Internationalisierung",
-  "plugin.schema.i18n.ensure-unique-localization": "Einzigartige Felder müssen lokalisiert sein",
   "plugin.schema.i18n.localized.description-content-type": "Ermöglicht es Inhalte in verschiedenen Sprachen zu pflegen",
   "plugin.schema.i18n.localized.description-field": "Das Feld kann verschiedene Werte in jeder Sprache haben",
   "plugin.schema.i18n.localized.label-content-type": "Übersetzungen",

--- a/packages/plugins/i18n/admin/src/translations/dk.json
+++ b/packages/plugins/i18n/admin/src/translations/dk.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Dette plugin gør det muligt at oprette, læse og redigere indhold på forskellige sprog, både fra admin panelt og igennem API.",
   "plugin.description.short": "Dette plugin gør det muligt at oprette, læse og redigere indhold på forskellige sprog, både fra admin panelt og igennem API.",
   "plugin.name": "Internationalisering",
-  "plugin.schema.i18n.ensure-unique-localization": "Unikke felter skal udfyldes for alle sprogvarianter",
   "plugin.schema.i18n.localized.description-content-type": "Muliggør indhold på forskellige sprog",
   "plugin.schema.i18n.localized.description-field": "Feltet kan have forskellige værdier for hver sprogvariant",
   "plugin.schema.i18n.localized.label-content-type": "Aktivér sprogvarianter for denne indholdstype",

--- a/packages/plugins/i18n/admin/src/translations/en.json
+++ b/packages/plugins/i18n/admin/src/translations/en.json
@@ -69,7 +69,6 @@
   "plugin.description.long": "This plugin enables to create, to read and to update content in different languages, both from the Admin Panel and from the API.",
   "plugin.description.short": "This plugin enables to create, to read and to update content in different languages, both from the Admin Panel and from the API.",
   "plugin.name": "Internationalization",
-  "plugin.schema.i18n.ensure-unique-localization": "Unique fields must be localized",
   "plugin.schema.i18n.localized.description-content-type": "Allows translating an entry into different languages",
   "plugin.schema.i18n.localized.description-field": "The field can have different values in each language",
   "plugin.schema.i18n.localized.label-content-type": "Internationalization",

--- a/packages/plugins/i18n/admin/src/translations/es.json
+++ b/packages/plugins/i18n/admin/src/translations/es.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Este plugin permite crear, leer y actualizar contenido en diferentes idiomas, tanto desde el Panel de Administración como desde la API.",
   "plugin.description.short": "Este plugin permite crear, leer y actualizar contenido en diferentes idiomas, tanto desde el Panel de Administración como desde la API.",
   "plugin.name": "Internacionalización",
-  "plugin.schema.i18n.ensure-unique-localization": "Los campos únicos deben estar localizados",
   "plugin.schema.i18n.localized.description-content-type": "Permitir que tengas contenido en diferentes configuraciones regionales.",
   "plugin.schema.i18n.localized.description-field": "El campo puede tener distintos valores en cada configuración regional.",
   "plugin.schema.i18n.localized.label-content-type": "Habilitar la localización para este Content-Type",

--- a/packages/plugins/i18n/admin/src/translations/fr.json
+++ b/packages/plugins/i18n/admin/src/translations/fr.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Créez, lisez et modifiez votre contenu en différentes langues depuis le panel d'administration et votre API.",
   "plugin.description.short": "Créez, lisez et modifiez votre contenu en différentes langues depuis le panel d'administration et votre API.",
   "plugin.name": "Internationalisation",
-  "plugin.schema.i18n.ensure-unique-localization": "Les champs uniques doivent avoir une locale",
   "plugin.schema.i18n.localized.description-content-type": "Donne la possibilité d'avoir du contenu dans différentes locales",
   "plugin.schema.i18n.localized.description-field": "Le champ peut avoir des valeurs différentes dans chaque locale",
   "plugin.schema.i18n.localized.label-content-type": "Activer la localisation pour ce type de contenu",

--- a/packages/plugins/i18n/admin/src/translations/ko.json
+++ b/packages/plugins/i18n/admin/src/translations/ko.json
@@ -53,7 +53,6 @@
   "plugin.description.long": "이 플러그인을 사용하면 어드민 패널과 API에서 서로 다른 언어로 된 컨텐츠를 만들고, 읽고, 업데이트할 수 있습니다.",
   "plugin.description.short": "이 플러그인을 사용하면 어드민 패널과 API에서 서로 다른 언어로 된 컨텐츠를 만들고, 읽고, 업데이트할 수 있습니다.",
   "plugin.name": "국제화",
-  "plugin.schema.i18n.ensure-unique-localization": "유니크 필드는 지역화(localized)되어야 합니다.",
   "plugin.schema.i18n.localized.description-content-type": "로케일별로 콘텐츠를 저장할 수 있습니다.",
   "plugin.schema.i18n.localized.description-field": "필드는 각 로케일에서 서로 다른 값을 가질 수 있습니다.",
   "plugin.schema.i18n.localized.label-content-type": "이 콘텐츠 타입의 지역화(localization) 켜기",

--- a/packages/plugins/i18n/admin/src/translations/pl.json
+++ b/packages/plugins/i18n/admin/src/translations/pl.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Ten plugin umożliwia tworzenie, czytanie i aktualizowanie treści w różnych językach, zarówno z poziomu panelu admina jak i z API.",
   "plugin.description.short": "Ten plugin umożliwia tworzenie, czytanie i aktualizowanie treści w różnych językach, zarówno z poziomu panelu admina jak i z API.",
   "plugin.name": "Internationalization",
-  "plugin.schema.i18n.ensure-unique-localization": "Unikalne pola muszą zostać zlokalizowane",
   "plugin.schema.i18n.localized.description-content-type": "Pozwala mieć treść w różnych ustawieniach regionalnych",
   "plugin.schema.i18n.localized.description-field": "To pole może mieć różne wartości w zależności od różnych ustawień regionalnych",
   "plugin.schema.i18n.localized.label-content-type": "Włącz lokalizację dla tego typu treści",

--- a/packages/plugins/i18n/admin/src/translations/ru.json
+++ b/packages/plugins/i18n/admin/src/translations/ru.json
@@ -56,7 +56,6 @@
   "plugin.description.long": "Этот плагин позволяет создавать, читать и обновлять контент (словом, производить всевозможные действия с контентом) на разных языках, как из панели администратора, так и через API.",
   "plugin.description.short": "Этот плагин позволяет создавать, читать и обновлять контент на разных языках, как из панели администратора, так и через API.",
   "plugin.name": "Интернационализация",
-  "plugin.schema.i18n.ensure-unique-localization": "Уникальные поля должны быть переведены",
   "plugin.schema.i18n.localized.description-content-type": "Позволяет перевести запись на разные языки",
   "plugin.schema.i18n.localized.description-field": "Поле может иметь разные значения на каждом языке",
   "plugin.schema.i18n.localized.label-content-type": "Интернационализация",

--- a/packages/plugins/i18n/admin/src/translations/tr.json
+++ b/packages/plugins/i18n/admin/src/translations/tr.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "Bu eklenti, hem Yönetim paneli hem de API üzerinden, farklı dillerdeki içeriği oluşturma, okuma ve güncelleme imkanı sağlar.",
   "plugin.description.short": "Bu eklenti, hem Yönetim paneli hem de API üzerinden, farklı dillerdeki içeriği oluşturma, okuma ve güncelleme imkanı sağlar.",
   "plugin.name": "Uluslararasılaştırma",
-  "plugin.schema.i18n.ensure-unique-localization": "Benzersiz alanlar yerelleştirilmelidir",
   "plugin.schema.i18n.localized.description-content-type": "İçerikleri yerelleştirebilmenize imkan tanır",
   "plugin.schema.i18n.localized.description-field": "Bu alan farklı yerel ayarlarda farklı değer alabilir",
   "plugin.schema.i18n.localized.label-content-type": "Bu İçerik-Tipi için yerelleştirmeyi etkinleştir",

--- a/packages/plugins/i18n/admin/src/translations/zh-Hans.json
+++ b/packages/plugins/i18n/admin/src/translations/zh-Hans.json
@@ -45,7 +45,6 @@
   "plugin.description.long": "开启此插件后，可以在管理面板或是API中创建，查询及更新不同语言的内容",
   "plugin.description.short": "在管理面板或是API中创建，查询及更新不同语言的内容",
   "plugin.name": "国际化",
-  "plugin.schema.i18n.ensure-unique-localization": "唯一字段必须本地化",
   "plugin.schema.i18n.localized.description-content-type": "允许您为内容设置不同的语言",
   "plugin.schema.i18n.localized.description-field": "该字段在不同的语言环境中有不同的值",
   "plugin.schema.i18n.localized.label-content-type": "为该内容类型开启本地化",

--- a/packages/plugins/i18n/admin/src/translations/zh.json
+++ b/packages/plugins/i18n/admin/src/translations/zh.json
@@ -54,7 +54,6 @@
   "plugin.description.long": "此外掛程式允許您從管理面板和 API 建立、讀取、更新不同語言的內容。",
   "plugin.description.short": "此外掛程式允許您從管理面板和 API 建立、讀取、更新不同語言的內容。",
   "plugin.name": "國際化",
-  "plugin.schema.i18n.ensure-unique-localization": "唯一欄位必須本地化",
   "plugin.schema.i18n.localized.description-content-type": "讓您的內容有多種地區設定",
   "plugin.schema.i18n.localized.description-field": "此欄位在各個地區設定中可以有不同數值",
   "plugin.schema.i18n.localized.label-content-type": "為此內容型別啟用本地化",

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -3,7 +3,6 @@ import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
 import { navToHeader } from '../../../utils/shared';
 import { sharedSetup } from '../../../utils/setup';
-import { createCollectionType } from '../../../utils/content-types';
 
 test.describe('Edit collection type', () => {
   // very long timeout for these tests because they restart the server multiple times
@@ -197,5 +196,38 @@ test.describe('Edit collection type', () => {
     await page.reload();
 
     await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
+  });
+
+  test('Can enable localization on a content type, create a text field, disable internationalization on the field and enable uniqueness on the same field', async ({
+    page,
+  }) => {
+    // Create a text field
+    await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
+    await page.getByLabel('Name', { exact: true }).fill('localizedField');
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Disable internationalization on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Enable localization for this field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Enable uniqueness on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Unique field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes an issue in i18n where it was not possible to define unique and non-localized fields for i18n content types. It modifies the handling of uniqueness constraints to allow these fields to function correctly in i18n models.

### How to test it?

1. Create an i18n content type with at least one unique and non-localized field.
2. Add multiple records to the content type in different locales.
3. Verify that the unique constraints are respected across locales for the non-localized field.
4. Confirm that the application does not throw errors when managing such content types.

### Related issue(s)/PR(s)

DX-1834