### PR TITLE
fix: define an initial ComponentProvider on top of the Relation Modal

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -333,6 +333,11 @@ const RelationModal = ({ children }: { children: React.ReactNode }) => {
   const currentDocument = useRelationModal('RelationModalForm', (state) => state.currentDocument);
   const isCreating = useRelationModal('RelationModalForm', (state) => state.isCreating);
 
+  /*
+   * We must wrap the modal window with Component Provider with reset values
+   * to avoid inheriting id and uid from the root document and having weird
+   * behaviors with simple relationships..
+   */
   return (
     <ComponentProvider id={undefined} level={-1} uid={undefined} type={undefined}>
       <Modal.Root

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -38,6 +38,7 @@ import { createYupSchema } from '../../../../../utils/validation';
 import { DocumentActionButton } from '../../../components/DocumentActions';
 import { DocumentStatus } from '../../DocumentStatus';
 import { FormLayout } from '../../FormLayout';
+import { ComponentProvider } from '../ComponentContext';
 
 import type { ContentManagerPlugin, DocumentActionProps } from '../../../../../content-manager';
 
@@ -333,94 +334,96 @@ const RelationModal = ({ children }: { children: React.ReactNode }) => {
   const isCreating = useRelationModal('RelationModalForm', (state) => state.isCreating);
 
   return (
-    <Modal.Root
-      open={state.isModalOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          dispatch({
-            type: 'CLOSE_MODAL',
-            payload: { shouldBypassConfirmation: false },
-          });
-        }
-      }}
-    >
-      {children}
-      <StyledModalContent>
-        <Modal.Header gap={2}>
-          <Flex justifyContent="space-between" alignItems="center" width="100%">
-            <Flex gap={2}>
+    <ComponentProvider id={undefined} level={-1} uid={undefined} type={undefined}>
+      <Modal.Root
+        open={state.isModalOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            dispatch({
+              type: 'CLOSE_MODAL',
+              payload: { shouldBypassConfirmation: false },
+            });
+          }
+        }}
+      >
+        {children}
+        <StyledModalContent>
+          <Modal.Header gap={2}>
+            <Flex justifyContent="space-between" alignItems="center" width="100%">
+              <Flex gap={2}>
+                <IconButton
+                  withTooltip={false}
+                  label={formatMessage({ id: 'global.back', defaultMessage: 'Back' })}
+                  variant="ghost"
+                  disabled={state.documentHistory.length < 2}
+                  onClick={() => {
+                    dispatch({
+                      type: 'GO_BACK',
+                      payload: { shouldBypassConfirmation: false },
+                    });
+                  }}
+                  marginRight={1}
+                >
+                  <ArrowLeft />
+                </IconButton>
+                <Typography tag="span" fontWeight={600}>
+                  {isCreating
+                    ? formatMessage({
+                        id: 'content-manager.relation.create',
+                        defaultMessage: 'Create a relation',
+                      })
+                    : formatMessage({
+                        id: 'content-manager.components.RelationInputModal.modal-title',
+                        defaultMessage: 'Edit a relation',
+                      })}
+                </Typography>
+              </Flex>
               <IconButton
-                withTooltip={false}
-                label={formatMessage({ id: 'global.back', defaultMessage: 'Back' })}
-                variant="ghost"
-                disabled={state.documentHistory.length < 2}
                 onClick={() => {
                   dispatch({
-                    type: 'GO_BACK',
-                    payload: { shouldBypassConfirmation: false },
+                    type: 'GO_FULL_PAGE',
                   });
-                }}
-                marginRight={1}
-              >
-                <ArrowLeft />
-              </IconButton>
-              <Typography tag="span" fontWeight={600}>
-                {isCreating
-                  ? formatMessage({
-                      id: 'content-manager.relation.create',
-                      defaultMessage: 'Create a relation',
-                    })
-                  : formatMessage({
-                      id: 'content-manager.components.RelationInputModal.modal-title',
-                      defaultMessage: 'Edit a relation',
-                    })}
-              </Typography>
-            </Flex>
-            <IconButton
-              onClick={() => {
-                dispatch({
-                  type: 'GO_FULL_PAGE',
-                });
-                if (!state.hasUnsavedChanges) {
-                  if (isCreating) {
-                    navigate(generateCreateUrl(currentDocumentMeta));
-                  } else {
-                    navigate(getFullPageUrl(currentDocumentMeta));
+                  if (!state.hasUnsavedChanges) {
+                    if (isCreating) {
+                      navigate(generateCreateUrl(currentDocumentMeta));
+                    } else {
+                      navigate(getFullPageUrl(currentDocumentMeta));
+                    }
                   }
-                }
-              }}
-              variant="tertiary"
-              label={formatMessage({
-                id: 'content-manager.components.RelationInputModal.button-fullpage',
-                defaultMessage: 'Go to entry',
-              })}
-            >
-              <ArrowsOut />
-            </IconButton>
-          </Flex>
-        </Modal.Header>
-        <Modal.Body>
-          <FormContext
-            method={isCreating ? 'POST' : 'PUT'}
-            initialValues={currentDocument.getInitialFormValues(isCreating)}
-            validate={(values: Record<string, unknown>, options: Record<string, string>) => {
-              const yupSchema = createYupSchema(
-                currentDocument.schema?.attributes,
-                currentDocument.components,
-                {
-                  status: currentDocument.document?.status,
-                  ...options,
-                }
-              );
+                }}
+                variant="tertiary"
+                label={formatMessage({
+                  id: 'content-manager.components.RelationInputModal.button-fullpage',
+                  defaultMessage: 'Go to entry',
+                })}
+              >
+                <ArrowsOut />
+              </IconButton>
+            </Flex>
+          </Modal.Header>
+          <Modal.Body>
+            <FormContext
+              method={isCreating ? 'POST' : 'PUT'}
+              initialValues={currentDocument.getInitialFormValues(isCreating)}
+              validate={(values: Record<string, unknown>, options: Record<string, string>) => {
+                const yupSchema = createYupSchema(
+                  currentDocument.schema?.attributes,
+                  currentDocument.components,
+                  {
+                    status: currentDocument.document?.status,
+                    ...options,
+                  }
+                );
 
-              return yupSchema.validate(values, { abortEarly: false });
-            }}
-          >
-            <RelationModalBody />
-          </FormContext>
-        </Modal.Body>
-      </StyledModalContent>
-    </Modal.Root>
+                return yupSchema.validate(values, { abortEarly: false });
+              }}
+            >
+              <RelationModalBody />
+            </FormContext>
+          </Modal.Body>
+        </StyledModalContent>
+      </Modal.Root>
+    </ComponentProvider>
   );
 };
 /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It avoids having issues of passing the ComponentProvider from the Edit view document to a new document in the create relaton

### Why is it needed?

Because otherwise if you try to create a document starting from a root document that contains a component the uid and id of the component are passed to the children

### How to test it?

Try to add a collection that contains a component with a relation and then try to create a new document from the parent DZ component, the new Document needs to contains another DZ

### Related issue(s)/PR(s)

CS-1419
