### PR TITLE
fix: header behind other elements

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -37,7 +37,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
           background="neutral0"
           shadow="tableShadow"
           width={`${width}px`}
-          zIndex={1}
+          zIndex={3}
           data-strapi-header-sticky
         >
           <Flex justifyContent="space-between">


### PR DESCRIPTION
### What does it do?

It fixes a z-index issue showing the content of an accordion above the sticky header in the admin interface.

![image](https://github.com/user-attachments/assets/a96720cf-9cfc-4d9a-ab13-901bdc495e56)
![image](https://github.com/user-attachments/assets/bd407bcd-e2c2-460b-baac-90c31f98abd2)

_ℹ️ I picked 3 as zIndex because I saw that the modal of the guided tour starts at 4 and the accordions are 1, it gives a tiny flexibility to have other elements at 2 while keeping the sticky header above._

### Why is it needed?

To improve the user experience on the site and improve readability when displaying accordions in the admin.

### How to test it?

- Go to the admin interface
- Go to Settings > Roles
- Click on any role
- Scroll to an accordion and expand it
- The header appear behind the content of the accordion

### Related issue(s)/PR(s)

Resolves #22208 

🚀