### PR TITLE
test(e2e): fix tests

### DIFF
--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, Page } from '@playwright/test';
-import { login } from '../../utils/login';
-import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { clickAndWait, describeOnCondition, findAndClose, skipCtbTour } from '../../utils/shared';
+import { clickAndWait, describeOnCondition, findAndClose, navToHeader } from '../../utils/shared';
 import { resetFiles } from '../../utils/file-reset';
 import { waitForRestart } from '../../utils/restart';
+import { sharedSetup } from '../../utils/setup';
+import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
@@ -37,17 +37,17 @@ const goToHistoryPage = async (page: Page) => {
 
 const goToContentTypeBuilder = async (page: Page) => {
   await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
-  await skipCtbTour(page);
 };
 
 describeOnCondition(edition === 'EE')('History', () => {
   test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin.tar', (cts) => cts, { coreStore: false });
-    await resetFiles();
-    await page.goto('/admin');
-    await page.evaluate(() => window.localStorage.setItem('GUIDED_TOUR_SKIPPED', 'true'));
-    await login({ page });
-    await page.waitForURL('/admin');
+    await sharedSetup('history-spec', page, {
+      login: true,
+      skipTour: true,
+      resetFiles: true,
+      importData: 'with-admin.tar',
+      resetAlways: true, // NOTE: this makes tests extremely slow, but it's necessary to ensure isolation between tests
+    });
   });
 
   test.afterAll(async () => {
@@ -55,9 +55,7 @@ describeOnCondition(edition === 'EE')('History', () => {
   });
 
   test('A user should be able to restore a history version', async ({ page }) => {
-    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-    await clickAndWait(page, page.getByRole('link', { name: /Create new entry/, exact: true }));
-    await page.waitForURL(ARTICLE_CREATE_URL);
+    await navToHeader(page, ['Content Manager', 'Create new entry'], 'Content Manager');
 
     const titleInput = page.getByRole('textbox', { name: 'title' });
     // Create an initial entry to also create an initial version
@@ -71,7 +69,6 @@ describeOnCondition(edition === 'EE')('History', () => {
     await findAndClose(page, 'Saved Document');
 
     await goToHistoryPage(page);
-    await page.waitForURL(ARTICLE_HISTORY_URL);
 
     // Select the original version and restore it
     const versionCards = page.getByRole('listitem', { name: 'Version card' });
@@ -81,7 +78,7 @@ describeOnCondition(edition === 'EE')('History', () => {
     const confirmationDialog = page.getByRole('alertdialog', { name: 'Confirmation' });
     await expect(confirmationDialog).toBeVisible();
     await confirmationDialog.getByRole('button', { name: 'Restore' }).click();
-    await page.waitForURL(ARTICLE_EDIT_URL);
+
     await expect(titleInput).toHaveValue('Being from Kansas');
   });
 

--- a/tests/e2e/tests/content-releases/releases-page.spec.ts
+++ b/tests/e2e/tests/content-releases/releases-page.spec.ts
@@ -1,19 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { clickAndWait, describeOnCondition, skipCtbTour } from '../../utils/shared';
-import { resetDatabaseAndImportDataFromPath } from '../../utils/dts-import';
-import { login } from '../../utils/login';
+import { clickAndWait, describeOnCondition } from '../../utils/shared';
 import { waitForRestart } from '../../utils/restart';
 import { resetFiles } from '../../utils/file-reset';
+import { sharedSetup } from '../../utils/setup';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
 
 describeOnCondition(edition === 'EE')('Releases page', () => {
   test.beforeEach(async ({ page }) => {
-    await resetDatabaseAndImportDataFromPath('with-admin.tar');
-    await resetFiles();
-    await page.goto('/admin');
-    await page.evaluate(() => window.localStorage.setItem('GUIDED_TOUR_SKIPPED', 'true'));
-    await login({ page });
+    await sharedSetup('history-spec', page, {
+      login: true,
+      skipTour: true,
+      resetFiles: true,
+      importData: 'with-admin.tar',
+      resetAlways: true, // NOTE: this makes tests extremely slow, but it's necessary to ensure isolation between tests
+    });
   });
 
   test.afterAll(async () => {
@@ -162,7 +163,6 @@ describeOnCondition(edition === 'EE')('Releases page', () => {
 
     // Disable draft & publish for the Article content type
     await clickAndWait(page, page.getByRole('link', { name: 'Content-Type Builder' }));
-    await skipCtbTour(page);
     await clickAndWait(page, page.getByRole('link', { name: 'Article' }));
     await clickAndWait(page, page.getByRole('button', { name: 'Edit', exact: true }));
     await clickAndWait(page, page.getByRole('tab', { name: /advanced settings/i }));

--- a/tests/e2e/utils/login.ts
+++ b/tests/e2e/utils/login.ts
@@ -28,11 +28,11 @@ export const login = async ({
 
   await page.getByRole('button', { name: 'Login' }).click();
 
-  try {
-    const dialog = page.getByRole('dialog', { name: "We're glad to have you on board" });
-    // Ensure the growth trial banner is closed
+  // Check for dialog with a short timeout
+  const dialog = page.getByRole('dialog', { name: "We're glad to have you on board" });
+  const isDialogVisible = await dialog.isVisible().catch(() => false);
+
+  if (isDialogVisible) {
     await dialog.getByRole('button', { name: 'Close' }).click();
-  } catch (e) {
-    // No dialog found, safe to continue
   }
 };


### PR DESCRIPTION
### What does it do?

fixes failing test suites impacted by changes by using the updated `sharedSetup` tools -- and giving it the ability to always reset instead of just once for suites that require isolation

### Why is it needed?

tests are failing but nothing is broken, it's just something to do with the trial skipping

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
