### PR TITLE
future: fix Final Step Popover has the LeftMenu link tooltip on top of it

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Divider, Flex, FlexComponent, useCollator } from '@strapi/design-system';
 import { Lightning } from '@strapi/icons';
 import { useIntl } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { type To, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { useAuth } from '../features/Auth';
@@ -16,6 +16,7 @@ import { NavBrand } from './MainNav/NavBrand';
 import { NavLink } from './MainNav/NavLink';
 import { NavUser } from './MainNav/NavUser';
 import { TrialCountdown } from './MainNav/TrialCountdown';
+import { tours as unstable_tours } from './UnstableGuidedTour/Tours';
 
 const sortLinks = (links: MenuItem[]) => {
   return links.sort((a, b) => {
@@ -46,6 +47,21 @@ const NavListWrapper = styled<FlexComponent<'ul'>>(Flex)`
 `;
 
 interface LeftMenuProps extends Pick<Menu, 'generalSectionLinks' | 'pluginsSectionLinks'> {}
+
+const getGuidedTourTooltip = (to: To) => {
+  const normalizedTo = to.toString().replace(/\//g, '');
+
+  switch (normalizedTo) {
+    case 'content-manager':
+      return unstable_tours.contentTypeBuilder.Finish;
+    case '':
+      return unstable_tours.apiTokens.Finish;
+    case 'settings':
+      return unstable_tours.contentManager.Finish;
+    default:
+      return React.Fragment;
+  }
+};
 
 const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) => {
   const user = useAuth('AuthenticatedApp', (state) => state.user);
@@ -88,38 +104,41 @@ const LeftMenu = ({ generalSectionLinks, pluginsSectionLinks }: LeftMenuProps) =
                   : undefined;
 
               const labelValue = formatMessage(link.intlLabel);
+              const GuidedTourTooltip = getGuidedTourTooltip(link.to);
               return (
                 <Flex tag="li" key={link.to}>
-                  <NavLink.Tooltip label={labelValue}>
-                    <NavLink.Link
-                      to={link.to}
-                      onClick={() => handleClickOnLink(link.to)}
-                      aria-label={labelValue}
-                    >
-                      <NavLink.Icon label={labelValue}>
-                        <LinkIcon width="20" height="20" fill="neutral500" />
-                      </NavLink.Icon>
-                      {badgeContentLock ? (
-                        <NavLinkBadgeLock
-                          label="locked"
-                          textColor="neutral500"
-                          paddingLeft={0}
-                          paddingRight={0}
-                        >
-                          {badgeContentLock}
-                        </NavLinkBadgeLock>
-                      ) : badgeContentNumeric ? (
-                        <NavLinkBadgeCounter
-                          label={badgeContentNumeric}
-                          backgroundColor="primary600"
-                          width="2.3rem"
-                          color="neutral0"
-                        >
-                          {badgeContentNumeric}
-                        </NavLinkBadgeCounter>
-                      ) : null}
-                    </NavLink.Link>
-                  </NavLink.Tooltip>
+                  <GuidedTourTooltip>
+                    <NavLink.Tooltip label={labelValue}>
+                      <NavLink.Link
+                        to={link.to}
+                        onClick={() => handleClickOnLink(link.to)}
+                        aria-label={labelValue}
+                      >
+                        <NavLink.Icon label={labelValue}>
+                          <LinkIcon width="20" height="20" fill="neutral500" />
+                        </NavLink.Icon>
+                        {badgeContentLock ? (
+                          <NavLinkBadgeLock
+                            label="locked"
+                            textColor="neutral500"
+                            paddingLeft={0}
+                            paddingRight={0}
+                          >
+                            {badgeContentLock}
+                          </NavLinkBadgeLock>
+                        ) : badgeContentNumeric ? (
+                          <NavLinkBadgeCounter
+                            label={badgeContentNumeric}
+                            backgroundColor="primary600"
+                            width="2.3rem"
+                            color="neutral0"
+                          >
+                            {badgeContentNumeric}
+                          </NavLinkBadgeCounter>
+                        ) : null}
+                      </NavLink.Link>
+                    </NavLink.Tooltip>
+                  </GuidedTourTooltip>
                 </Flex>
               );
             })

--- a/packages/core/admin/admin/src/components/MainNav/NavLink.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavLink.tsx
@@ -7,11 +7,8 @@ import {
   BadgeProps,
   AccessibleIcon,
 } from '@strapi/design-system';
-import { NavLink as RouterLink, LinkProps, To } from 'react-router-dom';
+import { NavLink as RouterLink, LinkProps } from 'react-router-dom';
 import { styled } from 'styled-components';
-
-import { tours as unstable_tours } from '../UnstableGuidedTour/Tours';
-
 /* -------------------------------------------------------------------------------------------------
  * Link
  * -----------------------------------------------------------------------------------------------*/
@@ -41,31 +38,9 @@ const MainNavLinkWrapper = styled(RouterLink)`
   }
 `;
 
-const getGuidedTourTooltip = (to: To) => {
-  const normalizedTo = to.toString().replace(/\//g, '');
-
-  switch (normalizedTo) {
-    case 'content-manager':
-      return unstable_tours.contentTypeBuilder.Finish;
-    case '':
-      return unstable_tours.apiTokens.Finish;
-    case 'settings':
-      return unstable_tours.contentManager.Finish;
-    default:
-      return React.Fragment;
-  }
-};
-
-const LinkImpl = ({ children, ...props }: LinkProps) => {
-  const GuidedTourTooltip = getGuidedTourTooltip(props.to);
-
-  return (
-    <GuidedTourTooltip>
-      <MainNavLinkWrapper {...props}>{children}</MainNavLinkWrapper>
-    </GuidedTourTooltip>
-  );
-};
-
+const LinkImpl = ({ children, ...props }: LinkProps) => (
+  <MainNavLinkWrapper {...props}>{children}</MainNavLinkWrapper>
+);
 /* -------------------------------------------------------------------------------------------------
  * Tooltip
  * -----------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix this undesired behaviour 
<img width="481" height="360" alt="tooltip" src="https://github.com/user-attachments/assets/f46b1d96-a1d3-4786-a85a-6da9cd566459" />

when we show the Final step of a Guided tour

### Why is it needed?

I want to solve this ui issue

### How to test it?

Try to run the new guided tour and reach the final step of every tour and check if the Popover near the LeftMenu Link is visible without the NavLink tooltip on top of it

### Related issue(s)/PR(s)

fixes https://github.com/strapi/content-squad/issues/39
