### PR TITLE
fix: invalid documentId type in the getvalues util

### DIFF
--- a/packages/core/types/src/modules/documents/params/attributes/index.ts
+++ b/packages/core/types/src/modules/documents/params/attributes/index.ts
@@ -77,7 +77,7 @@ export type ScalarValues = GetValue<
  */
 export type GetValues<TSchemaUID extends UID.Schema> = {
   id?: ID;
-  documentId?: TSchemaUID;
+  documentId?: DocumentID;
 } & OmitRelationsWithoutTarget<
   TSchemaUID,
   {


### PR DESCRIPTION
### What does it do?

Fix the `documentId` type in the documents' `GetValues` type util.

Make it point to a `DocumentId` type rather than the given Schema UID.

### How to test it?

Make sure the document service works fine with document IDs

### Related issue(s)/PR(s)

fix #22916