### PR TITLE
fix: use text for encrypted key of viewable api token

### DIFF
--- a/packages/core/admin/server/src/content-types/api-token.ts
+++ b/packages/core/admin/server/src/content-types/api-token.ts
@@ -48,7 +48,7 @@ export default {
       searchable: false,
     },
     encryptedKey: {
-      type: 'string',
+      type: 'text',
       minLength: 1,
       configurable: false,
       required: false,


### PR DESCRIPTION
### What does it do?

Uses 'text' instead of 'string' to store the encrypted key

### Why is it needed?

The size of the string exceeds the length of varchar(255) so mysql and postgres fail to start up

### How to test it?

- Set the encryptedKey config property
- using mysql + postgres
  - start up strapi; it should work now

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
