### PR TITLE
fix: await document exists

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -420,7 +420,7 @@ export default {
       const isUpdate = !isCreate;
       if (isUpdate) {
         // check if the document exists
-        const documentExists = documentManager.exists(model, id)!;
+        const documentExists = await documentManager.exists(model, id);
 
         if (!documentExists) {
           throw new errors.NotFoundError('Document not found');


### PR DESCRIPTION
### What does it do?

At [collection-types.ts#L423](https://github.com/strapi/strapi/blob/8264ee203574958f5f79b39d6365b90d99074674/packages/core/content-manager/server/src/controllers/collection-types.ts#L423), it appears that an asynchronous function call is missing the await keyword. As a result, the conditional branch that depends on its return value always evaluates to false, leading to behavior that deviates from the intended functionality.


### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/22951
