### PR TITLE
fix: widget type not exported from @strapi/admin/strapi-admin

### DIFF
--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -68,6 +68,7 @@ export type {
   Entity,
 } from '../../shared/contracts/shared';
 export type { RBACContext, RBACMiddleware } from './core/apis/rbac';
+export type { Widget as WidgetType } from './core/apis/Widgets';
 
 /**
  * Utils

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -14,7 +14,7 @@ import { useStrapiApp } from '../../features/StrapiApp';
 import { LastEditedWidget, LastPublishedWidget } from './components/ContentManagerWidgets';
 import { GuidedTour } from './components/GuidedTour';
 
-import type { Widget as WidgetType } from 'src/core/apis/Widgets';
+import type { WidgetType } from '@strapi/admin/strapi-admin';
 
 /* -------------------------------------------------------------------------------------------------
  * WidgetRoot


### PR DESCRIPTION
### What does it do?

Export the Widget type from `@strapi/admin/strapi-admin`

### Why is it needed?

To make TS happy

### How to test it?

Run yarn test:ts:front the tests should pass

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23397

It looks like it's causing an error on the release branch https://github.com/strapi/strapi/pull/23413

but I don't get it the code isn't on that branch 🤔 
