### PR TITLE
Fix 'woops' spelling disagreement 

### DIFF
--- a/packages/core/admin/admin/src/components/PageHelpers.tsx
+++ b/packages/core/admin/admin/src/components/PageHelpers.tsx
@@ -79,7 +79,7 @@ const Error = (props: ErrorProps) => {
           icon={<WarningCircle width="16rem" />}
           content={formatMessage({
             id: 'anErrorOccurred',
-            defaultMessage: 'Woops! Something went wrong. Please, try again.',
+            defaultMessage: 'Whoops! Something went wrong. Please, try again.',
           })}
           {...props}
         />

--- a/packages/core/admin/admin/src/components/tests/PageHelpers.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/PageHelpers.test.tsx
@@ -23,7 +23,7 @@ describe('PageHelpers', () => {
       render(<Page.Error />);
 
       expect(
-        screen.getByText('Woops! Something went wrong. Please, try again.')
+        screen.getByText('Whoops! Something went wrong. Please, try again.')
       ).toBeInTheDocument();
     });
 

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -383,7 +383,7 @@
   "admin.pages.MarketPlacePage.submit.provider.link": "Submit provider",
   "admin.pages.MarketPlacePage.subtitle": "Get more out of Strapi",
   "admin.pages.MarketPlacePage.tab-group.label": "Plugins and Providers for Strapi",
-  "anErrorOccurred": "Woops! Something went wrong. Please, try again.",
+  "anErrorOccurred": "Whoops! Something went wrong. Please, try again.",
   "noPreview": "No preview available",
   "app.component.CopyToClipboard.label": "Copy to clipboard",
   "app.component.search.label": "Search for {target}",

--- a/packages/core/admin/admin/src/translations/ja.json
+++ b/packages/core/admin/admin/src/translations/ja.json
@@ -193,7 +193,7 @@
   "admin.pages.MarketPlacePage.head": "マーケットプレイス - プラグイン",
   "admin.pages.MarketPlacePage.submit.plugin.link": "プラグインを送信",
   "admin.pages.MarketPlacePage.subtitle": "Get more out of Strapi",
-  "anErrorOccurred": "Woops! Something went wrong. Please, try again.",
+  "anErrorOccurred": "Whoops! Something went wrong. Please, try again.",
   "app.component.CopyToClipboard.label": "Copy to clipboard",
   "app.component.search.label": "{target}を検索",
   "app.component.table.duplicate": "{target}を復元",

--- a/packages/core/upload/admin/src/components/AssetDialog/tests/AssetDialog.test.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/tests/AssetDialog.test.tsx
@@ -109,7 +109,7 @@ describe('AssetDialog', () => {
         renderML();
 
         expect(
-          screen.getByText('Woops! Something went wrong. Please, try again.')
+          screen.getByText('Whoops! Something went wrong. Please, try again.')
         ).toBeInTheDocument();
       });
 
@@ -119,7 +119,7 @@ describe('AssetDialog', () => {
         renderML();
 
         expect(
-          screen.getByText('Woops! Something went wrong. Please, try again.')
+          screen.getByText('Whoops! Something went wrong. Please, try again.')
         ).toBeInTheDocument();
       });
     });


### PR DESCRIPTION
### What does it do?

I've added the missing `h` to whoops.

### Why is it needed?

To correct the spelling.

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
