### PR TITLE
security(deps): upgrade koa to 2.15.4

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -111,7 +111,7 @@
     "invariant": "^2.2.4",
     "is-localhost-ip": "2.0.0",
     "jsonwebtoken": "9.0.0",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-compose": "4.1.0",
     "koa-passport": "6.0.0",
     "koa-static": "5.0.0",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -73,7 +73,7 @@
     "fractional-indexing": "3.2.0",
     "highlight.js": "^10.4.1",
     "immer": "9.0.21",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "lodash": "4.17.21",
     "markdown-it": "^12.3.2",
     "markdown-it-abbr": "^1.0.4",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -82,7 +82,7 @@
     "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "14.5.2",
     "@types/koa": "2.13.4",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "msw": "1.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -84,7 +84,7 @@
     "@testing-library/user-event": "14.5.2",
     "@types/fs-extra": "11.0.4",
     "@types/pluralize": "0.0.30",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -82,7 +82,7 @@
     "http-errors": "2.0.0",
     "inquirer": "8.2.5",
     "is-docker": "2.2.1",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "koa-compose": "4.1.0",
     "koa-compress": "5.1.1",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -74,7 +74,7 @@
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
     "knex": "3.0.1",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "rimraf": "5.0.5",
     "typescript": "5.4.4"
   },

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -72,7 +72,7 @@
     "@testing-library/react": "15.0.7",
     "@types/koa": "2.13.4",
     "@types/lodash": "^4.14.191",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "msw": "1.3.0",
     "react": "18.3.1",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -51,7 +51,7 @@
     "@strapi/permissions": "5.10.3",
     "@strapi/utils": "5.10.3",
     "commander": "8.3.0",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "node-schedule": "2.1.1",
     "typedoc": "0.25.10",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -98,7 +98,7 @@
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
     "formidable": "3.5.1",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "msw": "1.3.0",
     "react": "18.3.1",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -62,7 +62,7 @@
     "@types/koa": "2.13.4",
     "@types/node": "18.19.24",
     "eslint-config-custom": "5.10.3",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "tsconfig": "5.10.3"
   },

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -87,7 +87,7 @@
     "@types/koa": "2.13.4",
     "@types/koa-session": "6.4.1",
     "@types/swagger-ui-dist": "3.30.4",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa-body": "6.0.1",
     "koa-session": "6.4.0",
     "msw": "1.3.0",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -78,7 +78,7 @@
     "@types/koa__cors": "5.0.0",
     "cross-env": "^7.0.3",
     "eslint-config-custom": "5.10.3",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.22.3",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -57,7 +57,7 @@
     "immer": "9.0.21",
     "jsonwebtoken": "9.0.0",
     "jwk-to-pem": "2.0.5",
-    "koa": "2.15.2",
+    "koa": "2.15.4",
     "koa2-ratelimit": "^1.1.3",
     "lodash": "4.17.21",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8664,7 +8664,7 @@ __metadata:
     invariant: "npm:^2.2.4"
     is-localhost-ip: "npm:2.0.0"
     jsonwebtoken: "npm:9.0.0"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     koa-compose: "npm:4.1.0"
     koa-passport: "npm:6.0.0"
@@ -8767,7 +8767,7 @@ __metadata:
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     markdown-it: "npm:^12.3.2"
@@ -8829,7 +8829,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
     formik: "npm:2.4.5"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
     node-schedule: "npm:2.1.1"
@@ -8873,7 +8873,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     pluralize: "npm:8.0.0"
@@ -8948,7 +8948,7 @@ __metadata:
     http-errors: "npm:2.0.0"
     inquirer: "npm:8.2.5"
     is-docker: "npm:2.2.1"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     koa-compose: "npm:4.1.0"
     koa-compress: "npm:5.1.1"
@@ -9001,7 +9001,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     inquirer: "npm:8.2.5"
     knex: "npm:3.0.1"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     lodash: "npm:4.17.21"
     ora: "npm:5.4.1"
     resolve-cwd: "npm:3.0.0"
@@ -9087,7 +9087,7 @@ __metadata:
     "@testing-library/react": "npm:15.0.7"
     "@types/koa": "npm:2.13.4"
     "@types/lodash": "npm:^4.14.191"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     koa2-ratelimit: "npm:^1.1.3"
     lodash: "npm:4.17.21"
@@ -9336,7 +9336,7 @@ __metadata:
     formik: "npm:2.4.5"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     koa-session: "npm:6.4.0"
     koa-static: "npm:^5.0.0"
@@ -9384,7 +9384,7 @@ __metadata:
     graphql-depth-limit: "npm:^1.1.0"
     graphql-playground-middleware-koa: "npm:^1.6.21"
     graphql-scalars: "npm:1.22.2"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-bodyparser: "npm:4.4.1"
     koa-compose: "npm:^4.1.0"
     lodash: "npm:4.17.21"
@@ -9443,7 +9443,7 @@ __metadata:
     immer: "npm:9.0.21"
     jsonwebtoken: "npm:9.0.0"
     jwk-to-pem: "npm:2.0.5"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa2-ratelimit: "npm:^1.1.3"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
@@ -9745,7 +9745,7 @@ __metadata:
     "@types/node-schedule": "npm:2.1.7"
     commander: "npm:8.3.0"
     eslint-config-custom: "npm:5.10.3"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     node-schedule: "npm:2.1.1"
@@ -9858,7 +9858,7 @@ __metadata:
     formik: "npm:2.4.5"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     koa-range: "npm:0.3.0"
     koa-static: "npm:5.0.0"
@@ -9899,7 +9899,7 @@ __metadata:
     eslint-config-custom: "npm:5.10.3"
     execa: "npm:5.1.1"
     http-errors: "npm:2.0.0"
-    koa: "npm:2.15.2"
+    koa: "npm:2.15.4"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     node-machine-id: "npm:1.1.12"
@@ -22524,9 +22524,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.2":
-  version: 2.15.2
-  resolution: "koa@npm:2.15.2"
+"koa@npm:2.15.4":
+  version: 2.15.4
+  resolution: "koa@npm:2.15.4"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -22551,7 +22551,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/ff486f4564c10340ba6d59ab667af5554058f2c4250352e8b15016c3c6d0079c25cef5e75aa787930617a2a57929617b7697341b1228db03e5da9f46f5f0b571
+  checksum: 10c0/fd2171b4dba706d35244fe60403a61671717a167453349813757999dad280049ddd0dcdba23cda197a5a3538f4c034cf0fd1f9caeb849be1ca1eecaa78db2f99
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

- upgrades `koa` to 2.15.4 to fix https://www.cve.org/CVERecord?id=CVE-2025-25200

### Why is it needed?

https://www.cve.org/CVERecord?id=CVE-2025-25200

### How to test it?

Everything should work as before, particularly anything koa specific

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
