### PR TITLE
Chore/api requests tracker

### DIFF
--- a/packages/core/core/src/services/metrics/middleware.ts
+++ b/packages/core/core/src/services/metrics/middleware.ts
@@ -19,7 +19,7 @@ const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
   const middleware: Core.MiddlewareHandler = async (ctx, next) => {
     const { url, method } = ctx.request;
 
-    if (!url.includes('.') && url.includes('/api') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
+    if (url.includes('/api') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
       if (Date.now() > state.expires) {
         state.expires = nextResetDate();
         state.counter = 0;

--- a/packages/core/core/src/services/metrics/middleware.ts
+++ b/packages/core/core/src/services/metrics/middleware.ts
@@ -19,7 +19,7 @@ const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
   const middleware: Core.MiddlewareHandler = async (ctx, next) => {
     const { url, method } = ctx.request;
 
-    if (!url.includes('.') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
+    if (!url.includes('.') && url.includes('/api') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
       if (Date.now() > state.expires) {
         state.expires = nextResetDate();
         state.counter = 0;

--- a/packages/core/strapi/src/cli/commands/transfer/command.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/command.ts
@@ -54,7 +54,6 @@ const command = () => {
             const hasToken = Boolean(process.env.STRAPI_TRANSFER_TOKEN);
 
             console.info('ℹ️  Data transfer documentation: https://docs.strapi.io/dev-docs/data-management/transfer');
-            console.log(); // Empty line for better readability
 
             if (hasUrl && hasToken) {
               console.info('ℹ️  Found transfer configuration in your environment:');

--- a/packages/core/strapi/src/cli/commands/transfer/command.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/command.ts
@@ -44,14 +44,129 @@ const command = () => {
       .hook('preAction', validateExcludeOnly)
       .hook(
         'preAction',
-        ifOptions(
-          (opts) => !(opts.from || opts.to) || (opts.from && opts.to),
-          async () =>
+        async (thisCommand) => {
+          const opts = thisCommand.opts();
+          
+          // If neither --from nor --to are provided, prompt for transfer direction
+          if (!(opts.from || opts.to)) {
+            // Log environment variables status
+            const hasUrl = Boolean(process.env.STRAPI_TRANSFER_URL);
+            const hasToken = Boolean(process.env.STRAPI_TRANSFER_TOKEN);
+
+            console.info('ℹ️  Data transfer documentation: https://docs.strapi.io/dev-docs/data-management/transfer');
+            console.log(); // Empty line for better readability
+
+            if (hasUrl && hasToken) {
+              console.info('ℹ️  Found transfer configuration in your environment:');
+              console.info('   → STRAPI_TRANSFER_URL environment variable value will be used as default URL');
+              console.info('   → STRAPI_TRANSFER_TOKEN environment variable value will be used as default token');
+            } else if (hasUrl || hasToken) {
+              if (hasUrl) {
+                console.info('ℹ️  Found partial transfer configuration:');
+                console.info('   → STRAPI_TRANSFER_URL environment variable value will be used as default URL');
+                console.info('   → STRAPI_TRANSFER_TOKEN environment variable not found ');
+              } else {
+                console.info('ℹ️  Found partial transfer configuration:');
+                console.info('   → STRAPI_TRANSFER_URL environment variable not found');
+                console.info('   → STRAPI_TRANSFER_TOKEN environment variable value will be used as default token');
+              }
+            } else {
+              console.info('ℹ️  No transfer configuration found in environment variables');
+              console.info('   → Add STRAPI_TRANSFER_URL and STRAPI_TRANSFER_TOKEN environment variables to make the transfer process faster for future runs');
+            }
+            console.log(); // Empty line for better readability
+
+            const { direction } = await inquirer.prompt([
+              {
+                type: 'list',
+                name: 'direction',
+                message: 'Choose transfer direction:',
+                choices: [
+                  { name: 'Pull data from remote Strapi to local', value: 'from' },
+                  { name: 'Push local data to remote Strapi', value: 'to' }
+                ]
+              }
+            ]);
+
+            if (direction === 'from') {
+              const { remoteUrl, token } = await inquirer.prompt([
+                {
+                  type: 'input',
+                  name: 'remoteUrl',
+                  message: 'Enter the URL of the remote Strapi instance to get data from:',
+                  default: process.env.STRAPI_TRANSFER_URL,
+                  validate: (input) => {
+                    try {
+                      const url = new URL(input);
+                      if (!['http:', 'https:'].includes(url.protocol)) {
+                        return 'URL must use http: or https: protocol';
+                      }
+                      return true;
+                    } catch (error) {
+                      return 'Please enter a valid URL (e.g., http://localhost:1337 or https://example.com)';
+                    }
+                  }
+                },
+                {
+                  type: 'password',
+                  name: 'token',
+                  message: 'Enter your transfer token for the remote Strapi source:',
+                  default: process.env.STRAPI_TRANSFER_TOKEN,
+                  validate: (input) => {
+                    if (!input?.length) {
+                      return 'Transfer token is required';
+                    }
+                    return true;
+                  }
+                }
+              ]);
+              opts.from = new URL(remoteUrl);
+              opts.fromToken = token;
+            } else {
+              const { remoteUrl, token } = await inquirer.prompt([
+                {
+                  type: 'input',
+                  name: 'remoteUrl',
+                  message: 'Enter the URL of the remote Strapi instance to send data to:',
+                  default: process.env.STRAPI_TRANSFER_URL,
+                  validate: (input) => {
+                    try {
+                      const url = new URL(input);
+                      if (!['http:', 'https:'].includes(url.protocol)) {
+                        return 'URL must use http: or https: protocol';
+                      }
+                      return true;
+                    } catch (error) {
+                      return 'Please enter a valid URL (e.g., http://localhost:1337 or https://example.com)';
+                    }
+                  }
+                },
+                {
+                  type: 'password',
+                  name: 'token',
+                  message: 'Enter your transfer token for the remote Strapi destination:',
+                  default: process.env.STRAPI_TRANSFER_TOKEN,
+                  validate: (input) => {
+                    if (!input?.length) {
+                      return 'Transfer token is required';
+                    }
+                    return true;
+                  }
+                }
+              ]);
+              opts.to = new URL(remoteUrl);
+              opts.toToken = token;
+            }
+          }
+          
+          // Validate that exactly one direction is specified
+          if (opts.from && opts.to) {
             exitWith(
               1,
               'Exactly one remote source (from) or destination (to) option must be provided'
-            )
-        )
+            );
+          }
+        }
       )
       // If --from is used, validate the URL and token
       .hook(

--- a/packages/core/strapi/src/cli/commands/transfer/command.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/command.ts
@@ -44,128 +44,14 @@ const command = () => {
       .hook('preAction', validateExcludeOnly)
       .hook(
         'preAction',
-        async (thisCommand) => {
-          const opts = thisCommand.opts();
-          
-          // If neither --from nor --to are provided, prompt for transfer direction
-          if (!(opts.from || opts.to)) {
-            // Log environment variables status
-            const hasUrl = Boolean(process.env.STRAPI_TRANSFER_URL);
-            const hasToken = Boolean(process.env.STRAPI_TRANSFER_TOKEN);
-
-            console.info('ℹ️  Data transfer documentation: https://docs.strapi.io/dev-docs/data-management/transfer');
-
-            if (hasUrl && hasToken) {
-              console.info('ℹ️  Found transfer configuration in your environment:');
-              console.info('   → STRAPI_TRANSFER_URL environment variable value will be used as default URL');
-              console.info('   → STRAPI_TRANSFER_TOKEN environment variable value will be used as default token');
-            } else if (hasUrl || hasToken) {
-              if (hasUrl) {
-                console.info('ℹ️  Found partial transfer configuration:');
-                console.info('   → STRAPI_TRANSFER_URL environment variable value will be used as default URL');
-                console.info('   → STRAPI_TRANSFER_TOKEN environment variable not found ');
-              } else {
-                console.info('ℹ️  Found partial transfer configuration:');
-                console.info('   → STRAPI_TRANSFER_URL environment variable not found');
-                console.info('   → STRAPI_TRANSFER_TOKEN environment variable value will be used as default token');
-              }
-            } else {
-              console.info('ℹ️  No transfer configuration found in environment variables');
-              console.info('   → Add STRAPI_TRANSFER_URL and STRAPI_TRANSFER_TOKEN environment variables to make the transfer process faster for future runs');
-            }
-            console.log(); // Empty line for better readability
-
-            const { direction } = await inquirer.prompt([
-              {
-                type: 'list',
-                name: 'direction',
-                message: 'Choose transfer direction:',
-                choices: [
-                  { name: 'Pull data from remote Strapi to local', value: 'from' },
-                  { name: 'Push local data to remote Strapi', value: 'to' }
-                ]
-              }
-            ]);
-
-            if (direction === 'from') {
-              const { remoteUrl, token } = await inquirer.prompt([
-                {
-                  type: 'input',
-                  name: 'remoteUrl',
-                  message: 'Enter the URL of the remote Strapi instance to get data from:',
-                  default: process.env.STRAPI_TRANSFER_URL,
-                  validate: (input) => {
-                    try {
-                      const url = new URL(input);
-                      if (!['http:', 'https:'].includes(url.protocol)) {
-                        return 'URL must use http: or https: protocol';
-                      }
-                      return true;
-                    } catch (error) {
-                      return 'Please enter a valid URL (e.g., http://localhost:1337 or https://example.com)';
-                    }
-                  }
-                },
-                {
-                  type: 'password',
-                  name: 'token',
-                  message: 'Enter your transfer token for the remote Strapi source:',
-                  default: process.env.STRAPI_TRANSFER_TOKEN,
-                  validate: (input) => {
-                    if (!input?.length) {
-                      return 'Transfer token is required';
-                    }
-                    return true;
-                  }
-                }
-              ]);
-              opts.from = new URL(remoteUrl);
-              opts.fromToken = token;
-            } else {
-              const { remoteUrl, token } = await inquirer.prompt([
-                {
-                  type: 'input',
-                  name: 'remoteUrl',
-                  message: 'Enter the URL of the remote Strapi instance to send data to:',
-                  default: process.env.STRAPI_TRANSFER_URL,
-                  validate: (input) => {
-                    try {
-                      const url = new URL(input);
-                      if (!['http:', 'https:'].includes(url.protocol)) {
-                        return 'URL must use http: or https: protocol';
-                      }
-                      return true;
-                    } catch (error) {
-                      return 'Please enter a valid URL (e.g., http://localhost:1337 or https://example.com)';
-                    }
-                  }
-                },
-                {
-                  type: 'password',
-                  name: 'token',
-                  message: 'Enter your transfer token for the remote Strapi destination:',
-                  default: process.env.STRAPI_TRANSFER_TOKEN,
-                  validate: (input) => {
-                    if (!input?.length) {
-                      return 'Transfer token is required';
-                    }
-                    return true;
-                  }
-                }
-              ]);
-              opts.to = new URL(remoteUrl);
-              opts.toToken = token;
-            }
-          }
-          
-          // Validate that exactly one direction is specified
-          if (opts.from && opts.to) {
+        ifOptions(
+          (opts) => !(opts.from || opts.to) || (opts.from && opts.to),
+          async () =>
             exitWith(
               1,
               'Exactly one remote source (from) or destination (to) option must be provided'
-            );
-          }
-        }
+            )
+        )
       )
       // If --from is used, validate the URL and token
       .hook(


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Limits the call to the didReceiveRequest event to API calls.
And it also expands the tracking to the u&p plugin logins.

### Why is it needed?
At the moment the event is also called during the admin navigation. 
And it's not called when the u&p plugin auth/local route is called with the identifier as an email.


### How to test it?
If you log something in the if condition I edited, you should see it logged only on api requests; before it was on any http request.

