### PR TITLE
Fix: upload-aws-s3 package support support for AWS STS sessions when developing locally

### DIFF
--- a/packages/providers/upload-aws-s3/src/__tests__/utils.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ import { extractCredentials } from '../utils';
 
 const accessKeyId = 'AWS_ACCESS_KEY_ID';
 const secretAccessKey = 'AWS_ACCESS_SECRET';
+const sessionToken = 'AWS_SESSION_TOKEN';
 
 const defaultOptions = {
   region: 'AWS_REGION',
@@ -31,6 +32,25 @@ describe('Utils', () => {
       expect(credentials).toEqual({
         accessKeyId,
         secretAccessKey,
+      });
+    });
+    test('Ensure sessionToken s3Options gets extracted when provided', () => {
+      const options: InitOptions = {
+        s3Options: {
+          credentials: {
+            accessKeyId,
+            secretAccessKey,
+            sessionToken,
+          },
+          ...defaultOptions,
+        },
+      };
+      const credentials = extractCredentials(options);
+
+      expect(credentials).toEqual({
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
       });
     });
     test('Does not throw an error when credentials are not present', () => {

--- a/packages/providers/upload-aws-s3/src/utils.ts
+++ b/packages/providers/upload-aws-s3/src/utils.ts
@@ -93,6 +93,7 @@ export const extractCredentials = (options: InitOptions): AwsCredentialIdentity 
     return {
       accessKeyId: options.s3Options.credentials.accessKeyId,
       secretAccessKey: options.s3Options.credentials.secretAccessKey,
+      sessionToken: options.s3Options.credentials.sessionToken,
     };
   }
   return null;


### PR DESCRIPTION
### What does it do?

Updated the function that handles the credentials for AWS so sessionTokens are passed through when specified.

### Why is it needed?

For developers who are running Strapi locally and aren't in a position to use a IAM user or are using STS credentials to have the ability to make requests to S3 and not depend on IAM credentials.

### How to test it?

Follow documentation to add the upload-aws-s3 locally
Add the following config to the S3 Options in the `plugins.ts` file
```
credentials: {
  accessKeyId: env('AWS_ACCESS_KEY_ID') || process.env.AWS_ACCESS_KEY_ID,
  secretAccessKey: env('AWS_SECRET_ACCESS_KEY') || process.env.AWS_SECRET_ACCESS_KEY,
  sessionToken: env('AWS_SESSION_TOKEN') || process.env.AWS_SESSION_TOKEN,
},
```
Test an upload in the Media Library

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
