### PR TITLE
future: add step count to all got it actions

### DIFF
--- a/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/UnstableGuidedTour/Tours.tsx
@@ -86,7 +86,8 @@ const tours = {
             id="tours.contentTypeBuilder.Components.content"
             defaultMessage="A reusable content structure that can be used across multiple content types, such as buttons, sliders or cards."
           />
-          <Step.Actions justifyContent="flex-end">
+          <Step.Actions>
+            <StepCount tourName="contentTypeBuilder" />
             <GotItAction
               onClick={() => dispatch({ type: 'next_step', payload: 'contentTypeBuilder' })}
             />
@@ -154,7 +155,8 @@ const tours = {
             id="tours.contentManager.Publish.content"
             defaultMessage="Publish entries to make their content available through the Document Service API."
           />
-          <Step.Actions justifyContent="flex-end">
+          <Step.Actions>
+            <StepCount tourName="contentManager" />
             <GotItAction
               onClick={() => dispatch({ type: 'next_step', payload: 'contentManager' })}
             />


### PR DESCRIPTION
### What does it do?

Adds the step count to all got it actions

### Why is it needed?

They are supposed to be there

### How to test it?

Go through all tours. You should always see the step count on a "Got it" step

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
