### PR TITLE
feat(strapi): add an openapi:generate command

### DIFF
--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -56,8 +56,9 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@strapi/utils": "npm:5.12.4",
+    "@strapi/utils": "5.12.4",
     "debug": "4.3.4",
+    "openapi-types": "12.1.3",
     "path-to-regexp": "8.2.0"
   },
   "devDependencies": {

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -122,6 +122,7 @@
     "@strapi/generators": "5.12.4",
     "@strapi/i18n": "5.12.4",
     "@strapi/logger": "5.12.4",
+    "@strapi/openapi": "5.12.4",
     "@strapi/permissions": "5.12.4",
     "@strapi/review-workflows": "5.12.4",
     "@strapi/types": "5.12.4",

--- a/packages/core/strapi/src/cli/commands/index.ts
+++ b/packages/core/strapi/src/cli/commands/index.ts
@@ -23,6 +23,7 @@ import { command as generateCommand } from './generate';
 import { command as reportCommand } from './report';
 import { command as startCommand } from './start';
 import { command as versionCommand } from './version';
+import { command as generateOpenAPICommand } from './openapi/generate';
 import exportCommand from './export/command';
 import importCommand from './import/command';
 import transferCommand from './transfer/command';
@@ -56,6 +57,7 @@ export const commands: StrapiCommand[] = [
   exportCommand,
   importCommand,
   transferCommand,
+  generateOpenAPICommand,
   /**
    * Cloud
    */

--- a/packages/core/strapi/src/cli/commands/openapi/generate.ts
+++ b/packages/core/strapi/src/cli/commands/openapi/generate.ts
@@ -16,7 +16,6 @@ const DEFAULT_OUTPUT = path.join(process.cwd(), 'specification.json');
 
 interface CommandOptions {
   output?: string;
-  summary: boolean;
 }
 
 interface StrapiInfoConfig {

--- a/packages/core/strapi/src/cli/commands/openapi/generate.ts
+++ b/packages/core/strapi/src/cli/commands/openapi/generate.ts
@@ -1,0 +1,90 @@
+import { compileStrapi, createStrapi } from '@strapi/core';
+import * as openapi from '@strapi/openapi';
+
+import type { Core } from '@strapi/types';
+
+import chalk from 'chalk';
+import { createCommand } from 'commander';
+import fse from 'fs-extra';
+import path from 'path';
+
+import { runAction } from '../../utils/helpers';
+
+import type { StrapiCommand } from '../../types';
+
+const DEFAULT_OUTPUT = path.join(process.cwd(), 'specification.json');
+
+interface CommandOptions {
+  output?: string;
+  summary: boolean;
+}
+
+interface StrapiInfoConfig {
+  name: string;
+  version: string;
+}
+
+const action = async (options: CommandOptions) => {
+  const filePath = options.output ?? DEFAULT_OUTPUT;
+  const app = await createStrapiApp();
+
+  const { document, durationMs } = openapi.generate(app, { type: 'content-api' });
+
+  writeDocumentToFile(document, filePath);
+  summarize(app, durationMs, filePath);
+
+  await teardownStrapiApp(app);
+};
+
+const createStrapiApp = async (): Promise<Core.Strapi> => {
+  const appContext = await compileStrapi();
+  const app = createStrapi(appContext);
+
+  // Make sure to not log Strapi debug info
+  app.log.level = 'error';
+
+  // Load internals
+  await app.load();
+
+  // Make sure the routes are mounted before generating the specification
+  app.server.mount();
+
+  return app;
+};
+
+const writeDocumentToFile = (document: unknown, filePath: string): void => {
+  fse.writeFileSync(filePath, JSON.stringify(document, null, 2));
+};
+
+const teardownStrapiApp = async (app: Core.Strapi) => {
+  await app.destroy();
+};
+
+const summarize = (app: Core.Strapi, durationMs: number, filePath: string): void => {
+  const cwd = process.cwd();
+  const relativeFilePath = path.relative(cwd, filePath);
+  const { name, version } = app.config.get<StrapiInfoConfig>('info');
+
+  const fName = chalk.cyan(name);
+  const fVersion = chalk.cyan(`v${version}`);
+  const fFile = chalk.magenta(relativeFilePath);
+  const fTime = chalk.green(`${durationMs}ms`);
+
+  console.log(
+    chalk.bold(
+      `Generated an OpenAPI specification for "${fName} ${fVersion}" at ${fFile} in ${fTime}`
+    )
+  );
+};
+
+/**
+ * `$ strapi openapi:generate [-o, --output <output>]`
+ */
+const command: StrapiCommand = () => {
+  return createCommand('openapi:generate')
+    .description('Generate an OpenAPI specification for the current Strapi application')
+    .option('-o, --output <output>', 'Output file path')
+    .action(runAction('openapi:generate', action));
+};
+
+export { action, command };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9199,6 +9199,7 @@ __metadata:
     "@strapi/utils": "npm:5.12.4"
     "@types/debug": "npm:^4"
     debug: "npm:4.3.4"
+    openapi-types: "npm:12.1.3"
     path-to-regexp: "npm:8.2.0"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,7 +9191,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/openapi@workspace:packages/core/openapi":
+"@strapi/openapi@npm:5.12.4, @strapi/openapi@workspace:packages/core/openapi":
   version: 0.0.0-use.local
   resolution: "@strapi/openapi@workspace:packages/core/openapi"
   dependencies:
@@ -9629,6 +9629,7 @@ __metadata:
     "@strapi/generators": "npm:5.12.4"
     "@strapi/i18n": "npm:5.12.4"
     "@strapi/logger": "npm:5.12.4"
+    "@strapi/openapi": "npm:5.12.4"
     "@strapi/permissions": "npm:5.12.4"
     "@strapi/review-workflows": "npm:5.12.4"
     "@strapi/ts-zen": "npm:^0.2.0"


### PR DESCRIPTION
### What does it do?

Add a command to generate an OpenAPI specification for the app's content-API

```bash
yarn strapi openapi:generate [-o, --output <output>]
```

Accept an optional output option to specify where to generate the specification (by default, set to `specification.json`)

### Why is it needed?

Integrate the OpenAPI work done in `@strapi/openapi` into Strapi

