### PR TITLE
fix: Added translations for the text "Create an Entry" in multiple languages.

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -35,6 +35,7 @@ import { useDocumentRBAC } from '../../../features/DocumentRBAC';
 import { useDoc } from '../../../hooks/useDocument';
 import { useDocumentActions } from '../../../hooks/useDocumentActions';
 import { CLONE_PATH, LIST_PATH } from '../../../router';
+import { getTranslation } from '../../../utils/translations';
 import { getDisplayName } from '../../../utils/users';
 
 import { DocumentActionsMenu } from './DocumentActions';
@@ -59,7 +60,7 @@ const Header = ({ isCreating, status, title: documentTitle = 'Untitled' }: Heade
 
   const title = isCreating
     ? formatMessage({
-        id: 'content-manager.containers.edit.title.new',
+        id: getTranslation('containers.edit.title.new'),
         defaultMessage: 'Create an entry',
       })
     : documentTitle;

--- a/packages/core/content-manager/admin/src/translations/ar.json
+++ b/packages/core/content-manager/admin/src/translations/ar.json
@@ -127,6 +127,7 @@
   "components.uid.suggested": "مقترح",
   "components.uid.unavailable": "غير متوفره",
   "containers.Edit.delete-entry": "احذف هذا الإدخال",
+  "containers.edit.title.new": "إنشاء إدخال",
   "containers.Edit.information": "معلومة",
   "containers.Edit.information.by": "بواسطة",
   "containers.Edit.information.created": "أُنشء",

--- a/packages/core/content-manager/admin/src/translations/ca.json
+++ b/packages/core/content-manager/admin/src/translations/ca.json
@@ -68,6 +68,7 @@
   "containers.Edit.clickToJump": "Click per anar al registre",
   "containers.Edit.delete": "Eliminar",
   "containers.Edit.delete-entry": "Eliminar aquesta entrada",
+  "containers.edit.title.new": "Crear una entrada",
   "containers.Edit.editing": "Editant...",
   "containers.Edit.information": "Informació",
   "containers.Edit.information.by": "Per",

--- a/packages/core/content-manager/admin/src/translations/cs.json
+++ b/packages/core/content-manager/admin/src/translations/cs.json
@@ -32,6 +32,7 @@
   "containers.Edit.addAnItem": "Přidat záznam...",
   "containers.Edit.clickToJump": "Klikněte pro přechod k záznamu",
   "containers.Edit.delete": "Odstranit",
+  "containers.edit.title.new": "Vytvořit záznam",
   "containers.Edit.editing": "Úpravy...",
   "containers.Edit.pluginHeader.title.new": "Vytvořit záznam",
   "containers.Edit.reset": "Resetovat",

--- a/packages/core/content-manager/admin/src/translations/de.json
+++ b/packages/core/content-manager/admin/src/translations/de.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Klicke, um zu einem Eintrag zu springen",
   "containers.Edit.delete": "Löschen",
   "containers.Edit.delete-entry": "Diesen Eintrag löschen",
+  "containers.edit.title.new": "Eintrag erstellen",
   "containers.Edit.editing": "Bearbeite...",
   "containers.Edit.information": "Informationen",
   "containers.Edit.information.by": "Von",

--- a/packages/core/content-manager/admin/src/translations/es.json
+++ b/packages/core/content-manager/admin/src/translations/es.json
@@ -64,6 +64,7 @@
   "containers.Edit.addAnItem": "Agregar un registro...",
   "containers.Edit.clickToJump": "Click para ir al registro",
   "containers.Edit.delete": "Eliminar",
+  "containers.edit.title.new": "Crear una entrada",
   "containers.Edit.delete-entry": "Eliminar esta entrada",
   "containers.Edit.editing": "Editando...",
   "containers.Edit.information": "Información",

--- a/packages/core/content-manager/admin/src/translations/eu.json
+++ b/packages/core/content-manager/admin/src/translations/eu.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Egin klik sarrerara salto egiteko",
   "containers.Edit.delete": "Ezabatu",
   "containers.Edit.delete-entry": "Ezabatu sarrera hau",
+  "containers.edit.title.new": "Sarrera bat sortu",
   "containers.Edit.editing": "Editatzen...",
   "containers.Edit.information": "Informazioa",
   "containers.Edit.information.by": "Nork",

--- a/packages/core/content-manager/admin/src/translations/fr.json
+++ b/packages/core/content-manager/admin/src/translations/fr.json
@@ -68,6 +68,7 @@
   "containers.Edit.clickToJump": "Cliquer pour voir l'entrée",
   "containers.Edit.delete": "Supprimer",
   "containers.Edit.delete-entry": "Supprimer cette entrée",
+  "containers.edit.title.new": "Créer une entrée",
   "containers.Edit.editing": "Édition en cours...",
   "containers.Edit.information": "Informations",
   "containers.Edit.information.by": "Par",

--- a/packages/core/content-manager/admin/src/translations/gu.json
+++ b/packages/core/content-manager/admin/src/translations/gu.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "એન્ટ્રી પર જવા માટે ક્લિક કરો",
   "containers.Edit.delete": "કાઢી નાખો",
   "containers.Edit.delete-entry": "આ એન્ટ્રી કાઢી નાખો",
+  "containers.edit.title.new": "એક એન્ટ્રી બનાવો",
   "containers.Edit.editing": "સંપાદન...",
   "containers.Edit.information": "માહિતી",
   "containers.Edit.information.by": "દ્વારા",

--- a/packages/core/content-manager/admin/src/translations/hi.json
+++ b/packages/core/content-manager/admin/src/translations/hi.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "प्रवेश पर जाने के लिए क्लिक करें",
   "containers.Edit.delete": "मिटाना",
   "containers.Edit.delete-entry": "मिटाना",
+  "containers.edit.title.new": "एक प्रविष्टि बनाएँ",
   "containers.Edit.editing": "संपादन...",
   "containers.Edit.information": "जानकारी",
   "containers.Edit.information.by": "द्वारा",

--- a/packages/core/content-manager/admin/src/translations/hu.json
+++ b/packages/core/content-manager/admin/src/translations/hu.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Kattintson a bejegyzésre ugráshoz",
   "containers.Edit.delete": "Törlés",
   "containers.Edit.delete-entry": "Bejegyzés törlése",
+  "containers.edit.title.new": "Bejegyzés létrehozása",
   "containers.Edit.editing": "Szerkesztés...",
   "containers.Edit.information": "Információ",
   "containers.Edit.information.by": "által",

--- a/packages/core/content-manager/admin/src/translations/id.json
+++ b/packages/core/content-manager/admin/src/translations/id.json
@@ -43,6 +43,7 @@
   "containers.Edit.clickToJump": "Klik untuk melompat ke entri",
   "containers.Edit.delete": "Hapus",
   "containers.Edit.delete-entry": "Hapus entri ini",
+  "containers.edit.title.new": "Buat Entri",
   "containers.Edit.editing": "Mengedit...",
   "containers.Edit.information": "Informasi",
   "containers.Edit.information.by": "Oleh",

--- a/packages/core/content-manager/admin/src/translations/it.json
+++ b/packages/core/content-manager/admin/src/translations/it.json
@@ -44,6 +44,7 @@
   "containers.Edit.clickToJump": "Clicca per andare all'elemento",
   "containers.Edit.delete": "Elimina",
   "containers.Edit.delete-entry": "Elimina questo elemento",
+  "containers.edit.title.new": "Crea una voce",
   "containers.Edit.editing": "Modifica in corso...",
   "containers.Edit.information": "Informazioni",
   "containers.Edit.information.by": "Da",

--- a/packages/core/content-manager/admin/src/translations/ja.json
+++ b/packages/core/content-manager/admin/src/translations/ja.json
@@ -65,6 +65,7 @@
   "containers.Edit.clickToJump": "クリックするとエントリにジャンプします",
   "containers.Edit.delete": "削除",
   "containers.Edit.delete-entry": "Delete this entry",
+  "containers.edit.title.new": "エントリを作成",
   "containers.Edit.editing": "編集...",
   "containers.Edit.information": "Information",
   "containers.Edit.information.by": "By",

--- a/packages/core/content-manager/admin/src/translations/ko.json
+++ b/packages/core/content-manager/admin/src/translations/ko.json
@@ -65,6 +65,7 @@
   "containers.Edit.clickToJump": "해당 항목으로 이동하려면 클릭",
   "containers.Edit.delete": "삭제",
   "containers.Edit.delete-entry": "이 항목 삭제",
+  "containers.edit.title.new": "항목 만들기",
   "containers.Edit.editing": "수정 중...",
   "containers.Edit.information": "정보",
   "containers.Edit.information.by": "편집자",

--- a/packages/core/content-manager/admin/src/translations/ml.json
+++ b/packages/core/content-manager/admin/src/translations/ml.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "എൻട്രിയിലേക്ക് പോകുന്നതിന് ക്ലിക്കുചെയ്യുക",
   "containers.Edit.delete": "ഇല്ലാതാക്കുക",
   "containers.Edit.delete-entry": "ഈ എൻട്രി ഇല്ലാതാക്കുക",
+  "containers.edit.title.new": "ഒരു എൻട്രി സൃഷ്ടിക്കുക",
   "containers.Edit.editing": "എഡിറ്റിംഗ്...",
   "containers.Edit.information": "വിവരങ്ങൾ",
   "containers.Edit.information.by": "എഴുതിയത്",

--- a/packages/core/content-manager/admin/src/translations/ms.json
+++ b/packages/core/content-manager/admin/src/translations/ms.json
@@ -38,6 +38,7 @@
   "containers.Edit.addAnItem": "Tambah item...",
   "containers.Edit.clickToJump": "Klik untuk pergi ke entri",
   "containers.Edit.delete": "Padam",
+  "containers.edit.title.new": "Cipta Entri",
   "containers.Edit.editing": "Menyunting...",
   "containers.Edit.pluginHeader.title.new": "Buat entri",
   "containers.Edit.reset": "Semula",

--- a/packages/core/content-manager/admin/src/translations/nl.json
+++ b/packages/core/content-manager/admin/src/translations/nl.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Klik om naar de invoer te springen",
   "containers.Edit.delete": "Verwijder",
   "containers.Edit.delete-entry": "Verwijder deze invoer",
+  "containers.edit.title.new": "Een item aanmaken",
   "containers.Edit.editing": "Aanpassen...",
   "containers.Edit.information": "Informatie",
   "containers.Edit.information.by": "Door",

--- a/packages/core/content-manager/admin/src/translations/pl.json
+++ b/packages/core/content-manager/admin/src/translations/pl.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Kliknij aby przejść do elementu",
   "containers.Edit.delete": "Usuń",
   "containers.Edit.delete-entry": "Usuń ten wpis",
+  "containers.edit.title.new": "Utwórz wpis",
   "containers.Edit.editing": "Edytowanie...",
   "containers.Edit.information": "Informacje",
   "containers.Edit.information.by": "Przez",

--- a/packages/core/content-manager/admin/src/translations/pt-BR.json
+++ b/packages/core/content-manager/admin/src/translations/pt-BR.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Clique para pular para o registro",
   "containers.Edit.delete": "Remover",
   "containers.Edit.delete-entry": "Remover este registro",
+  "containers.edit.title.new": "Criar uma entrada",
   "containers.Edit.editing": "Editando...",
   "containers.Edit.information": "Informação",
   "containers.Edit.information.by": "Por",

--- a/packages/core/content-manager/admin/src/translations/pt.json
+++ b/packages/core/content-manager/admin/src/translations/pt.json
@@ -21,6 +21,7 @@
   "containers.Edit.addAnItem": "Adicionar uma entrada...",
   "containers.Edit.clickToJump": "Clique para saltar para a entrada",
   "containers.Edit.delete": "Apagar",
+  "containers.edit.title.new": "Criar uma entrada",
   "containers.Edit.editing": "Editando...",
   "containers.Edit.reset": "Restabelecer",
   "containers.Edit.returnList": "Retornar à lista",

--- a/packages/core/content-manager/admin/src/translations/ru.json
+++ b/packages/core/content-manager/admin/src/translations/ru.json
@@ -71,6 +71,7 @@
   "containers.Edit.clickToJump": "Нажмите для перехода к записи",
   "containers.Edit.delete": "Удалить",
   "containers.Edit.delete-entry": "Удалить эту запись",
+  "containers.edit.title.new": "Создать запись",
   "containers.Edit.editing": "Редактирование...",
   "containers.Edit.information": "Информация",
   "containers.Edit.information.by": "Автор",

--- a/packages/core/content-manager/admin/src/translations/sa.json
+++ b/packages/core/content-manager/admin/src/translations/sa.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "प्रविष्टिं प्रति कूर्दितुं क्लिक् कुर्वन्तु",
   "containers.Edit.delete": "विलोपनम्",
   "containers.Edit.delete-entry": "एतत् प्रविष्टिं विलोपयतु",
+  "containers.edit.title.new": "प्रविष्टिं रचयतु",
   "containers.Edit.editing": "सम्पादनम्...",
   "containers.Edit.information": "सूचना",
   "containers.Edit.information.by": "द्वारा",

--- a/packages/core/content-manager/admin/src/translations/sk.json
+++ b/packages/core/content-manager/admin/src/translations/sk.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Kliknutím zobrazte položku",
   "containers.Edit.delete": "Zmazať",
   "containers.Edit.delete-entry": "Zmazať túto položku",
+  "containers.edit.title.new": "Vytvoriť záznam",
   "containers.Edit.editing": "Úprava...",
   "containers.Edit.information": "Informácie",
   "containers.Edit.information.by": "Autor",

--- a/packages/core/content-manager/admin/src/translations/sv.json
+++ b/packages/core/content-manager/admin/src/translations/sv.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "Klicka för att gå till posten",
   "containers.Edit.delete": "Ta bort",
   "containers.Edit.delete-entry": "Ta bort denna posten",
+  "containers.edit.title.new": "Skapa en post",
   "containers.Edit.editing": "Redigerar...",
   "containers.Edit.information": "Information",
   "containers.Edit.information.by": "Av",

--- a/packages/core/content-manager/admin/src/translations/th.json
+++ b/packages/core/content-manager/admin/src/translations/th.json
@@ -40,6 +40,7 @@
   "containers.Edit.addAnItem": "เพิ่มไอเท็ม...",
   "containers.Edit.clickToJump": "คลิกเพื่อข้ามไปยังรายการ",
   "containers.Edit.delete": "ลบ",
+  "containers.edit.title.new": "สร้างรายการ",
   "containers.Edit.editing": "กำลังแก้ไข...",
   "containers.Edit.pluginHeader.title.new": "สร้างรายการ",
   "containers.Edit.reset": "รีเซ็ต",

--- a/packages/core/content-manager/admin/src/translations/tr.json
+++ b/packages/core/content-manager/admin/src/translations/tr.json
@@ -67,6 +67,7 @@
   "containers.Edit.addAnItem": "Bir öğe ekle...",
   "containers.Edit.clickToJump": "Kayıta atlamak için tıklayın",
   "containers.Edit.delete": "Sil",
+  "containers.edit.title.new": "Giriş Oluştur",
   "containers.Edit.editing": "Düzenleniyor...",
   "containers.Edit.information": "Bilgi",
   "containers.Edit.information.by": "Tarafından",

--- a/packages/core/content-manager/admin/src/translations/vi.json
+++ b/packages/core/content-manager/admin/src/translations/vi.json
@@ -22,6 +22,7 @@
   "containers.Edit.addAnItem": "Thêm một bản ghi...",
   "containers.Edit.clickToJump": "Nhấn để nhảy vào bản ghi",
   "containers.Edit.delete": "Xóa",
+  "containers.edit.title.new": "Tạo một mục",
   "containers.Edit.editing": "Đăng sửa...",
   "containers.Edit.pluginHeader.title.new": "Tạo một Bản ghi",
   "containers.Edit.reset": "Làm lại",

--- a/packages/core/content-manager/admin/src/translations/zh.json
+++ b/packages/core/content-manager/admin/src/translations/zh.json
@@ -67,6 +67,7 @@
   "containers.Edit.clickToJump": "跳到該筆資料",
   "containers.Edit.delete": "刪除",
   "containers.Edit.delete-entry": "刪除這個項目",
+  "containers.edit.title.new": "建立項目",
   "containers.Edit.editing": "編輯中...",
   "containers.Edit.information": "資訊",
   "containers.Edit.information.by": "操作人",


### PR DESCRIPTION
### What does it do?

Added translations for the text "Create an Entry" in multiple languages.

### Why is it needed?

To fix issue [23902](https://github.com/strapi/strapi/issues/23902) : "Create an Entry" not localized 

### How to test it?

- Sign in to the admin panel with any language selected
- Click on Content Manager
- Choose any collection
- Click to the button to create a new entry (this button IS localized to the language so it shows "Crear nueva entrada" for Spanish, etc.)
- The title of the 'create' page is ALWAYS shown in English as "Create an Entry"

### Related issue(s)/PR(s)

fixes [23902](https://github.com/strapi/strapi/issues/23902)
