### PR TITLE
fix: remove policy from license-limit-info that breaks releases

### DIFF
--- a/packages/core/admin/ee/server/src/routes/license-limit.ts
+++ b/packages/core/admin/ee/server/src/routes/license-limit.ts
@@ -7,20 +7,7 @@ export default {
       path: '/license-limit-information',
       handler: 'admin.licenseLimitInformation',
       config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: [
-                'admin::users.create',
-                'admin::users.read',
-                'admin::users.update',
-                'admin::users.delete',
-              ],
-            },
-          },
-        ],
+        policies: ['admin::isAuthenticatedAdmin'],
       },
     },
   ],


### PR DESCRIPTION
### What does it do?

Removes the `admin::hasPermissions` policy from the `/license-limit-information` route to allow lower level users without the ability to CRUD admin users to create more than 3 workflows (up to their license limit)

### Why is it needed?

Currently only super-admins or roles with the following permissions could create more than 3 releases

- admin::users.create
- admin::users.read
- admin::users.update
- admin::users.delete

### How to test it?

See reproduction in https://github.com/strapi/strapi/issues/23423

### Related issue(s)/PR(s)

fixes: #23423 
