### PR TITLE
fix: relation menu link

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
@@ -96,7 +96,7 @@ const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleP
         {data?.results && (
           <>
             {data.results.map((entry) => (
-              <Menu.Item key={entry.documentId} disabled>
+              <Menu.Item key={entry.documentId}>
                 <Typography maxWidth="50rem" ellipsis>
                   {getRelationLabel(entry, mainField)}
                 </Typography>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes the "prohibited" icon (🚫) that shows up when hovering over related items in dropdowns. Items stay clickable, just without the confusing icon.

### Why is it needed?

When viewing relation fields in the list view, hovering over entries in the dropdown menu shows a 🚫 icon, which confuses non-technical users by suggesting these items aren't clickable when they actually are. This PR ensures the UI accurately represents the interactive nature of these items while maintaining their navigation functionality.

### How to test it?

Create two content-types with a many-to-many relation between them
Create some entries and set up relationships between them
Add the relation field to the list view
Click on the relation count to open the dropdown
Hover over the entries in the dropdown menu
Verify that the 🚫 icon no longer appears when hovering over the items
Verify that you can still click on the items to navigate to the related entries

### Related issue(s)/PR(s)

Fixes #20293 
Related to internal TID6726
