### PR TITLE
Feature/1103 manage seats

### DIFF
--- a/packages/core/admin/admin/src/translations/ar.json
+++ b/packages/core/admin/admin/src/translations/ar.json
@@ -618,7 +618,7 @@
   "Settings.application.description": "المعلومات العالمية للوحة الإدارة",
   "Settings.application.edition-title": "الإصدار الحالي",
   "Settings.application.ee-or-ce": "{communityEdition، select، true {Community Edition} أخرى {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud، select، true {Add seat} other {Contact sales}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud، select، true {Add seat} other {Manage seats}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "عند الحد: أضف مقاعد لدعوة المزيد من المستخدمين",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "احصل على مساعدة",

--- a/packages/core/admin/admin/src/translations/ar.json
+++ b/packages/core/admin/admin/src/translations/ar.json
@@ -618,7 +618,7 @@
   "Settings.application.description": "المعلومات العالمية للوحة الإدارة",
   "Settings.application.edition-title": "الإصدار الحالي",
   "Settings.application.ee-or-ce": "{communityEdition، select، true {Community Edition} أخرى {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud، select، true {Add seat} other {Manage seats}}",
+  "Settings.application.ee.admin-seats.add-seats": "Manage seats",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "عند الحد: أضف مقاعد لدعوة المزيد من المستخدمين",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "احصل على مساعدة",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -132,7 +132,7 @@
   "Settings.application.description": "Administration panel’s global information",
   "Settings.application.edition-title": "current edition",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Add seats} other {Contact sales}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Add seats} other {Manage seats}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "At limit: add seats to invite more users",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Get help",

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -132,7 +132,7 @@
   "Settings.application.description": "Administration panel’s global information",
   "Settings.application.edition-title": "current edition",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Add seats} other {Manage seats}}",
+  "Settings.application.ee.admin-seats.add-seats": "Manage seats",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "At limit: add seats to invite more users",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Get help",

--- a/packages/core/admin/admin/src/translations/fr.json
+++ b/packages/core/admin/admin/src/translations/fr.json
@@ -132,7 +132,7 @@
   "Settings.tokens.ListView.headers.lastUsedAt": "Dernière utilisation",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "Limite atteinte : ajouter des places pour inviter d'autres utilisateurs",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {AJouter des places} other {Contacter le service clients}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {AJouter des places} other {Gérer les places}}",
   "Settings.application.customization": "Customisation",
   "Settings.application.customization.auth-logo.carousel-hint": "Remplacer le logo dans la page de connexion",
   "Settings.application.customization.carousel-hint": "Changer le logo dans l'interface d'administration (dimensions maximales: {dimension}x{dimension}, poids maximal du fichier : {size}KB)",

--- a/packages/core/admin/admin/src/translations/fr.json
+++ b/packages/core/admin/admin/src/translations/fr.json
@@ -132,7 +132,7 @@
   "Settings.tokens.ListView.headers.lastUsedAt": "Dernière utilisation",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "Limite atteinte : ajouter des places pour inviter d'autres utilisateurs",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {AJouter des places} other {Gérer les places}}",
+  "Settings.application.ee.admin-seats.add-seats": "Gérer les places",
   "Settings.application.customization": "Customisation",
   "Settings.application.customization.auth-logo.carousel-hint": "Remplacer le logo dans la page de connexion",
   "Settings.application.customization.carousel-hint": "Changer le logo dans l'interface d'administration (dimensions maximales: {dimension}x{dimension}, poids maximal du fichier : {size}KB)",

--- a/packages/core/admin/admin/src/translations/ru.json
+++ b/packages/core/admin/admin/src/translations/ru.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "Глобальная информация панели администратора",
   "Settings.application.edition-title": "Текущий план",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Добавить места} other {Управление места}}",
+  "Settings.application.ee.admin-seats.add-seats": "Управление места",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "При исчерпании лимита: добавьте места, чтобы пригласить больше пользователей",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Получить помощь",

--- a/packages/core/admin/admin/src/translations/ru.json
+++ b/packages/core/admin/admin/src/translations/ru.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "Глобальная информация панели администратора",
   "Settings.application.edition-title": "Текущий план",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Добавить места} other {Обратитесь в отдел продаж}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Добавить места} other {Управление места}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "При исчерпании лимита: добавьте места, чтобы пригласить больше пользователей",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Получить помощь",

