### PR TITLE
fix: make sure to clean _cmp tables from orphaned morph types

### DIFF
--- a/packages/core/database/src/repairs/operations/remove-orphan-morph-types.ts
+++ b/packages/core/database/src/repairs/operations/remove-orphan-morph-types.ts
@@ -13,7 +13,6 @@ const isMorphRelationWithPivot = (
     attribute.type === 'relation' &&
     'relation' in attribute &&
     'joinTable' in attribute &&
-    'target' in attribute &&
     'name' in attribute.joinTable &&
     'pivotColumns' in attribute.joinTable &&
     attribute.joinTable.pivotColumns.includes(pivot)


### PR DESCRIPTION
### What does it do?

- removes unnecessary `target` check in `isMorphRelationWithPivot` method in the `remove-orphan-morph-types` repair method

### Why is it needed?

- when removing  components that exist in a dynamic zone, the join table between the entity and component resulting in a an error whenever trying to save and edit to the contentType in the Content Manager

### How to test it?

- Create component, 
- create a DZ and add the component
-  fill the component in the with some test data in the content-manager and save it 
- delete component from contentType builder
- come back to the contentType that used to have this component attempt to edit anything and save

this process should work with no error

### Related issue(s)/PR(s)

fixes #22641
