### PR TITLE
fix: adding component to dynamic zone overwrites data

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -574,8 +574,8 @@ const reducer = <TFormValues extends FormValues = FormValues>(
         }
 
         const [key] = generateNKeysBetween(
-          currentField.at(position > 0 ? position - 1 : position)?.__temp_key__,
-          currentField.at(position > 0 ? position : position - 1)?.__temp_key__,
+          position > 0 ? currentField.at(position - 1)?.__temp_key__ : null,
+          currentField.at(position)?.__temp_key__,
           1
         );
 

--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -574,15 +574,18 @@ const reducer = <TFormValues extends FormValues = FormValues>(
         }
 
         const [key] = generateNKeysBetween(
-          currentField.at(position - 1)?.__temp_key__,
-          currentField.at(position)?.__temp_key__,
+          currentField.at(position > 0 ? position - 1 : position)?.__temp_key__,
+          currentField.at(position > 0 ? position : position - 1)?.__temp_key__,
           1
         );
 
         draft.values = setIn(
           state.values,
           action.payload.field,
-          setIn(currentField, position.toString(), { ...action.payload.value, __temp_key__: key })
+          currentField.toSpliced(position, 0, {
+            ...action.payload.value,
+            __temp_key__: key,
+          })
         );
 
         break;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -149,7 +149,7 @@ const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger size="S" endIcon={null} paddingTop="4px" paddingLeft="7px" paddingRight="7px">
