### PR TITLE
fix(upgrade): incorrect path to codemods

### DIFF
--- a/packages/utils/upgrade/src/modules/codemod-repository/constants.ts
+++ b/packages/utils/upgrade/src/modules/codemod-repository/constants.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 
 export const INTERNAL_CODEMODS_DIRECTORY = path.join(
-  __dirname, // upgrade/dist
-  '..',
-  '..',
-  'resources', // upgrade/resources
-  'codemods' // upgrade/resources/codemods
+  __dirname, // upgrade/dist/src/modules/codemod-repository
+  '..', // upgrade/dist/src/modules
+  '..', // upgrade/dist/src
+  '..', // upgrade/dist
+  '..', // upgrade
+  'resources', // resources
+  'codemods' // resources/codemods
 );


### PR DESCRIPTION
### What does it do?

Update the path to codemods

### Why is it needed?

It is broken

### How to test it?

Create a strapi 5.12.1 app
From that app run

```
node ../../path-to-strapi/packages/utils/upgrade/bin/upgrade.js minor
```

It should upgrade and not throw an error