### PR TITLE
future: always run the tour regardless of app state

### DIFF
--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Popover, Portal, Flex, Button, FlexProps } from '@strapi/design-system';
+import { Box, Popover, Portal, Button } from '@strapi/design-system';
 import { FormattedMessage } from 'react-intl';
 import { styled } from 'styled-components';
 
@@ -115,9 +115,7 @@ const tours = {
   contentManager: createTour('contentManager', [
     {
       name: 'Introduction',
-      when: (completedActions) =>
-        completedActions.includes('didCreateContentTypeSchema') &&
-        !completedActions.includes('didCreateContent'),
+      when: (completedActions) => completedActions.includes('didCreateContentTypeSchema'),
       content: (Step) => (
         <Step.Root side="top" withArrow={false}>
           <Step.Title
@@ -183,7 +181,6 @@ const tours = {
   apiTokens: createTour('apiTokens', [
     {
       name: 'Introduction',
-      when: (completedActions) => !completedActions.includes('didCreateApiToken'),
       content: (Step) => (
         <Step.Root sideOffset={-36} withArrow={false}>
           <Step.Title id="tours.apiTokens.Introduction.title" defaultMessage="API tokens" />

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -301,138 +301,144 @@ const ListViewPage = () => {
   }
 
   return (
-    <Page.Main>
-      <Page.Title>{`${contentTypeTitle}`}</Page.Title>
-      <LayoutsHeaderCustom
-        primaryAction={canCreate ? <CreateButton /> : null}
-        subtitle={formatMessage(
-          {
-            id: getTranslation('pages.ListView.header-subtitle'),
-            defaultMessage:
-              '{number, plural, =0 {# entries} one {# entry} other {# entries}} found',
-          },
-          { number: pagination?.total }
-        )}
-        title={contentTypeTitle}
-        navigationAction={<BackButton />}
-      />
-      <Layouts.Action
-        endActions={
-          <>
-            <InjectionZone area="listView.actions" />
-            <ViewSettingsMenu
-              setHeaders={handleSetHeaders}
-              resetHeaders={() => setDisplayedHeaders(list.layout)}
-              headers={displayedHeaders.map((header) => header.name)}
-            />
-          </>
-        }
-        startActions={
-          <>
-            {list.settings.searchable && (
-              <SearchInput
-                disabled={results.length === 0}
-                label={formatMessage(
-                  { id: 'app.component.search.label', defaultMessage: 'Search for {target}' },
-                  { target: contentTypeTitle }
-                )}
-                placeholder={formatMessage({
-                  id: 'global.search',
-                  defaultMessage: 'Search',
-                })}
-                trackedEvent="didSearch"
+    <>
+      <unstable_tours.contentManager.Introduction>
+        {/* Invisible Anchor */}
+        <Box paddingTop={5} />
+      </unstable_tours.contentManager.Introduction>
+      <Page.Main>
+        <Page.Title>{`${contentTypeTitle}`}</Page.Title>
+        <LayoutsHeaderCustom
+          primaryAction={canCreate ? <CreateButton /> : null}
+          subtitle={formatMessage(
+            {
+              id: getTranslation('pages.ListView.header-subtitle'),
+              defaultMessage:
+                '{number, plural, =0 {# entries} one {# entry} other {# entries}} found',
+            },
+            { number: pagination?.total }
+          )}
+          title={contentTypeTitle}
+          navigationAction={<BackButton />}
+        />
+        <Layouts.Action
+          endActions={
+            <>
+              <InjectionZone area="listView.actions" />
+              <ViewSettingsMenu
+                setHeaders={handleSetHeaders}
+                resetHeaders={() => setDisplayedHeaders(list.layout)}
+                headers={displayedHeaders.map((header) => header.name)}
               />
-            )}
-            {list.settings.filterable && schema ? (
-              <Filters disabled={results.length === 0} schema={schema} />
-            ) : null}
-          </>
-        }
-      />
-      <Layouts.Content>
-        <Flex gap={4} direction="column" alignItems="stretch">
-          <Table.Root rows={results} headers={tableHeaders} isLoading={isFetching}>
-            <TableActionsBar />
-            <Table.Content>
-              <Table.Head>
-                <Table.HeaderCheckboxCell />
-                {tableHeaders.map((header: ListFieldLayout) => (
-                  <Table.HeaderCell key={header.name} {...header} />
-                ))}
-              </Table.Head>
-              <Table.Loading />
-              <Table.Empty action={canCreate ? <CreateButton variant="secondary" /> : null} />
-              <Table.Body>
-                {results.map((row) => {
-                  return (
-                    <Table.Row
-                      cursor="pointer"
-                      key={row.id}
-                      onClick={handleRowClick(row.documentId)}
-                    >
-                      <Table.CheckboxCell id={row.id} />
-                      {tableHeaders.map(({ cellFormatter, ...header }) => {
-                        if (header.name === 'status') {
-                          const { status } = row;
+            </>
+          }
+          startActions={
+            <>
+              {list.settings.searchable && (
+                <SearchInput
+                  disabled={results.length === 0}
+                  label={formatMessage(
+                    { id: 'app.component.search.label', defaultMessage: 'Search for {target}' },
+                    { target: contentTypeTitle }
+                  )}
+                  placeholder={formatMessage({
+                    id: 'global.search',
+                    defaultMessage: 'Search',
+                  })}
+                  trackedEvent="didSearch"
+                />
+              )}
+              {list.settings.filterable && schema ? (
+                <Filters disabled={results.length === 0} schema={schema} />
+              ) : null}
+            </>
+          }
+        />
+        <Layouts.Content>
+          <Flex gap={4} direction="column" alignItems="stretch">
+            <Table.Root rows={results} headers={tableHeaders} isLoading={isFetching}>
+              <TableActionsBar />
+              <Table.Content>
+                <Table.Head>
+                  <Table.HeaderCheckboxCell />
+                  {tableHeaders.map((header: ListFieldLayout) => (
+                    <Table.HeaderCell key={header.name} {...header} />
+                  ))}
+                </Table.Head>
+                <Table.Loading />
+                <Table.Empty action={canCreate ? <CreateButton variant="secondary" /> : null} />
+                <Table.Body>
+                  {results.map((row) => {
+                    return (
+                      <Table.Row
+                        cursor="pointer"
+                        key={row.id}
+                        onClick={handleRowClick(row.documentId)}
+                      >
+                        <Table.CheckboxCell id={row.id} />
+                        {tableHeaders.map(({ cellFormatter, ...header }) => {
+                          if (header.name === 'status') {
+                            const { status } = row;
 
+                            return (
+                              <Table.Cell key={header.name}>
+                                <DocumentStatus status={status} maxWidth={'min-content'} />
+                              </Table.Cell>
+                            );
+                          }
+                          if (['createdBy', 'updatedBy'].includes(header.name.split('.')[0])) {
+                            // Display the users full name
+                            // Some entries doesn't have a user assigned as creator/updater (ex: entries created through content API)
+                            // In this case, we display a dash
+                            return (
+                              <Table.Cell key={header.name}>
+                                <Typography textColor="neutral800">
+                                  {row[header.name.split('.')[0]]
+                                    ? getDisplayName(row[header.name.split('.')[0]])
+                                    : '-'}
+                                </Typography>
+                              </Table.Cell>
+                            );
+                          }
+                          if (typeof cellFormatter === 'function') {
+                            return (
+                              <Table.Cell key={header.name}>
+                                {/* @ts-expect-error – TODO: fix this TS error */}
+                                {cellFormatter(row, header, { collectionType, model })}
+                              </Table.Cell>
+                            );
+                          }
                           return (
                             <Table.Cell key={header.name}>
-                              <DocumentStatus status={status} maxWidth={'min-content'} />
+                              <CellContent
+                                content={row[header.name.split('.')[0]]}
+                                rowId={row.documentId}
+                                {...header}
+                              />
                             </Table.Cell>
                           );
-                        }
-                        if (['createdBy', 'updatedBy'].includes(header.name.split('.')[0])) {
-                          // Display the users full name
-                          // Some entries doesn't have a user assigned as creator/updater (ex: entries created through content API)
-                          // In this case, we display a dash
-                          return (
-                            <Table.Cell key={header.name}>
-                              <Typography textColor="neutral800">
-                                {row[header.name.split('.')[0]]
-                                  ? getDisplayName(row[header.name.split('.')[0]])
-                                  : '-'}
-                              </Typography>
-                            </Table.Cell>
-                          );
-                        }
-                        if (typeof cellFormatter === 'function') {
-                          return (
-                            <Table.Cell key={header.name}>
-                              {/* @ts-expect-error – TODO: fix this TS error */}
-                              {cellFormatter(row, header, { collectionType, model })}
-                            </Table.Cell>
-                          );
-                        }
-                        return (
-                          <Table.Cell key={header.name}>
-                            <CellContent
-                              content={row[header.name.split('.')[0]]}
-                              rowId={row.documentId}
-                              {...header}
-                            />
-                          </Table.Cell>
-                        );
-                      })}
-                      {/* we stop propagation here to allow the menu to trigger it's events without triggering the row redirect */}
-                      <ActionsCell onClick={(e) => e.stopPropagation()}>
-                        <TableActions document={row} />
-                      </ActionsCell>
-                    </Table.Row>
-                  );
-                })}
-              </Table.Body>
-            </Table.Content>
-          </Table.Root>
-          <Pagination.Root
-            {...pagination}
-            onPageSizeChange={() => trackUsage('willChangeNumberOfEntriesPerPage')}
-          >
-            <Pagination.PageSize />
-            <Pagination.Links />
-          </Pagination.Root>
-        </Flex>
-      </Layouts.Content>
-    </Page.Main>
+                        })}
+                        {/* we stop propagation here to allow the menu to trigger it's events without triggering the row redirect */}
+                        <ActionsCell onClick={(e) => e.stopPropagation()}>
+                          <TableActions document={row} />
+                        </ActionsCell>
+                      </Table.Row>
+                    );
+                  })}
+                </Table.Body>
+              </Table.Content>
+            </Table.Root>
+            <Pagination.Root
+              {...pagination}
+              onPageSizeChange={() => trackUsage('willChangeNumberOfEntriesPerPage')}
+            >
+              <Pagination.PageSize />
+              <Pagination.Links />
+            </Pagination.Root>
+          </Flex>
+        </Layouts.Content>
+      </Page.Main>
+    </>
   );
 };
 

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-default-export */
-import { useTracking, Layouts } from '@strapi/admin/strapi-admin';
+import { useTracking, Layouts, unstable_tours } from '@strapi/admin/strapi-admin';
 import { Box, Button, Flex, Typography } from '@strapi/design-system';
 import { Information, Pencil, Plus } from '@strapi/icons';
 import upperFirst from 'lodash/upperFirst';
@@ -143,6 +143,10 @@ const ListView = () => {
 
   return (
     <>
+      <unstable_tours.contentTypeBuilder.Introduction>
+        {/* Invisible Anchor */}
+        <Box paddingTop={5} />
+      </unstable_tours.contentTypeBuilder.Introduction>
       {isDeleted && (
         <Flex background="danger100" justifyContent={'center'} padding={4}>
           <Flex gap={2}>


### PR DESCRIPTION
### What does it do?

- Runs the tours no matter what the app state is

### Why is it needed?

Simplify

### How to test it?

0.0.0-experimental.7281e9ed655cf0093344801f3db6c50a4f6ec20f

- Test with this option: Start with an example structure & data? y
When the overview loads all tours should be marked as not done yet
When you go to the CTB it should propose the tour even if there is already a schema
When you go to the CM it should propose the tour even if there is already content
When you go to the API tokens it should propose the tour even if a new token has been created

Otherwise it should function the same as before. Test an empty app too to ensure this is the case. 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
