### PR TITLE
fix: relation modal not closing when opening self in full page

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -129,6 +129,9 @@ function reducer(state: State, action: Action): State {
 
       return {
         ...state,
+        documentHistory: [],
+        hasUnsavedChanges: false,
+        isModalOpen: false,
         confirmDialogIntent: null,
       };
     case 'CANCEL_CONFIRM_DIALOG':

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
@@ -180,10 +180,7 @@ describe('Document Modal Reducer', () => {
 
       const result = reducer(stateWithHistory, action);
 
-      expect(result).toEqual({
-        ...stateWithHistory,
-        confirmDialogIntent: null,
-      });
+      expect(result).toEqual(initialState);
     });
 
     it('should show navigate confirmation dialog when unsaved changes exist', () => {
@@ -269,7 +266,7 @@ describe('Document Modal Reducer', () => {
         documentHistory: [],
         confirmDialogIntent: null,
         isModalOpen: false,
-        hasUnsavedChanges: true,
+        hasUnsavedChanges: false,
       });
     });
   });


### PR DESCRIPTION
From entry A, open relation B in a modal, then on it click on relation A. Then click the open full page button. Before this fix the relation modal wouldn't close. Also make sure the open full page button still works in other cases