### PR TITLE
fix(types): add missing `settings.useTypescriptMigrations` prop to database config

### DIFF
--- a/packages/core/types/src/core/config/database.ts
+++ b/packages/core/types/src/core/config/database.ts
@@ -59,7 +59,8 @@ export interface Database<TClient extends ClientKind> {
       unknown
     >;
   settings?: {
-    forceMigration?: boolean;
-    runMigrations?: boolean;
+    forceMigration?: boolean | undefined;
+    runMigrations?: boolean | undefined;
+    useTypescriptMigrations?: boolean | undefined;
   };
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add missing `settings.useTypescriptMigrations` prop to database config

### Why is it needed?

When adding `settings.useTypescriptMigrations` to config/database.ts TS gives an error

```
Object literal may only specify known properties, and 'useTypescriptMigrations' does not exist in type '{ forceMigration?: boolean | undefined; runMigrations?: boolean | undefined; }'.ts(2353)
```

https://docs.strapi.io/cms/database-migrations#handling-migrations-with-typescript-code

### How to test it?

Add `settings.useTypescriptMigrations` to the `config/database.ts`
