### PR TITLE
fix(releases): check if review workflow service is available

### DIFF
--- a/packages/core/content-releases/server/src/services/release-action.ts
+++ b/packages/core/content-releases/server/src/services/release-action.ts
@@ -253,7 +253,8 @@ const createReleaseActionService = ({ strapi }: { strapi: Core.Strapi }) => {
           const acc = await accPromise;
           const contentTypeModel = strapi.getModel(contentTypeUid);
 
-          const workflow = await workflowsService.getAssignedWorkflow(contentTypeUid, {
+          // Workflows service may not be available depending on the license
+          const workflow = await workflowsService?.getAssignedWorkflow(contentTypeUid, {
             populate: 'stageRequiredToPublish',
           });
 

--- a/packages/core/content-releases/server/src/utils/index.ts
+++ b/packages/core/content-releases/server/src/utils/index.ts
@@ -55,7 +55,8 @@ export const isEntryValid = async (
     );
 
     const workflowsService = strapi.plugin('review-workflows').service('workflows');
-    const workflow = await workflowsService.getAssignedWorkflow(contentTypeUid, {
+    // Workflows service may not be available depending on the license
+    const workflow = await workflowsService?.getAssignedWorkflow(contentTypeUid, {
       populate: 'stageRequiredToPublish',
     });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

In the releases package, check if the review workflow service is available before calling its methods.

### Why is it needed?

#21882 integrated review workflows and releases together. There was an assumption that if the user had access to one feature, they would have access to the other. This isn't always the case however.

### How to test it?

I'll try to get it tested via an exp. release by one of the customers running into the issue before merging.
### Related issue(s)/PR(s)

fixes #23036