### PR TITLE
fix: issue with layout property in InputRenderer

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -6,13 +6,12 @@ import {
   InputRenderer as FormInputRenderer,
   useField,
 } from '@strapi/admin/strapi-admin';
-import { ContentTypeKind } from '@strapi/types/dist/struct';
 import { useIntl } from 'react-intl';
 
 import { SINGLE_TYPES } from '../../../constants/collections';
 import { useDocumentRBAC } from '../../../features/DocumentRBAC';
 import { useDoc, UseDocument } from '../../../hooks/useDocument';
-import { useDocumentLayout } from '../../../hooks/useDocumentLayout';
+import { useDocLayout, useDocumentLayout } from '../../../hooks/useDocumentLayout';
 import { useLazyComponents } from '../../../hooks/useLazyComponents';
 
 import { BlocksInput } from './FormInputs/BlocksInput/BlocksInput';
@@ -41,8 +40,9 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
  */
 const InputRenderer = ({ visible, hint: providedHint, document, ...props }: InputRendererProps) => {
   const { model: rootModel } = useDoc();
+  const docLayout = useDocLayout();
   const documentLayout = useDocumentLayout(document.schema?.uid ?? rootModel);
-  const components = documentLayout.edit.components;
+  const components = { ...documentLayout.edit.components, ...docLayout.edit.components };
 
   const collectionType =
     document.schema?.kind === 'collectionType' ? 'collection-types' : 'single-types';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the access of layout property from an undefined object.
It happens sometimes when you try to open a relation inside a document

### Why is it needed?

To avoid the error saying "not possible to access layout from undefined"
As you can see in this video

https://github.com/user-attachments/assets/c5797b0b-f160-4657-8586-1bedf2681457


### How to test it?

You can try to follow this video

https://github.com/user-attachments/assets/357c0a0f-2c29-4ff6-8961-e314fdd2e538


### Related issue(s)/PR(s)

CS-1374