### PR TITLE
future: add Bosnian and Mongolian Cyrillic language support

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -260,6 +260,22 @@
     "name": "Bosnian (bs)"
   },
   {
+    "code": "bs-Cyrl",
+    "name": "Bosnian (Cyrillic)"
+  },
+  {
+    "code": "bs-Cyrl-BA",
+    "name": "Bosnian (Cyrillic, Bosnia and Herzegovina)"
+  },
+  {
+    "code": "bs-Latn",
+    "name": "Bosnian (Latin)"
+  },
+  {
+    "code": "bs-Latn-BA",
+    "name": "Bosnian (Latin, Bosnia and Herzegovina)"
+  },
+  {
     "code": "bs-BA",
     "name": "Bosnian (Bosnia and Herzegovina) (bs-BA)"
   },
@@ -1602,6 +1618,10 @@
   {
     "code": "mn",
     "name": "Mongolian (mn)"
+  },
+  {
+    "code": "mn-Cyrl",
+    "name": "Mongolian (Cyrillic)"
   },
   {
     "code": "mfe",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds support for these missing languages:
- bs-Cyrl: Bosnian (Cyrillic)
- bs-Cyrl-BA: Bosnian (Cyrillic, Bosnia and Herzegovina)
- bs-Latn: Bosnian (Latin)
- bs-Latn-BA: Bosnian (Latin, Bosnia and Herzegovina)
- mn-Cyrl: Mongolian (Cyrillic)


### Why is it needed?

Currently, these language codes aren’t supported, blocking users from translating their apps into these locales.

### How to test it?

After merging, these languages should appear in your config and be selectable for translations.

### Related issue(s)/PR(s)

N/A
