### PR TITLE
feat(preview): add review workflow injection zone

### DIFF
--- a/packages/core/content-manager/admin/src/components/InjectionZone.tsx
+++ b/packages/core/content-manager/admin/src/components/InjectionZone.tsx
@@ -54,8 +54,8 @@ type InjectionZoneBlock = InjectionZoneArea extends `${string}.${string}.${infer
  * e.g. content-manager edit view, we just send the slug but we might not in the listView,
  * therefore, people should type it themselves on the components they render.
  */
-const InjectionZone = (props: { area: InjectionZoneArea; [key: string]: unknown }) => {
-  const components = useInjectionZone(props.area);
+const InjectionZone = ({ area, ...props }: { area: InjectionZoneArea; [key: string]: unknown }) => {
+  const components = useInjectionZone(area);
 
   return (
     <>

--- a/packages/core/content-manager/admin/src/components/InjectionZone.tsx
+++ b/packages/core/content-manager/admin/src/components/InjectionZone.tsx
@@ -10,6 +10,9 @@ const INJECTION_ZONES = {
     publishModalAdditionalInfos: [],
     unpublishModalAdditionalInfos: [],
   },
+  preview: {
+    actions: [],
+  },
 } satisfies InjectionZones;
 
 interface InjectionZones {
@@ -23,6 +26,9 @@ interface InjectionZones {
     publishModalAdditionalInfos: InjectionZoneComponent[];
     unpublishModalAdditionalInfos: InjectionZoneComponent[];
   };
+  preview: {
+    actions: InjectionZoneComponent[];
+  };
 }
 
 type InjectionZoneArea =
@@ -32,7 +38,8 @@ type InjectionZoneArea =
   | 'listView.unpublishModalAdditionalInfos'
   | 'listView.deleteModalAdditionalInfos'
   | 'listView.publishModalAdditionalInfos'
-  | 'listView.deleteModalAdditionalInfos';
+  | 'listView.deleteModalAdditionalInfos'
+  | 'preview.actions';
 
 type InjectionZoneModule = InjectionZoneArea extends `${infer Word}.${string}` ? Word : never;
 type InjectionZoneContainer = InjectionZoneArea extends `${string}.${infer Word}.${string}`
@@ -47,8 +54,8 @@ type InjectionZoneBlock = InjectionZoneArea extends `${string}.${string}.${infer
  * e.g. content-manager edit view, we just send the slug but we might not in the listView,
  * therefore, people should type it themselves on the components they render.
  */
-const InjectionZone = ({ area, ...props }: { area: InjectionZoneArea; [key: string]: unknown }) => {
-  const components = useInjectionZone(area);
+const InjectionZone = (props: { area: InjectionZoneArea; [key: string]: unknown }) => {
+  const components = useInjectionZone(props.area);
 
   return (
     <>

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -15,6 +15,7 @@ import { useIntl } from 'react-intl';
 import { Link, type To } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { InjectionZone } from '../../components/InjectionZone';
 import { DocumentActionButton } from '../../pages/EditView/components/DocumentActions';
 import { DocumentStatus } from '../../pages/EditView/components/DocumentStatus';
 import { getDocumentStatus } from '../../pages/EditView/EditViewPage';
@@ -121,29 +122,27 @@ const PreviewTabs = () => {
   }
 
   return (
-    <>
-      <Tabs.Root variant="simple" value={query.status || 'draft'} onValueChange={handleTabChange}>
-        <Tabs.List
-          aria-label={formatMessage({
-            id: 'preview.tabs.label',
-            defaultMessage: 'Document status',
+    <Tabs.Root variant="simple" value={query.status || 'draft'} onValueChange={handleTabChange}>
+      <Tabs.List
+        aria-label={formatMessage({
+          id: 'preview.tabs.label',
+          defaultMessage: 'Document status',
+        })}
+      >
+        <StatusTab value="draft">
+          {formatMessage({
+            id: 'content-manager.containers.List.draft',
+            defaultMessage: 'draft',
           })}
-        >
-          <StatusTab value="draft">
-            {formatMessage({
-              id: 'content-manager.containers.List.draft',
-              defaultMessage: 'draft',
-            })}
-          </StatusTab>
-          <StatusTab value="published" disabled={documentStatus === 'draft'}>
-            {formatMessage({
-              id: 'content-manager.containers.List.published',
-              defaultMessage: 'published',
-            })}
-          </StatusTab>
-        </Tabs.List>
-      </Tabs.Root>
-    </>
+        </StatusTab>
+        <StatusTab value="published" disabled={documentStatus === 'draft'}>
+          {formatMessage({
+            id: 'content-manager.containers.List.published',
+            defaultMessage: 'published',
+          })}
+        </StatusTab>
+      </Tabs.List>
+    </Tabs.Root>
   );
 };
 
@@ -212,7 +211,9 @@ const UnstablePreviewHeader = () => {
         gap={2}
         justifyContent={hasDraftAndPublish ? 'space-between' : 'flex-end'}
       >
-        <PreviewTabs />
+        <Flex flex="1 1 70%">
+          <PreviewTabs />
+        </Flex>
         <Flex gap={2}>
           <IconButton
             type="button"
@@ -224,6 +225,7 @@ const UnstablePreviewHeader = () => {
           >
             <LinkIcon />
           </IconButton>
+          <InjectionZone area="preview.actions" />
           <DescriptionComponentRenderer
             props={props}
             descriptions={(

--- a/packages/core/content-manager/admin/src/tests/content-manager.test.ts
+++ b/packages/core/content-manager/admin/src/tests/content-manager.test.ts
@@ -58,6 +58,9 @@ describe('content-manager', () => {
               "publishModalAdditionalInfos": [],
               "unpublishModalAdditionalInfos": [],
             },
+            "preview": {
+              "actions": [],
+            },
           },
           "name": "Content Manager",
         }

--- a/packages/core/review-workflows/admin/src/index.ts
+++ b/packages/core/review-workflows/admin/src/index.ts
@@ -1,5 +1,7 @@
 import { PLUGIN_ID, FEATURE_ID } from './constants';
+import { AssigneeSelect } from './routes/content-manager/model/id/components/AssigneeSelect';
 import { Panel } from './routes/content-manager/model/id/components/Panel';
+import { StageSelect } from './routes/content-manager/model/id/components/StageSelect';
 import { addColumnToTableHook } from './utils/cm-hooks';
 import { prefixPluginTranslations } from './utils/translations';
 
@@ -47,6 +49,19 @@ const admin: Plugin.Config.AdminInput = {
           const { PurchaseReviewWorkflows } = await import('./routes/purchase-review-workflows');
           return { default: PurchaseReviewWorkflows };
         },
+      });
+    }
+  },
+  bootstrap(app: StrapiApp) {
+    if (window.strapi.features.isEnabled(FEATURE_ID)) {
+      app.getPlugin('content-manager').injectComponent('preview', 'actions', {
+        name: 'review-workflows-assignee',
+        Component: AssigneeSelect,
+      });
+
+      app.getPlugin('content-manager').injectComponent('preview', 'actions', {
+        name: 'review-workflows-stage',
+        Component: StageSelect,
       });
     }
   },

--- a/packages/core/review-workflows/admin/src/index.ts
+++ b/packages/core/review-workflows/admin/src/index.ts
@@ -1,5 +1,5 @@
 import { PLUGIN_ID, FEATURE_ID } from './constants';
-import { AssigneeSelect } from './routes/content-manager/model/id/components/AssigneeSelect';
+import { Header } from './routes/content-manager/model/id/components/Header';
 import { Panel } from './routes/content-manager/model/id/components/Panel';
 import { StageSelect } from './routes/content-manager/model/id/components/StageSelect';
 import { addColumnToTableHook } from './utils/cm-hooks';
@@ -56,12 +56,7 @@ const admin: Plugin.Config.AdminInput = {
     if (window.strapi.features.isEnabled(FEATURE_ID)) {
       app.getPlugin('content-manager').injectComponent('preview', 'actions', {
         name: 'review-workflows-assignee',
-        Component: AssigneeSelect,
-      });
-
-      app.getPlugin('content-manager').injectComponent('preview', 'actions', {
-        name: 'review-workflows-stage',
-        Component: StageSelect,
+        Component: Header,
       });
     }
   },

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
@@ -89,6 +89,11 @@ const AssigneeSelect = ({ area }: { area?: InjectionZoneArea }) => {
     }
   };
 
+  const assigneeLabel = formatMessage({
+    id: 'content-manager.reviewWorkflows.assignee.label',
+    defaultMessage: 'Assignee',
+  });
+
   return (
     <Field.Root
       name={ASSIGNEE_ATTRIBUTE_NAME}
@@ -106,20 +111,10 @@ const AssigneeSelect = ({ area }: { area?: InjectionZoneArea }) => {
     >
       {isCompact ? (
         <VisuallyHidden>
-          <Field.Label>
-            {formatMessage({
-              id: 'content-manager.reviewWorkflows.assignee.label',
-              defaultMessage: 'Assignee',
-            })}
-          </Field.Label>
+          <Field.Label>{assigneeLabel}</Field.Label>
         </VisuallyHidden>
       ) : (
-        <Field.Label>
-          {formatMessage({
-            id: 'content-manager.reviewWorkflows.assignee.label',
-            defaultMessage: 'Assignee',
-          })}
-        </Field.Label>
+        <Field.Label>{assigneeLabel}</Field.Label>
       )}
       <Combobox
         clearLabel={formatMessage({

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
@@ -8,7 +8,7 @@ import {
   useQueryParams,
 } from '@strapi/admin/strapi-admin';
 import { unstable_useDocument } from '@strapi/content-manager/strapi-admin';
-import { Combobox, ComboboxOption, Field } from '@strapi/design-system';
+import { Combobox, ComboboxOption, Field, VisuallyHidden } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 
@@ -19,7 +19,10 @@ import { getDisplayName } from '../../../../../utils/users';
 
 import { ASSIGNEE_ATTRIBUTE_NAME } from './constants';
 
-const AssigneeSelect = () => {
+type InjectionZoneArea = 'preview.actions';
+
+const AssigneeSelect = ({ area }: { area?: InjectionZoneArea }) => {
+  const isCompact = area === 'preview.actions';
   const {
     collectionType = '',
     id,
@@ -101,12 +104,23 @@ const AssigneeSelect = () => {
         undefined
       }
     >
-      <Field.Label>
-        {formatMessage({
-          id: 'content-manager.reviewWorkflows.assignee.label',
-          defaultMessage: 'Assignee',
-        })}
-      </Field.Label>
+      {isCompact ? (
+        <VisuallyHidden>
+          <Field.Label>
+            {formatMessage({
+              id: 'content-manager.reviewWorkflows.assignee.label',
+              defaultMessage: 'Assignee',
+            })}
+          </Field.Label>
+        </VisuallyHidden>
+      ) : (
+        <Field.Label>
+          {formatMessage({
+            id: 'content-manager.reviewWorkflows.assignee.label',
+            defaultMessage: 'Assignee',
+          })}
+        </Field.Label>
+      )}
       <Combobox
         clearLabel={formatMessage({
           id: 'content-manager.reviewWorkflows.assignee.clear',
@@ -123,6 +137,7 @@ const AssigneeSelect = () => {
           defaultMessage: 'Select…',
         })}
         loading={isLoading || isLoadingPermissions || isMutating}
+        size={isCompact ? 'S' : undefined}
       >
         {users.map((user) => {
           return (

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/Header.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/Header.tsx
@@ -1,0 +1,42 @@
+import { unstable_useDocumentLayout as useDocumentLayout } from '@strapi/content-manager/strapi-admin';
+import { Flex } from '@strapi/design-system';
+import { useParams } from 'react-router-dom';
+
+import { AssigneeSelect } from './AssigneeSelect';
+import { StageSelect } from './StageSelect';
+
+const Header = () => {
+  const {
+    slug = '',
+    id,
+    collectionType,
+  } = useParams<{
+    collectionType: string;
+    slug: string;
+    id: string;
+  }>();
+
+  const {
+    edit: { options },
+  } = useDocumentLayout(slug);
+
+  if (
+    !window.strapi.isEE ||
+    !options?.reviewWorkflows ||
+    (collectionType !== 'single-types' && !id) ||
+    id === 'create'
+  ) {
+    return null;
+  }
+
+  return (
+    <Flex gap={2}>
+      <AssigneeSelect isCompact />
+      <StageSelect isCompact />
+    </Flex>
+  );
+};
+
+Header.type = 'preview';
+
+export { Header };

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
@@ -149,6 +149,11 @@ export const StageSelect = ({ area }: { area?: InjectionZoneArea }) => {
 
   const isLoading = isLoadingStages || isLoadingDocument;
 
+  const reviewStageLabel = formatMessage({
+    id: 'content-manager.reviewWorkflows.stage.label',
+    defaultMessage: 'Review stage',
+  });
+
   return (
     <>
       <Field.Root
@@ -166,20 +171,10 @@ export const StageSelect = ({ area }: { area?: InjectionZoneArea }) => {
       >
         {isCompact ? (
           <VisuallyHidden>
-            <Field.Label>
-              {formatMessage({
-                id: 'content-manager.reviewWorkflows.stage.label',
-                defaultMessage: 'Review stage',
-              })}
-            </Field.Label>
+            <Field.Label>{reviewStageLabel}</Field.Label>
           </VisuallyHidden>
         ) : (
-          <Field.Label>
-            {formatMessage({
-              id: 'content-manager.reviewWorkflows.stage.label',
-              defaultMessage: 'Review stage',
-            })}
-          </Field.Label>
+          <Field.Label>{reviewStageLabel}</Field.Label>
         )}
 
         <SingleSelect
@@ -209,7 +204,7 @@ export const StageSelect = ({ area }: { area?: InjectionZoneArea }) => {
           customizeContent={() => {
             return (
               <Flex tag="span" justifyContent="space-between" alignItems="center" width="100%">
-                <Typography textColor="neutral800" ellipsis style={{ lineHeight: 'inherit' }}>
+                <Typography textColor="neutral800" ellipsis lineHeight="inherit">
                   {activeWorkflowStage?.name ?? ''}
                 </Typography>
                 {isLoading ? (

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Loader,
   Typography,
+  VisuallyHidden,
 } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
@@ -27,7 +28,10 @@ import { STAGE_ATTRIBUTE_NAME } from './constants';
 
 import type { Data } from '@strapi/types';
 
-export const StageSelect = () => {
+type InjectionZoneArea = 'preview.actions';
+
+export const StageSelect = ({ area }: { area?: InjectionZoneArea }) => {
+  const isCompact = area === 'preview.actions';
   const {
     collectionType = '',
     slug: model = '',
@@ -160,13 +164,26 @@ export const StageSelect = () => {
         name={STAGE_ATTRIBUTE_NAME}
         id={STAGE_ATTRIBUTE_NAME}
       >
-        <Field.Label>
-          {formatMessage({
-            id: 'content-manager.reviewWorkflows.stage.label',
-            defaultMessage: 'Review stage',
-          })}
-        </Field.Label>
+        {isCompact ? (
+          <VisuallyHidden>
+            <Field.Label>
+              {formatMessage({
+                id: 'content-manager.reviewWorkflows.stage.label',
+                defaultMessage: 'Review stage',
+              })}
+            </Field.Label>
+          </VisuallyHidden>
+        ) : (
+          <Field.Label>
+            {formatMessage({
+              id: 'content-manager.reviewWorkflows.stage.label',
+              defaultMessage: 'Review stage',
+            })}
+          </Field.Label>
+        )}
+
         <SingleSelect
+          size={isCompact ? 'S' : undefined}
           disabled={stages.length === 0}
           value={activeWorkflowStage?.id}
           onChange={handleChange}
@@ -192,7 +209,7 @@ export const StageSelect = () => {
           customizeContent={() => {
             return (
               <Flex tag="span" justifyContent="space-between" alignItems="center" width="100%">
-                <Typography textColor="neutral800" ellipsis>
+                <Typography textColor="neutral800" ellipsis style={{ lineHeight: 'inherit' }}>
                   {activeWorkflowStage?.name ?? ''}
                 </Typography>
                 {isLoading ? (

--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -1,9 +1,45 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { describeOnCondition, findAndClose } from '../../utils/shared';
+import { clickAndWait, describeOnCondition, findAndClose } from '../../utils/shared';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+const checkAssignee = async (page) => {
+  /**
+   * Check the assignee combobox exists and set the assignee to our editor
+   */
+  await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
+  await page.getByRole('combobox', { name: 'Assignee' }).click();
+  await page.getByRole('option', { name: 'editor testing' }).click();
+
+  await findAndClose(page, 'Assignee updated');
+
+  /**
+   * Double check it's updated correctly, this would fail if
+   * the document is not updated with the assignee as we
+   * refetch said document.
+   */
+  await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue('editor testing');
+};
+
+const checkStage = async (page) => {
+  /**
+   * Check the stage combobox exists and set the stage to in progress
+   */
+  await expect(page.getByRole('combobox', { name: 'Review stage' })).toBeVisible();
+  await page.getByRole('combobox', { name: 'Review stage' }).click();
+  await page.getByRole('option', { name: 'In progress' }).click();
+
+  await findAndClose(page, 'Review stage updated');
+
+  /**
+   * Double check it's updated correctly, this would fail if
+   * the document is not updated with the stage as we
+   * refetch said document.
+   */
+  await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText('In progress');
+};
 
 describeOnCondition(edition === 'EE')('content-manager', () => {
   test.beforeEach(async ({ page }) => {
@@ -12,7 +48,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await login({ page });
   });
 
-  test('as a user I want to assign a document to a user and see this update in the list-view afterwards', async ({
+  test('I want to assign a document to a user and see this update in the list-view afterwards', async ({
     page,
   }) => {
     /**
@@ -21,21 +57,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await page.getByRole('link', { name: 'Content Manager' }).click();
     await page.getByRole('gridcell', { name: 'West Ham post match analysis' }).click();
 
-    /**
-     * Check the assignee combobox exists and set the assignee to our editor
-     */
-    await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
-    await page.getByRole('combobox', { name: 'Assignee' }).click();
-    await page.getByRole('option', { name: 'editor testing' }).click();
-
-    await findAndClose(page, 'Assignee updated');
-
-    /**
-     * Double check it's updated correctly, this would fail if
-     * the document is not updated with the assignee as we
-     * refetch said document.
-     */
-    await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue('editor testing');
+    await checkAssignee(page);
 
     /**
      * Go back to ensure the list view has correctly updated
@@ -51,7 +73,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue('editor testing');
   });
 
-  test('as a user I want to change the stage of a document and see this update in the list-view afterwards', async ({
+  test('I want to change the stage of a document and see this update in the list-view afterwards', async ({
     page,
   }) => {
     /**
@@ -60,21 +82,7 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await page.getByRole('link', { name: 'Content Manager' }).click();
     await page.getByRole('gridcell', { name: 'West Ham post match analysis' }).click();
 
-    /**
-     * Check the stage combobox exists and set the stage to in progress
-     */
-    await expect(page.getByRole('combobox', { name: 'Review stage' })).toBeVisible();
-    await page.getByRole('combobox', { name: 'Review stage' }).click();
-    await page.getByRole('option', { name: 'In progress' }).click();
-
-    await findAndClose(page, 'Review stage updated');
-
-    /**
-     * Double check it's updated correctly, this would fail if
-     * the document is not updated with the stage as we
-     * refetch said document.
-     */
-    await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText('In progress');
+    await checkStage(page);
 
     /**
      * Go back to ensure the list view has correctly updated
@@ -89,4 +97,82 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await expect(page.getByRole('combobox', { name: 'Review stage' })).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText('In progress');
   });
+
+  test('I want to change the stage of a document from preview and see this change in the edit and list views', async ({
+    page,
+  }) => {
+    // Open an edit view for a content type that has preview
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+    // Open the preview page
+    await clickAndWait(page, page.getByRole('link', { name: /open preview/i }));
+
+    await checkAssignee(page);
+
+    // Confirm the edit view updated
+    await clickAndWait(page, page.getByRole('link', { name: /close preview/i }));
+    await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue('editor testing');
+
+    // Confirm the list view updated
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+    await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
+  });
+
+  describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR === 'true')(
+    'Unstable Preview',
+    () => {
+      test('I want to change the assignee of a document from preview and see this change in the edit and list views', async ({
+        page,
+      }) => {
+        // Open an edit view for a content type that has preview
+        await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+        await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+        await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+        // Open the preview page
+        await clickAndWait(page, page.getByRole('link', { name: /open preview/i }));
+
+        await checkAssignee(page);
+
+        // Confirm the edit view updated
+        await clickAndWait(page, page.getByRole('link', { name: /close preview/i }));
+        await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
+        await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue(
+          'editor testing'
+        );
+
+        // Confirm the list view updated
+        await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+        await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
+      });
+
+      test('I want to change the stage of a document from preview and see this change in the edit and list views', async ({
+        page,
+      }) => {
+        // Open an edit view for a content type that has preview
+        await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+        await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+        await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
+
+        // Open the preview page
+        await clickAndWait(page, page.getByRole('link', { name: /open preview/i }));
+
+        await checkStage(page);
+
+        // Confirm the edit view updated
+        await clickAndWait(page, page.getByRole('link', { name: /close preview/i }));
+        await expect(page.getByRole('combobox', { name: 'Review stage' })).toBeVisible();
+        await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText(
+          'In progress'
+        );
+
+        // Confirm the list view updated
+        await page.getByRole('link', { name: 'Back' }).click();
+        await expect(page.getByRole('gridcell', { name: 'In progress' })).toBeVisible();
+      });
+    }
+  );
 });

--- a/tests/e2e/tests/review-workflows/content-manager.spec.ts
+++ b/tests/e2e/tests/review-workflows/content-manager.spec.ts
@@ -98,29 +98,6 @@ describeOnCondition(edition === 'EE')('content-manager', () => {
     await expect(page.getByRole('combobox', { name: 'Review stage' })).toHaveText('In progress');
   });
 
-  test('I want to change the stage of a document from preview and see this change in the edit and list views', async ({
-    page,
-  }) => {
-    // Open an edit view for a content type that has preview
-    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
-    await clickAndWait(page, page.getByRole('gridcell', { name: /west ham post match/i }));
-
-    // Open the preview page
-    await clickAndWait(page, page.getByRole('link', { name: /open preview/i }));
-
-    await checkAssignee(page);
-
-    // Confirm the edit view updated
-    await clickAndWait(page, page.getByRole('link', { name: /close preview/i }));
-    await expect(page.getByRole('combobox', { name: 'Assignee' })).toBeVisible();
-    await expect(page.getByRole('combobox', { name: 'Assignee' })).toHaveValue('editor testing');
-
-    // Confirm the list view updated
-    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
-    await expect(page.getByRole('gridcell', { name: 'editor testing' })).toBeVisible();
-  });
-
   describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR === 'true')(
     'Unstable Preview',
     () => {


### PR DESCRIPTION
### What does it do?

- Create a preview.actions injection zone
- Uses that injection zone for review workflows
- Updates the InjectionZone component to pass the area to the injected component. We need something like this to conditionally render things in the ReviewWorkflows components. It think it could be useful in other cases where components are injected in different places that require different behaviors. 

### Why is it needed?

To be able to update stage and assignee from preview

### How to test it?

Go to the preview page and update the stage and assignee

### Related issue(s)/PR(s)

This PR should be merged after https://github.com/strapi/strapi/pull/22902
