### PR TITLE
fix: delete orphan component data when schema changes

### DIFF
--- a/packages/core/admin/ee/server/src/utils/persisted-tables.ts
+++ b/packages/core/admin/ee/server/src/utils/persisted-tables.ts
@@ -24,7 +24,6 @@ const transformTableName = (table: string | PersistedTable) => {
  * @returns {Promise<string[]>}
  */
 export async function findTables({ strapi }: { strapi: LoadedStrapi }, regex: any) {
-  // @ts-expect-error - getTables is not typed into the schema inspector
   const tables = await strapi.db.dialect.schemaInspector.getTables();
   return tables.filter((tableName: string) => regex.test(tableName));
 }

--- a/packages/core/database/src/dialects/dialect.ts
+++ b/packages/core/database/src/dialects/dialect.ts
@@ -3,6 +3,7 @@ import type { Schema } from '../schema';
 
 export interface SchemaInspector {
   getSchema(): Promise<Schema>;
+  getTables(): Promise<string[]>;
 }
 
 export default class Dialect {
@@ -20,6 +21,10 @@ export default class Dialect {
   configure() {}
 
   initialize() {}
+
+  getTables() {
+    throw new Error('getTables not implemented for this dialect');
+  }
 
   getSqlType(type: unknown) {
     return type;

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -9,6 +9,7 @@ import { createLifecyclesProvider, LifecycleProvider } from './lifecycles';
 import { createConnection } from './connection';
 import * as errors from './errors';
 import { Callback, transactionCtx, TransactionObject } from './transaction-context';
+import { createRepairManager, type RepairManager } from './repairs';
 
 // TODO: move back into strapi
 import { transformContentTypes } from './utils/content-types';
@@ -23,10 +24,16 @@ interface Settings {
   [key: string]: unknown;
 }
 
+export type Logger = Record<
+  'info' | 'warn' | 'error' | 'debug',
+  (message: string | Record<string, unknown>) => void
+>;
+
 export interface DatabaseConfig {
   connection: Knex.Config;
   settings: Settings;
   models: Model[];
+  logger?: Logger;
 }
 
 class Database {
@@ -45,6 +52,8 @@ class Database {
   lifecycles: LifecycleProvider;
 
   entityManager: EntityManager;
+
+  repair: RepairManager;
 
   static transformContentTypes = transformContentTypes;
 
@@ -79,6 +88,8 @@ class Database {
     this.lifecycles = createLifecyclesProvider(this);
 
     this.entityManager = createEntityManager(this);
+
+    this.repair = createRepairManager(this);
   }
 
   query(uid: string) {

--- a/packages/core/database/src/repairs/__tests__/remove-orphan-morph-types.test.ts
+++ b/packages/core/database/src/repairs/__tests__/remove-orphan-morph-types.test.ts
@@ -1,0 +1,192 @@
+import createDebugger, { type Debugger } from 'debug';
+import { removeOrphanMorphType } from '../operations/remove-orphan-morph-types';
+import type { Database } from '../..';
+
+const PIVOT_COLUMN = 'component_type';
+const DEFAULT_TYPE = 'default_mycompo';
+
+jest.mock('debug', () => {
+  const debugInstance = jest.fn();
+  const createDebugger = jest.fn(() => debugInstance);
+  return createDebugger;
+});
+
+const mockCreateDebugger = jest.mocked(createDebugger);
+
+describe('removeOrphanMorphType', () => {
+  let mockDb: jest.Mocked<Database>;
+  let mockDebug: jest.MockedFunction<Debugger>;
+
+  beforeEach(() => {
+    mockDb = {
+      metadata: {
+        values: jest.fn(),
+        get: jest.fn(),
+      },
+      connection: jest.fn().mockImplementation(() => ({
+        distinct: jest.fn().mockReturnValue({
+          pluck: jest.fn().mockResolvedValue(['validType', DEFAULT_TYPE]),
+        }),
+        where: jest.fn().mockReturnValue({
+          del: jest.fn().mockResolvedValue(1),
+        }),
+      })),
+    } as unknown as jest.Mocked<Database>;
+
+    // Reset the mock functions for each test
+    mockCreateDebugger.mockClear();
+    mockDebug = mockCreateDebugger('strapi::database') as unknown as jest.MockedFunction<Debugger>;
+    mockDebug.mockClear();
+  });
+
+  it('should log debug messages and remove orphan morph types', async () => {
+    const mockMetadataMap = new Map([
+      [
+        'model1',
+        {
+          attributes: {
+            someRelation: {
+              type: 'relation',
+              relation: 'morph',
+              joinTable: {
+                name: 'some_table',
+                pivotColumns: [PIVOT_COLUMN],
+              },
+              target: 'someTarget',
+            },
+          },
+        },
+      ],
+    ]);
+
+    (mockDb.metadata.values as jest.Mock).mockReturnValue(mockMetadataMap.values());
+
+    mockDb.metadata.get = jest.fn().mockImplementation((type: string) => {
+      if (type === 'validType') {
+        return {}; // Simulate valid metadata
+      }
+      throw new Error('Metadata not found'); // Simulate missing metadata
+    }) as jest.MockedFunction<typeof mockDb.metadata.get>;
+
+    await removeOrphanMorphType(mockDb, { pivot: PIVOT_COLUMN });
+
+    expect(mockCreateDebugger).toHaveBeenCalledWith('strapi::database');
+    expect(mockDebug).toHaveBeenCalledWith(
+      expect.stringContaining(`Removing orphaned morph type: "${PIVOT_COLUMN}"`)
+    );
+    expect(mockDebug).toHaveBeenCalledWith(
+      expect.stringContaining(`Removing invalid morph type "${DEFAULT_TYPE}"`)
+    );
+    expect(mockDb.connection).toHaveBeenCalledWith('some_table');
+  });
+
+  it('should not query the database when there are no attributes with the specified pivot', async () => {
+    const mockMetadataMap = new Map([
+      [
+        'model1',
+        {
+          attributes: {
+            unrelatedRelation: {
+              type: 'relation',
+              relation: 'other',
+              joinTable: {
+                name: 'unrelated_table',
+                pivotColumns: ['unrelated'],
+              },
+              target: 'someTarget',
+            },
+          },
+        },
+      ],
+    ]);
+
+    (mockDb.metadata.values as jest.Mock).mockReturnValue(mockMetadataMap.values());
+
+    await removeOrphanMorphType(mockDb, { pivot: PIVOT_COLUMN });
+
+    expect(mockCreateDebugger).toHaveBeenCalledWith('strapi::database');
+    expect(mockDebug).toHaveBeenCalledWith(
+      expect.stringContaining(`Removing orphaned morph type: "${PIVOT_COLUMN}"`)
+    );
+    expect(mockDb.connection).not.toHaveBeenCalled();
+  });
+
+  it('should only query models with the specified pivot column', async () => {
+    const mockMetadataMap = new Map([
+      [
+        'model1',
+        {
+          attributes: {
+            someRelation: {
+              type: 'relation',
+              relation: 'morph',
+              joinTable: {
+                name: 'table_with_component_type',
+                pivotColumns: [PIVOT_COLUMN],
+              },
+              target: 'someTarget',
+            },
+          },
+        },
+      ],
+      [
+        'model2',
+        {
+          attributes: {
+            anotherRelation: {
+              type: 'relation',
+              relation: 'other',
+              joinTable: {
+                name: 'table_without_component_type',
+                pivotColumns: ['other_column'],
+              },
+              target: 'anotherTarget',
+            },
+          },
+        },
+      ],
+      [
+        'model3',
+        {
+          attributes: {
+            yetAnotherRelation: {
+              type: 'relation',
+              relation: 'morph',
+              joinTable: {
+                name: 'another_table_with_component_type',
+                pivotColumns: [PIVOT_COLUMN],
+              },
+              target: 'yetAnotherTarget',
+            },
+          },
+        },
+      ],
+    ]);
+
+    (mockDb.metadata.values as jest.Mock).mockReturnValue(mockMetadataMap.values());
+
+    mockDb.metadata.get = jest.fn().mockImplementation((type: string) => {
+      if (type === 'validType') {
+        return {}; // Simulate valid metadata
+      }
+      throw new Error('Metadata not found'); // Simulate missing metadata
+    }) as jest.MockedFunction<typeof mockDb.metadata.get>;
+
+    await removeOrphanMorphType(mockDb, { pivot: PIVOT_COLUMN });
+
+    expect(mockCreateDebugger).toHaveBeenCalledWith('strapi::database');
+    expect(mockDebug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Removing invalid morph type "${DEFAULT_TYPE}" from table "table_with_component_type".`
+      )
+    );
+    expect(mockDebug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Removing invalid morph type "${DEFAULT_TYPE}" from table "another_table_with_component_type".`
+      )
+    );
+    expect(mockDb.connection).toHaveBeenCalledWith('table_with_component_type');
+    expect(mockDb.connection).toHaveBeenCalledWith('another_table_with_component_type');
+    expect(mockDb.connection).not.toHaveBeenCalledWith('table_without_component_type');
+  });
+});

--- a/packages/core/database/src/repairs/__tests__/repair.test.ts
+++ b/packages/core/database/src/repairs/__tests__/repair.test.ts
@@ -1,0 +1,96 @@
+import { Database } from '../..';
+import { createRepairManager } from '../index';
+import { removeOrphanMorphType } from '../operations/remove-orphan-morph-types';
+import { createConnection } from '../../connection';
+
+// Mock all the dependencies
+jest.mock('../index', () => ({
+  createRepairManager: jest.fn(() => ({
+    removeOrphanMorphType: jest.requireActual('../operations/remove-orphan-morph-types')
+      .removeOrphanMorphType,
+  })),
+}));
+
+jest.mock('../../migrations', () => ({
+  createMigrationsProvider: jest.fn(() => ({})),
+}));
+
+jest.mock('../../schema', () => ({
+  createSchemaProvider: jest.fn(() => ({})),
+}));
+
+jest.mock('../../lifecycles', () => ({
+  createLifecyclesProvider: jest.fn(() => ({
+    clear: jest.fn(),
+  })),
+}));
+
+jest.mock('../../entity-manager', () => ({
+  createEntityManager: jest.fn(() => ({})),
+}));
+
+jest.mock('../../metadata', () => ({
+  createMetadata: jest.fn(() => ({})),
+}));
+
+jest.mock('../../connection', () => ({
+  createConnection: jest.fn(),
+}));
+
+describe('Database Repair Manager', () => {
+  let mockKnex: any;
+  let mockConfig: any;
+
+  beforeEach(() => {
+    // Mock Knex instance
+    mockKnex = {
+      destroy: jest.fn().mockResolvedValue(undefined),
+      transaction: jest.fn(),
+      client: {
+        connectionSettings: {},
+      },
+      schema: {
+        withSchema: jest.fn().mockReturnThis(),
+      },
+      raw: jest.fn().mockResolvedValue({}), // Mock raw SQL execution
+    };
+
+    // Mock Configuration
+    mockConfig = {
+      connection: {
+        client: 'sqlite',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true, // Suppress SQLite warnings
+      },
+      settings: {},
+      logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    };
+
+    // Mock the `createConnection` function to return the mocked Knex instance
+    (createConnection as jest.Mock).mockReturnValue(mockKnex);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize with a repair manager containing removeOrphanMorphType', async () => {
+    const database = new Database(mockConfig);
+
+    // Assertions
+    expect(createRepairManager).toHaveBeenCalledWith(database);
+    expect(database.repair).toBeDefined();
+    expect(database.repair.removeOrphanMorphType).toBeDefined();
+    expect(typeof database.repair.removeOrphanMorphType).toBe('function');
+    expect(database.repair.removeOrphanMorphType).toBe(removeOrphanMorphType);
+
+    // Simulate database destruction
+    await database.destroy();
+    expect(mockKnex.destroy).toHaveBeenCalled();
+  });
+});

--- a/packages/core/database/src/repairs/index.ts
+++ b/packages/core/database/src/repairs/index.ts
@@ -1,0 +1,11 @@
+import type { Database } from '..';
+import { removeOrphanMorphType as removeOrphanMorphTypeFunc } from './operations/remove-orphan-morph-types';
+import { asyncCurry } from '../utils/async-curry';
+
+export const createRepairManager = (db: Database) => {
+  return {
+    removeOrphanMorphType: asyncCurry(removeOrphanMorphTypeFunc)(db),
+  };
+};
+
+export type RepairManager = ReturnType<typeof createRepairManager>;

--- a/packages/core/database/src/repairs/operations/remove-orphan-morph-types.ts
+++ b/packages/core/database/src/repairs/operations/remove-orphan-morph-types.ts
@@ -1,0 +1,88 @@
+import createDebug from 'debug';
+import type { Database } from '../..';
+import type { Attribute, MorphRelationalAttribute } from '../../types';
+
+const debug = createDebug('strapi::database');
+
+export interface RemoveOrphanMorphTypeOptions {
+  pivot: string;
+}
+
+const isMorphRelationWithPivot = (
+  attribute: Attribute,
+  pivot: string
+): attribute is MorphRelationalAttribute => {
+  return (
+    attribute.type === 'relation' &&
+    'relation' in attribute &&
+    'joinTable' in attribute &&
+    'target' in attribute &&
+    'name' in attribute.joinTable &&
+    'pivotColumns' in attribute.joinTable &&
+    attribute.joinTable.pivotColumns.includes(pivot)
+  );
+};
+
+const filterMorphRelationalAttributes = (
+  attributes: Record<string, Attribute>,
+  pivot: string
+): MorphRelationalAttribute[] => {
+  return Object.values(attributes).filter((attribute): attribute is MorphRelationalAttribute =>
+    isMorphRelationWithPivot(attribute, pivot)
+  );
+};
+
+/**
+ * Removes morph relation data with invalid or non-existent morph type.
+ *
+ * This function iterates over the database metadata to identify morph relationships
+ * (relations with a `joinTable` containing the specified pivot column) and removes
+ * any entries in the relation's join table where the morph type is invalid.
+ *
+ * Note: This function does not check for orphaned IDs, only orphaned morph types.
+ *
+ * @param db - The database object containing metadata and a Knex connection.
+ * @param options.pivot - The name of the column in the join table representing the morph type.
+ */
+export const removeOrphanMorphType = async (
+  db: Database,
+  { pivot }: RemoveOrphanMorphTypeOptions
+) => {
+  debug(`Removing orphaned morph type: ${JSON.stringify(pivot)}`);
+
+  const mdValues = db.metadata.values();
+  for (const model of mdValues) {
+    const attributes = filterMorphRelationalAttributes(model.attributes || {}, pivot);
+
+    for (const attribute of attributes) {
+      const joinTableName = attribute.joinTable.name;
+
+      // Query distinct morph types from the join table
+      const morphTypes = await db.connection(joinTableName).distinct(pivot).pluck(pivot);
+
+      for (const morphType of morphTypes) {
+        // Check if metadata for the morph type exists
+        const deleteComponentType = await (async () => {
+          try {
+            return !db.metadata.get(morphType); // If no metadata found, mark for deletion
+          } catch {
+            debug(`Metadata for morph type "${morphType}" in table "${joinTableName}" not found`);
+            return true; // Return true to delete if metadata is missing
+          }
+        })();
+
+        if (deleteComponentType) {
+          debug(`Removing invalid morph type "${morphType}" from table "${joinTableName}".`);
+          try {
+            await db.connection(joinTableName).where(pivot, morphType).del();
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            debug(
+              `Failed to remove invalid morph type "${morphType}" from table "${joinTableName}": ${errorMessage}`
+            );
+          }
+        }
+      }
+    }
+  }
+};

--- a/packages/core/database/src/schema/index.ts
+++ b/packages/core/database/src/schema/index.ts
@@ -6,6 +6,7 @@ import createSchemaStorage from './storage';
 import { metadataToSchema } from './schema';
 
 import type { Database } from '..';
+import { SchemaDiff } from './types';
 
 export type * from './types';
 
@@ -15,8 +16,8 @@ export interface SchemaProvider {
   builder: ReturnType<typeof createSchemaBuilder>;
   schemaDiff: ReturnType<typeof createSchemaDiff>;
   schemaStorage: ReturnType<typeof createSchemaStorage>;
-  sync(): Promise<void>;
-  syncSchema(): Promise<void>;
+  sync(): Promise<SchemaDiff['status']>;
+  syncSchema(): Promise<SchemaDiff['status']>;
   reset(): Promise<void>;
   create(): Promise<void>;
   drop(): Promise<void>;
@@ -60,7 +61,7 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       await this.create();
     },
 
-    async syncSchema() {
+    async syncSchema(): Promise<SchemaDiff['status']> {
       debug('Synchronizing database schema');
 
       const DBSchema = await db.dialect.schemaInspector.getSchema();
@@ -72,12 +73,14 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       }
 
       await this.schemaStorage.add(schema);
+
+      return status;
     },
 
     // TODO: support options to migrate softly or forcefully
     // TODO: support option to disable auto migration & run a CLI command instead to avoid doing it at startup
     // TODO: Allow keeping extra indexes / extra tables / extra columns (globally or on a per table basis)
-    async sync() {
+    async sync(): Promise<SchemaDiff['status']> {
       if (await db.migrations.shouldRun()) {
         debug('Found migrations to run');
         await db.migrations.up();
@@ -102,6 +105,8 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       }
 
       debug('Schema unchanged');
+
+      return 'UNCHANGED';
     },
   };
 };

--- a/packages/core/database/src/utils/async-curry.ts
+++ b/packages/core/database/src/utils/async-curry.ts
@@ -1,0 +1,28 @@
+// lodash/fp curry does not handle async functions properly, and creates very "ugly" types,
+// so we will use our own version to ensure curried functions are typed correctly
+// TODO: Export this from root @strapi/utils so we don't have copies of it between packages
+
+/**
+ * @internal
+ */
+export const asyncCurry = <Args extends any[], R>(
+  fn: (...args: Args) => Promise<R>
+): CurriedAsyncFunction<Args, R> => {
+  const curried = (...args: any[]): any => {
+    if (args.length >= fn.length) {
+      return fn(...(args as Args));
+    }
+    return (...moreArgs: any[]) => curried(...args, ...moreArgs);
+  };
+
+  return curried as CurriedAsyncFunction<Args, R>;
+};
+
+/**
+ * @internal
+ */
+export type CurriedAsyncFunction<Args extends any[], R> = Args extends [infer First, ...infer Rest]
+  ? Rest extends []
+    ? (arg: First) => Promise<R>
+    : (arg: First) => CurriedAsyncFunction<Rest, R>
+  : () => Promise<R>;

--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -592,7 +592,12 @@ class Strapi implements StrapiI {
       contentTypes: this.contentTypes,
     });
 
-    await this.db.schema.sync();
+    const status = await this.db.schema.sync();
+
+    // if schemas have changed, run repairs
+    if (status === 'CHANGED') {
+      await this.db.repair.removeOrphanMorphType({ pivot: 'component_type' });
+    }
 
     if (this.EE) {
       await ee.checkLicense({ strapi: this });

--- a/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
+++ b/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const { createAuthRequest } = require('api-tests/request');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createTestBuilder } = require('api-tests/builder');
+const pluralize = require('pluralize');
+
+let strapi;
+let rq;
+const warnSpy = jest.fn();
+
+const restart = async () => {
+  await strapi.destroy();
+  strapi = await createStrapiInstance();
+
+  rq = await createAuthRequest({ strapi });
+};
+
+const compoSchema = {
+  category: 'default',
+  displayName: 'temporarycomponent',
+  attributes: {
+    title: { type: 'string', required: false },
+  },
+};
+
+const componentUID = `${compoSchema.category}.${compoSchema.displayName}`;
+
+const compoKeepSchema = {
+  category: 'default',
+  displayName: 'keepcomponent',
+  attributes: {
+    title: { type: 'string', required: false },
+  },
+};
+
+const componentKeepUID = `${compoKeepSchema.category}.${compoKeepSchema.displayName}`;
+
+const contentType = {
+  displayName: 'contentwithcomponent',
+  singularName: 'contentwithcomponent',
+  pluralName: 'contentwithcomponents',
+  // draftAndPublish: true,
+  attributes: {
+    tempcomp: {
+      type: 'component',
+      component: componentUID,
+      required: false,
+      repeatable: true,
+    },
+    keepcomp: {
+      type: 'component',
+      component: componentKeepUID,
+      required: false,
+      repeatable: true,
+    },
+  },
+};
+
+const testCollectionTypeUID = `api::${contentType.singularName}.${contentType.singularName}`;
+
+describe('Component Deletion and Cleanup Test', () => {
+  const builder = createTestBuilder();
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    // Create the permanent component
+    await rq({
+      method: 'POST',
+      url: '/content-type-builder/components',
+      body: {
+        component: compoKeepSchema,
+      },
+    });
+    await restart();
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('Create and delete component, then verify cleanup', async () => {
+    // Create a component
+    const compoResult = await rq({
+      method: 'POST',
+      url: '/content-type-builder/components',
+      body: {
+        component: compoSchema,
+      },
+    });
+
+    expect(compoResult.statusCode).toBe(201);
+    expect(compoResult.body).toEqual({
+      data: {
+        uid: componentUID,
+      },
+    });
+
+    await restart();
+
+    // Create content type with the component
+    const ctResult = await rq({
+      method: 'POST',
+      url: '/content-type-builder/content-types',
+      body: {
+        contentType,
+      },
+    });
+
+    expect(ctResult.statusCode).toBe(201);
+    expect(ctResult.body).toEqual({
+      data: {
+        uid: testCollectionTypeUID,
+      },
+    });
+
+    await restart();
+
+    // Create an entry with the component
+    const entryData = {
+      tempcomp: [{ title: 'Sample One' }, { title: 'Sample Two' }],
+      keepcomp: [{ title: 'Sample Three' }, { title: 'Sample Four' }],
+    };
+
+    const entryRes = await rq({
+      method: 'POST',
+      url: `/content-manager/collection-types/${testCollectionTypeUID}`,
+      body: entryData,
+    });
+
+    expect(entryRes.statusCode).toBe(200);
+
+    // Query the content type's components table to check for the entry's component data
+    const dbResultBeforeDeletion = await strapi.db.connection
+      .select('*')
+      .from(`${contentType.pluralName}_components`);
+
+    // Verify data for the components exists in the database
+    expect(dbResultBeforeDeletion.filter((row) => row.component_type === componentUID).length).toBe(
+      2
+    );
+    expect(
+      dbResultBeforeDeletion.filter((row) => row.component_type === componentKeepUID).length
+    ).toBe(2);
+
+    // Delete the component
+    const deleteComponentRes = await rq({
+      method: 'DELETE',
+      url: `/content-type-builder/components/${componentUID}`,
+    });
+
+    expect(deleteComponentRes.statusCode).toBe(200);
+    expect(deleteComponentRes.body).toEqual({
+      data: { uid: componentUID },
+    });
+
+    await restart();
+
+    // Verify the component is no longer accessible
+    const fetchDeletedComponentRes = await rq({
+      method: 'GET',
+      url: `/content-type-builder/components/${componentUID}`,
+    });
+
+    expect(fetchDeletedComponentRes.statusCode).toBe(404);
+    expect(fetchDeletedComponentRes.body).toEqual({
+      error: 'component.notFound',
+    });
+
+    // Ensure data related to the deleted component is no longer in the database
+    const dbResult = await strapi.db.connection.raw(
+      `SELECT * FROM ${contentType.pluralName}_components`
+    );
+
+    // Ensure table for the deleted component no longer exists
+    const tempComponentTableExists = await strapi.db.connection.schema.hasTable(
+      `components_${compoSchema.category}_${pluralize(compoSchema.displayName)}`
+    );
+    expect(tempComponentTableExists).toBe(false);
+
+    // Ensure table for the retained component still exists
+    const keepComponentTableExists = await strapi.db.connection.schema.hasTable(
+      `components_${compoKeepSchema.category}_${pluralize(compoKeepSchema.displayName)}`
+    );
+    expect(keepComponentTableExists).toBe(true);
+
+    // Verify our content type has no references to the deleted component
+    const hasDeletedComponentData = dbResult.some((row) => row.component_type === componentUID);
+    expect(hasDeletedComponentData).toBe(false);
+
+    // Recreate the component
+    const recreatedComponentResult = await rq({
+      method: 'POST',
+      url: '/content-type-builder/components',
+      body: {
+        component: compoSchema,
+      },
+    });
+
+    expect(recreatedComponentResult.statusCode).toBe(201);
+    expect(recreatedComponentResult.body).toEqual({
+      data: {
+        uid: componentUID,
+      },
+    });
+
+    await restart();
+
+    // Update content type to add it back to confirm it works (no remnants blocking it)
+    const updatedContentTypeResult = await rq({
+      method: 'PUT',
+      url: `/content-type-builder/content-types/${testCollectionTypeUID}`,
+      body: {
+        contentType,
+      },
+    });
+
+    expect(updatedContentTypeResult.statusCode).toBe(201);
+    expect(updatedContentTypeResult.body).toEqual({
+      data: {
+        uid: testCollectionTypeUID,
+      },
+    });
+  });
+});

--- a/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
+++ b/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
@@ -40,7 +40,6 @@ const contentType = {
   displayName: 'contentwithcomponent',
   singularName: 'contentwithcomponent',
   pluralName: 'contentwithcomponents',
-  // draftAndPublish: true,
   attributes: {
     tempcomp: {
       type: 'component',

--- a/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
+++ b/tests/api/core/strapi/components/cleanup-after-delete.test.api.js
@@ -7,7 +7,6 @@ const pluralize = require('pluralize');
 
 let strapi;
 let rq;
-const warnSpy = jest.fn();
 
 const restart = async () => {
   await strapi.destroy();


### PR DESCRIPTION
### What does it do?

- backports the [database repair manager](https://github.com/strapi/strapi/pull/22267)
- run it on startup when schema changes are detected

### Why is it needed?

Fixes https://github.com/strapi/strapi/issues/20931

### How to test it?

To test manually:

- create a component
- add it to a content type
- add some data for it
- delete the component
- the component data should no longer exist in the `_components` table for that content type

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/20931 for v4

Seems to fix https://github.com/strapi/strapi/issues/19535 for me, but waiting on confirmation

Backported from v5 PR: https://github.com/strapi/strapi/pull/22267

DX-1731
