### PR TITLE
fix: disable publish button when publishing a relation change

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -547,6 +547,7 @@ const PublishAction: DocumentActionComponent = ({
   const validate = useForm('PublishAction', (state) => state.validate);
   const setErrors = useForm('PublishAction', (state) => state.setErrors);
   const formValues = useForm('PublishAction', ({ values }) => values);
+  const resetForm = useForm('PublishAction', ({ resetForm }) => resetForm);
 
   const rootDocumentMeta = useDocumentContext('PublishAction', (state) => state.rootDocumentMeta);
   const currentDocumentMeta = useDocumentContext('PublishAction', (state) => state.meta);
@@ -666,6 +667,11 @@ const PublishAction: DocumentActionComponent = ({
         },
         transformData(formValues)
       );
+
+      // Reset form if successful
+      if ('data' in res) {
+        resetForm();
+      }
 
       if ('data' in res && collectionType !== SINGLE_TYPES) {
         /**


### PR DESCRIPTION
### What does it do?

Disables the 'publish' / 'save' button when publishing an entry that only updated a relation.

We were not reseting the form after publishing.

### Why is it needed?

After updating a relation (one to many in this case) and then clicking "publish", the "save" and "publish" buttons immediately became available again, and when trying to navigate away from the page it opened  the "are you sure" confirmation modal.

### How to test it?

1. Have an "article" and "category" type, with article having one category
2. Create an article
3. Publish it
4. Go back and edit the article, changing the category
5. Click publish
6. Publish and save should be disabled, as there is not any modified content.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/21378
