### PR TITLE
fix: disable lifecycle hooks on transfers [v4]

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/assets.test.ts
@@ -30,7 +30,13 @@ const strapiFactory = getStrapiFactory({
       public: 'static/public/assets',
     },
   },
-  db: { transaction },
+  db: {
+    transaction,
+    lifecycles: {
+      enable: jest.fn(),
+      disable: jest.fn(),
+    },
+  },
   config: {
     get(service) {
       if (service === 'plugin.upload') {

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/index.test.ts
@@ -44,7 +44,13 @@ describe('Local Strapi Source Destination', () => {
     test('Should not have a defined Strapi instance if bootstrap has not been called', () => {
       const provider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -61,7 +67,13 @@ describe('Local Strapi Source Destination', () => {
     test('Should have a defined Strapi instance if bootstrap has been called', async () => {
       const provider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -81,7 +93,13 @@ describe('Local Strapi Source Destination', () => {
     test('requires strategy to be restore', async () => {
       const restoreProvider = createLocalStrapiDestinationProvider({
         getStrapi: getStrapiFactory({
-          db: { transaction },
+          db: {
+            transaction,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           ...strapiCommonProperties,
         }),
         strategy: 'restore',
@@ -173,6 +191,10 @@ describe('Local Strapi Source Destination', () => {
               transacting: jest.fn().mockReturnThis(),
             }),
           }),
+          lifecycles: {
+            enable: jest.fn(),
+            disable: jest.fn(),
+          },
         },
         ...strapiCommonProperties,
       })();

--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -68,7 +68,7 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
     if (!this.strapi) {
       throw new ProviderInitializationError('Could not access local strapi');
     }
-
+    this.strapi.db.lifecycles.disable();
     this.transaction = utils.transaction.createTransaction(this.strapi);
   }
 
@@ -102,7 +102,8 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
   async close(): Promise<void> {
     const { autoDestroy } = this.options;
     this.transaction?.end();
-
+    assertValidStrapi(this.strapi);
+    this.strapi.db.lifecycles.enable();
     // Basically `!== false` but more deterministic
     if (autoDestroy === undefined || autoDestroy === true) {
       await this.strapi?.destroy();

--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/index.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/index.test.ts
@@ -11,13 +11,31 @@ import { createLocalStrapiSourceProvider } from '..';
 describe('Local Strapi Source Provider', () => {
   describe('Bootstrap', () => {
     test('Should not have a defined Strapi instance if bootstrap has not been called', () => {
-      const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory() });
+      const provider = createLocalStrapiSourceProvider({
+        getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
+      });
 
       expect(provider.strapi).not.toBeDefined();
     });
 
     test('Should have a defined Strapi instance if bootstrap has been called', async () => {
-      const provider = createLocalStrapiSourceProvider({ getStrapi: getStrapiFactory() });
+      const provider = createLocalStrapiSourceProvider({
+        getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
+      });
       await provider.bootstrap();
 
       expect(provider.strapi).toBeDefined();
@@ -29,7 +47,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
       });
 
       await provider.bootstrap();
@@ -42,7 +68,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
         autoDestroy: true,
       });
 
@@ -56,7 +90,15 @@ describe('Local Strapi Source Provider', () => {
       const destroy = jest.fn();
 
       const provider = createLocalStrapiSourceProvider({
-        getStrapi: getStrapiFactory({ destroy }),
+        getStrapi: getStrapiFactory({
+          destroy,
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
+        }),
         autoDestroy: false,
       });
 
@@ -98,6 +140,10 @@ describe('Local Strapi Source Provider', () => {
           contentTypes,
           db: {
             queryBuilder,
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
           },
           getModel: jest.fn((uid) => {
             return contentTypes[uid];
@@ -163,6 +209,12 @@ describe('Local Strapi Source Provider', () => {
 
       const provider = createLocalStrapiSourceProvider({
         getStrapi: getStrapiFactory({
+          db: {
+            lifecycles: {
+              enable: jest.fn(),
+              disable: jest.fn(),
+            },
+          },
           contentTypes,
           components,
         }),

--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -39,6 +39,7 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   async bootstrap(diagnostics?: IDiagnosticReporter): Promise<void> {
     this.#diagnostics = diagnostics;
     this.strapi = await this.options.getStrapi();
+    this.strapi.db.lifecycles.disable();
   }
 
   #reportInfo(message: string) {
@@ -54,7 +55,8 @@ class LocalStrapiSourceProvider implements ISourceProvider {
 
   async close(): Promise<void> {
     const { autoDestroy } = this.options;
-
+    assertValidStrapi(this.strapi);
+    this.strapi.db.lifecycles.enable();
     // Basically `!== false` but more deterministic
     if (autoDestroy === undefined || autoDestroy === true) {
       await this.strapi?.destroy();

--- a/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/utils.ts
@@ -126,6 +126,8 @@ export const handleWSUpgrade = (wss: WebSocketServer, ctx: Context, callback: WS
     }
 
     disableTimeouts();
+    strapi.db.lifecycles.disable();
+    strapi.log.info('[Data transfer] Disabling lifecycle hooks');
 
     // Create a connection between the client & the server
     wss.emit('connection', client, ctx.req);
@@ -348,6 +350,8 @@ export const handlerControllerFactory =
             cannotRespondHandler(err);
           } finally {
             resetTimeouts();
+            strapi.db.lifecycles.enable();
+            strapi.log.info('[Data transfer] Restoring lifecycle hooks');
           }
         });
         ws.on('error', async (...args) => {


### PR DESCRIPTION
### What does it do?
- disable lifecycle hooks during a transfer
enable them back again after a transfer

### Why is it needed?
- prevent lifecycle hooks from being triggered during transfer operations

### How to test it?
- during a transfer or import or export lifecycle hooks should not be triggered

### Related issue(s)/PR(s)

fixes #19383 
