### PR TITLE
fix: password validation tests

### DIFF
--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -29,6 +29,7 @@ import {
   useRegisterUserMutation,
 } from '../../../services/auth';
 import { isBaseQueryError } from '../../../utils/baseQuery';
+import { getByteSize } from '../../../utils/strings';
 import { translatedErrors } from '../../../utils/translatedErrors';
 
 const REGISTER_USER_SCHEMA = yup.object().shape({
@@ -48,8 +49,18 @@ const REGISTER_USER_SCHEMA = yup.object().shape({
         defaultMessage: 'Password must be less than 73 bytes',
       },
       function (value) {
-        if (!value) return true;
-        return new TextEncoder().encode(value).length <= 72;
+        if (!value) return true; // Allow empty values
+
+        try {
+          if (typeof value !== 'string') {
+            return false;
+          }
+
+          const byteSize = getByteSize(value);
+          return byteSize <= 72;
+        } catch (error) {
+          return false;
+        }
       }
     )
     .matches(/[a-z]/, {

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -51,16 +51,12 @@ const REGISTER_USER_SCHEMA = yup.object().shape({
       function (value) {
         if (!value) return true; // Allow empty values
 
-        try {
-          if (typeof value !== 'string') {
-            return false;
-          }
-
-          const byteSize = getByteSize(value);
-          return byteSize <= 72;
-        } catch (error) {
+        if (typeof value !== 'string') {
           return false;
         }
+
+        const byteSize = getByteSize(value);
+        return byteSize <= 72;
       }
     )
     .matches(/[a-z]/, {

--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -49,11 +49,7 @@ const REGISTER_USER_SCHEMA = yup.object().shape({
         defaultMessage: 'Password must be less than 73 bytes',
       },
       function (value) {
-        if (!value) return true; // Allow empty values
-
-        if (typeof value !== 'string') {
-          return false;
-        }
+        if (!value || typeof value !== 'string') return true; // validated elsewhere
 
         const byteSize = getByteSize(value);
         return byteSize <= 72;

--- a/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
@@ -38,11 +38,7 @@ const RESET_PASSWORD_SCHEMA = yup.object().shape({
         defaultMessage: 'Password must be less than 73 bytes',
       },
       function (value) {
-        if (!value) return true; // Allow empty values
-
-        if (typeof value !== 'string') {
-          return false;
-        }
+        if (!value || typeof value !== 'string') return true; // validated elsewhere
 
         const byteSize = getByteSize(value);
         return byteSize <= 72;

--- a/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
@@ -19,6 +19,7 @@ import {
 import { login } from '../../../reducer';
 import { useResetPasswordMutation } from '../../../services/auth';
 import { isBaseQueryError } from '../../../utils/baseQuery';
+import { getByteSize } from '../../../utils/strings';
 import { translatedErrors } from '../../../utils/translatedErrors';
 
 const RESET_PASSWORD_SCHEMA = yup.object().shape({
@@ -33,15 +34,22 @@ const RESET_PASSWORD_SCHEMA = yup.object().shape({
     .test(
       'required-byte-size',
       {
-        message: {
-          id: 'components.Input.error.contain.maxBytes',
-          defaultMessage: 'Password must be less than 73 bytes',
-        },
+        id: 'components.Input.error.contain.maxBytes',
+        defaultMessage: 'Password must be less than 73 bytes',
       },
       function (value) {
-        if (!value) return true;
-        const byteSize = new TextEncoder().encode(value).length;
-        return byteSize <= 72;
+        if (!value) return true; // Allow empty values
+
+        try {
+          if (typeof value !== 'string') {
+            return false;
+          }
+
+          const byteSize = getByteSize(value);
+          return byteSize <= 72;
+        } catch (error) {
+          return false;
+        }
       }
     )
     .matches(/[a-z]/, {

--- a/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/ResetPassword.tsx
@@ -40,16 +40,12 @@ const RESET_PASSWORD_SCHEMA = yup.object().shape({
       function (value) {
         if (!value) return true; // Allow empty values
 
-        try {
-          if (typeof value !== 'string') {
-            return false;
-          }
-
-          const byteSize = getByteSize(value);
-          return byteSize <= 72;
-        } catch (error) {
+        if (typeof value !== 'string') {
           return false;
         }
+
+        const byteSize = getByteSize(value);
+        return byteSize <= 72;
       }
     )
     .matches(/[a-z]/, {

--- a/packages/core/admin/admin/src/pages/Auth/components/tests/ResetPassword.test.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/tests/ResetPassword.test.tsx
@@ -59,5 +59,31 @@ describe('ResetPassword', () => {
 
       expect(await findByText('Passwords must match')).toBeInTheDocument();
     });
+
+    it('should fail if the password is too short', async () => {
+      const { getByRole, findByText, getByLabelText, user } = render(<ResetPassword />, {
+        initialEntries: [{ search: '?code=test' }],
+      });
+
+      await user.type(getByLabelText('Password*'), 'aA1!');
+      await user.type(getByLabelText('Confirm Password*'), 'aA1!');
+
+      fireEvent.click(getByRole('button', { name: 'Change password' }));
+
+      expect(await findByText('Password must be at least 8 characters')).toBeInTheDocument();
+    });
+
+    it('should fail if the password is too long', async () => {
+      const { getByRole, findByText, getByLabelText, user } = render(<ResetPassword />, {
+        initialEntries: [{ search: '?code=test' }],
+      });
+
+      await user.type(getByLabelText('Password*'), 'aA1!' + 'a'.repeat(70));
+      await user.type(getByLabelText('Confirm Password*'), 'aA1!' + 'a'.repeat(70));
+
+      fireEvent.click(getByRole('button', { name: 'Change password' }));
+
+      expect(await findByText('Password must be less than 73 bytes')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/core/admin/admin/src/utils/strings.ts
+++ b/packages/core/admin/admin/src/utils/strings.ts
@@ -5,8 +5,34 @@ function getByteSize(value: string) {
     return new TextEncoder().encode(value).length;
   }
 
-  // Fallback: Count bytes manually (assuming most non-ASCII chars are 2+ bytes)
-  return value.split('').reduce((sum, char) => sum + (char.charCodeAt(0) > 127 ? 2 : 1), 0);
+  // Manual UTF-8 encoding (fully reliable fallback)
+  let bytes = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+
+    if (code < 0x80) {
+      bytes += 1; // ASCII (1 byte)
+    } else if (code < 0x800) {
+      bytes += 2; // 2-byte UTF-8
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate (part of surrogate pair)
+      if (i + 1 < value.length) {
+        const nextCode = value.charCodeAt(i + 1);
+        if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+          // Valid surrogate pair (4-byte UTF-8)
+          bytes += 4;
+          i++; // Skip next code unit
+          continue;
+        }
+      }
+      bytes += 3; // Unmatched high surrogate → treated as 3-byte UTF-8
+    } else if (code < 0x10000) {
+      bytes += 3; // 3-byte UTF-8
+    } else {
+      bytes += 4; // 4-byte UTF-8
+    }
+  }
+  return bytes;
 }
 
 export { capitalise, getByteSize };

--- a/packages/core/admin/admin/src/utils/strings.ts
+++ b/packages/core/admin/admin/src/utils/strings.ts
@@ -1,3 +1,12 @@
 const capitalise = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
 
-export { capitalise };
+function getByteSize(value: string) {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length;
+  }
+
+  // Fallback: Count bytes manually (assuming most non-ASCII chars are 2+ bytes)
+  return value.split('').reduce((sum, char) => sum + (char.charCodeAt(0) > 127 ? 2 : 1), 0);
+}
+
+export { capitalise, getByteSize };

--- a/packages/core/admin/admin/src/utils/strings.ts
+++ b/packages/core/admin/admin/src/utils/strings.ts
@@ -1,38 +1,7 @@
 const capitalise = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
 
 function getByteSize(value: string) {
-  if (typeof TextEncoder !== 'undefined') {
-    return new TextEncoder().encode(value).length;
-  }
-
-  // Manual UTF-8 encoding (fully reliable fallback)
-  let bytes = 0;
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-
-    if (code < 0x80) {
-      bytes += 1; // ASCII (1 byte)
-    } else if (code < 0x800) {
-      bytes += 2; // 2-byte UTF-8
-    } else if (code >= 0xd800 && code <= 0xdbff) {
-      // High surrogate (part of surrogate pair)
-      if (i + 1 < value.length) {
-        const nextCode = value.charCodeAt(i + 1);
-        if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
-          // Valid surrogate pair (4-byte UTF-8)
-          bytes += 4;
-          i++; // Skip next code unit
-          continue;
-        }
-      }
-      bytes += 3; // Unmatched high surrogate → treated as 3-byte UTF-8
-    } else if (code < 0x10000) {
-      bytes += 3; // 3-byte UTF-8
-    } else {
-      bytes += 4; // 4-byte UTF-8
-    }
-  }
-  return bytes;
+  return new globalThis.TextEncoder().encode(value).length;
 }
 
 export { capitalise, getByteSize };

--- a/packages/core/admin/admin/src/utils/strings.ts
+++ b/packages/core/admin/admin/src/utils/strings.ts
@@ -1,7 +1,7 @@
 const capitalise = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1);
 
 function getByteSize(value: string) {
-  return new globalThis.TextEncoder().encode(value).length;
+  return new TextEncoder().encode(value).length;
 }
 
 export { capitalise, getByteSize };

--- a/packages/core/admin/admin/tests/setup.ts
+++ b/packages/core/admin/admin/tests/setup.ts
@@ -2,10 +2,6 @@ import { TextEncoder } from 'util';
 
 import { server } from './server';
 
-// Note: We set this here because setting it in the config is broken for projects: https://github.com/jestjs/jest/issues/9696
-// Also, there are issues with async tests unless it is set at global scope: https://github.com/jestjs/jest/issues/11543
-jest.setTimeout(60 * 1000);
-
 // Jest doesn't have access to TextEncoder
 // See https://github.com/inrupt/solid-client-authn-js/issues/1676#issuecomment-917016646
 global.TextEncoder = TextEncoder;

--- a/packages/core/admin/admin/tests/setup.ts
+++ b/packages/core/admin/admin/tests/setup.ts
@@ -1,4 +1,14 @@
+import { TextEncoder } from 'util';
+
 import { server } from './server';
+
+// Note: We set this here because setting it in the config is broken for projects: https://github.com/jestjs/jest/issues/9696
+// Also, there are issues with async tests unless it is set at global scope: https://github.com/jestjs/jest/issues/11543
+jest.setTimeout(60 * 1000);
+
+// Jest doesn't have access to TextEncoder
+// See https://github.com/inrupt/solid-client-authn-js/issues/1676#issuecomment-917016646
+global.TextEncoder = TextEncoder;
 
 beforeAll(() => {
   server.listen();

--- a/tests/api/core/admin/admin-auth.test.api.js
+++ b/tests/api/core/admin/admin-auth.test.api.js
@@ -413,6 +413,7 @@ describe('Admin Auth End to End', () => {
     });
 
     test('Fails on password of 73 bytes', async () => {
+      const password = `aA1${'b'.repeat(70)}`;
       const res = await rq({
         url: '/admin/register',
         method: 'POST',
@@ -421,7 +422,7 @@ describe('Admin Auth End to End', () => {
           userInfo: {
             firstname: 'test',
             lastname: 'Strapi',
-            password: `aA1${'b'.repeat(70)}`,
+            password,
           },
         },
       });
@@ -436,6 +437,7 @@ describe('Admin Auth End to End', () => {
               {
                 message: 'userInfo.password must be less than 73 bytes',
                 name: 'ValidationError',
+                value: password,
                 path: ['userInfo', 'password'],
               },
             ],


### PR DESCRIPTION
### What does it do?

- fix the validation on front end password reset and registration because `TextEncoder` is not available there
- fix the message itself which was incorrectly wrapped in an object
- adds additional tests for too short / too long
- fixes an api test that was not expecting correctly

### Why is it needed?

- the front end tests are failing because of the above reasons

### How to test it?

tests should pass

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
