### PR TITLE
fix(content-manager): ui issue when too many elements in dz in config…

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -487,6 +487,7 @@ const Field = ({ attribute, components, name, index, onMoveField, onRemoveField 
               alignItems="flex-start"
               gap={2}
               width="100%"
+              wrap="wrap"
             >
               {attribute?.components.map((uid) => (
                 <ComponentLink


### PR DESCRIPTION
…ure the view

### What does it do?

Fix the UI of the dynamic zone in configure the view to display all the elements correctly when there is a lot of them. Copying the same behaviour as the create / edit view of a content to fix the issue and placing elements on a new line.

Before:
![image](https://github.com/user-attachments/assets/4b71c4ca-4fe1-429e-af78-109abcbc6587)

After:
![Screenshot 2025-06-03 at 09 19 11](https://github.com/user-attachments/assets/e41a9482-a703-4144-b6e4-5069f03ef4b2)


### Why is it needed?

UI is broken when there are too many elements in the dynamic zone field in configure the view and the user can't see the rest of the elements + the elements are shrinking and the visual is not ideal.

### How to test it?

- Go to the content manager in the admin interface
- Go to a collection type or a single type that has a dynamic zone with a lot of children elements (if not, add them before)
- Create or edit an entry
- Click on the three dots to access the settings menu and select "Configure the view"

### Related issue(s)/PR(s)

Resolves #21056

🚀
