### PR TITLE
chore: track widgets usage

### DIFF
--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -6,7 +6,6 @@ import { useInitQuery, useTelemetryPropertiesQuery } from '../services/admin';
 
 import { useAppInfo } from './AppInfo';
 import { useAuth } from './Auth';
-import { useStrapiApp } from './StrapiApp';
 
 export interface TelemetryProperties {
   useTypescriptOnServer?: boolean;
@@ -40,42 +39,12 @@ export interface TrackingProviderProps {
 
 const TrackingProvider = ({ children }: TrackingProviderProps) => {
   const token = useAuth('App', (state) => state.token);
-  const getAllWidgets = useStrapiApp('TrackingProvider', (state) => state.widgets.getAll);
   const { data: initData } = useInitQuery();
   const { uuid } = initData ?? {};
 
   const { data } = useTelemetryPropertiesQuery(undefined, {
     skip: !initData?.uuid || !token,
   });
-
-  React.useEffect(() => {
-    if (uuid && data) {
-      const event = 'didInitializeAdministration';
-      try {
-        fetch('https://analytics.strapi.io/api/v2/track', {
-          method: 'POST',
-          body: JSON.stringify({
-            // This event is anonymous
-            event,
-            userId: '',
-            eventPropeties: {},
-            groupProperties: {
-              ...data,
-              projectId: uuid,
-              registeredWidgets: getAllWidgets().map((widget) => widget.uid),
-            },
-          }),
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Strapi-Event': event,
-          },
-        });
-      } catch {
-        // silence is golden
-      }
-    }
-  }, [data, uuid, getAllWidgets]);
-
   const value = React.useMemo(
     () => ({
       uuid,
@@ -101,7 +70,6 @@ const TrackingProvider = ({ children }: TrackingProviderProps) => {
 interface EventWithoutProperties {
   name:
     | 'changeComponentsOrder'
-    | 'didAccessAuthenticatedAdministration'
     | 'didAddComponentToDynamicZone'
     | 'didBulkDeleteEntries'
     | 'didNotBulkDeleteEntries'
@@ -195,6 +163,14 @@ interface EventWithoutProperties {
     | 'didEditFieldNameOnContentType'
     | 'didCreateRelease';
   properties?: never;
+}
+
+interface DidAccessAuthenticatedAdministrationEvent {
+  name: 'didAccessAuthenticatedAdministration';
+  properties: {
+    registeredWidgets: string[];
+    projectId: string;
+  };
 }
 
 interface DidFilterMediaLibraryElementsEvent {
@@ -384,6 +360,7 @@ interface DidUpdateCTBSchema {
 type EventsWithProperties =
   | CreateEntryEvents
   | PublishEntryEvents
+  | DidAccessAuthenticatedAdministrationEvent
   | DidAccessTokenListEvent
   | DidChangeModeEvent
   | DidCropFileEvent

--- a/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
@@ -20,6 +20,7 @@ import { UpsellBanner } from '../components/UpsellBanner';
 import { AppInfoProvider } from '../features/AppInfo';
 import { useAuth } from '../features/Auth';
 import { useConfiguration } from '../features/Configuration';
+import { useStrapiApp } from '../features/StrapiApp';
 import { useTracking } from '../features/Tracking';
 import { useMenu } from '../hooks/useMenu';
 import { useOnce } from '../hooks/useOnce';
@@ -93,14 +94,16 @@ const AdminLayout = () => {
     pluginsSectionLinks,
   } = useMenu(checkLatestStrapiVersion(strapiVersion, tagName));
 
-  /**
-   * Make sure the event is only send once after accessing the admin panel
-   * and not at runtime for example when regenerating the permissions with the ctb
-   * or with i18n
-   */
-  useOnce(() => {
-    trackUsage('didAccessAuthenticatedAdministration');
-  });
+  const getAllWidgets = useStrapiApp('TrackingProvider', (state) => state.widgets.getAll);
+  const projectId = appInfo?.projectId;
+  React.useEffect(() => {
+    if (projectId) {
+      trackUsage('didAccessAuthenticatedAdministration', {
+        registeredWidgets: getAllWidgets().map((widget) => widget.uid),
+        projectId,
+      });
+    }
+  }, [projectId, getAllWidgets, trackUsage]);
 
   // We don't need to wait for the release query to be fetched before rendering the plugins
   // however, we need the appInfos and the permissions


### PR DESCRIPTION
### What does it do?

- remove the didInitializeAdministration event as be block it anyway on amplitude as it created too many events
- move the widgets tracking to didAccessAuthenticatedAdministration instead

### How to test it?

check your networks tab, find didAccessAuthenticatedAdministration, see the registeredWidgets property with an array of string uids