### PR TITLE
test(e2e): text fields advanced settings

### DIFF
--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -81,7 +81,7 @@ const createConfig = ({ port, testDir, appDir }) => ({
     /* Default time each action such as `click()` can take */
     actionTimeout: getEnvNum(process.env.PLAYWRIGHT_ACTION_TIMEOUT, 10 * 1000),
     // Only record trace when retrying a test to optimize test performance
-    trace: 'on-first-retry',
+    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
     video: getEnvBool(process.env.PLAYWRIGHT_VIDEO, false)
       ? {
           mode: 'on-first-retry', // Only save videos when retrying a test

--- a/tests/e2e/tests/content-manager/create-content.spec.ts
+++ b/tests/e2e/tests/content-manager/create-content.spec.ts
@@ -88,9 +88,6 @@ test.describe('Adding content', () => {
       },
     });
 
-    // reload due to bug that doesn't update UI
-    await page.reload();
-
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
   });
 
@@ -169,7 +166,6 @@ test.describe('Adding content', () => {
   test('when I publish an empty required text field inside a dz I see an error', async ({
     page,
   }) => {
-    // TODO: add support for advanced options: required
     const fields = [
       {
         name: 'testdz',

--- a/tests/e2e/tests/content-manager/create-content.spec.ts
+++ b/tests/e2e/tests/content-manager/create-content.spec.ts
@@ -24,7 +24,9 @@ test.describe('Adding content', () => {
                 name: 'testrepeatablecomp2',
                 icon: 'moon',
                 categorySelect: 'product',
-                attributes: [{ type: 'text', name: 'testrepeatablecomp2text' }],
+                attributes: [
+                  { type: 'text', name: 'testrepeatablecomp2text', advanced: { required: true } },
+                ],
               },
             },
           },
@@ -37,7 +39,9 @@ test.describe('Adding content', () => {
                 name: 'testsinglecomp2',
                 icon: 'moon',
                 categorySelect: 'product',
-                attributes: [{ type: 'text', name: 'testsinglecomp2text' }],
+                attributes: [
+                  { type: 'text', name: 'testsinglecomp2text', advanced: { required: true } },
+                ],
               },
             },
           },
@@ -55,14 +59,20 @@ test.describe('Adding content', () => {
                       name: 'testnewcomponentrepeatable',
                       icon: 'moon',
                       categorySelect: 'product',
-                      attributes: [{ type: 'text', name: 'testnewcomponentexistingcategorytext' }],
+                      attributes: [
+                        {
+                          type: 'text',
+                          name: 'testnewcomponentexistingcategorytext',
+                          advanced: { required: true },
+                        },
+                      ],
                     },
                   },
                 },
                 // Existing component with existing category
                 {
                   type: 'component',
-                  name: 'testexistingcomponentexistingcategory', // TODO: is this used?
+                  name: 'testexistingcomponentexistingcategory',
                   component: {
                     useExisting: 'variations',
                     options: {
@@ -77,6 +87,9 @@ test.describe('Adding content', () => {
         ]);
       },
     });
+
+    // reload due to bug that doesn't update UI
+    await page.reload();
 
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
   });
@@ -153,25 +166,34 @@ test.describe('Adding content', () => {
   });
 
   // TODO: can this become a loop to test every field? might work best to have a create where every first attempt to enter an attribute is made without a name
-  test('when I fail to enter a name for a dz I see an error', async ({ page }) => {
+  test('when I publish an empty required text field inside a dz I see an error', async ({
+    page,
+  }) => {
     // TODO: add support for advanced options: required
     const fields = [
       {
-        name: '',
+        name: 'testdz',
         type: 'dz',
         value: [
           {
             category: 'product',
-            name: 'variations',
-            fields: [{ type: 'text', name: 'name', value: 'Second component text value' }],
+            name: 'newcomponentexistingcategory',
+            fields: [
+              {
+                type: 'text',
+                name: 'testnewcomponentexistingcategorytext',
+                value: '',
+              },
+            ],
           },
         ],
       },
     ] satisfies FieldValue[];
 
-    await createContent(page, 'Article', fields, { save: true, publish: false, verify: false });
+    await createContent(page, 'Article', fields, { save: false, publish: true, verify: false });
 
     // TODO: check that aria-invalid=true for this input
+
     expect(page.getByText('This value is required')).toBeVisible();
   });
 });

--- a/tests/e2e/tests/content-manager/create-content.spec.ts
+++ b/tests/e2e/tests/content-manager/create-content.spec.ts
@@ -151,4 +151,27 @@ test.describe('Adding content', () => {
     const before = await isElementBefore(source, target);
     expect(before).toBe(true);
   });
+
+  // TODO: can this become a loop to test every field? might work best to have a create where every first attempt to enter an attribute is made without a name
+  test('when I fail to enter a name for a dz I see an error', async ({ page }) => {
+    // TODO: add support for advanced options: required
+    const fields = [
+      {
+        name: '',
+        type: 'dz',
+        value: [
+          {
+            category: 'product',
+            name: 'variations',
+            fields: [{ type: 'text', name: 'name', value: 'Second component text value' }],
+          },
+        ],
+      },
+    ] satisfies FieldValue[];
+
+    await createContent(page, 'Article', fields, { save: true, publish: false, verify: false });
+
+    // TODO: check that aria-invalid=true for this input
+    expect(page.getByText('This value is required')).toBeVisible();
+  });
 });

