### PR TITLE
fix: removed unexpected padding around accordions

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/ContentTypesSection.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/ContentTypesSection.tsx
@@ -10,7 +10,7 @@ interface ContentTypesSectionProps {
 
 export const ContentTypesSection = ({ section = null, ...props }: ContentTypesSectionProps) => {
   return (
-    <Box padding={4} background="neutral0">
+    <Box>
       <Accordion.Root size="M">
         {section &&
           section.map((api, index) => (

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/Permissions.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/components/Permissions.tsx
@@ -22,6 +22,7 @@ export const Permissions = ({ ...props }) => {
         paddingRight={7}
         direction="column"
         alignItems="stretch"
+        gap={6}
       >
         <Flex direction="column" alignItems="stretch" gap={2}>
           <Typography variant="delta" tag="h2">


### PR DESCRIPTION
### What does it do?

- Removes unexpected padding around the accordions list
- Removed unused background property
- Added a gap between the subtitle and the accordions list

### Why is it needed?

It currently doesn't look good.

### Before

![CleanShot 2025-02-05 at 17 49 30@2x](https://github.com/user-attachments/assets/61d070f7-61ba-45d3-9b8b-bf67a5c1ab90)

### After

![CleanShot 2025-02-05 at 17 51 12@2x](https://github.com/user-attachments/assets/d526ca8d-441a-4cab-a696-a1df0a83c5e5)

### How to test it?

Go to Settings, API Tokens and check or create a token.