### PR TITLE
fix: webpack public path was missing a slash at the end

### DIFF
--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -167,7 +167,7 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<Configuratio
     output: {
       filename: '[name].js',
       path: ctx.distPath,
-      publicPath: ctx.basePath,
+      publicPath: `${ctx.basePath}/`,
     },
     infrastructureLogging: {
       level: 'error',

--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -167,7 +167,7 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<Configuratio
     output: {
       filename: '[name].js',
       path: ctx.distPath,
-      publicPath: `${ctx.basePath}/`,
+      publicPath: `${ctx.basePath.replace(/\/$/, '')}/`,
     },
     infrastructureLogging: {
       level: 'error',
@@ -193,7 +193,7 @@ const resolveProductionConfig = async (ctx: BuildContext): Promise<Configuration
     devtool: ctx.options.sourcemaps ? 'source-map' : false,
     output: {
       path: ctx.distPath,
-      publicPath: ctx.basePath,
+      publicPath: `${ctx.basePath.replace(/\/$/, '')}/`,
       // Utilize long-term caching by adding content hashes (not compilation hashes)
       // to compiled assets for production
       filename: '[name].[contenthash:8].js',


### PR DESCRIPTION
### What does it do?

It fixes the public path in the generated webpack config to include a slash as suffix


### Why is it needed?

The browser can not load the react backend when building with webpack.

Webpack was generating chunk paths like this `http://localhost:1337/admin1400.641ba92c.chunk.js` which results in a blank page as these files don't exist with that name. 

### How to test it?

I guess it should happen for anyone on current versions (I tried 5.6 and 5.8).

```
npx strapi build --bundler=webpack --debug
npx strapi start
```

### Workaround

We set this in our custom webpack config to keep the project running for now:

```
config.output.publicPath = "/admin/";
```