### PR TITLE
fix: marketplace remove incorrect query param

### DIFF
--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -90,7 +90,7 @@ const MarketplacePage = () => {
     possibleCollections,
     possibleCategories,
     pagination,
-  } = useMarketplaceData({ npmPackageType, debouncedSearch, query, tabQuery, strapiVersion });
+  } = useMarketplaceData({ npmPackageType, debouncedSearch, query, tabQuery });
 
   if (!isOnline) {
     return <OfflineLayout />;

--- a/packages/core/admin/admin/src/pages/Marketplace/hooks/useMarketplaceData.ts
+++ b/packages/core/admin/admin/src/pages/Marketplace/hooks/useMarketplaceData.ts
@@ -14,7 +14,6 @@ interface UseMarketplaceDataParams {
   debouncedSearch: string;
   query?: MarketplacePageQuery;
   tabQuery: TabQuery;
-  strapiVersion?: string | null;
 }
 
 type Collections =
@@ -102,7 +101,6 @@ function useMarketplaceData({
   debouncedSearch,
   query,
   tabQuery,
-  strapiVersion,
 }: UseMarketplaceDataParams) {
   const { notifyStatus } = useNotifyAT();
   const { formatMessage } = useIntl();
@@ -133,7 +131,6 @@ function useMarketplaceData({
     ...tabQuery.plugin,
     pagination: paginationParams,
     search: debouncedSearch,
-    version: strapiVersion,
   };
 
   const { data: pluginsResponse, status: pluginsStatus } = useQuery(
@@ -172,7 +169,6 @@ function useMarketplaceData({
     ...tabQuery.provider,
     pagination: paginationParams,
     search: debouncedSearch,
-    version: strapiVersion,
   };
 
   const { data: providersResponse, status: providersStatus } = useQuery(


### PR DESCRIPTION
### What does it do?

Remove version query, that send the current strapi version to the marketplace api,

### Why is it needed?

The implementation of this version query is not correct

### How to test it?

- everything should be working the same when loading the marketplace
-check the requested marketplace api it should not contain `version=CURRENT_STRAPI_VERSION` or something like this 
`https://market-api.strapi.io/providers?pagination%5Bpage%5D=1&pagination%5BpageSize%5D=24&search=&version=5.10.3`
