### PR TITLE
fix(upload): empty folder list in root view

### DIFF
--- a/packages/core/upload/admin/src/components/SelectTree/SelectTree.tsx
+++ b/packages/core/upload/admin/src/components/SelectTree/SelectTree.tsx
@@ -18,7 +18,7 @@ import { getValuesToClose } from './utils/getValuesToClose';
 const hasParent = (option: FlattenedNode<string | number | null>) => !option.parent;
 
 export type OptionSelectTree = {
-  value: string | number | null;
+  value: string | number;
   label?: string;
   children?: OptionSelectTree[];
 };
@@ -32,7 +32,7 @@ export interface SelectTreeProps<
 > {
   maxDisplayDepth?: number;
   defaultValue?: {
-    value?: string | number | null;
+    value?: string | number;
   };
   options: OptionSelectTree[];
   onChange?: (value: Record<string, string | number>) => void;
@@ -86,7 +86,7 @@ export const SelectTree = ({
     }
   }, [openValues, flatDefaultOptions, optionsFiltered]);
 
-  const handleToggle = (value: string | number | null) => {
+  const handleToggle = (value: string | number) => {
     if (openValues.includes(value)) {
       const valuesToClose = getValuesToClose(flatDefaultOptions, value);
       setOpenValues((prev) => prev.filter((prevData) => !valuesToClose.includes(prevData)));
@@ -124,12 +124,12 @@ interface SelectProps<
   ariaErrorMessage?: string;
   options: OptionSelectTree[];
   defaultValue?: {
-    value?: string | number | null;
+    value?: string | number;
   };
   isSearchable?: boolean;
   maxDisplayDepth?: number;
-  openValues?: (string | number | null)[];
-  onOptionToggle?: (value: string | number | null) => void;
+  openValues?: (string | number)[];
+  onOptionToggle?: (value: string | number) => void;
 }
 
 const Select = ({

--- a/packages/core/upload/admin/src/components/SelectTree/utils/getOpenValues.ts
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/getOpenValues.ts
@@ -1,10 +1,10 @@
 interface Option {
-  value: number | string | null;
+  value: number | string;
   parent?: number | string | null;
 }
 
 interface DefaultValue {
-  value?: number | string | null;
+  value?: number | string;
 }
 
 export function getOpenValues(options: Option[], defaultValue: DefaultValue = {}) {

--- a/packages/core/upload/admin/src/components/SelectTree/utils/tests/getOpenvalues.test.ts
+++ b/packages/core/upload/admin/src/components/SelectTree/utils/tests/getOpenvalues.test.ts
@@ -3,7 +3,7 @@ import { getOpenValues } from '../getOpenValues';
 
 const FIXTURE = flattenTree([
   {
-    value: null,
+    value: '',
     label: 'Media Library',
     children: [
       {
@@ -38,7 +38,7 @@ const FIXTURE = flattenTree([
 
 describe('getOpenValues', () => {
   test('returns 1 value for depth = 1', () => {
-    expect(getOpenValues(FIXTURE, { value: null })).toStrictEqual([null]);
+    expect(getOpenValues(FIXTURE, { value: '' })).toStrictEqual(['']);
   });
 
   test('returns 0 values for depth = 1 and no value', () => {
@@ -46,16 +46,16 @@ describe('getOpenValues', () => {
   });
 
   test('returns 1 value for depth = 2', () => {
-    expect(getOpenValues(FIXTURE, { value: 'f-1' })).toStrictEqual([null, 'f-1']);
+    expect(getOpenValues(FIXTURE, { value: 'f-1' })).toStrictEqual(['', 'f-1']);
   });
 
   test('returns 2 values for depth = 3', () => {
-    expect(getOpenValues(FIXTURE, { value: 'f-2-1' })).toStrictEqual([null, 'f-2', 'f-2-1']);
+    expect(getOpenValues(FIXTURE, { value: 'f-2-1' })).toStrictEqual(['', 'f-2', 'f-2-1']);
   });
 
   test('returns 3 values for depth = 4', () => {
     expect(getOpenValues(FIXTURE, { value: 'f-2-2-1' })).toStrictEqual([
-      null,
+      '',
       'f-2',
       'f-2-2',
       'f-2-2-1',

--- a/packages/core/upload/admin/src/hooks/useFolderStructure.ts
+++ b/packages/core/upload/admin/src/hooks/useFolderStructure.ts
@@ -16,7 +16,7 @@ const FIELD_MAPPING: Record<string, string> = {
 interface FolderNodeWithChildren extends Omit<FolderNode, 'children'> {
   children: FolderNodeWithChildren[];
   label?: string;
-  value: string | number | null;
+  value: string | number;
 }
 
 export const useFolderStructure = ({ enabled = true } = {}) => {
@@ -33,7 +33,7 @@ export const useFolderStructure = ({ enabled = true } = {}) => {
 
     return [
       {
-        value: null,
+        value: '',
         label: formatMessage({
           id: getTrad('form.input.label.folder-location-default-label'),
           defaultMessage: 'Media Library',

--- a/packages/core/upload/shared/contracts/folders.ts
+++ b/packages/core/upload/shared/contracts/folders.ts
@@ -44,7 +44,7 @@ export type FolderNode = Partial<Omit<Folder, 'children'>> & {
 };
 
 type FolderNodeWithValue = Omit<FolderNode, 'children'> & {
-  value: string | number | null;
+  value: string | number;
   children: FolderNodeWithValue[];
 };
 


### PR DESCRIPTION
In the media library, the dropdown used to move assets was not displaying the children folders. This was due to mixed values (`null` and `''`) while the check was using a strict comparison.

This PR fixes the issue by only using an empty string. I chose to not use the `null` value since it's also used in react-select which does not accept it.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It changes the default value of a folder list to an empty string instead of `null`.

### Why is it needed?

In the root view of the media library, it's not possible to use the bulk move feature since no folder structure is displayed on the dropdown.

### How to test it?

- In DEV env, run the get started example
- Go to the media library
- Add an asset (if not yet added)
- Add a folder
- Select the asset and click on the "move" button
- See the modal with the bulk move options
- PREVIOUS behaviour: the dropdown was not proposing the newly added folder
- NEW behaviour: the dropdown is proposing the newly added folder

### Related issue(s)/PR(s)

#20853 
