### PR TITLE
fix(upload): switching tab when updating pagination

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/AssetDialog.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/AssetDialog.tsx
@@ -146,6 +146,10 @@ export const AssetContent = ({
   const isLoading = isLoadingPermissions || isLoadingAssets || isLoadingFolders;
   const hasError = errorAssets || errorFolders;
 
+  const [activeTab, setActiveTab] = React.useState(
+    selectedAssets.length > 0 ? 'selected' : 'browse'
+  );
+
   if (isLoading) {
     return (
       <>
@@ -253,7 +257,7 @@ export const AssetContent = ({
         </Modal.Title>
       </Modal.Header>
 
-      <TabsRoot variant="simple" defaultValue={selectedAssets.length > 0 ? 'selected' : 'browse'}>
+      <TabsRoot variant="simple" value={activeTab} onValueChange={setActiveTab}>
         <Flex paddingLeft={8} paddingRight={8} paddingTop={6} justifyContent="space-between">
           <Tabs.List>
             <Tabs.Trigger value="browse">


### PR DESCRIPTION
### What does it do?

Fixes a tab switch triggered when changing page of number of items in the assets dialog.
ℹ️ It was happening if one or multiple items were already selected.

### Why is it needed?

It's not the expected behaviour and we should stay on the current tab instead of being redirected on the selected files tab.

### How to test it?

- Go to the admin interface > Content Manager
- Select a collection or a single type that has an image field
- Add / Edit an entry
- Click on the image field to open the assets modal
- Select an image
- Try to change the number of items displayed or the page in the pagination

### Related issue(s)/PR(s)

Resolves [@GemaMesasVelazquez](https://github.com/GemaMesasVelazquez) comment on [#23358](https://github.com/strapi/strapi/issues/23358#issuecomment-2918738995)

🚀