### PR TITLE
future: track registered widgets

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -6,6 +6,7 @@ import { useInitQuery, useTelemetryPropertiesQuery } from '../services/admin';
 
 import { useAppInfo } from './AppInfo';
 import { useAuth } from './Auth';
+import { useStrapiApp } from './StrapiApp';
 
 export interface TelemetryProperties {
   useTypescriptOnServer?: boolean;
@@ -39,6 +40,7 @@ export interface TrackingProviderProps {
 
 const TrackingProvider = ({ children }: TrackingProviderProps) => {
   const token = useAuth('App', (state) => state.token);
+  const getAllWidgets = useStrapiApp('TrackingProvider', (state) => state.widgets.getAll);
   const { data: initData } = useInitQuery();
   const { uuid } = initData ?? {};
 
@@ -57,7 +59,11 @@ const TrackingProvider = ({ children }: TrackingProviderProps) => {
             event,
             userId: '',
             eventPropeties: {},
-            groupProperties: { ...data, projectId: uuid },
+            groupProperties: {
+              ...data,
+              projectId: uuid,
+              registeredWidgets: getAllWidgets().map((widget) => widget.uid),
+            },
           }),
           headers: {
             'Content-Type': 'application/json',
@@ -68,7 +74,7 @@ const TrackingProvider = ({ children }: TrackingProviderProps) => {
         // silence is golden
       }
     }
-  }, [data, uuid]);
+  }, [data, uuid, getAllWidgets]);
 
   const value = React.useMemo(
     () => ({


### PR DESCRIPTION
### What does it do?

Adds information about registered widgets to the didInitializeAdministration tracking event

### Why is it needed?

So we can watch usage of the widgets API
### How to test it?

Open your admin. The first tracking event, that should only appear once, should be didInitializeAdministration. Look at the event payload. In the groupProperties object, you should see a registeredWidgets property that should be an array of UID strings (e.g. `global::mywidget`, or `plugin::myplugin.mywidget`)