### PR TITLE
fix: relation field search to find all strings, not only the first ch…

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -615,7 +615,7 @@ const RelationsInput = ({
       <Combobox
         ref={fieldRef}
         name={name}
-        autocomplete="list"
+        autocomplete={{ type: 'list', filter: 'contains' }}
         placeholder={
           placeholder ||
           formatMessage({


### PR DESCRIPTION
### What does it do?

Added a filter in autocomplete prop inside Combobox component equals to `contains`

### Why is it needed?

Fixed the relation field search to find all strings, not only the first characters

### How to test it?

Using the `examples/getstarted`:
Add an entry to the Categories collection and try to search for it in the relation field of the Address collection. 
Without the fix, it's only possible to find if you search for the string's beginning. 


| Before                                               | After                                                |
| ---------------------------------------------------- | ---------------------------------------------------- |
| <img width="815" alt="Captura de Tela 2025-03-25 às 17 01 14" src="https://github.com/user-attachments/assets/ccbbfd70-5cee-40de-bc8c-caace33906d0" /> | <img width="816" alt="Captura de Tela 2025-03-25 às 16 19 53" src="https://github.com/user-attachments/assets/c0cae811-8baa-4f41-9d87-4fc5d5da5b4b" /> |


### Related issue(s)/PR(s)

This old issue was solved on Strapi v4 but not on Strapi v5
https://github.com/strapi/strapi/issues/17391#issuecomment-2462439423
