### PR TITLE
future: add edit form to preview page

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 
-import { Button, Dialog, useCallbackRef, useComposedRefs } from '@strapi/design-system';
+import {
+  Box,
+  type BoxProps,
+  Button,
+  Dialog,
+  useCallbackRef,
+  useComposedRefs,
+} from '@strapi/design-system';
 import { WarningCircle } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import { produce } from 'immer';
@@ -114,7 +121,8 @@ interface FormHelpers<TFormValues extends FormValues = FormValues>
   extends Pick<FormContextValue<TFormValues>, 'setErrors' | 'setValues' | 'resetForm'> {}
 
 interface FormProps<TFormValues extends FormValues = FormValues>
-  extends Partial<Pick<FormContextValue<TFormValues>, 'disabled' | 'initialValues'>> {
+  extends Partial<Pick<FormContextValue<TFormValues>, 'disabled' | 'initialValues'>>,
+    Pick<BoxProps, 'width' | 'height'> {
   children:
     | React.ReactNode
     | ((
@@ -424,7 +432,15 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
     const composedRefs = useComposedRefs(formRef, ref);
 
     return (
-      <form ref={composedRefs} method={method} noValidate onSubmit={handleSubmit}>
+      <Box
+        tag="form"
+        ref={composedRefs}
+        method={method}
+        noValidate
+        onSubmit={handleSubmit}
+        width={props.width}
+        height={props.height}
+      >
         <FormProvider
           disabled={disabled}
           onChange={handleChange}
@@ -451,7 +467,7 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
               })
             : props.children}
         </FormProvider>
-      </form>
+      </Box>
     );
   }
 ) as <TFormValues extends FormValues>(

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -26,8 +26,6 @@ import { createYupSchema } from '../../utils/validation';
 import { FormLayout } from './components/FormLayout';
 import { Header } from './components/Header';
 import { Panels } from './components/Panels';
-import { transformDocument } from './utils/data';
-import { createDefaultForm } from './utils/forms';
 
 /* -------------------------------------------------------------------------------------------------
  * EditViewPage

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -23,9 +23,11 @@ export const ResponsiveGridItem = styled(Grid.Item)`
   }
 `;
 
-interface FormLayoutProps extends Pick<EditLayout, 'layout'> {}
+interface FormLayoutProps extends Pick<EditLayout, 'layout'> {
+  hasBackground?: boolean;
+}
 
-const FormLayout = ({ layout }: FormLayoutProps) => {
+const FormLayout = ({ layout, hasBackground = false }: FormLayoutProps) => {
   const { formatMessage } = useIntl();
   const { model } = useDoc();
 
@@ -56,14 +58,13 @@ const FormLayout = ({ layout }: FormLayoutProps) => {
         return (
           <Box
             key={index}
-            hasRadius
-            background="neutral0"
-            shadow="tableShadow"
-            paddingLeft={6}
-            paddingRight={6}
-            paddingTop={6}
-            paddingBottom={6}
-            borderColor="neutral150"
+            {...(!hasBackground && {
+              padding: 6,
+              borderColor: 'neutral150',
+              background: 'neutral0',
+              hasRadius: true,
+              shadow: 'tableShadow',
+            })}
           >
             <Flex direction="column" alignItems="stretch" gap={6}>
               {panel.map((row, gridRowIndex) => (

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -3,16 +3,20 @@ import * as React from 'react';
 import { Box, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
+import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { usePreviewContext } from '../pages/Preview';
 
 const UnstablePreviewContent = () => {
   const previewUrl = usePreviewContext('PreviewContent', (state) => state.url);
+  const layout = usePreviewContext('PreviewContent', (state) => state.layout);
 
   const { formatMessage } = useIntl();
 
   return (
-    <Flex height="100%">
-      <Box flex={1}>TODO: Side editor</Box>
+    <Flex flex={1} overflow="auto" alignItems="stretch">
+      <Box overflow="auto" flex={1} borderWidth="0 1px 0 0" borderColor="neutral150" padding={6}>
+        <FormLayout layout={layout.layout} hasBackground />
+      </Box>
       <Box
         src={previewUrl}
         /**

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 
-import { Page, useQueryParams, useRBAC, createContext } from '@strapi/admin/strapi-admin';
+import {
+  Page,
+  useQueryParams,
+  useRBAC,
+  createContext,
+  Form as FormContext,
+} from '@strapi/admin/strapi-admin';
 import { Box, Flex, FocusTrap, Portal } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
@@ -9,7 +15,7 @@ import { GetPreviewUrl } from '../../../../shared/contracts/preview';
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { type UseDocument, useDocument } from '../../hooks/useDocument';
-import { useDocumentLayout } from '../../hooks/useDocumentLayout';
+import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { buildValidParams } from '../../utils/api';
 import { PreviewContent, UnstablePreviewContent } from '../components/PreviewContent';
 import { PreviewHeader, UnstablePreviewHeader } from '../components/PreviewHeader';
@@ -27,6 +33,7 @@ interface PreviewContextValue {
   document: NonNullable<ReturnType<UseDocument>['document']>;
   meta: NonNullable<ReturnType<UseDocument>['meta']>;
   schema: NonNullable<ReturnType<UseDocument>['schema']>;
+  layout: EditLayout;
 }
 
 const [PreviewProvider, usePreviewContext] = createContext<PreviewContextValue>('PreviewPage');
@@ -130,20 +137,23 @@ const PreviewPage = () => {
         title={documentTitle}
         meta={documentResponse.meta}
         schema={documentResponse.schema}
+        layout={documentLayoutResponse.edit}
       >
-        <Flex direction="column" height="100%" alignItems="stretch">
-          {window.strapi.future.isEnabled('unstablePreviewSideEditor') ? (
-            <>
-              <UnstablePreviewHeader />
-              <UnstablePreviewContent />
-            </>
-          ) : (
-            <>
-              <PreviewHeader />
-              <PreviewContent />
-            </>
-          )}
-        </Flex>
+        <FormContext method="POST" initialValues={documentResponse.document} height="100%">
+          <Flex direction="column" height="100%" alignItems="stretch">
+            {window.strapi.future.isEnabled('unstablePreviewSideEditor') ? (
+              <>
+                <UnstablePreviewHeader />
+                <UnstablePreviewContent />
+              </>
+            ) : (
+              <>
+                <PreviewHeader />
+                <PreviewContent />
+              </>
+            )}
+          </Flex>
+        </FormContext>
       </PreviewProvider>
     </>
   );
@@ -161,7 +171,10 @@ const ProtectedPreviewPageImpl = () => {
     permissions = [],
     isLoading,
     error,
-  } = useRBAC([{ action: 'plugin::content-manager.explorer.read', subject: model }]);
+  } = useRBAC([
+    { action: 'plugin::content-manager.explorer.read', subject: model },
+    { action: 'plugin::content-manager.explorer.update', subject: model },
+  ]);
 
   if (isLoading) {
     return <Page.Loading />;
@@ -193,7 +206,11 @@ const ProtectedPreviewPageImpl = () => {
       zIndex={2}
       background="neutral0"
     >
-      <Page.Protect permissions={permissions}>
+      <Page.Protect
+        permissions={permissions.filter((permission) =>
+          permission.action.includes('explorer.read')
+        )}
+      >
         {({ permissions }) => (
           <DocumentRBAC permissions={permissions}>
             <PreviewPage />

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -211,11 +211,9 @@ const ProtectedPreviewPageImpl = () => {
           permission.action.includes('explorer.read')
         )}
       >
-        {({ permissions }) => (
-          <DocumentRBAC permissions={permissions}>
-            <PreviewPage />
-          </DocumentRBAC>
-        )}
+        <DocumentRBAC permissions={permissions}>
+          <PreviewPage />
+        </DocumentRBAC>
       </Page.Protect>
     </Box>
   );

--- a/packages/plugins/color-picker/admin/src/components/tests/__snapshots__/ColorPickerInput.test.tsx.snap
+++ b/packages/plugins/color-picker/admin/src/components/tests/__snapshots__/ColorPickerInput.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`<ColorPickerInput /> renders and matches the snapshot 1`] = `
 
 <div>
   <form
+    class=""
     method="POST"
     novalidate=""
   >

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -107,4 +107,14 @@ test.describe('Preview', () => {
       /\/preview\/api::article\.article\/.+\/en\/published$/
     );
   });
+
+  test('Edit form should be displayed on the preview page', async ({ page }) => {
+    // Open an edit view for a content type that has preview
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+    const titleBox = page.getByRole('textbox', { name: 'title' });
+    await expect(titleBox).toHaveValue(/west ham post match/i);
+  });
 });


### PR DESCRIPTION
### What does it do?

Renders the edit view form on the preview page. aka the side editor

This does NOT handle saving content updates on that form.

### Why is it needed?

Next iteration of preview

### How to test it?

Needs a future flag:

```
// config/features.js
module.exports = ({ env }) => ({
  future: {
    unstablePreviewSideEditor: true,
    unstableRelationsOnTheFly: true,
  },
});
```

Open the preview for an entry that has preview set up. You should see the edit view form for that entry on the left half of the page next to the preview iframe. The form should be editable.

Open that same page while authenticated as a user who has permissions to read but not update that content type. You should see the preview page, but the fields should be disabled.