### PR TITLE
fix(wrong-auth-redirection): Fix issue when redirecting user to auth page.

### DIFF
--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -92,7 +92,7 @@ const rtkQueryUnauthorizedMiddleware: Middleware =
     // isRejectedWithValue Or isRejected
     if (isRejected(action) && action.payload?.status === 401) {
       dispatch(logout());
-      window.location.href = '/admin/auth/login';
+      window.location.href = process.env.STRAPI_ADMIN_BACKEND_URL + '/admin/auth/login';
       return;
     }
 


### PR DESCRIPTION
This commit aim to fix the following issue :
- With a strapi behind a proxy, with a public url of `https://www.mywebsitedomain.fr/my-strapi` with a public_url set in `server.js` file
- As a user who has is session expired
- I try to access to any url starting by `https://www.mywebsitedomain.fr/my-strapi`
- I get redirected to Auth page but instead of `https://www.mywebsitedomain.fr/my-strapi/admin/auth/login` i get redirected to `https://www.mywebsitedomain.fr/admin/auth/login`


### What does it do?

Fix issue https://github.com/strapi/strapi/issues/23920

### Why is it needed?

Impossible for production user to properly access to strapi admin pannel.

### How to test it?

Read the ticket https://github.com/strapi/strapi/issues/23920, reproduce the issue with this fix

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/23920