### PR TITLE
test(e2e): ctb refreshes automatically after changes

### DIFF
--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -28,11 +28,9 @@ const goToHistoryPage = async (page: Page) => {
   await moreActionsButton.click();
   const historyButton = page.getByRole('menuitem', { name: /content history/i });
 
-  // TODO find out why the history button sometimes doesn't appear. Reloading shouldn't be necessary
   if (await historyButton.isVisible()) {
     await clickAndWait(page, historyButton);
   } else {
-    await page.reload();
     await goToHistoryPage(page);
   }
 };

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -41,8 +41,6 @@ test.describe('Edit collection type', () => {
     await page.getByRole('button', { name: 'Finish' }).click();
     await page.getByRole('button', { name: 'Save' }).click();
 
-    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
-    // Fix the bug then remove this
     await waitForRestart(page);
 
     await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
@@ -66,10 +64,6 @@ test.describe('Edit collection type', () => {
     await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
-    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
-    // Fix the bug then remove this
-    await page.reload();
-
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
@@ -88,10 +82,6 @@ test.describe('Edit collection type', () => {
     await page.getByRole('button', { name: 'Finish' }).click();
     await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
-
-    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
-    // Fix the bug then remove this
-    await page.reload();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit' }).first().click();
@@ -176,9 +166,6 @@ test.describe('Edit collection type', () => {
 
     await waitForRestart(page);
 
-    // TODO: fix bug that requires a page refresh to see that content types have been updated
-    await page.reload();
-
     await expect(page.getByRole('heading', { name: newname })).toBeVisible();
   });
 
@@ -191,9 +178,6 @@ test.describe('Edit collection type', () => {
     await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
     await waitForRestart(page);
-
-    // TODO: fix bug that requires a page refresh to see that content types have been updated
-    await page.reload();
 
     await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
   });

--- a/tests/e2e/tests/content-type-builder/components/update-components.spec.ts
+++ b/tests/e2e/tests/content-type-builder/components/update-components.spec.ts
@@ -137,9 +137,6 @@ test.describe('Update a new component', () => {
     // delete it
     await deleteComponent(page, 'SomeComponent');
 
-    // TODO: fix issue that components aren't removed from side navigation or content types until refresh
-    await page.reload({ waitUntil: 'networkidle' });
-
     // confirm that it no longer exists in the content type this component was in
     await navToHeader(page, ['Content-Type Builder', collectionType.name], collectionType.name);
     await expect(page.getByText(componentAttributeName, { exact: true })).not.toBeVisible();

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -40,10 +40,6 @@ test.describe('Edit single type', () => {
     await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
-    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
-    // Fix the bug then remove this
-    await page.reload();
-
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
@@ -62,10 +58,6 @@ test.describe('Edit single type', () => {
     await page.getByRole('button', { name: 'Finish' }).click();
     await waitForRestart(page);
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
-
-    // TODO: this is here because of a bug where the admin UI doesn't understand the option has changed
-    // Fix the bug then remove this
-    await page.reload();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
@@ -102,9 +94,6 @@ test.describe('Edit single type', () => {
 
     await waitForRestart(page);
 
-    // TODO: fix bug that requires a page refresh to see that content types have been updated
-    await page.reload();
-
     await expect(page.getByRole('heading', { name: newname })).toBeVisible();
   });
 
@@ -117,9 +106,6 @@ test.describe('Edit single type', () => {
     await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
     await waitForRestart(page);
-
-    // TODO: fix bug that requires a page refresh to see that content types have been updated
-    await page.reload();
 
     await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
   });


### PR DESCRIPTION
### What does it do?

removes workarounds caused by the bug that is being fixed

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
