### PR TITLE
fix: missing mock function causes typescript to fail

### DIFF
--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/tests/AssigneeSelect.test.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/tests/AssigneeSelect.test.tsx
@@ -103,6 +103,7 @@ describe('AssigneeSelect', () => {
       validate: jest.fn(),
       getInitialFormValues: jest.fn(),
       getTitle: jest.fn(),
+      refetch: jest.fn(),
       document: {
         documentId: '12345',
         id: 12345,


### PR DESCRIPTION
### What does it do?

Fixes the failing typescript test

### Why is it needed?

To pass the CI

### How to test it?

The Typescript tests should pass

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23024
