### PR TITLE
fix(cli): add --no-open option

### DIFF
--- a/packages/core/strapi/src/cli/commands/develop.ts
+++ b/packages/core/strapi/src/cli/commands/develop.ts
@@ -35,6 +35,7 @@ const command: StrapiCommand = ({ ctx }) => {
     .option('--watch-admin', 'Watch the admin panel for hot changes', true)
     .option('--no-watch-admin', 'Do not watch the admin panel for hot changes')
     .option('--open', 'Open the admin in your browser', true)
+    .option('--no-open', 'Do not open the admin in your browser')
     .description('Start your Strapi application in development mode')
     .action(async (options: DevelopCLIOptions) => {
       return action({ ...options, ...ctx });


### PR DESCRIPTION
### What does it do?

adds the --no-open option to `strapi develop`

### Why is it needed?

`--open` is a commander boolean which means it doesn't accept a value; so there's currently no way to turn it off. `--open=false` throws an error

### How to test it?

- run `strapi develop` and it should open an admin window if you don't already have one open
- and `strapi develop --no-open` and it should not open an admin window at all

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
