### PR TITLE
ci: use release app token permissions for release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,16 +10,21 @@ on:
           - patch
           - minor
 
-permissions:
-  contents: write
-
 jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
     if: github.repository == 'strapi/strapi'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets. RELEASE_APP_SECRET }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0 # Fetch full history
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v4
@@ -30,5 +35,5 @@ jobs:
         env:
           VERSION: ${{ github.event.inputs.version }}
           DIST_TAG: 'latest'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets. RELEASE_APP_SECRET }}
+          private-key: ${{ secrets.RELEASE_APP_SECRET }}
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -24,7 +24,7 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
   exit 1
 fi
 
-# Configure Git for bot commits
+# Configure Git
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -67,7 +67,6 @@ const yargs = require('yargs');
       dryRun: options.dryRun,
       verbose: options.verbose,
       gitCommit: options.gitCommit,
-      gitTag: options.gitTag,
       preid: options.preid,
     });
 
@@ -78,7 +77,7 @@ const yargs = require('yargs');
         dryRun: options.dryRun,
         verbose: options.verbose,
         gitCommit: false,
-        gitTag: false,
+        gitTag: options.gitTag,
       });
     }
   }


### PR DESCRIPTION
### What does it do?

Use github app token for permissions in release workflow

### Why is it needed?

Normal github token cannot bypass protected branches
