### PR TITLE
fix: avoid history data loss when license is missing

### DIFF
--- a/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
@@ -77,6 +77,7 @@ const mockStrapi = {
 // @ts-expect-error - ignore
 mockStrapi.documents.use = jest.fn();
 
+// @ts-expect-error - we're not mocking the full Strapi object
 const lifecyclesService = createLifecyclesService({ strapi: mockStrapi });
 
 describe('history lifecycles service', () => {

--- a/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
@@ -21,7 +21,11 @@ const mockGetRequestContext = jest.fn(() => {
 });
 
 const mockStrapi = {
-  service: jest.fn(),
+  service: jest.fn((name: string) => {
+    if (name === 'admin::persist-tables') {
+      return { persistTablesWithPrefix: jest.fn() };
+    }
+  }),
   plugins: {
     'content-manager': {
       service: jest.fn(() => ({
@@ -73,7 +77,6 @@ const mockStrapi = {
 // @ts-expect-error - ignore
 mockStrapi.documents.use = jest.fn();
 
-// @ts-expect-error - we're not mocking the full Strapi object
 const lifecyclesService = createLifecyclesService({ strapi: mockStrapi });
 
 describe('history lifecycles service', () => {
@@ -81,9 +84,9 @@ describe('history lifecycles service', () => {
     jest.useRealTimers();
   });
 
-  it('inits service only once', () => {
-    lifecyclesService.bootstrap();
-    lifecyclesService.bootstrap();
+  it('inits service only once', async () => {
+    await lifecyclesService.bootstrap();
+    await lifecyclesService.bootstrap();
     // @ts-expect-error - ignore
     expect(mockStrapi.documents.use).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -101,6 +101,7 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
   };
 
   const serviceUtils = createServiceUtils({ strapi });
+  const { persistTablesWithPrefix } = strapi.service('admin::persist-tables');
 
   return {
     async bootstrap() {
@@ -108,6 +109,9 @@ const createLifecyclesService = ({ strapi }: { strapi: Core.Strapi }) => {
       if (state.isInitialized) {
         return;
       }
+
+      // Avoid data loss in case users temporarily don't have a license
+      await persistTablesWithPrefix('strapi_history_versions');
 
       strapi.documents.use(async (context, next) => {
         const result = (await next()) as any;


### PR DESCRIPTION
### What does it do?

persists the history table

### Why is it needed?

We want to avoid deleting history data when users no longer have a valid license. They should be able to re-add a license and still have access to their old history.

Same thing is done for audit logs already

### How to test it?

User facing:
- Start the app with an EE license
- Make on an entry
- Open the history page, see the history versions
- Restart the app without the license
- Restart the app with the license again
- Check the history page for your entry. You should see the history versions

Or checking the implementation detail: open a database explorer, in the `core_store` table, find the `core_persisted_tables` table. The json content should include `strapi_history_versions`
