### PR TITLE
fix: resolved the issue of actions being hidden on smaller screens in dynamic Zone block

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -218,7 +218,7 @@ const DynamicComponent = ({
           <Accordion.Root value={collapseToOpen} onValueChange={setCollapseToOpen}>
             <Accordion.Item value={accordionValue}>
               <Accordion.Header>
-                <Accordion.Trigger
+                <StyledAccordionTrigger
                   icon={
                     icon && COMPONENT_ICONS[icon]
                       ? COMPONENT_ICONS[icon]
@@ -226,7 +226,7 @@ const DynamicComponent = ({
                   }
                 >
                   {accordionTitle}
-                </Accordion.Trigger>
+                </StyledAccordionTrigger>
                 <Accordion.Actions>{accordionActions}</Accordion.Actions>
               </Accordion.Header>
               <Accordion.Content>
@@ -315,6 +315,20 @@ const ComponentContainer = styled<BoxComponent<'li'>>(Box)`
   list-style: none;
   padding: 0;
   margin: 0;
+`;
+
+const StyledAccordionTrigger = styled(Accordion.Trigger)`
+  overflow: hidden;
+
+  > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  > span > span {
+    display: block;
+    overflow: hidden;
+  }
 `;
 
 export { DynamicComponent };


### PR DESCRIPTION
### What does it do?

This PR fixes the issue of actions being hidden on smaller screens in dynamic Zone block title

### Why is it needed?

To fix issue [21595](https://github.com/strapi/strapi/issues/21595): Dynamic Zone block titles should be truncated to avoid the right actions to be hidden on smaller screens

### How to test it?

1. Start a new Strapi project
2. Add a block with dynamic zone with long title to any content type.
3. Now the Accordion Title will get truncated and action buttons are visible

### Related issue(s)/PR(s)

fixes  [21595](https://github.com/strapi/strapi/issues/21595)
