### PR TITLE
feat(media-library): add aria-selected and click handlers for better …

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -34,6 +34,8 @@ export interface CarouselAssetsProps {
   onEditAsset?: (asset: FileAsset) => void;
   onNext: () => void;
   onPrevious: () => void;
+  onClickAsset: (asset: FileAsset, event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  onDoubleClickAsset: (asset: FileAsset, event?: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   required?: boolean;
   selectedAssetIndex: number;
   trackedLocation?: string;
@@ -55,6 +57,8 @@ export const CarouselAssets = React.forwardRef(
       onEditAsset,
       onNext,
       onPrevious,
+      onClickAsset,
+      onDoubleClickAsset,
       required = false,
       selectedAssetIndex,
       trackedLocation,
@@ -125,6 +129,12 @@ export const CarouselAssets = React.forwardRef(
                   },
                   { n: index + 1, m: assets.length }
                 )}
+                onClick={(event) => onClickAsset(asset, event)}
+                onDoubleClick={(event) => {  
+                  setIsEditingAsset(true);
+                  onDoubleClickAsset(asset, event);
+                }}
+                aria-selected={currentAsset.id === asset.id}
               >
                 <CarouselAsset asset={asset} />
               </CarouselSlide>

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
@@ -4,14 +4,15 @@ import * as React from 'react';
 import { useField, useNotification } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
 
-import { getTrad, getAllowedFiles, AllowedFiles } from '../../utils';
+import { AllowedFiles, getAllowedFiles, getTrad } from '../../utils';
 import { AssetDialog } from '../AssetDialog/AssetDialog';
 import { EditFolderDialog } from '../EditFolderDialog/EditFolderDialog';
-import { UploadAssetDialog, Asset } from '../UploadAssetDialog/UploadAssetDialog';
+import { Asset, UploadAssetDialog } from '../UploadAssetDialog/UploadAssetDialog';
 
 import { CarouselAssets, CarouselAssetsProps, FileWithoutIdHash } from './Carousel/CarouselAssets';
 
 import type { File } from '../../../../shared/contracts/files';
+
 type AllowedTypes = 'files' | 'images' | 'videos' | 'audios';
 
 const STEPS = {
@@ -180,6 +181,17 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
         : [allowedUploadedFiles[0]];
     }
 
+    const handleClickAsset = (asset: File) => {
+      const selectedIndex = selectedAssets.findIndex((prevAsset) => prevAsset.id === asset.id);
+      if (selectedIndex >= 0) {
+        setSelectedIndex(selectedAssets.findIndex((prevAsset) => prevAsset.id === asset.id));
+      }
+    };
+
+    const handleDoubleClickAsset = (asset: File) => {
+      handleAssetEdit(asset);
+    };
+
     return (
       <>
         <CarouselAssets
@@ -195,6 +207,8 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
           onEditAsset={handleAssetEdit}
           onNext={handleNext}
           onPrevious={handlePrevious}
+          onClickAsset={handleClickAsset}
+          onDoubleClickAsset={handleDoubleClickAsset}
           error={error}
           hint={hint}
           required={required}


### PR DESCRIPTION
Enhance asset selection with accessibility improvements

### What does it do?
- Adds aria-selected attribute to asset components for better accessibility
- Implements onClickAsset and onDoubleClickAsset methods to handle selection interactions
- Improves selection visibility in fields with large amounts of assets
- Provides styling options for customizing the media field appearance

### Why is it needed?
Media fields with large numbers of assets were difficult to navigate for users relying on assistive technologies. The aria-selected attribute enhances screen reader support by clearly communicating selection state. The improved selection handling and styling options allow developers to create more accessible and visually distinguishable interfaces when dealing with numerous assets in a single field.

### How to test it?
1. Create a media field with multiple assets (10+)
2. Navigate through assets using keyboard and verify aria-selected="true" is properly applied
3. Test with a screen reader to confirm selection announcements
4. Customize the styling using the new options and verify visual indicators for selection