### PR TITLE
fix: remove icon for fields without i18n

### DIFF
--- a/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
+++ b/packages/plugins/i18n/admin/src/contentManagerHooks/editView.tsx
@@ -62,12 +62,12 @@ const addLabelActionToField = (field: EditFieldLayout) => {
         ? 'This value is unique for the selected locale'
         : 'This value is the same across all locales',
     },
-    icon: isFieldLocalized ? <Earth /> : <EarthStriked />,
+    icon: isFieldLocalized ? <Earth /> : null,
   };
 
   return {
     ...field,
-    labelAction: <LabelAction {...labelActionProps} />,
+    labelAction: isFieldLocalized ? <LabelAction {...labelActionProps} /> : null,
   };
 };
 


### PR DESCRIPTION
### Why is it needed?

See https://github.com/strapi/strapi/pull/22242.

### How to test it?

See https://github.com/strapi/strapi/pull/22242.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22242
