### PR TITLE
fix(api-tokens): update lastUsedAt if it's null

### DIFF
--- a/packages/core/admin/server/src/strategies/api-token.ts
+++ b/packages/core/admin/server/src/strategies/api-token.ts
@@ -54,10 +54,17 @@ export const authenticate = async (ctx: Context) => {
     }
   }
 
-  // update lastUsedAt if the token has not been used in the last hour
-  // @ts-expect-error - FIXME: verify lastUsedAt is defined
-  const hoursSinceLastUsed = differenceInHours(currentDate, parseISO(apiToken.lastUsedAt));
-  if (hoursSinceLastUsed >= 1) {
+  if (!isNil(apiToken.lastUsedAt)) {
+    // update lastUsedAt if the token has not been used in the last hour
+    const hoursSinceLastUsed = differenceInHours(currentDate, parseISO(apiToken.lastUsedAt));
+    if (hoursSinceLastUsed >= 1) {
+      await strapi.db.query('admin::api-token').update({
+        where: { id: apiToken.id },
+        data: { lastUsedAt: currentDate },
+      });
+    }
+  } else {
+    // If lastUsedAt is not set, initialize it to the current date
     await strapi.db.query('admin::api-token').update({
       where: { id: apiToken.id },
       data: { lastUsedAt: currentDate },


### PR DESCRIPTION
### What does it do?

- Checks if lastUsedAt in api tokens is null and updates it to currentDate
- ensures that lastUsedAt is correctly updated

### Why is it needed?

- fix #23274 

### How to test it?
Create an Api Token, use it in any content-api request, Last Used should show and update like below
<img width="1577" alt="image" src="https://github.com/user-attachments/assets/b991cc2e-8a50-4fbc-92ee-64e5ed3785a8" />

### Related issue(s)/PR(s)

fix #23274 
