### PR TITLE
poc: content manager visual editing

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -7,32 +7,33 @@ import { unstable_useDocument as useDocument } from '@strapi/content-manager/str
 import { Grid, Flex, Typography, JSONInput, Box, Button, Portal } from '@strapi/design-system';
 import styled from 'styled-components';
 
-const FieldFrame = styled(Box)`
+const StyledFrame = styled(Box)`
   position: relative;
   width: 100%;
   button {
     position: absolute;
     top: 0;
-    /* transform: translateY(-100%); */
-    right: 0;
+    transform: translateY(-100%);
+    right: -2px;
     display: none;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
   &:hover {
     button {
       display: block;
     }
-    border: 2px solid ${({ theme }) => theme.colors.primary600};
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.primary500};
   }
 `;
 
 const FieldWrapper = ({ children, path, initialValue }) => {
   const [value, setValue] = React.useState(initialValue);
-  console.log('initialValue', initialValue, 'value', value);
+  const frame = React.useRef(null);
 
   React.useEffect(() => {
     const handleMessage = (message) => {
       if (message.data?.type === 'strapiFieldTyping' && message.data?.payload?.field === path) {
-        console.log('Field typing', message.data.payload.value);
         setValue(message.data.payload.value);
       }
     };
@@ -42,19 +43,27 @@ const FieldWrapper = ({ children, path, initialValue }) => {
   }, []);
 
   const handleClick = () => {
-    console.log(window.parent);
-    if (window.parent) {
-      window.parent.postMessage({ type: 'willEditField', payload: path }, '*');
+    if (window.parent && frame.current) {
+      window.parent.postMessage(
+        {
+          type: 'willEditField',
+          payload: {
+            path,
+            position: frame.current.getBoundingClientRect(),
+          },
+        },
+        '*'
+      );
     }
   };
 
   return (
-    <FieldFrame>
+    <StyledFrame ref={frame}>
       {children(value)}
-      <Button onClick={handleClick} size="XS">
+      <Button onClick={handleClick} size="XS" borderRadius="0">
         Edit
       </Button>
-    </FieldFrame>
+    </StyledFrame>
   );
 };
 
@@ -154,11 +163,7 @@ const PreviewComponent = () => {
                         City
                       </Typography>
                       <FieldWrapper path="city" initialValue={document?.city}>
-                        {(value) => (
-                          <Typography width={'100%'} tag="dd" display={'block'}>
-                            {value}
-                          </Typography>
-                        )}
+                        {(value) => <Typography tag="dd">{value}</Typography>}
                       </FieldWrapper>
                     </Grid.Item>
                   )}

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -4,7 +4,51 @@ import { useParams } from 'react-router-dom';
 // @ts-ignore
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
 import { unstable_useDocument as useDocument } from '@strapi/content-manager/strapi-admin';
-import { Grid, Flex, Typography, JSONInput } from '@strapi/design-system';
+import { Grid, Flex, Typography, JSONInput, Box, Button } from '@strapi/design-system';
+import styled from 'styled-components';
+
+const FieldFrame = styled(Box)`
+  position: relative;
+  width: 100%;
+  button {
+    position: absolute;
+    top: 0;
+    /* transform: translateY(-100%); */
+    right: 0;
+    display: none;
+  }
+  &:hover {
+    button {
+      display: block;
+    }
+    border: 2px solid ${({ theme }) => theme.colors.primary600};
+  }
+`;
+
+const FieldWrapper = ({ children, path }) => {
+  React.useEffect(() => {
+    const handleMessage = (message) => {};
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const handleClick = () => {
+    console.log(window.parent);
+    if (window.parent) {
+      window.parent.postMessage({ type: 'willEditField', payload: path }, '*');
+    }
+  };
+
+  return (
+    <FieldFrame>
+      {children}
+      <Button onClick={handleClick} size="XS">
+        Edit
+      </Button>
+    </FieldFrame>
+  );
+};
 
 const PreviewComponent = () => {
   const { uid: model, documentId, locale, status, collectionType } = useParams();
@@ -85,6 +129,16 @@ const PreviewComponent = () => {
                   Locale
                 </Typography>
                 <Typography tag="dd">{locale}</Typography>
+              </Grid.Item>
+              <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                <Typography variant="sigma" textColor="neutral600" tag="dt">
+                  City
+                </Typography>
+                <FieldWrapper path="city">
+                  <Typography width={'100%'} tag="dd" display={'block'}>
+                    {document?.city}
+                  </Typography>
+                </FieldWrapper>
               </Grid.Item>
             </Grid.Root>
             {document && <JSONInput value={JSON.stringify(document, null, 2)} disabled />}

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 // @ts-ignore
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
 import { unstable_useDocument as useDocument } from '@strapi/content-manager/strapi-admin';
-import { Grid, Flex, Typography, JSONInput, Box, Button } from '@strapi/design-system';
+import { Grid, Flex, Typography, JSONInput, Box, Button, Portal } from '@strapi/design-system';
 import styled from 'styled-components';
 
 const FieldFrame = styled(Box)`
@@ -25,9 +25,17 @@ const FieldFrame = styled(Box)`
   }
 `;
 
