### PR TITLE
chore: fix invalid template workflow to point to proper link

### DIFF
--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -152,10 +152,10 @@ jobs:
 
             Hello @${{ github.event.issue.user.login }},
 
-            We ask that you please follow the [issue template](https://raw.githubusercontent.com/strapi/strapi/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md).
-            A proper issue submission let's us better understand the origin of your bug and therefore help you. We will reopen your issue when we receive the issue following the template guidelines and properly fill out the template. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
+            We ask that you please follow the issue template.
+            A proper issue submission let's us better understand the origin of your bug and therefore help you. You can see the template guidelines for bug reports [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
 
-            Please update the issue with the template and we can reopen this report.
+            Please create a new issue and completely fill out the issue template, you can [open a new issue here](https://github.com/strapi/strapi/issues/new?template=BUG_REPORT.yml).
 
             Thank you.
       - name: 'Close: invalid bug report template'


### PR DESCRIPTION
### What does it do?

Fixes wrong issue template workflow pointing to an outdated markdown issue template

### Why is it needed?

Unclear instructions for users trying to open bug reports

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
