### PR TITLE
Fix placeholder/default issues in color picker custom field

### DIFF
--- a/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
+++ b/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx
@@ -83,7 +83,7 @@ export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerI
     const colorPickerButtonRef = React.useRef<HTMLButtonElement>(null!);
     const { formatMessage } = useIntl();
     const field = useField(name);
-    const color = field.value ?? '#000000';
+    const color = field.value ?? props.placeholder ?? '#000000';
 
     const composedRefs = useComposedRefs(forwardedRef, colorPickerButtonRef);
 
@@ -111,7 +111,7 @@ export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerI
                   <ColorPreview color={color} />
                   <Typography
                     style={{ textTransform: 'uppercase' }}
-                    textColor={field.value ? undefined : 'neutral600'}
+                    textColor={field.value ? undefined : 'neutral500'}
                     variant="omega"
                   >
                     {color}
@@ -139,7 +139,7 @@ export const ColorPickerInput = React.forwardRef<HTMLButtonElement, ColorPickerI
                     })}
                     style={{ textTransform: 'uppercase' }}
                     name={name}
-                    defaultValue={color}
+                    defaultValue={field.value}
                     placeholder="#000000"
                     onChange={field.onChange}
                     {...props}


### PR DESCRIPTION
### What does it do?

This commit fixes two issues in the color picker plugin.

When a placeholder is set, no value is set, and the popover is hidden, the placeholder was not actually shown (instead it was showing the default placeholder `#000000`). This fixes that by using the value of placeholder before the default placeholder.

The second issue is that when the popover is expanded, it was autofilling the field with the default placeholder value (`#000000`) regardless of whether a field value was actually set, or what the placeholder was.

### Why is it needed?

This makes users think that the field has a value of `#000000` despite the default implemented in code (and hinted by the placeholder) being something else. The configured placeholder should be shown instead.

### How to test it?

1. Add a custom field with the color picker plugin.
2. Set a placeholder in the view configurator.
3. Open the content manager and view the field
4. You should see the placeholder value, not `#000000`.

### Related issue(s)/PR(s)

Fixes #23854