### PR TITLE
fix: incorrect token source in pr diff

### DIFF
--- a/.github/actions/pr_diff/action.yml
+++ b/.github/actions/pr_diff/action.yml
@@ -33,7 +33,7 @@ runs:
         REPO: ${{ inputs.repo }}
         BASE_BRANCH: ${{ inputs.base_branch }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
 branding:
   icon: 'git-pull-request'
   color: 'blue'


### PR DESCRIPTION
### What does it do?

use `github.token` instead of `secrets.GITHUB_TOKEN` as the later is only accessible from workflows

