### PR TITLE
fix(content-manager): use UID instead of “undefined” for missing translations

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -36,13 +36,12 @@ export const ResponsiveGridItem =
 
 interface FormLayoutProps extends Pick<EditLayout, 'layout'> {
   hasBackground?: boolean;
-  model?: string;
   document: ReturnType<UseDocument>;
 }
 
 const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps) => {
   const { formatMessage } = useIntl();
-  const model = document.schema?.modelName;
+  const modelUid = document.schema?.uid;
 
   return (
     <Flex direction="column" alignItems="stretch" gap={6}>
@@ -54,7 +53,7 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
           const fieldWithTranslatedLabel = {
             ...field,
             label: formatMessage({
-              id: `content-manager.content-types.${model}.${field.name}`,
+              id: `content-manager.content-types.${modelUid}.${field.name}`,
               defaultMessage: field.label,
             }),
           };
@@ -86,7 +85,7 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
                     const fieldWithTranslatedLabel = {
                       ...field,
                       label: formatMessage({
-                        id: `content-manager.content-types.${model}.${field.name}`,
+                        id: `content-manager.content-types.${modelUid}.${field.name}`,
                         defaultMessage: field.label,
                       }),
                     };


### PR DESCRIPTION
### What does it do?

- To fix the "undefined" string, use `uid` instead of `modelName`.
- Remove the now-unused model?: string prop from the FormLayoutProps interface.

### Why is it needed?

In development mode, schema.modelName is always undefined, so every translation key fell back to:
```
Error: [@formatjs/intl Error MISSING_TRANSLATION] Missing message: "content-manager.content-types.undefined.content"
```
