### PR TITLE
fix: fix for Content-type builder cutting  off component types

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -252,7 +252,7 @@ const SubSection = ({ label, children }: { label: string; children: React.ReactN
           gap="2px"
           alignItems={'stretch'}
           style={{
-            maxHeight: isOpen ? '1000px' : 0,
+            maxHeight: isOpen ? 'fit-content' : 0,
             overflow: 'hidden',
             transition: isOpen
               ? 'max-height 1s ease-in-out'


### PR DESCRIPTION
### What does it do?

Fixed the components being cut off when the collection/components are more in number.

### Why is it needed?

To fix issue [23918](https://github.com/strapi/strapi/issues/23918) : Sidebar in Content-Type Builder UI cuts off component/collection types

### How to test it?

- Go to the Content-Type Builder in the Admin Panel.
- Add many collection types or components (more than the sidebar can fit vertically).
- Observe that the list gets cut off with no scrollbar.
- Attempting to scroll does not reveal all entries.

### Related issue(s)/PR(s)

fixes [23918](https://github.com/strapi/strapi/issues/23918)
