### PR TITLE
future: add the guided tour future flag

### DIFF
--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,3 +1,5 @@
 module.exports = ({ env }) => ({
-  future: {},
+  future: {
+    unstableGuidedTour: false,
+  },
 });

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -97,9 +97,12 @@ const UnstableGuidedTourTooltip = ({
     requiredActions?.every((action) => {
       return guidedTourMeta?.data?.completedActions.includes(action);
     }) ?? true;
-
+  const hasFutureFlag = window.strapi.future.isEnabled('unstableGuidedTour');
   const isEnabled =
-    guidedTourMeta?.data?.isFirstSuperAdminUser && !state.tours[tourName].isCompleted;
+    guidedTourMeta?.data?.isFirstSuperAdminUser &&
+    !state.tours[tourName].isCompleted &&
+    hasFutureFlag;
+
   const isPopoverOpen = isEnabled && isCurrentStep && hasCompletedRequiredActions;
 
   // Lock the scroll

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,5 +1,7 @@
 export interface FeaturesConfig {
-  future?: object;
+  future?: {
+    unstableGuidedTour?: boolean;
+  };
 }
 
 export interface FeaturesService {
@@ -9,5 +11,6 @@ export interface FeaturesService {
   config: FeaturesConfig | undefined;
   future: {
     isEnabled: (futureFlagName: string) => boolean;
+    unstableGuidedTour?: boolean;
   };
 }


### PR DESCRIPTION
### What does it do?

- Add the guided tour future flag
- Uses the future flag to control whether or not the tooltip should display

### Why is it needed?

To add the tours

### How to test it?

Go somewhere like CM ListViewPage and wrap an element:

```
<unstable_tours.TEST.Introduction>
  <EmptyStateLayout
    action={canCreate ? <CreateButton variant="secondary" /> : null}
    content={formatMessage({
      id: 'app.components.EmptyStateLayout.content-document',
      defaultMessage: 'No content found',
    })}
    hasRadius
    icon={<EmptyDocuments width="16rem" />}
  />
</unstable_tours.TEST.Introduction>
```

Then in examples/getstarted/config/features.js, turn the flag on and then off to ensure the tooltip displays / hides itself correctly

```
module.exports = ({ env }) => ({
  future: {
    unstableGuidedTour: false,
  },
});

```


https://github.com/user-attachments/assets/16724923-78a1-4c8d-9c3a-b6b52755e01d



### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23827
