### PR TITLE
fix: disable expanded mode on rich text fields in modals

### DIFF
--- a/packages/core/content-manager/admin/src/exports.ts
+++ b/packages/core/content-manager/admin/src/exports.ts
@@ -13,6 +13,8 @@ export {
 } from './hooks/useDocument';
 export { useDocumentActions as unstable_useDocumentActions } from './hooks/useDocumentActions';
 export { useDocumentLayout as unstable_useDocumentLayout } from './hooks/useDocumentLayout';
+export { useDocumentContext } from './hooks/useDocumentContext';
+export type { DocumentMeta } from './hooks/useDocumentContext';
 export type {
   EditFieldLayout,
   EditLayout,

--- a/packages/core/content-manager/admin/src/hooks/useDocumentContext.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentContext.ts
@@ -32,6 +32,7 @@ interface DocumentMeta {
 interface DocumentContextValue {
   currentDocumentMeta: DocumentMeta;
   currentDocument: ReturnType<UseDocument>;
+  isInModal: boolean;
 }
 
 function useDocumentContext(consumerName: string): DocumentContextValue {
@@ -64,6 +65,7 @@ function useDocumentContext(consumerName: string): DocumentContextValue {
   return {
     currentDocumentMeta: currentRelationDocumentMeta ?? urlDocumentMeta,
     currentDocument: currentRelationDocument ?? urlDocument,
+    isInModal: Boolean(currentRelationDocumentMeta),
   };
 }
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -9,6 +9,7 @@ import { withHistory } from 'slate-history';
 import { type RenderElementProps, Slate, withReact, ReactEditor, useSlate } from 'slate-react';
 import { styled, type CSSProperties } from 'styled-components';
 
+import { useDocumentContext } from '../../../../../hooks/useDocumentContext';
 import { getTranslation } from '../../../../../utils/translations';
 
 import { codeBlocks } from './Blocks/Code';
@@ -178,6 +179,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
     const [liveText, setLiveText] = React.useState('');
     const ariaDescriptionId = React.useId();
     const [isExpandedMode, setIsExpandedMode] = React.useState(false);
+    const { isInModal } = useDocumentContext('BlocksInput');
 
     const handleToggleExpand = () => {
       setIsExpandedMode((prev) => !prev);
@@ -252,7 +254,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
               <BlocksToolbar />
               <EditorDivider width="100%" />
               <BlocksContent {...contentProps} />
-              {!isExpandedMode && (
+              {!isExpandedMode && !isInModal && (
                 <ExpandIconButton
                   label={formatMessage({
                     id: getTranslation('components.Blocks.expand'),

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
@@ -4,6 +4,7 @@ import { useField, useStrapiApp, type InputProps } from '@strapi/admin/strapi-ad
 import { Field, Flex } from '@strapi/design-system';
 import { EditorFromTextArea } from 'codemirror5';
 
+import { useDocumentContext } from '../../../../../hooks/useDocumentContext';
 import { prefixFileUrlWithBackendUrl } from '../../../../../utils/urls';
 
 import { Editor, EditorApi } from './Editor';
@@ -30,6 +31,7 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
     const [mediaLibVisible, setMediaLibVisible] = React.useState(false);
     const [isExpandMode, setIsExpandMode] = React.useState(false);
     const components = useStrapiApp('ImageDialog', (state) => state.components);
+    const { isInModal } = useDocumentContext('BlocksInput');
 
     const MediaLibraryDialog = components['media-library'];
 
@@ -84,7 +86,7 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
               ref={forwardedRef}
             />
 
-            {!isExpandMode && <WysiwygFooter onToggleExpand={handleToggleExpand} />}
+            {!isExpandMode && !isInModal && <WysiwygFooter onToggleExpand={handleToggleExpand} />}
           </EditorLayout>
           <Field.Hint />
           <Field.Error />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- disables expanded mode button in Blocks and Markdown fields when inside a relation modal
- adds an isInModal property to the useDocumentContext return value, so we have a quick way to check if we're in a relation modal without having to select any data in particular
- exports useDocumentContext in the CM admin APIs. Because it can be useful for custom field developers

### How to test it?

- expand button should appear on the regular edit view or preview page
- should not appear when inside a relation modal

https://github.com/user-attachments/assets/0f5da282-32d0-4341-ad70-583c1bac2163

### Related issue(s)/PR(s)

https://www.notion.so/strapi/Expanding-the-blocks-or-markdown-field-does-not-work-in-the-modal-1c88f359807480ae9d6ac4664eeff2b6?pvs=4