### PR TITLE
fix(upload-aws-s3): use baseUrl even if upload location lacks protocol

### DIFF
--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -39,6 +39,7 @@ describe('AWS-S3 provider', () => {
       const file: File = {
         name: 'test',
         size: 100,
+        sizeInBytes: 100 * 1024,
         url: '',
         path: 'tmp',
         hash: 'test',
@@ -66,6 +67,7 @@ describe('AWS-S3 provider', () => {
       const file: File = {
         name: 'test',
         size: 100,
+        sizeInBytes: 100 * 1024,
         url: '',
         path: 'tmp',
         hash: 'test',
@@ -95,6 +97,44 @@ describe('AWS-S3 provider', () => {
       const file: File = {
         name: 'test',
         size: 100,
+        sizeInBytes: 100 * 1024,
+        url: '',
+        path: 'tmp/test',
+        hash: 'test',
+        ext: '.json',
+        mime: 'application/json',
+        buffer: Buffer.from(''),
+      };
+
+      await providerInstance.upload(file);
+
+      expect(uploadMock.done).toBeCalled();
+      expect(file.url).toBeDefined();
+      expect(file.url).toEqual('https://cdn.test/tmp/test/test.json');
+    });
+
+    test('Should use baseUrl even if location lacks protocol', async () => {
+      uploadMock.done.mockImplementationOnce(() =>
+        Promise.resolve({
+          Location: 'otherdomain.com/different/path/file.json',
+          $metadata: {},
+        })
+      );
+
+      const providerInstance = awsProvider.init({
+        baseUrl: 'https://cdn.test',
+        s3Options: {
+          region: 'test',
+          params: {
+            Bucket: 'test',
+          },
+        },
+      });
+
+      const file: File = {
+        name: 'test',
+        size: 100,
+        sizeInBytes: 100 * 1024,
         url: '',
         path: 'tmp/test',
         hash: 'test',
@@ -124,6 +164,7 @@ describe('AWS-S3 provider', () => {
       const file: File = {
         name: 'test',
         size: 100,
+        sizeInBytes: 100 * 1024,
         url: '',
         path: 'tmp/test',
         hash: 'test',

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -117,11 +117,16 @@ export default {
 
       const upload = (await uploadObj.done()) as UploadCommandOutput;
 
-      if (assertUrlProtocol(upload.Location)) {
-        file.url = baseUrl ? `${baseUrl}/${fileKey}` : upload.Location;
+      if (baseUrl) {
+        file.url = `${baseUrl}/${fileKey}`;
       } else {
-        // Default protocol to https protocol
-        file.url = `https://${upload.Location}`;
+        // No baseUrl provided, use upload.Location
+        if (assertUrlProtocol(upload.Location)) {
+          file.url = upload.Location;
+        } else {
+          // Default protocol to https protocol
+          file.url = `https://${upload.Location}`;
+        }
       }
     };
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

I have extended the use `baseUrl` in combination with the `fileKey` for providers that do not return a protocol in the `Location` prop. When the the `baseUrl` is not provided, it defaults to the previous behavior: use `Location` if it has the protocol, or append the protocol to `Location` if it's missing.

### Why is it needed?

The combination of using a `baseUrl` with a provider that does not return the protocol is broken. It never uses `baseUrl` in that case.

### How to test it?

1. Add the @strapi/provider-upload-aws-s3 plugin to a Strapi instance
2. Set up a provider that does not return the protocol in the Location prop (I have been using Hetzner Object Storage - I am happy to provide some access keys for you to test).
3. Upload a file
4. Resulting URL of the file should consider `baseUrl`

### Related issue(s)/PR(s)

Fixes #23399.
