### PR TITLE
fix: wip tentative fix for dz

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createContext } from '@strapi/admin/strapi-admin';
 
 import { useDocument, type UseDocument } from '../hooks/useDocument';
+import { useDocumentLayout } from '../hooks/useDocumentLayout';
 import { buildValidParams } from '../utils/api';
 
 interface DocumentMeta {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -59,9 +59,14 @@ const DynamicComponent = ({
   const { formatMessage } = useIntl();
   const formValues = useForm('DynamicComponent', (state) => state.values);
   const documentMeta = useDocumentContext('DynamicComponent', (state) => state.meta);
+  const rootDocumentMeta = useDocumentContext(
+    'DynamicComponent',
+    (state) => state.rootDocumentMeta
+  );
+  const isRootDocument = rootDocumentMeta.model === documentMeta.model;
   const {
     edit: { components },
-  } = useDocumentLayout(documentMeta.model);
+  } = useDocumentLayout(isRootDocument ? documentMeta.model : rootDocumentMeta.model);
 
   const title = React.useMemo(() => {
     const { mainField } = components[componentUid]?.settings ?? { mainField: 'id' };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -963,7 +963,7 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
   const { formatMessage } = useIntl();
   const [isModalOpen, setIsModalOpen] = React.useState(false);
 
-  const { href, id, label, status, documentId, apiData, locale } = relations[index];
+  const { href, id, label, status, documentId, apiData } = relations[index];
 
   const [{ handlerId, isDragging, handleKeyDown }, relationRef, dropRef, dragRef, dragPreviewRef] =
     useDragAndDrop<number, Omit<RelationDragPreviewProps, 'width'>, HTMLDivElement>(
@@ -987,21 +987,6 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
 
   const composedRefs = useComposedRefs<HTMLDivElement>(relationRef, dragRef);
 
-  const handleChangeModalContent = () => {
-    if (changeDocument) {
-      const newRelation = {
-        documentId: documentId ?? apiData?.documentId,
-        model: targetModel,
-        collectionType: getCollectionType(href)!,
-        params: {
-          locale: locale || null,
-        },
-      };
-
-      changeDocument(newRelation);
-    }
-  };
-
   const handleToggleModal = () => {
     if (isModalOpen) {
       setIsModalOpen(false);
@@ -1020,6 +1005,16 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
       );
     } else {
       setIsModalOpen(true);
+      const newRelation = {
+        documentId: documentId ?? apiData?.documentId,
+        model: targetModel,
+        collectionType: getCollectionType(href)!,
+        params: {
+          locale: apiData?.locale || null,
+        },
+      };
+
+      changeDocument(newRelation);
     }
   };
 
@@ -1070,23 +1065,10 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
             ) : null}
             <Flex width="100%" minWidth={0} justifyContent="space-between">
               <Box minWidth={0} paddingTop={1} paddingBottom={1} paddingRight={4}>
-                <Tooltip description={label}>
-                  {isModalOpen ? (
-                    <CustomTextButton onClick={handleChangeModalContent}>{label}</CustomTextButton>
-                  ) : (
-                    <CustomTextButton
-                      onClick={() => {
-                        handleChangeModalContent();
-                        setIsModalOpen(true);
-                      }}
-                    >
-                      {label}
-                    </CustomTextButton>
-                  )}
-                </Tooltip>
+                <CustomTextButton onClick={handleToggleModal}>{label}</CustomTextButton>
               </Box>
               {status ? <DocumentStatus status={status} /> : null}
-              {isModalOpen && <RelationModal open={isModalOpen} onToggle={handleToggleModal} />}
+              <RelationModal open={isModalOpen} onToggle={handleToggleModal} />
             </Flex>
           </FlexWrapper>
           <Box paddingLeft={4}>


### PR DESCRIPTION
### What does it do?

Update the InputRenderer to have access to _all_ components.

### Why is it needed?

So dz work

### How to test it?

Go to a content-type with relations in a DZ. Add the relation. Click the relation and it should open the modal.
