### PR TITLE
fix(admin): display correct version on admin notification

### DIFF
--- a/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { version as strapiVersion } from '@strapi/admin/package.json';
 import { Box, Flex, SkipToContent } from '@strapi/design-system';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -8,7 +9,6 @@ import { Outlet } from 'react-router-dom';
 import lt from 'semver/functions/lt';
 import valid from 'semver/functions/valid';
 
-import packageJSON from '../../../package.json';
 import { GuidedTourModal } from '../components/GuidedTour/Modal';
 import { useGuidedTour } from '../components/GuidedTour/Provider';
 import { LeftMenu } from '../components/LeftMenu';
@@ -25,8 +25,6 @@ import { useMenu } from '../hooks/useMenu';
 import { useOnce } from '../hooks/useOnce';
 import { useInformationQuery } from '../services/admin';
 import { hashAdminUserEmail } from '../utils/users';
-
-const strapiVersion = packageJSON.version;
 
 const AdminLayout = () => {
   const setGuidedTourVisibility = useGuidedTour(


### PR DESCRIPTION
### What does it do?

Defers loading package.json until `@strapi/admin` is built in the end application, instead of when preparing for a release.

### Why is it needed?

As explained in bug #22117 strapi always notifies the user that a new version is available. This is caused by the fact that the version of strapi is embedded in the `@strapi/admin` when the package is built prior to increasing the version.

### How to test it?

Create a new release, go to the Strapi admin page. The notification should be gone.

### Related issue(s)/PR(s)

#22117
