### PR TITLE
fix: preview should not have a background

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -224,7 +224,7 @@ const PreviewPage = () => {
                         <FormLayout
                           layout={documentLayoutResponse.edit.layout}
                           document={documentResponse}
-                          hasBackground
+                          hasBackground={false}
                         />
                       </Box>
                       <Box position="relative" flex={1} height="100%" overflow="hidden">


### PR DESCRIPTION
### What does it do?

Fixes incorrect boolean has background passed to layout

### Why is it needed?

To not see the background on the preview page

### How to test it?

Go to the preview page you should see this:


<img width="807" alt="Screenshot 2025-03-12 at 10 37 23" src="https://github.com/user-attachments/assets/c99ac504-5b1f-40f8-b12d-827ae6cb30aa" />
Not this:
<img width="789" alt="Screenshot 2025-03-12 at 10 37 40" src="https://github.com/user-attachments/assets/47643d2a-062c-4b6f-9ce8-4b9330077abb" />


### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
