### PR TITLE
security(deps): upgrade koa 2.16.1 

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -112,7 +112,7 @@
     "is-localhost-ip": "2.0.0",
     "js-cookie": "2.2.1",
     "jsonwebtoken": "9.0.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-bodyparser": "4.4.1",
     "koa-compose": "4.1.0",
     "koa-passport": "5.0.0",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -51,7 +51,7 @@
     "@sindresorhus/slugify": "1.1.0",
     "@strapi/types": "4.25.22",
     "@strapi/utils": "4.25.22",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-bodyparser": "4.4.1",
     "lodash": "4.17.21",
     "qs": "6.11.1"

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -80,7 +80,7 @@
     "@testing-library/user-event": "14.4.3",
     "@types/koa": "2.15.0",
     "@types/styled-components": "5.1.32",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "msw": "1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -85,7 +85,7 @@
     "@testing-library/user-event": "14.4.3",
     "@types/pluralize": "0.0.30",
     "history": "^4.9.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "5.3.4",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -73,7 +73,7 @@
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
     "knex": "2.5.0",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "rimraf": "3.0.2",
     "typescript": "5.2.2"
   },

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -69,7 +69,7 @@
     "@testing-library/react": "14.0.0",
     "@types/koa": "2.15.0",
     "@types/lodash": "^4.14.191",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "msw": "1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -77,7 +77,7 @@
     "styled-components": "5.3.3"
   },
   "peerDependencies": {
-    "koa": "^2.15.4",
+    "koa": "^2.16.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^5.2.0",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -152,7 +152,7 @@
     "https-proxy-agent": "5.0.1",
     "inquirer": "8.2.5",
     "is-docker": "2.2.1",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "4.2.0",
     "koa-compose": "4.1.0",
     "koa-compress": "5.1.0",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -52,7 +52,7 @@
     "@strapi/utils": "4.25.22",
     "commander": "8.3.0",
     "https-proxy-agent": "5.0.1",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "node-fetch": "2.7.0",
     "node-schedule": "2.1.1"
   },

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -57,7 +57,7 @@
     "@types/koa": "2.15.0",
     "@types/node": "18.18.4",
     "eslint-config-custom": "4.25.22",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa-body": "4.2.0",
     "tsconfig": "4.25.22"
   },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -73,7 +73,7 @@
     "@types/graphql-upload": "8.0.12",
     "cross-env": "^7.0.3",
     "eslint-config-custom": "4.25.22",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "5.3.4",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -56,7 +56,7 @@
     "immer": "9.0.19",
     "jsonwebtoken": "9.0.0",
     "jwk-to-pem": "2.0.5",
-    "koa": "2.15.4",
+    "koa": "2.16.1",
     "koa2-ratelimit": "^1.1.2",
     "lodash": "4.17.21",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8421,7 +8421,7 @@ __metadata:
     is-localhost-ip: "npm:2.0.0"
     js-cookie: "npm:2.2.1"
     jsonwebtoken: "npm:9.0.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-bodyparser: "npm:4.4.1"
     koa-compose: "npm:4.1.0"
     koa-passport: "npm:5.0.0"
@@ -8608,7 +8608,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.0"
     formik: "npm:2.4.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
     node-schedule: "npm:2.1.1"
@@ -8684,7 +8684,7 @@ __metadata:
     fs-extra: "npm:10.0.0"
     inquirer: "npm:8.2.5"
     knex: "npm:2.5.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     lodash: "npm:4.17.21"
     ora: "npm:5.4.1"
     resolve-cwd: "npm:3.0.0"
@@ -9137,7 +9137,7 @@ __metadata:
     "@strapi/utils": "npm:4.25.22"
     "@types/jest": "npm:29.5.2"
     "@types/lodash": "npm:^4.14.191"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-bodyparser: "npm:4.4.1"
     lodash: "npm:4.17.21"
     qs: "npm:6.11.1"
@@ -9198,7 +9198,7 @@ __metadata:
     fs-extra: "npm:10.0.0"
     history: "npm:^4.9.0"
     immer: "npm:9.0.19"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-bodyparser: "npm:4.4.1"
     lodash: "npm:4.17.21"
     pluralize: "npm:8.0.0"
@@ -9332,7 +9332,7 @@ __metadata:
     "@testing-library/react": "npm:14.0.0"
     "@types/koa": "npm:2.15.0"
     "@types/lodash": "npm:^4.14.191"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
     prop-types: "npm:^15.8.1"
@@ -9344,7 +9344,7 @@ __metadata:
     styled-components: "npm:5.3.3"
     yup: "npm:0.32.9"
   peerDependencies:
-    koa: ^2.15.4
+    koa: ^2.16.1
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^5.2.0
@@ -9406,7 +9406,7 @@ __metadata:
     graphql-playground-middleware-koa: "npm:^1.6.21"
     graphql-scalars: "npm:1.22.2"
     graphql-upload: "npm:^13.0.0"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-compose: "npm:^4.1.0"
     lodash: "npm:4.17.21"
     nexus: "npm:1.3.0"
@@ -9677,7 +9677,7 @@ __metadata:
     immer: "npm:9.0.19"
     jsonwebtoken: "npm:9.0.0"
     jwk-to-pem: "npm:2.0.5"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa2-ratelimit: "npm:^1.1.2"
     lodash: "npm:4.17.21"
     msw: "npm:1.3.0"
@@ -10018,7 +10018,7 @@ __metadata:
     https-proxy-agent: "npm:5.0.1"
     inquirer: "npm:8.2.5"
     is-docker: "npm:2.2.1"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:4.2.0"
     koa-compose: "npm:4.1.0"
     koa-compress: "npm:5.1.0"
@@ -10101,7 +10101,7 @@ __metadata:
     commander: "npm:8.3.0"
     eslint-config-custom: "npm:4.25.22"
     https-proxy-agent: "npm:5.0.1"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     node-fetch: "npm:2.7.0"
     node-schedule: "npm:2.1.1"
     tsconfig: "npm:4.25.22"
@@ -10194,7 +10194,7 @@ __metadata:
     date-fns: "npm:2.30.0"
     eslint-config-custom: "npm:4.25.22"
     http-errors: "npm:1.8.1"
-    koa: "npm:2.15.4"
+    koa: "npm:2.16.1"
     koa-body: "npm:4.2.0"
     lodash: "npm:4.17.21"
     p-map: "npm:4.0.0"
@@ -22946,9 +22946,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.4":
-  version: 2.15.4
-  resolution: "koa@npm:2.15.4"
+"koa@npm:2.16.1":
+  version: 2.16.1
+  resolution: "koa@npm:2.16.1"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -22973,7 +22973,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/fd2171b4dba706d35244fe60403a61671717a167453349813757999dad280049ddd0dcdba23cda197a5a3538f4c034cf0fd1f9caeb849be1ca1eecaa78db2f99
+  checksum: 10c0/66beb2e4d7968e1081341ea9a9c1f7f3fad4aaa0475c813f1be79ed84c345d9d45de9e34eeee3cdd790fc81ee5efbde2223d49fd5da571e29b0b3bed6baafb8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

updates koa for CVE-2025-32379

### Why is it needed?

CVE-2025-32379

### How to test it?

Everything should still work as before

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
