### PR TITLE
fix: issue #23572 support undefined allowed types

### DIFF
--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -28,7 +28,6 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": ["files", "images", "videos", "audios"],
       "pluginOptions": {}
     },
     "images": {

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/MediaLibraryInput.tsx
@@ -36,7 +36,7 @@ export interface MediaLibraryInputProps {
 export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibraryInputProps>(
   (
     {
-      attribute: { allowedTypes = ['videos', 'files', 'images', 'audios'], multiple = false } = {},
+      attribute: { allowedTypes = null, multiple = false } = {},
       label,
       hint,
       disabled = false,
@@ -48,7 +48,6 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
   ) => {
     const { formatMessage } = useIntl();
     const { onChange, value, error } = useField(name);
-    const fieldAllowedTypes = allowedTypes || ['files', 'images', 'videos', 'audios'];
     const [uploadedFiles, setUploadedFiles] = React.useState<Asset[] | File[]>([]);
     const [step, setStep] = React.useState<string | undefined>(undefined);
     const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -123,7 +122,7 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
       assets: FileWithoutIdHash[] | Asset[],
       callback: (assets?: AllowedFiles[], error?: string) => void
     ) => {
-      const allowedAssets = getAllowedFiles(fieldAllowedTypes, assets as AllowedFiles[]);
+      const allowedAssets = getAllowedFiles(allowedTypes, assets as AllowedFiles[]);
 
       if (allowedAssets.length > 0) {
         callback(allowedAssets);
@@ -137,7 +136,7 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
               defaultMessage: `You can't upload this type of file.`,
             },
             {
-              fileTypes: fieldAllowedTypes.join(','),
+              fileTypes: (allowedTypes ?? []).join(','),
             }
           ),
         });
@@ -170,10 +169,7 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
     let initiallySelectedAssets = selectedAssets;
 
     if (uploadedFiles.length > 0) {
-      const allowedUploadedFiles = getAllowedFiles(
-        fieldAllowedTypes,
-        uploadedFiles as AllowedFiles[]
-      );
+      const allowedUploadedFiles = getAllowedFiles(allowedTypes, uploadedFiles as AllowedFiles[]);
 
       initiallySelectedAssets = multiple
         ? [...allowedUploadedFiles, ...selectedAssets]
@@ -204,7 +200,7 @@ export const MediaLibraryInput = React.forwardRef<CarouselAssetsProps, MediaLibr
 
         {step === STEPS.AssetSelect && (
           <AssetDialog
-            allowedTypes={fieldAllowedTypes as AllowedTypes[]}
+            allowedTypes={allowedTypes as AllowedTypes[]}
             initiallySelectedAssets={initiallySelectedAssets}
             folderId={folderId}
             onClose={() => {

--- a/packages/core/upload/admin/src/utils/getAllowedFiles.ts
+++ b/packages/core/upload/admin/src/utils/getAllowedFiles.ts
@@ -15,7 +15,11 @@ export interface AllowedFiles extends File {
   type: string;
 }
 
-export const getAllowedFiles = (pluralTypes: string[], files: AllowedFiles[]) => {
+export const getAllowedFiles = (pluralTypes: string[] | null, files: AllowedFiles[]) => {
+  if (!pluralTypes) {
+    return files;
+  }
+
   const singularTypes = toSingularTypes(pluralTypes);
 
   const allowedFiles = files.filter((file) => {


### PR DESCRIPTION
### What does it do?

Fix #23572 

### Why is it needed?

We used a default allowed type preventing user from uploading different types even when their schema should allow it

### How to test it?

try to upload a gpx file for ex inside the CM edit view 

### Related issue(s)/PR(s)

#23572 