### PR TITLE
test(api): cleanup test data

### DIFF
--- a/tests/api/plugins/i18n/locales.test.api.js
+++ b/tests/api/plugins/i18n/locales.test.api.js
@@ -45,13 +45,17 @@ describe('CRUD locales', () => {
     rq = await createAuthRequest({ strapi });
 
     localeService = strapi.plugin('i18n').service('locales');
+
+    // ensure we don't have any data in the database left over from previous tests that didn't clean up
+    await strapi.db.query('api::product.product').deleteMany();
   });
 
   afterAll(async () => {
     await localeService.setDefaultLocale({ code: 'en' });
 
-    // Delete all locales that have been created
+    // Delete all data that has been created
     await strapi.db.query('plugin::i18n.locale').deleteMany({ code: { $ne: 'en' } });
+    await strapi.db.query('api::product.product').deleteMany();
 
     await strapi.destroy();
     await builder.cleanup();

--- a/tests/api/plugins/i18n/locales.test.api.js
+++ b/tests/api/plugins/i18n/locales.test.api.js
@@ -55,8 +55,6 @@ describe('CRUD locales', () => {
 
     // Delete all data that has been created
     await strapi.db.query('plugin::i18n.locale').deleteMany({ code: { $ne: 'en' } });
-    await strapi.db.query('api::product.product').deleteMany();
-
     await strapi.destroy();
     await builder.cleanup();
   });


### PR DESCRIPTION
### What does it do?

- deletes test data before test run

### Why is it needed?

- sometimes if a test is interrupted, or if a previous test creates similar data and fails to clean it up, this test fails

### How to test it?

- if you run the entire api test suite concurrently (`--runinband`) locally, the tests should all pass
- without this PR, generally the locales test will fail unless it is run by itself or in a shard on the CI

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
