### PR TITLE
test(e2e): test all attribute types for single type in CTB

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
@@ -9,7 +9,7 @@ test.describe('Create collection type with all field types', () => {
   test.describe.configure({ timeout: 300000 });
 
   test.beforeEach(async ({ page }) => {
-    await sharedSetup('ctb-edit-st', page, {
+    await sharedSetup('ctb-edit-ct', page, {
       login: true,
       skipTour: true,
       resetFiles: true,

--- a/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
@@ -1,28 +1,26 @@
-import { test, expect } from '@playwright/test';
-import { login } from '../../../utils/login';
-import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { waitForRestart } from '../../../utils/restart';
+import { test } from '@playwright/test';
 import { resetFiles } from '../../../utils/file-reset';
+import {
+  createCollectionType,
+  createSingleType,
+  type AddAttribute,
+} from '../../../utils/content-types';
+import { sharedSetup } from '../../../utils/setup';
 import { clickAndWait } from '../../../utils/shared';
 
-test.describe('Create single type', () => {
+test.describe('Create single type with all field types', () => {
   // very long timeout for these tests because they restart the server multiple times
   test.describe.configure({ timeout: 300000 });
 
   test.beforeEach(async ({ page }) => {
-    await resetFiles();
-    await resetDatabaseAndImportDataFromPath('with-admin.tar');
-    await page.goto('/admin');
-    await login({ page });
+    await sharedSetup('ctb-edit-st', page, {
+      login: true,
+      skipTour: true,
+      resetFiles: true,
+      importData: 'with-admin.tar',
+    });
 
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
-
-    // close the tutorial modal if it's visible
-    const modal = page.getByRole('button', { name: 'Close' });
-    if (modal.isVisible()) {
-      await modal.click();
-      await expect(modal).not.toBeVisible();
-    }
   });
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
@@ -31,32 +29,100 @@ test.describe('Create single type', () => {
     await resetFiles();
   });
 
-  test('Can create a single type', async ({ page, browserName }) => {
-    await clickAndWait(page, page.getByRole('button', { name: 'Create new single type' }));
+  test('Can create a collection type with all field types (except relations)', async ({ page }) => {
+    const attributes: AddAttribute[] = [
+      { type: 'text', name: 'testtext' },
+      { type: 'boolean', name: 'testboolean' },
+      { type: 'blocks', name: 'testblocks' },
+      { type: 'json', name: 'testjson' },
+      { type: 'number', name: 'testinteger', number: { format: 'integer' } },
+      { type: 'number', name: 'testbiginteger', number: { format: 'big integer' } },
+      { type: 'number', name: 'testdecimal', number: { format: 'decimal' } },
+      { type: 'email', name: 'testemail' },
+      { type: 'date', name: 'testdateonlydate', date: { format: 'date' } },
+      { type: 'date', name: 'testdatetime', date: { format: 'time' } },
+      { type: 'date', name: 'testdatedatetime', date: { format: 'datetime' } },
+      { type: 'password', name: 'testpassword' },
+      { type: 'media', name: 'testmediasingle', media: { multiple: false } },
+      { type: 'media', name: 'testmediamultiple', media: { multiple: true } },
+      {
+        type: 'enumeration',
+        name: 'testenumeration',
+        enumeration: { values: ['first', 'second', 'third'] },
+      },
+      { type: 'markdown', name: 'testmarkdown' },
+      // New single component with a new category
+      {
+        type: 'component',
+        name: 'testnewcomponentnewcategory',
+        component: {
+          options: {
+            repeatable: false,
+            name: 'testnewcomponentnewcategory',
+            icon: 'alien',
+            categoryCreate: 'testcategory',
+            attributes: [{ type: 'text', name: 'testnewcompotext' }],
+          },
+        },
+      },
+      // New repeatable component with existing category
+      {
+        type: 'component',
+        name: 'testnewcomponentexistingcategory',
+        component: {
+          options: {
+            repeatable: true,
+            name: 'testnewcomponentrepeatable',
+            icon: 'moon',
+            categorySelect: 'testcategory',
+            attributes: [{ type: 'text', name: 'testexistingcompotext' }],
+          },
+        },
+      },
+      // Existing component with existing category
+      {
+        type: 'component',
+        name: 'testexistingcomponentexistingcategory',
+        component: {
+          useExisting: 'testnewcomponentnewcategory',
+          options: {
+            repeatable: false,
+            name: 'testexistingcomponent',
+            icon: 'globe',
+            categorySelect: 'testcategory',
+          },
+        },
+      },
+      // Dynamic zone
+      {
+        type: 'dz',
+        name: 'testdynamiczone',
+        dz: {
+          components: [
+            {
+              type: 'component',
+              name: 'testdznewcomponentnewcategory',
+              component: {
+                options: {
+                  repeatable: false,
+                  name: 'testnewcomponentnewcategory',
+                  icon: 'paint',
+                  categoryCreate: 'testcategory',
+                  attributes: [{ type: 'text', name: 'testdzcompotext' }],
+                },
+              },
+            },
+          ],
+        },
+      },
+    ];
 
-    await expect(page.getByRole('heading', { name: 'Create a single type' })).toBeVisible();
+    const options = {
+      name: 'Secret Document',
+      singularId: 'secret-document',
+      attributes,
+    };
 
-    const displayName = page.getByLabel('Display name');
-    await displayName.fill('Secret Document');
-
-    const singularId = page.getByLabel('API ID (Singular)');
-    await expect(singularId).toHaveValue('secret-document');
-
-    const pluralId = page.getByLabel('API ID (Plural)');
-    await expect(pluralId).toHaveValue('secret-documents');
-
-    await clickAndWait(page, page.getByRole('button', { name: 'Continue' }));
-
-    await expect(page.getByText('Select a field for your single type')).toBeVisible();
-
-    await clickAndWait(page, page.getByText('Small or long text'));
-
-    await page.getByLabel('Name', { exact: true }).fill('myattribute');
-    await clickAndWait(page, page.getByRole('button', { name: 'Finish' }));
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-
-    await waitForRestart(page);
-
-    await expect(page.getByRole('heading', { name: 'Secret Document' })).toBeVisible();
+    await createSingleType(page, options);
   });
 });

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -3,7 +3,6 @@ import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
 import { navToHeader } from '../../../utils/shared';
 import { sharedSetup } from '../../../utils/setup';
-import { createSingleType } from '../../../utils/content-types';
 
 test.describe('Edit single type', () => {
   // very long timeout for these tests because they restart the server multiple times
@@ -13,6 +12,7 @@ test.describe('Edit single type', () => {
   const ctName = 'Homepage';
 
   test.beforeEach(async ({ page }) => {
+    await resetFiles();
     await sharedSetup('ctb-edit-st', page, {
       login: true,
       skipTour: true,
@@ -20,19 +20,41 @@ test.describe('Edit single type', () => {
       importData: 'with-admin.tar',
     });
 
-    // Then go to our content type
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterEach(async ({ page }) => {
+  test.afterEach(async () => {
     await resetFiles();
+  });
+
+  // Tests for GH#21398
+  test('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
+    // Create relation in Content-Type Builder
+    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
+    await page.getByRole('button', { name: /add another field to this single type/i }).click();
+    await page.getByRole('button', { name: /relation/i }).click();
+    await page.getByRole('button', { name: /article/i }).click();
+    await page.getByRole('menuitem', { name: /product/i }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await waitForRestart(page);
+
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
+
+    // update relation in Content-Type Builder to oneToOne
+    await page.getByRole('button', { name: /edit product/i }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
   });
 
   test('Can toggle internationalization', async ({ page }) => {
     // toggle off
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
@@ -41,7 +63,7 @@ test.describe('Edit single type', () => {
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Finish' }).click();
@@ -51,7 +73,7 @@ test.describe('Edit single type', () => {
 
   test('Can toggle draft&publish', async ({ page }) => {
     // toggle off
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
@@ -60,7 +82,7 @@ test.describe('Edit single type', () => {
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Finish' }).click();
@@ -70,6 +92,7 @@ test.describe('Edit single type', () => {
 
   test('Can add a field with default value', async ({ page }) => {
     await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+
     await page
       .getByRole('button', { name: 'Text Small or long text like title or description' })
       .click();
@@ -77,6 +100,53 @@ test.describe('Edit single type', () => {
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByRole('textbox', { name: 'Default value' }).fill('mydefault');
     await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await waitForRestart(page);
+
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+  });
+
+  /**
+   * TODO: This test is flaky likely due to an actual display bug
+   * where specific circumstances (demonstrated here) cause a modal to close/reopen on the first click
+   * instead of triggering the submit
+   * */
+  test('Can configure advanced settings for multiple fields sequentially', async ({ page }) => {
+    const fieldsToAdd = [
+      {
+        name: 'testfield',
+        defaultValue: 'mydefault',
+      },
+      {
+        name: 'testfield2',
+        defaultValue: 'mydefault2',
+      },
+    ];
+
+    for (const field of fieldsToAdd) {
+      await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+      await page
+        .getByRole('button', { name: 'Text Small or long text like title or description' })
+        .click();
+      await page.getByLabel('Name', { exact: true }).fill(field.name);
+
+      // This ensures that the modal state management correctly resets the active
+      // tab when adding/editing multiple fields sequentially
+      await expect(page.getByRole('tab', { name: 'Basic settings' })).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      await expect(page.getByRole('tab', { name: 'Advanced settings' })).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+
+      await page.getByRole('tab', { name: 'Advanced settings' }).click();
+      await page.getByRole('textbox', { name: 'Default value' }).fill(field.defaultValue);
+      await page.getByRole('button', { name: 'Finish' }).click();
+    }
+
     await page.getByRole('button', { name: 'Save' }).click();
 
     await waitForRestart(page);
@@ -108,5 +178,38 @@ test.describe('Edit single type', () => {
     await waitForRestart(page);
 
     await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
+  });
+
+  test('Can enable localization on a content type, create a text field, disable internationalization on the field and enable uniqueness on the same field', async ({
+    page,
+  }) => {
+    // Create a text field
+    await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
+    await page.getByLabel('Name', { exact: true }).fill('localizedField');
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Disable internationalization on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Enable localization for this field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Enable uniqueness on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Unique field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

- copies the enhancements from the collection type tests for creating every attribute type (except relations) to single types
 
### Why is it needed?

single type tests weren't testing attribute creation

### How to test it?

the tests should pass

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
