### PR TITLE
future(homepage): export widget helper components

### DIFF
--- a/packages/core/admin/admin/src/components/WidgetHelpers.tsx
+++ b/packages/core/admin/admin/src/components/WidgetHelpers.tsx
@@ -1,47 +1,11 @@
-import * as React from 'react';
+import { Flex, Loader, Typography } from '@strapi/design-system';
+import { WarningCircle } from '@strapi/icons';
+import { EmptyDocuments, EmptyPermissions } from '@strapi/icons/symbols';
+import { useIntl } from 'react-intl';
 
-import { Box, Flex, type FlexProps, Loader, Typography } from '@strapi/design-system';
-import { PuzzlePiece, WarningCircle } from '@strapi/icons';
-import { EmptyDocuments } from '@strapi/icons/symbols';
-import { type MessageDescriptor, useIntl } from 'react-intl';
-
-interface RootProps {
-  title: MessageDescriptor;
-  icon?: typeof import('@strapi/icons').PuzzlePiece;
-  children: React.ReactNode;
-}
-
-const Root = ({ title, icon = PuzzlePiece, children }: RootProps) => {
-  const { formatMessage } = useIntl();
-  const id = React.useId();
-  const Icon = icon;
-
-  return (
-    <Flex
-      width="100%"
-      hasRadius
-      direction="column"
-      alignItems="flex-start"
-      background="neutral0"
-      borderColor="neutral150"
-      shadow="tableShadow"
-      tag="section"
-      gap={4}
-      padding={6}
-      aria-labelledby={id}
-    >
-      <Flex direction="row" alignItems="center" gap={2} tag="header">
-        <Icon fill="neutral500" aria-hidden />
-        <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
-          {formatMessage(title)}
-        </Typography>
-      </Flex>
-      <Box width="100%" height="261px" overflow="auto" tag="main">
-        {children}
-      </Box>
-    </Flex>
-  );
-};
+/* -------------------------------------------------------------------------------------------------
+ * Loading
+ * -----------------------------------------------------------------------------------------------*/
 
 interface LoadingProps {
   children?: string;
@@ -62,6 +26,10 @@ const Loading = ({ children }: LoadingProps) => {
     </Flex>
   );
 };
+
+/* -------------------------------------------------------------------------------------------------
+ * Error
+ * -----------------------------------------------------------------------------------------------*/
 
 interface ErrorProps {
   children?: string;
@@ -90,6 +58,10 @@ const Error = ({ children }: ErrorProps) => {
   );
 };
 
+/* -------------------------------------------------------------------------------------------------
+ * NoData
+ * -----------------------------------------------------------------------------------------------*/
+
 interface NoDataProps {
   children?: string;
 }
@@ -111,11 +83,36 @@ const NoData = ({ children }: NoDataProps) => {
   );
 };
 
+/* -------------------------------------------------------------------------------------------------
+ * NoPermissions
+ * -----------------------------------------------------------------------------------------------*/
+
+interface NoPermissionsProps {
+  children?: string;
+}
+
+const NoPermissions = ({ children }: NoPermissionsProps) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Flex height="100%" direction="column" justifyContent="center" alignItems="center" gap={6}>
+      <EmptyPermissions width="16rem" height="8.8rem" />
+      <Typography textColor="neutral600">
+        {children ??
+          formatMessage({
+            id: 'HomePage.widget.no-permissions',
+            defaultMessage: 'You don’t have the permission to see this widget',
+          })}
+      </Typography>
+    </Flex>
+  );
+};
+
 const Widget = {
-  Root,
   Loading,
   Error,
   NoData,
+  NoPermissions,
 };
 
 export { Widget };

--- a/packages/core/admin/admin/src/components/tests/Widget.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Widget.test.tsx
@@ -1,14 +1,15 @@
 import { Cog } from '@strapi/icons';
 import { render, screen } from '@tests/utils';
 
