### PR TITLE
future: add confirmation dialog when closing the tour

### DIFF
--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Overview.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Overview.tsx
@@ -1,8 +1,10 @@
-import { Box, Button, Flex, Link, ProgressBar, Typography } from '@strapi/design-system';
+import { Box, Button, Dialog, Flex, Link, ProgressBar, Typography } from '@strapi/design-system';
 import { CheckCircle, ChevronRight } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import { styled, useTheme } from 'styled-components';
+
+import { ConfirmDialog } from '../ConfirmDialog';
 
 import { type ValidTourName, unstableUseGuidedTour } from './Context';
 
@@ -179,12 +181,22 @@ export const UnstableGuidedTourOverview = () => {
           <Typography variant="pi">{completionPercentage}%</Typography>
           <StyledProgressBar value={completionPercentage} />
         </Flex>
-        <Button variant="tertiary" onClick={() => dispatch({ type: 'skip_all_tours' })}>
-          {formatMessage({
-            id: 'tours.overview.close',
-            defaultMessage: 'Close guided tour',
-          })}
-        </Button>
+        <Dialog.Root>
+          <Dialog.Trigger>
+            <Button variant="tertiary">
+              {formatMessage({
+                id: 'tours.overview.close',
+                defaultMessage: 'Close guided tour',
+              })}
+            </Button>
+          </Dialog.Trigger>
+          <ConfirmDialog onConfirm={() => dispatch({ type: 'skip_all_tours' })}>
+            {formatMessage({
+              id: 'tours.overview.close.description',
+              defaultMessage: 'Are you sure you want to close the guided tour?',
+            })}
+          </ConfirmDialog>
+        </Dialog.Root>
       </ContentSection>
       <VerticalSeparator />
       {/* Task List */}

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -831,5 +831,6 @@
   "tours.overview.strapiCloud.link": "Read documentation",
   "tours.overview.tour.link": "Start",
   "tours.overview.tour.done": "Done",
+  "tours.overview.close.description": "Are you sure you want to close the guided tour?",
   "widget.profile.title": "Profile"
 }


### PR DESCRIPTION
### What does it do?

Add the confirmation dialog when closing the guided tour

### Why is it needed?

It's in the designs

### How to test it?

Make sure you have the future flag enabled and local storage is clear
Go to the overview and click close guided tour
You should see a confirmation dialog
Click confirm
It should close the dialog and the guided tour overview 


https://github.com/user-attachments/assets/68830e90-1b95-4ede-bb33-d92f29470e1d



### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
