### PR TITLE
fix(data-transfer): abort on errors

### DIFF
--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -772,7 +772,20 @@ class TransferEngine<
       // Note: This will be configurable in the future
       await this.destinationProvider.rollback?.(e as Error);
 
+      // Ensure we close providers even on error
+      try {
+        await this.close();
+      } catch (closeError) {
+        this.reportError(closeError as Error, 'error');
+      }
+
       throw e;
+    }
+
+    // Check if there were any errors in the diagnostics
+    const hasErrors = this.diagnostics.stack.items.some((item) => item.kind === 'error');
+    if (hasErrors) {
+      throw new Error('Transfer completed with errors. Check the logs for details.');
     }
 
     return {


### PR DESCRIPTION
### What does it do?

If there was an error in the transfer, don't treat it as a success

### Why is it needed?

fixes #23485

### How to test it?

Test that errors during the transfer process cause the whole transfer to fail and not report success

In particular, test that -handled- errors such as schema mismatch are allowed to be bypassed, and only unhandled errors cause the failure.

### Related issue(s)/PR(s)

fixes #23485
