### PR TITLE
fix: add z index property to the menu content in blocks and markdown

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/EditorToolbarObserver.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/EditorToolbarObserver.tsx
@@ -139,6 +139,7 @@ export const EditorToolbarObserver = ({
           maxHeight="100%"
           minWidth="256px"
           popoverPlacement="bottom-end"
+          zIndex={2}
         >
           {observedComponents.slice(menuIndex).map((component) => (
             <React.Fragment key={component.key}>{component.menu}</React.Fragment>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the visibility problem we had in preview with the blocks and markdowns when you reduce the width of the viewport and show the three dots menu

### Why is it needed?

Currently the menu is not shown

### How to test it?

Open an entry with a markdown field or a block field and open the preview page of it, then reduce the width of the page and click on the three dot menu in the header of the block field and markdown field and check it is working

### Related issue(s)/PR(s)

CS-1361
