### PR TITLE
fix: malformed validation message

### DIFF
--- a/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
+++ b/packages/core/admin/admin/src/pages/Auth/components/Register.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Box, Button, Flex, Grid, Typography, Link } from '@strapi/design-system';
 import omit from 'lodash/omit';
-import { useIntl } from 'react-intl';
+import { MessageDescriptor, PrimitiveType, useIntl } from 'react-intl';
 import { NavLink, Navigate, useNavigate, useMatch, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 import * as yup from 'yup';
@@ -187,6 +187,10 @@ interface RegisterFormValues {
   confirmPassword: string;
   registrationToken: string | undefined;
   news: boolean;
+}
+
+interface IntlFormattedMessage extends MessageDescriptor {
+  values?: Record<string, PrimitiveType>;
 }
 
 const Register = ({ hasAdmin }: RegisterProps) => {
@@ -395,7 +399,8 @@ const Register = ({ hasAdmin }: RegisterProps) => {
                 helpers.setErrors(
                   err.inner.reduce<Record<string, string>>((acc, { message, path }) => {
                     if (path && typeof message === 'object') {
-                      acc[path] = formatMessage(message);
+                      const typedMessage = message as IntlFormattedMessage;
+                      acc[path] = formatMessage(message, typedMessage.values);
                     }
                     return acc;
                   }, {})


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the malformed password validation message by ensuring the min variable is correctly interpolated in the error string. Previously, when the password did not meet the minimum length, the message displayed {min} instead of the actual number

### Why is it needed?

The current validation message for short passwords is misleading and confusing, as it literally shows {min} rather than the expected minimum length. This fix improves user experience by showing clear and correct validation feedback during registration.

### How to test it?

- Go to the registration form
- Fill in the required fields
- Enter a short password (less than 8 characters)
- Click "Let's start"
- Observe the validation message (it should now correctly display the required minimum length)

### Related issue(s)/PR(s)

Fixes #23930
