### PR TITLE
feat: do not update other locales if localized field was updated

### DIFF
--- a/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
+++ b/packages/plugins/i18n/server/src/services/__tests__/localizations.test.ts
@@ -115,7 +115,7 @@ describe('localizations service', () => {
       expect(update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: {},
-          where: { documentId: 'Doc1', locale: { $eq: 'fr' }, publishedAt: null },
+          where: { id: 1 },
         })
       );
     });

--- a/packages/plugins/i18n/server/src/services/localizations.ts
+++ b/packages/plugins/i18n/server/src/services/localizations.ts
@@ -20,20 +20,29 @@ const syncNonLocalizedAttributes = async (sourceEntry: any, model: Schema.Conten
   const locale = sourceEntry.locale;
   const status = sourceEntry?.publishedAt ? 'published' : 'draft';
 
-  // Find all the entries that need to be updated
-  // this is every other entry of the document in the same status but a different locale
+  // Fetch all fields needed for comparison and component update
+  const selectFields = ['locale', 'id', ...Object.keys(nonLocalizedAttributes)];
   const localeEntriesToUpdate = await strapi.db.query(uid).findMany({
     where: {
       documentId,
       publishedAt: status === 'published' ? { $ne: null } : null,
       locale: { $ne: locale },
     },
-    select: ['locale', 'id'],
+    select: selectFields,
   });
 
+  // Only update entries that have real changes
+  const entriesToActuallyUpdate = localeEntriesToUpdate.filter((entry: any) =>
+    Object.keys(nonLocalizedAttributes).some((key) => entry[key] !== nonLocalizedAttributes[key])
+  );
+
+  if (!entriesToActuallyUpdate.length) return;
+
+  // Prepare the main data for update (excluding components)
   const entryData = await strapi.documents(uid).omitComponentData(nonLocalizedAttributes);
 
-  await async.map(localeEntriesToUpdate, async (entry: any) => {
+  await async.map(entriesToActuallyUpdate, async (entry: any) => {
+    // Prepare transformed data for this entry
     const transformedData = await strapi.documents.utils.transformData(
       cloneDeep(nonLocalizedAttributes),
       {
@@ -44,21 +53,15 @@ const syncNonLocalizedAttributes = async (sourceEntry: any, model: Schema.Conten
       }
     );
 
-    // Update or create non localized components for the entry
+    // Update or create non-localized components for the entry
     const componentData = await strapi
       .documents(uid)
       .updateComponents(entry, transformedData as any);
 
-    // Update every other locale entry of this documentId in the same status
+    // Update the entry with merged data (main fields + updated components)
     await strapi.db.query(uid).update({
-      where: {
-        documentId,
-        publishedAt: status === 'published' ? { $ne: null } : null,
-        locale: { $eq: entry.locale },
-      },
-      // The data we send to the update function is the entry data merged with
-      // the updated component data
-      data: Object.assign(cloneDeep(entryData), componentData),
+      where: { id: entry.id },
+      data: { ...cloneDeep(entryData), ...componentData },
     });
   });
 };


### PR DESCRIPTION
### What does it do?

When changing a localized field inside a collection type (such as category in this example), only change the status of current locale. This was not working before because we were updating the "updatedAt" field of the document when any locale was changed, and other localizations seemed to be modified, when they were not. Now, we avoid updating this field if not necessary, causing every other part that checks the status of document to work properly.

### Why is it needed?

If an user is changing a localized field, other locales should not be marked as modified, since they weren't.

### How to test it?

```
cd ./examples/getstarted
yarn develop
```

- Add a new locale, in this example I used Brazilian Portuguese (pt-br) http://localhost:1337/admin/settings/internationalization
![image](https://github.com/user-attachments/assets/4ea04ceb-58cd-40fd-a5a2-95c96d58ff3b)
- Create a category that has 2 locales and publish them http://localhost:1337/admin/content-manager/collection-types/api::category.category/create?plugins%5Bi18n%5D%5Blocale%5D=en
![image](https://github.com/user-attachments/assets/4b5aa334-e854-43ea-bb54-03d03c278db1)
![image](https://github.com/user-attachments/assets/da761aab-eb88-4b9d-a20e-bb480b96ead5)
- When changing a localized field (such as `name` in this case) only the current locale status should be changed.
- When changing a non-localized field (such as `datetime` in this case), both locales status should be changed.

Before:
![Gravação de Tela 2025-07-03 às 15 30 57](https://github.com/user-attachments/assets/d13bc429-6701-4f45-b57c-97976537c7f0)

After:
![Gravação de Tela 2025-07-03 às 15 28 14](https://github.com/user-attachments/assets/8eaaf4a4-7b00-4bce-9541-0cf3110492f1)



### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
