### PR TITLE
fix: OTF relations wrong redirect when publishing a nested relation during new entry creation

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -650,7 +650,6 @@ const PublishAction: DocumentActionComponent = ({
       const { errors } = await validate(true, {
         status: 'published',
       });
-
       if (errors) {
         toggleNotification({
           type: 'danger',
@@ -660,10 +659,8 @@ const PublishAction: DocumentActionComponent = ({
               'There are validation errors in your document. Please fix them before saving.',
           }),
         });
-
         return;
       }
-
       const res = await publish(
         {
           collectionType,
@@ -673,12 +670,11 @@ const PublishAction: DocumentActionComponent = ({
         },
         transformData(formValues)
       );
-
       if ('data' in res && collectionType !== SINGLE_TYPES) {
         /**
          * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
          */
-        if (id === 'create') {
+        if (id === 'create' && !currentDocumentMeta.documentId) {
           navigate({
             pathname: `../${collectionType}/${model}/${res.data.documentId}`,
             search: rawQuery,
@@ -693,7 +689,6 @@ const PublishAction: DocumentActionComponent = ({
       }
     } finally {
       setSubmitting(false);
-
       if (onPreview) {
         onPreview();
       }

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -551,6 +551,8 @@ const PublishAction: DocumentActionComponent = ({
 
   const { currentDocumentMeta } = useDocumentContext('PublishAction');
 
+  const idToPublish = currentDocumentMeta.documentId || id;
+
   React.useEffect(() => {
     if (isErrorDraftRelations) {
       toggleNotification({
@@ -674,7 +676,7 @@ const PublishAction: DocumentActionComponent = ({
         /**
          * TODO: refactor the router so we can just do `../${res.data.documentId}` instead of this.
          */
-        if (id === 'create' && !currentDocumentMeta.documentId) {
+        if (idToPublish === 'create') {
           navigate({
             pathname: `../${collectionType}/${model}/${res.data.documentId}`,
             search: rawQuery,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -12,7 +12,6 @@ import {
 } from '@strapi/admin/strapi-admin';
 import {
   Box,
-  Button,
   Dialog,
   EmptyStateLayout,
   Flex,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It handles the case you publish, in the Relation on the fly modal, a relation starting from the creation entry form, because if you try to publish an entry from the creation view you have a redirect to the edit view of the just created document, but in the case of a relation modal, we need to skip this redirection

### Why is it needed?

We had a wrong redirection when we tried to Publish a nested relation inside a creation entry form

### How to test it?

- Go to a Collection and click "Create an entry"
- in the form you need to have a relation field, try to select a value for this relation field and click on it to open the Relation modal
- in the relation modal change a value and Publish
- you need to see a successful message and no redirections but instead remain in the modal

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/23286
