### PR TITLE
feat(uid): add regex attribute

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/UID.tsx
@@ -42,11 +42,12 @@ import type { Schema } from '@strapi/types';
 const UID_REGEX = /^[A-Za-z0-9-_.~]*$/;
 
 interface UIDInputProps extends Omit<InputProps, 'type'> {
+  attribute?: Pick<Schema.Attribute.UIDProperties, 'regex'>;
   type: Schema.Attribute.TypeOf<Schema.Attribute.UID>;
 }
 
 const UIDInput = React.forwardRef<any, UIDInputProps>(
-  ({ hint, label, labelAction, name, required, ...props }, ref) => {
+  ({ hint, label, labelAction, name, required, attribute = {}, ...props }, ref) => {
     const { currentDocumentMeta } = useDocumentContext('UIDInput');
     const allFormValues = useForm('InputUID', (form) => form.values);
     const [availability, setAvailability] = React.useState<CheckUIDAvailability.Response>();
@@ -60,6 +61,9 @@ const UIDInput = React.forwardRef<any, UIDInputProps>(
     const { formatMessage } = useIntl();
     const [{ query }] = useQueryParams();
     const params = React.useMemo(() => buildValidParams(query), [query]);
+
+    const { regex } = attribute;
+    const validationRegExp = regex ? new RegExp(regex) : UID_REGEX;
 
     const {
       data: defaultGeneratedUID,
@@ -143,7 +147,9 @@ const UIDInput = React.forwardRef<any, UIDInputProps>(
       {
         // Don't check availability if the value is empty or wasn't changed
         skip: !Boolean(
-          (hasChanged || isCloning) && debouncedValue && UID_REGEX.test(debouncedValue.trim())
+          (hasChanged || isCloning) &&
+            debouncedValue &&
+            validationRegExp.test(debouncedValue.trim())
         ),
       }
     );

--- a/packages/core/content-manager/admin/src/utils/validation.ts
+++ b/packages/core/content-manager/admin/src/utils/validation.ts
@@ -234,7 +234,9 @@ const createAttributeSchema = (
     case 'text':
       return yup.string();
     case 'uid':
-      return yup.string().matches(/^[A-Za-z0-9-_.~]*$/);
+      return yup
+        .string()
+        .matches(attribute.regex ? new RegExp(attribute.regex) : /^[A-Za-z0-9-_.~]*$/);
     default:
       /**
        * This allows any value.

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.ts
@@ -403,6 +403,7 @@ export const advancedForm = {
             attributeOptions.maxLength,
             attributeOptions.minLength,
             attributeOptions.private,
+            attributeOptions.regex,
           ],
         },
       ],

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
@@ -227,6 +227,23 @@ describe('Type validators', () => {
       expect(validator.isValidSync(attributes.slug)).toBe(isValid);
     });
 
+    test('Default value must match regex if a custom regex is defined', () => {
+      const attributes = {
+        slug: {
+          type: 'uid',
+          default: 'some/value',
+          regex: '^[A-Za-z0-9-_.~/]*$',
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.slug, {
+        types: ['uid'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.slug)).toBe(true);
+    });
+
     test('Default should not be defined if targetField is defined', () => {
       const attributes = {
         title: {

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -523,6 +523,12 @@ const uidSchema = basePropertiesSchema.extend({
       preserveLeadingUnderscore: z.boolean().optional(),
     })
     .optional(),
+  regex: z
+    .string()
+    .optional()
+    .refine((value) => {
+      return value === '' || !!new RegExp(value as string);
+    }, 'Invalid regular expression pattern'),
 });
 
 const customFieldSchema = basePropertiesSchema.extend({

--- a/packages/core/content-type-builder/server/src/controllers/validation/types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/types.ts
@@ -11,8 +11,8 @@ import {
   isValidDefaultJSON,
   isValidName,
   isValidEnum,
-  isValidUID,
   isValidRegExpPattern,
+  UID_REGEX,
 } from './common';
 
 export type GetTypeValidatorOptions = {
@@ -84,7 +84,19 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
               return !!(_.isNil(targetField) || _.isNil(value));
             }
           )
-          .test(isValidUID),
+          .test(
+            'isValidDefaultRegexUID',
+            `\${path} must match the custom regex or the default one "${UID_REGEX}"`,
+            function (value) {
+              const { regex } = this.parent;
+
+              if (regex) {
+                return !_.isNil(value) && (value === '' || new RegExp(regex).test(value));
+              }
+
+              return value === '' || UID_REGEX.test(value as string);
+            }
+          ),
         minLength: validators.minLength,
         maxLength: validators.maxLength.max(256).test(maxLengthIsGreaterThanOrEqualToMinLength),
         options: yup.object().shape({
@@ -94,6 +106,7 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
           customReplacements: yup.array().of(yup.array().of(yup.string()).min(2).max(2)),
           preserveLeadingUnderscore: yup.boolean(),
         }),
+        regex: yup.string().test(isValidRegExpPattern),
       };
     }
 

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -443,6 +443,10 @@ export const uidValidator = (
     return schema;
   }
 
+  if (metas.attr.regex) {
+    return schema.matches(new RegExp(metas.attr.regex));
+  }
+
   return schema.matches(/^[A-Za-z0-9-_.~]*$/);
 };
 

--- a/packages/core/types/src/schema/attribute/definitions/uid.ts
+++ b/packages/core/types/src/schema/attribute/definitions/uid.ts
@@ -15,6 +15,7 @@ export interface UIDProperties<
 > {
   targetField?: TTargetAttribute;
   options?: UIDOptions & TOptions;
+  regex?: RegExp['source'];
 }
 
 /**

--- a/tests/api/core/content-manager/content-manager/uid.test.api.js
+++ b/tests/api/core/content-manager/content-manager/uid.test.api.js
@@ -321,11 +321,12 @@ describe('Content Manager single types', () => {
         error: {
           status: 400,
           name: 'ValidationError',
-          message: 'value must match the following: "/^[A-Za-z0-9-_.~]*$/"',
+          message: 'value must match the custom regex or the default one "/^[A-Za-z0-9-_.~]*$/"',
           details: {
             errors: [
               {
-                message: 'value must match the following: "/^[A-Za-z0-9-_.~]*$/"',
+                message:
+                  'value must match the custom regex or the default one "/^[A-Za-z0-9-_.~]*$/"',
                 name: 'ValidationError',
                 path: ['value'],
               },


### PR DESCRIPTION
The UID field can be used to generate a slug but it misses the opportunity to include a slash (`/`).

This PR implements a new "regex" attribute based on the one from the Text field.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds a `regex` attribute on the UID field type.

### Why is it needed?

When using the UID field type to generate a slug, we may need to include a slash (`/`).

### How to test it?

- In the "get started" example, update the homepage content type to set the regex attribute of the `slug` property with the following pattern `^[A-Za-z0-9-_.~/]*$`. It's the same than the UID_REGEX used everywhere in the codebase, except it allows the `/` character.
- Edit the `slug` property in homepage content to replace the value with `home/page`.

### Screenshots

BEFORE

![Capture d’écran du 2025-03-13 09-15-32](https://github.com/user-attachments/assets/04936905-b654-427d-8a74-20a8e633ee5e)

AFTER

![Capture d’écran du 2025-03-13 11-31-42](https://github.com/user-attachments/assets/40cc9ebb-d133-4499-b0fc-2e2308c6e4be)
![Capture d’écran du 2025-03-13 11-30-55](https://github.com/user-attachments/assets/768e36b4-749c-45e8-b9b5-cd6d53110894)
![Capture d’écran du 2025-03-13 11-31-26](https://github.com/user-attachments/assets/dd0b5a4c-e3c4-420e-aa54-d068d4b0f16c)
