### PR TITLE
enhancement: add tracking for editing relations on-the-fly

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -325,6 +325,7 @@ interface PublishEntryEvents {
   name: 'willPublishEntry' | 'didPublishEntry';
   properties: {
     documentId?: string;
+    fromRelationModal?: boolean;
   };
 }
 
@@ -334,6 +335,7 @@ interface UpdateEntryEvents {
     documentId?: string;
     status?: string;
     error?: unknown;
+    fromRelationModal?: boolean;
   };
 }
 

--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -82,6 +82,7 @@ interface PanelComponent extends DescriptionComponent<PanelComponentProps, Panel
 
 interface DocumentActionProps extends EditViewContext {
   onPreview?: () => void;
+  fromRelationModal?: boolean;
 }
 
 interface DocumentActionComponent

--- a/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentActions.ts
@@ -58,7 +58,7 @@ type BulkOperationResponse<TResponse extends { data: any; error?: any }> =
   | Pick<TResponse, 'data'>
   | { error: BaseQueryError | SerializedError };
 
-type UseDocumentActions = () => {
+type UseDocumentActions = (fromRelationModal?: boolean) => {
   /**
    * @description Attempts to clone a document based on the provided sourceId.
    * This will return a list of the fields as an error if it's unable to clone.
@@ -189,7 +189,7 @@ type IUseDocumentActs = ReturnType<UseDocumentActions>;
  *
  * @see {@link https://contributor.strapi.io/docs/core/content-manager/hooks/use-document-operations} for more information
  */
-const useDocumentActions: UseDocumentActions = () => {
+const useDocumentActions: UseDocumentActions = (fromRelationModal = false) => {
   const { toggleNotification } = useNotification();
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
@@ -352,7 +352,7 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didPublishEntry', { documentId });
+        trackUsage('didPublishEntry', { documentId, fromRelationModal });
 
         toggleNotification({
           type: 'success',
@@ -372,7 +372,14 @@ const useDocumentActions: UseDocumentActions = () => {
         throw err;
       }
     },
-    [trackUsage, publishDocument, toggleNotification, formatMessage, formatAPIError]
+    [
+      trackUsage,
+      publishDocument,
+      fromRelationModal,
+      toggleNotification,
+      formatMessage,
+      formatAPIError,
+    ]
   );
 
   const [publishManyDocuments, { isLoading: isPublishingMany }] = usePublishManyDocumentsMutation();
@@ -439,7 +446,11 @@ const useDocumentActions: UseDocumentActions = () => {
           return { error: res.error };
         }
 
-        trackUsage('didEditEntry', { ...trackerProperty, documentId: res.data.data.documentId });
+        trackUsage('didEditEntry', {
+          ...trackerProperty,
+          documentId: res.data.data.documentId,
+          fromRelationModal,
+        });
         toggleNotification({
           type: 'success',
           message: formatMessage({
@@ -460,7 +471,14 @@ const useDocumentActions: UseDocumentActions = () => {
         throw err;
       }
     },
-    [trackUsage, updateDocument, toggleNotification, formatMessage, formatAPIError]
+    [
+      trackUsage,
+      updateDocument,
+      fromRelationModal,
+      toggleNotification,
+      formatMessage,
+      formatAPIError,
+    ]
   );
 
   const [unpublishDocument] = useUnpublishDocumentMutation();
@@ -595,7 +613,7 @@ const useDocumentActions: UseDocumentActions = () => {
         throw err;
       }
     },
-    [createDocument, formatAPIError, formatMessage, toggleNotification, trackUsage]
+    [createDocument, formatAPIError, formatMessage, setCurrentStep, toggleNotification, trackUsage]
   );
 
   const [autoCloneDocument] = useAutoCloneDocumentMutation();

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -518,6 +518,7 @@ const PublishAction: DocumentActionComponent = ({
   meta,
   document,
   onPreview,
+  fromRelationModal = false,
 }) => {
   const schema = useDocumentContext('PublishAction', (state) => state.document.schema);
   const navigate = useNavigate();
@@ -528,7 +529,7 @@ const PublishAction: DocumentActionComponent = ({
   const { id } = useParams();
   const { formatMessage } = useIntl();
   const canPublish = useDocumentRBAC('PublishAction', ({ canPublish }) => canPublish);
-  const { publish, isLoading } = useDocumentActions();
+  const { publish, isLoading } = useDocumentActions(fromRelationModal);
   const [
     countDraftRelations,
     { isLoading: isLoadingDraftRelations, isError: isErrorDraftRelations },
@@ -766,6 +767,7 @@ const UpdateAction: DocumentActionComponent = ({
   model,
   collectionType,
   onPreview,
+  fromRelationModal = false,
 }) => {
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
@@ -773,7 +775,7 @@ const UpdateAction: DocumentActionComponent = ({
   const cloneMatch = useMatch(CLONE_PATH);
   const isCloning = cloneMatch !== null;
   const { formatMessage } = useIntl();
-  const { create, update, clone, isLoading } = useDocumentActions();
+  const { create, update, clone, isLoading } = useDocumentActions(fromRelationModal);
   const [{ query, rawQuery }] = useQueryParams();
   const params = React.useMemo(() => buildValidParams(query), [query]);
 
@@ -892,6 +894,8 @@ const UpdateAction: DocumentActionComponent = ({
     cloneMatch?.params.origin,
     collectionType,
     create,
+    currentDocumentMeta.documentId,
+    currentDocumentMeta.params,
     document,
     documentId,
     formatMessage,
@@ -900,9 +904,11 @@ const UpdateAction: DocumentActionComponent = ({
     model,
     modified,
     navigate,
+    onPreview,
     params,
     rawQuery,
     resetForm,
+    rootDocumentMeta.documentId,
     setErrors,
     setSubmitting,
     toggleNotification,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -429,6 +429,7 @@ const RelationModalBody = ({ children }: RelationModalBodyProps) => {
     document: documentResponse.document,
     meta: documentResponse.meta,
     onPreview,
+    fromRelationModal: true,
   } satisfies DocumentActionProps;
 
   return (


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add the property fromRelationModal to true when we trigger the events didEditEntry and didPublishEntry

### Why is it needed?

to Distinguish between the Save and Publish events in the Relation modal and the ones outside it

### How to test it?

Try to save and modify an entry in the Relation modal and do the same in the Edit View and check if the event property fromRelationModal is set to true in the first case and to false in the other cases

### Related issue(s)/PR(s)

CS-1313
