### PR TITLE
fix: add initiallySelectedAssets prop

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/MediaLibraryDialog.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/MediaLibraryDialog.tsx
@@ -17,12 +17,14 @@ export interface MediaLibraryDialogProps {
   allowedTypes?: AllowedTypes[];
   onClose: () => void;
   onSelectAssets: (selectedAssets: File[]) => void;
+  initiallySelectedAssets?: File[];
 }
 
 export const MediaLibraryDialog = ({
   onClose,
   onSelectAssets,
   allowedTypes = ['files', 'images', 'videos', 'audios'],
+  initiallySelectedAssets,
 }: MediaLibraryDialogProps) => {
   const [step, setStep] = React.useState(STEPS.AssetSelect);
   const [folderId, setFolderId] = React.useState<number | null>(null);
@@ -33,6 +35,7 @@ export const MediaLibraryDialog = ({
         <AssetDialog
           allowedTypes={allowedTypes}
           folderId={folderId}
+          initiallySelectedAssets={initiallySelectedAssets}
           open
           onClose={onClose}
           onValidate={onSelectAssets}


### PR DESCRIPTION
### What does it do?

adds missing prop `initiallySelectedAssets` for MediaLibraryDialog which later is passed down to AssetDialog

### Why is it needed?

currently none is shown in MediaLibraryDialog's "selected files" tab wether assets were selected or not