### PR TITLE
feat: add tracker for conditional field count

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -29,6 +29,7 @@ import createAuth from './services/auth';
 import createCustomFields from './services/custom-fields';
 import createContentAPI from './services/content-api';
 import getNumberOfDynamicZones from './services/utils/dynamic-zones';
+import getNumberOfConditionalFields from './services/utils/conditional-fields';
 import { FeaturesService, createFeaturesService } from './services/features';
 import { createDocumentService } from './services/document-service';
 
@@ -301,6 +302,7 @@ class Strapi extends Container implements Core.Strapi {
           numberOfAllContentTypes: _.size(this.contentTypes), // TODO: V5: This event should be renamed numberOfContentTypes in V5 as the name is already taken to describe the number of content types using i18n.
           numberOfComponents: _.size(this.components),
           numberOfDynamicZones: getNumberOfDynamicZones(),
+          numberOfConditionalFields: getNumberOfConditionalFields(),
           numberOfCustomControllers: Object.values<Core.Controller>(this.controllers).filter(
             // TODO: Fix this at the content API loader level to prevent future types issues
             (controller) => controller !== undefined && factories.isCustomController(controller)

--- a/packages/core/core/src/services/utils/__tests__/conditional-fields.test.ts
+++ b/packages/core/core/src/services/utils/__tests__/conditional-fields.test.ts
@@ -1,0 +1,309 @@
+import type { Schema, UID } from '@strapi/types';
+import getNumberOfConditionalFields from '../conditional-fields';
+
+const mockStrapi = {
+  contentTypes: {} as Record<UID.ContentType, Schema.ContentType>,
+  components: {} as Record<UID.Component, Schema.Component>,
+};
+
+(global as any).strapi = mockStrapi;
+
+describe('getNumberOfConditionalFields', () => {
+  beforeEach(() => {
+    mockStrapi.contentTypes = {};
+    mockStrapi.components = {};
+  });
+
+  describe('when no schemas exist', () => {
+    it('should return 0 when there are no content types or components', () => {
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('when schemas have no conditional fields', () => {
+    it('should return 0 for content types without conditional fields', () => {
+      mockStrapi.contentTypes = {
+        'api::article.article': {
+          modelType: 'contentType',
+          uid: 'api::article.article',
+          kind: 'collectionType',
+          modelName: 'article',
+          globalId: 'Article',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            title: { type: 'string', required: true },
+            content: { type: 'text' },
+            publishedAt: { type: 'datetime' },
+          },
+        } as unknown as Schema.ContentType,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(0);
+    });
+
+    it('should return 0 for components without conditional fields', () => {
+      mockStrapi.components = {
+        'default.hero': {
+          modelType: 'component',
+          uid: 'default.hero',
+          category: 'default',
+          modelName: 'hero',
+          globalId: 'ComponentDefaultHero',
+          info: { displayName: 'Hero', icon: 'layer' },
+          options: {},
+          attributes: {
+            title: { type: 'string' },
+            subtitle: { type: 'string' },
+            image: { type: 'media', multiple: false },
+          },
+        } as unknown as Schema.Component,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('when schemas have conditional fields', () => {
+    it('should count conditional fields in content types correctly', () => {
+      mockStrapi.contentTypes = {
+        'api::article.article': {
+          modelType: 'contentType',
+          uid: 'api::article.article',
+          kind: 'collectionType',
+          modelName: 'article',
+          globalId: 'Article',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            title: { type: 'string' },
+            conditionalField: {
+              type: 'string',
+              conditions: { visible: true },
+            },
+            anotherConditionalField: {
+              type: 'text',
+              conditions: { required: { field: 'title', operator: 'isNotEmpty' } },
+            },
+            normalField: { type: 'string' },
+          },
+        } as unknown as Schema.ContentType,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(2);
+    });
+
+    it('should count conditional fields in components correctly', () => {
+      mockStrapi.components = {
+        'default.hero': {
+          modelType: 'component',
+          uid: 'default.hero',
+          category: 'default',
+          modelName: 'hero',
+          globalId: 'ComponentDefaultHero',
+          info: { displayName: 'Hero', icon: 'layer' },
+          options: {},
+          attributes: {
+            conditionalSubtitle: {
+              type: 'string',
+              conditions: { visible: { field: 'title', operator: 'isNotEmpty' } },
+            },
+            normalTitle: { type: 'string' },
+          },
+        } as unknown as Schema.Component,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(1);
+    });
+
+    it('should count conditional fields across multiple content types and components', () => {
+      mockStrapi.contentTypes = {
+        'api::article.article': {
+          modelType: 'contentType',
+          uid: 'api::article.article',
+          kind: 'collectionType',
+          modelName: 'article',
+          globalId: 'Article',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            conditionalField: {
+              type: 'string',
+              conditions: { visible: true },
+            },
+          },
+        } as unknown as Schema.ContentType,
+        'api::page.page': {
+          modelType: 'contentType',
+          uid: 'api::page.page',
+          kind: 'collectionType',
+          modelName: 'page',
+          globalId: 'Page',
+          info: { singularName: 'page', pluralName: 'pages', displayName: 'Page' },
+          options: {},
+          attributes: {
+            anotherConditionalField: {
+              type: 'text',
+              conditions: { required: { field: 'title', value: 'test' } },
+            },
+          },
+        } as unknown as Schema.ContentType,
+      };
+
+      mockStrapi.components = {
+        'default.hero': {
+          modelType: 'component',
+          uid: 'default.hero',
+          category: 'default',
+          modelName: 'hero',
+          globalId: 'ComponentDefaultHero',
+          info: { displayName: 'Hero', icon: 'layer' },
+          options: {},
+          attributes: {
+            conditionalSubtitle: {
+              type: 'string',
+              conditions: { visible: { field: 'title', operator: 'isNotEmpty' } },
+            },
+          },
+        } as unknown as Schema.Component,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(3); // 2 from content types + 1 from component
+    });
+  });
+
+  describe('when conditions are invalid', () => {
+    it('should ignore fields with non-object conditions', () => {
+      mockStrapi.contentTypes = {
+        'api::article.article': {
+          modelType: 'contentType',
+          uid: 'api::article.article',
+          kind: 'collectionType',
+          modelName: 'article',
+          globalId: 'Article',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            fieldWithStringCondition: {
+              type: 'string',
+              conditions: 'some string',
+            } as any,
+            fieldWithNumberCondition: {
+              type: 'string',
+              conditions: 123,
+            } as any,
+            fieldWithNullCondition: {
+              type: 'string',
+              conditions: null,
+            } as any,
+            fieldWithUndefinedCondition: {
+              type: 'string',
+              conditions: undefined,
+            } as any,
+            validConditionalField: {
+              type: 'string',
+              conditions: { visible: true },
+            },
+          },
+        } as unknown as Schema.ContentType,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(1); // Only the valid conditional field
+    });
+
+    it('should handle empty conditions object', () => {
+      mockStrapi.contentTypes = {
+        'api::article.article': {
+          modelType: 'contentType',
+          uid: 'api::article.article',
+          kind: 'collectionType',
+          modelName: 'article',
+          globalId: 'Article',
+          info: { singularName: 'article', pluralName: 'articles', displayName: 'Article' },
+          options: {},
+          attributes: {
+            fieldWithEmptyConditions: {
+              type: 'string',
+              conditions: {},
+            },
+            validConditionalField: {
+              type: 'string',
+              conditions: { visible: true },
+            },
+          },
+        } as unknown as Schema.ContentType,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(2); // Both should be counted as they have object conditions
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle schemas with empty attributes', () => {
+      mockStrapi.contentTypes = {
+        'api::empty.empty': {
+          modelType: 'contentType',
+          uid: 'api::empty.empty',
+          kind: 'collectionType',
+          modelName: 'empty',
+          globalId: 'Empty',
+          info: { singularName: 'empty', pluralName: 'empties', displayName: 'Empty' },
+          options: {},
+          attributes: {},
+        } as unknown as Schema.ContentType,
+      };
+
+      mockStrapi.components = {
+        'default.empty': {
+          modelType: 'component',
+          uid: 'default.empty',
+          category: 'default',
+          modelName: 'empty',
+          globalId: 'ComponentDefaultEmpty',
+          info: { displayName: 'Empty', icon: 'layer' },
+          options: {},
+          attributes: {},
+        } as unknown as Schema.Component,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(0);
+    });
+
+    it('should handle large numbers of conditional fields', () => {
+      const attributes: Record<string, Schema.Attribute.AnyAttribute> = {};
+
+      // Create 100 conditional fields
+      for (let i = 0; i < 100; i += 1) {
+        attributes[`conditionalField${i}`] = {
+          type: 'string',
+          conditions: { visible: true },
+        };
+      }
+
+      mockStrapi.contentTypes = {
+        'api::large.large': {
+          modelType: 'contentType',
+          uid: 'api::large.large',
+          kind: 'collectionType',
+          modelName: 'large',
+          globalId: 'Large',
+          info: { singularName: 'large', pluralName: 'larges', displayName: 'Large' },
+          options: {},
+          attributes,
+        } as unknown as Schema.ContentType,
+      };
+
+      const result = getNumberOfConditionalFields();
+      expect(result).toBe(100);
+    });
+  });
+});

--- a/packages/core/core/src/services/utils/conditional-fields.ts
+++ b/packages/core/core/src/services/utils/conditional-fields.ts
@@ -1,0 +1,29 @@
+import { map, values, sumBy, pipe, flatMap } from 'lodash/fp';
+import type { Schema, UID } from '@strapi/types';
+
+const getNumberOfConditionalFields = () => {
+  const contentTypes: Record<UID.ContentType, Schema.ContentType> = strapi.contentTypes;
+  const components: Record<UID.Component, Schema.Component> = strapi.components;
+
+  const countConditionalFieldsInSchema = (
+    schema: Record<string, Schema.ContentType | Schema.Component>
+  ) => {
+    return pipe(
+      map('attributes'),
+      flatMap(values),
+      sumBy((attribute: Schema.Attribute.AnyAttribute) => {
+        if (attribute.conditions && typeof attribute.conditions === 'object') {
+          return 1;
+        }
+        return 0;
+      })
+    )(schema);
+  };
+
+  const contentTypeCount = countConditionalFieldsInSchema(contentTypes);
+  const componentCount = countConditionalFieldsInSchema(components);
+
+  return contentTypeCount + componentCount;
+};
+
+export default getNumberOfConditionalFields;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

add conditional field count tracker

### Why is it needed?

because

### How to test it?

1. in `packages/core/core/src/services/metrics/sender.ts` OR do a global find/replace (necessary if you are testing some events that happen outside of normal Strapi usage) 
2. replace the `https://analytics.strapi.io/`string to be `http://localhost`
You may have to replace it in several places, and when starting your Strapi server, you should see your localhost (http://localhost/) URL in the logs rather than analytics.strapi.io
3. Build Strapi again so that it builds with that URL
4. Run the command `npx http-echo-server 80` in a terminal window
NOTE: if you don't have port 80 available for this purpose, you’ll need to add a port to the previous line such as 'http://localhost:1234'
5.In another terminal window, start Strapi (or run the CLI command desired, whatever is sending the analytics you are testing) and do whatever action desired to send telemetry events

You should see those events sent by Strapi in the terminal window where the http-echo-server is running

You should see `"numberOfConditionalFields` and its value changes as you add / delete conditional field

### Related issue(s)/PR(s)

DX-2087
