### PR TITLE
future(homepage): missing addTagTypes results in stale data

### DIFF
--- a/packages/core/content-manager/admin/src/services/homepage.ts
+++ b/packages/core/content-manager/admin/src/services/homepage.ts
@@ -2,25 +2,29 @@ import * as Homepage from '../../../shared/contracts/homepage';
 
 import { contentManagerApi } from './api';
 
-const homepageService = contentManagerApi.injectEndpoints({
-  /**
-   * TODO: Remove overrideExisting when we remove the future flag
-   * and delete the old homepage service in the admin
-   */
-  overrideExisting: true,
-  endpoints: (builder) => ({
-    getRecentDocuments: builder.query<
-      Homepage.GetRecentDocuments.Response['data'],
-      Homepage.GetRecentDocuments.Request['query']
-    >({
-      query: (params) => `/content-manager/homepage/recent-documents?action=${params.action}`,
-      transformResponse: (response: Homepage.GetRecentDocuments.Response) => response.data,
-      providesTags: (res, _err, { action }) => [
-        { type: 'RecentDocumentList' as const, id: action },
-      ],
+const homepageService = contentManagerApi
+  .enhanceEndpoints({
+    addTagTypes: ['RecentDocumentList'],
+  })
+  .injectEndpoints({
+    /**
+     * TODO: Remove overrideExisting when we remove the future flag
+     * and delete the old homepage service in the admin
+     */
+    overrideExisting: true,
+    endpoints: (builder) => ({
+      getRecentDocuments: builder.query<
+        Homepage.GetRecentDocuments.Response['data'],
+        Homepage.GetRecentDocuments.Request['query']
+      >({
+        query: (params) => `/content-manager/homepage/recent-documents?action=${params.action}`,
+        transformResponse: (response: Homepage.GetRecentDocuments.Response) => response.data,
+        providesTags: (res, _err, { action }) => [
+          { type: 'RecentDocumentList' as const, id: action },
+        ],
+      }),
     }),
-  }),
-});
+  });
 
 const { useGetRecentDocumentsQuery } = homepageService;
 


### PR DESCRIPTION
### What does it do?

Fixes the cache invalidation for the homepage widgets in the content manager

### Why is it needed?

The cache becomes stale and requires a refresh

### How to test it?

Make sure you have the future flag set for unstableWidgetsApi (set by default in examples/getstarted)
Go edit an entry
Go to the homepage
You should see your update without refreshing
Go publish and entry
Go to the hompage
You should see your published entry without refreshing



https://github.com/user-attachments/assets/5a4d236a-0049-4b35-b799-893371facd6c




