### PR TITLE
fix: not searchable relation by document Id

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -35,8 +35,8 @@ const sanitizeMainField = (model: any, mainField: any, userAbility: any) => {
   const canReadMainField = permissionChecker.can.read(null, mainField);
 
   if (!isMainFieldListable || !canReadMainField) {
-    // Default to 'id' if the actual main field shouldn't be displayed
-    return 'id';
+    // Default to 'documentId' if the actual main field shouldn't be displayed
+    return 'documentId';
   }
 
   // Edge cases


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It fixes the issue when you try to search relations by document Id you receive always the message "No relations available"

### Why is it needed?

It is impossible to search for a relation when the mainField is the documentId

### How to test it?

- Go to content manager
- Open a document that contains a Relation with the document Id as main field
- Try to filter the relation options by document id  and check if you are able to do it
- and the message "No relations available" is not always shown

### Related issue(s)/PR(s)

fixes https://github.com/strapi/strapi/issues/21964