--- a/tests/e2e/tests/content-manager/date.spec.ts
+++ b/tests/e2e/tests/content-manager/date.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import { sharedSetup } from '../../utils/setup';
+import { addAttributesToContentType } from '../../utils/content-types';
+import { clickAndWait } from '../../utils/shared';
+import { createContent } from '../../utils/content-creation';
+import { resetFiles } from '../../utils/file-reset';
+
+// Helper to get date in MM/DD/YYYY format consistently
+function toMMDDYYYY(date: Date) {
+  // Always zero-pad month/day:
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${mm}/${dd}/${date.getFullYear()}`;
+}
+
+test.describe('Date field tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await sharedSetup('ctb-edit-st', page, {
+      login: true,
+      skipTour: true,
+      resetFiles: true,
+      importData: 'with-admin.tar',
+      afterSetup: async ({ page }) => {
+        // Adds a date attribute to the 'Article' content type
+        await addAttributesToContentType(page, 'Article', [
+          {
+            type: 'date',
+            name: 'date',
+            date: {
+              format: 'date', // set to "date" so we only deal with the date (no time)
+            },
+          },
+        ]);
+      },
+    });
+
+    // Navigate to Content Manager
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+  });
+
+  test.afterAll(async () => {
+    await resetFiles();
+  });
+
+  test('should select the current date from the UI datepicker', async ({ page }) => {
+    const today = new Date();
+    const zeroPadded = toMMDDYYYY(today);
+
+    await createContent(
+      page,
+      'Article',
+      [
+        {
+          type: 'date_date',
+          name: 'date',
+          value: zeroPadded,
+        },
+      ],
+      {
+        save: true,
+        verify: true,
+      }
+    );
+
+    // Double-check the final input value
+    const dateValue = await page.getByLabel('date').inputValue();
+    expect(dateValue).toBe(zeroPadded);
+  });
+
+  test('should select a future date by directly filling the input (skipping UI clicks)', async ({
+    page,
+  }) => {
+    const future = new Date();
+    future.setFullYear(future.getFullYear() + 1); // go 1 year in the future
+    const zeroPaddedFuture = toMMDDYYYY(future);
+
+    await createContent(
+      page,
+      'Article',
+      [
+        {
+          type: 'date_date',
+          name: 'date',
+          value: zeroPaddedFuture,
+        },
+      ],
+      {
+        save: true,
+        verify: true,
+      }
+    );
+
+    const dateValue = await page.getByLabel('date').inputValue();
+    expect(dateValue).toBe(zeroPaddedFuture);
+  });
+
+  test('should handle an ISO-formatted date properly', async ({ page }) => {
+    // Using ISO string to avoid locale/timezone parsing issues
+    const isoString = '2025-01-09';
+
+    const date = new Date(isoString);
+    const zeroPaddedDate = toMMDDYYYY(date);
+
+    await createContent(
+      page,
+      'Article',
+      [
+        {
+          type: 'date_date',
+          name: 'date',
+          value: zeroPaddedDate,
+        },
+      ],
+      {
+        save: true,
+        verify: true,
+      }
+    );
+
+    const dateValue = await page.getByLabel('date').inputValue();
+    expect(dateValue).toBe(zeroPaddedDate);
+  });
+});

--- a/tests/e2e/utils/content-creation.ts
+++ b/tests/e2e/utils/content-creation.ts
@@ -194,12 +194,12 @@ export const createContent = async (
 
   if (options.save) {
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Saved Document');
+    await findAndClose(page, 'Saved Document', { required: options.verify });
   }
 
   if (options.publish) {
     await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
-    await findAndClose(page, 'Published Document');
+    await findAndClose(page, 'Published Document', { required: options.verify });
   }
 
   if (options.verify) {

--- a/tests/e2e/utils/content-types.ts
+++ b/tests/e2e/utils/content-types.ts
@@ -1,8 +1,8 @@
-import { kebabCase } from 'lodash/fp';
+import { isBoolean, kebabCase } from 'lodash/fp';
 import { waitForRestart } from './restart';
 import pluralize from 'pluralize';
-import { expect, type Page } from '@playwright/test';
-import { clickAndWait, findByRowColumn, navToHeader } from './shared';
+import { expect, Locator, type Page } from '@playwright/test';
+import { clickAndWait, ensureCheckbox, findByRowColumn, navToHeader } from './shared';
 
 export interface AddAttribute {
   type: string;
@@ -365,7 +365,15 @@ export const fillAttribute = async (page: Page, attribute: AddAttribute, options
     await page.locator('textarea[name="enum"]').fill(attribute.enumeration?.values.join('\n'));
   }
 
-  // TODO: add support for advanced options
+  if (attribute.advanced) {
+    const adv = attribute.advanced;
+    await page.getByText('Advanced Settings').click();
+
+    if (isBoolean(adv.required)) {
+      const checkbox = page.getByRole('checkbox', { name: 'Required field' });
+      await ensureCheckbox(checkbox, adv.required);
+    }
+  }
 };
 
 export const addAttributes = async (

--- a/tests/e2e/utils/content-types.ts
+++ b/tests/e2e/utils/content-types.ts
@@ -80,8 +80,6 @@ type AddComponentOptions = {
   repeatable: boolean;
 } & CreateComponentOptions;
 
-type AddDynamicZoneOptions = {};
-
 // lookup table for attribute types+subtypes so they can be found
 // buttonName is the header of the button clicked from the "Add Attribute" screen
 // listLabel is how they appear in the list of all attributes on the content type page

--- a/tests/e2e/utils/shared.ts
+++ b/tests/e2e/utils/shared.ts
@@ -84,15 +84,22 @@ export const clickAndWait = async (page: Page, locator: Locator) => {
 /**
  * Look for an element containing text, and then click a sibling close button
  */
-export const findAndClose = async (
-  page: Page,
-  text: string,
-  role: string = 'status',
-  closeLabel: string = 'Close'
-) => {
+
+interface FindAndCloseOptions {
+  role?: string;
+  closeLabel?: string;
+  required?: boolean;
+}
+
+export const findAndClose = async (page: Page, text: string, options: FindAndCloseOptions = {}) => {
+  const { role = 'status', closeLabel = 'Close', required = true } = options;
+
   // Verify the popup text is visible.
   const elements = page.locator(`:has-text("${text}")[role="${role}"]`);
-  await expect(elements.first()).toBeVisible(); // expect at least one element
+
+  if (required) {
+    await expect(elements.first()).toBeVisible(); // expect at least one element
+  }
 
   // Find all 'Close' buttons that are siblings of the elements containing the specified text.
   const closeBtns = page.locator(
@@ -382,4 +389,19 @@ export const isElementBefore = async (firstLocator, secondLocator) => {
   return await firstHandle.evaluate((first, second) => {
     return !!(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING);
   }, secondHandle);
+};
+
+/**
+ * Ensures that the specified checkbox is in the desired checked state.
+ * If the checkbox's current state does not match the desired state, it clicks the checkbox to toggle it.
+ *
+ * @param {Locator} locator - Playwright locator for the checkbox element.
+ * @param {boolean} checked - Desired checked state of the checkbox (true for checked, false for unchecked).
+ * @returns {Promise<void>} - Resolves when the checkbox state is correctly set.
+ */
+export const ensureCheckbox = async (locator: Locator, checked: boolean) => {
+  const isChecked = await locator.isChecked();
+  if (isChecked !== checked) {
+    await locator.click();
+  }
 };


### PR DESCRIPTION
### What does it do?

Adds testing for text field "required" and "regexp" advanced settings, from creating it in the CTB to entering data for them in basic fields, components, and dzs.

More specifically:

- adds util for to ensure a checkbox value
- retain logs on failure locally (helps with debugging flaky tests)
- findAndClose allows to skip in case of expected error
- add test that error messages show up when a required text field in a dynamic zone is not entered

TODO:

- [ ] add test that basic required field shows error
- [ ] add test that required field within component (NOT in a dz) shows error
- [ ] check that aria-invalid is set
- [ ] add regexp and test it

### Why is it needed?

gap in testing

### How to test it?

run them

### Related issue(s)/PR(s)

DX-1843