### PR TITLE
future: only show guided tour overview to first super admin

### DIFF
--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Overview.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Overview.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import { styled, useTheme } from 'styled-components';
 
+import { useGetGuidedTourMetaQuery } from '../../services/admin';
 import { ConfirmDialog } from '../ConfirmDialog';
 
 import { type ValidTourName, unstableUseGuidedTour } from './Context';
@@ -141,13 +142,14 @@ export const UnstableGuidedTourOverview = () => {
   const tours = unstableUseGuidedTour('Overview', (s) => s.state.tours);
   const dispatch = unstableUseGuidedTour('Overview', (s) => s.dispatch);
   const enabled = unstableUseGuidedTour('Overview', (s) => s.state.enabled);
+  const { data: guidedTourMeta } = useGetGuidedTourMetaQuery();
   const tourNames = Object.keys(tours) as ValidTourName[];
 
   const completedTours = tourNames.filter((tourName) => tours[tourName].isCompleted);
   const completionPercentage =
     tourNames.length > 0 ? Math.round((completedTours.length / tourNames.length) * 100) : 0;
 
-  if (!enabled) {
+  if (!guidedTourMeta?.data.isFirstSuperAdminUser || !enabled) {
     return null;
   }
 


### PR DESCRIPTION
### What does it do?

Esnures only first super admin can see the guided tour overview

### Why is it needed?

It's a product requirement

### How to test it?

Turn the future flag on
Ensure local storage is clear of STRAPI_GUIDED_TOUR in case you've closed the overview before
Login as the first super admin
Go to the homepage
You should see the guided tour
Login as another user regardless of role
You should not see the guided tour

