### PR TITLE
fix(upload): window title in media library

### DIFF
--- a/packages/core/upload/admin/src/pages/App/App.tsx
+++ b/packages/core/upload/admin/src/pages/App/App.tsx
@@ -37,16 +37,12 @@ export const Upload = () => {
   }, [isLoading, isError, config, rawQuery, setQuery]);
 
   if (isLoading) {
-    return (
-      <>
-        <Page.Title>{title}</Page.Title>
-        <Page.Loading />
-      </>
-    );
+    return <Page.Loading />;
   }
 
   return (
     <Page.Main>
+      <Page.Title>{title}</Page.Title>
       {rawQuery ? (
         <React.Suspense fallback={<Page.Loading />}>
           <Routes>


### PR DESCRIPTION
### What does it do?

The window title is not set when opening the Media Library.

### Why is it needed?

Other Strapi components correctly set the Media Library. Without this change, a tab with the Media Library open shows a wrong title.

### How to test it?

Open the Media Library, look at the browsers window title.