### PR TITLE
fix: deprecated step summary output

### DIFF
--- a/.github/actions/pr_diff/action.yml
+++ b/.github/actions/pr_diff/action.yml
@@ -33,7 +33,7 @@ runs:
         REPO: ${{ inputs.repo }}
         BASE_BRANCH: ${{ inputs.base_branch }}
         TARGET_BRANCH: ${{ inputs.target_branch }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
 branding:
   icon: 'git-pull-request'
   color: 'blue'

--- a/.github/actions/pr_diff/action.yml
+++ b/.github/actions/pr_diff/action.yml
@@ -26,8 +26,8 @@ runs:
     - name: 'Run Fetch Merged PRs Script'
       shell: bash
       run: |
-        chmod +x ./script.sh
-        ./script.sh
+        chmod +x ${{ github.action_path }}/script.sh
+        ${{ github.action_path }}/script.sh
       env:
         OWNER: ${{ inputs.owner }}
         REPO: ${{ inputs.repo }}

--- a/.github/workflows/diff_prs.yml
+++ b/.github/workflows/diff_prs.yml
@@ -26,8 +26,8 @@ jobs:
         id: pr_diff
         uses: ./.github/actions/pr_diff
         with:
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.repository }}
+          owner: strapi
+          repo: strapi
           base_branch: ${{ github.event.inputs.base_branch }}
           target_branch: ${{ github.event.inputs.target_branch }}
 

--- a/.github/workflows/diff_prs.yml
+++ b/.github/workflows/diff_prs.yml
@@ -1,4 +1,4 @@
-name: Diff as PRs
+name: Export Pull Requests Diff Table
 
 on:
   workflow_dispatch:
@@ -30,27 +30,3 @@ jobs:
           repo: strapi
           base_branch: ${{ github.event.inputs.base_branch }}
           target_branch: ${{ github.event.inputs.target_branch }}
-
-      - name: Format output
-        shell: bash
-        run: |
-          # Check if there are merged PRs
-          if [ -z "${{ steps.pr_diff.outputs.prs }}" ]; then
-            echo "No merged pull requests found." >> $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
-
-          # Write the Markdown table to the GitHub Actions summary
-          echo "### Merged Pull Requests Between '${{ github.event.inputs.base_branch }}' and '${{ github.event.inputs.target_branch }}'" >> $GITHUB_STEP_SUMMARY
-          echo "| PR Number | Title                      | Author      | Link                               |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|----------------------------|-------------|-----------------------------------|" >> $GITHUB_STEP_SUMMARY
-
-          for pr in $(echo "${{ steps.pr_diff.outputs.prs }}" | jq -c '.[]'); do
-            pr_number=$(echo "$pr" | jq -r '.number')
-            pr_title=$(echo "$pr" | jq -r '.title')
-            pr_author=$(echo "$pr" | jq -r '.author')
-            pr_link=$(echo "$pr" | jq -r '.html_url')
-
-            # Append each PR row to the summary table
-            echo "| #${pr_number} | ${pr_title} | ${pr_author} | [Link](${pr_link}) |" >> $GITHUB_STEP_SUMMARY
-          done


### PR DESCRIPTION
### What does it do?

use the new step summary instead of the deprecated set:output for the pr diff
