### PR TITLE
feat(relations): add back button history

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -33,6 +33,8 @@ interface DocumentContextValue {
   document: ReturnType<UseDocument>;
   meta: DocumentMeta;
   changeDocument: (newRelation: DocumentMeta) => void;
+  documentHistory: DocumentMeta[];
+  setDocumentHistory: (document: DocumentMeta[]) => void;
 }
 
 const [DocumentProvider, useDocumentContext] =
@@ -67,6 +69,8 @@ const DocumentContextProvider = ({
   );
   const document = useDocument({ ...currentDocumentMeta, params });
 
+  const [documentHistory, setDocumentHistory] = React.useState<DocumentMeta[]>([]);
+
   return (
     <DocumentProvider
       changeDocument={changeDocument}
@@ -78,11 +82,13 @@ const DocumentContextProvider = ({
         params: initialDocument.params,
       }}
       meta={currentDocumentMeta}
+      documentHistory={documentHistory}
+      setDocumentHistory={setDocumentHistory}
     >
       {children}
     </DocumentProvider>
   );
 };
 
-export { DocumentContextProvider, useDocumentContext };
+export { useDocumentContext, DocumentContextProvider };
 export type { DocumentMeta };

--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -34,7 +34,7 @@ interface DocumentContextValue {
   meta: DocumentMeta;
   changeDocument: (newRelation: DocumentMeta) => void;
   documentHistory: DocumentMeta[];
-  setDocumentHistory: (document: DocumentMeta[]) => void;
+  setDocumentHistory: React.Dispatch<React.SetStateAction<DocumentMeta[]>>;
 }
 
 const [DocumentProvider, useDocumentContext] =

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -57,6 +57,19 @@ const CustomModalContent = styled(Modal.Content)`
   max-height: 100%;
 `;
 
+interface RelationModalContextValue {
+  parentModified: boolean;
+  depth: number;
+}
+
+const [RelationModalProvider, useRelationModal] = createContext<RelationModalContextValue>(
+  'RelationModal',
+  {
+    parentModified: false,
+    depth: 0,
+  }
+);
+
 const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalProps) => {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
@@ -71,16 +84,38 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
   );
   const currentDocumentMeta = useDocumentContext('RelationModalBody', (state) => state.meta);
   const changeDocument = useDocumentContext('RelationModalBody', (state) => state.changeDocument);
+  const documentHistory = useDocumentContext('RelationModalBody', (state) => state.documentHistory);
+  const setDocumentHistory = useDocumentContext(
+    'RelationModalBody',
+    (state) => state.setDocumentHistory
+  );
 
   const [isConfirmationOpen, setIsConfirmationOpen] = React.useState(false);
-  const [isNavigating, setIsNavigating] = React.useState(false);
+  const [actionPosition, setActionPosition] = React.useState<'cancel' | 'back' | 'navigate'>(
+    'cancel'
+  );
 
   const [isModalOpen, setIsModalOpen] = React.useState(false);
+  // NOTE: Not sure about this relation modal context, maybe we should move this to DocumentContext?
   // Get parent modal context if it exists
   const parentContext = useRelationModal('RelationModalWrapper', (state) => state);
