### PR TITLE
future: add future flag for the Guided tour initiative

### DIFF
--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,3 +1,5 @@
 module.exports = ({ env }) => ({
-  future: {},
+  future: {
+    unstableGuidedTour: false,
+  },
 });

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Context.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Context.tsx
@@ -55,6 +55,9 @@ const UnstableGuidedTourContext = ({
   // NOTE: Maybe we just import this directly instead of a prop?
   tours: Tours;
 }) => {
+  if (!window.strapi.future.isEnabled('unstableGuidedTour')) {
+    return children;
+  }
   // Derive the tour state from the tours object
   const tours = Object.keys(registeredTours).reduce(
     (acc, tourName) => {

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -87,7 +87,8 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
     const dispatch = unstableUseGuidedTour('GuidedTourPopover', (s) => s.dispatch);
     const state = unstableUseGuidedTour('GuidedTourPopover', (s) => s.state);
     const currentStep = state.tours[tourName].currentStep + 1;
-    const tourLength = state.tours[tourName].length;
+    // TODO: at the moment we are removing from count the final step taking into consideration every guided tour has a final step. We can consider to change this count to be "smarter" filtering the steps that don't need to be counted
+    const tourLength = state.tours[tourName].length - 1;
 
     return (
       <ActionsContainer width="100%" padding={3} paddingLeft={5}>

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -69,16 +69,28 @@ const UnstableGuidedTourTooltip = ({
   tourName: ValidTourName;
   step: number;
 }) => {
+  // TODO: To remove when the future is ready to be released
+  const disabledUnstableGuidedTour = !window.strapi.future.isEnabled('unstableGuidedTour');
   const state = unstableUseGuidedTour('UnstableGuidedTourTooltip', (s) => s.state);
   const dispatch = unstableUseGuidedTour('UnstableGuidedTourTooltip', (s) => s.dispatch);
   const Step = React.useMemo(() => createStepComponents(tourName), [tourName]);
 
-  const isCurrentStep = state.tours[tourName].currentStep === step;
-  const isPopoverOpen = isCurrentStep && !state.tours[tourName].isCompleted;
+  // TODO: Condition to remove when the future is ready to be released
+  const isCurrentStep = disabledUnstableGuidedTour
+    ? undefined
+    : state.tours[tourName].currentStep === step;
+  // TODO: Condition to remove when the future is ready to be released
+  const isPopoverOpen = disabledUnstableGuidedTour
+    ? undefined
+    : isCurrentStep && !state.tours[tourName].isCompleted;
 
   // Lock the scroll
   React.useEffect(() => {
-    if (!isPopoverOpen) return;
+    /**
+     *  TODO: replace with if (!isPopoverOpen) return;
+     *  when the guided tour is ready to be released
+     */
+    if (!isPopoverOpen || disabledUnstableGuidedTour) return;
 
     const originalStyle = window.getComputedStyle(document.body).overflow;
     document.body.style.overflow = 'hidden';
@@ -86,7 +98,12 @@ const UnstableGuidedTourTooltip = ({
     return () => {
       document.body.style.overflow = originalStyle;
     };
-  }, [isPopoverOpen]);
+  }, [disabledUnstableGuidedTour, isPopoverOpen]);
+
+  // TODO: To remove when the future is ready to be released
+  if (disabledUnstableGuidedTour) {
+    return children;
+  }
 
   return (
     <>

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -14,6 +14,7 @@ import {
   useRBAC,
   Layouts,
   useTable,
+  unstable_tours,
 } from '@strapi/admin/strapi-admin';
 import {
   Button,
@@ -294,138 +295,140 @@ const ListViewPage = () => {
   }
 
   return (
-    <Page.Main>
-      <Page.Title>{`${contentTypeTitle}`}</Page.Title>
-      <LayoutsHeaderCustom
-        primaryAction={canCreate ? <CreateButton /> : null}
-        subtitle={formatMessage(
-          {
-            id: getTranslation('pages.ListView.header-subtitle'),
-            defaultMessage:
-              '{number, plural, =0 {# entries} one {# entry} other {# entries}} found',
-          },
-          { number: pagination?.total }
-        )}
-        title={contentTypeTitle}
-        navigationAction={<BackButton />}
-      />
-      <Layouts.Action
-        endActions={
-          <>
-            <InjectionZone area="listView.actions" />
-            <ViewSettingsMenu
-              setHeaders={handleSetHeaders}
-              resetHeaders={() => setDisplayedHeaders(list.layout)}
-              headers={displayedHeaders.map((header) => header.name)}
-            />
-          </>
-        }
-        startActions={
-          <>
-            {list.settings.searchable && (
-              <SearchInput
-                disabled={results.length === 0}
-                label={formatMessage(
-                  { id: 'app.component.search.label', defaultMessage: 'Search for {target}' },
-                  { target: contentTypeTitle }
-                )}
-                placeholder={formatMessage({
-                  id: 'global.search',
-                  defaultMessage: 'Search',
-                })}
-                trackedEvent="didSearch"
+    <unstable_tours.contentManager.Introduction>
+      <Page.Main>
+        <Page.Title>{`${contentTypeTitle}`}</Page.Title>
+        <LayoutsHeaderCustom
+          primaryAction={canCreate ? <CreateButton /> : null}
+          subtitle={formatMessage(
+            {
+              id: getTranslation('pages.ListView.header-subtitle'),
+              defaultMessage:
+                '{number, plural, =0 {# entries} one {# entry} other {# entries}} found',
+            },
+            { number: pagination?.total }
+          )}
+          title={contentTypeTitle}
+          navigationAction={<BackButton />}
+        />
+        <Layouts.Action
+          endActions={
+            <>
+              <InjectionZone area="listView.actions" />
+              <ViewSettingsMenu
+                setHeaders={handleSetHeaders}
+                resetHeaders={() => setDisplayedHeaders(list.layout)}
+                headers={displayedHeaders.map((header) => header.name)}
               />
-            )}
-            {list.settings.filterable && schema ? (
-              <Filters disabled={results.length === 0} schema={schema} />
-            ) : null}
-          </>
-        }
-      />
-      <Layouts.Content>
-        <Flex gap={4} direction="column" alignItems="stretch">
-          <Table.Root rows={results} headers={tableHeaders} isLoading={isFetching}>
-            <TableActionsBar />
-            <Table.Content>
-              <Table.Head>
-                <Table.HeaderCheckboxCell />
-                {tableHeaders.map((header: ListFieldLayout) => (
-                  <Table.HeaderCell key={header.name} {...header} />
-                ))}
-              </Table.Head>
-              <Table.Loading />
-              <Table.Empty action={canCreate ? <CreateButton variant="secondary" /> : null} />
-              <Table.Body>
-                {results.map((row) => {
-                  return (
-                    <Table.Row
-                      cursor="pointer"
-                      key={row.id}
-                      onClick={handleRowClick(row.documentId)}
-                    >
-                      <Table.CheckboxCell id={row.id} />
-                      {tableHeaders.map(({ cellFormatter, ...header }) => {
-                        if (header.name === 'status') {
-                          const { status } = row;
+            </>
+          }
+          startActions={
+            <>
+              {list.settings.searchable && (
+                <SearchInput
+                  disabled={results.length === 0}
+                  label={formatMessage(
+                    { id: 'app.component.search.label', defaultMessage: 'Search for {target}' },
+                    { target: contentTypeTitle }
+                  )}
+                  placeholder={formatMessage({
+                    id: 'global.search',
+                    defaultMessage: 'Search',
+                  })}
+                  trackedEvent="didSearch"
+                />
+              )}
+              {list.settings.filterable && schema ? (
+                <Filters disabled={results.length === 0} schema={schema} />
+              ) : null}
+            </>
+          }
+        />
+        <Layouts.Content>
+          <Flex gap={4} direction="column" alignItems="stretch">
+            <Table.Root rows={results} headers={tableHeaders} isLoading={isFetching}>
+              <TableActionsBar />
+              <Table.Content>
+                <Table.Head>
+                  <Table.HeaderCheckboxCell />
+                  {tableHeaders.map((header: ListFieldLayout) => (
+                    <Table.HeaderCell key={header.name} {...header} />
+                  ))}
+                </Table.Head>
+                <Table.Loading />
+                <Table.Empty action={canCreate ? <CreateButton variant="secondary" /> : null} />
+                <Table.Body>
+                  {results.map((row) => {
+                    return (
+                      <Table.Row
+                        cursor="pointer"
+                        key={row.id}
+                        onClick={handleRowClick(row.documentId)}
+                      >
+                        <Table.CheckboxCell id={row.id} />
+                        {tableHeaders.map(({ cellFormatter, ...header }) => {
+                          if (header.name === 'status') {
+                            const { status } = row;
 
+                            return (
+                              <Table.Cell key={header.name}>
+                                <DocumentStatus status={status} maxWidth={'min-content'} />
+                              </Table.Cell>
+                            );
+                          }
+                          if (['createdBy', 'updatedBy'].includes(header.name.split('.')[0])) {
+                            // Display the users full name
+                            // Some entries doesn't have a user assigned as creator/updater (ex: entries created through content API)
+                            // In this case, we display a dash
+                            return (
+                              <Table.Cell key={header.name}>
+                                <Typography textColor="neutral800">
+                                  {row[header.name.split('.')[0]]
+                                    ? getDisplayName(row[header.name.split('.')[0]])
+                                    : '-'}
+                                </Typography>
+                              </Table.Cell>
+                            );
+                          }
+                          if (typeof cellFormatter === 'function') {
+                            return (
+                              <Table.Cell key={header.name}>
+                                {/* @ts-expect-error – TODO: fix this TS error */}
+                                {cellFormatter(row, header, { collectionType, model })}
+                              </Table.Cell>
+                            );
+                          }
                           return (
                             <Table.Cell key={header.name}>
-                              <DocumentStatus status={status} maxWidth={'min-content'} />
+                              <CellContent
+                                content={row[header.name.split('.')[0]]}
+                                rowId={row.documentId}
+                                {...header}
+                              />
                             </Table.Cell>
                           );
-                        }
-                        if (['createdBy', 'updatedBy'].includes(header.name.split('.')[0])) {
-                          // Display the users full name
-                          // Some entries doesn't have a user assigned as creator/updater (ex: entries created through content API)
-                          // In this case, we display a dash
-                          return (
-                            <Table.Cell key={header.name}>
-                              <Typography textColor="neutral800">
-                                {row[header.name.split('.')[0]]
-                                  ? getDisplayName(row[header.name.split('.')[0]])
-                                  : '-'}
-                              </Typography>
-                            </Table.Cell>
-                          );
-                        }
-                        if (typeof cellFormatter === 'function') {
-                          return (
-                            <Table.Cell key={header.name}>
-                              {/* @ts-expect-error – TODO: fix this TS error */}
-                              {cellFormatter(row, header, { collectionType, model })}
-                            </Table.Cell>
-                          );
-                        }
-                        return (
-                          <Table.Cell key={header.name}>
-                            <CellContent
-                              content={row[header.name.split('.')[0]]}
-                              rowId={row.documentId}
-                              {...header}
-                            />
-                          </Table.Cell>
-                        );
-                      })}
-                      {/* we stop propagation here to allow the menu to trigger it's events without triggering the row redirect */}
-                      <ActionsCell onClick={(e) => e.stopPropagation()}>
-                        <TableActions document={row} />
-                      </ActionsCell>
-                    </Table.Row>
-                  );
-                })}
-              </Table.Body>
-            </Table.Content>
-          </Table.Root>
-          <Pagination.Root
-            {...pagination}
-            onPageSizeChange={() => trackUsage('willChangeNumberOfEntriesPerPage')}
-          >
-            <Pagination.PageSize />
-            <Pagination.Links />
-          </Pagination.Root>
-        </Flex>
-      </Layouts.Content>
-    </Page.Main>
+                        })}
+                        {/* we stop propagation here to allow the menu to trigger it's events without triggering the row redirect */}
+                        <ActionsCell onClick={(e) => e.stopPropagation()}>
+                          <TableActions document={row} />
+                        </ActionsCell>
+                      </Table.Row>
+                    );
+                  })}
+                </Table.Body>
+              </Table.Content>
+            </Table.Root>
+            <Pagination.Root
+              {...pagination}
+              onPageSizeChange={() => trackUsage('willChangeNumberOfEntriesPerPage')}
+            >
+              <Pagination.PageSize />
+              <Pagination.Links />
+            </Pagination.Root>
+          </Flex>
+        </Layouts.Content>
+      </Page.Main>
+    </unstable_tours.contentManager.Introduction>
   );
 };
 

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -9,5 +9,6 @@ export interface FeaturesService {
   config: FeaturesConfig | undefined;
   future: {
     isEnabled: (futureFlagName: string) => boolean;
+    unstableGuidedTour?: boolean;
   };
 }

--- a/tests/e2e/app-template/config/features.js
+++ b/tests/e2e/app-template/config/features.js
@@ -1,3 +1,5 @@
 module.exports = ({ env }) => ({
-  future: {},
+  future: {
+    unstableGuidedTour: env.bool('STRAPI_FEATURES_UNSTABLE_GUIDED_TOUR', false),
+  },
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds the future flag for the guided tour initiative

### Why is it needed?

It is needed to enable/disable the future before the release

### How to test it?

Go to the config/features.js file in your project (for example the getStarted) and try to enable/disable the future flag like this
`module.exports = ({ env }) => ({
  future: {
    unstableGuidedTour: false,
  },
});`

Then go to the Content Manager page and check if the Guided tour is shown or not

