### PR TITLE
Display error when loading email provider

### DIFF
--- a/packages/core/email/server/src/bootstrap.ts
+++ b/packages/core/email/server/src/bootstrap.ts
@@ -37,7 +37,9 @@ const createProvider = (emailConfig: EmailConfig) => {
   try {
     provider = require(modulePath);
   } catch (err) {
-    throw new Error(`Could not load email provider "${providerName}".`);
+    const newError = new Error(`Could not load upload provider "${providerName}".`);
+    newError.stack = err.stack;
+    throw newError;
   }
 
   return provider.init(emailConfig.providerOptions, emailConfig.settings);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Display custom email provider errors
Similar as https://github.com/strapi/strapi/pull/13092

### Why is it needed?

Currently in a process to write a custom email provider. 
There were errors in the provider, Strapi greets me with a generic "Could not load email provider" when starting in development mode. 
Got mislead thinking it was a setup error somewhere in the local provider setup (first time developing a custom provider).
Hopefully this will help someone in the futur!

### How to test it?

- Create a local email custom provider See https://docs.strapi.io/cms/providers#local-providers
- Add an error in the `index.js`
- Start Strapi

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/13092
