### PR TITLE
chore(content-manager): fix typo in code comment

### DIFF
--- a/packages/core/content-manager/admin/src/utils/api.ts
+++ b/packages/core/content-manager/admin/src/utils/api.ts
@@ -18,7 +18,7 @@ type TransformedQuery<TQuery extends Query> = Omit<TQuery, 'plugins'> & {
 /**
  * @description
  * Creates a valid query params object for get requests
- * ie. plugins[18n][locale]=en becomes locale=en
+ * ie. plugins[i18n][locale]=en becomes locale=en
  */
 const buildValidParams = <TQuery extends Query>(query: TQuery): TransformedQuery<TQuery> => {
   if (!query) return query;


### PR DESCRIPTION
### What does it do?

This small change makes sure this line of code appears when searching for `plugins[i18n][locale]`.

### Why is it needed?

I was searching the strapi code to determine how `plugins[i18n][locale]` is read from the URL. I would have found this sooner when this comment did not have this typo.