### PR TITLE
Experiment/cloud cli

### DIFF
--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -25,7 +25,7 @@ export async function promptLogin(ctx: CLIContext) {
 }
 
 export default async function loginAction(ctx: CLIContext): Promise<boolean> {
-  const { logger } = ctx;
+  const { logger, isMatrixExperiment } = ctx;
   const tokenService = await tokenServiceFactory(ctx);
   const existingToken = await tokenService.retrieveToken();
   const cloudApiService = await cloudApiFactory(ctx, existingToken || undefined);
@@ -62,7 +62,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
     logger.debug(e);
     return false;
   }
-  await trackEvent(ctx, cloudApiService, 'willLoginAttempt', {});
+  await trackEvent(ctx, cloudApiService, 'willLoginAttempt', { isMatrixExperiment });
 
   logger.debug('🔐 Creating device authentication request...', {
     client_id: cliConfig.clientId,
@@ -155,7 +155,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
             'There seems to be a problem with your login information. Please try logging in again.'
           );
           spinnerFail();
-          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli' });
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli', isMatrixExperiment });
           return false;
         }
         if (
@@ -164,7 +164,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
         ) {
           logger.debug(e);
           spinnerFail();
-          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli' });
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli', isMatrixExperiment });
           return false;
         }
         // Await interval before retrying
