### PR TITLE
test(e2e): use afterAll instead of afterEach to reset files to reduce flakiness

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/create-collection-type.spec.ts
@@ -19,8 +19,6 @@ test.describe('Create collection type with all field types', () => {
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
   });
 
-  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
-  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
   test.afterAll(async () => {
     await resetFiles();
   });

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -23,9 +23,7 @@ test.describe('Edit collection type', () => {
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
 
-  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
-  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await resetFiles();
   });
 

--- a/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/create-single-type.spec.ts
@@ -23,8 +23,6 @@ test.describe('Create single type with all field types', () => {
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
   });
 
-  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
-  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
   test.afterAll(async () => {
     await resetFiles();
   });

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -23,9 +23,7 @@ test.describe('Edit single type', () => {
     await navToHeader(page, ['Content-Type Builder', ctName], ctName);
   });
 
-  // TODO: each test should have a beforeAll that does this, maybe combine all the setup into one util to simplify it
-  // to keep other suites that don't modify files from needing to reset files, clean up after ourselves at the end
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await resetFiles();
   });
 


### PR DESCRIPTION
### What does it do?

Resets files with afterAll instead of afterEach

### Why is it needed?

Resetting files in the e2e test suites is very expensive (time-wise) and also a minor source of flakiness on its own. Even though the ideal would be to reset files after each test to avoid cross-contamination, for efficiency and reduced flakiness we will switch to `afterAll` and in cases where tests need to avoid interfering with each other a reset can be done in the specific tests that require it.

### How to test it?

They should all pass

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
