### PR TITLE
chore: bump vite to 5.4.17

### DIFF
--- a/examples/experimental-dev/package.json
+++ b/examples/experimental-dev/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "@vitejs/plugin-react": "4.2.1",
     "babel-plugin-react-compiler": "0.0.0-experimental-c23de8d-20240515",
-    "vite": "5.4.15"
+    "vite": "5.4.17"
   }
 }

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -167,7 +167,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "6.22.3",
     "styled-components": "6.1.8",
-    "vite": "5.4.15",
+    "vite": "5.4.17",
     "vite-plugin-dts": "^4.3.0"
   },
   "peerDependencies": {

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -165,7 +165,7 @@
     "semver": "7.5.4",
     "style-loader": "3.3.4",
     "typescript": "5.4.4",
-    "vite": "5.4.15",
+    "vite": "5.4.17",
     "webpack": "^5.90.3",
     "webpack-bundle-analyzer": "^4.10.1",
     "webpack-dev-middleware": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8713,7 +8713,7 @@ __metadata:
     styled-components: "npm:6.1.8"
     typescript: "npm:5.4.4"
     use-context-selector: "npm:1.4.1"
-    vite: "npm:5.4.15"
+    vite: "npm:5.4.17"
     vite-plugin-dts: "npm:^4.3.0"
     yup: "npm:0.32.9"
     zod: "npm:^3.22.4"
@@ -9714,7 +9714,7 @@ __metadata:
     style-loader: "npm:3.3.4"
     tsconfig: "npm:5.12.3"
     typescript: "npm:5.4.4"
-    vite: "npm:5.4.15"
+    vite: "npm:5.4.17"
     webpack: "npm:^5.90.3"
     webpack-bundle-analyzer: "npm:^4.10.1"
     webpack-dev-middleware: "npm:6.1.2"
@@ -17837,7 +17837,7 @@ __metadata:
     react-dom: "npm:rc"
     react-router-dom: "npm:6.22.3"
     styled-components: "npm:6.1.8"
-    vite: "npm:5.4.15"
+    vite: "npm:5.4.17"
   languageName: unknown
   linkType: soft
 
@@ -31302,9 +31302,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:5.4.15":
-  version: 5.4.15
-  resolution: "vite@npm:5.4.15"
+"vite@npm:5.4.17":
+  version: 5.4.17
+  resolution: "vite@npm:5.4.17"
   dependencies:
     esbuild: "npm:^0.21.3"
     fsevents: "npm:~2.3.3"
@@ -31341,7 +31341,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/f8a4893bf9d57fe3ded6dc0a2278e8ded707fc9cf38d5a3255fe3caaeea41c52f29bf4deb5e85c9e8dbc8848e9046a7306727ca3fb7b67847d75ee2f2afda5e5
+  checksum: 10c0/3322bd6d8da30cbc87b1b24cd14fdbca75abb36de81217d1062c8b4c574a1a0d28d11dfe23a3eed08b3d179d2bdc1510e0d7b9f3e1b722a45bd7631c7cec72eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Bumps vite to 5.4.17.
Prevents vulnerability on dev environments, not really impacted on strpai


