### PR TITLE
fix: preserve cookie in sso login

### DIFF
--- a/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
+++ b/packages/core/admin/ee/admin/src/pages/AuthResponse.tsx
@@ -41,8 +41,6 @@ const AuthResponse = () => {
           })
         );
 
-        deleteCookie('jwtToken');
-
         navigate('/auth/login');
       } else {
         redirectToOops();


### PR DESCRIPTION
### What does it do?

prevent deleting cookie in SSO sense we will re-set the cookie in the login logic anyways

### Why is it needed?

We are using the session cookies for login now, deleting the cookie will log the user out

