### PR TITLE
fix: On production build webhooks detail page intermediate value issue.

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/constants.ts
+++ b/packages/core/admin/admin/src/pages/Settings/constants.ts
@@ -73,10 +73,10 @@ export const ROUTES_CE: RouteObject[] = [
   },
   {
     lazy: async () => {
-      const { ProtectedEditPage } = await import('./pages/Webhooks/EditPage');
+      const editWebhook = await import('./pages/Webhooks/EditPage');
 
       return {
-        Component: ProtectedEditPage,
+        Component: editWebhook.ProtectedEditPage,
       };
     },
     path: 'webhooks/:id',


### PR DESCRIPTION
### What does it do?

Updated the import of ProtectedEditPage in the webhook module to prevent failure in the production build. Introduced delayed import by first assigning the module to a const and resolving it afterwards.

### Why is it needed?

It solves the issue : Cannot destructure property 'ProtectedEditPage' of '(intermediate value)' as it is undefined. On production build webhooks detail page.

### How to test it?

I validated this by creating a webhook in an older version and attempting to update it. Before applying this fix, I encountered the error:
"Cannot destructure property 'ProtectedEditPage' of '(intermediate value)' as it is undefined."
After implementing the fix, the issue is resolved.

### Related issue(s)/PR(s)

It is related to #23099.