### PR TITLE
Ci publish script commit once

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -77,8 +77,8 @@ const yargs = require('yargs');
         version: workspaceVersion,
         dryRun: options.dryRun,
         verbose: options.verbose,
-        gitCommit: !options.dryRun,
-        gitCommitArgs: '',
+        gitCommit: false,
+        gitTag: false,
       });
     }
   }


### PR DESCRIPTION
### What does it do?

prevent commiting twice

### Why is it needed?

the script is failing because it commits again to an empty directory
