### PR TITLE
future: add missing widget link button

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import { Box, Flex, Grid, Main, Typography } from '@strapi/design-system';
 import { CheckCircle, Pencil, PuzzlePiece } from '@strapi/icons';
-import { MessageDescriptor, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
+import { Link as ReactRouterLink } from 'react-router-dom';
 
 import { Layouts } from '../../components/Layouts/Layout';
 import { Page } from '../../components/PageHelpers';
@@ -20,10 +21,7 @@ import type { WidgetType } from '@strapi/admin/strapi-admin';
  * WidgetRoot
  * -----------------------------------------------------------------------------------------------*/
 
-interface RootProps {
-  title: MessageDescriptor;
-  icon?: typeof import('@strapi/icons').PuzzlePiece;
-  permissions?: WidgetType['permissions'];
+interface WidgetRootProps extends Pick<WidgetType, 'title' | 'icon' | 'permissions' | 'link'> {
   children: React.ReactNode;
 }
 
@@ -32,7 +30,8 @@ export const WidgetRoot = ({
   icon = PuzzlePiece,
   permissions = [],
   children,
-}: RootProps) => {
+  link,
+}: WidgetRootProps) => {
   const { formatMessage } = useIntl();
   const id = React.useId();
   const Icon = icon;
@@ -74,11 +73,24 @@ export const WidgetRoot = ({
       padding={6}
       aria-labelledby={id}
     >
-      <Flex direction="row" alignItems="center" gap={2} tag="header">
-        <Icon fill="neutral500" aria-hidden />
-        <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
-          {formatMessage(title)}
-        </Typography>
+      <Flex direction="row" gap={2} justifyContent="space-between" width="100%" tag="header">
+        <Flex gap={2}>
+          <Icon fill="neutral500" aria-hidden />
+          <Typography textColor="neutral500" variant="sigma" tag="h2" id={id}>
+            {formatMessage(title)}
+          </Typography>
+        </Flex>
+        {link && (
+          <Typography
+            tag={ReactRouterLink}
+            variant="omega"
+            textColor="primary600"
+            style={{ textDecoration: 'none' }}
+            to={link.href}
+          >
+            {formatMessage(link.label)}
+          </Typography>
+        )}
       </Flex>
       <Box width="100%" height="261px" overflow="auto" tag="main">
         {permissionStatus === 'loading' && <Widget.Loading />}
@@ -148,6 +160,7 @@ const UnstableHomePageCe = () => {
                     title={widget.title}
                     icon={widget.icon}
                     permissions={widget.permissions}
+                    link={widget.link}
                   >
                     <WidgetComponent component={widget.component} />
                   </WidgetRoot>


### PR DESCRIPTION
### What does it do?

Displays the link that may be provided through the widget API

### Why is it needed?

we forgot about it, it's in the API and the designs

### How to test it?

Either register a new plugin with a link, or modify the CM plugins locally to add a link like this:


https://github.com/user-attachments/assets/f8a51fd7-09f3-40dc-a856-7b724a3717dd



### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
