### PR TITLE
chore(deps): upgrade formidable to 3.5.4

### DIFF
--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -96,7 +96,7 @@
     "@types/koa": "2.13.4",
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
-    "formidable": "3.5.1",
+    "formidable": "3.5.4",
     "koa": "2.16.1",
     "koa-body": "6.0.1",
     "msw": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,7 +5939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@paralleldrive/cuid2@npm:2.2.2":
+"@paralleldrive/cuid2@npm:2.2.2, @paralleldrive/cuid2@npm:^2.2.2":
   version: 2.2.2
   resolution: "@paralleldrive/cuid2@npm:2.2.2"
   dependencies:
@@ -9886,7 +9886,7 @@ __metadata:
     byte-size: "npm:8.1.1"
     cropperjs: "npm:1.6.1"
     date-fns: "npm:2.30.0"
-    formidable: "npm:3.5.1"
+    formidable: "npm:3.5.4"
     formik: "npm:2.4.5"
     fs-extra: "npm:11.2.0"
     immer: "npm:9.0.21"
@@ -18577,14 +18577,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formidable@npm:3.5.1":
-  version: 3.5.1
-  resolution: "formidable@npm:3.5.1"
+"formidable@npm:3.5.4":
+  version: 3.5.4
+  resolution: "formidable@npm:3.5.4"
   dependencies:
+    "@paralleldrive/cuid2": "npm:^2.2.2"
     dezalgo: "npm:^1.0.4"
-    hexoid: "npm:^1.0.0"
     once: "npm:^1.4.0"
-  checksum: 10c0/c02fa1a027876dd9fc5abde16e9c537bec41bc652b362d0b3fd26daaae0615b9a472129c29b328a130d11f543f676acd1b13e6f28f3adc1b088cdaea9fb9e054
+  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

upgrades formidable from 3.5.1 to 3.5.4

### Why is it needed?

Removes warning for CVE-2025-46653 although Strapi does not appear to be vulnerable

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

DX-2051
