### PR TITLE
added div on top of CarouselSlide component 

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { CarouselInput, CarouselSlide } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
+import { styled } from 'styled-components';
 
 import { getTrad } from '../../../utils/getTrad';
 import { EditAssetDialog } from '../../EditAssetDialog/EditAssetContent';
@@ -66,6 +67,11 @@ export const CarouselAssets = React.forwardRef(
 
     const currentAsset = assets[selectedAssetIndex];
 
+    const CarouselSlideWrapper = styled.div<{ $selected: boolean }>`
+      & > div {
+        display: ${({ $selected }) => ($selected ? 'flex' : 'none')};
+      }
+    `;
     return (
       <>
         <CarouselInput
@@ -99,35 +105,40 @@ export const CarouselAssets = React.forwardRef(
           }
         >
           {assets.length === 0 ? (
-            <CarouselSlide
-              label={formatMessage(
-                {
-                  id: getTrad('mediaLibraryInput.slideCount'),
-                  defaultMessage: '{n} of {m} slides',
-                },
-                { n: 1, m: 1 }
-              )}
-            >
-              <EmptyStateAsset
-                disabled={disabled}
-                onClick={onAddAsset}
-                onDropAsset={onDropAsset!}
-              />
-            </CarouselSlide>
-          ) : (
-            assets.map((asset, index) => (
+            <CarouselSlideWrapper $selected={selectedAssetIndex === 0}>
               <CarouselSlide
-                key={asset.id}
                 label={formatMessage(
                   {
                     id: getTrad('mediaLibraryInput.slideCount'),
                     defaultMessage: '{n} of {m} slides',
                   },
-                  { n: index + 1, m: assets.length }
+                  { n: 1, m: 1 }
                 )}
+                selected={selectedAssetIndex === 0}
               >
-                <CarouselAsset asset={asset} />
+                <EmptyStateAsset
+                  disabled={disabled}
+                  onClick={onAddAsset}
+                  onDropAsset={onDropAsset!}
+                />
               </CarouselSlide>
+            </CarouselSlideWrapper>
+          ) : (
+            assets.map((asset, index) => (
+              <CarouselSlideWrapper key={asset.id} $selected={selectedAssetIndex === index}>
+                <CarouselSlide
+                  label={formatMessage(
+                    {
+                      id: getTrad('mediaLibraryInput.slideCount'),
+                      defaultMessage: '{n} of {m} slides',
+                    },
+                    { n: index + 1, m: assets.length }
+                  )}
+                  selected={selectedAssetIndex === index}
+                >
+                  <CarouselAsset asset={asset} />
+                </CarouselSlide>
+              </CarouselSlideWrapper>
             ))
           )}
         </CarouselInput>


### PR DESCRIPTION
it switches display property according to CarouselSlide's selected prop

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added a div above CarouselSlider component that switches display property between flex and none, similar to how CarouselSlide itself does to show an enlarged selected image. This resolves the issue with conflicting display property.

https://github.com/user-attachments/assets/c5bcae65-874f-47c7-b717-08a1ec1749b1


### Why is it needed?

The [issue](https://github.com/strapi/strapi/issues/21843), pertains with an interfering display property that disabled CarouselSlider component's ability to switch display property between flex and none and remain stuck to disply:flex, rendering the CarouselSlider to not show an enlarged version of the image selected.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

fixes [#21843](https://github.com/strapi/strapi/issues/21843)
