### PR TITLE
fix: locale selector dropdown showing incorrect status in content man…

### DIFF
--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -283,7 +283,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       const otherStatus = await this.getManyAvailableStatus(uid, document.localizations);
 
       document.localizations = document.localizations.map((d) => {
-        const status = otherStatus.find((s) => s.documentId === d.documentId);
+        const status = otherStatus.find((s) => s.documentId === d.documentId && s.locale === d.locale);
         return {
           ...d,
           status: this.getStatus(d, status ? [status] : []),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
The PR fixes the issue of showing incorrect status of the locale in content manager locale dropdown.
When the API is called for model it includes localisations array with available locales, however the status for some of the locale is set incorrect because the filtering for `document.localisation` was incorrect. I have added another condition to check if the locale with that `documentId` and `locale` name is present otherwise empty array should be passed. This ensures the locale status is set correctly.

### Why is it needed?
Issue reported: https://github.com/strapi/strapi/issues/23414

### How to test it?
Repeat the steps mentioned in the issue. Check the status for all locales remains correct and does not show incorrect value.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/23414
