### PR TITLE
Fixes #22021- removed character from description

### DIFF
--- a/packages/core/admin/admin/src/translations/ar.json
+++ b/packages/core/admin/admin/src/translations/ar.json
@@ -442,7 +442,7 @@
   "content-manager.emptyAttributes.description": "أضف حقلك الأول إلى نوع المجموعة الخاصة بك",
   "content-manager.form.Input.hint.character.unit": "{maxValue, plural, one { character} other { characters}}",
   "content-manager.form.Input.hint.minMaxDivider": " / ",
-  "content-manager.form.Input.hint.text": "{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}{unit}{br}{description}",
+  "content-manager.form.Input.hint.text": "{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}",
   "content-manager.form.Input.pageEntries.inputDescription": "ملاحظة: يمكنك تجاوز هذه القيمة في صفحة إعدادات نوع المجموعة.",
   "content-manager.form.Input.sort.order": "ترتيب الافتراضي",
   "content-manager.form.Input.wysiwyg": "WYSIWYG عرض كـ",

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -220,13 +220,13 @@ const useFieldHint = (
     {
       id: 'content-manager.form.Input.hint.text',
       defaultMessage:
-        '{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}{unit}{br}{description}',
+        '{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}',
     },
     {
       min: minimum,
       max: maximum,
-      description: hint,
-      unit: units,
+      // description: hint,
+      // unit: units,
       divider: hasMinAndMax
         ? formatMessage({
             id: 'content-manager.form.Input.hint.minMaxDivider',

--- a/packages/core/content-manager/admin/src/translations/zh-Hans.json
+++ b/packages/core/content-manager/admin/src/translations/zh-Hans.json
@@ -771,7 +771,7 @@
   "content-manager.form.Input.filters": "启用筛选器",
   "content-manager.form.Input.hint.character.unit": "{maxValue, plural, one { 个字符} other { 个字符}}",
   "content-manager.form.Input.hint.minMaxDivider": " / ",
-  "content-manager.form.Input.hint.text": "{min, select, undefined {} other {最小. {min}}}{divider}{max, select, undefined {} other {最大. {max}}}{unit}{br}{description}",
+  "content-manager.form.Input.hint.text": "{min, select, undefined {} other {最小. {min}}}{divider}{max, select, undefined {} other {最大. {max}}}",
   "content-manager.form.Input.label": "标签",
   "content-manager.form.Input.label.inputDescription": "此值会覆盖表头中显示的标签",
   "content-manager.form.Input.pageEntries": "每页条目数",

--- a/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
+++ b/packages/core/content-type-builder/admin/src/components/GenericInputs.tsx
@@ -500,13 +500,13 @@ const useFieldHint = ({ description, fieldSchema, type }: UseFieldHintProps) => 
       {
         id: 'content-manager.form.Input.hint.text',
         defaultMessage:
-          '{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}{unit}{br}{description}',
+          '{min, select, undefined {} other {min. {min}}}{divider}{max, select, undefined {} other {max. {max}}}',
       },
       {
         min: minimum,
         max: maximum,
-        description: buildDescription(),
-        unit: units?.message && hasMinOrMax ? formatMessage(units.message, units.values) : null,
+        // description: buildDescription(),
+        // unit: units?.message && hasMinOrMax ? formatMessage(units.message, units.values) : null,
         divider: hasMinAndMax
           ? formatMessage({
               id: 'content-manager.form.Input.hint.minMaxDivider',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removed `{unit}{br}{description}` from `content-manager.form.Input.hint.text`. These were responsible for adding the word `character` after the min and max hint that was showed when setting field to `number` - `decimal` and giving it minimum and maximum values.
![Screenshot from 2025-06-11 11-14-07](https://github.com/user-attachments/assets/77194ab1-9a19-4bfc-a500-12513c7f716a)

### Why is it needed?

The issue at hand is of unnecessary addition of word `character` in a place where it does not need to signify character limit but rather range between 2 numbers.
![Screenshot from 2025-06-10 17-44-34](https://github.com/user-attachments/assets/5a30c717-a753-4024-a92a-94d82f7c0742)

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

This is a pull request with changes that resolve error in the following issue: https://github.com/strapi/strapi/issues/22021
