### PR TITLE
fix(core/database): type Event.result for afterXXX events

### DIFF
--- a/packages/core/database/src/lifecycles/types.ts
+++ b/packages/core/database/src/lifecycles/types.ts
@@ -37,7 +37,7 @@ export interface Event {
   model: Meta;
   params: Params;
   state: Record<string, unknown>;
-  result?: any;
+  result?: Record<string, unknown> | undefined;
 }
 
 export type SubscriberFn = (event: Event) => Promise<void> | void;


### PR DESCRIPTION
### What does it do?

Type the Event.result of afterXXX lifecycle hooks for Strapi v5

<img width="666" alt="image" src="https://github.com/user-attachments/assets/8f356897-1d9e-4859-90a9-1a6f5b7fe078" />

https://docs.strapi.io/dev-docs/backend-customization/models#hook-event-object

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22775