### PR TITLE
fix: add the correct locale and document Id when we reorder the relations

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -802,9 +802,7 @@ const RelationsList = ({
             ...{
               apiData: {
                 id: relation.id,
-                documentId: relation.documentId
-                  ? relation.documentId
-                  : relation.apiData?.documentId || '',
+                documentId: relation.documentId ?? relation.apiData?.documentId ?? '',
                 locale: relation.locale || relation.apiData?.locale,
                 position,
               },

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -802,8 +802,10 @@ const RelationsList = ({
             ...{
               apiData: {
                 id: relation.id,
-                documentId: relation.documentId,
-                locale: relation.locale,
+                documentId: relation.documentId
+                  ? relation.documentId
+                  : relation.apiData?.documentId || '',
+                locale: relation.locale || relation.apiData?.locale,
                 position,
               },
             },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Pass the correct data on reordering

### Why is it needed?

Because otherwise we have this issue in the Relations on the fly modal

https://github.com/user-attachments/assets/757e85f5-9caa-4dad-a602-5cedcf129ff4


### How to test it?

adding a new relation, reorder, click to open the modal

### Related issue(s)/PR(s)
