### PR TITLE
fix: add reducer to be able to mutate widgets in register function

### DIFF
--- a/packages/core/admin/admin/src/core/apis/Widgets.ts
+++ b/packages/core/admin/admin/src/core/apis/Widgets.ts
@@ -29,6 +29,8 @@ type WidgetArgs = {
 
 type Widget = Omit<WidgetArgs, 'id' | 'pluginId'> & { uid: WidgetUID };
 
+type DescriptionReducer<T extends object> = (prev: Record<string, T>) => Record<string, T>;
+
 class Widgets {
   widgets: Record<string, Widget>;
 
@@ -36,19 +38,21 @@ class Widgets {
     this.widgets = {};
   }
 
-  register = (widget: WidgetArgs | WidgetArgs[]) => {
-    if (Array.isArray(widget)) {
-      widget.forEach((newWidget) => {
+  register = (widgets: WidgetArgs | WidgetArgs[] | DescriptionReducer<Widget>) => {
+    if (Array.isArray(widgets)) {
+      widgets.forEach((newWidget) => {
         this.register(newWidget);
       });
+    } else if (typeof widgets === 'function') {
+      this.widgets = widgets(this.widgets);
     } else {
-      invariant(widget.id, 'An id must be provided');
-      invariant(widget.component, 'A component must be provided');
-      invariant(widget.title, 'A title must be provided');
-      invariant(widget.icon, 'An icon must be provided');
+      invariant(widgets.id, 'An id must be provided');
+      invariant(widgets.component, 'A component must be provided');
+      invariant(widgets.title, 'A title must be provided');
+      invariant(widgets.icon, 'An icon must be provided');
 
       // Replace id and pluginId with computed uid
-      const { id, pluginId, ...widgetToStore } = widget;
+      const { id, pluginId, ...widgetToStore } = widgets;
       const uid: WidgetUID = pluginId ? `plugin::${pluginId}.${id}` : `global::${id}`;
 
       this.widgets[uid] = { ...widgetToStore, uid };

--- a/packages/core/admin/admin/src/core/apis/tests/widgets.test.ts
+++ b/packages/core/admin/admin/src/core/apis/tests/widgets.test.ts
@@ -61,6 +61,25 @@ describe('Widgets', () => {
       );
     });
 
+    test('execute reducer to alter existing widgets', () => {
+      const secondWidget = {
+        ...mockWidget,
+        id: 'second-widget',
+      };
+      widgets.register([mockWidget, secondWidget]);
+
+      // Swap the order using the reducer
+      widgets.register((widgetsMap) => {
+        const arr = Object.values(widgetsMap);
+        const reversed = arr.reverse();
+        return Object.fromEntries(reversed.map((w) => [w.uid, w]));
+      });
+
+      const registeredWidgets = widgets.getAll();
+      expect(registeredWidgets[0].uid).toBe(`global::${secondWidget.id}`);
+      expect(registeredWidgets[1].uid).toBe(`global::${mockWidget.id}`);
+    });
+
     test('throws when id is missing', () => {
       const invalidWidget = { ...mockWidget, id: undefined };
       expect(() => widgets.register(invalidWidget as any)).toThrow('An id must be provided');

--- a/packages/core/content-manager/admin/src/index.ts
+++ b/packages/core/content-manager/admin/src/index.ts
@@ -8,6 +8,8 @@ import { previewAdmin } from './preview';
 import { routes } from './router';
 import { prefixPluginTranslations } from './utils/translations';
 
+import type { WidgetType } from '@strapi/admin/strapi-admin';
+
 // NOTE: we have to preload it to ensure chunks will have it available as global
 import 'prismjs';
 
@@ -76,6 +78,19 @@ export default {
         permissions: [{ action: 'plugin::content-manager.explorer.read' }],
       },
     ]);
+
+    // Always put the last-edited-entries and last-published-entries widgets first in the list of widgets
+    app.widgets.register((widgets: Record<string, WidgetType>) => {
+      const desiredOrder = [
+        'plugin::content-manager.last-edited-entries',
+        'plugin::content-manager.last-published-entries',
+      ];
+      const ordered = [
+        ...desiredOrder.map((uid) => widgets[uid]).filter(Boolean),
+        ...Object.values(widgets).filter((w) => !desiredOrder.includes(w.uid)),
+      ];
+      return Object.fromEntries(ordered.map((w) => [w.uid, w]));
+    });
   },
   bootstrap(app: any) {
     if (typeof historyAdmin.bootstrap === 'function') {


### PR DESCRIPTION
fix: put widgets from content-manager first in list
fix: put review-workflows widget last in list

### What does it do?

Provides a reducer to the register function of the widgets in order to allow mutations on it.
The purpose here is to be able to reorder the widgets by using the same method than for the addDocumentAction (to reorder items in action menus in the content manager -> ex: history action before delete actions).
_The two widgets from the content-manager (last edited entries and last published entries need to always be the two first widgets on the homepage)._

### Why is it needed?

Be able to alter the list of widgets on the homepage by using the register function.

### How to test it?

- Go to the admin interface homepage
-> The list of widget should be in the following order:
  - Last edited entries
  - Last published entries
  - Profile
  - Entries (chart) -> when https://github.com/strapi/strapi/pull/23903 will be merged
  - Assigned to me

🚀