### PR TITLE
feat: add a link icon on the left of the relation option

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -22,7 +22,7 @@ import {
   FlexComponent,
   BoxComponent,
 } from '@strapi/design-system';
-import { Cross, Drag, ArrowClockwise } from '@strapi/icons';
+import { Cross, Drag, ArrowClockwise, Link as LinkIcon } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import pipe from 'lodash/fp/pipe';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -641,7 +641,10 @@ const RelationsInput = ({
           return (
             <ComboboxOption key={opt.id} value={opt.id.toString()} textValue={textValue}>
               <Flex gap={2} justifyContent="space-between">
-                <Typography ellipsis>{textValue}</Typography>
+                <Flex gap={2}>
+                  <LinkIcon fill="neutral500" />
+                  <Typography ellipsis>{textValue}</Typography>
+                </Flex>
                 {opt.status ? <DocumentStatus status={opt.status} /> : null}
               </Flex>
             </ComboboxOption>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a link icon on the left of the relation option's label

### Why is it needed?

It is required from the design

### How to test it?

Open a collection with a relation field and try to open the combobox of the Relation's field to check the presence of the icon

### Related issue(s)/PR(s)

CS-1309
