### PR TITLE
feat: add email confirmation error redirection settings

### DIFF
--- a/examples/getstarted/config/plugins.js
+++ b/examples/getstarted/config/plugins.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = ({ env }) => ({
+module.exports = () => ({
   graphql: {
     enabled: true,
     config: {
@@ -34,23 +34,5 @@ module.exports = ({ env }) => ({
   todo: {
     enabled: false,
     resolve: `../plugins/todo-example`, // From the /examples/plugins folder
-  },
-
-  email: {
-    config: {
-      provider: 'nodemailer',
-      providerOptions: {
-        host: env('SMTP_HOST'),
-        port: env('SMTP_PORT', 1025),
-        auth: {
-          user: env('SMTP_USERNAME'),
-          pass: env('SMTP_PASSWORD'),
-        },
-      },
-      settings: {
-        defaultFrom: env('SMTP_EMAIL'),
-        defaultReplyTo: env('SMTP_EMAIL'),
-      },
-    },
   },
 });

--- a/examples/getstarted/config/plugins.js
+++ b/examples/getstarted/config/plugins.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = () => ({
+module.exports = ({ env }) => ({
   graphql: {
     enabled: true,
     config: {
@@ -34,5 +34,23 @@ module.exports = () => ({
   todo: {
     enabled: false,
     resolve: `../plugins/todo-example`, // From the /examples/plugins folder
+  },
+
+  email: {
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: env('SMTP_HOST'),
+        port: env('SMTP_PORT', 1025),
+        auth: {
+          user: env('SMTP_USERNAME'),
+          pass: env('SMTP_PASSWORD'),
+        },
+      },
+      settings: {
+        defaultFrom: env('SMTP_EMAIL'),
+        defaultReplyTo: env('SMTP_EMAIL'),
+      },
+    },
   },
 });

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/schema.test.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/tests/schema.test.js
@@ -16,6 +16,7 @@ describe('schema', () => {
       schema.validateSync({
         email_confirmation: true,
         email_confirmation_redirection: 'http://example.com/redirection',
+        email_confirmation_error_redirection: 'http://example.com/redirection-error',
         email_reset_password: null,
       })
     ).not.toThrow();
@@ -24,6 +25,7 @@ describe('schema', () => {
       schema.validateSync({
         email_confirmation: true,
         email_confirmation_redirection: 'https://example.com/redirection',
+        email_confirmation_error_redirection: 'http://example.com/redirection-error',
         email_reset_password: null,
       })
     ).not.toThrow();
@@ -32,6 +34,7 @@ describe('schema', () => {
       schema.validateSync({
         email_confirmation: true,
         email_confirmation_redirection: 'some://link',
+        email_confirmation_error_redirection: 'some://link',
         email_reset_password: null,
       })
     ).not.toThrow();
@@ -40,6 +43,7 @@ describe('schema', () => {
       schema.validateSync({
         email_confirmation: true,
         email_confirmation_redirection: 'market://details?id=com.example.com',
+        email_confirmation_error_redirection: 'market://details?id=com.example.com',
         email_reset_password: null,
       })
     ).not.toThrow();

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
@@ -1,98 +1,62 @@
 import { getTrad } from '../../../utils';
 
+const createField = ({ id, defaultMessage, name, type = 'string', size = 12, placeholder }) => ({
+  label: {
+    id: getTrad(`EditForm.inputToggle.label.${id}`),
+    defaultMessage,
+  },
+  hint: {
+    id: getTrad(`EditForm.inputToggle.description.${id}`),
+    defaultMessage: `Description for ${defaultMessage}`,
+  },
+  name,
+  type,
+  size,
+  ...(placeholder && {
+    placeholder: {
+      id: getTrad(`EditForm.inputToggle.placeholder.${id}`),
+      defaultMessage: placeholder,
+    },
+  }),
+});
+
 const layout = [
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.email'),
-      defaultMessage: 'One account per email address',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.email'),
-      defaultMessage:
-        'Disallow the user to create multiple accounts using the same email address with different authentication providers.',
-    },
+  createField({
+    id: 'email',
+    defaultMessage: 'One account per email address',
     name: 'unique_email',
     type: 'boolean',
-    size: 12,
-  },
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.sign-up'),
-      defaultMessage: 'Enable sign-ups',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.sign-up'),
-      defaultMessage:
-        'When disabled (OFF), the registration process is forbidden. No one can subscribe anymore no matter the used provider.',
-    },
+  }),
+  createField({
+    id: 'sign-up',
+    defaultMessage: 'Enable sign-ups',
     name: 'allow_register',
     type: 'boolean',
-    size: 12,
-  },
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.email-reset-password'),
-      defaultMessage: 'Reset password page',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.email-reset-password'),
-      defaultMessage: "URL of your application's reset password page.",
-    },
-    placeholder: {
-      id: getTrad('EditForm.inputToggle.placeholder.email-reset-password'),
-      defaultMessage: 'ex: https://youtfrontend.com/reset-password',
-    },
+  }),
+  createField({
+    id: 'email-reset-password',
+    defaultMessage: 'Reset password page',
     name: 'email_reset_password',
-    type: 'string',
-    size: 12,
-  },
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.email-confirmation'),
-      defaultMessage: 'Enable email confirmation',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.email-confirmation'),
-      defaultMessage: 'When enabled (ON), new registered users receive a confirmation email.',
-    },
+    placeholder: 'ex: https://youtfrontend.com/reset-password',
+  }),
+  createField({
+    id: 'email-confirmation',
+    defaultMessage: 'Enable email confirmation',
     name: 'email_confirmation',
     type: 'boolean',
-    size: 12,
-  },
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.email-confirmation-redirection'),
-      defaultMessage: 'Redirection url',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.email-confirmation-redirection'),
-      defaultMessage: 'After you confirmed your email, choose where you will be redirected.',
-    },
-    placeholder: {
-      id: getTrad('EditForm.inputToggle.placeholder.email-confirmation-redirection'),
-      defaultMessage: 'ex: https://youtfrontend.com/email-confirmation',
-    },
+  }),
+  createField({
+    id: 'email-confirmation-redirection',
+    defaultMessage: 'Redirection url',
     name: 'email_confirmation_redirection',
-    type: 'string',
-    size: 12,
-  },
-  {
-    label: {
-      id: getTrad('EditForm.inputToggle.label.email-confirmation-error-redirection'),
-      defaultMessage: 'Email confirmation error redirect url',
-    },
-    hint: {
-      id: getTrad('EditForm.inputToggle.description.email-confirmation-error-redirection'),
-      defaultMessage: 'Enter the URL to redirect users to if email confirmation fails.',
-    },
-    placeholder: {
-      id: getTrad('EditForm.inputToggle.placeholder.email-confirmation-error-redirection'),
-      defaultMessage: 'e.g. https://yourfrontend.com/email-confirmation-error',
-    },
+    placeholder: 'ex: https://youtfrontend.com/email-confirmation',
+  }),
+  createField({
+    id: 'email-confirmation-error-redirection',
+    defaultMessage: 'Email confirmation error redirect url',
     name: 'email_confirmation_error_redirection',
-    type: 'string',
-    size: 12,
-  },
+    placeholder: 'e.g. https://yourfrontend.com/email-confirmation-error',
+  }),
 ];
 
 export default layout;

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
@@ -76,6 +76,23 @@ const layout = [
     type: 'string',
     size: 12,
   },
+  {
+    label: {
+      id: getTrad('EditForm.inputToggle.label.email-confirmation-error-redirection'),
+      defaultMessage: 'Email confirmation error redirect URL',
+    },
+    hint: {
+      id: getTrad('EditForm.inputToggle.description.email-confirmation-error-redirection'),
+      defaultMessage: 'Enter the URL to redirect users to if email confirmation fails.',
+    },
+    placeholder: {
+      id: getTrad('EditForm.inputToggle.placeholder.email-confirmation-error-redirection'),
+      defaultMessage: 'e.g. https://yourfrontend.com/email-confirmation-error',
+    },
+    name: 'email_confirmation_error_redirection',
+    type: 'string',
+    size: 12,
+  },
 ];
 
 export default layout;

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/layout.js
@@ -79,7 +79,7 @@ const layout = [
   {
     label: {
       id: getTrad('EditForm.inputToggle.label.email-confirmation-error-redirection'),
-      defaultMessage: 'Email confirmation error redirect URL',
+      defaultMessage: 'Email confirmation error redirect url',
     },
     hint: {
       id: getTrad('EditForm.inputToggle.description.email-confirmation-error-redirection'),

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/schema.js
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/utils/schema.js
@@ -10,6 +10,11 @@ const schema = yup.object().shape({
     then: yup.string().matches(URL_REGEX).required(),
     otherwise: yup.string().nullable(),
   }),
+  email_confirmation_error_redirection: yup.mixed().when('email_confirmation_error', {
+    is: true,
+    then: yup.string().matches(URL_REGEX).required(),
+    otherwise: yup.string().nullable(),
+  }),
   email_reset_password: yup
     .string(translatedErrors.string)
     .matches(URL_REGEX, {

--- a/packages/plugins/users-permissions/admin/src/tests/setup.js
+++ b/packages/plugins/users-permissions/admin/src/tests/setup.js
@@ -175,6 +175,7 @@ const handlers = [
           default_role: 'authenticated',
           email_confirmation: false,
           email_confirmation_redirection: '',
+          email_confirmation_error_redirection: '',
           email_reset_password: 'https://cat-bounce.com/',
           unique_email: false,
         },

--- a/packages/plugins/users-permissions/server/bootstrap/index.js
+++ b/packages/plugins/users-permissions/server/bootstrap/index.js
@@ -93,6 +93,7 @@ const initAdvancedOptions = async (pluginStore) => {
       email_confirmation: false,
       email_reset_password: null,
       email_confirmation_redirection: null,
+      email_confirmation_error_redirection: null,
       default_role: 'authenticated',
     };
 

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -403,7 +403,17 @@ module.exports = ({ strapi }) => ({
 
     const [user] = await userService.fetchAll({ filters: { confirmationToken } });
 
+    const settings = await strapi
+      .store({ type: 'plugin', name: 'users-permissions', key: 'advanced' })
+      .get();
+
     if (!user) {
+      const redirectUrl = settings.email_confirmation_error_redirection ?? null;
+
+      if (redirectUrl) {
+        return ctx.redirect(redirectUrl);
+      }
+
       throw new ValidationError('Invalid token');
     }
 
@@ -415,10 +425,6 @@ module.exports = ({ strapi }) => ({
         user: await sanitizeUser(user, ctx),
       });
     } else {
-      const settings = await strapi
-        .store({ type: 'plugin', name: 'users-permissions', key: 'advanced' })
-        .get();
-
       ctx.redirect(settings.email_confirmation_redirection || '/');
     }
   },

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -408,7 +408,7 @@ module.exports = ({ strapi }) => ({
       .get();
 
     if (!user) {
-      const redirectUrl = settings.email_confirmation_error_redirection ?? null;
+      const redirectUrl = settings.email_confirmation_error_redirection || null;
 
       if (redirectUrl) {
         return ctx.redirect(redirectUrl);


### PR DESCRIPTION
**What does it do?**

<img width="1435" alt="Capture d’écran 2025-01-19 à 19 10 46" src="https://github.com/user-attachments/assets/d6fa6313-4390-4d10-81d5-19735cf4eee5" />

---

This PR adds an optional error redirection URL in the admin panel for email confirmation. If a user clicks their confirmation link more than once, they are redirected to a custom page instead of seeing a raw 403 error. If no error URL is set, the default 403 message still appears, preserving the existing behavior.

```js
if (!user) {
  const redirectUrl = settings.email_confirmation_error_redirection || null;

  if (redirectUrl) {
    return ctx.redirect(redirectUrl);
  }

  throw new ValidationError('Invalid token');
}
```
**Why is it needed?**

Several developers have reported that end users often click the confirmation link multiple times and run into the unformatted 403 error. In all cases, offering a custom error page leads to a better user experience for end users by providing a more friendly and informative message in case of errors.

see:

- [https://feedback.strapi.io/feature-requests/p/redirect-a-user-after-confirmation-link-failed](https://feedback.strapi.io/feature-requests/p/redirect-a-user-after-confirmation-link-failed)

- [https://forum.strapi.io/search?q=email%20confirmation%20link](https://forum.strapi.io/search?q=email%20confirmation%20link)

<img width="1166" alt="Capture d’écran 2025-01-18 à 23 11 44" src="https://github.com/user-attachments/assets/f5f67de3-396f-4352-9f78-5e2cd8401151" />


Allowing a custom redirect URL provides a smoother experience and avoids confusion.

Some email providers scan or visit links for security reasons before the user clicks them, which can automatically validate the account and cause an error when the real user tries to confirm. This solution gives developers the option to display a custom page if that happens, preserving a smoother experience for end users.

**How to test it?**

	1.	Enable email confirmation in your Strapi settings.
	2.	Set a custom error redirection URL in the admin panel.
	3.	Sign up a new test user and confirm their email.
	4.	Click the confirmation link to validate account and click to the link a second time.
	5.	Verify that you are redirected to your custom page rather than seeing the 403 error.
	6.	Remove the custom URL to confirm the default 403 behavior remains intact.

**Additional Note**
- I’m not entirely sure how to implement this directly, but ideally, the confirmation link would include the user’s email as a parameter. That way, in the async emailConfirmation(ctx, next, returnUser) function, we could use the userService to check if the user is already validated and return a success response.

- I have added the default text to the translations, but I did not edit all the translation files since I only speak English and French.

Related issue(s)/PR(s)

User and dev documentation : https://github.com/strapi/documentation/pull/2364

Related:
https://github.com/strapi/strapi/issues/14627
