### PR TITLE
refactor: remove didusersendmessage tracking event

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -378,14 +378,6 @@ interface DidUsePresetPromptEvent {
   };
 }
 
-interface DidUserSendMessageEvent {
-  name: 'didUserSendMessage';
-  properties: {
-    'attachment-type': 'code' | 'figma' | 'image' | 'none';
-    'number-of-input-tokens': number;
-  };
-}
-
 interface DidAnswerMessageEvent {
   name: 'didAnswerMessage';
   properties: {
@@ -431,7 +423,6 @@ type EventsWithProperties =
   | DidSortMediaLibraryElementsEvent
   | DidSubmitWithErrorsFirstAdminEvent
   | DidUsePresetPromptEvent
-  | DidUserSendMessageEvent
   | DidAnswerMessageEvent
   | DidVoteAnswerEvent
   | LogoEvent

--- a/packages/core/content-type-builder/admin/src/components/AIChat/UploadCodeModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/UploadCodeModal.tsx
@@ -376,8 +376,7 @@ export const UploadCodeModal = () => {
   });
 
   const { isCodeUploadOpen, closeCodeUpload, submitOnFinish } = useUploadProjectToChat();
-  const { setMessages, reload, openChat, input, setInput, setCurrentAttachmentType } =
-    useStrapiChat();
+  const { setMessages, reload, openChat, input, setInput } = useStrapiChat();
 
   const handleCancel = () => {
     setProjectName(null);
@@ -386,8 +385,6 @@ export const UploadCodeModal = () => {
   };
 
   const handleComplete = async () => {
-    setCurrentAttachmentType('code');
-
     // Ensure chat is opened
     openChat();
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/UploadFigmaModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/UploadFigmaModal.tsx
@@ -274,8 +274,6 @@ export const UploadFigmaModal = () => {
   const [selectedImages, setSelectedImages] = useState<string[]>([]);
   const { t } = useTranslations();
 
-  const { setCurrentAttachmentType } = useStrapiChat();
-
   const { addAttachments } = useAttachments();
   const { isFigmaUploadOpen, closeFigmaUpload, submitOnFinish } = useUploadFigmaToChat();
   const { input, setInput, setMessages, reload, openChat } = useStrapiChat();
@@ -319,8 +317,6 @@ export const UploadFigmaModal = () => {
       closeFigmaUpload();
       return;
     }
-
-    setCurrentAttachmentType('figma');
 
     // Ensure chat is opened
     openChat();

--- a/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAttachments.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/hooks/useAttachments.ts
@@ -11,7 +11,7 @@ import { useFetchUploadMedia } from './useAIFetch';
 import type { Attachment } from '../lib/types/attachments';
 
 export function useAttachments() {
-  const { setAttachments, attachments, id: chatId, setCurrentAttachmentType } = useStrapiChat();
+  const { setAttachments, attachments, id: chatId } = useStrapiChat();
   const { toggleNotification } = useNotification();
 
   const { fetch: fetchUploadMedia } = useFetchUploadMedia();
@@ -85,10 +85,6 @@ export function useAttachments() {
         }
       }
 
-      if (limitedFiles.length > 0) {
-        setCurrentAttachmentType('image');
-      }
-
       // Upload
       for (const file of limitedFiles) {
         const pendingAttachment: Attachment = {
@@ -149,7 +145,6 @@ export function useAttachments() {
       fetchUploadMedia,
       removeAttachment,
       updateAttachment,
-      setCurrentAttachmentType,
     ]
   );
 

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
@@ -20,8 +20,6 @@ import { UploadFigmaToChatProvider } from '../UploadFigmaModal';
 
 import { SchemaChatProvider } from './SchemaProvider';
 
-type AttachmentType = 'code' | 'figma' | 'image' | 'none';
-
 interface ChatContextType extends Omit<ReturnType<typeof useChat>, 'messages'> {
   isChatEnabled: boolean;
   title?: string;
@@ -37,9 +35,6 @@ interface ChatContextType extends Omit<ReturnType<typeof useChat>, 'messages'> {
   // Attachments
   attachments: Attachment[];
   setAttachments: React.Dispatch<React.SetStateAction<Attachment[]>>;
-  // Attachment type tracking
-  currentAttachmentType: AttachmentType;
-  setCurrentAttachmentType: (type: AttachmentType) => void;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -61,9 +56,6 @@ export const BaseChatProvider = ({
 
   // Files
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-
-  // Attachment type tracking - set by providers
-  const [currentAttachmentType, setCurrentAttachmentType] = useState<AttachmentType>('none');
 
   const { trackUsage } = useTracking();
 
@@ -111,26 +103,7 @@ export const BaseChatProvider = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat.messages]);
 
-  // Reset attachment type when attachments change
-  useEffect(() => {
-    if (attachments.length === 0) {
-      setCurrentAttachmentType('none');
-    }
-  }, [attachments]);
-
-  const getTokenCount = (text: string): number => {
-    // TODO: Implement token counting
-    return text.length;
-  };
-
   const handleSubmit = async (event: Parameters<typeof chat.handleSubmit>[0]) => {
-    const tokenCount = getTokenCount(chat.input || '');
-
-    trackUsage('didUserSendMessage', {
-      'attachment-type': currentAttachmentType,
-      'number-of-input-tokens': tokenCount,
-    });
-
     chat.handleSubmit(event, {
       experimental_attachments: attachments
         // Transform to ai/sdk format and remove any attachments that are not yet ready
@@ -209,9 +182,6 @@ export const BaseChatProvider = ({
         // Attachments
         attachments,
         setAttachments,
-        // Attachment type tracking
-        currentAttachmentType,
-        setCurrentAttachmentType,
       }}
     >
       {children}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes the tracking event `didUserSendMessage` from the CTB

We don't know the token count from the client. Therefore it may make more sense to send the amplitude tracking event `didUserSendMessage` from https://github.com/strapi/strapi-ai where we know these values

See https://github.com/strapi/strapi-ai/pull/22 - we should wait for this approach to be approved before merging

### Related issue(s)/PR(s)

DX-2026