@@ -179,7 +179,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
       'To access your dashboard, please copy and paste the following URL into your web browser:'
     );
     logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects`));
-    await trackEvent(ctx, cloudApiService, 'didLogin', { loginMethod: 'cli' });
+    await trackEvent(ctx, cloudApiService, 'didLogin', { loginMethod: 'cli', isMatrixExperiment });
   };
 
   await authenticate();

--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -25,7 +25,7 @@ export async function promptLogin(ctx: CLIContext) {
 }
 
 export default async function loginAction(ctx: CLIContext): Promise<boolean> {
-  const { logger, isMatrixExperiment } = ctx;
+  const { logger, promptExperiment } = ctx;
   const tokenService = await tokenServiceFactory(ctx);
   const existingToken = await tokenService.retrieveToken();
   const cloudApiService = await cloudApiFactory(ctx, existingToken || undefined);
@@ -62,7 +62,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
     logger.debug(e);
     return false;
   }
-  await trackEvent(ctx, cloudApiService, 'willLoginAttempt', { isMatrixExperiment });
+  await trackEvent(ctx, cloudApiService, 'willLoginAttempt', { promptExperiment });
 
   logger.debug('🔐 Creating device authentication request...', {
     client_id: cliConfig.clientId,
@@ -155,7 +155,10 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
             'There seems to be a problem with your login information. Please try logging in again.'
           );
           spinnerFail();
-          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli', isMatrixExperiment });
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', {
+            loginMethod: 'cli',
+            promptExperiment,
+          });
           return false;
         }
         if (
@@ -164,7 +167,10 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
         ) {
           logger.debug(e);
           spinnerFail();
-          await trackEvent(ctx, cloudApiService, 'didNotLogin', { loginMethod: 'cli', isMatrixExperiment });
+          await trackEvent(ctx, cloudApiService, 'didNotLogin', {
+            loginMethod: 'cli',
+            promptExperiment,
+          });
           return false;
         }
         // Await interval before retrying
@@ -179,7 +185,7 @@ export default async function loginAction(ctx: CLIContext): Promise<boolean> {
       'To access your dashboard, please copy and paste the following URL into your web browser:'
     );
     logger.log(chalk.underline(`${apiConfig.dashboardBaseUrl}/projects`));
-    await trackEvent(ctx, cloudApiService, 'didLogin', { loginMethod: 'cli', isMatrixExperiment });
+    await trackEvent(ctx, cloudApiService, 'didLogin', { loginMethod: 'cli', promptExperiment });
   };
 
   await authenticate();

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -34,7 +34,7 @@ export type CloudCliConfig = {
 export interface CLIContext {
   cwd: string;
   logger: Logger;
-  isMatrixExperiment?: boolean;
+  promptExperiment?: string;
 }
 
 export type StrapiCloudCommand = (params: {

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -34,6 +34,7 @@ export type CloudCliConfig = {
 export interface CLIContext {
   cwd: string;
   logger: Logger;
+  isMatrixExperiment?: boolean;
 }
 
 export type StrapiCloudCommand = (params: {

--- a/packages/cli/create-strapi-app/src/cloud.ts
+++ b/packages/cli/create-strapi-app/src/cloud.ts
@@ -2,6 +2,22 @@ import inquirer from 'inquirer';
 import { cli as cloudCli, services as cloudServices } from '@strapi/cloud-cli';
 import parseToChalk from './utils/parse-to-chalk';
 
+const matrixPrompt = {
+  introText: `
+Before you dive in, choose your path:
+
+The {red}✦ Red ✦{/red} pill:
+Create a free Strapi Cloud account — deploy in minutes, get built-in hosting, scaling, and a dashboard made for Strapi.
+
+{bold}No credit card.{/bold} 14-day free trial.
+
+The {blueBright}✦ Blue ✦{/blueBright} pill:
+Spin up your project locally — you’re on your own.
+`,
+  choices: [parseToChalk(`Take the {red}✦ Red ✦{/red} pill (Login/Sign up)`), parseToChalk(`Take the {blueBright}✦ Blue ✦{/blueBright} pill (Skip)`)],
+  message: "Remember, all we're offering is the truth, nothing more."
+};
+
 interface CloudError {
   response: {
     status: number;
@@ -25,9 +41,22 @@ export async function handleCloudLogin(): Promise<void> {
   const defaultErrorMessage =
     'An error occurred while trying to interact with Strapi Cloud. Use strapi deploy command once the project is generated.';
 
+  // const defaultPrompt = { introText: '', choices: ['Login/Sign up', 'Skip for now'], message: 'Please log in or sign up.' };
+  // const useExperiment = Math.random() < 0.5;
+  const useExperiment = 1;
+
+  const promptToUse = useExperiment
+    ? matrixPrompt
+    : matrixPrompt;
+    
   try {
     const { data: config } = await cloudApiService.config();
-    logger.log(parseToChalk(config.projectCreation.introText));
+
+    if (!useExperiment) {
+      promptToUse.introText = config.projectCreation.introText;
+    }
+
+    logger.log(parseToChalk(promptToUse.introText));
   } catch (e: unknown) {
     logger.debug(e);
     logger.error(defaultErrorMessage);
@@ -37,15 +66,17 @@ export async function handleCloudLogin(): Promise<void> {
     {
       type: 'list',
       name: 'userChoice',
-      message: `Please log in or sign up.`,
-      choices: ['Login/Sign up', 'Skip'],
+      message: promptToUse.message,
+      choices: promptToUse.choices,
     },
   ]);
 
-  if (userChoice !== 'Skip') {
+
+  if (!userChoice.includes('Skip')) {
     const cliContext = {
       logger,
       cwd: process.cwd(),
+      ...(userChoice.includes('pill') && { isMatrixExperiment: true })
     };
 
     try {

--- a/packages/cli/create-strapi-app/src/experiment/prompt.ts
+++ b/packages/cli/create-strapi-app/src/experiment/prompt.ts
@@ -1,0 +1,22 @@
+import parseToChalk from '../utils/parse-to-chalk';
+
+export const experimentPrompt = {
+  introText: `
+You’re about to launch your project.
+
+🚀 The {red}Millennium Falcon{/red}:
+Create a free Strapi Cloud account — deploy in minutes, get built-in hosting, scaling, and a dashboard made for speed.
+
+Includes a 14-day free trial. {bold}No credit card.{/bold}
+
+🚗 The {blueBright}Landspeeder{/blueBright}:
+Spin up your project locally. Full control, full setup, no help from Chewie.
+
+`,
+  choices: [
+    parseToChalk(`Take the {red}Millennium Falcon{/red} (Login/Sign up)`),
+    parseToChalk(`Take a {blueBright}Landspeeder{/blueBright} (Skip)`),
+  ],
+  message: 'Which way do you want to fly?',
+  reference: 'starWars',
+};


### PR DESCRIPTION
### What does it do?
This PR introduces an A/B test for the Strapi CLI prompt shown during project creation. It randomly displays one of two variants:

- Control: Existing prompt from the Cloud
- Variant: A Star Wars–themed prompt ("Take the Millennium Falcon or Take a Landspeeder") designed to potentially improve developer engagement and conversion to Strapi Cloud signups. _The Star Wars theme might change_.

The randomization logic (Math.random() < 0.5) determines which version is shown. The experimental prompt content is defined inline in the CLI flow.

### Why is it needed?
We're running an experiment to test whether themed, dev-relevant copy improves the conversion rate of developers opting to log in or sign up for Strapi Cloud during the project creation flow. Our hypothesis is that a more engaging and familiar metaphor (e.g. Star Wars) will encourage more developers to explore Strapi Cloud.

### How to test it?

`node packages/cli/create-strapi-app/bin/index.js`

On execution, the CLI will randomly show either:

The current default prompt (control group), or the new Star Wars–themed prompt (test group).

Check that:

- The prompt displays correctly
- The login/signup and skip options function as expected
- No regressions in the project creation flow

Note: You may need to run the command multiple times to see both variants due to random selection.