### PR TITLE
fix(strapi): add output option for openapi generation command

### DIFF
--- a/packages/core/strapi/src/cli/commands/openapi/generate.ts
+++ b/packages/core/strapi/src/cli/commands/openapi/generate.ts
@@ -58,7 +58,7 @@ const createStrapiApp = async (): Promise<Core.Strapi> => {
 };
 
 const writeDocumentToFile = (document: unknown, filePath: string): void => {
-  fse.writeFileSync(filePath, JSON.stringify(document, null, 2));
+  fse.outputFileSync(filePath, JSON.stringify(document, null, 2));
 };
 
 const teardownStrapiApp = async (app: Core.Strapi) => {

--- a/packages/core/strapi/src/cli/commands/openapi/index.ts
+++ b/packages/core/strapi/src/cli/commands/openapi/index.ts
@@ -16,6 +16,7 @@ const command: StrapiCommand = () => {
   openapi
     .command('generate')
     .description('Generate an OpenAPI specification for the current Strapi application')
+    .option('-o, --output <path>', 'Output file path for the OpenAPI specification')
     .action(runAction('openapi:generate', generate));
 
   return openapi;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Correctly add the --output option to the command:

`strapi openapi generate --output path/to/output.json`

- Uses `outputFileSync` so the path is created if it doesn't exist

### How to test it?

Run this from `examples/getstarted`

`strapi openapi generate --output path/to/output.json`
