### PR TITLE
fix: updated word break property for word wrap around (#23265)

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
@@ -364,7 +364,7 @@ const EditorStylesContainer = styled.div<{ $disabled?: boolean; $isExpandMode?: 
   .CodeMirror-wrap pre.CodeMirror-line-like {
     word-wrap: break-word;
     white-space: pre-wrap;
-    word-break: normal;
+    word-break: break-word;
   }
 
   .CodeMirror-linebackground {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes word wrap issue in text editor

### Why is it needed?

See #23265 

### How to test it?

Enter a long word and notice that the word is getting wrapped around

### Related issue(s)/PR(s)

#23265 
