### PR TITLE
feat(relations): add save and publish actions to relations modal

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -29,6 +29,7 @@ interface DocumentMeta {
 }
 
 interface DocumentContextValue {
+  rootDocumentMeta: DocumentMeta;
   document: ReturnType<UseDocument>;
   meta: DocumentMeta;
   changeDocument: (newRelation: DocumentMeta) => void;
@@ -70,6 +71,12 @@ const DocumentContextProvider = ({
     <DocumentProvider
       changeDocument={changeDocument}
       document={document}
+      rootDocumentMeta={{
+        documentId: initialDocument.documentId,
+        model: initialDocument.model,
+        collectionType: initialDocument.collectionType,
+        params: initialDocument.params,
+      }}
       meta={currentDocumentMeta}
     >
       {children}

--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -22,8 +22,8 @@ interface DocumentMeta {
    */
   collectionType: string;
   /**
-   * The parsed query params
-   * i.e. ?i18n=en parsed to { i18n: 'en' }
+   * Query params object
+   * i.e. { locale: 'fr' }
    */
   params?: Record<string, string | string[] | null>;
 }

--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -25,7 +25,7 @@ interface DocumentMeta {
    * The parsed query params
    * i.e. ?i18n=en parsed to { i18n: 'en' }
    */
-  params?: Record<string, string>;
+  params?: Record<string, string | string[] | null>;
 }
 
 interface DocumentContextValue {

--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createContext } from '@strapi/admin/strapi-admin';
 
 import { useDocument, type UseDocument } from '../hooks/useDocument';
+import { buildValidParams } from '../utils/api';
 
 interface DocumentMeta {
   /**
@@ -20,6 +21,11 @@ interface DocumentMeta {
    * i.e. collection-types or single-types
    */
   collectionType: string;
+  /**
+   * The parsed query params
+   * i.e. ?i18n=en parsed to { i18n: 'en' }
+   */
+  params?: Record<string, string>;
 }
 
 interface DocumentContextValue {
@@ -54,7 +60,11 @@ const DocumentContextProvider = ({
    * one of the root level document's relations.
    */
   const [currentDocumentMeta, changeDocument] = React.useState<DocumentMeta>(initialDocument);
-  const document = useDocument(currentDocumentMeta);
+  const params = React.useMemo(
+    () => buildValidParams(currentDocumentMeta.params ?? {}),
+    [currentDocumentMeta.params]
+  );
+  const document = useDocument({ ...currentDocumentMeta, params });
 
   return (
     <DocumentProvider

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -26,6 +26,7 @@ import { DefaultTheme, styled } from 'styled-components';
 
 import { PUBLISHED_AT_ATTRIBUTE_NAME } from '../../../constants/attributes';
 import { SINGLE_TYPES } from '../../../constants/collections';
+import { useDocumentContext } from '../../../features/DocumentContext';
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
 import { useDoc } from '../../../hooks/useDocument';
 import { useDocumentActions } from '../../../hooks/useDocumentActions';
@@ -40,7 +41,7 @@ import type { DocumentActionComponent } from '../../../content-manager';
 /* -------------------------------------------------------------------------------------------------
  * Types
  * -----------------------------------------------------------------------------------------------*/
-type DocumentActionPosition = 'panel' | 'header' | 'table-row' | 'preview';
+type DocumentActionPosition = 'panel' | 'header' | 'table-row' | 'preview' | 'relation-modal';
 
 interface DocumentActionDescription {
   label: string;
@@ -517,7 +518,7 @@ const PublishAction: DocumentActionComponent = ({
   meta,
   document,
 }) => {
-  const { schema } = useDoc();
+  const schema = useDocumentContext('PublishAction', (state) => state.document.schema);
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
   const { _unstableFormatValidationErrors: formatValidationErrors } = useAPIErrorHandler();
@@ -689,7 +690,7 @@ const PublishAction: DocumentActionComponent = ({
 
   return {
     loading: isLoading,
-    position: ['panel', 'preview'],
+    position: ['panel', 'preview', 'relation-modal'],
     /**
      * Disabled when:
      *  - currently if you're cloning a document we don't support publish & clone at the same time.
@@ -748,7 +749,7 @@ const PublishAction: DocumentActionComponent = ({
 };
 
 PublishAction.type = 'publish';
-PublishAction.position = ['panel', 'preview'];
+PublishAction.position = ['panel', 'preview', 'relation-modal'];
 
 const UpdateAction: DocumentActionComponent = ({
   activeTab,
@@ -921,12 +922,12 @@ const UpdateAction: DocumentActionComponent = ({
       defaultMessage: 'Save',
     }),
     onClick: handleUpdate,
-    position: ['panel', 'preview'],
+    position: ['panel', 'preview', 'relation-modal'],
   };
 };
 
 UpdateAction.type = 'update';
-UpdateAction.position = ['panel', 'preview'];
+UpdateAction.position = ['panel', 'preview', 'relation-modal'];
 
 const UNPUBLISH_DRAFT_OPTIONS = {
   KEEP: 'keep',

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -545,6 +545,9 @@ const PublishAction: DocumentActionComponent = ({
   const setErrors = useForm('PublishAction', (state) => state.setErrors);
   const formValues = useForm('PublishAction', ({ values }) => values);
 
+  const rootDocumentMeta = useDocumentContext('PublishAction', (state) => state.rootDocumentMeta);
+  const currentDocumentMeta = useDocumentContext('PublishAction', (state) => state.meta);
+
   React.useEffect(() => {
     if (isErrorDraftRelations) {
       toggleNotification({
@@ -650,12 +653,13 @@ const PublishAction: DocumentActionComponent = ({
         return;
       }
 
+      const isPublishingRelation = rootDocumentMeta.documentId !== currentDocumentMeta.documentId;
       const res = await publish(
         {
           collectionType,
           model,
           documentId,
-          params,
+          params: isPublishingRelation ? currentDocumentMeta.params : params,
         },
         transformData(formValues)
       );
@@ -775,6 +779,9 @@ const UpdateAction: DocumentActionComponent = ({
   const setErrors = useForm('UpdateAction', (state) => state.setErrors);
   const resetForm = useForm('PublishAction', ({ resetForm }) => resetForm);
 
+  const rootDocumentMeta = useDocumentContext('UpdateAction', (state) => state.rootDocumentMeta);
+  const currentDocumentMeta = useDocumentContext('UpdateAction', (state) => state.meta);
+
   const handleUpdate = React.useCallback(async () => {
     setSubmitting(true);
 
@@ -826,12 +833,14 @@ const UpdateAction: DocumentActionComponent = ({
           setErrors(formatValidationErrors(res.error));
         }
       } else if (documentId || collectionType === SINGLE_TYPES) {
+        const isEditingRelation = rootDocumentMeta.documentId !== currentDocumentMeta.documentId;
+
         const res = await update(
           {
             collectionType,
             model,
             documentId,
-            params,
+            params: isEditingRelation ? currentDocumentMeta.params : params,
           },
           transformData(document)
         );

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentStatus.tsx
@@ -23,14 +23,8 @@ const DocumentStatus = ({ status = 'draft', size = 'S', ...restProps }: Document
   const { formatMessage } = useIntl();
 
   return (
-    <Status
-      {...restProps}
-      size={size}
-      variant={statusVariant}
-      role="status"
-      aria-labelledby="document-status"
-    >
-      <Typography tag="span" variant="omega" fontWeight="bold" id="document-status">
+    <Status {...restProps} size={size} variant={statusVariant} role="status" aria-label={status}>
+      <Typography tag="span" variant="omega" fontWeight="bold">
         {formatMessage({
           id: `content-manager.containers.List.${status}`,
           defaultMessage: capitalise(status),

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -94,7 +94,7 @@ const RelationModalBody = () => {
   const documentMeta = useDocumentContext('RelationModalBody', (state) => state.meta);
   const documentResponse = useDocumentContext('RelationModalBody', (state) => state.document);
   const documentLayoutResponse = useDocumentLayout(documentMeta.model);
-  const plugins = useStrapiApp('PreviewHeader', (state) => state.plugins);
+  const plugins = useStrapiApp('RelationModalBody', (state) => state.plugins);
 
   const initialValues = documentResponse.getInitialFormValues();
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import { Form as FormContext, useRBAC } from '@strapi/admin/strapi-admin';
+import {
+  DescriptionComponentRenderer,
+  Form as FormContext,
+  useRBAC,
+  useStrapiApp,
+} from '@strapi/admin/strapi-admin';
 import {
   Box,
   Button,
@@ -13,6 +18,7 @@ import {
 } from '@strapi/design-system';
 import { ArrowLeft, WarningCircle } from '@strapi/icons';
 import { useIntl } from 'react-intl';
+import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { COLLECTION_TYPES, SINGLE_TYPES } from '../../../../../constants/collections';
@@ -20,15 +26,16 @@ import { PERMISSIONS } from '../../../../../constants/plugin';
 import { useDocumentContext } from '../../../../../features/DocumentContext';
 import { DocumentRBAC } from '../../../../../features/DocumentRBAC';
 import { useDocumentLayout } from '../../../../../hooks/useDocumentLayout';
+import { createYupSchema } from '../../../../../utils/validation';
+import { DocumentActionButton } from '../../../components/DocumentActions';
 import { DocumentStatus } from '../../DocumentStatus';
 import { FormLayout } from '../../FormLayout';
+
+import type { ContentManagerPlugin, DocumentActionProps } from '../../../../../content-manager';
 
 interface RelationModalProps {
   open: boolean;
   onToggle: () => void;
-  id?: string;
-  model: string;
-  relationUrl: string;
 }
 
 export function getCollectionType(url: string) {
@@ -44,39 +51,35 @@ const CustomModalContent = styled(Modal.Content)`
   max-height: 100%;
 `;
 
-const RelationModal = ({ open, onToggle, id, model, relationUrl }: RelationModalProps) => {
+const RelationModal = ({ open, onToggle }: RelationModalProps) => {
   const { formatMessage } = useIntl();
 
   return (
     <Modal.Root open={open} onOpenChange={onToggle}>
       <CustomModalContent>
-        <Modal.Header>
-          <Flex>
-            <IconButton
-              withTooltip={false}
-              label="Back"
-              variant="ghost"
-              disabled
-              onClick={() => {}}
-              marginRight={1}
-            >
-              <ArrowLeft />
-            </IconButton>
-            <Typography tag="span" fontWeight={600}>
-              {formatMessage({
-                id: 'content-manager.components.RelationInputModal.modal-title',
-                defaultMessage: 'Edit a relation',
-              })}
-            </Typography>
+        <Modal.Header gap={2}>
+          <Flex justifyContent="space-between" alignItems="center" width="100%">
+            <Flex gap={2}>
+              <IconButton
+                withTooltip={false}
+                label="Back"
+                variant="ghost"
+                disabled
+                onClick={() => {}}
+                marginRight={1}
+              >
+                <ArrowLeft />
+              </IconButton>
+              <Typography tag="span" fontWeight={600}>
+                {formatMessage({
+                  id: 'content-manager.components.RelationInputModal.modal-title',
+                  defaultMessage: 'Edit a relation',
+                })}
+              </Typography>
+            </Flex>
           </Flex>
         </Modal.Header>
-        <RelationModalBody
-          id={id}
-          model={model}
-          collectionType={getCollectionType(relationUrl)!}
-          isModalOpen={open}
-          onToggleModal={onToggle}
-        />
+        <RelationModalBody />
         <Modal.Footer>
           <Button onClick={onToggle} variant="tertiary">
             {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'Cancel' })}
@@ -87,25 +90,18 @@ const RelationModal = ({ open, onToggle, id, model, relationUrl }: RelationModal
   );
 };
 
-interface RelationModalBodyProps {
-  model: string;
-  id?: string;
-  collectionType: string;
-  isModalOpen: boolean;
-  onToggleModal: () => void;
-}
-
-const RelationModalBody = ({ id }: RelationModalBodyProps) => {
+const RelationModalBody = () => {
   const { formatMessage } = useIntl();
   const documentMeta = useDocumentContext('RelationModalBody', (state) => state.meta);
   const documentResponse = useDocumentContext('RelationModalBody', (state) => state.document);
   const documentLayoutResponse = useDocumentLayout(documentMeta.model);
+  const plugins = useStrapiApp('PreviewHeader', (state) => state.plugins);
 
   const initialValues = documentResponse.getInitialFormValues();
 
   const {
     permissions = [],
-    isLoading,
+    isLoading: isLoadingPermissions,
     error,
   } = useRBAC(
     PERMISSIONS.map((action) => ({
@@ -114,7 +110,9 @@ const RelationModalBody = ({ id }: RelationModalBodyProps) => {
     }))
   );
 
-  if (isLoading || documentResponse.isLoading || documentLayoutResponse.isLoading) {
+  const isLoading =
+    isLoadingPermissions || documentLayoutResponse.isLoading || documentResponse.isLoading;
+  if (isLoading && !documentResponse.document?.documentId) {
     return (
       <Loader small>
         {formatMessage({
@@ -148,23 +146,92 @@ const RelationModalBody = ({ id }: RelationModalBodyProps) => {
   }
 
   const documentTitle = documentResponse.getTitle(documentLayoutResponse.edit.settings.mainField);
-
   const hasDraftAndPublished = documentResponse.schema?.options?.draftAndPublish ?? false;
+
+  const props = {
+    activeTab: 'draft',
+    collectionType: documentMeta.collectionType,
+    model: documentMeta.model,
+    documentId: documentMeta.documentId,
+    document: documentResponse.document,
+    meta: documentResponse.meta,
+  } satisfies DocumentActionProps;
 
   return (
     <Modal.Body>
       <DocumentRBAC permissions={permissions} model={documentMeta.model}>
-        <Flex direction="column" alignItems="flex-start" gap={2}>
-          <Typography tag="h2" variant="alpha">
-            {documentTitle}
-          </Typography>
-          {hasDraftAndPublished ? (
-            <Box marginTop={1}>
-              <DocumentStatus status={documentResponse.document?.status} />
-            </Box>
-          ) : null}
-        </Flex>
-        <FormContext initialValues={initialValues} method={id ? 'PUT' : 'POST'}>
+        <FormContext
+          initialValues={initialValues}
+          validate={(values: Record<string, unknown>, options: Record<string, string>) => {
+            const yupSchema = createYupSchema(
+              documentResponse.schema?.attributes,
+              documentResponse.components,
+              {
+                status: documentResponse.document?.status,
+                ...options,
+              }
+            );
+
+            return yupSchema.validate(values, { abortEarly: false });
+          }}
+          method="PUT"
+        >
+          <Flex alignItems="flex-start" direction="column" gap={2}>
+            <Flex width="100%" justifyContent="space-between" gap={2}>
+              <Typography tag="h2" variant="alpha">
+                {documentTitle}
+              </Typography>
+              <Flex gap={2}>
+                <DescriptionComponentRenderer
+                  props={props}
+                  descriptions={(
+                    plugins['content-manager'].apis as ContentManagerPlugin['config']['apis']
+                  ).getDocumentActions('relation-modal')}
+                >
+                  {(actions) => {
+                    const filteredActions = actions.filter((action) => {
+                      return [action.position].flat().includes('relation-modal');
+                    });
+                    const [primaryAction, secondaryAction] = filteredActions;
+
+                    if (!primaryAction && !secondaryAction) return null;
+
+                    // Both actions are available when draft and publish enabled
+                    if (primaryAction && secondaryAction) {
+                      return (
+                        <>
+                          {/* Save */}
+                          <DocumentActionButton
+                            {...secondaryAction}
+                            variant={secondaryAction.variant || 'secondary'}
+                          />
+                          {/* Publish */}
+                          <DocumentActionButton
+                            {...primaryAction}
+                            variant={primaryAction.variant || 'default'}
+                          />
+                        </>
+                      );
+                    }
+
+                    // Otherwise we just have the save action
+                    return (
+                      <DocumentActionButton
+                        {...primaryAction}
+                        variant={primaryAction.variant || 'secondary'}
+                      />
+                    );
+                  }}
+                </DescriptionComponentRenderer>
+              </Flex>
+            </Flex>
+            {hasDraftAndPublished ? (
+              <Box>
+                <DocumentStatus status={documentResponse.document?.status} />
+              </Box>
+            ) : null}
+          </Flex>
+
           <Flex flex={1} overflow="auto" alignItems="stretch" paddingTop={7}>
             <Box overflow="auto" flex={1}>
               <FormLayout layout={documentLayoutResponse.edit.layout} hasBackground={false} />

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -18,7 +18,6 @@ import {
 } from '@strapi/design-system';
 import { ArrowLeft, WarningCircle } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { COLLECTION_TYPES, SINGLE_TYPES } from '../../../../../constants/collections';

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -1017,7 +1017,7 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
       triggerRefetchDocument(
         document,
         // Favor the cache
-        false
+        true
       );
     } else {
       setIsModalOpen(true);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -958,7 +958,6 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
     targetModel,
   } = data;
   const changeDocument = useDocumentContext('RelationsList', (state) => state.changeDocument);
-  const currentDocument = useDocumentContext('RelationsList', (state) => state.document);
   const rootDocumentMeta = useDocumentContext('RelationsList', (state) => state.rootDocumentMeta);
 
   const { formatMessage } = useIntl();

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -958,12 +958,13 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
     targetModel,
   } = data;
   const changeDocument = useDocumentContext('RelationsList', (state) => state.changeDocument);
+  const currentDocument = useDocumentContext('RelationsList', (state) => state.document);
   const rootDocumentMeta = useDocumentContext('RelationsList', (state) => state.rootDocumentMeta);
 
   const { formatMessage } = useIntl();
   const [isModalOpen, setIsModalOpen] = React.useState(false);
 
-  const { href, id, label, status, documentId, apiData } = relations[index];
+  const { href, id, label, status, documentId, apiData, locale } = relations[index];
 
   const [{ handlerId, isDragging, handleKeyDown }, relationRef, dropRef, dragRef, dragPreviewRef] =
     useDragAndDrop<number, Omit<RelationDragPreviewProps, 'width'>, HTMLDivElement>(
@@ -993,6 +994,9 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
         documentId: documentId ?? apiData?.documentId,
         model: targetModel,
         collectionType: getCollectionType(href)!,
+        params: {
+          locale: locale || null,
+        },
       };
 
       changeDocument(newRelation);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
@@ -166,6 +166,28 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
     isLoading: false,
     allowedActions: { canUpdate: true, canDelete: true, canPublish: true },
   })),
+  useStrapiApp: jest.fn((name, getter) =>
+    getter({
+      customFields: {
+        get: jest.fn(),
+      },
+      plugins: {
+        'content-manager': {
+          initializer: jest.fn(),
+          injectionZones: {},
+          isReady: true,
+          name: 'content-manager',
+          pluginId: 'content-manager',
+          injectComponent: jest.fn(),
+          getInjectedComponents: jest.fn(),
+          apis: {
+            getDocumentActions: () => [],
+            getHeaderActions: () => [],
+          },
+        },
+      },
+    })
+  ),
 }));
 
 describe('<RelationModal />', () => {
@@ -175,13 +197,7 @@ describe('<RelationModal />', () => {
   it("doesn't render the modal if we pass an open prop to false", () => {
     render(
       <DocumentContextProvider {...relationContext}>
-        <RelationModal
-          open={false}
-          onToggle={() => {}}
-          model="api::test.test"
-          id="abcdefg"
-          relationUrl="../collection-types/api::test.test/abcdefg?"
-        />
+        <RelationModal open={false} onToggle={() => {}} />
       </DocumentContextProvider>
     );
 
@@ -191,13 +207,7 @@ describe('<RelationModal />', () => {
   it('renders the modal if we pass an open prop to true', () => {
     render(
       <DocumentContextProvider {...relationContext}>
-        <RelationModal
-          open={true}
-          onToggle={() => {}}
-          model="api::test.test"
-          id="abcdefg"
-          relationUrl="../collection-types/api::test.test/abcdefg"
-        />
+        <RelationModal open={true} onToggle={() => {}} />
       </DocumentContextProvider>
     );
 
@@ -206,13 +216,7 @@ describe('<RelationModal />', () => {
   it('shows the modal with the Edit a relation title, the relation title, the X button and the Cancel button when the modal is to Edit a relation', () => {
     render(
       <DocumentContextProvider {...relationContext}>
-        <RelationModal
-          open={true}
-          onToggle={() => {}}
-          model="api::test.test"
-          id="abcdefg"
-          relationUrl="../collection-types/api::test.test/abcdefg?"
-        />
+        <RelationModal open={true} onToggle={() => {}} />
       </DocumentContextProvider>
     );
 

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -37,7 +37,7 @@ const UnstablePreviewContent = () => {
         paddingRight={isSideEditorOpen ? 6 : 0}
         transition="all 0.2s ease-in-out"
       >
-        <FormLayout layout={layout.layout} hasBackground />
+        <FormLayout layout={layout.layout} hasBackground={false} />
       </Box>
       <Box position="relative" flex={1} height="100%" overflow="hidden">
         <Box

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -62,7 +62,6 @@ const PreviewPage = () => {
     plugins?: Record<string, unknown>;
     status?: string;
   }>();
-
   const params = React.useMemo(() => buildValidParams(query), [query]);
 
   if (!collectionType) {

--- a/tests/e2e/tests/content-manager/preview.spec.ts
+++ b/tests/e2e/tests/content-manager/preview.spec.ts
@@ -142,7 +142,7 @@ describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR ===
 
       // Confirm initial state
       await expect(titleBox).toHaveValue(/west ham post match/i);
-      await expect(page.getByRole('status', { name: /draft/i })).toBeVisible();
+      await expect(page.getByRole('status', { name: /draft/i }).first()).toBeVisible();
       await expect(draftTab).toHaveAttribute('aria-selected', 'true');
       await expect(draftTab).toBeEnabled();
       await expect(publishedTab).toHaveAttribute('aria-selected', 'false');
@@ -153,13 +153,13 @@ describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR ===
       await expect(saveButton).toBeEnabled();
       await clickAndWait(page, saveButton);
       await expect(titleBox).toHaveValue(/west ham pre match pep talk/i);
-      await expect(page.getByRole('status', { name: /draft/i })).toBeVisible();
+      await expect(page.getByRole('status', { name: /draft/i }).first()).toBeVisible();
 
       // Publish
       await expect(publishButton).toBeEnabled();
       await clickAndWait(page, publishButton);
       await expect(titleBox).toHaveValue(/west ham pre match pep talk/i);
-      await expect(page.getByRole('status', { name: /published/i })).toBeVisible();
+      await expect(page.getByRole('status', { name: /published/i }).first()).toBeVisible();
       await expect(publishedTab).toBeEnabled();
       await clickAndWait(page, publishedTab);
       await expect(titleBox).toBeDisabled();
@@ -170,7 +170,7 @@ describeOnCondition(process.env.STRAPI_FEATURES_UNSTABLE_PREVIEW_SIDE_EDITOR ===
       await expect(saveButton).toBeEnabled();
       await clickAndWait(page, saveButton);
       await expect(titleBox).toHaveValue(/west ham pre match jokes/i);
-      await expect(page.getByRole('status', { name: /modified/i })).toBeVisible();
+      await expect(page.getByRole('status', { name: /modified/i }).first()).toBeVisible();
     });
   }
 );

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -37,5 +37,9 @@ test.describe('Unstable Relations on the fly', () => {
     await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
     await expect(name).toHaveValue('Mr. Coach Beard');
     await expect(page.getByRole('status', { name: 'Published' }).first()).toBeVisible();
+
+    // Close the relation modal to see the updated relation on the root document
+    await page.getByRole('button', { name: 'Close modal' }).click();
+    await expect(page.getByRole('button', { name: 'Mr. Coach Beard' })).toBeVisible();
   });
 });

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { clickAndWait } from '../../utils/shared';
+import { clickAndWait, describeOnCondition, findAndClose } from '../../utils/shared';
 
 test.describe('Unstable Relations on the fly', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,15 +10,32 @@ test.describe('Unstable Relations on the fly', () => {
     await login({ page });
   });
 
-  test('as a user I want to open a relation modal inside a collection', async ({ page }) => {
+  test('I want to edit an existing relation in a modal and save and publish the related document', async ({
+    page,
+  }) => {
     await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-    await clickAndWait(page, page.getByRole('link', { name: 'Author' }));
-    await clickAndWait(page, page.getByRole('gridcell', { name: 'Ted Lasso' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
 
-    await expect(page.getByRole('heading', { name: 'Ted Lasso' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'West Ham post match analysis' })).toBeVisible();
 
-    await clickAndWait(page, page.getByRole('button', { name: 'Pourquoi je préfère le' }));
-    // it opens the edit relations modal
+    // Open the relation modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Coach Beard' }));
     await expect(page.getByText('Edit a relation')).toBeVisible();
+
+    // Confirm the relation is initialized with correct data
+    const name = page.getByRole('textbox', { name: 'name' });
+    await expect(name).toHaveValue('Coach Beard');
+
+    // Save the related document as draft
+    await name.fill('Mr. Coach Beard');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await expect(name).toHaveValue('Mr. Coach Beard');
+    await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
+
+    // Publish the related document
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
+    await expect(name).toHaveValue('Mr. Coach Beard');
+    await expect(page.getByRole('status', { name: 'Published' }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

- Adds the save and publish actions

### Why is it needed?

To save and publish

### How to test it?

Open the relation modal
Make a change
Save or publish

## TODO

- [x] Update e2e tests
- [x] Fetch the correct locale
- [x] Save the correct locale

### Known issue
- There is an issue where save reverts back to the original data, then updates with the newly saved data. Removing `resetForm` in UpdateAction fixes the issue but causes issues on the editview form. Still investigating. 

https://github.com/user-attachments/assets/76d1440e-bce0-4fc1-9a71-67392c887416


- A relation that has not been saved does not refresh its data when edited