### PR TITLE
security(deps): upgrade koa to 2.16.1

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -111,7 +111,7 @@
     "invariant": "^2.2.4",
     "is-localhost-ip": "2.0.0",
     "jsonwebtoken": "9.0.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-compose": "4.1.0",
     "koa-passport": "6.0.0",
     "koa-static": "5.0.0",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -73,7 +73,7 @@
     "fractional-indexing": "3.2.0",
     "highlight.js": "^10.4.1",
     "immer": "9.0.21",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "lodash": "4.17.21",
     "markdown-it": "^13.0.2",
     "markdown-it-abbr": "^1.0.4",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -82,7 +82,7 @@
     "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "14.5.2",
     "@types/koa": "2.13.4",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "msw": "1.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -89,7 +89,7 @@
     "@testing-library/user-event": "14.5.2",
     "@types/fs-extra": "11.0.4",
     "@types/pluralize": "0.0.30",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -82,7 +82,7 @@
     "http-errors": "2.0.0",
     "inquirer": "8.2.5",
     "is-docker": "2.2.1",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "koa-compose": "4.1.0",
     "koa-compress": "5.1.1",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -74,7 +74,7 @@
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
     "knex": "3.0.1",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "rimraf": "5.0.5",
     "typescript": "5.4.4"
   },

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -72,7 +72,7 @@
     "@testing-library/react": "15.0.7",
     "@types/koa": "2.13.4",
     "@types/lodash": "^4.14.191",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "msw": "1.3.0",
     "react": "18.3.1",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -51,7 +51,7 @@
     "@strapi/permissions": "5.14.0",
     "@strapi/utils": "5.14.0",
     "commander": "8.3.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "node-schedule": "2.1.1",
     "typedoc": "0.25.10",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -97,7 +97,7 @@
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
     "formidable": "3.5.1",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "msw": "1.3.0",
     "react": "18.3.1",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -64,7 +64,7 @@
     "@types/koa": "2.13.4",
     "@types/node": "18.19.24",
     "eslint-config-custom": "5.14.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "tsconfig": "5.14.0"
   },

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -87,7 +87,7 @@
     "@types/koa": "2.13.4",
     "@types/koa-session": "6.4.1",
     "@types/swagger-ui-dist": "3.30.4",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "6.0.1",
     "koa-session": "6.4.0",
     "msw": "1.3.0",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -78,7 +78,7 @@
     "@types/koa__cors": "5.0.0",
     "cross-env": "^7.0.3",
     "eslint-config-custom": "5.14.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.22.3",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -57,7 +57,7 @@
     "immer": "9.0.21",
     "jsonwebtoken": "9.0.0",
     "jwk-to-pem": "2.0.5",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa2-ratelimit": "^1.1.3",
     "lodash": "4.17.21",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8692,7 +8692,7 @@ __metadata:
     invariant: "npm:^2.2.4"
     is-localhost-ip: "npm:2.0.0"
     jsonwebtoken: "npm:9.0.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa-compose: "npm:4.1.0"
     koa-passport: "npm:6.0.0"
@@ -8795,7 +8795,7 @@ __metadata:
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     markdown-it: "npm:^13.0.2"
@@ -8857,7 +8857,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
     formik: "npm:2.4.5"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
     node-schedule: "npm:2.1.1"
@@ -8905,7 +8905,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     pluralize: "npm:8.0.0"
@@ -8981,7 +8981,7 @@ __metadata:
     http-errors: "npm:2.0.0"
     inquirer: "npm:8.2.5"
     is-docker: "npm:2.2.1"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa-compose: "npm:4.1.0"
     koa-compress: "npm:5.1.1"
@@ -9034,7 +9034,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     inquirer: "npm:8.2.5"
     knex: "npm:3.0.1"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     lodash: "npm:4.17.21"
     ora: "npm:5.4.1"
     resolve-cwd: "npm:3.0.0"
@@ -9120,7 +9120,7 @@ __metadata:
     "@testing-library/react": "npm:15.0.7"
     "@types/koa": "npm:2.13.4"
     "@types/lodash": "npm:^4.14.191"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa2-ratelimit: "npm:^1.1.3"
     lodash: "npm:4.17.21"
@@ -9367,7 +9367,7 @@ __metadata:
     formik: "npm:2.4.5"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa-session: "npm:6.4.0"
     koa-static: "npm:^5.0.0"
@@ -9415,7 +9415,7 @@ __metadata:
     graphql-depth-limit: "npm:^1.1.0"
     graphql-playground-middleware-koa: "npm:^1.6.21"
     graphql-scalars: "npm:1.22.2"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-bodyparser: "npm:4.4.1"
     koa-compose: "npm:^4.1.0"
     lodash: "npm:4.17.21"
@@ -9474,7 +9474,7 @@ __metadata:
     immer: "npm:9.0.21"
     jsonwebtoken: "npm:9.0.0"
     jwk-to-pem: "npm:2.0.5"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa2-ratelimit: "npm:^1.1.3"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
@@ -9775,7 +9775,7 @@ __metadata:
     "@types/node-schedule": "npm:2.1.7"
     commander: "npm:8.3.0"
     eslint-config-custom: "npm:5.14.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     node-schedule: "npm:2.1.1"
@@ -9887,7 +9887,7 @@ __metadata:
     formik: "npm:2.4.5"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa-range: "npm:0.3.0"
     koa-static: "npm:5.0.0"
@@ -9930,7 +9930,7 @@ __metadata:
     execa: "npm:5.1.1"
     http-errors: "npm:2.0.0"
     json-logic-js: "npm:2.0.5"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"
     node-machine-id: "npm:1.1.12"
@@ -22598,9 +22598,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.4":
-  version: 2.15.4
-  resolution: "koa@npm:2.15.4"
+"koa@npm:2.16.1":
+  version: 2.16.1
+  resolution: "koa@npm:2.16.1"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -22625,7 +22625,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/fd2171b4dba706d35244fe60403a61671717a167453349813757999dad280049ddd0dcdba23cda197a5a3538f4c034cf0fd1f9caeb849be1ca1eecaa78db2f99
+  checksum: 10c0/66beb2e4d7968e1081341ea9a9c1f7f3fad4aaa0475c813f1be79ed84c345d9d45de9e34eeee3cdd790fc81ee5efbde2223d49fd5da571e29b0b3bed6baafb8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Upgrades koa from 2.15.4 to 2.16.1 for CVE-2025-32379

### Why is it needed?

CVE-2025-32379
Fixes #23653

### How to test it?

All existing tests should pass

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
