### PR TITLE
fix: design of user status

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -288,14 +288,10 @@ const TABLE_HEADERS: Array<
     cellFormatter({ isActive }) {
       return (
         <Flex>
-          <Status
-            size="S"
-            borderWidth={0}
-            background="transparent"
-            color="neutral800"
-            variant={isActive ? 'success' : 'danger'}
-          >
-            <Typography>{isActive ? 'Active' : 'Inactive'}</Typography>
+          <Status size="S" variant={isActive ? 'success' : 'danger'}>
+            <Typography tag="span" variant="omega" fontWeight="bold">
+              {isActive ? 'Active' : 'Inactive'}
+            </Typography>
           </Status>
         </Flex>
       );


### PR DESCRIPTION
### What does it do?

Fixing the design of the user's status in the list in Settings > Administration Panel > Users to match other badges in the CMS.

Before:

![Screenshot 2025-06-18 at 16 09 54](https://github.com/user-attachments/assets/1780eb3b-5f23-4780-9243-65d904acadfc)
![Screenshot 2025-06-18 at 16 10 23](https://github.com/user-attachments/assets/b7625f27-52a7-4630-9f61-dc208a560af4)

After:

![Screenshot 2025-06-17 at 16 06 56](https://github.com/user-attachments/assets/d369390d-846a-48c1-9ffe-f8f63987a5a6)
![Screenshot 2025-06-17 at 16 07 12](https://github.com/user-attachments/assets/693125db-8d4d-407d-8def-42de0015e090)

_There's also an initiative to revamp the badges in the design system to unify them on the CMS here: https://github.com/strapi/design-system/issues/1935_

### Why is it needed?

To unify the experience of the badges and their meaning.

### How to test it?

- Go to the admin interface > Settings > Administration panel > Users
- The tags are displayed in each element of the list (Active / Inactive)

### Related issue(s)/PR(s)

Resolves #21343

🚀