### PR TITLE
fix(core/database): type Event.result for afterXXX events

### DIFF
--- a/packages/core/database/src/lifecycles/types.ts
+++ b/packages/core/database/src/lifecycles/types.ts
@@ -37,6 +37,7 @@ export interface Event {
   model: Meta;
   params: Params;
   state: Record<string, unknown>;
+  result?: Record<string, unknown> | undefined;
 }
 
 export type SubscriberFn = (event: Event) => Promise<void> | void;


### PR DESCRIPTION
### What does it do?

Type the Event.result of afterXXX lifecycle hooks for Strapi v4

<img width="744" alt="image" src="https://github.com/user-attachments/assets/380c7f42-a160-401d-8833-bc69c6e771ce" />

https://docs-v4.strapi.io/dev-docs/backend-customization/models#hook-event-object

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22777