### PR TITLE
chore: add documentId to tracking events

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -131,7 +131,6 @@ interface EventWithoutProperties {
     | 'didNotCreateFirstAdmin'
     | 'didNotSaveComponent'
     | 'didPluginLearnMore'
-    | 'didPublishEntry'
     | 'didBulkPublishEntries'
     | 'didNotBulkPublishEntries'
     | 'didUnpublishEntry'
@@ -183,7 +182,6 @@ interface EventWithoutProperties {
     | 'willEditStage'
     | 'willFilterEntries'
     | 'willInstallPlugin'
-    | 'willPublishEntry'
     | 'willUnpublishEntry'
     | 'willSaveComponent'
     | 'willSaveContentType'
@@ -317,14 +315,23 @@ interface DeleteEntryEvents {
 interface CreateEntryEvents {
   name: 'willCreateEntry' | 'didCreateEntry' | 'didNotCreateEntry';
   properties: {
+    documentId?: string;
     status?: string;
     error?: unknown;
+  };
+}
+
+interface PublishEntryEvents {
+  name: 'willPublishEntry' | 'didPublishEntry';
+  properties: {
+    documentId?: string;
   };
 }
 
 interface UpdateEntryEvents {
   name: 'willEditEntry' | 'didEditEntry' | 'didNotEditEntry';
   properties: {
+    documentId?: string;
     status?: string;
     error?: unknown;
   };
@@ -348,6 +355,7 @@ interface DidPublishRelease {
 
 type EventsWithProperties =
   | CreateEntryEvents
+  | PublishEntryEvents
   | DidAccessTokenListEvent
   | DidChangeModeEvent
   | DidCropFileEvent

--- a/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
@@ -352,7 +352,7 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didPublishEntry', { documentId: res.data.data.documentId });
+        trackUsage('didPublishEntry', { documentId });
 
         toggleNotification({
           type: 'success',

--- a/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
@@ -337,7 +337,7 @@ const useDocumentActions: UseDocumentActions = () => {
   const publish: IUseDocumentActs['publish'] = React.useCallback(
     async ({ collectionType, model, documentId, params }, data) => {
       try {
-        trackUsage('willPublishEntry');
+        trackUsage('willPublishEntry', { documentId });
 
         const res = await publishDocument({
           collectionType,
@@ -352,7 +352,7 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didPublishEntry');
+        trackUsage('didPublishEntry', { documentId: res.data.data.documentId });
 
         toggleNotification({
           type: 'success',
@@ -439,7 +439,7 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didEditEntry', trackerProperty);
+        trackUsage('didEditEntry', { ...trackerProperty, documentId: res.data.data.documentId });
         toggleNotification({
           type: 'success',
           message: formatMessage({
@@ -571,7 +571,7 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didCreateEntry', trackerProperty);
+        trackUsage('didCreateEntry', { ...trackerProperty, documentId: res.data.data.documentId });
 
         toggleNotification({
           type: 'success',


### PR DESCRIPTION
### What does it do?

adds documentId to some tracking events
### Why is it needed?

telemetry for the product team to understand which features lead to more content being published
### How to test it?

- publish content
- update content
- create content

for each action inspect the devtools, see the tracking request, you should see the documentId in the eventProperties object
