### PR TITLE
future: add the Popover.Arrow in the guided tour

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Provider.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Provider.tsx
@@ -143,7 +143,10 @@ const GuidedTourProvider = ({ children }: GuidedTourProviderProps) => {
       setSkipped={setSkipped}
       setStepState={setStepState}
       startSection={startSection}
-      isGuidedTourVisible={isGuidedTourVisible}
+      // TODO: remove the future condition when the unstable guided tour will be released
+      isGuidedTourVisible={
+        isGuidedTourVisible && !window.strapi.future.isEnabled('unstableGuidedTour')
+      }
       isSkipped={isSkipped}
     >
       {children}

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -62,7 +62,7 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
         <Flex width="360px" direction="column" alignItems="start">
           {props.children}
         </Flex>
-        {currentStep > 1 && <PopoverArrowStandard />}
+        {currentStep > 1 && <PopoverArrowStandard width="20px" height="12px" />}
       </Popover.Content>
     );
   }),

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -55,12 +55,14 @@ const PopoverArrowStandard = styled(Popover.Arrow)`
 
 const createStepComponents = (tourName: ValidTourName): Step => ({
   Root: React.forwardRef((props, ref) => {
+    const state = unstableUseGuidedTour('GuidedTourPopover', (s) => s.state);
+    const currentStep = state.tours[tourName].currentStep + 1;
     return (
       <Popover.Content ref={ref} side="top" align="center" {...props}>
         <Flex width="360px" direction="column" alignItems="start">
           {props.children}
         </Flex>
-        <PopoverArrowStandard />
+        {currentStep > 1 && <PopoverArrowStandard />}
       </Popover.Content>
     );
   }),

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -49,7 +49,7 @@ const ActionsContainer = styled(Flex)`
   border-top: ${({ theme }) => `1px solid ${theme.colors.neutral150}`};
 `;
 
-const PopoverArrowStandard = styled(Popover.Arrow)`
+const PopoverArrow = styled(Popover.Arrow)`
   fill: ${({ theme }) => `${theme.colors.neutral0}`};
 `;
 
@@ -62,7 +62,7 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
         <Flex width="360px" direction="column" alignItems="start">
           {props.children}
         </Flex>
