### PR TITLE
fix: color of release status icon

### DIFF
--- a/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
+++ b/packages/core/content-releases/admin/src/components/EntryValidationPopover.tsx
@@ -29,6 +29,34 @@ const StyledPopoverFlex = styled(Flex)`
   }
 `;
 
+const ButtonContent = styled(Flex)`
+  svg {
+    fill: currentColor;
+  }
+`;
+
+const CustomStatusButton = ({
+  children,
+  icon,
+  color,
+}: {
+  icon: React.ReactElement;
+  color: string;
+} & React.PropsWithChildren) => {
+  return (
+    <Popover.Trigger>
+      <Button variant="ghost" endIcon={<CaretDown />}>
+        <ButtonContent color={color} gap={2}>
+          {icon}
+          <Typography textColor={color} variant="omega" fontWeight="bold">
+            {children}
+          </Typography>
+        </ButtonContent>
+      </Button>
+    </Popover.Trigger>
+  );
+};
+
 interface EntryValidationPopoverProps {
   action: ReleaseAction['type'];
   schema?: Struct.ContentTypeSchema & {
@@ -59,109 +87,65 @@ const EntryStatusTrigger = ({
   if (action === 'publish') {
     if (hasErrors || (requiredStage && requiredStage.id !== entryStage?.id)) {
       return (
-        <Popover.Trigger>
-          <Button
-            variant="ghost"
-            startIcon={<CrossCircle fill="danger600" />}
-            endIcon={<CaretDown />}
-          >
-            <Typography textColor="danger600" variant="omega" fontWeight="bold">
-              {formatMessage({
-                id: 'content-releases.pages.ReleaseDetails.entry-validation.not-ready',
-                defaultMessage: 'Not ready to publish',
-              })}
-            </Typography>
-          </Button>
-        </Popover.Trigger>
+        <CustomStatusButton icon={<CrossCircle />} color="danger600">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.not-ready',
+            defaultMessage: 'Not ready to publish',
+          })}
+        </CustomStatusButton>
       );
     }
 
     if (status === 'draft') {
       return (
-        <Popover.Trigger>
-          <Button
-            variant="ghost"
-            startIcon={<CheckCircle fill="success600" />}
-            endIcon={<CaretDown />}
-          >
-            <Typography textColor="success600" variant="omega" fontWeight="bold">
-              {formatMessage({
-                id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
-                defaultMessage: 'Ready to publish',
-              })}
-            </Typography>
-          </Button>
-        </Popover.Trigger>
+        <CustomStatusButton icon={<CheckCircle />} color="success600">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-publish',
+            defaultMessage: 'Ready to publish',
+          })}
+        </CustomStatusButton>
       );
     }
 
     if (status === 'modified') {
       return (
-        <Popover.Trigger>
-          <Button
-            variant="ghost"
-            startIcon={<ArrowsCounterClockwise fill="alternative600" />}
-            endIcon={<CaretDown />}
-          >
-            <Typography variant="omega" fontWeight="bold" textColor="alternative600">
-              {formatMessage({
-                id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
-                defaultMessage: 'Ready to publish changes',
-              })}
-            </Typography>
-          </Button>
-        </Popover.Trigger>
+        <CustomStatusButton icon={<ArrowsCounterClockwise />} color="alternative600">
+          {formatMessage({
+            id: 'content-releases.pages.ReleaseDetails.entry-validation.modified',
+            defaultMessage: 'Ready to publish changes',
+          })}
+        </CustomStatusButton>
       );
     }
 
     return (
-      <Popover.Trigger>
-        <Button
-          variant="ghost"
-          startIcon={<CheckCircle fill="success600" />}
-          endIcon={<CaretDown />}
-        >
-          <Typography textColor="success600" variant="omega" fontWeight="bold">
-            {formatMessage({
-              id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
-              defaultMessage: 'Already published',
-            })}
-          </Typography>
-        </Button>
-      </Popover.Trigger>
+      <CustomStatusButton icon={<CheckCircle />} color="success600">
+        {formatMessage({
+          id: 'content-releases.pages.ReleaseDetails.entry-validation.already-published',
+          defaultMessage: 'Already published',
+        })}
+      </CustomStatusButton>
     );
   }
 
   if (status === 'published') {
     return (
-      <Popover.Trigger>
-        <Button
-          variant="ghost"
-          startIcon={<CheckCircle fill="success600" />}
-          endIcon={<CaretDown />}
-        >
-          <Typography textColor="success600" variant="omega" fontWeight="bold">
-            {formatMessage({
-              id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-unpublish',
-              defaultMessage: 'Ready to unpublish',
-            })}
-          </Typography>
-        </Button>
-      </Popover.Trigger>
+      <CustomStatusButton icon={<CheckCircle />} color="success600">
+        {formatMessage({
+          id: 'content-releases.pages.ReleaseDetails.entry-validation.ready-to-unpublish',
+          defaultMessage: 'Ready to unpublish',
+        })}
+      </CustomStatusButton>
     );
   }
 
   return (
-    <Popover.Trigger>
-      <Button variant="ghost" startIcon={<CheckCircle fill="success600" />} endIcon={<CaretDown />}>
-        <Typography textColor="success600" variant="omega" fontWeight="bold">
-          {formatMessage({
-            id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
-            defaultMessage: 'Already unpublished',
-          })}
-        </Typography>
-      </Button>
-    </Popover.Trigger>
+    <CustomStatusButton icon={<CheckCircle />} color="success600">
+      {formatMessage({
+        id: 'content-releases.pages.ReleaseDetails.entry-validation.already-unpublished',
+        defaultMessage: 'Already unpublished',
+      })}
+    </CustomStatusButton>
   );
 };
 


### PR DESCRIPTION
### What does it do?

Overriding the color of the icon in the button of the status of an entry in Releases.

<img width="308" alt="Screenshot 2025-06-30 at 08 58 05" src="https://github.com/user-attachments/assets/5e860608-fc11-45c2-be2a-db37747faf77" />

This specific variant doesn't exist in the design system so we need to override the style of the icon. We can't use an existing variant because it's also using the alternative600 color and there's no button for this one. But it could be a suggestion to provide it at some point @lucasboilly?

### Why is it needed?

To improve consistency with the design system.

### How to test it?

- Go to the admin interface
- You have to create a release (if you don't already have one)
- You have to put some entries to your release
  - Publish action (select Publish action when adding to a release -> the three dots icon next to the Publish button)
    - One entry with some errors on any field => "Not ready to publish"
    - One entry with status Draft => "Ready to publish"
    - One entry with status Modified => "Ready to publish changes"
    - One entry with status Published => "Already published"
  - Unpublish action
    - One entry with status Published => "Ready to unpublish"
    - One entry with status Unpublished => "Already unpublished"
- Then go to Releases and select the release you put all your entries
-> You should see the status of each entry in the list

### Related issue(s)/PR(s)

Resolves #23760

🚀