### PR TITLE
Fix report generation and upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,7 +244,7 @@ jobs:
         if: '!cancelled()'
         uses: trunk-io/analytics-uploader@main
         with:
-          junit-paths: test-apps/e2e/test-results/**/junit.xml
+          junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi
           token: ${{ secrets.TRUNK_API_TOKEN }}
         continue-on-error: true
@@ -296,7 +296,7 @@ jobs:
         if: '!cancelled()'
         uses: trunk-io/analytics-uploader@main
         with:
-          junit-paths: test-apps/e2e/test-results/**/junit.xml
+          junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi
           token: ${{ secrets.TRUNK_API_TOKEN }}
         continue-on-error: true

--- a/playwright.base.config.js
+++ b/playwright.base.config.js
@@ -28,14 +28,14 @@ const getEnvBool = (envVar, defaultValue) => {
 
 /**
  * @typedef ConfigOptions
- * @type {{ port: number; testDir: string; appDir: string }}
+ * @type {{ port: number; testDir: string; appDir: string; reportFileName: string }}
  */
 
 /**
  * @see https://playwright.dev/docs/test-configuration
  * @type {(options: ConfigOptions) => import('@playwright/test').PlaywrightTestConfig}
  */
-const createConfig = ({ port, testDir, appDir }) => ({
+const createConfig = ({ port, testDir, appDir, reportFileName }) => ({
   testDir,
 
   /* default timeout for a jest test */
@@ -64,8 +64,8 @@ const createConfig = ({ port, testDir, appDir }) => ({
       'junit',
       {
         outputFile: path.join(
-          getEnvString(process.env.PLAYWRIGHT_OUTPUT_DIR, '../test-results/'),
-          'junit.xml'
+          getEnvString(process.env.PLAYWRIGHT_OUTPUT_DIR, '../../junit-reports/'),
+          reportFileName
         ),
       },
     ],

--- a/tests/scripts/run-e2e-tests.js
+++ b/tests/scripts/run-e2e-tests.js
@@ -212,6 +212,7 @@ yargs
                 testDir: path.join(testDomainRoot, domain),
                 port,
                 appDir: testAppPath,
+                reportFileName: `playwright-${domain}-${port}.xml`,
               });
 
               const configFileTemplate = `
@@ -219,7 +220,6 @@ const config = ${JSON.stringify(config)}
 
 module.exports = config
               `;
-
               await fs.writeFile(pathToPlaywrightConfig, configFileTemplate);
 
               // Store the filesystem state with git so it can be reset between tests

--- a/tests/scripts/run-e2e-tests.js
+++ b/tests/scripts/run-e2e-tests.js
@@ -220,6 +220,7 @@ const config = ${JSON.stringify(config)}
 
 module.exports = config
               `;
+
               await fs.writeFile(pathToPlaywrightConfig, configFileTemplate);
 
               // Store the filesystem state with git so it can be reset between tests


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

There are some problems with JUnit report generation. 
- Look like all the files are called junit, which collides
- Looks like the `test-apps/e2e/test-results` was getting wiped between runs so only the last run ever gets saved there
- Updates the upload job to Trunk, which should point now to `test-apps/junit-reports/*.xml`

This instead outputs different test domains as separate files in a path that isn't wiped between runs
<img width="274" alt="Screenshot 2025-03-25 at 1 45 57 PM" src="https://github.com/user-attachments/assets/c5ec00ef-fd7c-4532-ad6d-61b7f9290fbb" />

Existing HTML reports aren't changed.

### Why is it needed?

Currently, uploads to Trunk is incorrect, this affects flaky tests detection.

Further more, this will allow accurate display if you choose to enable PR comments: https://docs.trunk.io/flaky-tests/github-pull-request-comments

### How to test it?

Run tests and observe the outputted XML files. Also view upload succeeds in CI and uploads are found in Trunk.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
