### PR TITLE
fix(content-manager): undefined model name in translation path #23255

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -42,7 +42,7 @@ interface FormLayoutProps extends Pick<EditLayout, 'layout'> {
 
 const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps) => {
   const { formatMessage } = useIntl();
-  const model = document.schema?.modelName;
+  const model = document.schema?.uid;
 
   return (
     <Flex direction="column" alignItems="stretch" gap={6}>


### PR DESCRIPTION
### What does it do?

Fixes the broken translation path of the content-type related labels in the content-manager EditView

### Why is it needed?

All translation keys related to the `FormLayout` contains "undefined" instead of the document id. It breaks translations in EditView part of the administration and makes impossible customizations per document translation.

### How to test it?

To reproduce the issue : 

- the issue can be reproduce on version >= 5.12
- follow the get started guide, use the develop branch
- add a translation for the Spanish language in the file `examples/getstarted/src/admin/app.jsx`, for the example `"content-manager.content-types.api::address.address.postal_code" : "Código Postal"`
- login into admin
- go to user profil and change the interface language for Spanish
- go to "address" the collection in the content manager section
- open the browser console in order to display error messages
- create a new entry
- in the console, you can see errors related the content type translation : 'Missing message : "content-manager.content-types.undefined.postal_code"'
- The label for the field "postal_code" is not translated

To test the fix : 

- switch to this branch
- Follow the same steps
- For the missing translations the error is now : 'Missing message : "content-manager.content-types.api::address.address.xxx"'
- The label for the field "postal_code" is translated

### Related issue(s)/PR(s)

Related issue : https://github.com/strapi/strapi/issues/23255
