### PR TITLE
fix: rich text editors focus mode modals

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -114,13 +114,6 @@ const EditorDivider = styled(Divider)`
   background: ${({ theme }) => theme.colors.neutral200};
 `;
 
-const ExpandIconButton = styled(IconButton)`
-  position: absolute;
-  bottom: 1.2rem;
-  right: 1.2rem;
-  box-shadow: ${({ theme }) => theme.shadows.filterShadow};
-`;
-
 /**
  * Forces an update of the Slate editor when the value prop changes from outside of Slate.
  * The root cause is that Slate is not a controlled component: https://github.com/ianstormtaylor/slate/issues/4612
@@ -177,11 +170,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
     );
     const [liveText, setLiveText] = React.useState('');
     const ariaDescriptionId = React.useId();
-    const [isExpandedMode, setIsExpandedMode] = React.useState(false);
-
-    const handleToggleExpand = () => {
-      setIsExpandedMode((prev) => !prev);
-    };
+    const [isExpandedMode, handleToggleExpand] = React.useReducer((prev) => !prev, false);
 
     /**
      * Editable is not able to hold the ref, https://github.com/ianstormtaylor/slate/issues/4082
@@ -246,14 +235,18 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
             <EditorLayout
               error={error}
               disabled={disabled}
-              onCollapse={handleToggleExpand}
+              onToggleExpand={handleToggleExpand}
               ariaDescriptionId={ariaDescriptionId}
             >
               <BlocksToolbar />
               <EditorDivider width="100%" />
               <BlocksContent {...contentProps} />
               {!isExpandedMode && (
-                <ExpandIconButton
+                <IconButton
+                  position="absolute"
+                  bottom="1.2rem"
+                  right="1.2rem"
+                  shadow="filterShadow"
                   label={formatMessage({
                     id: getTranslation('components.Blocks.expand'),
                     defaultMessage: 'Expand',
@@ -261,7 +254,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
                   onClick={handleToggleExpand}
                 >
                   <Expand />
-                </ExpandIconButton>
+                </IconButton>
               )}
             </EditorLayout>
           </BlocksEditorProvider>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
@@ -27,16 +27,6 @@ const EditorLayout = ({
   const { formatMessage } = useIntl();
   const { isExpandedMode } = useBlocksEditorContext('editorLayout');
 
-  React.useEffect(() => {
-    if (isExpandedMode) {
-      document.body.classList.add('lock-body-scroll');
-    }
-
-    return () => {
-      document.body.classList.remove('lock-body-scroll');
-    };
-  }, [isExpandedMode]);
-
   return (
     <>
       {isExpandedMode && (

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
@@ -31,8 +31,8 @@ const EditorLayout = ({
     <>
       {isExpandedMode && (
         <Modal.Root open={isExpandedMode} onOpenChange={onToggleExpand}>
-          <Modal.Content>
-            <Flex height="100%" alignItems="flex-start" direction="column">
+          <Modal.Content style={{ maxWidth: 'unset', width: 'unset' }}>
+            <Flex height="90vh" width="90vw" alignItems="flex-start" direction="column">
               {children}
               <IconButton
                 position="absolute"

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/EditorLayout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Flex, FocusTrap, Portal, IconButton, FlexComponent } from '@strapi/design-system';
+import { Flex, IconButton, FlexComponent, Modal } from '@strapi/design-system';
 import { Collapse } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { css, styled } from 'styled-components';
@@ -9,21 +9,10 @@ import { getTranslation } from '../../../../../utils/translations';
 
 import { useBlocksEditorContext } from './BlocksEditor';
 
-const CollapseIconButton = styled(IconButton)`
-  position: absolute;
-  bottom: 1.2rem;
-  right: 1.2rem;
-`;
-
-const ExpandWrapper = styled<FlexComponent>(Flex)`
-  // Background with 20% opacity
-  background: ${({ theme }) => `${theme.colors.neutral800}1F`};
-`;
-
 interface EditorLayoutProps {
   children: React.ReactNode;
   error?: string;
-  onCollapse: () => void;
+  onToggleExpand: () => void;
   disabled: boolean;
   ariaDescriptionId: string;
 }
@@ -32,7 +21,7 @@ const EditorLayout = ({
   children,
   error,
   disabled,
-  onCollapse,
+  onToggleExpand,
   ariaDescriptionId,
 }: EditorLayoutProps) => {
   const { formatMessage } = useIntl();
@@ -48,63 +37,43 @@ const EditorLayout = ({
     };
   }, [isExpandedMode]);
 
-  if (isExpandedMode) {
-    return (
-      <Portal role="dialog" aria-modal={false}>
-        <FocusTrap onEscape={onCollapse}>
-          <ExpandWrapper
-            position="fixed"
-            top={0}
-            left={0}
-            right={0}
-            bottom={0}
-            zIndex={4}
-            justifyContent="center"
-            onClick={onCollapse}
-          >
-            <Box<'div'>
-              background="neutral0"
-              hasRadius
-              shadow="popupShadow"
-              overflow="hidden"
-              width="90%"
-              height="90%"
-              onClick={(e) => e.stopPropagation()}
-              aria-describedby={ariaDescriptionId}
-              position="relative"
-            >
-              <Flex height="100%" alignItems="flex-start" direction="column">
-                {children}
-                <CollapseIconButton
-                  label={formatMessage({
-                    id: getTranslation('components.Blocks.collapse'),
-                    defaultMessage: 'Collapse',
-                  })}
-                  onClick={onCollapse}
-                >
-                  <Collapse />
-                </CollapseIconButton>
-              </Flex>
-            </Box>
-          </ExpandWrapper>
-        </FocusTrap>
-      </Portal>
-    );
-  }
-
   return (
-    <InputWrapper
-      direction="column"
-      alignItems="flex-start"
-      height="512px"
-      $disabled={disabled}
-      $hasError={Boolean(error)}
-      style={{ overflow: 'hidden' }}
-      aria-describedby={ariaDescriptionId}
-      position="relative"
-    >
-      {children}
-    </InputWrapper>
+    <>
+      {isExpandedMode && (
+        <Modal.Root open={isExpandedMode} onOpenChange={onToggleExpand}>
+          <Modal.Content>
+            <Flex height="100%" alignItems="flex-start" direction="column">
+              {children}
+              <IconButton
+                position="absolute"
+                bottom="1.2rem"
+                right="1.2rem"
+                shadow="filterShadow"
+                label={formatMessage({
+                  id: getTranslation('components.Blocks.collapse'),
+                  defaultMessage: 'Collapse',
+                })}
+                onClick={onToggleExpand}
+              >
+                <Collapse />
+              </IconButton>
+            </Flex>
+          </Modal.Content>
+        </Modal.Root>
+      )}
+      <InputWrapper
+        direction="column"
+        alignItems="flex-start"
+        height="512px"
+        $disabled={disabled}
+        $hasError={Boolean(error)}
+        style={{ overflow: 'hidden' }}
+        aria-describedby={ariaDescriptionId}
+        position="relative"
+      >
+        {!isExpandedMode && children}
+      </InputWrapper>
+    </>
   );
 };
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/EditorLayout.tsx
@@ -27,7 +27,7 @@ const EditorLayout = ({
   if (isExpandMode) {
     return (
       <Modal.Root open={isExpandMode} onOpenChange={onCollapse}>
-        <Modal.Content style={{ maxWidth: 'unset' }}>
+        <Modal.Content style={{ maxWidth: 'unset', width: 'unset' }}>
           <Flex height="90vh" width="90vw" alignItems="flex-start">
             <BoxWithBorder flex="1" height="100%">
               {children}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/EditorLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/EditorLayout.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react';
 
-import {
-  Button,
-  Box,
-  BoxComponent,
-  Flex,
-  FlexComponent,
-  FocusTrap,
-  Portal,
-  Typography,
-} from '@strapi/design-system';
+import { Button, Box, BoxComponent, Flex, Typography, Modal } from '@strapi/design-system';
 import { Collapse } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -33,71 +24,39 @@ const EditorLayout = ({
 }: EditorLayoutProps) => {
   const { formatMessage } = useIntl();
 
-  React.useEffect(() => {
-    if (isExpandMode) {
-      document.body.classList.add('lock-body-scroll');
-    }
-
-    return () => {
-      document.body.classList.remove('lock-body-scroll');
-    };
-  }, [isExpandMode]);
-
   if (isExpandMode) {
     return (
-      <Portal role="dialog" aria-modal={false}>
-        <FocusTrap onEscape={onCollapse}>
-          <ExpandWrapper
-            position="fixed"
-            top={0}
-            left={0}
-            right={0}
-            bottom={0}
-            zIndex={4}
-            justifyContent="center"
-            onClick={onCollapse}
-          >
-            <Box<'div'>
-              background="neutral0"
-              hasRadius
-              shadow="popupShadow"
-              overflow="hidden"
-              width="90%"
-              height="90%"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Flex height="100%" alignItems="flex-start">
-                <BoxWithBorder flex="1" height="100%">
-                  {children}
-                </BoxWithBorder>
-                <Flex alignItems="start" direction="column" flex={1} height="100%" width="100%">
-                  <Flex
-                    height="4.8rem"
-                    background="neutral100"
-                    justifyContent="flex-end"
-                    shrink={0}
-                    width="100%"
-                  >
-                    <ExpandButton onClick={onCollapse} variant="tertiary" size="M">
-                      <Typography>
-                        {formatMessage({
-                          id: 'components.Wysiwyg.collapse',
-                          defaultMessage: 'Collapse',
-                        })}
-                      </Typography>
-                      <Collapse />
-                    </ExpandButton>
-                  </Flex>
-
-                  <Box position="relative" height="100%" width="100%">
-                    <PreviewWysiwyg data={previewContent} />
-                  </Box>
-                </Flex>
+      <Modal.Root open={isExpandMode} onOpenChange={onCollapse}>
+        <Modal.Content style={{ maxWidth: 'unset' }}>
+          <Flex height="90vh" width="90vw" alignItems="flex-start">
+            <BoxWithBorder flex="1" height="100%">
+              {children}
+            </BoxWithBorder>
+            <Flex alignItems="start" direction="column" flex={1} height="100%" width="100%">
+              <Flex
+                height="4.8rem"
+                background="neutral100"
+                justifyContent="flex-end"
+                shrink={0}
+                width="100%"
+              >
+                <ExpandButton onClick={onCollapse} variant="tertiary" size="M">
+                  <Typography>
+                    {formatMessage({
+                      id: 'components.Wysiwyg.collapse',
+                      defaultMessage: 'Collapse',
+                    })}
+                  </Typography>
+                  <Collapse />
+                </ExpandButton>
               </Flex>
-            </Box>
-          </ExpandWrapper>
-        </FocusTrap>
-      </Portal>
+              <Box position="relative" height="100%" width="100%">
+                <PreviewWysiwyg data={previewContent} />
+              </Box>
+            </Flex>
+          </Flex>
+        </Modal.Content>
+      </Modal.Root>
     );
   }
 
@@ -114,13 +73,6 @@ const EditorLayout = ({
     </Flex>
   );
 };
-
-const ExpandWrapper = styled<FlexComponent>(Flex)`
-  background: ${({ theme }) =>
-    `${theme.colors.neutral800}${Math.floor(0.2 * 255)
-      .toString(16)
-      .padStart(2, '0')}`};
-`;
 
 const BoxWithBorder = styled<BoxComponent>(Box)`
   border-right: 1px solid ${({ theme }) => theme.colors.neutral200};

--- a/tests/e2e/tests/content-manager/relations.spec.ts
+++ b/tests/e2e/tests/content-manager/relations.spec.ts
@@ -65,6 +65,20 @@ test.describe('Relations on the fly', () => {
     await expect(page.getByRole('heading', { name: 'Coach Beard' })).toBeVisible();
   });
 
+  test('I want to open a blocks editor modal on top of a relation modal', async ({ page }) => {
+    // Open in a relation modal an entry that has a blocks editor
+    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+    await clickAndWait(page, page.getByRole('link', { name: 'Author' }));
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'Coach Beard' }));
+    await clickAndWait(page, page.getByRole('button', { name: 'West Ham post match analysis' }));
+    await expect(page.getByText('Edit a relation')).toBeVisible();
+    // Open the blocks editor modal on top of the relation modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Expand' }));
+    await expect(page.getByText('Howdy')).toBeVisible();
+    // If the collapse button is available, it means we're indeed in the blocks editor modal
+    await clickAndWait(page, page.getByRole('button', { name: 'Collapse' }));
+  });
+
   test('I want to open some nested relations and click the back button to open the initial relation', async ({
     page,
   }) => {


### PR DESCRIPTION
### What does it do?

Changes the implementation of the blocks and markdown editor "focus mode" modals, in order to use the Modal component from the design system instead of a DIY React portal

### Why is it needed?

Without it the modal can't be rendered on top of the ROTF relation modal. It also removes some old imperative code
### How to test it?
Use the markdown and blocks editors in the edit view, try the focus mode, preview mode for markdown, etc.

Also try it in the context of a relation modal: Tag entry => open Kitchensink relation modal => see rich text fields

### Related issue(s)/PR(s)

Replaces #23296