### PR TITLE
enhancement: remove warning when project is at seat limit

### DIFF
--- a/packages/core/admin/ee/admin/src/hooks/tests/useLicenseLimitNotification.test.tsx
+++ b/packages/core/admin/ee/admin/src/hooks/tests/useLicenseLimitNotification.test.tsx
@@ -78,7 +78,7 @@ describe('useLicenseLimitNotification', () => {
     expect(toggleNotification).not.toHaveBeenCalled();
   });
 
-  it('should not display notification if status is not AT_LIMIT or OVER_LIMIT', () => {
+  it('should not display notification if status is not OVER_LIMIT', () => {
     // @ts-expect-error – mock
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
@@ -91,33 +91,12 @@ describe('useLicenseLimitNotification', () => {
     expect(toggleNotification).not.toHaveBeenCalled();
   });
 
-  it('should display a notification when license limit is over or at limit', () => {
-    setup();
-    expect(toggleNotification).toHaveBeenCalled();
-  });
-
-  it('should display a soft warning notification when license limit is at limit', () => {
-    setup();
-
-    expect(toggleNotification).toHaveBeenCalledWith({
-      type: 'warning',
-      message:
-        "Add seats to re-enable Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title: 'At seat limit (5/5)',
-      link: {
-        url: 'https://strapi.io/billing/request-seats',
-        label: 'CONTACT SALES',
-      },
-      blockTransition: true,
-      onClose: expect.any(Function),
-    });
-  });
-
-  it('should display a warning notification when license limit is at limit', () => {
+  it('should display a danger notification when license limit is over the limit', () => {
     // @ts-expect-error – mock
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
         ...baseLicenseInfo,
+        enforcementUserCount: 6,
         licenseLimitStatus: 'OVER_LIMIT',
       },
     }));
@@ -128,7 +107,7 @@ describe('useLicenseLimitNotification', () => {
       type: 'danger',
       message:
         "Add seats to invite Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title: 'Over seat limit (5/5)',
+      title: 'Over seat limit (6/5)',
       link: {
         url: 'https://strapi.io/billing/request-seats',
         label: 'CONTACT SALES',
@@ -143,6 +122,7 @@ describe('useLicenseLimitNotification', () => {
     useLicenseLimits.mockImplementationOnce(() => ({
       license: {
         ...baseLicenseInfo,
+        licenseLimitStatus: 'OVER_LIMIT',
         isHostedOnStrapiCloud: true,
       },
     }));
@@ -150,10 +130,10 @@ describe('useLicenseLimitNotification', () => {
     setup();
 
     expect(toggleNotification).toHaveBeenCalledWith({
-      type: 'warning',
+      type: 'danger',
       message:
-        "Add seats to re-enable Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
-      title: 'At seat limit (5/5)',
+        "Add seats to invite Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
+      title: 'Over seat limit (5/5)',
       link: {
         url: 'https://cloud.strapi.io/profile/billing',
         label: 'ADD SEATS',

--- a/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
+++ b/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
@@ -35,14 +35,12 @@ export const useLicenseLimitNotification = () => {
     const shouldDisplayNotification =
       !isNil(permittedSeats) &&
       !window.sessionStorage.getItem(`${STORAGE_KEY_PREFIX}-${pathname}`) &&
-      (licenseLimitStatus === 'AT_LIMIT' || licenseLimitStatus === 'OVER_LIMIT');
+      licenseLimitStatus === 'OVER_LIMIT';
 
     let notificationType: NotificationConfig['type'];
 
     if (licenseLimitStatus === 'OVER_LIMIT') {
       notificationType = 'danger';
-    } else if (licenseLimitStatus === 'AT_LIMIT') {
-      notificationType = 'warning';
     }
 
     if (shouldDisplayNotification) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove unwanted warning on seat limit reached

### Why is it needed?

A bit too visible and unecessary when you are just at the limit

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