+        <Menu.Trigger size="S" endIcon={null} paddingTop={1} paddingLeft="7px" paddingRight="7px">
           <More aria-hidden focusable={false} />
           <VisuallyHidden tag="span">
             {formatMessage({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -7,11 +7,11 @@ import {
   Flex,
   Grid,
   IconButton,
-  VisuallyHidden,
   useComposedRefs,
   Menu,
   MenuItem,
   BoxComponent,
+  VisuallyHidden,
 } from '@strapi/design-system';
 import { Drag, More, Trash } from '@strapi/icons';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -156,6 +156,7 @@ const DynamicComponent = ({
               id: getTranslation('components.DynamicZone.more-actions'),
               defaultMessage: 'More actions',
             })}
+            tag="span"
           >
             <More aria-hidden focusable={false} />
           </IconButton>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -149,14 +149,16 @@ const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger size="S" endIcon={null} paddingTop={1} paddingLeft="7px" paddingRight="7px">
-          <More aria-hidden focusable={false} />
-          <VisuallyHidden tag="span">
-            {formatMessage({
+        <Menu.Trigger size="S" endIcon={null} paddingLeft={0} paddingRight={0}>
+          <IconButton
+            variant="ghost"
+            label={formatMessage({
               id: getTranslation('components.DynamicZone.more-actions'),
               defaultMessage: 'More actions',
             })}
-          </VisuallyHidden>
+          >
+            <More aria-hidden focusable={false} />
+          </IconButton>
         </Menu.Trigger>
         <Menu.Content>
           <Menu.SubRoot>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -11,7 +11,6 @@ import {
   Menu,
   MenuItem,
   BoxComponent,
-  VisuallyHidden,
 } from '@strapi/design-system';
 import { Drag, More, Trash } from '@strapi/icons';
 import { getEmptyImage } from 'react-dnd-html5-backend';

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -149,14 +149,7 @@ const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger
-          size="S"
-          endIcon={null}
-          paddingTop="4px"
-          // paddingBottom="4px"
-          paddingLeft="7px"
-          paddingRight="7px"
-        >
+        <Menu.Trigger size="S" endIcon={null} paddingTop="4px" paddingLeft="7px" paddingRight="7px">
           <More aria-hidden focusable={false} />
           <VisuallyHidden tag="span">
             {formatMessage({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -149,7 +149,14 @@ const DynamicComponent = ({
         <Drag />
       </IconButton>
       <Menu.Root>
-        <Menu.Trigger size="S" endIcon={null} paddingLeft={2} paddingRight={2}>
+        <Menu.Trigger
+          size="S"
+          endIcon={null}
+          paddingTop="4px"
+          // paddingBottom="4px"
+          paddingLeft="7px"
+          paddingRight="7px"
+        >
           <More aria-hidden focusable={false} />
           <VisuallyHidden tag="span">
             {formatMessage({

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -694,10 +694,16 @@ test.describe('Edit View', () => {
       expect(components[0]).toHaveText(/product carousel/i);
       expect(components[1]).toHaveText(/content and image/i);
 
-      // Add components add specific locations
+      // Add components add specific locations:
+      // - very last position
+      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).click();
+      await page.getByRole('menuitem', { name: /product carousel/i }).click();
+      // - very first position
       await components[0].getByRole('button', { name: /more actions/i }).click();
       await page.getByRole('menuitem', { name: /add component above/i }).click();
       await page.getByRole('menuitem', { name: /hero image/i }).click();
+      // - middle position
       await components[1].getByRole('button', { name: /more actions/i }).click();
       await page.getByRole('menuitem', { name: /add component below/i }).click();
       await page.getByRole('menuitem', { name: /hero image/i }).click();
@@ -707,11 +713,12 @@ test.describe('Edit View', () => {
         .getByRole('listitem')
         .filter({ has: page.getByRole('heading') })
         .all();
-      expect(updatedComponents).toHaveLength(4);
+      expect(updatedComponents).toHaveLength(5);
       expect(updatedComponents[0]).toHaveText(/hero image/i);
       expect(updatedComponents[1]).toHaveText(/product carousel/i);
       expect(updatedComponents[2]).toHaveText(/hero image/i);
       expect(updatedComponents[3]).toHaveText(/content and image/i);
+      expect(updatedComponents[4]).toHaveText(/product carousel/i);
     });
   });
 });

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -696,17 +696,17 @@ test.describe('Edit View', () => {
 
       // Add components add specific locations:
       // - very last position
-      await components[1].getByRole('button', { name: /more actions/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /product carousel/i }).click({ force: true });
+      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).dispatchEvent('click');
+      await page.getByRole('menuitem', { name: /product carousel/i }).dispatchEvent('click');
       // - very first position
-      await components[0].getByRole('button', { name: /more actions/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /add component above/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
+      await components[0].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component above/i }).dispatchEvent('click');
+      await page.getByRole('menuitem', { name: /hero image/i }).dispatchEvent('click');
       // - middle position
-      await components[1].getByRole('button', { name: /more actions/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
-      await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
+      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).dispatchEvent('click');
+      await page.getByRole('menuitem', { name: /hero image/i }).dispatchEvent('click');
 
       // Make sure we get the desired components order
       const updatedComponents = await page

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { findAndClose } from '../../utils/shared';
+import { clickAndWait, findAndClose, navToHeader } from '../../utils/shared';
 
 test.describe('Edit View', () => {
   test.beforeEach(async ({ page }) => {
@@ -677,6 +677,41 @@ test.describe('Edit View', () => {
       );
       await expect(page.getByRole('tab', { name: 'Draft' })).not.toBeDisabled();
       await expect(page.getByRole('tab', { name: 'Published' })).toBeDisabled();
+    });
+
+    test('as a user I want to add a component to a dynamic zone at a specific position', async ({
+      page,
+    }) => {
+      await page.getByLabel('Content Manager').click();
+      await navToHeader(page, ['Content Manager', 'Shop'], 'UK Shop');
+
+      // There should be a dynamic zone with two components
+      const components = await page
+        .getByRole('listitem')
+        .filter({ has: page.getByRole('heading') })
+        .all();
+      expect(components).toHaveLength(2);
+      expect(components[0]).toHaveText(/product carousel/i);
+      expect(components[1]).toHaveText(/content and image/i);
+
+      // Add components add specific locations
+      await components[0].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component above/i }).click();
+      await page.getByRole('menuitem', { name: /hero image/i }).click();
+      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).click();
+      await page.getByRole('menuitem', { name: /hero image/i }).click();
+
+      // Make sure we get the desired components order
+      const updatedComponents = await page
+        .getByRole('listitem')
+        .filter({ has: page.getByRole('heading') })
+        .all();
+      expect(updatedComponents).toHaveLength(4);
+      expect(updatedComponents[0]).toHaveText(/hero image/i);
+      expect(updatedComponents[1]).toHaveText(/product carousel/i);
+      expect(updatedComponents[2]).toHaveText(/hero image/i);
+      expect(updatedComponents[3]).toHaveText(/content and image/i);
     });
   });
 });

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -696,15 +696,15 @@ test.describe('Edit View', () => {
 
       // Add components add specific locations:
       // - very last position
-      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await components[1].getByRole('button', { name: /more actions/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /product carousel/i }).click({ force: true });
       // - very first position
-      await components[0].getByRole('button', { name: /more actions/i }).click();
+      await components[0].getByRole('button', { name: /more actions/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /add component above/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
       // - middle position
-      await components[1].getByRole('button', { name: /more actions/i }).click();
+      await components[1].getByRole('button', { name: /more actions/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
       await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
 

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -694,7 +694,7 @@ test.describe('Edit View', () => {
       expect(components[0]).toHaveText(/product carousel/i);
       expect(components[1]).toHaveText(/content and image/i);
 
-      // Add components add specific locations:
+      // Add components at specific locations:
       // - very last position
       await components[1].getByRole('button', { name: /more actions/i }).click();
       await page.getByRole('menuitem', { name: /add component below/i }).dispatchEvent('click');

--- a/tests/e2e/tests/content-manager/editview.spec.ts
+++ b/tests/e2e/tests/content-manager/editview.spec.ts
@@ -697,16 +697,16 @@ test.describe('Edit View', () => {
       // Add components add specific locations:
       // - very last position
       await components[1].getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /add component below/i }).click();
-      await page.getByRole('menuitem', { name: /product carousel/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
+      await page.getByRole('menuitem', { name: /product carousel/i }).click({ force: true });
       // - very first position
       await components[0].getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /add component above/i }).click();
-      await page.getByRole('menuitem', { name: /hero image/i }).click();
+      await page.getByRole('menuitem', { name: /add component above/i }).click({ force: true });
+      await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
       // - middle position
       await components[1].getByRole('button', { name: /more actions/i }).click();
-      await page.getByRole('menuitem', { name: /add component below/i }).click();
-      await page.getByRole('menuitem', { name: /hero image/i }).click();
+      await page.getByRole('menuitem', { name: /add component below/i }).click({ force: true });
+      await page.getByRole('menuitem', { name: /hero image/i }).click({ force: true });
 
       // Make sure we get the desired components order
       const updatedComponents = await page


### PR DESCRIPTION
### What does it do?

- Fixes #22399. I do the fix by not relying on setIn anymore, because it's designed to overwrite content at the index it's given. I use toSpliced instead (the FP version of splice) which just inserts at the the given position
- Adds new e2e test case to catch the issue
- Fixes the alignment of the "more" action button on components

### Why is it needed?

To avoid accidental data loss

### How to test it?

Create content in dynamic zones, add components to the top, to the bottom, in the middle, maybe delete and recreate some.

Also do sanity check changing review workflows stages, because it seems to use the same addFieldRow util.
