### PR TITLE
fix(core/admin): no warn if StrapiApp link no component, use correct useRBAC

### DIFF
--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
@@ -72,14 +72,12 @@ In the below example, we're checking if a user can "create" a post from the cont
 import { useRBAC } from '@strapi/strapi/admin';
 
 const MyComponent = () => {
-  const { isLoading, allowedActions } = useRBAC({
-    create: [
-      {
-        action: 'plugin::content-manager.explorer.create',
-        subject: 'api::post.post',
-      },
-    ],
-  });
+  const { isLoading, allowedActions } = useRBAC([
+    {
+      action: 'plugin::content-manager.explorer.create',
+      subject: 'api::post.post',
+    },
+  ]);
 
   if (isLoading) {
     return <p>Loading...</p>;

--- a/packages/core/admin/admin/src/core/apis/router.tsx
+++ b/packages/core/admin/admin/src/core/apis/router.tsx
@@ -155,11 +155,10 @@ class Router {
     );
 
     if (
-      !link.Component ||
-      (link.Component &&
-        typeof link.Component === 'function' &&
-        // @ts-expect-error – shh
-        link.Component[Symbol.toStringTag] === 'AsyncFunction')
+      link.Component &&
+      typeof link.Component === 'function' &&
+      // @ts-expect-error – shh
+      link.Component[Symbol.toStringTag] === 'AsyncFunction'
     ) {
       console.warn(
         `
@@ -278,11 +277,10 @@ class Router {
     );
 
     if (
-      !link.Component ||
-      (link.Component &&
-        typeof link.Component === 'function' &&
-        // @ts-expect-error – shh
-        link.Component[Symbol.toStringTag] === 'AsyncFunction')
+      link.Component &&
+      typeof link.Component === 'function' &&
+      // @ts-expect-error – shh
+      link.Component[Symbol.toStringTag] === 'AsyncFunction'
     ) {
       console.warn(
         `

--- a/packages/core/admin/admin/src/core/store/hooks.ts
+++ b/packages/core/admin/admin/src/core/store/hooks.ts
@@ -1,4 +1,3 @@
-import { createSelector, Selector } from '@reduxjs/toolkit';
 import { useDispatch, useStore, TypedUseSelectorHook, useSelector } from 'react-redux';
 
 import type { RootState, Store } from './configure';
@@ -9,7 +8,4 @@ const useTypedDispatch: () => AppDispatch = useDispatch;
 const useTypedStore = useStore as () => Store;
 const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;
 
-const createTypedSelector = <TResult>(selector: Selector<RootState, TResult>) =>
-  createSelector((state: RootState) => state, selector);
-
-export { useTypedDispatch, useTypedStore, useTypedSelector, createTypedSelector };
+export { useTypedDispatch, useTypedStore, useTypedSelector };

--- a/packages/core/admin/admin/src/features/Configuration.tsx
+++ b/packages/core/admin/admin/src/features/Configuration.tsx
@@ -71,8 +71,8 @@ const ConfigurationProvider = ({
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions.settings?.['project-settings']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['project-settings'] ?? {}).flat()
   );
   const token = useAuth('ConfigurationProvider', (state) => state.token);
 

--- a/packages/core/admin/admin/src/hooks/tests/useRBAC.test.ts
+++ b/packages/core/admin/admin/src/hooks/tests/useRBAC.test.ts
@@ -6,48 +6,40 @@ import { useRBAC } from '../useRBAC';
 describe('useRBAC', () => {
   it('should return by default falsey values and if the permissions match then it should return truthy values', async () => {
     const { result } = renderHook(() =>
-      useRBAC({
-        create: [
-          {
-            id: 1,
-            actionParameters: {},
-            action: 'admin::roles.create',
-            subject: null,
-            conditions: [],
-            properties: {},
-          },
-        ],
-        delete: [
-          {
-            id: 2,
-            actionParameters: {},
-            action: 'admin::roles.delete',
-            subject: null,
-            conditions: [],
-            properties: {},
-          },
-        ],
-        read: [
-          {
-            id: 3,
-            actionParameters: {},
-            action: 'admin::roles.read',
-            subject: null,
-            conditions: [],
-            properties: {},
-          },
-        ],
-        update: [
-          {
-            id: 4,
-            actionParameters: {},
-            action: 'admin::roles.update',
-            subject: null,
-            conditions: [],
-            properties: {},
-          },
-        ],
-      })
+      useRBAC([
+        {
+          id: 1,
+          actionParameters: {},
+          action: 'admin::roles.create',
+          subject: null,
+          conditions: [],
+          properties: {},
+        },
+        {
+          id: 2,
+          actionParameters: {},
+          action: 'admin::roles.delete',
+          subject: null,
+          conditions: [],
+          properties: {},
+        },
+        {
+          id: 3,
+          actionParameters: {},
+          action: 'admin::roles.read',
+          subject: null,
+          conditions: [],
+          properties: {},
+        },
+        {
+          id: 4,
+          actionParameters: {},
+          action: 'admin::roles.update',
+          subject: null,
+          conditions: [],
+          properties: {},
+        },
+      ])
     );
 
     expect(result.current.allowedActions).toEqual({
@@ -93,18 +85,16 @@ describe('useRBAC', () => {
   describe('checking against the server if there are conditions in the permissions', () => {
     it.skip('should return truthy values if the permissions condition passes', async () => {
       const { result } = renderHook(() => {
-        return useRBAC({
-          create: [
-            {
-              id: 1,
-              actionParameters: {},
-              action: 'admin::roles.create',
-              subject: null,
-              conditions: ['willPass'],
-              properties: {},
-            },
-          ],
-        });
+        return useRBAC([
+          {
+            id: 1,
+            actionParameters: {},
+            action: 'admin::roles.create',
+            subject: null,
+            conditions: ['willPass'],
+            properties: {},
+          },
+        ]);
       });
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -121,14 +111,7 @@ describe('useRBAC', () => {
 
       const { result } = renderHook(
         () => {
-          return useRBAC({
-            create: [
-              {
-                action: 'admin::roles.create',
-                subject: null,
-              },
-            ],
-          });
+          return useRBAC([{ action: 'admin::roles.create', subject: null }]);
         },
         {
           providerOptions: {

--- a/packages/core/admin/admin/src/hooks/useRBAC.ts
+++ b/packages/core/admin/admin/src/hooks/useRBAC.ts
@@ -10,6 +10,28 @@ import { usePrev } from './usePrev';
 
 type AllowedActions = Record<string, boolean>;
 
+interface UseRBACReturnType {
+  allowedActions: AllowedActions;
+  isLoading: boolean;
+  error?: unknown;
+  permissions: Permission[];
+}
+
+interface UseRBAC {
+  /** @deprecated useRBAC should only take an array of permissions, not an object. */
+  (
+    permissionsToCheck?: Record<string, Permission[]> | undefined,
+    passedPermissions?: Permission[] | undefined,
+    rawQueryContext?: string | undefined
+  ): UseRBACReturnType;
+
+  (
+    permissionsToCheck?: Permission[] | undefined,
+    passedPermissions?: Permission[] | undefined,
+    rawQueryContext?: string | undefined
+  ): UseRBACReturnType;
+}
+
 /**
  * @public
  * @description This hooks takes an object or array of permissions (the latter preferred) and
@@ -41,16 +63,7 @@ type AllowedActions = Record<string, boolean>;
  * }
  * ```
  */
-const useRBAC = (
-  permissionsToCheck: Record<string, Permission[]> | Permission[] = [],
-  passedPermissions?: Permission[],
-  rawQueryContext?: string
-): {
-  allowedActions: AllowedActions;
-  isLoading: boolean;
-  error?: unknown;
-  permissions: Permission[];
-} => {
+const useRBAC: UseRBAC = (permissionsToCheck = [], passedPermissions, rawQueryContext) => {
   const isLoadingAuth = useAuth('useRBAC', (state) => state.isLoading);
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState<unknown>();

--- a/packages/core/admin/admin/src/hooks/useSettingsMenu.ts
+++ b/packages/core/admin/admin/src/hooks/useSettingsMenu.ts
@@ -7,7 +7,7 @@ import { SETTINGS_LINKS_CE, SettingsMenuLink } from '../constants';
 import { useAppInfo } from '../features/AppInfo';
 import { useAuth } from '../features/Auth';
 import { useStrapiApp } from '../features/StrapiApp';
-import { selectAdminPermissions } from '../selectors';
+import { useTypedSelector } from '../core/store/hooks';
 import { PermissionMap } from '../types/permissions';
 
 import { useEnterprise } from './useEnterprise';
@@ -72,7 +72,7 @@ const useSettingsMenu = (): {
   );
   const shouldUpdateStrapi = useAppInfo('useSettingsMenu', (state) => state.shouldUpdateStrapi);
   const settings = useStrapiApp('useSettingsMenu', (state) => state.settings);
-  const permissions = useSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) => state.admin_app.permissions);
 
   /**
    * memoize the return value of this function to avoid re-computing it on every render

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/EditView/EditViewPage.tsx
@@ -43,7 +43,9 @@ export const EditView = () => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
   const { state: locationState } = useLocation();
-  const permissions = useTypedSelector((state) => state.admin_app.permissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['api-tokens'] ?? {}).flat()
+  );
   const [apiToken, setApiToken] = React.useState<ApiToken | null>(
     locationState?.apiToken?.accessKey
       ? {
@@ -57,7 +59,7 @@ export const EditView = () => {
   const setCurrentStep = useGuidedTour('EditView', (state) => state.setCurrentStep);
   const {
     allowedActions: { canCreate, canUpdate, canRegenerate },
-  } = useRBAC(permissions.settings?.['api-tokens']);
+  } = useRBAC(permissions);
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const match = useMatch('/settings/api-tokens/:id');
   const id = match?.params?.id;

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
@@ -60,8 +60,8 @@ const TABLE_HEADERS = [
 export const ListView = () => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions.settings?.['api-tokens']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['api-tokens'] ?? {}).flat()
   );
   const {
     allowedActions: { canRead, canCreate, canDelete, canUpdate },

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
@@ -12,10 +12,10 @@ import { useConfiguration } from '../../../../features/Configuration';
 import { useTracking } from '../../../../features/Tracking';
 import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { useRBAC } from '../../../../hooks/useRBAC';
-import { selectAdminPermissions } from '../../../../selectors';
 
 import { LogoInput, LogoInputProps } from './components/LogoInput';
 import { DIMENSION, SIZE } from './utils/constants';
+import { useTypedSelector } from '../../../../core/store/hooks';
 
 const AdminSeatInfoCE = () => null;
 
@@ -28,7 +28,9 @@ const ApplicationInfoPage = () => {
   const { formatMessage } = useIntl();
   const { logos: serverLogos, updateProjectSettings } = useConfiguration('ApplicationInfoPage');
   const [logos, setLogos] = React.useState({ menu: serverLogos.menu, auth: serverLogos.auth });
-  const { settings } = useSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['project-settings'] ?? {}).flat()
+  );
 
   const communityEdition = useAppInfo('ApplicationInfoPage', (state) => state.communityEdition);
   const latestStrapiReleaseTag = useAppInfo(
@@ -51,7 +53,7 @@ const ApplicationInfoPage = () => {
 
   const {
     allowedActions: { canRead, canUpdate },
-  } = useRBAC(settings ? settings['project-settings'] : {});
+  } = useRBAC(permissions);
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/ListPage.tsx
@@ -28,14 +28,15 @@ import { useAPIErrorHandler } from '../../../../hooks/useAPIErrorHandler';
 import { useFetchClient } from '../../../../hooks/useFetchClient';
 import { useQueryParams } from '../../../../hooks/useQueryParams';
 import { useRBAC } from '../../../../hooks/useRBAC';
-import { selectAdminPermissions } from '../../../../selectors';
 import { isFetchError } from '../../../../utils/getFetchClient';
 
 import { RoleRow, RoleRowProps } from './components/RoleRow';
 
 const ListPage = () => {
   const { formatMessage } = useIntl();
-  const permissions = useTypedSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.roles ?? {}).flat()
+  );
   const { formatAPIError } = useAPIErrorHandler();
   const { toggleNotification } = useNotification();
   const [isWarningDeleteAllOpened, setIsWarningDeleteAllOpenend] = React.useState(false);
@@ -43,7 +44,7 @@ const ListPage = () => {
   const {
     isLoading: isLoadingForPermissions,
     allowedActions: { canCreate, canDelete, canRead, canUpdate },
-  } = useRBAC(permissions.settings?.roles);
+  } = useRBAC(permissions);
 
   const { roles, refetch: refetchRoles } = useAdminRoles(
     { filters: query?._q ? { name: { $containsi: query._q } } : undefined },

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/EditView.tsx
@@ -61,8 +61,8 @@ const EditView = () => {
   );
   const { trackUsage } = useTracking();
   const setCurrentStep = useGuidedTour('EditView', (state) => state.setCurrentStep);
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions.settings?.['transfer-tokens']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['transfer-tokens'] ?? {}).flat()
   );
   const {
     allowedActions: { canCreate, canUpdate, canRegenerate },

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
@@ -66,8 +66,8 @@ const tableHeaders = [
 const ListView = () => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions.settings?.['transfer-tokens']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['transfer-tokens'] ?? {}).flat()
   );
   const {
     isLoading: isLoadingRBAC,

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
@@ -18,7 +18,6 @@ import { useNotification } from '../../../../features/Notifications';
 import { useAPIErrorHandler } from '../../../../hooks/useAPIErrorHandler';
 import { useEnterprise } from '../../../../hooks/useEnterprise';
 import { useRBAC } from '../../../../hooks/useRBAC';
-import { selectAdminPermissions } from '../../../../selectors';
 import { useAdminUsers, useUpdateUserMutation } from '../../../../services/users';
 import { isBaseQueryError } from '../../../../utils/baseQuery';
 import { translatedErrors } from '../../../../utils/translatedErrors';
@@ -69,15 +68,15 @@ const EditPage = () => {
     _unstableFormatValidationErrors: formatValidationErrors,
   } = useAPIErrorHandler();
 
-  const permissions = useTypedSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) => [
+    ...(state.admin_app.permissions.settings?.users.read ?? []),
+    ...(state.admin_app.permissions.settings?.users.update ?? []),
+  ]);
 
   const {
     isLoading: isLoadingRBAC,
     allowedActions: { canUpdate },
-  } = useRBAC({
-    read: permissions.settings?.users.read ?? [],
-    update: permissions.settings?.users.update ?? [],
-  });
+  } = useRBAC(permissions);
 
   const [updateUser] = useUpdateUserMutation();
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -32,10 +32,12 @@ import { ModalForm } from './components/NewUserForm';
 const ListPageCE = () => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const [isModalOpened, setIsModalOpen] = React.useState(false);
-  const permissions = useTypedSelector((state) => state.admin_app.permissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.users ?? {}).flat()
+  );
   const {
     allowedActions: { canCreate, canDelete, canRead },
-  } = useRBAC(permissions.settings?.users);
+  } = useRBAC(permissions);
   const navigate = useNavigate();
   const { toggleNotification } = useNotification();
   const { formatMessage } = useIntl();

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/EditPage.tsx
@@ -9,7 +9,6 @@ import { Page } from '../../../../components/PageHelpers';
 import { useTypedSelector } from '../../../../core/store/hooks';
 import { useNotification } from '../../../../features/Notifications';
 import { useAPIErrorHandler } from '../../../../hooks/useAPIErrorHandler';
-import { selectAdminPermissions } from '../../../../selectors';
 import { isBaseQueryError } from '../../../../utils/baseQuery';
 
 import { WebhookForm, WebhookFormProps, WebhookFormValues } from './components/WebhookForm';
@@ -190,7 +189,7 @@ const EditPage = () => {
  * -----------------------------------------------------------------------------------------------*/
 
 const ProtectedEditPage = () => {
-  const permissions = useTypedSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) => state.admin_app.permissions);
 
   return (
     <Page.Protect permissions={permissions.settings?.webhooks.update}>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/ListPage.tsx
@@ -43,7 +43,9 @@ import { useWebhooks } from './hooks/useWebhooks';
 const ListPage = () => {
   const [showModal, setShowModal] = React.useState(false);
   const [webhooksToDelete, setWebhooksToDelete] = React.useState<string[]>([]);
-  const permissions = useTypedSelector((state) => state.admin_app.permissions.settings?.webhooks);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.webhooks ?? {}).flat()
+  );
   const { formatMessage } = useIntl();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { toggleNotification } = useNotification();

--- a/packages/core/admin/admin/src/selectors.ts
+++ b/packages/core/admin/admin/src/selectors.ts
@@ -1,9 +1,0 @@
-import { createTypedSelector } from './core/store/hooks';
-
-/**
- * @deprecated
- *
- * Use `useTypedSelector` and access the state directly, this was only used so we knew
- * we were using the correct path. Which is state.admin_app.permissions
- */
-export const selectAdminPermissions = createTypedSelector((state) => state.admin_app.permissions);

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/ApplicationInfoPage/components/AdminSeatInfo.tsx
@@ -4,19 +4,21 @@ import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
 import { useRBAC } from '../../../../../../../../admin/src/hooks/useRBAC';
-import { selectAdminPermissions } from '../../../../../../../../admin/src/selectors';
 import { useLicenseLimits } from '../../../../../hooks/useLicenseLimits';
+import { useTypedSelector } from '../../../../../../../../admin/src/core/store/hooks';
 
 const BILLING_SELF_HOSTED_URL = 'https://strapi.io/billing/request-seats';
 const MANAGE_SEATS_URL = 'https://strapi.io/billing/manage-seats';
 
 export const AdminSeatInfoEE = () => {
   const { formatMessage } = useIntl();
-  const { settings } = useSelector(selectAdminPermissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.users ?? {}).flat()
+  );
   const {
     isLoading: isRBACLoading,
     allowedActions: { canRead, canCreate, canUpdate, canDelete },
-  } = useRBAC(settings?.users ?? {});
+  } = useRBAC(permissions);
   const {
     license,
     isError,

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -20,15 +20,15 @@ import { getDisplayedFilters } from './utils/getDisplayedFilters';
 
 const ListPage = () => {
   const { formatMessage } = useIntl();
-  const permissions = useTypedSelector((state) => state.admin_app.permissions.settings);
+  const permissions = useTypedSelector((state) => [
+    ...Object.values(state.admin_app.permissions.settings?.auditLogs ?? {}).flat(),
+    ...(state.admin_app.permissions.settings?.users.read ?? []),
+  ]);
 
   const {
     allowedActions: { canRead: canReadAuditLogs, canReadUsers },
     isLoading: isLoadingRBAC,
-  } = useRBAC({
-    ...permissions?.auditLogs,
-    readUsers: permissions?.users.read || [],
-  });
+  } = useRBAC(permissions);
 
   const [{ query }, setQuery] = useQueryParams<{ id?: AuditLog['id'] }>();
   const {

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/SingleSignOnPage.tsx
@@ -51,7 +51,10 @@ const SCHEMA = yup.object().shape({
 
 export const SingleSignOnPage = () => {
   const { formatMessage } = useIntl();
-  const permissions = useTypedSelector((state) => state.admin_app.permissions);
+  const permissions = useTypedSelector((state) => [
+    ...Object.values(state.admin_app.permissions.settings?.sso ?? {}).flat(),
+    ...(state.admin_app.permissions.settings?.roles.read ?? []),
+  ]);
   const { toggleNotification } = useNotification();
   const {
     _unstableFormatAPIError: formatAPIError,
@@ -66,10 +69,7 @@ export const SingleSignOnPage = () => {
   const {
     isLoading: isLoadingPermissions,
     allowedActions: { canUpdate, canRead: canReadRoles },
-  } = useRBAC({
-    ...permissions.settings?.sso,
-    readRoles: permissions.settings?.roles.read ?? [],
-  });
+  } = useRBAC(permissions);
 
   const { roles, isLoading: isLoadingRoles } = useAdminRoles(undefined, {
     skip: !canReadRoles,

--- a/packages/core/content-releases/admin/src/components/ReleaseAction.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseAction.tsx
@@ -21,7 +21,7 @@ import { Formik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 
 import { CreateManyReleaseActions } from '../../../shared/contracts/release-actions';
-import { PERMISSIONS as releasePermissions } from '../constants';
+import { allPermissions } from '../constants';
 import { useCreateManyReleaseActionsMutation, useGetReleasesQuery } from '../services/release';
 
 import {
@@ -35,22 +35,16 @@ import { ReleaseActionOptions } from './ReleaseActionOptions';
 import type { BulkActionComponent } from '@strapi/content-manager/strapi-admin';
 import type { UID } from '@strapi/types';
 
-const getContentPermissions = (subject: string) => {
-  const permissions = {
-    publish: [
-      {
-        action: 'plugin::content-manager.explorer.publish',
-        subject,
-        id: '',
-        actionParameters: {},
-        properties: {},
-        conditions: [],
-      },
-    ],
-  };
-
-  return permissions;
-};
+const getContentPermissions = (subject: string) => [
+  {
+    action: 'plugin::content-manager.explorer.publish',
+    subject,
+    id: '',
+    actionParameters: {},
+    properties: {},
+    conditions: [],
+  },
+];
 
 const ReleaseAction: BulkActionComponent = ({ documents, model }) => {
   const { formatMessage } = useIntl();
@@ -63,7 +57,7 @@ const ReleaseAction: BulkActionComponent = ({ documents, model }) => {
   } = useRBAC(contentPermissions);
   const {
     allowedActions: { canCreate },
-  } = useRBAC(releasePermissions);
+  } = useRBAC(allPermissions);
   const { hasDraftAndPublish } = useContentManagerContext();
 
   // Get all the releases not published

--- a/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionMenu.tsx
@@ -15,7 +15,7 @@ import { styled } from 'styled-components';
 
 import { DeleteReleaseAction, ReleaseAction } from '../../../shared/contracts/release-actions';
 import { Release } from '../../../shared/contracts/releases';
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import { useDeleteReleaseActionMutation } from '../services/release';
 
 // TODO: has to be fixed in the DS - https://github.com/strapi/design-system/issues/1934
@@ -46,7 +46,7 @@ const DeleteReleaseActionItem = ({ releaseId, actionId }: DeleteReleaseActionIte
   const [deleteReleaseAction] = useDeleteReleaseActionMutation();
   const {
     allowedActions: { canDeleteAction },
-  } = useRBAC(PERMISSIONS);
+  } = useRBAC(allPermissions);
 
   const handleDeleteAction = async () => {
     const response = await deleteReleaseAction({
@@ -131,14 +131,12 @@ const ReleaseActionEntryLinkItem = ({
 
   const {
     allowedActions: { canUpdate: canUpdateContentType },
-  } = useRBAC({
-    updateContentType: [
-      {
-        action: 'plugin::content-manager.explorer.update',
-        subject: contentTypeUid,
-      },
-    ],
-  });
+  } = useRBAC([
+    {
+      action: 'plugin::content-manager.explorer.update',
+      subject: contentTypeUid,
+    },
+  ]);
 
   if (!canUpdateContentType || !canUpdateEntryForLocale) {
     return null;
@@ -201,7 +199,7 @@ interface RootProps {
 const Root = ({ children }: RootProps) => {
   const { formatMessage } = useIntl();
 
-  const { allowedActions } = useRBAC(PERMISSIONS);
+  const { allowedActions } = useRBAC(allPermissions);
 
   return (
     // A user can access the dropdown if they have permissions to delete a release-action OR update a release

--- a/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleaseActionModal.tsx
@@ -27,7 +27,7 @@ import { Link as ReactRouterLink } from 'react-router-dom';
 import * as yup from 'yup';
 
 import { CreateReleaseAction } from '../../../shared/contracts/release-actions';
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import { useCreateReleaseActionMutation, useGetReleasesForEntryQuery } from '../services/release';
 
 import { ReleaseActionOptions } from './ReleaseActionOptions';
@@ -170,7 +170,7 @@ const ReleaseActionModalForm: DocumentActionComponent = ({
   collectionType,
 }: DocumentActionProps) => {
   const { formatMessage } = useIntl();
-  const { allowedActions } = useRBAC(PERMISSIONS);
+  const { allowedActions } = useRBAC(allPermissions);
   const { canCreateAction } = allowedActions;
   const [createReleaseAction, { isLoading }] = useCreateReleaseActionMutation();
   const { toggleNotification } = useNotification();

--- a/packages/core/content-releases/admin/src/components/ReleasesPanel.tsx
+++ b/packages/core/content-releases/admin/src/components/ReleasesPanel.tsx
@@ -3,7 +3,7 @@ import { unstable_useDocumentLayout as useDocumentLayout } from '@strapi/content
 import { Box, Flex, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import { useGetReleasesForEntryQuery } from '../services/release';
 import { getTimezoneOffset } from '../utils/time';
 
@@ -25,7 +25,7 @@ const Panel: PanelComponent = ({
   } = useDocumentLayout(model);
   const { formatMessage, formatDate, formatTime } = useIntl();
 
-  const { allowedActions } = useRBAC(PERMISSIONS);
+  const { allowedActions } = useRBAC(allPermissions);
   const { canRead, canDeleteAction } = allowedActions;
 
   const response = useGetReleasesForEntryQuery(

--- a/packages/core/content-releases/admin/src/constants.ts
+++ b/packages/core/content-releases/admin/src/constants.ts
@@ -73,6 +73,8 @@ export const PERMISSIONS = {
   ],
 } satisfies Record<string, StrapiPermission[]>;
 
+export const allPermissions = Object.values(PERMISSIONS).flat();
+
 export const PERMISSIONS_SETTINGS = {
   read: [
     {

--- a/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleaseDetailsPage.tsx
@@ -44,7 +44,7 @@ import { RelativeTime } from '../components/RelativeTime';
 import { ReleaseActionMenu } from '../components/ReleaseActionMenu';
 import { ReleaseActionOptions } from '../components/ReleaseActionOptions';
 import { ReleaseModal, FormValues } from '../components/ReleaseModal';
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import {
   GetReleaseActionsQueryParams,
   useGetReleaseActionsQuery,
@@ -103,7 +103,7 @@ const ReleaseDetailsLayout = ({
   const [publishRelease, { isLoading: isPublishing }] = usePublishReleaseMutation();
   const { toggleNotification } = useNotification();
   const { formatAPIError } = useAPIErrorHandler();
-  const { allowedActions } = useRBAC(PERMISSIONS);
+  const { allowedActions } = useRBAC(allPermissions);
   const { canUpdate, canDelete, canPublish } = allowedActions;
   const dispatch = useTypedDispatch();
   const { trackUsage } = useTracking();
@@ -379,7 +379,7 @@ const ReleaseDetailsBody = ({ releaseId }: ReleaseDetailsBodyProps) => {
   } = useGetReleaseQuery({ id: releaseId });
   const {
     allowedActions: { canUpdate },
-  } = useRBAC(PERMISSIONS);
+  } = useRBAC(allPermissions);
   const runHookWaterfall = useStrapiApp('ReleaseDetailsPage', (state) => state.runHookWaterfall);
 
   // TODO: Migrated displayedHeader to v5

--- a/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesPage.tsx
@@ -37,7 +37,7 @@ import { styled } from 'styled-components';
 import { GetReleases, type Release } from '../../../shared/contracts/releases';
 import { RelativeTime as BaseRelativeTime } from '../components/RelativeTime';
 import { ReleaseModal, FormValues } from '../components/ReleaseModal';
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import {
   useGetReleasesQuery,
   useGetReleaseSettingsQuery,
@@ -197,7 +197,7 @@ const ReleasesPage = () => {
   const { trackUsage } = useTracking();
   const {
     allowedActions: { canCreate },
-  } = useRBAC(PERMISSIONS);
+  } = useRBAC(allPermissions);
 
   const { isLoading: isLoadingReleases, isSuccess, isError } = response;
   const activeTab = response?.currentData?.meta?.activeTab || 'pending';

--- a/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
+++ b/packages/core/content-releases/admin/src/pages/ReleasesSettingsPage.tsx
@@ -40,8 +40,8 @@ const ReleasesSettingsPage = () => {
   const { data, isLoading: isLoadingSettings } = useGetReleaseSettingsQuery();
   const [updateReleaseSettings, { isLoading: isSubmittingForm }] =
     useUpdateReleaseSettingsMutation();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions['settings']?.['releases']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions['settings']?.['releases'] ?? {}).flat()
   );
   const {
     allowedActions: { canUpdate },
@@ -209,8 +209,8 @@ const ReleasesSettingsPage = () => {
 };
 
 const TimezoneDropdown = () => {
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions['settings']?.['releases']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions['settings']?.['releases'] ?? {}).flat()
   );
   const {
     allowedActions: { canUpdate },

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
@@ -25,14 +25,16 @@ const AssigneeSelect = ({ isCompact }: { isCompact?: boolean }) => {
     id,
     slug: model = '',
   } = useParams<{ collectionType: string; slug: string; id: string }>();
-  const permissions = useTypedSelector((state) => state.admin_app.permissions);
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.users ?? {}).flat()
+  );
   const { formatMessage } = useIntl();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { toggleNotification } = useNotification();
   const {
     allowedActions: { canRead },
     isLoading: isLoadingPermissions,
-  } = useRBAC(permissions.settings?.users);
+  } = useRBAC(permissions);
   const [{ query }] = useQueryParams();
   const params = React.useMemo(() => buildValidParams(query), [query]);
   const {

--- a/packages/core/review-workflows/admin/src/routes/settings/id.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/id.tsx
@@ -124,8 +124,8 @@ const EditPage = () => {
     update,
     create,
   } = useReviewWorkflows();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions['settings']?.['review-workflows']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions['settings']?.['review-workflows'] ?? {}).flat()
   );
   const {
     allowedActions: { canDelete, canUpdate, canCreate },

--- a/packages/core/review-workflows/admin/src/routes/settings/index.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/index.tsx
@@ -26,8 +26,8 @@ export const ReviewWorkflowsListView = () => {
   const { data, isLoading: isLoadingModels } = useGetContentTypesQuery();
   const { meta, workflows, isLoading, delete: deleteAction } = useReviewWorkflows();
   const { getFeature, isLoading: isLicenseLoading } = useLicenseLimits();
-  const permissions = useTypedSelector(
-    (state) => state.admin_app.permissions.settings?.['review-workflows']
+  const permissions = useTypedSelector((state) =>
+    Object.values(state.admin_app.permissions.settings?.['review-workflows'] ?? []).flat()
   );
   const {
     allowedActions: { canCreate, canRead, canUpdate, canDelete },

--- a/packages/core/upload/admin/src/hooks/useMediaLibraryPermissions.ts
+++ b/packages/core/upload/admin/src/hooks/useMediaLibraryPermissions.ts
@@ -3,9 +3,10 @@ import { useRBAC, type AllowedActions } from '@strapi/admin/strapi-admin';
 import { PERMISSIONS } from '../constants';
 
 const { main: _main, ...restPermissions } = PERMISSIONS;
+const allPermissions = Object.values(restPermissions).flat();
 
 export const useMediaLibraryPermissions = (): AllowedActions & { isLoading: boolean } => {
-  const { allowedActions, isLoading } = useRBAC(restPermissions);
+  const { allowedActions, isLoading } = useRBAC(allPermissions);
 
   return { ...allowedActions, isLoading };
 };

--- a/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
+++ b/packages/plugins/documentation/admin/src/components/SettingsForm.tsx
@@ -18,7 +18,7 @@ import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 import * as yup from 'yup';
 
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import { DocumentInfos, SettingsInput } from '../types';
 import { getTrad } from '../utils';
 
@@ -54,7 +54,7 @@ type SettingsFormProps = {
 export const SettingsForm = ({ data, onSubmit }: SettingsFormProps) => {
   const { formatMessage } = useIntl();
   const [passwordShown, setPasswordShown] = React.useState(false);
-  const { allowedActions } = useRBAC(PERMISSIONS);
+  const { allowedActions } = useRBAC(allPermissions);
 
   return (
     <Formik

--- a/packages/plugins/documentation/admin/src/constants.ts
+++ b/packages/plugins/documentation/admin/src/constants.ts
@@ -15,3 +15,5 @@ export const PERMISSIONS = {
   regenerate: [{ action: 'plugin::documentation.settings.regenerate', subject: null }],
   update: [{ action: 'plugin::documentation.settings.update', subject: null }],
 };
+
+export const allPermissions = Object.values(PERMISSIONS).flat();

--- a/packages/plugins/documentation/admin/src/pages/App.tsx
+++ b/packages/plugins/documentation/admin/src/pages/App.tsx
@@ -27,7 +27,7 @@ import {
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
-import { PERMISSIONS } from '../constants';
+import { allPermissions } from '../constants';
 import {
   useGetInfoQuery,
   useRegenerateDocMutation,
@@ -44,7 +44,7 @@ const App = () => {
   const [deleteVersion] = useDeleteVersionMutation();
   const [showConfirmDelete, setShowConfirmDelete] = React.useState<boolean>(false);
   const [versionToDelete, setVersionToDelete] = React.useState<string>();
-  const { allowedActions, isLoading: isLoadingRBAC } = useRBAC(PERMISSIONS);
+  const { allowedActions, isLoading: isLoadingRBAC } = useRBAC(allPermissions);
 
   const isLoading = isLoadingInfo || isLoadingRBAC;
 

--- a/packages/plugins/i18n/admin/src/constants.ts
+++ b/packages/plugins/i18n/admin/src/constants.ts
@@ -5,3 +5,5 @@ export const PERMISSIONS = {
   update: [{ action: 'plugin::i18n.locale.update', subject: null }],
   read: [{ action: 'plugin::i18n.locale.read', subject: null }],
 };
+
+export const allPermissions = Object.values(PERMISSIONS).flat();

--- a/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
+++ b/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
@@ -13,7 +13,7 @@ import { useIntl } from 'react-intl';
 
 import { CreateLocale } from '../components/CreateLocale';
 import { LocaleTable } from '../components/LocaleTable';
-import { PERMISSIONS } from '../constants';
+import { PERMISSIONS, allPermissions } from '../constants';
 import { useGetLocalesQuery } from '../services/locales';
 import { getTranslation } from '../utils/getTranslation';
 
@@ -25,7 +25,7 @@ const SettingsPage = () => {
   const {
     isLoading: isLoadingRBAC,
     allowedActions: { canUpdate, canCreate, canDelete },
-  } = useRBAC(PERMISSIONS);
+  } = useRBAC(allPermissions);
 
   React.useEffect(() => {
     if (error) {

--- a/packages/plugins/users-permissions/admin/src/constants.js
+++ b/packages/plugins/users-permissions/admin/src/constants.js
@@ -27,3 +27,10 @@ export const PERMISSIONS = {
   readProviders: [{ action: 'plugin::users-permissions.providers.read', subject: null }],
   updateProviders: [{ action: 'plugin::users-permissions.providers.update', subject: null }],
 };
+
+export const allPermissions = [
+  ...PERMISSIONS.createRole,
+  ...PERMISSIONS.readRoles,
+  ...PERMISSIONS.updateRole,
+  ...PERMISSIONS.deleteRole,
+];

--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
@@ -38,7 +38,7 @@ const AdvancedSettingsPage = () => {
   const {
     isLoading: isLoadingForPermissions,
     allowedActions: { canUpdate },
-  } = useRBAC({ update: PERMISSIONS.updateAdvancedSettings });
+  } = useRBAC(PERMISSIONS.updateAdvancedSettings);
 
   const { isLoading: isLoadingData, data } = useQuery(
     ['users-permissions', 'advanced'],

--- a/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/EmailTemplates/index.jsx
@@ -39,7 +39,7 @@ const EmailTemplatesPage = () => {
   const {
     isLoading: isLoadingForPermissions,
     allowedActions: { canUpdate },
-  } = useRBAC({ update: PERMISSIONS.updateEmailTemplates });
+  } = useRBAC(PERMISSIONS.updateEmailTemplates);
 
   const { isLoading: isLoadingData, data } = useQuery(
     ['users-permissions', 'email-templates'],

--- a/packages/plugins/users-permissions/admin/src/pages/Providers/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Providers/index.jsx
@@ -47,7 +47,7 @@ export const ProvidersPage = () => {
   const {
     isLoading: isLoadingPermissions,
     allowedActions: { canUpdate },
-  } = useRBAC({ update: PERMISSIONS.updateProviders });
+  } = useRBAC(PERMISSIONS.updateProviders);
 
   const { isLoading: isLoadingData, data } = useQuery(
     ['users-permissions', 'get-providers'],

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -30,7 +30,7 @@ import { useIntl } from 'react-intl';
 import { useMutation, useQuery } from 'react-query';
 import { NavLink } from 'react-router-dom';
 
-import { PERMISSIONS } from '../../../../constants';
+import { PERMISSIONS, allPermissions } from '../../../../constants';
 import { getTrad } from '../../../../utils';
 
 import TableBody from './components/TableBody';
@@ -49,12 +49,7 @@ export const RolesListPage = () => {
   const {
     isLoading: isLoadingForPermissions,
     allowedActions: { canRead, canDelete, canCreate, canUpdate },
-  } = useRBAC({
-    create: PERMISSIONS.createRole,
-    read: PERMISSIONS.readRoles,
-    update: PERMISSIONS.updateRole,
-    delete: PERMISSIONS.deleteRole,
-  });
+  } = useRBAC(allPermissions);
 
   const {
     isLoading: isLoadingForData,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- No warn on `StrapiApp#addMenuLink` and `StrapiApp#addSettingsLink` missing component
- Remove some deprecated `useRBAC` calls that produce warnings
- Adjust `useRBAC` to report deprecated usage in IDE

### Why is it needed?

<img width="649" alt="image" src="https://github.com/user-attachments/assets/e70daff1-1696-4626-a7a5-795c554d4035" />

<img width="551" alt="image" src="https://github.com/user-attachments/assets/8bccd60a-74a3-42c0-a0e1-de943dd0cb9c" />

<img width="391" alt="image" src="https://github.com/user-attachments/assets/e6fe1ce6-91f1-41b3-bb2a-17525a2d5449" />

PS: After all `Object.values({}).flat()`, I'm not sure if it was worth deprecating object notation.

PS2: I'm thinking to split this PR in 2 more simple PRs

- [ ] no warn if StrapiApp link no component
- [ ] type useRBAC to show deprecated use of object notation

`useRBAC` changes to use array notation will be dropped, and let the devs stop using it.
