### PR TITLE
feat: updating Plan label now that we have a Growth plan

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
@@ -178,7 +178,7 @@ const ApplicationInfoPage = () => {
                     <Typography variant="sigma" textColor="neutral600" tag="dt">
                       {formatMessage({
                         id: 'Settings.application.edition-title',
-                        defaultMessage: 'current plan',
+                        defaultMessage: 'current edition',
                       })}
                     </Typography>
                     <Flex gap={3} direction="column" alignItems="start" tag="dd">

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -130,7 +130,7 @@
   "Settings.application.customization.modal.upload.next": "Next",
   "Settings.application.customization.size-details": "Max dimension: {dimension}×{dimension}, Max file size: {size}KB",
   "Settings.application.description": "Administration panel’s global information",
-  "Settings.application.edition-title": "current plan",
+  "Settings.application.edition-title": "current edition",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
   "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Add seats} other {Contact sales}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "At limit: add seats to invite more users",


### PR DESCRIPTION
### What does it do?

Simply updates the label in Settings -> Overview to Current Edition

### Why is it needed?

When buying a Growth Plan, Enterprise Edition is currently shown under a label saying Current Plan.

### How to test it?

Start Strapi and navigate to Settings -> Overview. The label should say Current Edition
