### PR TITLE
chore: swap Download icon for Earth icon

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -29,7 +29,7 @@ import {
   Dialog,
   type StatusVariant,
 } from '@strapi/design-system';
-import { WarningCircle, ListPlus, Trash, Download, Cross, Plus } from '@strapi/icons';
+import { WarningCircle, ListPlus, Trash, Earth, Cross, Plus } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -292,7 +292,7 @@ const FillFromAnotherLocaleAction = ({
 
   return {
     type: 'icon',
-    icon: <Download />,
+    icon: <Earth />,
     disabled: availableLocales.length === 0,
     label: formatMessage({
       id: getTranslation('CMEditViewCopyLocale.copy-text'),


### PR DESCRIPTION
### What does it do?

Replaces the download icon with the eartch icon for fill in from another locale

### Why is it needed?

It's confusing

### How to test it?

Take a look
Enabled
<img width="281" alt="Screenshot 2025-02-13 at 18 06 06" src="https://github.com/user-attachments/assets/ddd3014f-f6d6-47dc-8597-ff1be5def0a1" />
Disabled
<img width="330" alt="Screenshot 2025-02-13 at 18 06 14" src="https://github.com/user-attachments/assets/0d2b1608-3452-4494-9678-c6a7e1ce1412" />

