### PR TITLE
Limiting the api tracker to api requests

### DIFF
--- a/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
@@ -34,7 +34,7 @@ describe('Metrics middleware', () => {
       {
         request: {
           method,
-          url: '/some-api',
+          url: '/api',
         },
       } as any,
       jest.fn()
@@ -52,7 +52,7 @@ describe('Metrics middleware', () => {
         {
           request: {
             method: 'GET',
-            url: '/some-api',
+            url: '/api',
           },
         } as any,
         jest.fn()
@@ -73,7 +73,7 @@ describe('Metrics middleware', () => {
         {
           request: {
             method: 'GET',
-            url: '/some-api',
+            url: '/api',
           },
         } as any,
         jest.fn()
@@ -86,7 +86,7 @@ describe('Metrics middleware', () => {
       {
         request: {
           method: 'GET',
-          url: '/some-api',
+          url: '/api',
         },
       } as any,
       jest.fn()

--- a/packages/core/core/src/services/metrics/middleware.ts
+++ b/packages/core/core/src/services/metrics/middleware.ts
@@ -19,8 +19,7 @@ const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
   const middleware: Core.MiddlewareHandler = async (ctx, next) => {
     const { url, method } = ctx.request;
 
-    if (!url.includes('.') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {
-      if (Date.now() > state.expires) {
+    if (!url.includes('.') && url.includes('/api') && ['GET', 'PUT', 'POST', 'DELETE'].includes(method)) {      if (Date.now() > state.expires) {
         state.expires = nextResetDate();
         state.counter = 0;
       }


### PR DESCRIPTION
What does it do?
Limits the call to the didReceiveRequest event to API calls.
And it also expands the tracking to the u&p plugin logins.

Why is it needed?
At the moment the event is also called during the admin navigation.
And it's not called when the u&p plugin auth/local route is called with the identifier as an email.

How to test it?
If you log something in the if condition I edited, you should see it logged only on api requests; before it was on any http request.