### PR TITLE
chore: update nodemailer from 6.9.1 to 6.10.1

### DIFF
--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "lodash": "4.17.21",
-    "nodemailer": "6.9.1"
+    "nodemailer": "6.10.1"
   },
   "devDependencies": {
     "@types/nodemailer": "6.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9528,7 +9528,7 @@ __metadata:
     "@types/nodemailer": "npm:6.4.7"
     eslint-config-custom: "npm:5.15.0"
     lodash: "npm:4.17.21"
-    nodemailer: "npm:6.9.1"
+    nodemailer: "npm:6.10.1"
     tsconfig: "npm:5.15.0"
   languageName: unknown
   linkType: soft
@@ -24637,10 +24637,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:6.9.1":
-  version: 6.9.1
-  resolution: "nodemailer@npm:6.9.1"
-  checksum: 10c0/adeaef441e31025776e8b1fa818e4b260850fbb60150f6ff7210e4de443bb32f0881a8a4967c42bb108d620f68f18369a42db29fe7cdec5e4ec09b0ddd51b19c
+"nodemailer@npm:6.10.1":
+  version: 6.10.1
+  resolution: "nodemailer@npm:6.10.1"
+  checksum: 10c0/e81fde258ea4f4e5646e9e3eebe89294d007939999d2d1a8c96c5488fa00bf659e46cf76fccb2697e9aa6ef9807a1ed47ff2aef6ad30b795e3849b6997066d16
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Updates the nodemailer package in the nodemailer email provider from `6.9.1` to `6.10.1`

### Why is it needed?

Resolves: https://github.com/advisories/GHSA-9h6g-pr28-7cqp

### How to test it?

Configure nodemailer provider and try to send emails

### Related issue(s)/PR(s)

Related to internal TID 1780
