### PR TITLE
fix: incomplete relation dropdown search results in RelationModalRenderer

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -725,7 +725,7 @@ const RelationModalWithContext = ({
           }}
           creatableStartIcon={<Plus fill="neutral500" />}
           name={name}
-          autocomplete="list"
+          autocomplete="none"
           placeholder={
             placeholder ||
             formatMessage({
@@ -757,6 +757,7 @@ const RelationModalWithContext = ({
           onInputChange={(event) => {
             handleSearch(event.currentTarget.value);
           }}
+          allowCustomValue
           {...props}
         >
           {options?.map((opt) => {


### PR DESCRIPTION
## What does it do?
Fixes a bug in the `RelationModalRenderer` where the relation dropdown failed to display all matching results from the backend when performing a search.

**Fix Summary:**
- Set `autocomplete="none"` on the `Combobox` to prevent browser autofill interference.
- Added `allowCustomValue` to support full search result display for dynamic queries.

## Why is it needed?
When users typed into a relation field, the dropdown only showed one result — even if the backend returned more. This made it difficult to find and select the correct relation.

After the fix, all relevant results from the API now appear properly in the dropdown.

## How to test it?
1. Go to a content type with a relation field (e.g., `midbanners`) in Content Manager.
2. Search with:
   - `20`
   - `uhr`
3. Confirm that all matching results are displayed.

---

## 🔍 API response (after fix)

### Query: `20`
**Request:**
```
GET /content-manager/relations/api::category.category/midbanners?locale=en&id=&pageSize=10&_q=20&page=1
```

**Response:**
```json
{
  "results": [
    {
      "id": 1,
      "documentId": "aby4jrsqrw4ncu8hoval0wq1",
      "title": "20Uhr-Lieferung-Morgens",
      "publishedAt": null,
      "updatedAt": "2025-07-05T10:50:15.429Z",
      "locale": "en",
      "status": "published"
    },
    {
      "id": 3,
      "documentId": "pi86y42gdsmt8s8i38pi30ij",
      "title": "Kategorie-Banner-Apple-AirPods-Pro-Januar-2021",
      "publishedAt": null,
      "updatedAt": "2025-07-05T10:50:32.035Z",
      "locale": "en",
      "status": "published"
    },
    {
      "id": 5,
      "documentId": "nnf722ev651kfw20q95kqbtw",
      "title": "Kategorie-Banner-Tech21-Samsung-Galaxy-S20-Ultra-5G-Antibakterielle-Display-Schutzfolie",
      "publishedAt": null,
      "updatedAt": "2025-07-05T10:50:46.170Z",
      "locale": "en",
      "status": "published"
    }
  ],
  "pagination": {
    "page": 1,
    "pageSize": 10,
    "pageCount": 1,
    "total": 3
  }
}
```

Screenshot:
Dropdown correctly shows 3 results after typing "20"
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/eaca03b9-53fd-4f24-bc5f-7f00d0e5429e" />

### Query: `uhr`
**Request:**
```
GET /content-manager/relations/api::category.category/midbanners?locale=en&id=&pageSize=10&_q=uhr&page=1
```

**Response:**
```json
{
  "results": [
    {
      "id": 1,
      "documentId": "aby4jrsqrw4ncu8hoval0wq1",
      "title": "20Uhr-Lieferung-Morgens",
      "publishedAt": null,
      "updatedAt": "2025-07-05T10:50:15.429Z",
      "locale": "en",
      "status": "published"
    }
  ],
  "pagination": {
    "page": 1,
    "pageSize": 10,
    "pageCount": 1,
    "total": 1
  }
}
```

Screenshot:
Dropdown correctly shows 1 result after typing "uhr"
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/ff46ba7f-9ae0-436f-895f-be3f95dc7108" />

## Related issue(s)/PR(s)
Fixes #23875 