### PR TITLE
ci: passing github token to publishing script

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,3 +30,5 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
           DIST_TAG: 'latest'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -18,7 +18,17 @@ if [[ -z "$distTag" ]]; then
   read -r distTag
 fi
 
+# Ensure GitHub token is available
+if [[ -z "$GITHUB_TOKEN" ]]; then
+  echo "Error: GITHUB_TOKEN environment variable is not set."
+  exit 1
+fi
+
+# Configure Git for bot commits
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
 # publish packages
 ./node_modules/.bin/nx run-many --target=clean --nx-ignore-cycles
 ./node_modules/.bin/nx run-many --target=build --nx-ignore-cycles --skip-nx-cache
-yarn release --version "$version" --tag "$distTag" --dry-run false "$@"
+GITHUB_TOKEN=$GITHUB_TOKEN yarn release --version "$version" --tag "$distTag" --dry-run false "$@"


### PR DESCRIPTION
### What does it do?

- setup the github actor to do the commits 
- ensures the github token is passed to the script

### Why is it needed?

- make the workflow work