-const FieldWrapper = ({ children, path }) => {
+const FieldWrapper = ({ children, path, initialValue }) => {
+  const [value, setValue] = React.useState(initialValue);
+  console.log('initialValue', initialValue, 'value', value);
+
   React.useEffect(() => {
-    const handleMessage = (message) => {};
+    const handleMessage = (message) => {
+      if (message.data?.type === 'strapiFieldTyping' && message.data?.payload?.field === path) {
+        console.log('Field typing', message.data.payload.value);
+        setValue(message.data.payload.value);
+      }
+    };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
@@ -42,7 +50,7 @@ const FieldWrapper = ({ children, path }) => {
 
   return (
     <FieldFrame>
-      {children}
+      {children(value)}
       <Button onClick={handleClick} size="XS">
         Edit
       </Button>
@@ -78,74 +86,90 @@ const PreviewComponent = () => {
   }, []);
 
   return (
-    <Layouts.Root>
-      <Page.Main>
-        <Page.Title>{`Previewing ${model}`}</Page.Title>
-        <Layouts.Header title="Static Preview" subtitle="Dummy preview for getstarted app" />
-        <Layouts.Content>
-          <Flex
-            direction="column"
-            alignItems="stretch"
-            gap={4}
-            hasRadius
-            background="neutral0"
-            shadow="tableShadow"
-            paddingTop={6}
-            paddingBottom={6}
-            paddingRight={7}
-            paddingLeft={7}
-          >
-            <Typography variant="delta" tag="h3">
-              Details
-            </Typography>
+    <Portal>
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        bottom={0}
+        background="neutral100"
+        zIndex={100}
+      >
+        <Layouts.Root>
+          <Page.Main>
+            <Page.Title>{`Previewing ${model}`}</Page.Title>
+            <Layouts.Header title="Static Preview" subtitle="Dummy preview for getstarted app" />
+            <Layouts.Content>
+              <Flex
+                direction="column"
+                alignItems="stretch"
+                gap={4}
+                hasRadius
+                background="neutral0"
+                shadow="tableShadow"
+                paddingTop={6}
+                paddingBottom={6}
+                paddingRight={7}
+                paddingLeft={7}
+              >
+                <Typography variant="delta" tag="h3">
+                  Details
+                </Typography>
 
-            <Grid.Root gap={5} tag="dl">
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Content Type
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{model}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Document Id
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{documentId}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Status
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{status}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Locale
-                </Typography>
-                <Typography tag="dd">{locale}</Typography>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  City
-                </Typography>
-                <FieldWrapper path="city">
-                  <Typography width={'100%'} tag="dd" display={'block'}>
-                    {document?.city}
-                  </Typography>
-                </FieldWrapper>
-              </Grid.Item>
-            </Grid.Root>
-            {document && <JSONInput value={JSON.stringify(document, null, 2)} disabled />}
-          </Flex>
-        </Layouts.Content>
-      </Page.Main>
-    </Layouts.Root>
+                <Grid.Root gap={5} tag="dl">
+                  <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                    <Typography variant="sigma" textColor="neutral600" tag="dt">
+                      Content Type
+                    </Typography>
+                    <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                      <Typography>{model}</Typography>
+                    </Flex>
+                  </Grid.Item>
+                  <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                    <Typography variant="sigma" textColor="neutral600" tag="dt">
+                      Document Id
+                    </Typography>
+                    <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                      <Typography>{documentId}</Typography>
+                    </Flex>
+                  </Grid.Item>
+                  <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                    <Typography variant="sigma" textColor="neutral600" tag="dt">
+                      Status
+                    </Typography>
+                    <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                      <Typography>{status}</Typography>
+                    </Flex>
+                  </Grid.Item>
+                  <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                    <Typography variant="sigma" textColor="neutral600" tag="dt">
+                      Locale
+                    </Typography>
+                    <Typography tag="dd">{locale}</Typography>
+                  </Grid.Item>
+                  {document && (
+                    <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                      <Typography variant="sigma" textColor="neutral600" tag="dt">
+                        City
+                      </Typography>
+                      <FieldWrapper path="city" initialValue={document?.city}>
+                        {(value) => (
+                          <Typography width={'100%'} tag="dd" display={'block'}>
+                            {value}
+                          </Typography>
+                        )}
+                      </FieldWrapper>
+                    </Grid.Item>
+                  )}
+                </Grid.Root>
+                {document && <JSONInput value={JSON.stringify(document, null, 2)} disabled />}
+              </Flex>
+            </Layouts.Content>
+          </Page.Main>
+        </Layouts.Root>
+      </Box>
+    </Portal>
   );
 };
 


### PR DESCRIPTION
### What does it do?

Experiments with an implementation of visual editing in the Content Manager.

Questions:
- is there a way to not require client components for the rendering of data in RSC frameworks?
- where would the sdk part live? bundled with the client lib? somewhere else?
- what more could we do with the events? e.g. on page navigation so strapi can warn about leaving the preview
- can we rely on content source-maps to omit the need for the path field? and to get rid of FieldWrapper altogether for a global listener component?

### How to test it?

- open an Address entry
- open its preview
- hover the city field in the preview
- update content in the popover
