### PR TITLE
chore(content-manager): fix deprecation in Tooltip usage

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/components/NpmPackageCard.tsx
@@ -120,7 +120,7 @@ const NpmPackageCard = ({
                 </Tooltip>
               )}
               {attributes.madeByStrapi && (
-                <Tooltip description={madeByStrapiMessage}>
+                <Tooltip label={madeByStrapiMessage}>
                   <Box
                     tag="img"
                     src={StrapiLogo}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations.tsx
@@ -1461,7 +1461,7 @@ const UnstableListItem = ({ data, index, style }: ListItemProps) => {
             ) : null}
             <Flex width="100%" minWidth={0} justifyContent="space-between">
               <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
-                <Tooltip description={label}>
+                <Tooltip label={label}>
                   {/*  eslint-disable-next-line no-console */}
                   <CustomTextButton onClick={() => console.log('OPEN MODAL')}>
                     {label}
@@ -1577,7 +1577,7 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
             ) : null}
             <Flex width="100%" minWidth={0} justifyContent="space-between">
               <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
-                <Tooltip description={label}>
+                <Tooltip label={label}>
                   {href ? (
                     <LinkEllipsis tag={NavLink} to={href} isExternal={false}>
                       {label}

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -125,7 +125,7 @@ const EntryValidationText = ({ validationErrors, status }: EntryValidationTextPr
     return (
       <Flex gap={2}>
         <CrossCircle fill="danger600" />
-        <Tooltip description={validationErrorsMessages}>
+        <Tooltip label={validationErrorsMessages}>
           <TypographyMaxWidth textColor="danger600" variant="omega" fontWeight="semiBold" ellipsis>
             {validationErrorsMessages}
           </TypographyMaxWidth>

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -52,7 +52,7 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
 
     case 'string':
       return (
-        <Tooltip description={content}>
+        <Tooltip label={content}>
           <Typography maxWidth="30rem" ellipsis textColor="neutral800">
             <CellValue type={attribute.type} value={content} />
           </Typography>

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Media.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Media.tsx
@@ -50,7 +50,7 @@ const MediaSingle = ({ url, mime, alternativeText, name, ext, formats }: MediaSi
   const fileName = name.length > 100 ? `${name.substring(0, 100)}...` : name;
 
   return (
-    <Tooltip description={fileName}>
+    <Tooltip label={fileName}>
       <FileWrapper>{fileExtension}</FileWrapper>
     </Tooltip>
   );


### PR DESCRIPTION
### What does it do?

Replace references to the deprecated `description` property of the `Tooltip` component with `label`, as suggested.

### Why is it needed?

Forward compatibility with newer design-system releases that remove the deprecated `description` prop.

### How to test it?

Visit any page that uses a tooltip and observe that they still work.
