### PR TITLE
fix: update jwk-to-pem dependency in plugin-user-permission

### DIFF
--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -55,7 +55,7 @@
     "grant-koa": "5.4.8",
     "immer": "9.0.19",
     "jsonwebtoken": "9.0.0",
-    "jwk-to-pem": "2.0.5",
+    "jwk-to-pem": "2.0.7",
     "koa": "2.15.4",
     "koa2-ratelimit": "^1.1.2",
     "lodash": "4.17.21",


### PR DESCRIPTION
### What does it do?

This PR updates the `jwk-to-pem` dependency in the `plugin-user-permission` package to a patched version that resolves the GHSA-vjh7-7g9h-fjfh vulnerability. This update ensures that any functionality relying on the conversion of JSON Web Keys (JWK) to PEM format is protected against potential exploits.

### Why is it needed?

The vulnerability outlined in [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh) poses a risk by potentially allowing attackers to exploit the JWK-to-PEM conversion process. Addressing this vulnerability is crucial to maintain the security and integrity of the `plugin-user-permission` functionality within Strapi.

### How to test it?

- **Environment:** Ensure that your environment uses the updated dependency.
- **Tests:** Run the existing test suite to verify that all functionality remains intact.
- **Manual Verification:** Specifically, check the user permissions features that rely on `jwk-to-pem` to confirm they are working as expected.
- **Additional Checks:** Optionally, test the JWK to PEM conversion process to verify the patch’s effectiveness.

### Related issue(s)/PR(s)

- Fixes issue related to the [GHSA-vjh7-7g9h-fjfh vulnerability](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh)