### PR TITLE
feat(admin/sso): remember user until token expires

### DIFF
--- a/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
+++ b/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
@@ -38,10 +38,12 @@ const AuthResponse = () => {
         dispatch(
           login({
             token: jwtToken,
+            persist: getCookieValue('rememberMe') === 'true',
           })
         );
 
         deleteCookie('jwtToken');
+        deleteCookie('rememberMe');
 
         navigate('/auth/login');
       } else {

--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
@@ -109,6 +109,7 @@ export const redirectWithAuth: Core.MiddlewareHandler = (ctx) => {
   strapi.eventHub.emit('admin.auth.success', { user: sanitizedUser, provider });
 
   ctx.cookies.set('jwtToken', jwt, cookiesOptions);
+  ctx.cookies.set('rememberMe', 'true', cookiesOptions);
   ctx.redirect(redirectUrls.success);
 };
 


### PR DESCRIPTION
> [!NOTE]
> This might be considered a breaking change because it changes the default behavior of SSO Remember Me.
> Feel free to close this PR if it does not align with Strapi
> This was more of an experimental PR. I needed this feature and did it via a patch at the moment (see at the end)

### What does it do?

When using `provider` admin sign-in persist the `jwtToken` in `localStorage` instead of `sessionStorage`

### Why is it needed?

When using the `local` admin sign-in, we have the option to remember me.
In the case of the `provider` sign-in, the user has to do it each time the tab is closed.

### How to test it?

- Change `auth.options.expiresIn` to `1m` in admin config
- Admin SignIn with an SSO provider.
- After login, close and reopen the tab.
- The user is still signed in.
- After 1 minute, the user is redirected to the Sign In page again.

<details><summary>patches/@strapi+admin+5.6.0.patch</summary>
<p>

```diff
diff --git a/node_modules/@strapi/admin/dist/admin/AuthResponse-CWs8VL81.mjs b/node_modules/@strapi/admin/dist/admin/AuthResponse-CWs8VL81.mjs
index 9ffc321..f411f9f 100644
--- a/node_modules/@strapi/admin/dist/admin/AuthResponse-CWs8VL81.mjs
+++ b/node_modules/@strapi/admin/dist/admin/AuthResponse-CWs8VL81.mjs
@@ -44,10 +44,12 @@ const AuthResponse = () => {
       if (jwtToken) {
         dispatch(
           login({
+            persist: getCookieValue("rememberMe") === 'true',
             token: jwtToken
           })
         );
         deleteCookie("jwtToken");
+        deleteCookie("rememberMe");
         navigate("/auth/login");
       } else {
         redirectToOops();
diff --git a/node_modules/@strapi/admin/dist/server/index.js b/node_modules/@strapi/admin/dist/server/index.js
index d403a63..2891268 100644
--- a/node_modules/@strapi/admin/dist/server/index.js
+++ b/node_modules/@strapi/admin/dist/server/index.js
@@ -6318,6 +6318,7 @@ const redirectWithAuth = (ctx) => {
   const sanitizedUser = getService("user").sanitizeUser(user2);
   strapi.eventHub.emit("admin.auth.success", { user: sanitizedUser, provider });
   ctx.cookies.set("jwtToken", jwt2, cookiesOptions);
+  ctx.cookies.set("rememberMe", 'true', cookiesOptions);
   ctx.redirect(redirectUrls.success);
 };
 const middlewares = {
```

</p>
</details> 