### PR TITLE
fix: class Plugin is not immerable

### DIFF
--- a/packages/core/admin/admin/src/components/PluginsInitializer.tsx
+++ b/packages/core/admin/admin/src/components/PluginsInitializer.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { produce } from 'immer';
-import set from 'lodash/set';
 
 import { Page } from '../components/PageHelpers';
 import { StrapiAppContextValue, useStrapiApp } from '../features/StrapiApp';
@@ -94,7 +93,7 @@ const reducer: React.Reducer<State, Action> = (state = initialState, action: Act
   produce(state, (draftState) => {
     switch (action.type) {
       case 'SET_PLUGIN_READY': {
-        set(draftState, ['plugins', action.pluginId, 'isReady'], true);
+        draftState.plugins[action.pluginId].isReady = true;
         break;
       }
       default:

--- a/packages/core/admin/admin/src/core/apis/Plugin.ts
+++ b/packages/core/admin/admin/src/core/apis/Plugin.ts
@@ -1,6 +1,8 @@
 /* eslint-disable check-file/filename-naming-convention */
 import * as React from 'react';
 
+import { immerable } from 'immer';
+
 export interface PluginConfig
   extends Partial<Pick<Plugin, 'apis' | 'initializer' | 'injectionZones' | 'isReady'>> {
   name: string;
@@ -8,6 +10,8 @@ export interface PluginConfig
 }
 
 export class Plugin {
+  [immerable] = true;
+
   apis: Record<string, unknown>;
   initializer: React.ComponentType<{ setPlugin(pluginId: string): void }> | null;
   injectionZones: Record<


### PR DESCRIPTION
### What does it do?

Make the Plugin class immerable 

https://immerjs.github.io/immer/complex-objects/

### Why is it needed?

It fixes an infinite loading state

### How to test it?

The bug is only reproducible in production. It can be reproduced on strapi cloud.

The work here is published on an experimental: `0.0.0-experimental.a4df7ad5ff6a4366442059f7c067a0424ba1e2f9`

Deploy a project to strapi cloud to reproduce the bug
Login, you should be stuck with infinite loading

Update your project with the experimental and redploy
Login, the homepage should load

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/21811
https://github.com/strapi/strapi/pull/22402
