### PR TITLE
fix(admin): building the admin with webpack

### DIFF
--- a/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { version as strapiVersion } from '@strapi/admin/package.json';
+import packageInfo from '@strapi/admin/package.json';
 import { Box, Flex, SkipToContent } from '@strapi/design-system';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -24,6 +24,8 @@ import { useMenu } from '../hooks/useMenu';
 import { useOnce } from '../hooks/useOnce';
 import { useInformationQuery } from '../services/admin';
 import { hashAdminUserEmail } from '../utils/users';
+
+const { version: strapiVersion } = packageInfo;
 
 const AdminLayout = () => {
   const setGuidedTourVisibility = useGuidedTour(


### PR DESCRIPTION
### What does it do?

Use the default export from package.json instead of a named export.

### Why is it needed?

Only the default export can be imported from a JSON file using webpack when using ES modules.

Commit a6235c371be33d4fe306f5ead9b48bd3a0453f7a introduced mjs files shortly after be068eb4403fd20e7c662dc05f5d18858a72dd3f was merged. Together, they break building strapi using webpack.

### How to test it?

Run `yarn build --bundler=webpack` in examples/getstarted.

### Related issue(s)/PR(s)

Fixes #22994