### PR TITLE
fix: display name of upload plugin in roles settings

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/PluginsAndSettings.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/components/PluginsAndSettings.tsx
@@ -91,6 +91,8 @@ const Row = ({
   const { formatMessage } = useIntl();
 
   const categoryName = name.split('::').pop() ?? '';
+  const categoryDisplayName =
+    categoryName === 'upload' ? 'Media Library' : capitalise(categoryName.replace(/-/g, ' '));
 
   return (
     <Accordion.Item value={name}>
@@ -102,7 +104,7 @@ const Row = ({
             { category: categoryName }
           )} ${kind === 'plugins' ? 'plugin' : kind}`}
         >
-          {capitalise(categoryName)}
+          {categoryDisplayName}
         </Accordion.Trigger>
       </Accordion.Header>
       <Accordion.Content>

--- a/packages/plugins/users-permissions/admin/src/utils/formatPluginName.js
+++ b/packages/plugins/users-permissions/admin/src/utils/formatPluginName.js
@@ -15,7 +15,7 @@ function formatPluginName(pluginSlug) {
     case 'plugin::i18n':
       return 'i18n';
     case 'plugin::upload':
-      return 'Upload';
+      return 'Media Library';
     case 'plugin::users-permissions':
       return 'Users-permissions';
     default:


### PR DESCRIPTION
### What does it do?

Changes the name of the upload plugin in Roles and Permissions from Upload to Media Library.

Before:

![image](https://github.com/user-attachments/assets/4d91576f-b804-4471-b5c7-cc98e564d200)

After:

<img width="1046" alt="Screenshot 2025-06-13 at 11 39 05" src="https://github.com/user-attachments/assets/3697ed34-cf26-476e-9843-272df33d7db1" />


### Why is it needed?

It's confusing to the user since the plugin is called Media Library on the CMS. Even if the plugin is called upload, on the frontend it's displayed and identified as Media Library.
In a second time, we should consider moving the plugin itself but for now we just changed the displayed name in the Roles and Permissions.

### How to test it?

- Go to the admin interface > Settings > Roles
- Select any role
- Go to Plugins tab (if in Admin Roles) or by just scrolling to the accordion (if in Users & Permissions)

### Related issue(s)/PR(s)

Resolves #20842

🚀