### PR TITLE
feat(content-manager): support right click open in content list

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -210,11 +210,13 @@ const ListViewPage = () => {
         defaultMessage: 'Untitled',
       });
 
+  const linkSearch = query.plugins ? stringify({ plugins: query.plugins }) : undefined;
+
   const handleRowClick = (id: Modules.Documents.ID) => () => {
     trackUsage('willEditEntryFromList');
     navigate({
       pathname: id.toString(),
-      search: stringify({ plugins: query.plugins }),
+      search: linkSearch,
     });
   };
 
@@ -326,6 +328,7 @@ const ListViewPage = () => {
                             <CellContent
                               content={row[header.name.split('.')[0]]}
                               rowId={row.documentId}
+                              linkSearch={linkSearch}
                               {...header}
                             />
                           </Table.Cell>

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -1,20 +1,31 @@
-import { Tooltip, Typography } from '@strapi/design-system';
+import { Link, Tooltip, Typography } from '@strapi/design-system';
 import isEmpty from 'lodash/isEmpty';
+import { useHref } from 'react-router-dom';
 
 import { CellValue } from './CellValue';
-import { SingleComponent, RepeatableComponent } from './Components';
-import { MediaSingle, MediaMultiple } from './Media';
+import { RepeatableComponent, SingleComponent } from './Components';
+import { MediaMultiple, MediaSingle } from './Media';
 import { RelationMultiple, RelationSingle } from './Relations';
 
 import type { ListFieldLayout } from '../../../../hooks/useDocumentLayout';
-import type { Schema, Data } from '@strapi/types';
+import type { Data, Schema } from '@strapi/types';
 
 interface CellContentProps extends Omit<ListFieldLayout, 'cellFormatter'> {
   content: Schema.Attribute.Value<Schema.Attribute.AnyAttribute>;
   rowId: Data.ID;
+  linkSearch?: string | undefined;
 }
 
-const CellContent = ({ content, mainField, attribute, rowId, name }: CellContentProps) => {
+const CellContent = ({
+  content,
+  mainField,
+  attribute,
+  rowId,
+  name,
+  linkSearch,
+}: CellContentProps) => {
+  const href = useHref({ pathname: rowId.toString(), search: linkSearch });
+
   if (!hasContent(content, mainField, attribute)) {
     return (
       <Typography
@@ -51,11 +62,14 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
       return <SingleComponent mainField={mainField} content={content} />;
 
     case 'string':
+      // Use a regular link to prevent conflicts between NavLink and handleRowClick() in ListViewPage
       return (
         <Tooltip description={content}>
-          <Typography maxWidth="30rem" ellipsis textColor="neutral800">
-            <CellValue type={attribute.type} value={content} />
-          </Typography>
+          <Link tag="a" href={href}>
+            <Typography maxWidth="30rem" ellipsis textColor="neutral800">
+              <CellValue type={attribute.type} value={content} />
+            </Typography>
+          </Link>
         </Tooltip>
       );
 


### PR DESCRIPTION
### What does it do?

This change allows users to right click a cell in the content list and open the edit page in a new browser window / tab.

### Why is it needed?

It's sometimes handy to open a bunch of content items in browser tabs to edit them.

### How to test it?

Open a content list page, right click an item and observe that the browser offers open in new tab etc.

### Related issue(s)/PR(s)

It was mentioned somewhere in an issue but I can't find it anymore.