-  const isNested = parentContext.depth > 0;
-  // Track this modal's depth
-  const depth = isNested ? parentContext.depth + 1 : 1;
+  // Get depth of nested modals
+  const depth = parentContext ? parentContext.depth + 1 : 0;
+  // Check if this is a nested modal
+  const isNested = depth > 0;
+
+  const addDocumentToHistory = (document: DocumentMeta) =>
+    setDocumentHistory([...documentHistory, document]);
+
+  const getPreviousDocument = () => {
+    if (documentHistory.length === 0) return undefined;
+
+    const lastDocument = documentHistory[documentHistory.length - 1];
+
+    setDocumentHistory([...documentHistory].slice(0, documentHistory.length - 1));
+
+    return lastDocument;
+  };
 
   const handleToggleModal = () => {
     if (isModalOpen) {
@@ -92,6 +127,10 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
       };
       // Change back to the root document
       changeDocument(document);
+      // Reset the document history
+      setDocumentHistory([]);
+      // Reset action position
+      setActionPosition('cancel');
       // Read from cache or refetch root document
       triggerRefetchDocument(
         document,
@@ -125,8 +164,13 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
   };
 
   const handleConfirm = () => {
-    if (isNavigating) {
+    if (actionPosition === 'navigate') {
       handleRedirection();
+    } else if (actionPosition === 'back') {
+      const previousRelation = getPreviousDocument();
+      if (previousRelation) {
+        changeDocument(previousRelation);
+      }
     } else {
       handleToggleModal();
     }
@@ -150,6 +194,9 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
       }}
     >
       {({ modified, isSubmitting, resetForm }) => {
+        // We don't count the root document, so history starts after 1
+        const hasHistory = documentHistory.length > 1;
+
         return (
           <RelationModalProvider parentModified={modified} depth={depth}>
             <Modal.Root
@@ -177,6 +224,10 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
                         if (modified && !isSubmitting) {
                           setIsConfirmationOpen(true);
                         } else {
+                          // Add current relation to history before opening a new one
+                          if (currentDocumentMeta && Object.keys(currentDocumentMeta).length > 0) {
+                            addDocumentToHistory(currentDocumentMeta);
+                          }
                           handleToggleModal();
                         }
 
@@ -198,8 +249,18 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
                         withTooltip={false}
                         label="Back"
                         variant="ghost"
-                        disabled
-                        onClick={() => {}}
+                        disabled={!hasHistory}
+                        onClick={() => {
+                          setActionPosition('back');
+                          if (modified && !isSubmitting) {
+                            setIsConfirmationOpen(true);
+                          } else {
+                            const previousRelation = getPreviousDocument();
+                            if (previousRelation) {
+                              changeDocument(previousRelation);
+                            }
+                          }
+                        }}
                         marginRight={1}
                       >
                         <ArrowLeft />
@@ -216,7 +277,7 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
                 <RelationModalBody>
                   <IconButton
                     onClick={() => {
-                      setIsNavigating(true);
+                      setActionPosition('navigate');
 
                       if (modified && !isSubmitting) {
                         setIsConfirmationOpen(true);
@@ -277,19 +338,6 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
     </FormContext>
   );
 };
-
-interface RelationModalContextValue {
-  parentModified: boolean;
-  depth: number;
-}
-
-const [RelationModalProvider, useRelationModal] = createContext<RelationModalContextValue>(
-  'RelationModal',
-  {
-    parentModified: false,
-    depth: 0,
-  }
-);
 
 const CustomTextButton = styled(TextButton)`
   & > span {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -105,16 +105,18 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
   const isNested = depth > 0;
 
   const addDocumentToHistory = (document: DocumentMeta) =>
-    setDocumentHistory([...documentHistory, document]);
+    setDocumentHistory((prev) => [...prev, document]);
 
   const getPreviousDocument = () => {
     if (documentHistory.length === 0) return undefined;
 
     const lastDocument = documentHistory[documentHistory.length - 1];
 
-    setDocumentHistory([...documentHistory].slice(0, documentHistory.length - 1));
-
     return lastDocument;
+  };
+
+  const removeLastDocumentFromHistory = () => {
+    setDocumentHistory((prev) => [...prev].slice(0, prev.length - 1));
   };
 
   const handleToggleModal = () => {
@@ -169,6 +171,7 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
     } else if (actionPosition === 'back') {
       const previousRelation = getPreviousDocument();
       if (previousRelation) {
+        removeLastDocumentFromHistory();
         changeDocument(previousRelation);
       }
     } else {
@@ -257,6 +260,7 @@ const RelationModalWrapper = ({ relation, triggerButtonLabel }: RelationModalPro
                           } else {
                             const previousRelation = getPreviousDocument();
                             if (previousRelation) {
+                              removeLastDocumentFromHistory();
                               changeDocument(previousRelation);
                             }
                           }

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -65,6 +65,35 @@ test.describe('Unstable Relations on the fly', () => {
     await expect(page.getByRole('heading', { name: 'Coach Beard' })).toBeVisible();
   });
 
+  test('I want to open some nested relations and click the back button to open the initial relation', async ({
+    page,
+  }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+
+    // Open the relation modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Coach Beard' }));
+    await expect(page.getByRole('button', { name: 'Back' })).toBeDisabled();
+
+    // Open a nested relation
+    await clickAndWait(page, page.getByRole('button', { name: 'West Ham post match analysis' }));
+    await expect(page.getByRole('button', { name: 'Back' })).toBeEnabled();
+    // and another nested relation
+    await clickAndWait(page, page.getByRole('button', { name: 'Coach Beard' }));
+    await expect(page.getByRole('button', { name: 'Back' })).toBeEnabled();
+
+    // click on the Back button once
+    await clickAndWait(page, page.getByRole('button', { name: 'Back' }));
+    await expect(page.getByRole('heading', { name: 'West Ham post match analysis' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back' })).toBeEnabled();
+
+    // click on the Back button again
+    await clickAndWait(page, page.getByRole('button', { name: 'Back' }));
+    await expect(page.getByRole('heading', { name: 'Coach Beard' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back' })).toBeDisabled();
+  });
+
   test('I want to click on a nested relation in the relation modal without saving the data in the form', async ({
     page,
   }) => {
@@ -131,5 +160,33 @@ test.describe('Unstable Relations on the fly', () => {
 
     await page.waitForURL(AUTHOR_EDIT_URL);
     await expect(page.getByRole('heading', { name: 'Coach Beard' })).toBeVisible();
+  });
+
+  test('I want to click the back button to open the previous relation without saving the data in the form', async ({
+    page,
+  }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+
+    // Open the relation modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Coach Beard' }));
+
+    // Open a nested relation
+    await clickAndWait(page, page.getByRole('button', { name: 'West Ham post match analysis' }));
+    // and another nested relation
+    await clickAndWait(page, page.getByRole('button', { name: 'Coach Beard' }));
+
+    // Change the name of the author
+    const name = page.getByRole('textbox', { name: 'name' });
+    await name.fill('Mr. Coach Beard');
+
+    // click on the Back button
+    await clickAndWait(page, page.getByRole('button', { name: 'Back' }));
+
+    // Check the confirmation modal is shown and click confirm
+    await clickAndWait(page, page.getByRole('button', { name: 'Confirm' }));
+
+    await expect(page.getByRole('heading', { name: 'West Ham post match analysis' })).toBeVisible();
   });
 });


### PR DESCRIPTION
### What does it do?

Maintains document history in DocumentContext

### Why is it needed?

So we can use the back button in the relation modal

### How to test it?

Go to an entry with relation, that has a relation, that has a relation...or something like that
Click the relation, then its relation, then its relation.
The go back, back, back.
You should be where you started.
Going back with with unsaved changes should trigger a confirm dialog

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
