### PR TITLE
Resolved datepicker overlap on first open by changing z index

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -172,7 +172,7 @@ const PopoverImpl = () => {
   };
 
   return (
-    <Popover.Content>
+    <Popover.Content style={{ zIndex: 5 }}>
       <Box padding={3}>
         <Form
           method="POST"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changed the z-index of Filter component used in content manager.

https://github.com/user-attachments/assets/dd31d3f1-1867-46e3-8470-759250526f8c



### Why is it needed?

To resolve the issue on first opening the filter drawer, the calendar for the default “createdAt” field appears underneath the drawer making it difficult to select the year and month

### How to test it?

The steps provided to reproduce the issue in the issue Pr (https://github.com/strapi/strapi/issues/23838) are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/23838