### PR TITLE
chore: bump axios to 1.8.4

### DIFF
--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@strapi/utils": "5.12.3",
-    "axios": "1.8.2",
+    "axios": "1.8.4",
     "boxen": "5.1.2",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -93,7 +93,7 @@
     "@testing-library/dom": "10.1.0",
     "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "14.5.2",
-    "axios": "1.8.2",
+    "axios": "1.8.4",
     "bcryptjs": "2.4.3",
     "boxen": "5.1.2",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8661,7 +8661,7 @@ __metadata:
     "@types/react-window": "npm:1.8.8"
     "@types/sanitize-html": "npm:2.13.0"
     "@vitejs/plugin-react-swc": "npm:3.6.0"
-    axios: "npm:1.8.2"
+    axios: "npm:1.8.4"
     bcryptjs: "npm:2.4.3"
     boxen: "npm:5.1.2"
     chalk: "npm:^4.1.2"
@@ -8734,7 +8734,7 @@ __metadata:
     "@types/cli-progress": "npm:3.11.5"
     "@types/eventsource": "npm:1.1.15"
     "@types/lodash": "npm:^4.14.191"
-    axios: "npm:1.8.2"
+    axios: "npm:1.8.4"
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
@@ -13193,7 +13193,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.8.2, axios@npm:^1.6.0, axios@npm:^1.7.4":
+"axios@npm:1.8.4":
+  version: 1.8.4
+  resolution: "axios@npm:1.8.4"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/450993c2ba975ffccaf0d480b68839a3b2435a5469a71fa2fb0b8a55cdb2c2ae47e609360b9c1e2b2534b73dfd69e2733a1cf9f8215bee0bcd729b72f801b0ce
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.0, axios@npm:^1.7.4":
   version: 1.8.2
   resolution: "axios@npm:1.8.2"
   dependencies:


### PR DESCRIPTION
### What does it do?

Update axios dependency to prevent [reported vulnerability](https://github.com/strapi/strapi/security/dependabot/487)

