### PR TITLE
feat(provider-email-amazon-ses): migrate to native AWS SDK v3

### DIFF
--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@strapi/utils": "5.17.0",
-    "node-ses": "^3.0.3"
+    "@aws-sdk/client-ses": "^3.840.0"
   },
   "devDependencies": {
     "eslint-config-custom": "5.17.0",


### PR DESCRIPTION
… of 3rd party package

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Currently, `node-ses` is used to send e-mail to the Amazon Simple Email Service. This PR migratie to the SES client provided and maintained by AWS itself.

### Why is it needed?

Reduce 3rd party dependencies. More features like default credential chain usage, etc.

### How to test it?

Send e-mail using SES as the configured e-mail plugin.



Please let me know if you require more changes. Would be great to also backport this into the v4 provider, since it does not conflict with Strapi core.