-        {currentStep > 1 && <PopoverArrowStandard width="20px" height="12px" />}
+        {currentStep > 1 && <PopoverArrow width="20px" height="12px" />}
       </Popover.Content>
     );
   }),

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -15,7 +15,6 @@ type WithChildren = {
   children: React.ReactNode;
   id?: never;
   defaultMessage?: never;
-  withArrow?: boolean;
 };
 
 type WithIntl = {
@@ -41,7 +40,9 @@ type StepProps = WithChildren | WithIntl;
 type ActionsProps = WithActionsChildren | WithActionsProps;
 
 type Step = {
-  Root: React.ForwardRefExoticComponent<React.ComponentProps<typeof Popover.Content>>;
+  Root: React.ForwardRefExoticComponent<
+    React.ComponentProps<typeof Popover.Content> & { withArrow?: boolean }
+  >;
   Title: (props: StepProps) => React.ReactNode;
   Content: (props: StepProps) => React.ReactNode;
   Actions: (props: ActionsProps & { to?: string }) => React.ReactNode;
@@ -51,14 +52,32 @@ const ActionsContainer = styled(Flex)`
   border-top: ${({ theme }) => `1px solid ${theme.colors.neutral150}`};
 `;
 
+/**
+ * TODO:
+ * We should probably move all arrow styles + svg to the DS
+ */
 const PopoverArrow = styled(Popover.Arrow)`
-  fill: ${({ theme }) => `${theme.colors.neutral0}`};
+  fill: ${({ theme }) => theme.colors.neutral0};
+  transform: translateY(-16px) rotate(-90deg);
 `;
 
 const createStepComponents = (tourName: ValidTourName): Step => ({
-  Root: React.forwardRef((props, ref) => {
+  Root: React.forwardRef(({ withArrow = true, ...props }, ref) => {
     return (
-      <Popover.Content ref={ref} side="top" align="center" {...props}>
+      <Popover.Content ref={ref} side="top" align="center" style={{ border: 'none' }} {...props}>
+        {withArrow && (
+          <PopoverArrow asChild>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="23"
+              height="25"
+              viewBox="0 0 23 25"
+              fill="none"
+            >
+              <path d="M11 24.5L1.82843 15.3284C0.266332 13.7663 0.26633 11.2337 1.82843 9.67157L11 0.5L23 12.5L11 24.5Z" />
+            </svg>
+          </PopoverArrow>
+        )}
         <Flex width="360px" direction="column" alignItems="start">
           {props.children}
         </Flex>
@@ -80,22 +99,17 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
     );
   },
 
-  Content: ({ withArrow = true, ...restProps }) => (
+  Content: (props) => (
     <>
       <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
-        {'children' in restProps ? (
-          restProps.children
+        {'children' in props ? (
+          props.children
         ) : (
           <Typography tag="div" variant="omega">
-            <FormattedMessage
-              tagName="p"
-              id={restProps.id}
-              defaultMessage={restProps.defaultMessage}
-            />
+            <FormattedMessage tagName="p" id={props.id} defaultMessage={props.defaultMessage} />
           </Typography>
         )}
       </Box>
-      {withArrow && <PopoverArrow />}
     </>
   ),
 

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -100,17 +100,15 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
   },
 
   Content: (props) => (
-    <>
-      <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
-        {'children' in props ? (
-          props.children
-        ) : (
-          <Typography tag="div" variant="omega">
-            <FormattedMessage tagName="p" id={props.id} defaultMessage={props.defaultMessage} />
-          </Typography>
-        )}
-      </Box>
-    </>
+    <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
+      {'children' in props ? (
+        props.children
+      ) : (
+        <Typography tag="div" variant="omega">
+          <FormattedMessage tagName="p" id={props.id} defaultMessage={props.defaultMessage} />
+        </Typography>
+      )}
+    </Box>
   ),
 
   Actions: ({ showStepCount = true, showSkip = false, to, ...props }) => {

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -49,14 +49,21 @@ const ActionsContainer = styled(Flex)`
   border-top: ${({ theme }) => `1px solid ${theme.colors.neutral150}`};
 `;
 
+const PopoverArrowStandard = styled(Popover.Arrow)`
+  fill: ${({ theme }) => `${theme.colors.neutral0}`};
+`;
+
 const createStepComponents = (tourName: ValidTourName): Step => ({
-  Root: React.forwardRef((props, ref) => (
-    <Popover.Content ref={ref} side="top" align="center" style={{ border: 'none' }} {...props}>
-      <Flex width="360px" direction="column" alignItems="start">
-        {props.children}
-      </Flex>
-    </Popover.Content>
-  )),
+  Root: React.forwardRef((props, ref) => {
+    return (
+      <Popover.Content ref={ref} side="top" align="center" {...props}>
+        <Flex width="360px" direction="column" alignItems="start">
+          {props.children}
+        </Flex>
+        <PopoverArrowStandard />
+      </Popover.Content>
+    );
+  }),
 
   Title: (props) => {
     return (

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Step.tsx
@@ -15,12 +15,14 @@ type WithChildren = {
   children: React.ReactNode;
   id?: never;
   defaultMessage?: never;
+  withArrow?: boolean;
 };
 
 type WithIntl = {
   children?: undefined;
   id: MessageDescriptor['id'];
   defaultMessage: MessageDescriptor['defaultMessage'];
+  withArrow?: boolean;
 };
 
 type WithActionsChildren = {
@@ -55,14 +57,11 @@ const PopoverArrow = styled(Popover.Arrow)`
 
 const createStepComponents = (tourName: ValidTourName): Step => ({
   Root: React.forwardRef((props, ref) => {
-    const state = unstableUseGuidedTour('GuidedTourPopover', (s) => s.state);
-    const currentStep = state.tours[tourName].currentStep + 1;
     return (
       <Popover.Content ref={ref} side="top" align="center" {...props}>
         <Flex width="360px" direction="column" alignItems="start">
           {props.children}
         </Flex>
-        {currentStep > 1 && <PopoverArrow width="20px" height="12px" />}
       </Popover.Content>
     );
   }),
@@ -81,16 +80,23 @@ const createStepComponents = (tourName: ValidTourName): Step => ({
     );
   },
 
-  Content: (props) => (
-    <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
-      {'children' in props ? (
-        props.children
-      ) : (
-        <Typography tag="div" variant="omega">
-          <FormattedMessage tagName="p" id={props.id} defaultMessage={props.defaultMessage} />
-        </Typography>
-      )}
-    </Box>
+  Content: ({ withArrow = true, ...restProps }) => (
+    <>
+      <Box paddingBottom={5} paddingLeft={5} paddingRight={5} width="100%">
+        {'children' in restProps ? (
+          restProps.children
+        ) : (
+          <Typography tag="div" variant="omega">
+            <FormattedMessage
+              tagName="p"
+              id={restProps.id}
+              defaultMessage={restProps.defaultMessage}
+            />
+          </Typography>
+        )}
+      </Box>
+      {withArrow && <PopoverArrow />}
+    </>
   ),
 
   Actions: ({ showStepCount = true, showSkip = false, to, ...props }) => {

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -33,6 +33,7 @@ const tours = {
           <Step.Content
             id="tours.contentTypeBuilder.Introduction.content"
             defaultMessage="Create and manage your content structure with collection types, single types and components."
+            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>
@@ -113,6 +114,7 @@ const tours = {
           <Step.Content
             id="tours.contentManager.Introduction.content"
             defaultMessage="Create and manage content from your collection types and single types."
+            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>
@@ -121,7 +123,7 @@ const tours = {
     {
       name: 'Fields',
       content: (Step) => (
-        <Step.Root side={'top'} sideOffset={-36}>
+        <Step.Root sideOffset={-36}>
           <Step.Title id="tours.contentManager.Fields.title" defaultMessage="Fields" />
           <Step.Content
             id="tours.contentManager.Fields.content"
@@ -171,6 +173,7 @@ const tours = {
           <Step.Content
             id="tours.apiTokens.Introduction.content"
             defaultMessage="Create and manage API tokens with highly customizable permissions."
+            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -5,7 +5,6 @@ import { FormattedMessage } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { type GetGuidedTourMeta } from '../../../../shared/contracts/admin';
 import { useGetGuidedTourMetaQuery } from '../../services/admin';
 
 import {
@@ -115,7 +114,6 @@ const tours = {
           <Step.Actions showSkip />
         </Step.Root>
       ),
-      when: (completedActions) => !completedActions.includes('didCreateApiToken'),
     },
     {
       name: 'CreateAnAPIToken',
@@ -203,7 +201,7 @@ const tours = {
     {
       name: 'Fields',
       content: (Step) => (
-        <Step.Root side={'top'} align="start" sideOffset={-36}>
+        <Step.Root side={'top'} sideOffset={-36}>
           <Step.Title id="tours.contentManager.Fields.title" defaultMessage="Fields" />
           <Step.Content
             id="tours.contentManager.Fields.content"

--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -25,7 +25,7 @@ const tours = {
     {
       name: 'Introduction',
       content: (Step) => (
-        <Step.Root side="bottom">
+        <Step.Root side="bottom" withArrow={false}>
           <Step.Title
             id="tours.contentTypeBuilder.Introduction.title"
             defaultMessage="Content-Type Builder"
@@ -33,7 +33,6 @@ const tours = {
           <Step.Content
             id="tours.contentTypeBuilder.Introduction.content"
             defaultMessage="Create and manage your content structure with collection types, single types and components."
-            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>
@@ -42,7 +41,7 @@ const tours = {
     {
       name: 'CollectionTypes',
       content: (Step) => (
-        <Step.Root side="right" sideOffset={26}>
+        <Step.Root side="right" sideOffset={16}>
           <Step.Title
             id="tours.contentTypeBuilder.CollectionTypes.title"
             defaultMessage="Collection Types"
@@ -58,7 +57,7 @@ const tours = {
     {
       name: 'SingleTypes',
       content: (Step) => (
-        <Step.Root side="right" sideOffset={26}>
+        <Step.Root side="right" sideOffset={16}>
           <Step.Title
             id="tours.contentTypeBuilder.SingleTypes.title"
             defaultMessage="Single Types"
@@ -74,7 +73,7 @@ const tours = {
     {
       name: 'Components',
       content: (Step) => (
-        <Step.Root side="right" sideOffset={26}>
+        <Step.Root side="right" sideOffset={16}>
           <Step.Title id="tours.contentTypeBuilder.Components.title" defaultMessage="Components" />
           <Step.Content
             id="tours.contentTypeBuilder.Components.content"
@@ -87,7 +86,7 @@ const tours = {
     {
       name: 'Finish',
       content: (Step) => (
-        <Step.Root side="right" sideOffset={32}>
+        <Step.Root side="right">
           <Step.Title
             id="tours.contentTypeBuilder.Finish.title"
             defaultMessage="It’s time to create content!"
@@ -106,7 +105,7 @@ const tours = {
     {
       name: 'Introduction',
       content: (Step) => (
-        <Step.Root side="top">
+        <Step.Root side="top" withArrow={false}>
           <Step.Title
             id="tours.contentManager.Introduction.title"
             defaultMessage="Content manager"
@@ -114,7 +113,6 @@ const tours = {
           <Step.Content
             id="tours.contentManager.Introduction.content"
             defaultMessage="Create and manage content from your collection types and single types."
-            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>
@@ -123,7 +121,7 @@ const tours = {
     {
       name: 'Fields',
       content: (Step) => (
-        <Step.Root sideOffset={-36}>
+        <Step.Root sideOffset={-12}>
           <Step.Title id="tours.contentManager.Fields.title" defaultMessage="Fields" />
           <Step.Content
             id="tours.contentManager.Fields.content"
@@ -136,7 +134,7 @@ const tours = {
     {
       name: 'Publish',
       content: (Step) => (
-        <Step.Root side="left" align="center" sideOffset={20}>
+        <Step.Root side="left" align="center">
           <Step.Title id="tours.contentManager.Publish.title" defaultMessage="Publish" />
           <Step.Content
             id="tours.contentManager.Publish.content"
@@ -149,7 +147,7 @@ const tours = {
     {
       name: 'Finish',
       content: (Step) => (
-        <Step.Root side="right" sideOffset={32}>
+        <Step.Root side="right">
           <Step.Title
             id="tours.contentManager.FinalStep.title"
             defaultMessage="It’s time to create API Tokens!"
@@ -168,12 +166,11 @@ const tours = {
     {
       name: 'Introduction',
       content: (Step) => (
-        <Step.Root sideOffset={-36}>
+        <Step.Root sideOffset={-36} withArrow={false}>
           <Step.Title id="tours.apiTokens.Introduction.title" defaultMessage="API tokens" />
           <Step.Content
             id="tours.apiTokens.Introduction.content"
             defaultMessage="Create and manage API tokens with highly customizable permissions."
-            withArrow={false}
           />
           <Step.Actions showSkip />
         </Step.Root>
@@ -182,7 +179,7 @@ const tours = {
     {
       name: 'CreateAnAPIToken',
       content: (Step) => (
-        <Step.Root side="bottom" sideOffset={20} align="end">
+        <Step.Root side="bottom" align="end" sideOffset={-10}>
           <Step.Title
             id="tours.apiTokens.CreateAnAPIToken.title"
             defaultMessage="Create an API token"
@@ -198,7 +195,7 @@ const tours = {
     {
       name: 'CopyAPIToken',
       content: (Step) => (
-        <Step.Root side="bottom" align="start">
+        <Step.Root side="bottom" align="start" sideOffset={-5}>
           <Step.Title
             id="tours.apiTokens.CopyAPIToken.title"
             defaultMessage="Copy your new API token"
@@ -217,7 +214,7 @@ const tours = {
       content: (Step) => {
         const dispatch = unstableUseGuidedTour('GuidedTourPopover', (s) => s.dispatch);
         return (
-          <Step.Root side="right" align="start" sideOffset={32}>
+          <Step.Root side="right" align="start">
             <Step.Title
               id="tours.apiTokens.FinalStep.title"
               defaultMessage="It’s time to deploy your application!"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds the Popover.Arrow to the Guided tour popovers

### Why is it needed?

it is required by design

### How to test it?

- Clean the local storage and create a new Strapi project from scratch without collectiions
- try to create new Collections following the Guided tour
- and add new content using the Content manager
- and create a new Api token

use the experimental 0.0.0-experimental.f37a0ea0333947b6879c4608fae75646d63c07a1  to create the project
