### PR TITLE
fix: incorrect file path and parameters for pr_diff

### DIFF
--- a/.github/actions/pr_diff/action.yml
+++ b/.github/actions/pr_diff/action.yml
@@ -33,7 +33,7 @@ runs:
         REPO: ${{ inputs.repo }}
         BASE_BRANCH: ${{ inputs.base_branch }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
 branding:
   icon: 'git-pull-request'
   color: 'blue'

--- a/.github/actions/pr_diff/action.yml
+++ b/.github/actions/pr_diff/action.yml
@@ -26,8 +26,8 @@ runs:
     - name: 'Run Fetch Merged PRs Script'
       shell: bash
       run: |
-        chmod +x ./script.sh
-        ./script.sh
+        chmod +x ${{ github.action_path }}/script.sh
+        ${{ github.action_path }}/script.sh
       env:
         OWNER: ${{ inputs.owner }}
         REPO: ${{ inputs.repo }}

--- a/.github/workflows/diff_prs.yml
+++ b/.github/workflows/diff_prs.yml
@@ -26,8 +26,8 @@ jobs:
         id: pr_diff
         uses: ./.github/actions/pr_diff
         with:
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.repository }}
+          owner: strapi
+          repo: strapi
           base_branch: ${{ github.event.inputs.base_branch }}
           target_branch: ${{ github.event.inputs.target_branch }}
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Use the absolute path to the script
- Use hardcoded `strapi` values for the owner and repo parameters as it's not possible to dynamically get the repository name from the `github` namespace (`github.repository` equals `strapi/strapi` instead of `strapi`) 