### PR TITLE
Resolved filter overlapping issue by changing z-index

### DIFF
--- a/packages/core/upload/admin/src/components/FilterPopover/FilterPopover.tsx
+++ b/packages/core/upload/admin/src/components/FilterPopover/FilterPopover.tsx
@@ -259,7 +259,7 @@ export const FilterPopover = ({
   const appliedFilter = displayedFilters.find((filter) => filter.name === modifiedData.name);
 
   return (
-    <Popover.Content sideOffset={4}>
+    <Popover.Content sideOffset={4} style={{ zIndex: 499 }}>
       <form onSubmit={handleSubmit}>
         <Flex padding={3} direction="column" alignItems="stretch" gap={1} style={{ minWidth: 184 }}>
           <Box>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changed the z-index of the filter popover component used in `Media Library`.

https://github.com/user-attachments/assets/93e4b4c0-a077-407d-8d67-9d86cadd8749


### Why is it needed?

To resolve the issue of the filter popover overlapping the datepicker, making parts of the datepicker unusable.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #23952 
