### PR TITLE
fix(preview): updating the document causes full page reload

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -98,9 +98,9 @@ const PreviewPage = () => {
   const documentLayoutResponse = useDocumentLayout(model);
 
   if (
-    documentResponse.isLoading ||
     previewUrlResponse.isLoading ||
-    documentLayoutResponse.isLoading
+    documentLayoutResponse.isLoading ||
+    !documentResponse.document.documentId
   ) {
     return <Page.Loading />;
   }


### PR DESCRIPTION
### What does it do?

- Remove the full page loading state triggered by the document action
- Handled the same way as the edit view

### Why is it needed?

- To not have a full page reload when we update or publish

### How to test it?

Provide information about the environment and the path to verify the behaviour.

