### PR TITLE
fix: delete previous relations in morph to many relation

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -615,6 +615,15 @@ export const createEntityManager = (db: Database): EntityManager => {
             row.order = orderMap[encodedId];
           });
 
+          // delete previous relations
+          await deleteRelatedMorphOneRelationsAfterMorphToManyUpdate(rows as any, {
+            uid,
+            attributeName,
+            joinTable,
+            db,
+            transaction: trx,
+          });
+
           await this.createQueryBuilder(joinTable.name).insert(rows).transacting(trx).execute();
 
           continue;


### PR DESCRIPTION
### What does it do?

This PR calls the `attachRelations` function in the database package to remove previous relations before creating new ones, restoring behavior from earlier versions.

### Why is it needed?

Starting from version **5.4.0**, a bug was introduced that prevents updating files linked to an entry via the [upload entry file query](https://docs.strapi.io/dev-docs/plugins/upload#upload-entry-files) if the entry already has an associated file.

### How to test it?

1. Create an entity with a field of type **Media**.
2. Upload a file linked to this entity using the following parameters:

   ```javascript
   {
     ref: 'plugin::users-permissions.user',
     refId: userId,
     field: 'avatar',
   }
3. Attempt to update the media file. The update should now succeed.

### Findings
When an image is already linked to a content-type (e.g., user avatar) and you try to link a new image using the [upload entry file query](https://docs.strapi.io/dev-docs/plugins/upload#upload-entry-files), it creates a new entry in the database without deleting the old entry. When fetching the image, only the first record is returned, so it appears that the new image isn’t linked.
![400131118-f23b3235-a456-4183-8993-18dd9cdec4d9](https://github.com/user-attachments/assets/6edb60a4-9aa6-4c19-8f22-b10395511eee)

### Related issue(s)/PR(s)
Fixes #22476 