--- a/packages/core/admin/admin/src/translations/uk.json
+++ b/packages/core/admin/admin/src/translations/uk.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "Глобальна інформація панелі адміністрації",
   "Settings.application.edition-title": "поточний план",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Додайте місця} other {Зверніться до відділу продажів}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Додайте місця} other {Керування місця}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "На вичерпанні ліміту: додайте місця, щоб запросити більше користувачів",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Отримати допомогу",

--- a/packages/core/admin/admin/src/translations/uk.json
+++ b/packages/core/admin/admin/src/translations/uk.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "Глобальна інформація панелі адміністрації",
   "Settings.application.edition-title": "поточний план",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {Community Edition} other {Enterprise Edition}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {Додайте місця} other {Керування місця}}",
+  "Settings.application.ee.admin-seats.add-seats": "Керування місця",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "На вичерпанні ліміту: додайте місця, щоб запросити більше користувачів",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "Отримати допомогу",

--- a/packages/core/admin/admin/src/translations/zh-Hans.json
+++ b/packages/core/admin/admin/src/translations/zh-Hans.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "管理面板的全局信息",
   "Settings.application.edition-title": "当前版本",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {社区版} other {企业版}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {添加座位} other {联系销售}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {添加座位} other {管理座位}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "已达上限:添加座位以邀请更多用户",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "获取帮助",

--- a/packages/core/admin/ee/admin/src/hooks/tests/useLicenseLimitNotification.test.tsx
+++ b/packages/core/admin/ee/admin/src/hooks/tests/useLicenseLimitNotification.test.tsx
@@ -109,8 +109,8 @@ describe('useLicenseLimitNotification', () => {
         "Add seats to invite Users. If you already did it but it's not reflected in Strapi yet, make sure to restart your app.",
       title: 'Over seat limit (6/5)',
       link: {
-        url: 'https://strapi.io/billing/request-seats',
-        label: 'CONTACT SALES',
+        url: 'https://https://strapi.io/billing/manage-seats',
+        label: 'MANAGE SEATS',
       },
       blockTransition: true,
       onClose: expect.any(Function),

--- a/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
+++ b/packages/core/admin/ee/admin/src/hooks/useLicenseLimitNotification.ts
@@ -15,8 +15,7 @@ import { useLicenseLimits } from './useLicenseLimits';
 
 const STORAGE_KEY_PREFIX = 'strapi-notification-seat-limit';
 
-const BILLING_STRAPI_CLOUD_URL = 'https://cloud.strapi.io/profile/billing';
-const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
+const MANAGE_SEATS_URL = 'https://strapi.io/billing/manage-seats';
 
 export const useLicenseLimitNotification = () => {
   const { formatMessage } = useIntl();
@@ -67,14 +66,13 @@ export const useLicenseLimitNotification = () => {
           }
         ),
         link: {
-          url: isHostedOnStrapiCloud ? BILLING_STRAPI_CLOUD_URL : BILLING_SELF_HOSTED_URL,
+          url: MANAGE_SEATS_URL,
           label: formatMessage(
             {
               id: 'notification.ee.warning.seat-limit.link',
               defaultMessage:
-                '{isHostedOnStrapiCloud, select, true {ADD SEATS} other {CONTACT SALES}}',
-            },
-            { isHostedOnStrapiCloud }
+                'Manage seats',
+            }
           ),
         },
         blockTransition: true,

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
@@ -93,7 +93,7 @@ export const AdminSeatInfoEE = () => {
           {
             id: 'Settings.application.ee.admin-seats.add-seats',
             defaultMessage:
-              '{isHostedOnStrapiCloud, select, true {Add seats} other {Manage seats}}',
+              'Manage seats',
           },
           { isHostedOnStrapiCloud }
         )}

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
@@ -7,8 +7,7 @@ import { useRBAC } from '../../../../../../../../admin/src/hooks/useRBAC';
 import { selectAdminPermissions } from '../../../../../../../../admin/src/selectors';
 import { useLicenseLimits } from '../../../../../hooks/useLicenseLimits';
 
