### PR TITLE
chore: Update settings nav UI

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { useLicenseLimits } from '../../../../../ee/admin/src/hooks/useLicenseLimits';
 import { SubNav } from '../../../components/SubNav';
 import { useTracking } from '../../../features/Tracking';
 import { SettingsMenu } from '../../../hooks/useSettingsMenu';
@@ -22,6 +23,17 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const { pathname } = useLocation();
+  const { license } = useLicenseLimits();
+
+  const availableFeatureNames = license?.features.map((feature) => feature.name);
+
+  const linksIdsToLicenseFeaturesNames = {
+    'content-releases': 'cms-content-releases',
+    'review-workflows': 'review-workflows',
+    sso: 'sso',
+    auditLogs: 'audit-logs',
+    'auditLogs-purchase-page': 'audit-logs',
+  };
 
   const filteredMenu = menu.filter(
     (section) => !section.links.every((link) => link.isDisplayed === false)
@@ -67,7 +79,19 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
                   endAction={
                     <>
                       {link?.licenseOnly && (
-                        <Lightning fill="primary600" width="1.5rem" height="1.5rem" />
+                        <Lightning
+                          fill={
+                            (availableFeatureNames || []).includes(
+                              linksIdsToLicenseFeaturesNames[
+                                link.id as keyof typeof linksIdsToLicenseFeaturesNames
+                              ] as keyof typeof availableFeatureNames
+                            )
+                              ? 'primary600'
+                              : 'neutral300'
+                          }
+                          width="1.5rem"
+                          height="1.5rem"
+                        />
                       )}
                       {link?.hasNotification && (
                         <StyledBadge

--- a/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
@@ -9,6 +9,15 @@ import { SubNav } from '../../../components/SubNav';
 import { useTracking } from '../../../features/Tracking';
 import { SettingsMenu } from '../../../hooks/useSettingsMenu';
 
+type LinkId =
+  | 'content-releases'
+  | 'review-workflows'
+  | 'sso'
+  | 'auditLogs'
+  | 'auditLogs-purchase-page';
+
+type FeatureName = 'cms-content-releases' | 'review-workflows' | 'sso' | 'audit-logs';
+
 interface SettingsNavProps {
   menu: SettingsMenu;
 }
@@ -27,7 +36,7 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
 
   const availableFeatureNames = license?.features.map((feature) => feature.name);
 
-  const linksIdsToLicenseFeaturesNames = {
+  const linksIdsToLicenseFeaturesNames: Record<LinkId, FeatureName> = {
     'content-releases': 'cms-content-releases',
     'review-workflows': 'review-workflows',
     sso: 'sso',
@@ -46,6 +55,7 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
       links: section.links.map((link) => {
         return {
           ...link,
+          id: link.id as LinkId,
           title: link.intlLabel,
           name: link.id,
         };
@@ -82,9 +92,7 @@ const SettingsNav = ({ menu }: SettingsNavProps) => {
                         <Lightning
                           fill={
                             (availableFeatureNames || []).includes(
-                              linksIdsToLicenseFeaturesNames[
-                                link.id as keyof typeof linksIdsToLicenseFeaturesNames
-                              ] as keyof typeof availableFeatureNames
+                              linksIdsToLicenseFeaturesNames[link.id]
                             )
                               ? 'primary600'
                               : 'neutral300'

--- a/packages/core/admin/admin/src/pages/Settings/components/tests/SettingsNav.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/tests/SettingsNav.test.tsx
@@ -2,6 +2,14 @@ import { render } from '@tests/utils';
 
 import { SettingsNav, SettingsNavProps } from '../SettingsNav';
 
+jest.mock('../../../../../../ee/admin/src/hooks/useLicenseLimits', () => ({
+  useLicenseLimits: jest.fn(() => ({
+    license: {
+      features: [],
+    },
+  })),
+}));
+
 const menu = [
   {
     id: 'global',

--- a/packages/core/admin/admin/src/pages/Settings/tests/SettingsPage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/tests/SettingsPage.test.tsx
@@ -8,6 +8,14 @@ import { Layout } from '../Layout';
 
 jest.mock('../../../hooks/useSettingsMenu');
 
+jest.mock('../../../../../ee/admin/src/hooks/useLicenseLimits', () => ({
+  useLicenseLimits: jest.fn(() => ({
+    license: {
+      features: [],
+    },
+  })),
+}));
+
 const LocationDisplay = () => {
   const location = useLocation();
 

--- a/packages/core/admin/ee/admin/src/constants.ts
+++ b/packages/core/admin/ee/admin/src/constants.ts
@@ -72,6 +72,7 @@ export const SETTINGS_LINKS_EE = (): SettingsMenu => ({
             intlLabel: { id: 'Settings.sso.title', defaultMessage: 'Single Sign-On' },
             to: '/settings/single-sign-on',
             id: 'sso',
+            licenseOnly: true,
           },
         ]
       : []),
@@ -84,6 +85,7 @@ export const SETTINGS_LINKS_EE = (): SettingsMenu => ({
             intlLabel: { id: 'global.auditLogs', defaultMessage: 'Audit Logs' },
             to: '/settings/audit-logs?pageSize=50&page=1&sort=date:DESC',
             id: 'auditLogs',
+            licenseOnly: true,
           },
         ]
       : []),

--- a/packages/core/content-releases/admin/src/index.ts
+++ b/packages/core/content-releases/admin/src/index.ts
@@ -67,6 +67,7 @@ const admin: Plugin.Config.AdminInput = {
           id: `${pluginId}.plugin.name`,
           defaultMessage: 'Releases',
         },
+        licenseOnly: true,
         permissions: [],
         async Component() {
           const { ProtectedReleasesSettingsPage } = await import('./pages/ReleasesSettingsPage');

--- a/packages/core/review-workflows/admin/src/index.ts
+++ b/packages/core/review-workflows/admin/src/index.ts
@@ -30,6 +30,7 @@ const admin: Plugin.Config.AdminInput = {
           id: `${PLUGIN_ID}.plugin.name`,
           defaultMessage: 'Review Workflows',
         },
+        licenseOnly: true,
         permissions: [],
         async Component() {
           const { Router } = await import('./router');


### PR DESCRIPTION
### What does it do?

Update the lighting icons in the settings left navigation column. Now all links related to premium features always show the icon, gray when the feature is disabled, and blue when the feature is available

![Screenshot 2025-06-03 alle 19 21 21](https://github.com/user-attachments/assets/50d0798c-f492-4fbc-a26d-b443dbcf1739)

### How to test it?

Using different type of licenses, make sure the icons are correctly rendered
