### PR TITLE
fix(upload): folder subtitles for folders without assets or subfolders

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
@@ -402,7 +402,7 @@ export const BrowseStep = ({
                                 {
                                   id: getTrad('list.folder.subtitle'),
                                   defaultMessage:
-                                    '{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} one {# asset} other {# assets}}',
+                                    '{folderCount, plural, one {# folder} other {# folders}}, {filesCount, plural, one {# asset} other {# assets}}',
                                 },
                                 {
                                   folderCount: folder.children?.count,

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
@@ -459,7 +459,7 @@ export const MediaLibrary = () => {
                                     {
                                       id: getTrad('list.folder.subtitle'),
                                       defaultMessage:
-                                        '{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} one {# asset} other {# assets}}',
+                                        '{folderCount, plural, one {# folder} other {# folders}}, {filesCount, plural, one {# asset} other {# assets}}',
                                     },
                                     {
                                       folderCount: (folder as FolderDefinition).children?.count,

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -57,7 +57,7 @@
   "list.assets.to-upload": "{number, plural, =0 {No asset} one {1 asset} other {# assets}} ready to upload",
   "list.folder.edit": "Edit folder",
   "list.folder.select": "Select {name} folder",
-  "list.folder.subtitle": "{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} one {# asset} other {# assets}}",
+  "list.folder.subtitle": "{folderCount, plural, one {# folder} other {# folders}}, {filesCount, plural, one {# asset} other {# assets}}",
   "list.folders.title": "Folders ({count})",
   "list.folders.link-label": "Access folder",
   "mediaLibraryInput.actions.nextSlide": "Next slide",

--- a/packages/core/upload/admin/src/translations/es.json
+++ b/packages/core/upload/admin/src/translations/es.json
@@ -106,7 +106,7 @@
   "list.assets.title": "Archivos",
   "list.assets.to-upload": "{number, plural, =0 {No asset} one {1 archivo} other {# archivos}} listo para subir",
   "list.folder.edit": "Editar carpeta",
-  "list.folder.subtitle": "{folderCount, plural, =0 {# folder} one {# folder} other {# folders}}, {filesCount, plural, =0 {# asset} uno {# asset} otro {# assets}}",
+  "list.folder.subtitle": "{folderCount, plural, one {# carpeta} other {# carpetas}}, {filesCount, plural, one {# archivo} other {# archivos}}",
   "list.folders.title": "Carpetas",
   "modal.folder.elements.count": "{folderCount} carpetas, {assetCount} archivos",
   "modal.header.go-back": "Volver",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Before:

![image](https://github.com/user-attachments/assets/bdecfc51-2152-4527-9d50-a113b7b04a08)

After:

![image](https://github.com/user-attachments/assets/1cae8dab-6ec5-4bca-a308-af6e097234d2)

It also fixes the Spanish language, the translation seemed inaccurate.

### Why is it needed?

The subtitle of folders is incorrect for zero subfolders and / or zero assets.

### How to test it?

Create a folder, observe the subtitle in the Media Library.