### PR TITLE
fix: run cronjobs closer to app start

### DIFF
--- a/packages/core/review-workflows/server/src/services/metrics/weekly-metrics.ts
+++ b/packages/core/review-workflows/server/src/services/metrics/weekly-metrics.ts
@@ -60,7 +60,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       let weeklySchedule = currentSchedule;
 
       if (!currentSchedule || !lastWeeklyUpdate || lastWeeklyUpdate + ONE_WEEK < now.getTime()) {
-        weeklySchedule = getWeeklyCronScheduleAt(add(now, { seconds: 10 }));
+        weeklySchedule = getWeeklyCronScheduleAt(add(now, { seconds: 15 }));
         await setMetricsStoreValue({ ...metricsInfoStored, weeklySchedule });
       }
 

--- a/packages/core/upload/server/src/services/weekly-metrics.ts
+++ b/packages/core/upload/server/src/services/weekly-metrics.ts
@@ -117,7 +117,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     let weeklySchedule = currentSchedule;
 
     if (!weeklySchedule || !lastWeeklyUpdate || lastWeeklyUpdate + ONE_WEEK < now.getTime()) {
-      weeklySchedule = getWeeklyCronScheduleAt(add(now, { minutes: 5 }));
+      weeklySchedule = getWeeklyCronScheduleAt(add(now, { seconds: 15 }));
       await setMetricsStoreValue({ ...metricsInfoStored, weeklySchedule });
 
       return weeklySchedule;


### PR DESCRIPTION
### What does it do?

Upload cronjob take 5 minutes until it first, and its too much time for cloud environments that shutdown the container if there is no use.

This PR reduces this time.

