### PR TITLE
fix: typo in `data-transfer` CLI

### DIFF
--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -286,7 +286,7 @@ const loadersFactory = (defaultLoaders: Loaders = {} as Loaders) => {
     const speed =
       elapsedTime > 0 ? `(${readableBytes(((stageData?.bytes ?? 0) * 1000) / elapsedTime)}/s)` : '';
 
-    loaders[stage].text = `${stage}: ${stageData?.count ?? 0} transfered (${size}) (${elapsed}) ${
+    loaders[stage].text = `${stage}: ${stageData?.count ?? 0} transferred (${size}) (${elapsed}) ${
       !stageData?.endTime ? speed : ''
     }`;
 


### PR DESCRIPTION
### What does it do?

Current CLI output:

```
✔ entities: 93 transfered (size: 177.2 KB) (elapsed: 123 ms) (1.4 MB/s)
✔ assets: 12 transfered (size: 439.1 KB) (elapsed: 35 ms) (12.3 MB/s)
✔ links: 303 transfered (size: 53.4 KB) (elapsed: 17 ms) (3.1 MB/s)
✔ configuration: 49 transfered (size: 148.1 KB) (elapsed: 7 ms) (20.7 MB/s)
```

The word 'transfered' appears in the output; this PR corrects it to 'transferred'.

### Why is it needed?

Grammatically correct output is always nice.

### How to test it?

Perform a `strapi import -f ...` CLI command
