### PR TITLE
chore(ci): update trunk to v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,7 +238,7 @@ jobs:
         # Add the Trunk Analytics Uploader step
       - name: Upload results to trunk
         if: '!cancelled()'
-        uses: trunk-io/analytics-uploader@main
+        uses: trunk-io/analytics-uploader@v1
         with:
           junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi
@@ -289,7 +289,7 @@ jobs:
       # Add the Trunk Analytics Uploader step
       - name: Upload results to trunk
         if: '!cancelled()'
-        uses: trunk-io/analytics-uploader@main
+        uses: trunk-io/analytics-uploader@v1
         with:
           junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi


### PR DESCRIPTION
### What does it do?

updates trunk to stable `v1`

### Why is it needed?

for stability, we shouldn't be using `main` (`latest`)

### How to test it?

if it somehow stops reporting data to trunk, we revert it

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
