### PR TITLE
fix: validation error code

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -8,6 +8,7 @@ backend:
   - 'packages/core/*/{lib,bin,ee}/**'
   - 'tests/api/**'
   - 'packages/core/database/**'
+  - 'packages/**/**/middlewares/**/*.(js|ts)'
 frontend:
   - '.github/actions/yarn-nm-install/*.yml'
   - '.github/workflows/**'

--- a/packages/core/strapi/src/middlewares/errors.ts
+++ b/packages/core/strapi/src/middlewares/errors.ts
@@ -3,14 +3,16 @@ import type { Common } from '@strapi/types';
 
 import { formatApplicationError, formatHttpError, formatInternalError } from '../services/errors';
 
-// NOTE: The error.name check is not necessary in the v5 branch!
-// Therefore it should be considered a hack workaround for an actual bug which means that there is a bug
-// somewhere else in the code.
-// The issue is most likely somewhere where ValidationErrors are being created that are not
-// instanceof errors.ApplicationError despite actually being ApplicationErrors.
-//
-// This code is only included because v4 is in maintenance mode and this is a safe fix, but does not solve the
-// root cause of the problem.
+/**
+ * NOTE: In the v5 branch, this error.name check is not needed.
+ * This is a temporary workaround to cover a deeper bug elsewhere in the code.
+ *
+ * The real issue is likely that somewhere a ValidationError is being created
+ * that does not pass instanceof errors.ApplicationError, despite actually being an ApplicationError.
+ *
+ * This workaround is included only because v4 is in maintenance mode and this is a safe fix.
+ * It does not address the root cause of the problem.
+ */
 export function isErrorOfTypeOrSubclass<T>(
   error: any,
   constructor: { new (...args: any[]): T }


### PR DESCRIPTION
### What does it do?

- Loosens the check for error types to only compare constructor name rather than actually using `instanceof`
- Changes the CI workflow to run API tests when the middlewares files are modified so this change can be tested

### Why is it needed?

This solves an issue currently causing tests to fail where some ValidationErrors are being sent to the content API as 500 errors instead of their correct status code because despite being a ValidationError, when we check how to format the error we use `instanceof` which fails because wherever the ValidationError is coming from it's a different instance of the class.

I couldn't quickly figure out where the problem was actually coming from, and this workaround should be fine considering v4 is in maintenance mode; it actually makes it more resilient in exchange for potential problems if someone creates incompatible error classes to our own with identical names but nobody should be doing that anyway and that's an extreme edge case where the worst that would happen is an invalid status code from what I can tell.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

DX-2049
