### PR TITLE
Media Library Breadcrumbs Broken for Deeply Nested Folders (404 Error).

### DIFF
--- a/packages/core/upload/admin/src/utils/getBreadcrumbDataML.ts
+++ b/packages/core/upload/admin/src/utils/getBreadcrumbDataML.ts
@@ -33,22 +33,31 @@ export const getBreadcrumbDataML = (
     },
   ];
 
-  if (folder?.parent && typeof folder?.parent !== 'number' && folder?.parent?.parent) {
-    data.push([]);
-  }
-
-  if (folder?.parent && typeof folder.parent !== 'number') {
-    data.push({
-      id: folder.parent.id,
-      label: folder.parent.name,
-      href: getFolderURL(pathname, query || {}, {
-        folder: folder.parent.id?.toString(),
-        folderPath: folder.parent.path,
-      }),
-    });
-  }
-
+  // Build the complete ancestor path if folder exists
   if (folder) {
+    // Collect all ancestors in the correct order
+    const ancestors: Folder[] = [];
+    let currentFolder = folder;
+
+    // Traverse up the folder hierarchy to collect all ancestors
+    while (currentFolder.parent && typeof currentFolder.parent !== 'number') {
+      ancestors.unshift(currentFolder.parent); // Add parent to the beginning of the array
+      currentFolder = currentFolder.parent;
+    }
+
+    // Add all ancestors to the breadcrumb data
+    ancestors.forEach((ancestor) => {
+      data.push({
+        id: ancestor.id,
+        label: ancestor.name,
+        href: getFolderURL(pathname, query || {}, {
+          folder: ancestor.id?.toString(),
+          folderPath: ancestor.path,
+        }),
+      });
+    });
+
+    // Add the current folder as the last item
     data.push({
       id: folder.id,
       label: folder.name,


### PR DESCRIPTION
What does it do?

Media Library Breadcrumbs Broken for Deeply Nested Folders (404 Error)

Why is it needed?

To fix issue https://github.com/strapi/strapi/issues/22885 Media Library Breadcrumbs Broken for Deeply Nested Folders 

How to test it?

Open Strapi's Media Library.
Create a folder named Folder1.
Inside Folder2, create a folder named Folder3.
Go into the Folder3 folder.
At the top, in the breadcrumb trail, click on Folder1.
Error:
Related issue(s)/PR(s)

fixes [22885](https://github.com/strapi/strapi/issues/22885)
