### PR TITLE
fix: one to many relations returns published and draft versions

### DIFF
--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -1,4 +1,4 @@
-import { get } from 'lodash/fp';
+import { get, merge } from 'lodash/fp';
 import { async, errors } from '@strapi/utils';
 import type { Internal } from '@strapi/types';
 
@@ -58,8 +58,14 @@ export default ({ strapi }: Context) => {
           }
         );
 
-        const dbQuery = strapi.get('query-params').transform(targetUID, sanitizedQuery);
-
+        const transformedQuery = strapi.get('query-params').transform(targetUID, sanitizedQuery);
+        const defaultFilters = {
+          where: {
+            // Return the same draft and publish version as the parent
+            publishedAt: { $notNull: parent.publishedAt !== null },
+          },
+        };
+        const dbQuery = merge(defaultFilters, transformedQuery);
         const data = await strapi.db?.query(contentTypeUID).load(parent, attributeName, dbQuery);
 
         const info = {

--- a/tests/api/core/strapi/document-service/dp/dz-component-relation.test.api.ts
+++ b/tests/api/core/strapi/document-service/dp/dz-component-relation.test.api.ts
@@ -1,0 +1,111 @@
+'use strict';
+
+import { Core } from '@strapi/types';
+import { createTestBuilder } from 'api-tests/builder';
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createContentAPIRequest } from 'api-tests/request';
+
+const article = {
+  kind: 'collectionType',
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  draftAndPublish: true,
+  attributes: {
+    title: {
+      type: 'string',
+    },
+  },
+};
+
+const category = {
+  kind: 'collectionType',
+  singularName: 'category',
+  pluralName: 'categories',
+  displayName: 'Category',
+  attributes: {
+    dz: {
+      type: 'dynamiczone',
+      components: ['default.component-with-relation'],
+    },
+  },
+};
+const componentWithOneToManyRelation = {
+  displayName: 'component-with-relation',
+  attributes: {
+    name: {
+      type: 'string',
+    },
+    articles: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::article.article',
+    },
+  },
+};
+
+let strapi: Core.Strapi;
+let rq;
+
+describe('Dynamic zone with component containing relation', () => {
+  const builder = createTestBuilder();
+
+  beforeAll(async () => {
+    await builder
+      .addContentType(article)
+      .addComponent(componentWithOneToManyRelation)
+      .addContentType(category)
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = await createContentAPIRequest({ strapi });
+
+    const article1 = await strapi.documents('api::article.article').create({
+      data: {
+        title: 'Article 1',
+      },
+    });
+
+    await strapi.documents('api::article.article').publish({
+      documentId: article1.documentId,
+    });
+
+    await strapi.documents('api::category.category').create({
+      data: {
+        dz: [
+          {
+            __component: 'default.component-with-relation',
+            articles: [article1.documentId],
+            name: 'TEST DZ',
+          },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  it('returns only published documents', async () => {
+    const { body } = await rq({
+      method: 'GET',
+      url: `/categories`,
+      qs: {
+        populate: {
+          dz: {
+            on: {
+              'default.component-with-relation': {
+                populate: '*',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(body.data[0].dz[0].articles.length).toBe(1);
+    expect(body.data[0].dz[0].articles.every((article) => article.publishedAt)).toBe(true);
+  });
+});


### PR DESCRIPTION
### What does it do?

- Forwards the filters to dynamic zones that contain the 'on' keyword
- Filters a graphql association to return the correct dp version

### Why is it needed?

Dynamic zones and containing a component with a oneToMany relation returns both draft and published versions

Graphql oneToMany relations (at root level) return draft and published versions

### How to test it?

**REST with DZ**
Create a dynamic zone with a component containing a one to many relation
Make a request example query `(/api/tester-rels/g3ihtqhceeog7yq8az0k84xe?populate[dz][on][default.dz-compo-rel][populate]=*)`
It should only return published relations

**GraphQL**
Create a oneToMany relation between two content types
Make a request like:
```
query TesterRels {
  testerRels {
    documentId
    testers {
      title
      documentId
    }
  }
}
```
It should only return published relations

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/23524#issuecomment-2933458701
