### PR TITLE
Fix: Docker Service Allows Dangerous Privilege Escalation Without Protection in docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,11 @@
 version: '3'
 
 services:
+    security_opt:
+      - no-new-privileges:true
   postgres:
+    security_opt:
+      - no-new-privileges:true
     image: postgres
     restart: always
     volumes:


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'postgres' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** docker-compose.dev.yml
- **Lines Affected:** 4 - 4

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker-compose.dev.yml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.