### PR TITLE
fix: update the values of new relations added and not yet saved when we modify their name or status in the modal

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -34,6 +34,7 @@ import { RelationDragPreviewProps } from '../../../../../components/DragPreviews
 import { COLLECTION_TYPES } from '../../../../../constants/collections';
 import { ItemTypes } from '../../../../../constants/dragAndDrop';
 import { useDebounce } from '../../../../../hooks/useDebounce';
+import { useDocument } from '../../../../../hooks/useDocument';
 import { type DocumentMeta, useDocumentContext } from '../../../../../hooks/useDocumentContext';
 import { type EditFieldLayout } from '../../../../../hooks/useDocumentLayout';
 import {
@@ -46,6 +47,7 @@ import {
   useLazySearchRelationsQuery,
   RelationResult,
 } from '../../../../../services/relations';
+import { type MainField } from '../../../../../utils/attributes';
 import { getRelationLabel } from '../../../../../utils/relations';
 import { getTranslation } from '../../../../../utils/translations';
 import { DocumentStatus } from '../../DocumentStatus';
@@ -118,6 +120,8 @@ interface Relation extends Pick<RelationResult, 'documentId' | 'id' | 'locale' |
     id: RelationResult['id'];
     locale?: RelationResult['locale'];
     position: RelationPosition;
+    // Added this property to prevent call useDocument with a not temporary relation (one already saved in the database)
+    temporary?: boolean;
   };
 }
 
@@ -305,6 +309,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           id: relation.id,
           documentId: relation.documentId,
           locale: relation.locale,
+          temporary: true,
         },
         status: relation.status,
         /**
@@ -376,6 +381,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           relationType={props.attribute.relation}
           // @ts-expect-error – targetModel does exist on the attribute. But it's not typed.
           targetModel={props.attribute.targetModel}
+          mainField={props.mainField}
         />
       </Flex>
     );
@@ -447,7 +453,6 @@ const addLabelAndHref =
 /* -------------------------------------------------------------------------------------------------
  * RelationsInput
  * -----------------------------------------------------------------------------------------------*/
-
 interface RelationsInputProps extends Omit<RelationsFieldProps, 'type'> {
   id?: string;
   model: string;
@@ -664,6 +669,7 @@ interface RelationsListProps extends Pick<RelationsFieldProps, 'disabled' | 'nam
    */
   serverData: RelationResult[];
   targetModel: string;
+  mainField?: MainField;
 }
 
 const RelationsList = ({
@@ -674,6 +680,7 @@ const RelationsList = ({
   isLoading,
   relationType,
   targetModel,
+  mainField,
 }: RelationsListProps) => {
   const ariaDescriptionId = React.useId();
   const { formatMessage } = useIntl();
@@ -785,6 +792,7 @@ const RelationsList = ({
                 id: relation.id,
                 documentId: relation.documentId ?? relation.apiData?.documentId ?? '',
                 locale: relation.locale || relation.apiData?.locale,
+                temporary: relation.apiData?.temporary,
                 position,
               },
             },
@@ -892,6 +900,7 @@ const RelationsList = ({
           handleDisconnect,
           relations: data,
           targetModel,
+          mainField,
         }}
         itemKey={(index) => data[index].id}
         innerElementType="ol"
@@ -955,6 +964,7 @@ interface ListItemProps extends Pick<ListChildComponentProps, 'style' | 'index'>
     name: string;
     relations: Relation[];
     targetModel: string;
+    mainField?: MainField;
   };
 }
 
@@ -971,11 +981,34 @@ const ListItem = ({ data, index, style }: ListItemProps) => {
     name,
     relations,
     targetModel,
+    mainField,
   } = data;
+  const { currentDocumentMeta } = useDocumentContext('RelationsField');
 
   const { formatMessage } = useIntl();
 
-  const { href, id, label, status, documentId, apiData, locale } = relations[index];
+  const {
+    href,
+    id,
+    label: originalLabel,
+    status: originalStatus,
+    documentId,
+    apiData,
+    locale,
+  } = relations[index];
+
+  const collectionType = getCollectionType(href)!;
+  const { document } = useDocument(
+    {
+      collectionType,
+      model: targetModel,
+      documentId: documentId ?? apiData?.documentId,
+      params: currentDocumentMeta.params,
+    },
+    { skip: !apiData?.temporary }
+  );
+  const label = document != null ? getRelationLabel(document, mainField) : originalLabel;
+  const status = document !== null ? document?.status : originalStatus;
 
   const [{ handlerId, isDragging, handleKeyDown }, relationRef, dropRef, dragRef, dragPreviewRef] =
     useDragAndDrop<number, Omit<RelationDragPreviewProps, 'width'>, HTMLDivElement>(

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -6,7 +6,7 @@ import { clickAndWait } from '../../utils/shared';
 const AUTHOR_EDIT_URL =
   /\/admin\/content-manager\/collection-types\/api::author.author\/(?!create)[^/]/;
 
-test.describe('Unstable Relations on the fly', () => {
+test.describe('Relations on the fly', () => {
   test.beforeEach(async ({ page }) => {
     await resetDatabaseAndImportDataFromPath('with-admin.tar');
     await page.goto('/admin');
@@ -207,5 +207,36 @@ test.describe('Unstable Relations on the fly', () => {
     await expect(
       page.getByRole('heading', { name: 'Nike Mens 23/24 Away Stadium Jersey' })
     ).toBeVisible();
+  });
+
+  test('I want to add a new relation in the edit view, open the relation and change its name, change is status and close the modal and see the changes reflected in the Edit view', async ({
+    page,
+  }) => {
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    // Step 1. Got to Article collection-type and open one article
+    await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+
+    // Step 2. Add a new relation in the authors field
+    await clickAndWait(page, page.getByRole('combobox', { name: 'authors' }));
+    await clickAndWait(page, page.getByLabel('Led Tasso'));
+    const newAuthor = page.getByRole('button', { name: 'Led Tasso' });
+    await expect(newAuthor).toBeVisible();
+    await expect(page.getByText('Led TassoDraft')).toBeVisible();
+
+    // Step 3. Open the relation modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Led Tasso' }));
+
+    // Step 4. Change the name of the author and Publish
+    const name = page.getByRole('textbox', { name: 'name' });
+    await name.fill('Mr. Led Tasso');
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
+    await expect(name).toHaveValue('Mr. Led Tasso');
+    await expect(page.getByRole('status', { name: 'Published' }).first()).toBeVisible();
+
+    // Step 5. Close the modal and check the changes are reflected in the Edit view
+    await page.getByRole('button', { name: 'Close modal' }).click();
+    await expect(page.getByRole('button', { name: 'Mr. Led Tasso' })).toBeVisible();
+    await expect(page.getByText('Mr. Led TassoPublished')).toBeVisible();
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It solves an issue we had when we added new relations in an entry or in a new entry without saving the new relation and then we opened the modal to change the name of the relation, we saved or published and then we closed the modal, the changes were not reflected in the initial entry

### Why is it needed?

Because we need to show always to the user the updated value of the relations, to prevent these kind of errors

https://github.com/user-attachments/assets/c7ac23f2-fa8e-4d9b-b38a-98c7bcc3f999


https://github.com/user-attachments/assets/94b39bd9-bd06-42d8-971b-79b6f1bf4a11


### How to test it?

To test it you can create a new entry or edit an old one
- in the Edit/Create view add a new relation and click on it (without saving)
- then the relation modal try to change the name of the relations and Save (or Publish) to change also its status
- close the relation modal and check if the changes are reflected in the relations field

### Related issue(s)/PR(s)

CS-1390 and CS-1391