-const BILLING_STRAPI_CLOUD_URL = 'https://cloud.strapi.io/profile/billing';
-const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
+const MANAGE_SEATS_URL = 'https://strapi.io/billing/manage-seats';
 
 export const AdminSeatInfoEE = () => {
   const { formatMessage } = useIntl();
@@ -86,7 +85,7 @@ export const AdminSeatInfoEE = () => {
         )}
       </Flex>
       <Link
-        href={isHostedOnStrapiCloud ? BILLING_STRAPI_CLOUD_URL : BILLING_SELF_HOSTED_URL}
+        href={MANAGE_SEATS_URL}
         isExternal
         endIcon={<ExternalLink />}
       >
@@ -94,7 +93,7 @@ export const AdminSeatInfoEE = () => {
           {
             id: 'Settings.application.ee.admin-seats.add-seats',
             defaultMessage:
-              '{isHostedOnStrapiCloud, select, true {Add seats} other {Contact sales}}',
+              '{isHostedOnStrapiCloud, select, true {Add seats} other {Manage seats}}',
           },
           { isHostedOnStrapiCloud }
         )}

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/tests/AdminSeatInfo.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/tests/AdminSeatInfo.test.tsx
@@ -66,11 +66,11 @@ describe('<AdminSeatInfo />', () => {
 
     const { getByText } = render(<AdminSeatInfoEE />);
 
-    expect(getByText('Contact sales')).toBeInTheDocument();
+    expect(getByText('Manage seats')).toBeInTheDocument();
     // eslint-disable-next-line testing-library/no-node-access
-    expect(getByText('Contact sales').closest('a')).toHaveAttribute(
+    expect(getByText('Manage seats').closest('a')).toHaveAttribute(
       'href',
-      'https://strapi.io/billing/request-seats'
+      'https://strapi.io/billing/manage-seats'
     );
   });
 

--- a/packages/core/content-manager/admin/src/translations/zh-Hans.json
+++ b/packages/core/content-manager/admin/src/translations/zh-Hans.json
@@ -127,7 +127,7 @@
   "Settings.application.customization.modal.upload.from-url": "从URL",
   "Settings.application.customization.modal.upload.from-url.input-label": "URL",
   "Settings.application.customization.modal.upload.next": "下一步",
-  "Settings.application.customization.size-details": "最大尺寸:{dimension}×{dimension},最大文件大小:{size}KB",
+  "Settings.application.customization.size-details": "最大尺寸:{dimension}×{dimension},最大文件大小:{size}KB",  
   "Settings.application.description": "管理面板的全局信息",
   "Settings.application.edition-title": "当前计划",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {社区版} other {企业版}}",

--- a/packages/core/content-manager/admin/src/translations/zh-Hans.json
+++ b/packages/core/content-manager/admin/src/translations/zh-Hans.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "管理面板的全局信息",
   "Settings.application.edition-title": "当前计划",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {社区版} other {企业版}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {添加座位} other {管理座位}}",
+  "Settings.application.ee.admin-seats.add-seats": "管理座位",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "已达上限:添加座位以邀请更多用户",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "获取帮助",

--- a/packages/core/content-manager/admin/src/translations/zh-Hans.json
+++ b/packages/core/content-manager/admin/src/translations/zh-Hans.json
@@ -131,7 +131,7 @@
   "Settings.application.description": "管理面板的全局信息",
   "Settings.application.edition-title": "当前计划",
   "Settings.application.ee-or-ce": "{communityEdition, select, true {社区版} other {企业版}}",
-  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {添加座位} other {联系销售}}",
+  "Settings.application.ee.admin-seats.add-seats": "{isHostedOnStrapiCloud, select, true {添加座位} other {管理座位}}",
   "Settings.application.ee.admin-seats.at-limit-tooltip": "已达上限:添加座位以邀请更多用户",
   "Settings.application.ee.admin-seats.count": "<text>{enforcementUserCount}</text>/{permittedSeats}",
   "Settings.application.get-help": "获取帮助",


### PR DESCRIPTION
### What does it do?

Rather than inviting self-serve customers to contact support, it adds a link to the chargebee portal where they can manage their seats themselves.

### Why is it needed?

To allow users the freedom to modify their subscription easily

### How to test it?

If you go to Settings / Overview, in the section ADMIN SEATS, you now have a text saying Manage seats. When you click on this text, you will arrive on the chargebee portal.

