### PR TITLE
Experiment adding doc links in HeaderLayout

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -58,7 +58,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
     const { trackUsage } = useTracking();
 
     const docLinkButton = docLink ? (
-      <Flex paddingLeft={2}>
+      <Flex>
         <IconButton
           onClick={() =>
             trackUsage('didClickOnDocLink', { from: docLink.pathname, to: docLink.link })
@@ -93,7 +93,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
           zIndex={1}
           data-strapi-header-sticky
         >
-          <Flex justifyContent="space-between">
+          <Flex gap={2} justifyContent="space-between">
             <Flex>
               {navigationAction && <Box paddingRight={3}>{navigationAction}</Box>}
               <Box>
@@ -112,7 +112,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
             </Flex>
             <Flex>
               {primaryAction ? (
-                <Flex gap={2}>
+                <Flex>
                   {docLinkButton}
                   {primaryAction}
                 </Flex>
@@ -123,6 +123,8 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
       );
     }
 
+    console.log(primaryAction ? true : false);
+    
     return (
       <Box
         ref={ref}
@@ -134,7 +136,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
         data-strapi-header
       >
         {navigationAction ? <Box paddingBottom={2}>{navigationAction}</Box> : null}
-        <Flex justifyContent="space-between">
+        <Flex gap={2} justifyContent="space-between">
           <Flex minWidth={0}>
             <Typography tag="h1" variant="alpha" {...props}>
               {title}
@@ -142,7 +144,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
             {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
           </Flex>
           {/* Experiment */}
-          <Flex gap={2}>
+          <Flex>
             {docLinkButton}
             {primaryAction}
           </Flex>
@@ -169,13 +171,8 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
   const baseHeaderLayoutRef = React.useRef<HTMLDivElement>(null);
   const [headerSize, setHeaderSize] = React.useState<DOMRect | null>(null);
   const [isVisible, setIsVisible] = React.useState(true);
-  const [docLink, setDocLink] = React.useState<{
-    link: string;
-    title: string;
-    pathname: string;
-  } | null>(null);
-
   const { pathname } = useLocation();
+  const docLink = getMatchingDocLink(pathname);
 
   const containerRef = useElementOnScreen<HTMLDivElement>(setIsVisible, {
     root: null,
@@ -194,15 +191,6 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
       setHeaderSize(baseHeaderLayoutRef.current.getBoundingClientRect());
     }
   }, [baseHeaderLayoutRef]);
-
-  React.useEffect(() => {
-    const fetchDocLink = async () => {
-      const result = await getMatchingDocLink(pathname);
-      setDocLink(result);
-    };
-
-    fetchDocLink();
-  }, [pathname]);
 
   return (
     <>

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -124,7 +124,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
     }
 
     console.log(primaryAction ? true : false);
-    
+
     return (
       <Box
         ref={ref}

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -34,7 +34,7 @@ interface BaseHeaderLayoutProps extends Omit<TypographyProps<'div'>, 'tag'> {
   subtitle?: React.ReactNode;
   sticky?: boolean;
   width?: number;
-  docLink: DocLink | null;
+  docLink?: DocLink | null;
 }
 
 const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>(
@@ -109,10 +109,15 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
                 )}
               </Box>
               {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
-              {/* Experiment */}
-              {docLinkButton}
             </Flex>
-            <Flex>{primaryAction ? <Box paddingLeft={2}>{primaryAction}</Box> : undefined}</Flex>
+            <Flex>
+              {primaryAction ? (
+                <Flex gap={2}>
+                  {docLinkButton}
+                  {primaryAction}
+                </Flex>
+              ) : undefined}
+            </Flex>
           </Flex>
         </Box>
       );
@@ -135,10 +140,12 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
               {title}
             </Typography>
             {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
-            {/* Experiment */}
-            {docLinkButton}
           </Flex>
-          {primaryAction}
+          {/* Experiment */}
+          <Flex gap={2}>
+            {docLinkButton}
+            {primaryAction}
+          </Flex>
         </Flex>
         {isSubtitleString ? (
           <Typography variant="epsilon" textColor="neutral600" tag="p">

--- a/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
+++ b/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
@@ -1,0 +1,163 @@
+const matchingLinks = [
+  {
+    pathname: '/content-manager',
+    link: 'https://docs.strapi.io/user-docs/content-manager',
+    title: 'Content Manager',
+  },
+  {
+    pathname: '/content-type-builder',
+    link: 'https://docs.strapi.io/user-docs/content-type-builder',
+    title: 'Content-Type Builder',
+  },
+  {
+    pathname: '/plugins/upload',
+    link: 'https://docs.strapi.io/user-docs/media-library',
+    title: 'Media Library',
+  },
+  {
+    pathname: '/content-releases',
+    link: 'https://docs.strapi.io/user-docs/releases/introduction',
+    title: 'Releases',
+  },
+  {
+    pathname: '/purchase-content-releases',
+    link: 'https://docs.strapi.io/user-docs/releases/introduction',
+    title: 'Releases',
+  },
+  {
+    pathname: '/plugins/documentation',
+    link: 'https://docs.strapi.io/dev-docs/plugins/documentation',
+    title: 'Documentation plugin',
+  },
+  {
+    pathname: '/list-plugins',
+    link: 'https://docs.strapi.io/dev-docs/plugins',
+    title: 'Plugins',
+  },
+  {
+    pathname: '/marketplace',
+    link: 'https://docs.strapi.io/user-docs/plugins/installing-plugins-via-marketplace',
+    title: 'Marketplace',
+  },
+  {
+    pathname: '/settings/application-infos',
+    link: 'https://docs.strapi.io/user-docs/settings/introduction',
+    title: 'General settings',
+  },
+  {
+    pathname: '/settings/api-tokens',
+    link: 'https://docs.strapi.io/user-docs/settings/API-tokens',
+    title: 'API Tokens settings',
+  },
+  {
+    pathname: '/settings/documentation',
+    link: 'https://docs.strapi.io/dev-docs/plugins/documentation',
+    title: 'Documentation plugin settings',
+  },
+  {
+    pathname: '/settings/internationalization',
+    link: 'https://docs.strapi.io/user-docs/settings/internationalization',
+    title: 'Internationalization settings (i18n)',
+  },
+  {
+    pathname: '/settings/media-library',
+    link: 'https://docs.strapi.io/user-docs/settings/media-library-settings',
+    title: 'Media Library settings',
+  },
+  {
+    pathname: '/settings/review-workflows',
+    link: 'https://docs.strapi.io/user-docs/settings/review-workflows',
+    title: 'Review Workflows settings',
+  },
+  {
+    pathname: '/settings/purchase-review-workflows',
+    link: 'https://docs.strapi.io/user-docs/settings/review-workflows',
+    title: 'Review Workflows settings',
+  },
+  {
+    pathname: '/settings/single-sign-on',
+    link: 'https://docs.strapi.io/user-docs/settings/single-sign-on',
+    title: 'SSO settings',
+  },
+  {
+    pathname: '/settings/purchase-single-sign-on',
+    link: 'https://docs.strapi.io/user-docs/settings/single-sign-on',
+    title: 'SSO settings',
+  },
+  {
+    pathname: '/settings/purchase-content-history',
+    link: 'https://docs.strapi.io/cms/features/content-history',
+    title: 'Content History',
+  },
+  {
+    pathname: '/settings/transfer-tokens',
+    link: 'https://docs.strapi.io/user-docs/settings/transfer-tokens',
+    title: 'Transfer Tokens',
+  },
+  {
+    pathname: '/settings/webhooks',
+    link: 'https://docs.strapi.io/dev-docs/backend-customization/webhooks',
+    title: 'Webhooks',
+  },
+  {
+    pathname: '/settings/roles',
+    link: 'https://docs.strapi.io/user-docs/users-roles-permissions/configuring-administrator-roles',
+    title: 'Users & Permissions',
+  },
+  {
+    pathname: '/settings/users',
+    link: 'https://docs.strapi.io/user-docs/users-roles-permissions/managing-administrators',
+    title: 'Users & Permissions',
+  },
+  {
+    pathname: '/settings/audit-logs',
+    link: 'https://docs.strapi.io/user-docs/settings/audit-logs',
+    title: 'Audit Logs',
+  },
+  {
+    pathname: '/settings/purchase-audit-logs',
+    link: 'https://docs.strapi.io/user-docs/settings/audit-logs',
+    title: 'Audit Logs',
+  },
+  {
+    pathname: '/settings/email',
+    link: 'https://docs.strapi.io/dev-docs/plugins/email',
+    title: 'Email plugin',
+  },
+  {
+    pathname: '/settings/users-permissions/roles',
+    link: 'https://docs.strapi.io/user-docs/users-roles-permissions/configuring-end-users-roles',
+    title: 'End-users roles',
+  },
+  {
+    pathname: '/settings/users-permissions/providers',
+    link: 'https://docs.strapi.io/user-docs/settings/configuring-users-permissions-plugin-settings#configuring-providers',
+    title: 'Providers',
+  },
+  {
+    pathname: '/settings/users-permissions/email-templates',
+    link: 'https://docs.strapi.io/user-docs/settings/configuring-users-permissions-plugin-settings#configuring-email-templates',
+    title: 'Email Templates',
+  },
+  {
+    pathname: '/settings/users-permissions/advanced-settings',
+    link: 'https://docs.strapi.io/user-docs/settings/configuring-users-permissions-plugin-settings#configuring-advanced-settings',
+    title: 'U&P Advanced settings',
+  },
+  {
+    pathname: '/me',
+    link: 'https://docs.strapi.io/user-docs/getting-started/setting-up-admin-panel#setting-up-your-administrator-profile',
+    title: 'Administrator profile',
+  },
+];
+
+export async function getMatchingDocLink(pathname: string) {
+  const result =
+    matchingLinks.find((item) => pathname === item.pathname) ||
+    matchingLinks.find((item) => pathname.includes(item.pathname));
+
+  if (!result) {
+    return null;
+  }
+  return { ...result };
+}

--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -266,6 +266,14 @@ interface WillNavigateEvent {
   };
 }
 
+interface DidClickOnDocLink {
+  name: 'didClickOnDocLink';
+  properties: {
+    from: string;
+    to: string;
+  };
+}
+
 interface DidAccessTokenListEvent {
   name: 'didAccessTokenList';
   properties: {
@@ -376,6 +384,7 @@ type EventsWithProperties =
   | UpdateEntryEvents
   | WillModifyTokenEvent
   | WillNavigateEvent
+  | DidClickOnDocLink
   | DidPublishRelease
   | MediaEvents;
 

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -565,6 +565,7 @@
   "app.utils.ready-to-publish-changes": "Ready to publish changes",
   "app.utils.ready-to-unpublish-changes": "Ready to unpublish",
   "app.confirm.body": "Are you sure?",
+  "app.HeaderLayout.docLink.label": "Learn more on our documentation",
   "clearLabel": "Clear",
   "coming.soon": "This content is currently under construction and will be back in a few weeks!",
   "component.Input.error.validation.integer": "The value must be an integer",


### PR DESCRIPTION
### What does it do?

Include a documentation helper link on every pages of the CMS.

### Why is it needed?

We need to understand if the users feel already disoriented in the admin panel and on which sections. By introducing a tracked documentation link through an `IconButton` component next the the page HeaderLayout, we could get a the number of click = users looking for information about that particular page.

### How to test it?

- Go to any page of the CMS
- If there is an `IconButton` next to the page title, it should redirect you, when clicking on it, on the associated documentation page.
- Same should happen on the sticky version of the Header of the page.
