### PR TITLE
fix: edit view dialog ui

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -797,7 +797,10 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
               defaultMessage: 'Confirmation',
             })}
           </Dialog.Header>
-          <Dialog.Body icon={<WarningCircle width="24px" height="24px" fill="danger600" />}>
+          <Dialog.Body
+            icon={<WarningCircle width="24px" height="24px" fill="danger600" />}
+            textAlign="center"
+          >
             {formatMessage({
               id: 'global.prompt.unsaved',
               defaultMessage: 'You have unsaved changes, are you sure you want to leave?',
@@ -805,7 +808,7 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
           </Dialog.Body>
           <Dialog.Footer>
             <Dialog.Cancel>
-              <Button variant="tertiary">
+              <Button variant="tertiary" fullWidth>
                 {formatMessage({
                   id: 'app.components.Button.cancel',
                   defaultMessage: 'Cancel',
@@ -818,6 +821,7 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
                 blocker.proceed();
               }}
               variant="danger"
+              fullWidth
             >
               {formatMessage({
                 id: 'app.components.Button.confirm',

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -735,7 +735,7 @@
   "global.plugins.users-permissions": "Roles & Permissions",
   "global.plugins.users-permissions.description": "Protect your API with a full authentication process based on JWT. This plugin comes also with an ACL strategy that allows you to manage the permissions between the groups of users.",
   "global.profile": "Profile settings",
-  "global.prompt.unsaved": "Are you sure you want to leave this page? All your modifications will be lost",
+  "global.prompt.unsaved": "Are you sure you want to leave this page? All your modifications will be lost.",
   "global.reset-password": "Reset password",
   "global.roles": "Roles",
   "global.save": "Save",


### PR DESCRIPTION
### What does it do?

Describe the technical changes you did.

- Center text.
- Add `fullWidth` to the 2 buttons.
- Add a missing dot in the english translation.

### Why is it needed?

The UI was broken.

#### Before 
![CleanShot 2025-04-11 at 16 23 32@2x](https://github.com/user-attachments/assets/523c15da-6444-4d69-9d38-f65273ab3d0b)

#### After
![CleanShot 2025-04-11 at 16 20 44@2x](https://github.com/user-attachments/assets/d4ae097e-2806-4943-9e3b-9d87d02df31a)

### How to test it?

Go to the edit view, update a field and try to leave the page without saving.

### Related issue(s)/PR(s)

None.