### PR TITLE
fix: correctly read asset stream for dts asset remote providers

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -29,7 +29,7 @@ function getFileStream(
 
       if (res.body) {
         // pipe the image data
-        Readable.fromWeb(new webStream.ReadableStream(res.body)).pipe(readableStream);
+        Readable.fromWeb(res.body as any).pipe(readableStream);
       } else {
         readableStream.emit('error', new Error('Empty data found for file'));
       }

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import { Duplex, PassThrough, Readable } from 'stream';
-import * as webStream from 'stream/web';
 import { stat, createReadStream, ReadStream } from 'fs-extra';
 import type { Core } from '@strapi/types';
 

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { Duplex, PassThrough, Readable } from 'stream';
 import { stat, createReadStream, ReadStream } from 'fs-extra';
+import * as webStream from 'stream/web';
 import type { Core } from '@strapi/types';
 
 import type { IAsset, IFile } from '../../../../types';
@@ -28,7 +29,7 @@ function getFileStream(
 
       if (res.body) {
         // pipe the image data
-        Readable.fromWeb(res.body as any).pipe(readableStream);
+        Readable.fromWeb(res.body as webStream.ReadableStream<Uint8Array>).pipe(readableStream);
       } else {
         readableStream.emit('error', new Error('Empty data found for file'));
       }


### PR DESCRIPTION
### What does it do?

- res.body is already a readable stream no need to convert it

### Why is it needed?

- reading assets streams from remote providers is not working and getting stuck

### How to test it?

experimental: `0.0.0-experimental.9678892591ed5d28450369e1511b3d21cb7db4f9`

- test a pull transfer against a project hosted on cloud
- or setup a project with aws or cloundinary providers and try to pull

### Related issue(s)/PR(s)

possibly fixes #16473 
fixes #22038 


