### PR TITLE
test(e2e): launch initial server in watch mode

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -15,11 +15,15 @@ frontend:
   - 'jest-preset.front.js'
   - 'fileTransformer.js'
 api:
+  - 'tests/scripts/run-api-tests.js'
+  - 'tests/scripts/generate-test-app.js'
   - 'tests/api/**'
 e2e:
+  - 'tests/scripts/run-e2e-tests.js'
   - 'tests/e2e/**'
   - 'playwright.base.config.js'
 cli:
+  - 'tests/scripts/run-cli-tests.js'
   - 'tests/cli/**'
 docs:
   - 'docs/**'

--- a/tests/scripts/run-e2e-tests.js
+++ b/tests/scripts/run-e2e-tests.js
@@ -249,7 +249,7 @@ module.exports = config
 
               // Start Strapi and wait for it to be ready
               console.log(`Starting Strapi for domain '${domain}' to generate files...`);
-              const strapiProcess = execa('npm', ['run', 'develop', '--', '--no-watch-admin'], {
+              const strapiProcess = execa('npm', ['run', 'develop'], {
                 cwd: testAppPath,
                 env: {
                   PORT: port,


### PR DESCRIPTION
### What does it do?

launch dev server in watch mode on initial run to save the admin build time on every test domain (20-30 seconds on github runners)

also updates the workflow filter to actually run the tests when their runners are modified

### Why is it needed?

In https://github.com/strapi/strapi/pull/23337 I erroneously used `--no-watch-admin` but that's only needed for the server launched by playwright; since we're only waiting for this one to come up and run bootstrap, we don't care if the admin is built or not

### How to test it?

tests should pass (but a bit faster)

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
