### PR TITLE
fix: bulk publish mutliple locales does not validate required media

### DIFF
--- a/packages/core/content-manager/server/src/services/utils/__tests__/validatable-fields-populate.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/validatable-fields-populate.test.ts
@@ -38,6 +38,15 @@ describe('getPopulateForValidation', () => {
         },
       },
     },
+    media: {
+      modelName: 'Fake media model',
+      attributes: {
+        mediaAttrName: {
+          required: true,
+          type: 'media',
+        },
+      },
+    },
   } as any;
 
   beforeEach(() => {
@@ -65,6 +74,22 @@ describe('getPopulateForValidation', () => {
 
     expect(result).toEqual({
       fields: ['title'], // Only scalar fields requiring validation
+    });
+  });
+
+  test('with media model', () => {
+    const uid = 'media';
+
+    const result = getPopulateForValidation(uid as any);
+
+    expect(result).toEqual({
+      populate: {
+        mediaAttrName: {
+          populate: {
+            folder: true,
+          },
+        },
+      },
     });
   });
 

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -50,6 +50,7 @@ function getPopulateForRelation(
   // Mainly needed for bulk locale publishing, so the Client has all the information necessary to perform validations
   if (attributeName === 'localizations') {
     const validationPopulate = getPopulateForValidation(model.uid as UID.Schema);
+
     return {
       populate: validationPopulate.populate,
     };
@@ -207,6 +208,18 @@ const getPopulateForValidation = (uid: UID.Schema): Record<string, any> => {
         populateAcc.fields.push(attributeName);
       }
       return populateAcc;
+    }
+
+    if (isMedia(attribute)) {
+      if (getDoesAttributeRequireValidation(attribute)) {
+        populateAcc.populate = populateAcc.populate || {};
+        populateAcc.populate[attributeName] = {
+          populate: {
+            folder: true,
+          },
+        };
+        return populateAcc;
+      }
     }
 
     if (isComponent(attribute)) {


### PR DESCRIPTION
### What does it do?

Ensures required media are populated for validation across locales

### Why is it needed?

Bulk publish in multiple locales does not validate since the localization attribute is not populated correctly

### How to test it?

Use a content-type with i18n, draft and publish, and a required media attribute
Create a document with a draft version in two languages (don't add the image)
Click the 3 dots and then Publish in multiple locales
In the modal you should see validation failing for both since there is no image
Go update the drafts for both to include an image
Now try to publish multiple locales again
There should be no validation errors and you should be able to publish in both locales

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/23056
