### PR TITLE
fix(relations): dynamic zones and components do not work

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -50,6 +50,7 @@ const [DocumentProvider, useDocumentContext] =
  * - meta: information about the currentDocument,
  * - document: the actual document,
  * - changeDocument: a function to change the current document to one of its relations.
+ * - rootDocumentMeta: information about the root level document (current page)
  */
 const DocumentContextProvider = ({
   children,

--- a/packages/core/content-manager/admin/src/features/DocumentContext.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentContext.tsx
@@ -79,7 +79,6 @@ const DocumentContextProvider = ({
         documentId: initialDocument.documentId,
         model: initialDocument.model,
         collectionType: initialDocument.collectionType,
-        params: initialDocument.params,
       }}
       meta={currentDocumentMeta}
       documentHistory={documentHistory}

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -45,6 +45,7 @@ const EditViewPage = () => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
 
+  const doc = useDoc();
   const {
     document,
     meta,
@@ -57,7 +58,7 @@ const EditViewPage = () => {
     hasError,
     getTitle,
     getInitialFormValues,
-  } = useDoc();
+  } = doc;
 
   const hasDraftAndPublished = schema?.options?.draftAndPublish ?? false;
 
@@ -185,10 +186,10 @@ const EditViewPage = () => {
                 <Grid.Root paddingTop={8} gap={4}>
                   <Grid.Item col={9} s={12} direction="column" alignItems="stretch">
                     <Tabs.Content value="draft">
-                      <FormLayout layout={layout} />
+                      <FormLayout layout={layout} document={doc} />
                     </Tabs.Content>
                     <Tabs.Content value="published">
-                      <FormLayout layout={layout} />
+                      <FormLayout layout={layout} document={doc} />
                     </Tabs.Content>
                   </Grid.Item>
                   <Grid.Item col={3} s={12} direction="column" alignItems="stretch">

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/NonRepeatable.tsx
@@ -2,6 +2,7 @@ import { useField } from '@strapi/admin/strapi-admin';
 import { Box, Flex } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
+import { useDocumentContext } from '../../../../../features/DocumentContext';
 import { ResponsiveGridItem, ResponsiveGridRoot } from '../../FormLayout';
 import { ComponentProvider, useComponent } from '../ComponentContext';
 
@@ -19,6 +20,7 @@ const NonRepeatableComponent = ({
   const { value } = useField(name);
   const level = useComponent('NonRepeatableComponent', (state) => state.level);
   const isNested = level > 0;
+  const currentDocument = useDocumentContext('NonRepeatableComponent', (state) => state.document);
 
   return (
     <ComponentProvider id={value?.id} uid={attribute.component} level={level + 1} type="component">
@@ -58,7 +60,12 @@ const NonRepeatableComponent = ({
                       direction="column"
                       alignItems="stretch"
                     >
-                      {children({ ...field, label: translatedLabel, name: completeFieldName })}
+                      {children({
+                        ...field,
+                        label: translatedLabel,
+                        name: completeFieldName,
+                        document: currentDocument,
+                      })}
                     </ResponsiveGridItem>
                   );
                 })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -51,10 +51,8 @@ const RepeatableComponent = ({
   const { formatMessage } = useIntl();
   const { search: searchString } = useLocation();
   const search = React.useMemo(() => new URLSearchParams(searchString), [searchString]);
-  const components = useDocumentContext(
-    'RepeatableComponent',
-    (state) => state.document.components
-  );
+  const currentDocument = useDocumentContext('RepeatableComponent', (state) => state.document);
+  const components = currentDocument.components;
 
   const {
     value = [],
@@ -304,6 +302,7 @@ const RepeatableComponent = ({
                               ...field,
                               label: translatedLabel,
                               name: completeFieldName,
+                              document: currentDocument,
                             })}
                           </ResponsiveGridItem>
                         );

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -69,15 +69,28 @@ const ResponsiveAccordionContent = styled(Accordion.Content)`
   container-type: inline-size;
 `;
 
-const Grid = styled(Box)`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 100%);
-  grid-gap: ${({ theme }) => theme.spaces[1]};
+/**
+ * TODO:
+ * JSDOM cannot handle container queries.
+ * This is a temporary workaround so that tests do not fail in the CI when jestdom throws an error
+ * for failing to parse the stylesheet.
+ */
+const Grid =
+  process.env.NODE_ENV !== 'test'
+    ? styled(Box)`
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 100%);
+        grid-gap: 4px;
 
-  @container (min-width: ${() => RESPONSIVE_CONTAINER_BREAKPOINTS.sm}) {
-    grid-template-columns: repeat(auto-fill, 14rem);
-  }
-`;
+        @container (min-width: ${() => RESPONSIVE_CONTAINER_BREAKPOINTS.sm}) {
+          grid-template-columns: repeat(auto-fill, 14rem);
+        }
+      `
+    : styled(Box)`
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 100%);
+        grid-gap: 4px;
+      `;
 
 const ComponentBox = styled<FlexComponent<'button'>>(Flex)`
   color: ${({ theme }) => theme.colors.neutral600};

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -20,7 +20,6 @@ import { styled } from 'styled-components';
 import { COMPONENT_ICONS } from '../../../../../components/ComponentIcon';
 import { ItemTypes } from '../../../../../constants/dragAndDrop';
 import { useDocumentContext } from '../../../../../features/DocumentContext';
-import { useDocument } from '../../../../../hooks/useDocument';
 import { useDocumentLayout } from '../../../../../hooks/useDocumentLayout';
 import { type UseDragAndDropOptions, useDragAndDrop } from '../../../../../hooks/useDragAndDrop';
 import { getIn } from '../../../../../utils/objects';

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -20,6 +20,7 @@ import { styled } from 'styled-components';
 import { COMPONENT_ICONS } from '../../../../../components/ComponentIcon';
 import { ItemTypes } from '../../../../../constants/dragAndDrop';
 import { useDocumentContext } from '../../../../../features/DocumentContext';
+import { useDocument } from '../../../../../hooks/useDocument';
 import { useDocumentLayout } from '../../../../../hooks/useDocumentLayout';
 import { type UseDragAndDropOptions, useDragAndDrop } from '../../../../../hooks/useDragAndDrop';
 import { getIn } from '../../../../../utils/objects';
@@ -59,9 +60,15 @@ const DynamicComponent = ({
   const { formatMessage } = useIntl();
   const formValues = useForm('DynamicComponent', (state) => state.values);
   const documentMeta = useDocumentContext('DynamicComponent', (state) => state.meta);
+  const rootDocumentMeta = useDocumentContext(
+    'DynamicComponent',
+    (state) => state.rootDocumentMeta
+  );
+  const isRootDocument = rootDocumentMeta.model === documentMeta.model;
   const {
     edit: { components },
-  } = useDocumentLayout(documentMeta.model);
+  } = useDocumentLayout(isRootDocument ? documentMeta.model : rootDocumentMeta.model);
+  const document = useDocumentContext('DynamicComponent', (state) => state.document);
 
   const title = React.useMemo(() => {
     const { mainField } = components[componentUid]?.settings ?? { mainField: 'id' };
@@ -269,9 +276,17 @@ const DynamicComponent = ({
                                   alignItems="stretch"
                                 >
                                   {children ? (
-                                    children({ ...fieldWithTranslatedLabel, name: fieldName })
+                                    children({
+                                      ...fieldWithTranslatedLabel,
+                                      document,
+                                      name: fieldName,
+                                    })
                                   ) : (
-                                    <InputRenderer {...fieldWithTranslatedLabel} name={fieldName} />
+                                    <InputRenderer
+                                      {...fieldWithTranslatedLabel}
+                                      document={document}
+                                      name={fieldName}
+                                    />
                                   )}
                                 </ResponsiveGridItem>
                               );

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -486,7 +486,11 @@ const RelationModalBody = ({ children }: RelationModalBodyProps) => {
 
         <Flex flex={1} overflow="auto" alignItems="stretch" paddingTop={7}>
           <Box overflow="auto" flex={1}>
-            <FormLayout layout={documentLayoutResponse.edit.layout} hasBackground={false} />
+            <FormLayout
+              layout={documentLayoutResponse.edit.layout}
+              document={documentResponse}
+              hasBackground={false}
+            />
           </Box>
         </Flex>
       </DocumentRBAC>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -99,6 +99,7 @@ function useHandleDisconnect(fieldName: string, consumerName: string) {
 /* -------------------------------------------------------------------------------------------------
  * RelationsField
  * -----------------------------------------------------------------------------------------------*/
+
 const RELATIONS_TO_DISPLAY = 5;
 const ONE_WAY_RELATIONS = ['oneWay', 'oneToOne', 'manyToOne', 'oneToManyMorph', 'oneToOneMorph'];
 
@@ -159,11 +160,12 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
     const documentMeta = isRootDocument ? rootDocumentMeta : currentDocumentMeta;
 
     /**
-     * A document shares a document id across dimensions, however,
-     * a document being created in a new dimension (en document is being created as french)
-     * then the documentId does not exist yet on the actual document, but we are aware of what it will be
-     * since it is defined on the english dimension (documentMeta). We use the actual documentId for the dimension
-     * in order to be sure we always fetch the correct relations for the document when it hasn't been created yet.
+     * This value is the actual documentId on the created document.
+     * A document shares a documentId across dimensions.
+     * If a document is being created in a new dimension (e.g. creating french dimension of english document),
+     * we are aware of what the documentId will be via the english dimension's documentMeta, but we should use the
+     * french dimension's documentId which is undefined until it is created. This is important for fetching the correct relations
+     * at the right time (create vs update).
      */
     const dimensionSpecificDocumentId = currentDocument.document?.documentId;
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -160,7 +160,8 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
 
     const { formatMessage } = useIntl();
 
-    const params = currentDocumentMeta.params;
+    const [{ query }] = useQueryParams();
+    const params = currentDocumentMeta.params ?? buildValidParams(query);
 
     const isMorph = props.attribute.relation.toLowerCase().includes('morph');
     const isDisabled = isMorph || disabled;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -159,15 +159,8 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
     const isRootDocument = rootDocumentMeta.documentId === currentDocumentMeta.documentId;
     const documentMeta = isRootDocument ? rootDocumentMeta : currentDocumentMeta;
 
-    /**
-     * This value is the actual documentId on the created document.
-     * A document shares a documentId across dimensions.
-     * If a document is being created in a new dimension (e.g. creating french dimension of english document),
-     * we are aware of what the documentId will be via the english dimension's documentMeta, but we should use the
-     * french dimension's documentId which is undefined until it is created. This is important for fetching the correct relations
-     * at the right time (create vs update).
-     */
-    const dimensionSpecificDocumentId = currentDocument.document?.documentId;
+    // Use the documentId from the actual document, not the params (meta)
+    const documentId = currentDocument.document?.documentId;
 
     const { formatMessage } = useIntl();
 
@@ -194,7 +187,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
      * Same with `uid` and `documentModel`.
      */
     const model = component ? component.uid : documentMeta.model;
-    const id = component && componentId ? componentId.toString() : dimensionSpecificDocumentId;
+    const id = component && componentId ? componentId.toString() : documentId;
 
     /**
      * The `name` prop is a complete path to the field, e.g. `field1.field2.field3`.
@@ -361,13 +354,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           <RelationsInput
             disabled={isDisabled}
             // NOTE: we should not default to using the documentId if the component is being created (componentUID is undefined)
-            id={
-              componentUID && component
-                ? componentId
-                  ? `${componentId}`
-                  : ''
-                : dimensionSpecificDocumentId
-            }
+            id={componentUID && component ? (componentId ? `${componentId}` : '') : documentId}
             label={`${label} ${relationsCount > 0 ? `(${relationsCount})` : ''}`}
             model={model}
             onChange={handleConnect}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -213,7 +213,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           'target' in attribute &&
           'target' in props.attribute &&
           attribute.target === props.attribute.target
-      ).length > 0 && Object.keys(schemaAttributes).includes(targetField);
+      ).length > 0;
 
     const { data, isLoading, isFetching } = useGetRelationsQuery(
       {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/Relations.test.tsx
@@ -7,59 +7,11 @@ import { RelationsInput, RelationsFieldProps } from '../Relations';
 
 const relationContext = {
   initialDocument: {
-    documentId: 'abcdefg',
-    model: 'api::test.test',
+    documentId: '12345',
+    model: 'api::address.address',
     collectionType: 'collection-types',
   },
 };
-
-jest.mock('../../../../../../hooks/useDocument', () => ({
-  useDoc: jest.fn(() => ({})),
-  useDocument: jest.fn(() => ({
-    isLoading: false,
-    components: {},
-    document: {
-      category: {
-        count: 1,
-      },
-      createdAt: '2025-02-10T09:44:42.354Z',
-      createdBy: {
-        firstname: 'John',
-        id: '1',
-        lastname: 'Doe',
-        username: 'johndoe',
-      },
-      documentId: 'abcdefg',
-      id: 1,
-      locale: null,
-      name: 'test',
-      updatedAt: '2025-02-10T09:44:42.354Z',
-      updatedBy: {
-        firstname: 'John',
-        id: '1',
-        lastname: 'Doe',
-        username: 'johndoe',
-      },
-    },
-    getTitle: jest.fn().mockReturnValue('Test'),
-    getInitialFormValues: jest.fn().mockReturnValue({
-      name: 'test',
-      category: {
-        connect: [],
-        disconnect: [],
-      },
-    }),
-    meta: {
-      availableLocales: [],
-      availableStatus: [],
-    },
-    schema: {
-      options: {
-        draftAndPublish: false,
-      },
-    },
-  })),
-}));
 
 const render = ({
   initialEntries,
@@ -117,7 +69,7 @@ describe('Relations', () => {
     expect(await screen.findAllByRole('option')).toHaveLength(3);
   });
 
-  it('should by render the relations list when there is data from the API', async () => {
+  it('should render the relations list when there is data from the API', async () => {
     render();
 
     expect(screen.getByLabelText('relations')).toBe(screen.getByRole('combobox'));

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -16,10 +16,13 @@ export const ResponsiveGridRoot = styled(Grid.Root)`
   container-type: inline-size;
 `;
 
-// We need to use a different grid item for the responsive layout in the test environment
-// because @container is not supported in jsdom and it throws an error
 export const ResponsiveGridItem =
-  // TODO: we need to find a better solution to avoid using process.env.NODE_ENV in the code to fix the tests with this styled component
+  /**
+   * TODO:
+   * JSDOM cannot handle container queries.
+   * This is a temporary workaround so that tests do not fail in the CI when jestdom throws an error
+   * for failing to parse the stylesheet.
+   */
   process.env.NODE_ENV !== 'test'
     ? styled(Grid.Item)<{ col: number }>`
         grid-column: span 12;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -2,10 +2,11 @@ import { Box, Flex, Grid } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
-import { useDocumentContext } from '../../../features/DocumentContext';
 import { EditLayout } from '../../../hooks/useDocumentLayout';
 
 import { InputRenderer } from './InputRenderer';
+
+import type { UseDocument } from '../../../hooks/useDocument';
 
 export const RESPONSIVE_CONTAINER_BREAKPOINTS = {
   sm: '27.5rem', // 440px
@@ -33,12 +34,12 @@ export const ResponsiveGridItem =
 interface FormLayoutProps extends Pick<EditLayout, 'layout'> {
   hasBackground?: boolean;
   model?: string;
+  document: ReturnType<UseDocument>;
 }
 
-const FormLayout = ({ layout, hasBackground = true }: FormLayoutProps) => {
+const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps) => {
   const { formatMessage } = useIntl();
-  const documentMeta = useDocumentContext('FormLayout', (state) => state.meta);
-  const model = documentMeta.model;
+  const model = document.schema?.modelName;
 
   return (
     <Flex direction="column" alignItems="stretch" gap={6}>
@@ -58,7 +59,7 @@ const FormLayout = ({ layout, hasBackground = true }: FormLayoutProps) => {
           return (
             <Grid.Root key={field.name} gap={4}>
               <Grid.Item col={12} s={12} xs={12} direction="column" alignItems="stretch">
-                <InputRenderer {...fieldWithTranslatedLabel} />
+                <InputRenderer {...fieldWithTranslatedLabel} document={document} />
               </Grid.Item>
             </Grid.Root>
           );
@@ -95,7 +96,7 @@ const FormLayout = ({ layout, hasBackground = true }: FormLayoutProps) => {
                         direction="column"
                         alignItems="stretch"
                       >
-                        <InputRenderer {...fieldWithTranslatedLabel} />
+                        <InputRenderer {...fieldWithTranslatedLabel} document={document} />
                       </ResponsiveGridItem>
                     );
                   })}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -10,10 +10,9 @@ import { ContentTypeKind } from '@strapi/types/dist/struct';
 import { useIntl } from 'react-intl';
 
 import { SINGLE_TYPES } from '../../../constants/collections';
-import { useDocumentContext } from '../../../features/DocumentContext';
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
 import { useDoc, UseDocument } from '../../../hooks/useDocument';
-import { useDocLayout, useDocumentLayout } from '../../../hooks/useDocumentLayout';
+import { useDocumentLayout } from '../../../hooks/useDocumentLayout';
 import { useLazyComponents } from '../../../hooks/useLazyComponents';
 
 import { BlocksInput } from './FormInputs/BlocksInput/BlocksInput';
@@ -34,12 +33,10 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
 
 const InputRenderer = ({ visible, hint: providedHint, document, ...props }: InputRendererProps) => {
   const { model: rootModel } = useDoc();
-  const documentLayout = useDocumentLayout(document.schema?.modelName ?? rootModel);
+  const documentLayout = useDocumentLayout(document.schema?.uid ?? rootModel);
 
   const collectionType =
-    document.schema?.kind === ('collection-type' as ContentTypeKind)
-      ? 'collection-types'
-      : 'single-types';
+    document.schema?.kind === 'collectionType' ? 'collection-types' : 'single-types';
 
   const isInDynamicZone = useDynamicZone('isInDynamicZone', (state) => state.isInDynamicZone);
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -31,6 +31,14 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
   document: ReturnType<UseDocument>;
 };
 
+/**
+ * @internal
+ *
+ * @description An abstraction around the regular form input renderer designed
+ * specifically to be used in the EditView of the content-manager this understands
+ * the complete EditFieldLayout and will handle RBAC conditions and rendering CM specific
+ * components such as Blocks / Relations.
+ */
 const InputRenderer = ({ visible, hint: providedHint, document, ...props }: InputRendererProps) => {
   const { model: rootModel } = useDoc();
   const documentLayout = useDocumentLayout(document.schema?.uid ?? rootModel);

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -218,7 +218,11 @@ const PreviewPage = () => {
                       paddingRight={isSideEditorOpen ? 6 : 0}
                       transition="all 0.2s ease-in-out"
                     >
-                      <FormLayout layout={documentLayoutResponse.edit.layout} hasBackground />
+                      <FormLayout
+                        layout={documentLayoutResponse.edit.layout}
+                        document={documentResponse}
+                        hasBackground
+                      />
                     </Box>
                     <Box position="relative" flex={1} height="100%" overflow="hidden">
                       <Box

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -189,4 +189,23 @@ test.describe('Unstable Relations on the fly', () => {
 
     await expect(page.getByRole('heading', { name: 'West Ham post match analysis' })).toBeVisible();
   });
+
+  test('I want to open a relation inside a dynamic zone component, update its content, and save', async ({
+    page,
+  }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    // Step 1. Got to Shop single-type
+    await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
+    // Step 2. Choose the product carousel component and open its toggle
+    await page.getByRole('button', { name: 'Product carousel' }).click();
+    // Step 3. Select a product
+    await page.getByRole('combobox', { name: 'products' }).click();
+    await page.getByRole('option', { name: 'Nike Mens 23/24 Away Stadium Jersey' }).click();
+    // Step 4. Open the relation modal
+    await page.getByRole('button', { name: 'Nike Mens 23/24 Away Stadium Jersey' }).click();
+    await expect(page.getByText('Edit a relation')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Nike Mens 23/24 Away Stadium Jersey' })
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
### What does it do?

Main quest:

The main goal of the PR is to fix dynamic zones and components. Currently they do not work at all. After this PR you should be able to see components and dynamic zones. If they have a relation you should be able to open that relation in a modal.

Side quests:
I also made some other improvements and fixed some issues with i18n, see below:

- Passes document to InputRenderer as a prop. (This just simplifies what document we are dealing with in the InputRenderer).
- Fix issues with locale relations

### How to test it?

- You should be able to open the relation modal from a relation inside a component or dynamic zone
- The browser console should have no network request errors for relations when the modal is open

Please also check i18n specific edge cases at the root level and in dz and components:
- entry with locale fetches relations in the same locale
- entry without locale fetches relations in all locales
- creating a new locale dimension of an existing locale entry fetches the correct relations
  1. create an entry in english
  2. from the english entry click the globe icon in the top right to "Create a fr entry"
  3. Now ensure it fetches relations correctly for that locale
- updating a relation in a specific locale updates the correct locale relation

## Known issues
- Creating a locale dimension of an existing entry will first fetch the english relations after clicking "Create <lang> relation", but a refresh fetches the correct locale relations. I will probably fix this in another PR.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
