### PR TITLE
fix: add Introduction step in the Single collection Edit view

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -10,7 +10,7 @@ import {
   useQueryParams,
   unstable_tours,
 } from '@strapi/admin/strapi-admin';
-import { Grid, Main, Tabs } from '@strapi/design-system';
+import { Grid, Main, Tabs, Box } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useLocation, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
@@ -140,6 +140,14 @@ const EditViewPage = () => {
   return (
     <Main paddingLeft={10} paddingRight={10}>
       <Page.Title>{pageTitle}</Page.Title>
+      {
+        isSingleType && (
+          <unstable_tours.contentManager.Introduction>
+            {/* Invisible Anchor */}
+            <Box paddingTop={5} />
+          </unstable_tours.contentManager.Introduction>
+        )
+      }
       <Form
         disabled={hasDraftAndPublished && status === 'published'}
         initialValues={initialValues}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the absence of the Introduction step in the content manager guided tour when you create a new single collection document

### Why is it needed?

In the case you are starting with a single collection the lack of this step can cause confusion

### How to test it?

Use this experimental to create a new strapi project and follow the guided tour steps, create a single collection instead of a collection and then try to add some content to this new collection

### Related issue(s)/PR(s)

fixes https://github.com/strapi/content-squad/issues/35
