### PR TITLE
fix: blocks ui

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -41,6 +41,8 @@ const ToolbarSeparator = styled(Toolbar.Separator)`
   background: ${({ theme }) => theme.colors.neutral150};
   width: 1px;
   height: 2.4rem;
+  margin-left: 0.8rem;
+  margin-right: 0.8rem;
 `;
 
 const FlexButton = styled<FlexComponent<'button'>>(Flex)`
@@ -331,7 +333,7 @@ const BlockOption = ({ value, icon: Icon, label, blockSelected }: BlockOptionPro
 
   return (
     <SingleSelectOption
-      startIcon={<Icon fill={isSelected ? 'primary600' : 'neutral600'} />}
+      startIcon={<Icon fill={isSelected ? 'primary600' : 'neutral500'} />}
       value={value}
     >
       {formatMessage(label)}
@@ -443,11 +445,11 @@ const ListButton = ({ block, format, location = 'toolbar' }: ListButtonProps) =>
 
     return (
       <StyledMenuItem
+        startIcon={<Icon />}
         onSelect={() => toggleList(format)}
         isActive={isListActive()}
         disabled={isListDisabled()}
       >
-        <Icon />
         {formatMessage(block.label)}
       </StyledMenuItem>
     );
@@ -532,8 +534,7 @@ const LinkButton = ({
 
   if (location === 'menu') {
     return (
-      <StyledMenuItem onSelect={addLink} isActive={isLinkActive()} disabled={isLinkDisabled()}>
-        <Link />
+      <StyledMenuItem startIcon={<Link />} onSelect={addLink} isActive={isLinkActive()} disabled={isLinkDisabled()}>
         {formatMessage(label)}
       </StyledMenuItem>
     );
@@ -651,28 +652,16 @@ const MoreMenu = ({ setLastVisibleIndex, hasHiddenItems, rootRef, children }: Mo
 };
 
 const StyledMenuItem = styled(Menu.Item)<{ isActive: boolean }>`
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.primary100};
-  }
-
   ${(props) =>
     props.isActive &&
     css`
-      font-weight: bold;
-      background-color: ${({ theme }) => theme.colors.primary100};
       color: ${({ theme }) => theme.colors.primary600};
-      font-weight: bold;
+      font-weight: 600;
     `}
-
-  > span {
-    display: inline-flex;
-    gap: ${({ theme }) => theme.spaces[2]};
-    align-items: center;
-  }
 
   svg {
     fill: ${({ theme, isActive }) =>
-      isActive ? theme.colors.primary600 : theme.colors.neutral600};
+      isActive ? theme.colors.primary600 : theme.colors.neutral500};
   }
 `;
 
@@ -730,8 +719,7 @@ const BlocksToolbar = () => {
           />
         ),
         menu: (
-          <StyledMenuItem onSelect={handleSelect} isActive={isActive}>
-            <Icon />
+          <StyledMenuItem startIcon={<Icon />} onSelect={handleSelect} isActive={isActive}>
             {formatMessage(modifier.label)}
           </StyledMenuItem>
         ),
@@ -746,8 +734,8 @@ const BlocksToolbar = () => {
     {
       // List buttons can only be rendered together when in the toolbar
       toolbar: (
-        <Flex direction="row" gap={1}>
-          <ToolbarSeparator />
+        <Flex direction="row" >
+          <ToolbarSeparator style={{ marginLeft: "0.4rem" }} />
           <Toolbar.ToggleGroup type="single" asChild>
             <Flex gap={1}>
               <ListButton block={blocks['list-unordered']} format="unordered" location="toolbar" />
@@ -769,7 +757,7 @@ const BlocksToolbar = () => {
 
   return (
     <Toolbar.Root aria-disabled={disabled} asChild>
-      <ToolbarWrapper gap={2} padding={2} width="100%">
+      <ToolbarWrapper padding={2} width="100%">
         <BlocksDropdown />
         <ToolbarSeparator />
         <Toolbar.ToggleGroup type="multiple" asChild>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
@@ -13,6 +13,7 @@ const CollapseIconButton = styled(IconButton)`
   position: absolute;
   bottom: 1.2rem;
   right: 1.2rem;
+  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
 `;
 
 const ExpandWrapper = styled<FlexComponent>(Flex)`


### PR DESCRIPTION
### What does it do?

- Harmonize spacing between modifiers groups
- Change icons colors
- Use the `startIcon` property
- Add a shadow the the collapse `IconButton` in the expanded mode
- Remove some CSS properties to use the ones inherited from `Menu.Item`

### Why is it needed?

It's currently not 100% aligned with the designs.

### How to test it?

You can see the changes in an entry that has a Rich text (Blocks) field.

### Related issue(s)/PR(s)

None.