### PR TITLE
fix: add origin to preview message

### DIFF
--- a/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/PreviewHeader.tsx
@@ -185,7 +185,10 @@ const UnstablePreviewHeader = () => {
     document,
     meta,
     onPreview: () => {
-      iframeRef?.current?.contentWindow?.postMessage({ type: 'strapiUpdate' });
+      iframeRef?.current?.contentWindow?.postMessage(
+        { type: 'strapiUpdate' },
+        new URL(iframeRef.current.src).origin
+      );
     },
   } satisfies DocumentActionProps;
 

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -8,7 +8,7 @@ import {
   Form as FormContext,
 } from '@strapi/admin/strapi-admin';
 import { Box, Flex, FocusTrap, IconButton, Portal } from '@strapi/design-system';
-import { ArrowLeft } from '@strapi/icons';
+import { ArrowLineLeft } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useLocation, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -47,7 +47,7 @@ const [PreviewProvider, usePreviewContext] = createContext<PreviewContextValue>(
  * PreviewPage
  * -----------------------------------------------------------------------------------------------*/
 
-const AnimatedArrow = styled(ArrowLeft)<{ isSideEditorOpen: boolean }>`
+const AnimatedArrow = styled(ArrowLineLeft)<{ isSideEditorOpen: boolean }>`
   will-change: transform;
   rotate: ${(props) => (props.isSideEditorOpen ? '0deg' : '180deg')};
   transition: rotate 0.2s ease-in-out;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- adds origin to preview postMessage events
- also uses the new icon for the side editor toggle
### Why is it needed?

fix cross-origin errors