-import { Widget } from '../../../../components/WidgetHelpers';
+import { WidgetRoot } from '../../pages/Home/HomePage';
+import { Widget } from '../WidgetHelpers';
 
 describe('Homepage Widget component', () => {
   it('should render the widget with info from props', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }} icon={Cog}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }} icon={Cog}>
         actual widget content
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.queryByText(/loading widget/i)).not.toBeInTheDocument();
@@ -18,9 +19,9 @@ describe('Homepage Widget component', () => {
 
   it('should render a spinner while a widget is loading', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
         <Widget.Loading />
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.getByText(/loading widget/i)).toBeInTheDocument();
@@ -29,9 +30,9 @@ describe('Homepage Widget component', () => {
 
   it('should render an error message when a widget fails to load', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
         <Widget.Error />
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
@@ -40,9 +41,9 @@ describe('Homepage Widget component', () => {
 
   it('should render a custom error message when provided', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
         <Widget.Error>Custom error message</Widget.Error>
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.getByText(/custom error message/i)).toBeInTheDocument();
@@ -51,9 +52,9 @@ describe('Homepage Widget component', () => {
 
   it('should render a no data message when a widget has no data', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
         <Widget.NoData />
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.getByText(/no content found/i)).toBeInTheDocument();
@@ -61,9 +62,9 @@ describe('Homepage Widget component', () => {
 
   it('should render a custom no data message when provided', () => {
     render(
-      <Widget.Root title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
+      <WidgetRoot title={{ defaultMessage: 'Cool widget title', id: 'notarealid' }}>
         <Widget.NoData>Custom no data message</Widget.NoData>
-      </Widget.Root>
+      </WidgetRoot>
     );
 
     expect(screen.getByText(/custom no data message/i)).toBeInTheDocument();

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -17,6 +17,7 @@ export * from './components/Filters';
 export * from './components/Form';
 export * from './components/FormInputs/Renderer';
 export * from './components/PageHelpers';
+export * from './components/WidgetHelpers';
 export * from './components/Pagination';
 export * from './components/SearchInput';
 export * from './components/Table';

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import { Flex, Grid, Main } from '@strapi/design-system';
-import { useIntl } from 'react-intl';
+import { Box, Flex, Grid, Main, Typography } from '@strapi/design-system';
+import { CheckCircle, Pencil, PuzzlePiece } from '@strapi/icons';
+import { MessageDescriptor, useIntl } from 'react-intl';
 
 import { Layouts } from '../../components/Layouts/Layout';
 import { Page } from '../../components/PageHelpers';
@@ -10,6 +11,47 @@ import { useAuth } from '../../features/Auth';
 
 import { LastEditedWidget, LastPublishedWidget } from './components/ContentManagerWidgets';
 import { GuidedTour } from './components/GuidedTour';
+
+/* -------------------------------------------------------------------------------------------------
+ * Root
+ * -----------------------------------------------------------------------------------------------*/
+
+interface RootProps {
+  title: MessageDescriptor;
+  icon?: typeof import('@strapi/icons').PuzzlePiece;
+  children: React.ReactNode;
+}
+const WidgetRoot = ({ title, icon = PuzzlePiece, children }: RootProps) => {
+  const { formatMessage } = useIntl();
+  const id = React.useId();
+  const Icon = icon;
+
+  return (
+    <Flex
+      width="100%"
+      hasRadius
+      direction="column"
+      alignItems="flex-start"
+      background="neutral0"
+      borderColor="neutral150"
+      shadow="tableShadow"
+      tag="section"
+      gap={4}
+      padding={6}
+      aria-labelledby={id}
+    >
+      <Flex direction="row" alignItems="center" gap={2} tag="header">
+        <Icon fill="neutral500" aria-hidden />
+        <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
+          {formatMessage(title)}
+        </Typography>
+      </Flex>
+      <Box width="100%" height="261px" overflow="auto" tag="main">
+        {children}
+      </Box>
+    </Flex>
+  );
+};
 
 /* -------------------------------------------------------------------------------------------------
  * HomePageCE
@@ -40,10 +82,26 @@ const HomePageCE = () => {
           <GuidedTour />
           <Grid.Root gap={5}>
             <Grid.Item col={6} s={12}>
-              <LastEditedWidget />
+              <WidgetRoot
+                title={{
+                  id: 'content-manager.widget.last-edited.title',
+                  defaultMessage: 'Last edited entries',
+                }}
+                icon={Pencil}
+              >
+                <LastEditedWidget />
+              </WidgetRoot>
             </Grid.Item>
             <Grid.Item col={6} s={12}>
-              <LastPublishedWidget />
+              <WidgetRoot
+                title={{
+                  id: 'content-manager.widget.last-published.title',
+                  defaultMessage: 'Last published entries',
+                }}
+                icon={CheckCircle}
+              >
+                <LastPublishedWidget />
+              </WidgetRoot>
             </Grid.Item>
           </Grid.Root>
         </Flex>

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -21,7 +21,8 @@ interface RootProps {
   icon?: typeof import('@strapi/icons').PuzzlePiece;
   children: React.ReactNode;
 }
-const WidgetRoot = ({ title, icon = PuzzlePiece, children }: RootProps) => {
+
+export const WidgetRoot = ({ title, icon = PuzzlePiece, children }: RootProps) => {
   const { formatMessage } = useIntl();
   const id = React.useId();
   const Icon = icon;

--- a/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/ContentManagerWidgets.tsx
@@ -1,15 +1,16 @@
+import React from 'react';
+
 import { Box, IconButton, Status, Table, Tbody, Td, Tr, Typography } from '@strapi/design-system';
-import { CheckCircle, Pencil } from '@strapi/icons';
+import { Pencil } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { Link, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { RelativeTime } from '../../../components/RelativeTime';
+import { Widget } from '../../../components/WidgetHelpers';
 import { useTracking } from '../../../features/Tracking';
 import { useGetRecentDocumentsQuery } from '../../../services/homepage';
 import { capitalise } from '../../../utils/strings';
-
-import { Widget } from './Widget';
 
 import type { RecentDocument } from '../../../../../shared/contracts/homepage';
 
@@ -127,7 +128,7 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
  * LastEditedWidget
  * -----------------------------------------------------------------------------------------------*/
 
-const LastEditedWidgetContent = () => {
+const LastEditedWidget = () => {
   const { formatMessage } = useIntl();
   const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'update' });
 
@@ -153,25 +154,11 @@ const LastEditedWidgetContent = () => {
   return <RecentDocumentsTable documents={data} />;
 };
 
-const LastEditedWidget = () => {
-  return (
-    <Widget.Root
-      title={{
-        id: 'content-manager.widget.last-edited.title',
-        defaultMessage: 'Last edited entries',
-      }}
-      icon={Pencil}
-    >
-      <LastEditedWidgetContent />
-    </Widget.Root>
-  );
-};
-
 /* -------------------------------------------------------------------------------------------------
  * LastPublishedWidget
  * -----------------------------------------------------------------------------------------------*/
 
-const LastPublishedWidgetContent = () => {
+const LastPublishedWidget = () => {
   const { formatMessage } = useIntl();
   const { data, isLoading, error } = useGetRecentDocumentsQuery({ action: 'publish' });
 
@@ -195,20 +182,6 @@ const LastPublishedWidgetContent = () => {
   }
 
   return <RecentDocumentsTable documents={data} />;
-};
-
-const LastPublishedWidget = () => {
-  return (
-    <Widget.Root
-      title={{
-        id: 'content-manager.widget.last-published.title',
-        defaultMessage: 'Last published entries',
-      }}
-      icon={CheckCircle}
-    >
-      <LastPublishedWidgetContent />
-    </Widget.Root>
-  );
 };
 
 export { LastEditedWidget, LastPublishedWidget };

--- a/packages/core/admin/admin/src/pages/Home/components/tests/Widget.test.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/tests/Widget.test.tsx
@@ -1,7 +1,7 @@
 import { Cog } from '@strapi/icons';
 import { render, screen } from '@tests/utils';
 
-import { Widget } from '../Widget';
+import { Widget } from '../../../../components/WidgetHelpers';
 
 describe('Homepage Widget component', () => {
   it('should render the widget with info from props', () => {

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -67,6 +67,7 @@
   "HomePage.widget.loading": "Loading widget content",
   "HomePage.widget.error": "Couldn't load widget content.",
   "HomePage.widget.no-data": "No content found.",
+  "HomePage.widget.no-permissions": "You don’t have the permission to see this widget",
   "Media Library": "Media Library",
   "New entry": "New entry",
   "Password": "Password",


### PR DESCRIPTION
### What does it do?

- Exports the widget helper components
- Does NOT export the root since all widgets will be wrapped in this component
- Adds a NoPermissions helper component
- Refactors the current homepage to use the Root directly

### Why is it needed?

Prepare for incoming widgets

### How to test it?

No visible change. The homepage should look and function exactly the same. 

You should be able to import Widget from a plugin like:

```
import { Widget } from '@strapi/strapi/admin';
```

