### PR TITLE
feat(preview): refresh iframe when strapi updates

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useParams } from 'react-router-dom';
 
 // @ts-ignore
@@ -14,6 +14,20 @@ const PreviewComponent = () => {
     params: { locale, status },
     collectionType,
   });
+
+  React.useEffect(() => {
+    const handleStrapiUpdate = (event) => {
+      if (event.data?.type === 'strapiUpdate') {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener('message', handleStrapiUpdate);
+
+    return () => {
+      window.removeEventListener('message', handleStrapiUpdate);
+    };
+  }, []);
 
   return (
     <Layouts.Root>

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -8,7 +8,7 @@ import { Grid, Flex, Typography, JSONInput } from '@strapi/design-system';
 
 const PreviewComponent = () => {
   const { uid: model, documentId, locale, status, collectionType } = useParams();
-  const { document } = useDocument({
+  const { document, refetch } = useDocument({
     model,
     documentId,
     params: { locale, status },
@@ -18,7 +18,7 @@ const PreviewComponent = () => {
   React.useEffect(() => {
     const handleStrapiUpdate = (event) => {
       if (event.data?.type === 'strapiUpdate') {
-        window.location.reload();
+        refetch();
       }
     };
 

--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -80,7 +80,9 @@ interface PanelComponent extends DescriptionComponent<PanelComponentProps, Panel
   type?: 'actions' | 'releases';
 }
 
-interface DocumentActionProps extends EditViewContext {}
+interface DocumentActionProps extends EditViewContext {
+  onPreview?: () => void;
+}
 
 interface DocumentActionComponent
   extends DescriptionComponent<DocumentActionProps, DocumentActionDescription> {

--- a/packages/core/content-manager/admin/src/hooks/useDocument.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocument.ts
@@ -63,6 +63,7 @@ type UseDocument = (
   schema?: Schema;
   schemas?: Schema[];
   hasError?: boolean;
+  refetch: () => void;
   validate: (document: Document) => null | FormErrors;
   /**
    * Get the document's title
@@ -115,6 +116,7 @@ const useDocument: UseDocument = (args, opts) => {
     isLoading: isLoadingDocument,
     isFetching: isFetchingDocument,
     error,
+    refetch,
   } = useGetDocumentQuery(args, {
     ...opts,
     skip: (!args.documentId && args.collectionType !== SINGLE_TYPES) || opts?.skip,
@@ -227,6 +229,7 @@ const useDocument: UseDocument = (args, opts) => {
     validate,
     getTitle,
     getInitialFormValues,
+    refetch,
   } satisfies ReturnType<UseDocument>;
 };
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -516,6 +516,7 @@ const PublishAction: DocumentActionComponent = ({
   collectionType,
   meta,
   document,
+  onPreview,
 }) => {
   const { schema } = useDoc();
   const navigate = useNavigate();
@@ -678,6 +679,10 @@ const PublishAction: DocumentActionComponent = ({
       }
     } finally {
       setSubmitting(false);
+
+      if (onPreview) {
+        onPreview();
+      }
     }
   };
 
@@ -755,6 +760,7 @@ const UpdateAction: DocumentActionComponent = ({
   documentId,
   model,
   collectionType,
+  onPreview,
 }) => {
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
@@ -867,6 +873,9 @@ const UpdateAction: DocumentActionComponent = ({
       }
     } finally {
       setSubmitting(false);
+      if (onPreview) {
+        onPreview();
+      }
     }
   }, [
     clone,

--- a/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewContent.tsx
@@ -1,88 +1,7 @@
-import * as React from 'react';
-
-import { Box, Flex, IconButton } from '@strapi/design-system';
-import { ArrowLeft } from '@strapi/icons';
+import { Box } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
-import { styled } from 'styled-components';
 
-import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { usePreviewContext } from '../pages/Preview';
-
-// TODO use ArrowLineLeft once it's available in the DS
-const AnimatedArrow = styled(ArrowLeft)<{ isSideEditorOpen: boolean }>`
-  will-change: transform;
-  rotate: ${(props) => (props.isSideEditorOpen ? '0deg' : '180deg')};
-  transition: rotate 0.2s ease-in-out;
-`;
-
-const UnstablePreviewContent = () => {
-  const previewUrl = usePreviewContext('PreviewContent', (state) => state.url);
-  const layout = usePreviewContext('PreviewContent', (state) => state.layout);
-
-  const { formatMessage } = useIntl();
-
-  const [isSideEditorOpen, setIsSideEditorOpen] = React.useState(true);
-
-  return (
-    <Flex flex={1} overflow="auto" alignItems="stretch">
-      <Box
-        overflow="auto"
-        width={isSideEditorOpen ? '50%' : 0}
-        borderWidth="0 1px 0 0"
-        borderColor="neutral150"
-        paddingTop={6}
-        paddingBottom={6}
-        // Remove horizontal padding when the editor is closed or it won't fully disappear
-        paddingLeft={isSideEditorOpen ? 6 : 0}
-        paddingRight={isSideEditorOpen ? 6 : 0}
-        transition="all 0.2s ease-in-out"
-      >
-        <FormLayout layout={layout.layout} hasBackground />
-      </Box>
-      <Box position="relative" flex={1} height="100%" overflow="hidden">
-        <Box
-          src={previewUrl}
-          /**
-           * For some reason, changing an iframe's src tag causes the browser to add a new item in the
-           * history stack. This is an issue for us as it means clicking the back button will not let us
-           * go back to the edit view. To fix it, we need to trick the browser into thinking this is a
-           * different iframe when the preview URL changes. So we set a key prop to force React
-           * to mount a different node when the src changes.
-           */
-          key={previewUrl}
-          title={formatMessage({
-            id: 'content-manager.preview.panel.title',
-            defaultMessage: 'Preview',
-          })}
-          width="100%"
-          height="100%"
-          borderWidth={0}
-          tag="iframe"
-        />
-        <IconButton
-          variant="tertiary"
-          label={formatMessage(
-            isSideEditorOpen
-              ? {
-                  id: 'content-manager.preview.content.close-editor',
-                  defaultMessage: 'Close editor',
-                }
-              : {
-                  id: 'content-manager.preview.content.open-editor',
-                  defaultMessage: 'Open editor',
-                }
-          )}
-          onClick={() => setIsSideEditorOpen((prev) => !prev)}
-          position="absolute"
-          top={2}
-          left={2}
-        >
-          <AnimatedArrow isSideEditorOpen={isSideEditorOpen} />
-        </IconButton>
-      </Box>
-    </Flex>
-  );
-};
 
 const PreviewContent = () => {
   const previewUrl = usePreviewContext('PreviewContent', (state) => state.url);
@@ -112,4 +31,4 @@ const PreviewContent = () => {
   );
 };
 
-export { PreviewContent, UnstablePreviewContent };
+export { PreviewContent };

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -177,7 +177,7 @@ const UnstablePreviewHeader = () => {
   };
 
   const hasDraftAndPublish = schema.options?.draftAndPublish ?? false;
-  const props = {
+  const documentActionProps = {
     activeTab: query.status ?? null,
     collectionType: schema.kind === 'collectionType' ? 'collection-types' : 'single-types',
     model: schema.uid,
@@ -231,7 +231,7 @@ const UnstablePreviewHeader = () => {
           </IconButton>
           <InjectionZone area="preview.actions" />
           <DescriptionComponentRenderer
-            props={props}
+            props={documentActionProps}
             descriptions={(
               plugins['content-manager'].apis as ContentManagerPlugin['config']['apis']
             ).getDocumentActions('preview')}

--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -156,6 +156,7 @@ const UnstablePreviewHeader = () => {
   const schema = usePreviewContext('PreviewHeader', (state) => state.schema);
   const meta = usePreviewContext('PreviewHeader', (state) => state.meta);
   const plugins = useStrapiApp('PreviewHeader', (state) => state.plugins);
+  const iframeRef = usePreviewContext('PreviewHeader', (state) => state.iframeRef);
 
   const [{ query }] = useQueryParams<{
     status?: 'draft' | 'published';
@@ -183,6 +184,9 @@ const UnstablePreviewHeader = () => {
     documentId: document.documentId,
     document,
     meta,
+    onPreview: () => {
+      iframeRef?.current?.contentWindow?.postMessage({ type: 'strapiUpdate' });
+    },
   } satisfies DocumentActionProps;
 
   return (


### PR DESCRIPTION
### What does it do?

- Uses [window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to inform the preview iframe that strapi was updated

### Why is it needed?

- To refresh the preview content without having to reload the page

### How to test it?

Go to a preview page. Make an update and click save or publish. You should see the data updated in the preview iframe. It should the correct data based on the document status.

### TODO

- [ ] Update the test env app to have an iframe that display content to run tests against. Not sure how that will go with testing in an iframe 🤔 