### PR TITLE
chore: upgrade prismjs to 1.30.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
     "@docusaurus/theme-mermaid": "3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.1.1",
-    "prism-react-renderer": "^2.1.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "18.3.0",
     "react-dom": "18.3.0"
   },

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5325,9 +5325,9 @@ __metadata:
   linkType: hard
 
 "@types/prismjs@npm:^1.26.0":
-  version: 1.26.3
-  resolution: "@types/prismjs@npm:1.26.3"
-  checksum: 10c0/3e8a64bcf0ab5f9a47ec2590938c5a8a20ac849b4949a95ed96e73e64cb890fc56e9c9b724286914717458267b28405f965709e1b9f80db5d68817a7ce5a18a9
+  version: 1.26.5
+  resolution: "@types/prismjs@npm:1.26.5"
+  checksum: 10c0/5619cb449e0d8df098c8759d6f47bf8fdd510abf5dbdfa999e55c6a2545efbd1e209cc85a33d8d9f4ff2898089a1a6d9a70737c9baffaae635c46852c40d384a
   languageName: node
   linkType: hard
 
@@ -8044,7 +8044,7 @@ __metadata:
     "@mdx-js/react": "npm:^3.0.0"
     clsx: "npm:^1.1.1"
     docusaurus-plugin-typedoc: "npm:0.22.0"
-    prism-react-renderer: "npm:^2.1.0"
+    prism-react-renderer: "npm:^2.4.1"
     react: "npm:18.3.0"
     react-dom: "npm:18.3.0"
     typedoc: "npm:0.25.9"
@@ -13302,22 +13302,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prism-react-renderer@npm:^2.1.0, prism-react-renderer@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "prism-react-renderer@npm:2.3.1"
+"prism-react-renderer@npm:^2.3.0, prism-react-renderer@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "prism-react-renderer@npm:2.4.1"
   dependencies:
     "@types/prismjs": "npm:^1.26.0"
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ">=16.0.0"
-  checksum: 10c0/566932127ca18049a651aa038a8f8c7c1ca15950d21b659c2ce71fd95bd03bef2b5d40c489e7aa3453eaf15d984deef542a609d7842e423e6a13427dd90bd371
+  checksum: 10c0/ebbe8feb975224344bbdd046b3a937d121592dbe4b8f22ba0be31f5af37b9a8219f441138ef6cab1c5b96f2aa6b529015200959f7e5e85b60ca69c81d35edcd4
   languageName: node
   linkType: hard
 
 "prismjs@npm:^1.29.0":
-  version: 1.29.0
-  resolution: "prismjs@npm:1.29.0"
-  checksum: 10c0/d906c4c4d01b446db549b4f57f72d5d7e6ccaca04ecc670fb85cea4d4b1acc1283e945a9cbc3d81819084a699b382f970e02f9d1378e14af9808d366d9ed7ec6
+  version: 1.30.0
+  resolution: "prismjs@npm:1.30.0"
+  checksum: 10c0/f56205bfd58ef71ccfcbcb691fd0eb84adc96c6ff21b0b69fc6fdcf02be42d6ef972ba4aed60466310de3d67733f6a746f89f2fb79c00bf217406d465b3e8f23
   languageName: node
   linkType: hard
 

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -86,7 +86,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "1.0.0",
     "node-schedule": "2.1.1",
-    "prismjs": "^1.29.0",
+    "prismjs": "1.30.0",
     "qs": "6.11.1",
     "react-dnd": "16.0.1",
     "react-dnd-html5-backend": "16.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8582,7 +8582,7 @@ __metadata:
     markdown-it-sup: "npm:1.0.0"
     msw: "npm:1.3.0"
     node-schedule: "npm:2.1.1"
-    prismjs: "npm:^1.29.0"
+    prismjs: "npm:1.30.0"
     qs: "npm:6.11.1"
     react: "npm:18.3.1"
     react-dnd: "npm:16.0.1"
@@ -26226,10 +26226,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.29.0":
-  version: 1.29.0
-  resolution: "prismjs@npm:1.29.0"
-  checksum: 10c0/d906c4c4d01b446db549b4f57f72d5d7e6ccaca04ecc670fb85cea4d4b1acc1283e945a9cbc3d81819084a699b382f970e02f9d1378e14af9808d366d9ed7ec6
+"prismjs@npm:1.30.0":
+  version: 1.30.0
+  resolution: "prismjs@npm:1.30.0"
+  checksum: 10c0/f56205bfd58ef71ccfcbcb691fd0eb84adc96c6ff21b0b69fc6fdcf02be42d6ef972ba4aed60466310de3d67733f6a746f89f2fb79c00bf217406d465b3e8f23
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Upgrades prismjs to 1.30.0

### Why is it needed?

Remove warnings for CVE-2024-53382 -- in Strapi's usage there does not appear to be an actual vulnerability

### How to test it?

syntax highlighting should still work

### Related issue(s)/PR(s)

DX-1951
