### PR TITLE
fix: disable preview form when status is modified

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -175,7 +175,7 @@ const PreviewPage = () => {
           disabled={
             query.status === 'published' &&
             documentResponse &&
-            documentResponse.document.status === 'published'
+            documentResponse.document.status !== 'draft'
           }
           initialValues={documentResponse.getInitialFormValues()}
           initialErrors={location?.state?.forceValidation ? validateSync(initialValues, {}) : {}}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

disables preview side editor form when on the published tab if the status is modified
### Why is it needed?

it should only be editable on the draft tab, just like on the edit view
### Related issue(s)/PR(s)

fixes #23079