### PR TITLE
Resolved filter overlap with datepicker by reducing zIndex of filter …

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -108,8 +108,14 @@ const Trigger = React.forwardRef<HTMLButtonElement, Filters.TriggerProps>(
 /* -------------------------------------------------------------------------------------------------
  * Popover
  * -----------------------------------------------------------------------------------------------*/
-
-const PopoverImpl = () => {
+/**
+ * The zIndex property is used to override the zIndex of the Portal element of the Popover.
+ * This is needed to ensure that the DatePicker is rendered above the Popover when opened.
+ * The issue was that both the DatePicker and the Popover are rendered in a Portal and have the same zIndex.
+ * On init, since the DatePicker is rendered before the Popover in the DOM,
+ * it's causing the issue of appearing behind the Popover.
+ */
+const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
   const [{ query }, setQuery] = useQueryParams<Filters.Query>();
   const { formatMessage } = useIntl();
   const options = useFilters('Popover', ({ options }) => options);
@@ -172,7 +178,7 @@ const PopoverImpl = () => {
   };
 
   return (
-    <Popover.Content style={{ zIndex: 499 }}>
+    <Popover.Content style={{ zIndex }}>
       <Box padding={3}>
         <Form
           method="POST"

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -172,7 +172,7 @@ const PopoverImpl = () => {
   };
 
   return (
-    <Popover.Content>
+    <Popover.Content style={{ zIndex: 499 }}>
       <Box padding={3}>
         <Form
           method="POST"

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/ListPage.tsx
@@ -146,7 +146,7 @@ const ListPageCE = () => {
             />
             <Filters.Root options={FILTERS}>
               <Filters.Trigger />
-              <Filters.Popover />
+              <Filters.Popover zIndex={499} />
               <Filters.List />
             </Filters.Root>
           </>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -109,7 +109,7 @@ const ListPage = () => {
         startActions={
           <Filters.Root options={displayedFilters}>
             <Filters.Trigger />
-            <Filters.Popover />
+            <Filters.Popover zIndex={499} />
             <Filters.List />
           </Filters.Root>
         }

--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -215,7 +215,7 @@ const FiltersImpl = ({ disabled, schema }: FiltersProps) => {
       onChange={handleFilterChange}
     >
       <Filters.Trigger />
-      <Filters.Popover />
+      <Filters.Popover zIndex={499} />
       <Filters.List />
     </Filters.Root>
   );


### PR DESCRIPTION
…container

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Reduced `z-index` of the container filter to make the entire `datePicker` to be visible in its entirety. 

https://github.com/user-attachments/assets/cc76ac92-fd51-4b05-86c1-34b8d5024ca0


### Why is it needed?

The `filter` box overlaps with the `datepicker` popover, causing the last line of dates from the `datePicker` to be inaccessible.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #23541 .
