### PR TITLE
chore: update trial ended modal logic

### DIFF
--- a/packages/core/admin/admin/src/pages/Home/components/FreeTrialEndedModal.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/FreeTrialEndedModal.tsx
@@ -57,9 +57,17 @@ export const FreeTrialEndedModal = () => {
     setOpen(false);
   };
 
+  const handleOnOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setPreviouslyOpen(true);
+    }
+
+    setOpen(isOpen);
+  };
+
   if (!previouslyOpen && isTrialEndedRecently) {
     return (
-      <Modal.Root open={open} onOpenChange={setOpen}>
+      <Modal.Root open={open} onOpenChange={handleOnOpenChange}>
         <StyledModalContent aria-labelledby="title">
           <StyledModalBody>
             <Box position="absolute" top={0} right={0} padding={2}>

--- a/packages/core/admin/admin/src/pages/Home/components/FreeTrialWelcomeModal.tsx
+++ b/packages/core/admin/admin/src/pages/Home/components/FreeTrialWelcomeModal.tsx
@@ -45,12 +45,20 @@ export const FreeTrialWelcomeModal = () => {
     setOpen(false);
   };
 
+  const handleOnOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setPreviouslyOpen(true);
+    }
+
+    setOpen(isOpen);
+  };
+
   if (previouslyOpen || !license?.isTrial) {
     return null;
   }
 
   return (
-    <Modal.Root open={open} onOpenChange={setOpen}>
+    <Modal.Root open={open} onOpenChange={handleOnOpenChange}>
       <StyledModalContent aria-labelledby="title">
         <StyledModalBody>
           <Box position="absolute" top={0} right={0} padding={2}>


### PR DESCRIPTION
### What does it do?

Fix 2 bugs found during QA

- The trial ended dialog not appearing when trial ends -> the `FreeTrialEndedModal` component now use the same logic as the `UpsellBanner` component

- LocalStorage is not updated when `FreeTrialEndedModal` and `FreeTrialWelcomeModal` modals are closed by clicking the modal background layer -> logic updated for the `onOpenChange` prop
