### PR TITLE
fix(relations): no components available in relation modal dynamic zone

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -63,10 +63,20 @@ const DynamicComponent = ({
     'DynamicComponent',
     (state) => state.rootDocumentMeta
   );
-  const isRootDocument = rootDocumentMeta.model === documentMeta.model;
+
   const {
-    edit: { components },
-  } = useDocumentLayout(isRootDocument ? documentMeta.model : rootDocumentMeta.model);
+    edit: { components: rootComponents },
+  } = useDocumentLayout(rootDocumentMeta.model);
+  const {
+    edit: { components: relatedComponents },
+  } = useDocumentLayout(documentMeta.model);
+
+  // Merge the root level components and related components
+  const components = React.useMemo(
+    () => ({ ...rootComponents, ...relatedComponents }),
+    [rootComponents, relatedComponents]
+  );
+
   const document = useDocumentContext('DynamicComponent', (state) => state.document);
 
   const title = React.useMemo(() => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -42,6 +42,7 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
 const InputRenderer = ({ visible, hint: providedHint, document, ...props }: InputRendererProps) => {
   const { model: rootModel } = useDoc();
   const documentLayout = useDocumentLayout(document.schema?.uid ?? rootModel);
+  const components = documentLayout.edit.components;
 
   const collectionType =
     document.schema?.kind === 'collectionType' ? 'collection-types' : 'single-types';
@@ -75,8 +76,6 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
   );
 
   const hint = useFieldHint(providedHint, props.attribute);
-
-  const components = documentLayout.edit.components;
 
   // We pass field in case of Custom Fields to keep backward compatibility
   const field = useField(props.name);


### PR DESCRIPTION
### What does it do?

Fix related document components in dynamic zones not diplaying

### Why is it needed?

A related document could not display its components within the relation modal

### How to test it?

Create a relation with a document that has a dynamic zone and one of the dz components has a relation input
Open the relation in the relation modal, go to the dz and select a component, you should see the form
Select a relation in the component form
Open that relation in the modal to confirm it works

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
