### PR TITLE
fix(types): add missing flags prop to admin config

### DIFF
--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -35,6 +35,11 @@ export interface TransferProp {
   token: TransferTokenProp;
 }
 
+export interface FlagsProp {
+  nps?: boolean | undefined;
+  promoteEE?: boolean | undefined;
+}
+
 export interface Admin {
   // required
   apiToken: ApiTokenProp;
@@ -46,4 +51,5 @@ export interface Admin {
   url?: string;
   forgotPassword?: ForgotPasswordProp;
   rateLimit?: RateLimitProp;
+  flags?: FlagsProp;
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds the missing config `Admin['flags']` prop

### Why is it needed?

When typing `config/admin.ts`  TS gives an error

```
Object literal may only specify known properties, and 'flags' does not exist in type 'Admin'.ts(2353)
```

https://docs.strapi.io/cms/configurations/admin-panel#available-options

| Parameter | Description | Type | Default |
|--------|--------|--------|--------|
| `flags` | Settings to turn certain features or elements of the admin on or off | `object` | - |
| `flags.nps` | Enable/Disable the Net Promoter Score popup | `boolean` | `true` | 
| `flags.promoteEE` | Enable/Disable the promotion of Strapi Enterprise features | `boolean` | `true` | 

### How to test it?

Add `Core.Config.Admin` return type to the `config/admin.ts`

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/22620
