### PR TITLE
fix: fails to update self referencing relations on publish

### DIFF
--- a/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
@@ -73,6 +73,11 @@ const load = async (uid: UID.ContentType, { oldVersions }: LoadContext) => {
           continue;
         }
 
+        // If it's a self referencing relation, there is no need to sync any relation
+        if (model.uid === uid) {
+          continue;
+        }
+
         const joinTable = attribute.joinTable;
         if (!joinTable) {
           continue;
@@ -150,6 +155,11 @@ const sync = async (
       const sourceColumn = joinTable.inverseJoinColumn.name;
       const targetColumn = joinTable.joinColumn.name;
       const orderColumn = joinTable.orderColumnName;
+
+      // Failsafe in case those don't exist
+      if (!sourceColumn || !targetColumn || !orderColumn) {
+        continue;
+      }
 
       // Update order values for each relation
       // TODO: Find a way to batch it more efficiently

--- a/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
@@ -74,6 +74,7 @@ const load = async (uid: UID.ContentType, { oldVersions }: LoadContext) => {
         }
 
         // If it's a self referencing relation, there is no need to sync any relation
+        // The order will already be handled as both sides are inside the same content type
         if (model.uid === uid) {
           continue;
         }

--- a/tests/api/core/strapi/api/relations.test.api.ts
+++ b/tests/api/core/strapi/api/relations.test.api.ts
@@ -1,3 +1,15 @@
+/**
+ * TODO:
+ * # Bidirectional relations
+ *
+ *  Testing bidirectional relations is a bit tricky with our current setup on the api test.
+ *  As soon as we can test it we should implement:
+ *  - Bidirectional relations targeting the same content type (self referencing)
+ *    - Can connect, disconnect, reorder
+ *    - Can publish and discard
+ *  - Test inverse order of relations is preserved when publishing.
+ *
+ */
 import { createTestBuilder } from 'api-tests/builder';
 import { createStrapiInstance } from 'api-tests/strapi';
 import { createContentAPIRequest } from 'api-tests/request';


### PR DESCRIPTION
### What does it do?
When publishing, we were re we were syncing bidirectional relations order
https://github.com/strapi/strapi/pull/22834

This PR introduced a rather manual process in the document service, to handle the inverse order of relations when publishing.

It was achieved by retrieving all relations connected to a soon to be published entry, and overwritting the order of new relations.

This introduced an issue for bidirectional relations targeting itself (same content type). Those do not store any inverse order, and the code didn't account for null order values.

The current PR addresses the issue by NOT syncing any bidirectional relation that targets itself (the same content type)


### How to test it?

- Create a content type (e.g Category) with Draft and Publish enabled
- Create a bidirectional relation (e.g oneToMany) that targets itself  (categories -> category)
- Create a draft entry and connect a category relation
- Publish the entry
- Update the draft and try to publish

Before, this resulted in the error described in  https://github.com/strapi/strapi/issues/23070

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/23070