### PR TITLE
fix: auth providers generate unique username on conflict

### DIFF
--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -86,9 +86,28 @@ module.exports = ({ strapi }) => {
       .query('plugin::users-permissions.role')
       .findOne({ where: { type: advancedSettings.default_role } });
 
+    let username = email.split('@')[0];
+
+    // Get all users with the same username
+    const usersWithUsername = await strapi.db
+      .query("plugin::users-permissions.user")
+      .findMany({
+        where: { username },
+      });
+
+    // If there are users with the same username, append a number to the username
+    if (usersWithUsername.length > 0) {
+      let counter = 1;
+      while (usersWithUsername.some(user => user.username === username)) {
+        username = `${email.split('@')[0]}${counter}`;
+        counter++;
+      }
+    }
+
     // Create the new user.
     const newUser = {
       ...profile,
+      username, // use the generated or provided username
       email, // overwrite with lowercased email
       provider,
       role: defaultRole.id,

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -8,7 +8,7 @@
 const _ = require('lodash');
 const urlJoin = require('url-join');
 
-const { getService } = require('../utils');
+const { getService, findUniqueUsername } = require('../utils');
 
 module.exports = ({ strapi }) => {
   /**
@@ -86,23 +86,8 @@ module.exports = ({ strapi }) => {
       .query('plugin::users-permissions.role')
       .findOne({ where: { type: advancedSettings.default_role } });
 
-    let username = email.split('@')[0];
-
-    // Get all users with the same username
-    const usersWithUsername = await strapi.db
-      .query("plugin::users-permissions.user")
-      .findMany({
-        where: { username },
-      });
-
-    // If there are users with the same username, append a number to the username
-    if (usersWithUsername.length > 0) {
-      let counter = 1;
-      while (usersWithUsername.some(user => user.username === username)) {
-        username = `${email.split('@')[0]}${counter}`;
-        counter++;
-      }
-    }
+    // Generate a unique username based on the email prefix
+    const username = await findUniqueUsername(email.split('@')[0]);
 
     // Create the new user.
     const newUser = {

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -86,8 +86,9 @@ module.exports = ({ strapi }) => {
       .query('plugin::users-permissions.role')
       .findOne({ where: { type: advancedSettings.default_role } });
 
-    // Generate a unique username based on the email prefix
-    const username = await findUniqueUsername(email.split('@')[0]);
+    // Username: prefer profile, else email prefix; findUniqueUsername ensures valid + unique
+    const base = (profile.username && profile.username.trim()) || email.split('@')[0];
+    const username = await findUniqueUsername(base);
 
     // Create the new user.
     const newUser = {

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -8,7 +8,7 @@
 const _ = require('lodash');
 const urlJoin = require('url-join');
 
-const { getService, findUniqueUsername } = require('../utils');
+const { getService, findValidUsername } = require('../utils');
 
 module.exports = ({ strapi }) => {
   /**
@@ -88,7 +88,7 @@ module.exports = ({ strapi }) => {
 
     // Username: prefer profile, else email prefix; findUniqueUsername ensures valid + unique
     const base = (profile.username && profile.username.trim()) || email.split('@')[0];
-    const username = await findUniqueUsername(base);
+    const username = await findValidUsername(base);
 
     // Create the new user.
     const newUser = {

--- a/packages/plugins/users-permissions/server/services/providers.js
+++ b/packages/plugins/users-permissions/server/services/providers.js
@@ -86,7 +86,7 @@ module.exports = ({ strapi }) => {
       .query('plugin::users-permissions.role')
       .findOne({ where: { type: advancedSettings.default_role } });
 
-    // Username: prefer profile, else email prefix; findUniqueUsername ensures valid + unique
+    // Username: prefer profile, else email prefix; findValidUsername ensures valid + unique
     const base = (profile.username && profile.username.trim()) || email.split('@')[0];
     const username = await findValidUsername(base);
 

--- a/packages/plugins/users-permissions/server/utils/__tests__/index.test.js
+++ b/packages/plugins/users-permissions/server/utils/__tests__/index.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/* eslint-env jest */
+
+const crypto = require('crypto');
+
+// Mock crypto to control randomInt and randomUUID outputs
+jest.mock('crypto', () => ({
+  ...jest.requireActual('crypto'),
+  randomInt: jest.fn(),
+  randomUUID: jest.fn(),
+}));
+
+const { isUsernameTaken, findValidUsername } = require('../index');
+
+const makeQueryMock = (findOneFn) => ({
+  db: {
+    query: jest.fn().mockReturnValue({ findOne: findOneFn }),
+  },
+  getModel: jest.fn().mockReturnValue({
+    attributes: { username: { minLength: 3 } },
+  }),
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isUsernameTaken', () => {
+  it('returns false when username is not found', async () => {
+    global.strapi = makeQueryMock(jest.fn().mockResolvedValue(null));
+
+    const result = await isUsernameTaken('joe');
+
+    expect(result).toBe(false);
+    expect(strapi.db.query).toHaveBeenCalledWith('plugin::users-permissions.user');
+  });
+
+  it('returns true when username is found', async () => {
+    global.strapi = makeQueryMock(jest.fn().mockResolvedValue({ id: 1, username: 'joe' }));
+
+    const result = await isUsernameTaken('joe');
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('findValidUsername', () => {
+  it('returns basename when available and meets minLength', async () => {
+    global.strapi = makeQueryMock(jest.fn().mockResolvedValue(null));
+
+    const result = await findValidUsername('joe');
+
+    expect(result).toBe('joe');
+  });
+
+  it('returns suffixed username when basename is taken', async () => {
+    const findOne = jest
+      .fn()
+      .mockResolvedValueOnce({ id: 1, username: 'joe' }) // basename taken
+      .mockResolvedValueOnce(null); // joe1234 available
+
+    global.strapi = makeQueryMock(findOne);
+    crypto.randomInt.mockReturnValue(1234);
+
+    const result = await findValidUsername('joe');
+
+    expect(result).toBe('joe1234');
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips basename and appends suffix when basename is shorter than minLength', async () => {
+    global.strapi = makeQueryMock(jest.fn().mockResolvedValue(null));
+    crypto.randomInt.mockReturnValue(5678);
+
+    const result = await findValidUsername('jo'); // length 2 < minLength 3
+
+    // Should not try 'jo' first; goes straight to 'jo5678'
+    expect(result).toBe('jo5678');
+  });
+
+  it('retries on suffix collision and returns next available', async () => {
+    const findOne = jest
+      .fn()
+      .mockResolvedValueOnce({ id: 1 }) // basename taken
+      .mockResolvedValueOnce({ id: 2 }) // first suffix taken
+      .mockResolvedValueOnce(null); // second suffix available
+
+    global.strapi = makeQueryMock(findOne);
+    crypto.randomInt.mockReturnValueOnce(1111).mockReturnValueOnce(2222);
+
+    const result = await findValidUsername('joe');
+
+    expect(result).toBe('joe2222');
+    expect(findOne).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to UUID when all 10 attempts are taken', async () => {
+    // All calls return a taken user
+    const findOne = jest.fn().mockResolvedValue({ id: 1 });
+
+    global.strapi = makeQueryMock(findOne);
+    crypto.randomInt.mockReturnValue(1234);
+    crypto.randomUUID.mockReturnValue('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+    const result = await findValidUsername('joe');
+
+    expect(result).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1);
+    // 1 basename attempt + 10 suffix attempts = 11 total
+    expect(findOne).toHaveBeenCalledTimes(11);
+  });
+
+  it('respects custom minLength from model attributes', async () => {
+    global.strapi = {
+      db: { query: jest.fn().mockReturnValue({ findOne: jest.fn().mockResolvedValue(null) }) },
+      getModel: jest.fn().mockReturnValue({
+        attributes: { username: { minLength: 6 } },
+      }),
+    };
+    crypto.randomInt.mockReturnValue(9999);
+
+    // 'joe' length 3 < minLength 6 → skip basename, use suffix
+    const result = await findValidUsername('joe');
+
+    expect(result).toBe('joe9999');
+  });
+});

--- a/packages/plugins/users-permissions/server/utils/index.d.ts
+++ b/packages/plugins/users-permissions/server/utils/index.d.ts
@@ -17,3 +17,5 @@ type S = {
 };
 
 export function getService<T extends keyof S>(name: T): ReturnType<S[T]>;
+
+export function findUniqueUsername(basename: string): Promise<string>;

--- a/packages/plugins/users-permissions/server/utils/index.d.ts
+++ b/packages/plugins/users-permissions/server/utils/index.d.ts
@@ -18,4 +18,6 @@ type S = {
 
 export function getService<T extends keyof S>(name: T): ReturnType<S[T]>;
 
-export function findUniqueUsername(basename: string): Promise<string>;
+export function isUsernameTaken(username: string): Promise<boolean>;
+
+export function findValidUsername(basename: string): Promise<string>;

--- a/packages/plugins/users-permissions/server/utils/index.js
+++ b/packages/plugins/users-permissions/server/utils/index.js
@@ -1,12 +1,44 @@
 'use strict';
 
+const crypto = require('crypto');
 const sanitize = require('./sanitize');
+
+const MAX_USERNAME_ATTEMPTS = 10;
 
 const getService = (name) => {
   return strapi.plugin('users-permissions').service(name);
 };
 
+const findUniqueUsername = async (basename) => {
+  // First, check if the basename itself is available
+  const existingUser = await strapi.db
+    .query('plugin::users-permissions.user')
+    .findOne({ where: { username: basename } });
+
+  if (!existingUser) {
+    return basename;
+  }
+
+  // Try appending random numbers
+  for (let attempt = 0; attempt < MAX_USERNAME_ATTEMPTS; attempt++) {
+    const randomSuffix = crypto.randomInt(1000, 9999);
+    const candidateUsername = `${basename}${randomSuffix}`;
+
+    const userExists = await strapi.db
+      .query('plugin::users-permissions.user')
+      .findOne({ where: { username: candidateUsername } });
+
+    if (!userExists) {
+      return candidateUsername;
+    }
+  }
+
+  // Fallback to UUID if all attempts fail
+  return crypto.randomUUID();
+};
+
 module.exports = {
   getService,
+  findUniqueUsername,
   sanitize,
 };

--- a/packages/plugins/users-permissions/server/utils/index.js
+++ b/packages/plugins/users-permissions/server/utils/index.js
@@ -9,36 +9,34 @@ const getService = (name) => {
   return strapi.plugin('users-permissions').service(name);
 };
 
-const findUniqueUsername = async (basename) => {
-  // First, check if the basename itself is available
-  const existingUser = await strapi.db
-    .query('plugin::users-permissions.user')
-    .findOne({ where: { username: basename } });
+const isUsernameTaken = async (username) => {  
+  const user = await strapi.db  
+    .query('plugin::users-permissions.user')  
+    .findOne({ where: { username } });  
+  return Boolean(user);  
+};  
 
-  if (!existingUser) {
-    return basename;
-  }
+const findValidUsername = async (basename) => {  
+  const minLength =  
+    strapi.getModel('plugin::users-permissions.user')?.attributes?.username?.minLength ?? 3;  
+  const tryBasenameFirst = basename.length >= minLength;  
 
-  // Try appending random numbers
-  for (let attempt = 0; attempt < MAX_USERNAME_ATTEMPTS; attempt++) {
-    const randomSuffix = crypto.randomInt(1000, 9999);
-    const candidateUsername = `${basename}${randomSuffix}`;
+  let attempt = 0;  
+  let candidate;  
+  let taken;  
+  do {  
+    candidate =  
+      attempt === 0 && tryBasenameFirst ? basename : `${basename}${crypto.randomInt(1000, 9999)}`;  
+    taken = await isUsernameTaken(candidate);  
+    attempt += 1;  
+  } while (taken && attempt <= MAX_USERNAME_ATTEMPTS);  
 
-    const userExists = await strapi.db
-      .query('plugin::users-permissions.user')
-      .findOne({ where: { username: candidateUsername } });
-
-    if (!userExists) {
-      return candidateUsername;
-    }
-  }
-
-  // Fallback to UUID if all attempts fail
-  return crypto.randomUUID();
-};
+  return taken ? crypto.randomUUID() : candidate;  
+};  
 
 module.exports = {
   getService,
-  findUniqueUsername,
+  isUsernameTaken,
+  findValidUsername,
   sanitize,
 };

--- a/packages/plugins/users-permissions/server/utils/index.js
+++ b/packages/plugins/users-permissions/server/utils/index.js
@@ -9,30 +9,30 @@ const getService = (name) => {
   return strapi.plugin('users-permissions').service(name);
 };
 
-const isUsernameTaken = async (username) => {  
-  const user = await strapi.db  
-    .query('plugin::users-permissions.user')  
-    .findOne({ where: { username } });  
-  return Boolean(user);  
-};  
+const isUsernameTaken = async (username) => {
+  const user = await strapi.db
+    .query('plugin::users-permissions.user')
+    .findOne({ where: { username } });
+  return Boolean(user);
+};
 
-const findValidUsername = async (basename) => {  
-  const minLength =  
-    strapi.getModel('plugin::users-permissions.user')?.attributes?.username?.minLength ?? 3;  
-  const tryBasenameFirst = basename.length >= minLength;  
+const findValidUsername = async (basename) => {
+  const minLength =
+    strapi.getModel('plugin::users-permissions.user')?.attributes?.username?.minLength ?? 3;
+  const tryBasenameFirst = basename.length >= minLength;
 
-  let attempt = 0;  
-  let candidate;  
-  let taken;  
-  do {  
-    candidate =  
-      attempt === 0 && tryBasenameFirst ? basename : `${basename}${crypto.randomInt(1000, 9999)}`;  
-    taken = await isUsernameTaken(candidate);  
-    attempt += 1;  
-  } while (taken && attempt <= MAX_USERNAME_ATTEMPTS);  
+  let attempt = 0;
+  let candidate;
+  let taken;
+  do {
+    candidate =
+      attempt === 0 && tryBasenameFirst ? basename : `${basename}${crypto.randomInt(1000, 9999)}`;
+    taken = await isUsernameTaken(candidate);
+    attempt += 1;
+  } while (taken && attempt <= MAX_USERNAME_ATTEMPTS);
 
-  return taken ? crypto.randomUUID() : candidate;  
-};  
+  return taken ? crypto.randomUUID() : candidate;
+};
 
 module.exports = {
   getService,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This change appends a number at the end of a username if the username generated from the PROVIDER email is already taken instead of making a duplicate username.


### Why is it needed?

fix #23852 

This change is motivated by a bug I incountered in my application. Registering normally, with a username `joe`, after which trying to register with `joe@gmail.com` or any other provider, due to the current handling of usernames, allowed the user to be created with the username `joe` again. Leaving us with 2 users with the same username. This is a breaking issue, that needs to be looked at. I think it is best to append a counter at the end of an already taken username in these scenarios. Initially register `joe` would still stay. Newly registered with provider, `joe@gmail.com` will get the username `joe1` instead of the duplicate `joe`, which fixes the issue.

### How to test it?

Register using a username that you have a username on any provider with, ex. `joe` and you have an email ex. `joe@random.com`. It is important not to use the google account here and use a different email. After this user any auth provider login/register, and register with the provider account ex. `joe@google.com`. A user with username `joe1` will be created, instead of the duplicate `joe`. Therefore fixing the issue.