### PR TITLE
chore(deps): upgrade image-size package in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,8 @@
   "resolutions": {
     "@babel/helpers": "7.27.0",
     "@babel/runtime": "7.26.10",
-    "@babel/runtime-corejs3": "7.26.10"
+    "@babel/runtime-corejs3": "7.26.10",
+    "image-size": "1.2.1"
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "1.1.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9732,14 +9732,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"image-size@npm:^1.0.2":
-  version: 1.1.1
-  resolution: "image-size@npm:1.1.1"
+"image-size@npm:1.2.1":
+  version: 1.2.1
+  resolution: "image-size@npm:1.2.1"
   dependencies:
     queue: "npm:6.0.2"
   bin:
     image-size: bin/image-size.js
-  checksum: 10c0/2660470096d12be82195f7e80fe03274689fbd14184afb78eaf66ade7cd06352518325814f88af4bde4b26647889fe49e573129f6e7ba8f5ff5b85cc7f559000
+  checksum: 10c0/f8b3c19d4476513f1d7e55c3e6db80997b315444743e2040d545cbcaee59be03d2eb40c46be949a8372697b7003fdb0c04925d704390a7f606bc8181e25c0ed4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Fix: Update image-size to 1.2.1 in docs to resolve CVE

Dependabot Alert: image-size Denial of Service via Infinite Loop during Image Processing #486

This commit resolves a vulnerability in the `image-size` package by forcing its version to `1.2.1` within the `docs/package.json` using Yarn resolutions.

The `image-size` package, a transitive dependency pulled in by Docusaurus, had a Denial of Service vulnerability (versions >= 1.1.0, < 1.2.1). The patched version is 1.2.1.

Initially, I attempted to update the Docusaurus packages (`@docusaurus/core`, `@docusaurus/preset-classic`, `@docusaurus/theme-mermaid`) from `3.7.0`, but they were already at their latest versions and did not bring in the patched `image-size`.

I then used the `resolutions` field in `docs/package.json` to explicitly set `image-size` to `1.2.1`. This change was verified in `docs/yarn.lock`.

Note: The Docusaurus documentation website build currently fails due to unrelated TypeScript and Docusaurus configuration errors. These issues are pre-existing and outside the scope of this specific vulnerability fix. This commit solely addresses the `image-size` CVE.


### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/security/dependabot/486