### PR TITLE
fix: add support for IPv6 addresses

### DIFF
--- a/packages/core/core/src/configuration/urls.ts
+++ b/packages/core/core/src/configuration/urls.ts
@@ -79,7 +79,8 @@ const getAbsoluteUrl =
 
     const serverConfig = config.server as ServerConfig;
     const hostname =
-      config.environment === 'development' && ['127.0.0.1', '0.0.0.0'].includes(serverConfig.host)
+      config.environment === 'development' &&
+      ['127.0.0.1', '0.0.0.0', '::1', '::'].includes(serverConfig.host)
         ? 'localhost'
         : serverConfig.host;
 


### PR DESCRIPTION
### What does it do?

Treat `::` like `0.0.0.0 `and `::1` like `127.0.0.1` when showing the local Strapi URL. This PR is basically the same as #17160 

### Why is it needed?

By default Strapi listens on `0.0.0.0` i.e. only on IPv4. This is a problem because Node v18 (current LTS) https://github.com/nodejs/node/issues/40537. So if you're running another Node process, say a Next.js app, that tries to connect to Strapi it will probably fail with `ECONNREFUSED ::1:1337`. (Probably because it depends on how exactly the network is configured on your machine.)

That's why I set `HOST=::` in .env. `::` the IPv6 equivalent of `0.0.0.0`.

But that way Strapi shows an invalid URL in the logs, which won't work if somebody tries to open it in the browser. Either strapi develop or strapi start print:

```
To manage your project 🚀, go to the administration panel at:
http://:::1337/admin

To access the server ⚡️, go to:
http://:::1337
```
This change should make it show `http://localhost:1337`, like it already does for `0.0.0.0`.
### How to test it?

Start a Strapi app and see what URL it prints to the console.

### Related issue(s)/PR(s)

#12285 