### PR TITLE
fix: number and boolean values in JSON fields break admin panel

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Json.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Json.tsx
@@ -25,7 +25,11 @@ const JsonInput = React.forwardRef<JSONInputRef, InputProps>(
         <JSONInputImpl
           ref={composedRefs}
           value={
-            typeof field.value == 'object' ? JSON.stringify(field.value, null, 2) : field.value
+            typeof field.value == 'object' ||
+            typeof field.value == 'boolean' ||
+            typeof field.value == 'number'
+              ? JSON.stringify(field.value, null, 2)
+              : field.value
           }
           onChange={(json) => {
             // Default to null when the field is not required and there is no input value


### PR DESCRIPTION
### What does it do?

This PR converts `object`, `number`, and `boolean` data types to strings using `JSON.stringify`, as the `JSONInput` component from the Strapi design system requires string inputs.

### Why is it needed?

When saving a JSON field containing a `number` or `boolean` value, the following errors occur:

1. **`(config2.doc || "").split is not a function`** – This error appears when creating a new entry.
2. **`Cannot read properties of undefined (reading 'length')`** – This error occurs when updating an existing entry.

### How to test it?

1. Create a new content type with a single **JSON** field.
2. Create a new entry and enter values such as `42` or `true` into the JSON field.
3. Attempt to save the entry, and it should now save successfully without errors.

### Related issue(s)/PR(s)

Fixes #22565
