### PR TITLE
enhancement: data transfer CLI command prompts

### DIFF
--- a/packages/core/strapi/src/cli/commands/transfer/command.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/command.ts
@@ -53,16 +53,17 @@ const command = () => {
       )
       .hook('preAction', async (thisCommand) => {
         const opts = thisCommand.opts();
+        const hasEnvUrl = process.env.STRAPI_TRANSFER_URL;
+        const hasEnvToken = process.env.STRAPI_TRANSFER_TOKEN;
 
         const logDocumentation = () => {
-          const hasUrl = process.env.STRAPI_TRANSFER_URL;
-          const hasToken = process.env.STRAPI_TRANSFER_TOKEN;
-
           console.info(
             'ℹ️  Data transfer documentation: https://docs.strapi.io/dev-docs/data-management/transfer'
           );
+        };
 
-          if (!hasUrl && !hasToken) {
+        const logEnvironmentVariables = () => {
+          if (!hasEnvUrl && !hasEnvToken) {
             console.info('ℹ️  No transfer configuration found in environment variables');
             console.info(
               '   → Add STRAPI_TRANSFER_URL and STRAPI_TRANSFER_TOKEN environment variables to make the transfer process faster for future runs'
@@ -72,13 +73,13 @@ const command = () => {
 
           console.info('ℹ️  Found transfer configuration in your environment:');
 
-          if (hasUrl) {
+          if (hasEnvUrl) {
             console.info(
-              `   → Environment STRAPI_TRANSFER_URL (${hasUrl}) will be used as the transfer URL`
+              `   → Environment STRAPI_TRANSFER_URL (${hasEnvUrl}) will be used as the transfer URL`
             );
           }
 
-          if (hasToken) {
+          if (hasEnvToken) {
             console.info(
               '   → Environment STRAPI_TRANSFER_TOKEN value will be used as the transfer token'
             );
@@ -88,15 +89,19 @@ const command = () => {
         };
 
         const determineDirection = async () => {
+          // If user has not provided a direction from CLI, log the documentation
+          if (!opts.from && !opts.to) {
+            logDocumentation();
+          }
+
+          logEnvironmentVariables();
+
           if (opts.from) {
             return opts.from;
           }
           if (opts.to) {
             return opts.to;
           }
-
-          // If user has not provided a direction from CLI, log the documentation
-          logDocumentation();
 
           const { dir } = await inquirer.prompt([
             {


### PR DESCRIPTION
What does it do?
Adding support for the strapi transfer command; running this command the user can chose the kind of operation to run and insert the needed data (url and token). Furthermore, the URL and token values fall back to dedicated environment variables value.
![425207109-2f6070c0-1053-4945-bd16-4f5baf4ef1f4](https://github.com/user-attachments/assets/9bbe16d8-8532-4388-a2ac-2a6d2dd162c3)



Why is it needed?
Inserting the many and long options needed to transfer/push or transfer/pull data can be confusing and difficult; and it's so even more when the transfer is run iteratively.

How to test it?
Just run the strapi transfer command and enjoy the journey.
Set the STRAPI_TRANSFER_URL and STRAPI_TRANSFER_TOKEN env variables to enjoy it even more.