### PR TITLE
fix(graphql): draft and publish document does not forward status arg …

### DIFF
--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -121,6 +121,15 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
   const path: string = config('endpoint');
 
   const landingPage = determineLandingPage(strapi);
+  /**
+   * We need the arguments passed to the root query to be available in the association resolver
+   * so we can forward those arguments along to any relations.
+   *
+   * In order to do that we are currently storing the arguments in context.
+   * There is likely a better solution, but for now this is the simplest fix we could find.
+   *
+   * @see https://github.com/strapi/strapi/issues/23524
+   */
   const pluginAddRootQueryArgs: ApolloServerPlugin<StrapiGraphQLContext> = {
     async requestDidStart() {
       return {
@@ -128,6 +137,7 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
           return {
             willResolveField({ source, args, contextValue, info }) {
               if (!source && info.operation.operation === 'query') {
+                // NOTE: context.rootQueryArgs is intended for internal use only
                 contextValue.rootQueryArgs = args;
               }
             },

--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -22,8 +22,6 @@ const merge = mergeWith((a, b) => {
 
 type StrapiGraphQLContext = BaseContext & {
   rootQueryArgs?: Record<string, unknown>;
-  state: any; // if you want to be stricter, replace 'any' with your app-specific state shape
-  koaContext: any;
 };
 
 export const determineLandingPage = (

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -57,16 +57,21 @@ export default ({ strapi }: Context) => {
             auth,
           }
         );
-
         const transformedQuery = strapi.get('query-params').transform(targetUID, sanitizedQuery);
 
         const defaultFilters = {
           where: {
-            // Return the same draft and publish version as the parent
-            publishedAt: { $notNull: 'publishedAt' in parent ? parent.publishedAt !== null : true },
+            publishedAt: {
+              $notNull: context.rootQueryArgs?.status
+                ? // Filter by the same status as the root query if the argument is present
+                  context.rootQueryArgs?.status === 'published'
+                : // Otherwise fallback to the published version
+                  true,
+            },
           },
         };
         const dbQuery = merge(defaultFilters, transformedQuery);
+
         const data = await strapi.db?.query(contentTypeUID).load(parent, attributeName, dbQuery);
 
         const info = {

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -1,5 +1,5 @@
 import { get, merge } from 'lodash/fp';
-import { async, errors } from '@strapi/utils';
+import { async, contentTypes, errors } from '@strapi/utils';
 import type { Internal } from '@strapi/types';
 
 import type { Context } from '../../types';
@@ -59,19 +59,23 @@ export default ({ strapi }: Context) => {
         );
         const transformedQuery = strapi.get('query-params').transform(targetUID, sanitizedQuery);
 
-        const defaultFilters = {
-          where: {
-            publishedAt: {
-              $notNull: context.rootQueryArgs?.status
-                ? // Filter by the same status as the root query if the argument is present
-                  context.rootQueryArgs?.status === 'published'
-                : // Otherwise fallback to the published version
-                  true,
-            },
-          },
-        };
-        const dbQuery = merge(defaultFilters, transformedQuery);
+        const isTargetDraftAndPublishContentType =
+          contentTypes.hasDraftAndPublish(targetContentType);
+        const defaultFilters = isTargetDraftAndPublishContentType
+          ? {
+              where: {
+                publishedAt: {
+                  $notNull: context.rootQueryArgs?.status
+                    ? // Filter by the same status as the root query if the argument is present
+                      context.rootQueryArgs?.status === 'published'
+                    : // Otherwise fallback to the published version
+                      true,
+                },
+              },
+            }
+          : {};
 
+        const dbQuery = merge(defaultFilters, transformedQuery);
         const data = await strapi.db?.query(contentTypeUID).load(parent, attributeName, dbQuery);
 
         const info = {

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
@@ -16,7 +16,10 @@ export default ({ strapi }: Context) => ({
           auth: ctx?.state?.auth,
         });
 
-        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        /**
+         * NOTE: For internal use only
+         * Store the root query args in context so they can be forwarded to deep relations
+         */
         ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findMany({ status: 'published', ...sanitizedQuery });
@@ -31,7 +34,10 @@ export default ({ strapi }: Context) => ({
           auth: ctx?.state?.auth,
         });
 
-        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        /**
+         * NOTE: For internal use only
+         * Store the root query args in context so they can be forwarded to deep relations
+         */
         ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findFirst({ status: 'published', ...sanitizedQuery });
@@ -48,7 +54,10 @@ export default ({ strapi }: Context) => ({
           auth: ctx?.state?.auth,
         });
 
-        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        /**
+         * NOTE: For internal use only
+         * Store the root query args in context so they can be forwarded to deep relations
+         */
         ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findOne({

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
@@ -16,6 +16,9 @@ export default ({ strapi }: Context) => ({
           auth: ctx?.state?.auth,
         });
 
+        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        ctx.rootQueryArgs = args;
+
         return strapi.documents!(uid).findMany({ status: 'published', ...sanitizedQuery });
       },
 
@@ -27,6 +30,9 @@ export default ({ strapi }: Context) => ({
         const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
+
+        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findFirst({ status: 'published', ...sanitizedQuery });
       },
@@ -41,6 +47,9 @@ export default ({ strapi }: Context) => ({
         const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
+
+        // Store the root query args in context so they can be accessed deeply down the tree (dz, components, etc..)
+        ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findOne({
           status: 'published',

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/query.ts
@@ -16,12 +16,6 @@ export default ({ strapi }: Context) => ({
           auth: ctx?.state?.auth,
         });
 
-        /**
-         * NOTE: For internal use only
-         * Store the root query args in context so they can be forwarded to deep relations
-         */
-        ctx.rootQueryArgs = args;
-
         return strapi.documents!(uid).findMany({ status: 'published', ...sanitizedQuery });
       },
 
@@ -33,12 +27,6 @@ export default ({ strapi }: Context) => ({
         const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
-
-        /**
-         * NOTE: For internal use only
-         * Store the root query args in context so they can be forwarded to deep relations
-         */
-        ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findFirst({ status: 'published', ...sanitizedQuery });
       },
@@ -53,12 +41,6 @@ export default ({ strapi }: Context) => ({
         const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
-
-        /**
-         * NOTE: For internal use only
-         * Store the root query args in context so they can be forwarded to deep relations
-         */
-        ctx.rootQueryArgs = args;
 
         return strapi.documents!(uid).findOne({
           status: 'published',


### PR DESCRIPTION
### What does it do?

- Stores the root query args in context so they can be accessed in the association resolver

### Why is it needed?

- parent doesn't refer to the root, in the context of a component parent is the component not the root document so it doesn't have a publishedAt attribute. 
- associations should use the same status as the root query for any relations with draft and publish

### How to test it?

GIVEN a content-type WITHOUT draft and publish that has relations, components with relations, dynamic zones with components with relations
OR 
GIVEN a content-type WITH draft and publish that has relations, components with relations, dynamic zones with components with relations

WHEN 

```
query Articles {
  articles {
    documentId
    publishedAt
    categories {
      documentId
      name
      locale
      publishedAt
    }
    compo {
      categories {
        documentId
        name
        publishedAt
      }
    }
    dz {
      ... on ComponentDefaultRelations {
        categories {
          documentId
          name
          locale
          publishedAt
        }
      }
    }
  }
}
```

THEN

- Should return all published entries all the way down the tree (NEVER both draft and published)
- The same query with articles(status: DRAFT) should return all draft entries all the way down the tree
- The same query with articles(status: PUBLISH) should return all published entries all the way down the tree

See video below where I have relations, component with relations, dz with compoonent with relations for one content-type with draft and publish and one content-type without draft and publish. 

https://github.com/user-attachments/assets/5a6544d2-550f-40c0-aaa4-dee23e009720

Test the extensions api

In your app's index file's register function add a custom resolver

```
const extension = {
  resolversConfig: {
    'Query.articleDpViaCat': {
      auth: false,
    },
  },
  typeDefs: `
    type Query {
      articleDpViaCat(catName: String!, status: String): Articledp
    }
  `,
  resolvers: {
    Query: {
      articleDpViaCat: {
        resolve: async (parent, args, context, info) => {
          const entry = await strapi.documents('api::article.article').findFirst({
            filters: {
              category: { name: args.catName },
            },
            status: args.status || 'published',
          });

          return entry;
        },
      },
    },
  },
};
// ...
register({ strapi }) {
    strapi.plugin('graphql').service('extension').use(extension);
  },
//...
```

Then query it in the playground. The expectations should be the same as above.


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/23524#issuecomment-2966669833
https://github.com/strapi/strapi/pull/23673
