### PR TITLE
fix: corrected typing mistake in translation key

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/EditAssetContent.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/EditAssetContent.tsx
@@ -277,7 +277,7 @@ export const EditAssetContent = ({
                     <Field.Root
                       name="alternativeText"
                       hint={formatMessage({
-                        id: getTrad('form.input.decription.file-alt'),
+                        id: getTrad('form.input.description.file-alt'),
                         defaultMessage: 'This text will be displayed if the asset can’t be shown.',
                       })}
                       error={errors.alternativeText}

--- a/packages/core/upload/admin/src/translations/ca.json
+++ b/packages/core/upload/admin/src/translations/ca.json
@@ -16,7 +16,7 @@
   "control-card.stop-crop": "Deixa de retallar",
   "filter.add": "Afegeix un filtre",
   "form.button.replace-media": "Substituïu els fitxers",
-  "form.input.decription.file-alt": "Aquest text es mostrarà si el recurs no es pot mostrar.",
+  "form.input.description.file-alt": "Aquest text es mostrarà si el recurs no es pot mostrar.",
   "form.input.label.file-alt": "Text alternatiu",
   "form.input.label.file-caption": "Subtítol",
   "form.input.label.file-name": "Nom de l'arxiu",

--- a/packages/core/upload/admin/src/translations/de.json
+++ b/packages/core/upload/admin/src/translations/de.json
@@ -15,7 +15,7 @@
   "control-card.stop-crop": "Zuschneiden abbrechen",
   "filter.add": "Filter hinzufügen",
   "form.button.replace-media": "Datei ersetzen",
-  "form.input.decription.file-alt": "Dieser Text wird angezeigt, wenn das Datei nicht angezeigt werden kann.",
+  "form.input.description.file-alt": "Dieser Text wird angezeigt, wenn das Datei nicht angezeigt werden kann.",
   "form.input.label.file-alt": "Alternativtext",
   "form.input.label.file-caption": "Bildtext",
   "form.input.label.file-name": "Dateiname",

--- a/packages/core/upload/admin/src/translations/dk.json
+++ b/packages/core/upload/admin/src/translations/dk.json
@@ -15,7 +15,7 @@
   "control-card.stop-crop": "Stop beskæring",
   "filter.add": "Tilføj filter",
   "form.button.replace-media": "Erstat medie",
-  "form.input.decription.file-alt": "Teksten bliver vist hvis mediet ikke kan vises.",
+  "form.input.description.file-alt": "Teksten bliver vist hvis mediet ikke kan vises.",
   "form.input.label.file-alt": "Alternativ tekst",
   "form.input.label.file-caption": "Billedeskrift",
   "form.input.label.file-name": "Filnavn",

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -17,7 +17,7 @@
   "control-card.stop-crop": "Stop cropping",
   "filter.add": "Add filter",
   "form.button.replace-media": "Replace media",
-  "form.input.decription.file-alt": "This text will be displayed if the asset can’t be shown.",
+  "form.input.description.file-alt": "This text will be displayed if the asset can’t be shown.",
   "form.input.label.file-alt": "Alternative text",
   "form.input.label.file-caption": "Caption",
   "form.input.label.file-name": "File name",

--- a/packages/core/upload/admin/src/translations/es.json
+++ b/packages/core/upload/admin/src/translations/es.json
@@ -15,7 +15,7 @@
   "control-card.stop-crop": "Deja de recortar",
   "filter.add": "Añadir filtro",
   "form.button.replace-media": "Reemplazar multimedia",
-  "form.input.decription.file-alt": "Este texto se mostrará si el recurso no se puede mostrar.",
+  "form.input.description.file-alt": "Este texto se mostrará si el recurso no se puede mostrar.",
   "form.input.label.file-alt": "Texto alternativo",
   "form.input.label.file-caption": "Subtítulo",
   "form.input.label.file-name": "Nombre del archivo",

--- a/packages/core/upload/admin/src/translations/fr.json
+++ b/packages/core/upload/admin/src/translations/fr.json
@@ -17,7 +17,7 @@
   "control-card.stop-crop": "Arrêter le recadrage",
   "filter.add": "Ajouter un filtre",
   "form.button.replace-media": "Remplacer le média",
-  "form.input.decription.file-alt": "Ce texte sera affiché si le média ne peut pas être affiché.",
+  "form.input.description.file-alt": "Ce texte sera affiché si le média ne peut pas être affiché.",
   "form.input.label.file-alt": "Texte alternatif",
   "form.input.label.file-caption": "Légende",
   "form.input.label.file-name": "Nom du fichier",

--- a/packages/core/upload/admin/src/translations/he.json
+++ b/packages/core/upload/admin/src/translations/he.json
@@ -12,7 +12,7 @@
   "control-card.save": "שמור",
   "filter.add": "הוסף פילטר",
   "form.button.replace-media": "החלף מדיה",
-  "form.input.decription.file-alt": "טקסט זה יוצג אם לא ניתן להציג את הנכס.",
+  "form.input.description.file-alt": "טקסט זה יוצג אם לא ניתן להציג את הנכס.",
   "form.input.label.file-alt": "טקסט חלופי",
   "form.input.label.file-caption": "כיתוב",
   "form.input.label.file-name": "שם קובץ",

--- a/packages/core/upload/admin/src/translations/it.json
+++ b/packages/core/upload/admin/src/translations/it.json
@@ -12,7 +12,7 @@
   "control-card.save": "Salva",
   "filter.add": "Aggiungi filtro",
   "form.button.replace-media": "Rimpiazza media",
-  "form.input.decription.file-alt": "Questo testo viene mostrato quando la risorsa non può essere visualizzata.",
+  "form.input.description.file-alt": "Questo testo viene mostrato quando la risorsa non può essere visualizzata.",
   "form.input.label.file-alt": "Testo alternativo",
   "form.input.label.file-caption": "Didascalia",
   "form.input.label.file-name": "Nome file",

--- a/packages/core/upload/admin/src/translations/ja.json
+++ b/packages/core/upload/admin/src/translations/ja.json
@@ -12,7 +12,7 @@
   "control-card.save": "保存",
   "filter.add": "フィルタを追加",
   "form.button.replace-media": "メディアの置き換え",
-  "form.input.decription.file-alt": "このテキストはアセットを表示できない場合に表示されます。",
+  "form.input.description.file-alt": "このテキストはアセットを表示できない場合に表示されます。",
   "form.input.label.file-alt": "代替テキスト",
   "form.input.label.file-caption": "キャプション",
   "form.input.label.file-name": "ファイル名",

--- a/packages/core/upload/admin/src/translations/ko.json
+++ b/packages/core/upload/admin/src/translations/ko.json
@@ -15,7 +15,7 @@
   "control-card.stop-crop": "그만 자르기",
   "filter.add": "필터 추가",
   "form.button.replace-media": "미디어 교체",
-  "form.input.decription.file-alt": "에셋을 표시할 수 없는 경우 이 텍스트가 표시됩니다.",
+  "form.input.description.file-alt": "에셋을 표시할 수 없는 경우 이 텍스트가 표시됩니다.",
   "form.input.label.file-alt": "대체 텍스트",
   "form.input.label.file-caption": "캡션",
   "form.input.label.file-name": "파일명",

--- a/packages/core/upload/admin/src/translations/ms.json
+++ b/packages/core/upload/admin/src/translations/ms.json
@@ -10,7 +10,7 @@
   "control-card.edit": "Edit",
   "control-card.save": "Simpan",
   "filter.add": "Tambah penapis",
-  "form.input.decription.file-alt": "Teks ini akan dipaparkan jika aset tidak dapat ditunjukkan.",
+  "form.input.description.file-alt": "Teks ini akan dipaparkan jika aset tidak dapat ditunjukkan.",
   "form.input.label.file-alt": "Teks alternatif",
   "form.input.label.file-caption": "Kapsyen",
   "form.input.label.file-name": "Nama fail",

--- a/packages/core/upload/admin/src/translations/pl.json
+++ b/packages/core/upload/admin/src/translations/pl.json
@@ -15,7 +15,7 @@
   "control-card.stop-crop": "Zatrzymaj przycinanie",
   "filter.add": "Dodaj filtr",
   "form.button.replace-media": "Zamień",
-  "form.input.decription.file-alt": "Ten tekst zostanie wyświetlony, jeżeli medium nie będzie mogło zostać pokazane.",
+  "form.input.description.file-alt": "Ten tekst zostanie wyświetlony, jeżeli medium nie będzie mogło zostać pokazane.",
   "form.input.label.file-alt": "Tekst alternatywny",
   "form.input.label.file-caption": "Podpis",
   "form.input.label.file-name": "Nazwa pliku",

--- a/packages/core/upload/admin/src/translations/pt-BR.json
+++ b/packages/core/upload/admin/src/translations/pt-BR.json
@@ -12,7 +12,7 @@
   "control-card.save": "Salvar",
   "filter.add": "Adicionar filtro",
   "form.button.replace-media": "Substituir mídia",
-  "form.input.decription.file-alt": "Esse texto será mostrado se a imagem não puder ser carregada.",
+  "form.input.description.file-alt": "Esse texto será mostrado se a imagem não puder ser carregada.",
   "form.input.label.file-alt": "Texto alternativo",
   "form.input.label.file-caption": "Legenda",
   "form.input.label.file-name": "Nome do arquivo",

--- a/packages/core/upload/admin/src/translations/pt.json
+++ b/packages/core/upload/admin/src/translations/pt.json
@@ -12,7 +12,7 @@
   "control-card.save": "Guardar",
   "filter.add": "Adicionar filtro",
   "form.button.replace-media": "Substituir média",
-  "form.input.decription.file-alt": "Esse texto será mostrado se a imagem não puder ser carregada.",
+  "form.input.description.file-alt": "Esse texto será mostrado se a imagem não puder ser carregada.",
   "form.input.label.file-alt": "Texto alternativo",
   "form.input.label.file-caption": "Legenda",
   "form.input.label.file-name": "Nome do ficheiro",

--- a/packages/core/upload/admin/src/translations/ru.json
+++ b/packages/core/upload/admin/src/translations/ru.json
@@ -12,7 +12,7 @@
   "control-card.save": "Сохранить",
   "filter.add": "Добавить фильтр",
   "form.button.replace-media": "Заменить медиа",
-  "form.input.decription.file-alt": "Этот текст будет показан, если ресурс не может быть отображён.",
+  "form.input.description.file-alt": "Этот текст будет показан, если ресурс не может быть отображён.",
   "form.input.label.file-alt": "Альтернативный текст",
   "form.input.label.file-caption": "Заголовок",
   "form.input.label.file-name": "Имя файла",

--- a/packages/core/upload/admin/src/translations/sk.json
+++ b/packages/core/upload/admin/src/translations/sk.json
@@ -17,7 +17,7 @@
   "control-card.stop-crop": "Ukončiť orezávanie",
   "filter.add": "Pridať filter",
   "form.button.replace-media": "Nahradiť súbor",
-  "form.input.decription.file-alt": "Tento text sa ukáže, keď sa súbor nepodarí zobraziť.",
+  "form.input.description.file-alt": "Tento text sa ukáže, keď sa súbor nepodarí zobraziť.",
   "form.input.label.file-alt": "Alternatívny text",
   "form.input.label.file-caption": "Popis",
   "form.input.label.file-name": "Názov súboru",

--- a/packages/core/upload/admin/src/translations/th.json
+++ b/packages/core/upload/admin/src/translations/th.json
@@ -12,7 +12,7 @@
   "control-card.save": "บันทึก",
   "filter.add": "เพิ่มตัวกรอง",
   "form.button.replace-media": "แทนที่สื่อ",
-  "form.input.decription.file-alt": "ข้อความนี้จะถูกแสดงหากไฟล์ไม่สามารถแสดงผลได้.",
+  "form.input.description.file-alt": "ข้อความนี้จะถูกแสดงหากไฟล์ไม่สามารถแสดงผลได้.",
   "form.input.label.file-alt": "ข้อความทางเลือก",
   "form.input.label.file-caption": "คำบรรยาย",
   "form.input.label.file-name": "ชื่อไฟล์",

--- a/packages/core/upload/admin/src/translations/tr.json
+++ b/packages/core/upload/admin/src/translations/tr.json
@@ -17,7 +17,7 @@
   "control-card.stop-crop": "Kırpmayı durdur",
   "filter.add": "Filtre ekle",
   "form.button.replace-media": "Ortamı değiştir",
-  "form.input.decription.file-alt": "Dosya gösterilemediğinde bu yazı görünecek.",
+  "form.input.description.file-alt": "Dosya gösterilemediğinde bu yazı görünecek.",
   "form.input.label.file-alt": "Alternatif metin",
   "form.input.label.file-caption": "Başlık",
   "form.input.label.file-name": "Dosya adı",

--- a/packages/core/upload/admin/src/translations/uk.json
+++ b/packages/core/upload/admin/src/translations/uk.json
@@ -11,7 +11,7 @@
   "control-card.save": "Зберегти",
   "filter.add": "Додати фільтр",
   "form.button.replace-media": "Замінити медіа",
-  "form.input.decription.file-alt": "Цей текст буде показаний якщо файл не може бути показаний",
+  "form.input.description.file-alt": "Цей текст буде показаний якщо файл не може бути показаний",
   "form.input.label.file-alt": "Альтернативний текст (alt)",
   "form.input.label.file-caption": "Підпис",
   "form.input.label.file-name": "Назва файлу",

--- a/packages/core/upload/admin/src/translations/zh-Hans.json
+++ b/packages/core/upload/admin/src/translations/zh-Hans.json
@@ -14,7 +14,7 @@
   "control-card.save": "保存",
   "filter.add": "添加筛选条件",
   "form.button.replace-media": "替换媒体",
-  "form.input.decription.file-alt": "当此素材无法显示时，会显示该文本。",
+  "form.input.description.file-alt": "当此素材无法显示时，会显示该文本。",
   "form.input.label.file-alt": "备用文本",
   "form.input.label.file-caption": "标题",
   "form.input.label.file-name": "文件名",

--- a/packages/core/upload/admin/src/translations/zh.json
+++ b/packages/core/upload/admin/src/translations/zh.json
@@ -17,7 +17,7 @@
   "control-card.stop-crop": "停止裁切",
   "filter.add": "增加過濾條件",
   "form.button.replace-media": "取代原本的媒體檔",
-  "form.input.decription.file-alt": "當素材找不到時此文字會被顯示",
+  "form.input.description.file-alt": "當素材找不到時此文字會被顯示",
   "form.input.label.file-alt": "預設顯示文字",
   "form.input.label.file-caption": "標題",
   "form.input.label.file-name": "檔案名稱",

--- a/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
@@ -23,7 +23,7 @@ const getRequiredAttributes = (allAttributes: Struct.SchemaAttributes) => {
 };
 
 /**
- * @decription Get all open api schema objects for a given content type
+ * @description Get all open api schema objects for a given content type
  *
  * @param {object} apiInfo
  * @property {string} apiInfo.uniqueName - Api name | Api name + Content type name


### PR DESCRIPTION
### What does it do?

Changes the word `decription` to `description` in the `form.input.decription.file-alt` translation key, resulting in `form.input.description.file-alt`.

### Why is it needed?

It's simply an enhancement to have a cleaner codebase.

### How to test it?

Check all files in the diff.