### PR TITLE
fix: updated icon button to include disabled flag for repeatable comp

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -439,6 +439,7 @@ const Component = ({
             <Accordion.Trigger>{displayValue}</Accordion.Trigger>
             <Accordion.Actions>
               <IconButton
+                disabled={disabled}
                 variant="ghost"
                 onClick={onDeleteComponent}
                 label={formatMessage({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -438,30 +438,33 @@ const Component = ({
           <Accordion.Header>
             <Accordion.Trigger>{displayValue}</Accordion.Trigger>
             <Accordion.Actions>
-              <IconButton
-                disabled={disabled}
-                variant="ghost"
-                onClick={onDeleteComponent}
-                label={formatMessage({
-                  id: getTranslation('containers.Edit.delete'),
-                  defaultMessage: 'Delete',
-                })}
-              >
-                <Trash />
-              </IconButton>
-              <IconButton
-                ref={composedAccordionRefs}
-                variant="ghost"
-                onClick={(e) => e.stopPropagation()}
-                data-handler-id={handlerId}
-                label={formatMessage({
-                  id: getTranslation('components.DragHandle-label'),
-                  defaultMessage: 'Drag',
-                })}
-                onKeyDown={handleKeyDown}
-              >
-                <Drag />
-              </IconButton>
+              <Flex direction="row" gap={disabled ? 4 : 0}>
+                <IconButton
+                  disabled={disabled}
+                  variant="ghost"
+                  onClick={onDeleteComponent}
+                  label={formatMessage({
+                    id: getTranslation('containers.Edit.delete'),
+                    defaultMessage: 'Delete',
+                  })}
+                >
+                  <Trash />
+                </IconButton>
+                <IconButton
+                  disabled={disabled}
+                  ref={composedAccordionRefs}
+                  variant="ghost"
+                  onClick={(e) => e.stopPropagation()}
+                  data-handler-id={handlerId}
+                  label={formatMessage({
+                    id: getTranslation('components.DragHandle-label'),
+                    defaultMessage: 'Drag',
+                  })}
+                  onKeyDown={handleKeyDown}
+                >
+                  <Drag />
+                </IconButton>
+              </Flex>
             </Accordion.Actions>
           </Accordion.Header>
           <Accordion.Content>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -438,33 +438,31 @@ const Component = ({
           <Accordion.Header>
             <Accordion.Trigger>{displayValue}</Accordion.Trigger>
             <Accordion.Actions>
-              <Flex direction="row" gap={disabled ? 4 : 0}>
-                <IconButton
-                  disabled={disabled}
-                  variant="ghost"
-                  onClick={onDeleteComponent}
-                  label={formatMessage({
-                    id: getTranslation('containers.Edit.delete'),
-                    defaultMessage: 'Delete',
-                  })}
-                >
-                  <Trash />
-                </IconButton>
-                <IconButton
-                  disabled={disabled}
-                  ref={composedAccordionRefs}
-                  variant="ghost"
-                  onClick={(e) => e.stopPropagation()}
-                  data-handler-id={handlerId}
-                  label={formatMessage({
-                    id: getTranslation('components.DragHandle-label'),
-                    defaultMessage: 'Drag',
-                  })}
-                  onKeyDown={handleKeyDown}
-                >
-                  <Drag />
-                </IconButton>
-              </Flex>
+              <IconButton
+                disabled={disabled}
+                variant="ghost"
+                onClick={onDeleteComponent}
+                label={formatMessage({
+                  id: getTranslation('containers.Edit.delete'),
+                  defaultMessage: 'Delete',
+                })}
+              >
+                <Trash />
+              </IconButton>
+              <IconButton
+                disabled={disabled}
+                ref={composedAccordionRefs}
+                variant="ghost"
+                onClick={(e) => e.stopPropagation()}
+                data-handler-id={handlerId}
+                label={formatMessage({
+                  id: getTranslation('components.DragHandle-label'),
+                  defaultMessage: 'Drag',
+                })}
+                onKeyDown={handleKeyDown}
+              >
+                <Drag />
+              </IconButton>
             </Accordion.Actions>
           </Accordion.Header>
           <Accordion.Content>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Disables the icon button for repeatable component in published tab 

### Why is it needed?

See #23305 

### How to test it?

Go to a repeatable component and try clicking on delete icon when in Published tab. 
Nothing will happen as it is disabled. 

Go to draft tab and click the delete button and it will work. 

### Related issue(s)/PR(s)

#23305 
