### PR TITLE
fix(media-library): Fix broken breadcrumbs for deeply nested folders (404 Error)

### DIFF
--- a/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.tsx
+++ b/packages/core/upload/admin/src/components/Breadcrumbs/CrumbSimpleMenuAsync.tsx
@@ -22,6 +22,7 @@ export const CrumbSimpleMenuAsync = ({
   const [shouldFetch, setShouldFetch] = React.useState(false);
   const { data, isLoading } = useFolderStructure({ enabled: shouldFetch });
   const { pathname } = useLocation();
+  const fullPathname = `/admin${pathname}`;
   const [{ query }] = useQueryParams();
   const { formatMessage } = useIntl();
 
@@ -70,8 +71,8 @@ export const CrumbSimpleMenuAsync = ({
             );
           }
 
-          const url = getFolderURL(pathname, query, {
-            folder: typeof ascendant?.id === 'string' ? ascendant.id : undefined,
+          const url = getFolderURL(fullPathname, query, {
+            folder: String(ascendant.id),
             folderPath: ascendant?.path,
           });
 

--- a/packages/core/upload/admin/src/components/SelectTree/utils/flattenTree.ts
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/flattenTree.ts
@@ -2,6 +2,7 @@ type TreeNode<T> = {
   value: T;
   children?: TreeNode<T>[];
   label?: string;
+  path?: string;
 };
 
 export type FlattenedNode<T> = {
@@ -10,17 +11,24 @@ export type FlattenedNode<T> = {
   depth: number;
   // we need the label in places where flattenTree is used
   label?: string;
+  path?: string;
   children?: TreeNode<T>[];
 };
 
 export function flattenTree<T>(
   tree: TreeNode<T>[],
   parent: TreeNode<T> | null = null,
-  depth: number = 0
+  depth: number = 0,
+  path: string = ''
 ): FlattenedNode<T>[] {
-  return tree.flatMap((item) =>
-    item.children
-      ? [{ ...item, parent: parent?.value, depth }, ...flattenTree(item.children, item, depth + 1)]
-      : { ...item, depth, parent: parent?.value }
-  );
+  return tree.flatMap((item) => {
+    const newPath = item.value ? `${path}/${item.value}` : path;
+
+    return item.children
+      ? [
+          { ...item, parent: parent?.value, depth, path: newPath },
+          ...flattenTree(item.children, item, depth + 1, newPath),
+        ]
+      : { ...item, depth, parent: parent?.value, path: newPath };
+  });
 }

--- a/packages/core/upload/admin/src/utils/getFolderParents.ts
+++ b/packages/core/upload/admin/src/utils/getFolderParents.ts
@@ -23,7 +23,11 @@ export const getFolderParents = (folders: FolderStructureValue[], currentFolderI
   while (parent !== undefined) {
     // eslint-disable-next-line no-loop-func
     const parentToStore = flatFolders.find(({ value }) => value === parent);
-    parents.push({ id: parentToStore?.value, label: parentToStore?.label });
+    parents.push({
+      id: parentToStore?.value,
+      label: parentToStore?.label,
+      path: parentToStore?.path,
+    });
     parent = parentToStore?.parent;
   }
 


### PR DESCRIPTION
### What does it do?

This commit fixes the issue where breadcrumbs were broken for deeply nested folders in the Media Library, resulting in a 404 error. The fix ensures that breadcrumbs are correctly generated for all folder levels.

### Why is it needed?

The current implementation of breadcrumbs in the Media Library does not handle deeply nested folders correctly, leading to a 404 error. This fix addresses the issue and improves the user experience by ensuring breadcrumbs work as expected.

### How to test it?

1. Go to the Media Library.
2. Create multiple nested folders.
3. Navigate through the nested folders and observe the breadcrumbs.
4. Ensure that the breadcrumbs are correctly displayed and no 404 errors occur.

### Related issue(s)/PR(s)

Fixes #22885

