### PR TITLE
fix: subnav component list not scrollable

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -253,7 +253,7 @@ const SubSection = ({ label, children }: { label: string; children: React.ReactN
           alignItems={'stretch'}
           style={{
             maxHeight: isOpen ? '1000px' : 0,
-            overflow: 'hidden',
+            overflowY: 'auto',
             transition: isOpen
               ? 'max-height 1s ease-in-out'
               : 'max-height 0.5s cubic-bezier(0, 1, 0, 1)',


### PR DESCRIPTION
fix #23734 

Now >>
[scrollable.webm](https://github.com/user-attachments/assets/374f0b4e-c2d3-4a15-8c09-0eb1f16039d6)
