### PR TITLE
enhancement(ctb): add aria data to relations buttons

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
@@ -108,8 +108,11 @@ export const RelationNaturePicker = ({
                     }}
                     padding={2}
                     type="button"
+                    aria-label={formatMessage({ id: getTrad(`relation.${relation}`) })}
+                    aria-pressed={relationType === relation}
+                    data-relation-type={relation}
                   >
-                    <Asset key={relation} />
+                    <Asset key={relation} aria-hidden="true" />
                   </IconWrapper>
                 );
               })}
@@ -117,7 +120,7 @@ export const RelationNaturePicker = ({
           </KeyboardNavigable>
         </Flex>
       </Wrapper>
-      <InfosWrapper justifyContent="center">
+      <InfosWrapper justifyContent="center" aria-live="polite">
         <Typography>{truncate(leftDisplayedValue, { length: 24 })}&nbsp;</Typography>
         <Typography textColor="primary600">
           {formatMessage({ id: getTrad(`relation.${relationType}`) })}&nbsp;

--- a/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/Relation/RelationNaturePicker/RelationNaturePicker.tsx
@@ -120,7 +120,7 @@ export const RelationNaturePicker = ({
           </KeyboardNavigable>
         </Flex>
       </Wrapper>
-      <InfosWrapper justifyContent="center" aria-live="polite">
+      <InfosWrapper justifyContent="center">
         <Typography>{truncate(leftDisplayedValue, { length: 24 })}&nbsp;</Typography>
         <Typography textColor="primary600">
           {formatMessage({ id: getTrad(`relation.${relationType}`) })}&nbsp;

--- a/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
@@ -9,7 +9,7 @@ test.describe('Create collection type with all field types', () => {
   test.describe.configure({ timeout: 300000 });
 
   test.beforeEach(async ({ page }) => {
-    await sharedSetup('ctb-edit-st', page, {
+    await sharedSetup('ctb-edit-ct', page, {
       login: true,
       skipTour: true,
       resetFiles: true,
@@ -25,28 +25,121 @@ test.describe('Create collection type with all field types', () => {
     await resetFiles();
   });
 
-  test('Can create a collection type with all field types (except relations)', async ({ page }) => {
+  const advancedRequired = { required: true };
+  const advancedRegex = { required: true, regexp: '^(?!.*fail).*' };
+
+  test('Can create a collection type with all field types', async ({ page }) => {
     const attributes: AddAttribute[] = [
-      { type: 'text', name: 'testtext' },
-      { type: 'boolean', name: 'testboolean' },
-      { type: 'blocks', name: 'testblocks' },
-      { type: 'json', name: 'testjson' },
-      { type: 'number', name: 'testinteger', number: { format: 'integer' } },
-      { type: 'number', name: 'testbiginteger', number: { format: 'big integer' } },
-      { type: 'number', name: 'testdecimal', number: { format: 'decimal' } },
-      { type: 'email', name: 'testemail' },
-      { type: 'date', name: 'testdateonlydate', date: { format: 'date' } },
-      { type: 'date', name: 'testdatetime', date: { format: 'time' } },
-      { type: 'date', name: 'testdatedatetime', date: { format: 'datetime' } },
-      { type: 'password', name: 'testpassword' },
-      { type: 'media', name: 'testmediasingle', media: { multiple: false } },
-      { type: 'media', name: 'testmediamultiple', media: { multiple: true } },
+      { type: 'text', name: 'testtext', advanced: advancedRegex },
+      { type: 'boolean', name: 'testboolean', advanced: advancedRequired },
+      { type: 'blocks', name: 'testblocks', advanced: advancedRequired },
+      { type: 'json', name: 'testjson', advanced: advancedRequired },
+      {
+        type: 'number',
+        name: 'testinteger',
+        number: { format: 'integer' },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'number',
+        name: 'testbiginteger',
+        number: { format: 'big integer' },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'number',
+        name: 'testdecimal',
+        number: { format: 'decimal' },
+        advanced: advancedRequired,
+      },
+      { type: 'email', name: 'testemail', advanced: advancedRequired },
+      {
+        type: 'date',
+        name: 'testdateonlydate',
+        date: { format: 'date' },
+        advanced: advancedRequired,
+      },
+      { type: 'date', name: 'testdatetime', date: { format: 'time' }, advanced: advancedRequired },
+      {
+        type: 'date',
+        name: 'testdatedatetime',
+        date: { format: 'datetime' },
+        advanced: advancedRequired,
+      },
+      { type: 'password', name: 'testpassword', advanced: advancedRequired },
+      {
+        type: 'media',
+        name: 'testmediasingle',
+        media: { multiple: false },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'media',
+        name: 'testmediamultiple',
+        media: { multiple: true },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testonewayrelation',
+        relation: {
+          type: 'oneWay',
+          target: { select: 'Article', name: 'testonewayrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testonetoonerelation',
+        relation: {
+          type: 'oneToOne',
+          target: { select: 'Article', name: 'testonetoonerelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testonetomanyrelation',
+        relation: {
+          type: 'oneToMany',
+          target: { select: 'Article', name: 'testonetomanyrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testmanytoonerelation',
+        relation: {
+          type: 'manyToOne',
+          target: { select: 'Article', name: 'testmanytoonerelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testmanytomanyrelation',
+        relation: {
+          type: 'manyToMany',
+          target: { select: 'Article', name: 'testmanytomanyrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'testmanywayrelation',
+        relation: {
+          type: 'manyWay',
+          target: { select: 'Article', name: 'testmanywayrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
       {
         type: 'enumeration',
         name: 'testenumeration',
         enumeration: { values: ['first', 'second', 'third'] },
+        advanced: advancedRequired,
       },
-      { type: 'markdown', name: 'testmarkdown' },
+      { type: 'markdown', name: 'testmarkdown', advanced: advancedRequired },
       // New single component with a new category
       {
         type: 'component',
@@ -57,7 +150,13 @@ test.describe('Create collection type with all field types', () => {
             name: 'testnewcomponentnewcategory',
             icon: 'alien',
             categoryCreate: 'testcategory',
-            attributes: [{ type: 'text', name: 'testnewcompotext' }],
+            attributes: [
+              {
+                type: 'text',
+                name: 'testnewcompotext',
+                advanced: advancedRegex,
+              },
+            ],
           },
         },
       },
@@ -71,7 +170,13 @@ test.describe('Create collection type with all field types', () => {
             name: 'testnewcomponentrepeatable',
             icon: 'moon',
             categorySelect: 'testcategory',
-            attributes: [{ type: 'text', name: 'testexistingcompotext' }],
+            attributes: [
+              {
+                type: 'text',
+                name: 'testexistingcompotext',
+                advanced: advancedRegex,
+              },
+            ],
           },
         },
       },
@@ -104,7 +209,13 @@ test.describe('Create collection type with all field types', () => {
                   name: 'testnewcomponentnewcategory',
                   icon: 'paint',
                   categoryCreate: 'testcategory',
-                  attributes: [{ type: 'text', name: 'testdzcompotext' }],
+                  attributes: [
+                    {
+                      type: 'text',
+                      name: 'testdzcompotext',
+                      advanced: advancedRegex,
+                    },
+                  ],
                 },
               },
             },

--- a/tests/e2e/tests/content-type-builder/components/create-components.spec.ts
+++ b/tests/e2e/tests/content-type-builder/components/create-components.spec.ts
@@ -37,30 +37,85 @@ test.describe('Create a new component', () => {
     await createComponent(page, options);
   });
 
-  test('Can create a component with every attribute type permutation (except relations)', async ({
-    page,
-  }) => {
-    const attributes = [
-      { type: 'text', name: 'testtext' },
-      { type: 'boolean', name: 'testboolean' },
-      { type: 'blocks', name: 'testblocks' },
-      { type: 'json', name: 'testjson' },
-      { type: 'number', name: 'testinteger', number: { format: 'integer' } },
-      { type: 'number', name: 'testbiginteger', number: { format: 'big integer' } },
-      { type: 'number', name: 'testdecimal', number: { format: 'decimal' } },
-      { type: 'email', name: 'testemail' },
-      { type: 'date', name: 'testdateonlydate', date: { format: 'date' } },
-      { type: 'date', name: 'testdatetime', date: { format: 'time' } },
-      { type: 'date', name: 'testdatedatetime', date: { format: 'datetime' } },
-      { type: 'password', name: 'testpassword' },
-      { type: 'media', name: 'testmediasingle', media: { multiple: false } },
-      { type: 'media', name: 'testmediamultiple', media: { multiple: true } },
+  const advancedRequired = { required: true };
+  const advancedRegex = { required: true, regexp: '^(?!.*fail).*' };
+
+  test('Can create a component with all field types', async ({ page }) => {
+    const attributes: AddAttribute[] = [
+      { type: 'text', name: 'testtext', advanced: advancedRegex },
+      { type: 'boolean', name: 'testboolean', advanced: advancedRequired },
+      { type: 'blocks', name: 'testblocks', advanced: advancedRequired },
+      { type: 'json', name: 'testjson', advanced: advancedRequired },
+      {
+        type: 'number',
+        name: 'testinteger',
+        number: { format: 'integer' },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'number',
+        name: 'testbiginteger',
+        number: { format: 'big integer' },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'number',
+        name: 'testdecimal',
+        number: { format: 'decimal' },
+        advanced: advancedRequired,
+      },
+      { type: 'email', name: 'testemail', advanced: advancedRequired },
+      {
+        type: 'date',
+        name: 'testdateonlydate',
+        date: { format: 'date' },
+        advanced: advancedRequired,
+      },
+      { type: 'date', name: 'testdatetime', date: { format: 'time' }, advanced: advancedRequired },
+      {
+        type: 'date',
+        name: 'testdatedatetime',
+        date: { format: 'datetime' },
+        advanced: advancedRequired,
+      },
+      { type: 'password', name: 'testpassword', advanced: advancedRequired },
+      {
+        type: 'media',
+        name: 'testmediasingle',
+        media: { multiple: false },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'media',
+        name: 'testmediamultiple',
+        media: { multiple: true },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'comptestonewayrelation',
+        relation: {
+          type: 'oneWay',
+          target: { select: 'Article', name: 'comptestonewayrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
+      {
+        type: 'relation',
+        name: 'comptestmanywayrelation',
+        relation: {
+          type: 'manyWay',
+          target: { select: 'Article', name: 'comptestmanywayrelationtarget' },
+        },
+        advanced: advancedRequired,
+      },
       {
         type: 'enumeration',
         name: 'testenumeration',
         enumeration: { values: ['first', 'second', 'third'] },
+        advanced: advancedRequired,
       },
-      { type: 'markdown', name: 'testmarkdown' },
+      { type: 'markdown', name: 'testmarkdown', advanced: advancedRequired },
       // new single component with new category
       {
         type: 'component',
@@ -103,9 +158,7 @@ test.describe('Create a new component', () => {
           },
         },
       },
-      // TODO: test relations
-      // { type: 'relation', name: 'testrelation' },
-    ] satisfies AddAttribute[];
+    ];
 
     const options = {
       name: 'ArticlesComponent',

--- a/tests/e2e/tests/content-type-builder/components/edit-components.spec.ts
+++ b/tests/e2e/tests/content-type-builder/components/edit-components.spec.ts
@@ -21,6 +21,7 @@ test.describe('Update a new component', () => {
   const addedAttribute = {
     type: 'text',
     name: 'addedtext',
+    advanced: { required: true, regexp: '^(?!.*fail).*' },
   };
 
   const componentAttributeName = 'mycomponentname';

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -3,7 +3,6 @@ import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
 import { navToHeader } from '../../../utils/shared';
 import { sharedSetup } from '../../../utils/setup';
-import { createSingleType } from '../../../utils/content-types';
 
 test.describe('Edit single type', () => {
   // very long timeout for these tests because they restart the server multiple times
@@ -13,6 +12,7 @@ test.describe('Edit single type', () => {
   const ctName = 'Homepage';
 
   test.beforeEach(async ({ page }) => {
+    await resetFiles();
     await sharedSetup('ctb-edit-st', page, {
       login: true,
       skipTour: true,
@@ -20,19 +20,41 @@ test.describe('Edit single type', () => {
       importData: 'with-admin.tar',
     });
 
-    // Then go to our content type
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
 
   // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
   // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterEach(async ({ page }) => {
+  test.afterEach(async () => {
     await resetFiles();
+  });
+
+  // Tests for GH#21398
+  test('Can update relation of type manyToOne to oneToOne', async ({ page }) => {
+    // Create relation in Content-Type Builder
+    await navToHeader(page, ['Content-Type Builder', ctName], ctName);
+    await page.getByRole('button', { name: /add another field to this single type/i }).click();
+    await page.getByRole('button', { name: /relation/i }).click();
+    await page.getByRole('button', { name: /article/i }).click();
+    await page.getByRole('menuitem', { name: /product/i }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await waitForRestart(page);
+
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
+
+    // update relation in Content-Type Builder to oneToOne
+    await page.getByRole('button', { name: /edit product/i }).click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('cell', { name: 'product', exact: true })).toBeVisible();
   });
 
   test('Can toggle internationalization', async ({ page }) => {
     // toggle off
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
@@ -41,7 +63,7 @@ test.describe('Edit single type', () => {
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Internationalization').click();
     await page.getByRole('button', { name: 'Finish' }).click();
@@ -51,7 +73,7 @@ test.describe('Edit single type', () => {
 
   test('Can toggle draft&publish', async ({ page }) => {
     // toggle off
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Yes, disable' }).click();
@@ -60,7 +82,7 @@ test.describe('Edit single type', () => {
     await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
 
     // toggle on - we see that the "off" worked because here it doesn't prompt to confirm data loss
-    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit' }).first().click();
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByText('Draft & publish').click();
     await page.getByRole('button', { name: 'Finish' }).click();
@@ -70,6 +92,7 @@ test.describe('Edit single type', () => {
 
   test('Can add a field with default value', async ({ page }) => {
     await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+
     await page
       .getByRole('button', { name: 'Text Small or long text like title or description' })
       .click();
@@ -77,6 +100,53 @@ test.describe('Edit single type', () => {
     await page.getByRole('tab', { name: 'Advanced settings' }).click();
     await page.getByRole('textbox', { name: 'Default value' }).fill('mydefault');
     await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await waitForRestart(page);
+
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+  });
+
+  /**
+   * TODO: This test is flaky likely due to an actual display bug
+   * where specific circumstances (demonstrated here) cause a modal to close/reopen on the first click
+   * instead of triggering the submit
+   * */
+  test('Can configure advanced settings for multiple fields sequentially', async ({ page }) => {
+    const fieldsToAdd = [
+      {
+        name: 'testfield',
+        defaultValue: 'mydefault',
+      },
+      {
+        name: 'testfield2',
+        defaultValue: 'mydefault2',
+      },
+    ];
+
+    for (const field of fieldsToAdd) {
+      await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+      await page
+        .getByRole('button', { name: 'Text Small or long text like title or description' })
+        .click();
+      await page.getByLabel('Name', { exact: true }).fill(field.name);
+
+      // This ensures that the modal state management correctly resets the active
+      // tab when adding/editing multiple fields sequentially
+      await expect(page.getByRole('tab', { name: 'Basic settings' })).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      await expect(page.getByRole('tab', { name: 'Advanced settings' })).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+
+      await page.getByRole('tab', { name: 'Advanced settings' }).click();
+      await page.getByRole('textbox', { name: 'Default value' }).fill(field.defaultValue);
+      await page.getByRole('button', { name: 'Finish' }).click();
+    }
+
     await page.getByRole('button', { name: 'Save' }).click();
 
     await waitForRestart(page);
@@ -108,5 +178,38 @@ test.describe('Edit single type', () => {
     await waitForRestart(page);
 
     await expect(page.getByRole('heading', { name: ctName })).not.toBeVisible();
+  });
+
+  test('Can enable localization on a content type, create a text field, disable internationalization on the field and enable uniqueness on the same field', async ({
+    page,
+  }) => {
+    // Create a text field
+    await page.getByRole('button', { name: 'Add another field', exact: true }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
+    await page.getByLabel('Name', { exact: true }).fill('localizedField');
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Disable internationalization on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Enable localization for this field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
+
+    // Enable uniqueness on the field
+    await page.getByRole('button', { name: 'Edit localizedField' }).click();
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByText('Unique field').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+    await expect(page.getByRole('heading', { name: ctName })).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

Adds aria attributes to the relations buttons in the CTB

NOTE: I accidentally merged [some tests](https://github.com/strapi/strapi/pull/23078) into this that were dependant on this PR and I had intended to wait until this was merged. But they're just tests and technically do test this functionality 😆 and they've already been reviewed [here](https://github.com/strapi/strapi/pull/23078)

### Why is it needed?

There was no way for screen readers (or Playwright) to identify which button was which, nor to detect which button was currently active. This way we tell screen readers to ignore the svg and read the new label instead.

### How to test it?

inspect element on the ctb relations buttons as you use them and see the labels

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
