### PR TITLE
Ctm debounced search

### DIFF
--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -5,6 +5,7 @@ import { Search as SearchIcon } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { TrackingEvent, useTracking } from '../features/Tracking';
+import { useDebounce } from '../hooks/useDebounce';
 import { useQueryParams } from '../hooks/useQueryParams';
 
 interface SearchInputProps {
@@ -29,6 +30,7 @@ const SearchInput = ({
 
   const [value, setValue] = React.useState(query?._q || '');
   const [isOpen, setIsOpen] = React.useState(!!value);
+  const debouncedSearch = useDebounce(value, 500) || '';
 
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
@@ -46,25 +48,27 @@ const SearchInput = ({
     setQuery({ _q: '' }, 'remove');
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    // Ensure value is a string
-    if (value) {
-      if (trackedEvent) {
-        trackUsage(trackedEvent, trackedEventDetails);
+  const handleSearch = React.useCallback(
+    (term: string) => {
+      if (term) {
+        if (trackedEvent) {
+          trackUsage(trackedEvent, trackedEventDetails);
+        }
+        setQuery({ _q: encodeURIComponent(term), page: 1 });
+      } else {
+        setQuery({ _q: '' }, 'remove');
       }
-      setQuery({ _q: encodeURIComponent(value), page: 1 });
-    } else {
-      handleToggle();
-      setQuery({ _q: '' }, 'remove');
-    }
-  };
+    },
+    [setQuery, trackUsage, trackedEvent, trackedEventDetails]
+  );
+
+  React.useEffect(() => {
+    handleSearch(debouncedSearch);
+  }, [debouncedSearch, handleSearch]);
 
   if (isOpen) {
     return (
-      <SearchForm onSubmit={handleSubmit}>
+      <SearchForm>
         <Searchbar
           ref={inputRef}
           name="search"

--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -5,7 +5,6 @@ import { Search as SearchIcon } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { TrackingEvent, useTracking } from '../features/Tracking';
-import { useDebounce } from '../hooks/useDebounce';
 import { useQueryParams } from '../hooks/useQueryParams';
 
 interface SearchInputProps {
@@ -30,7 +29,6 @@ const SearchInput = ({
 
   const [value, setValue] = React.useState(query?._q || '');
   const [isOpen, setIsOpen] = React.useState(!!value);
-  const debouncedSearch = useDebounce(value, 500) || '';
 
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
@@ -48,27 +46,25 @@ const SearchInput = ({
     setQuery({ _q: '' }, 'remove');
   };
 
-  const handleSearch = React.useCallback(
-    (term: string) => {
-      if (term) {
-        if (trackedEvent) {
-          trackUsage(trackedEvent, trackedEventDetails);
-        }
-        setQuery({ _q: encodeURIComponent(term), page: 1 });
-      } else {
-        setQuery({ _q: '' }, 'remove');
-      }
-    },
-    [setQuery, trackUsage, trackedEvent, trackedEventDetails]
-  );
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
 
-  React.useEffect(() => {
-    handleSearch(debouncedSearch);
-  }, [debouncedSearch, handleSearch]);
+    // Ensure value is a string
+    if (value) {
+      if (trackedEvent) {
+        trackUsage(trackedEvent, trackedEventDetails);
+      }
+      setQuery({ _q: encodeURIComponent(value), page: 1 });
+    } else {
+      handleToggle();
+      setQuery({ _q: '' }, 'remove');
+    }
+  };
 
   if (isOpen) {
     return (
-      <SearchForm>
+      <SearchForm onSubmit={handleSubmit}>
         <Searchbar
           ref={inputRef}
           name="search"

--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -48,23 +48,16 @@ const SearchInput = ({
     setQuery({ _q: '' }, 'remove');
   };
 
-  const handleSearch = React.useCallback(
-    (term: string) => {
-      if (term) {
-        if (trackedEvent) {
-          trackUsage(trackedEvent, trackedEventDetails);
-        }
-        setQuery({ _q: encodeURIComponent(term), page: 1 });
-      } else {
-        setQuery({ _q: '' }, 'remove');
-      }
-    },
-    [setQuery, trackUsage, trackedEvent, trackedEventDetails]
-  );
-
   React.useEffect(() => {
-    handleSearch(debouncedSearch);
-  }, [debouncedSearch, handleSearch]);
+    if (debouncedSearch) {
+      if (trackedEvent) {
+        trackUsage(trackedEvent, trackedEventDetails);
+      }
+      setQuery({ _q: encodeURIComponent(debouncedSearch), page: 1 });
+    } else {
+      setQuery({ _q: '' }, 'remove');
+    }
+  }, [debouncedSearch, trackedEvent, trackedEventDetails, setQuery, trackUsage]);
 
   if (isOpen) {
     return (

--- a/packages/core/admin/admin/src/components/SearchInput.tsx
+++ b/packages/core/admin/admin/src/components/SearchInput.tsx
@@ -44,8 +44,8 @@ const SearchInput = ({
   }, [isOpen]);
 
   const handleClear = () => {
-    setValue('');
     setQuery({ _q: '' }, 'remove');
+    setValue('');
   };
 
   React.useEffect(() => {

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -28,7 +28,7 @@ describe('SearchInput', () => {
     expect(getByRole('textbox', { name: 'Search label' })).toBeInTheDocument();
   });
 
-  it('should push value to query params', async () => {
+  it('should push value to query params after debounce delay', async () => {
     const { user, getByRole } = render(<SearchInput label="Search label" />, {
       renderOptions: {
         wrapper({ children }) {
@@ -46,13 +46,14 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
-
-    const searchString = getByRole('listitem').textContent ?? '';
-    const searchParams = new URLSearchParams(searchString);
-
-    expect(searchParams.has('_q')).toBe(true);
-    expect(searchParams.get('_q')).toBe('michka');
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
+          'michka'
+        );
+      },
+      { timeout: 600 }
+    ); // Wait for debounce (500ms) + buffer
   });
 
   it('should clear value and update query params', async () => {
@@ -73,15 +74,25 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
-
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
+          'michka'
+        );
+      },
+      { timeout: 600 }
+    );
 
     await user.click(getByRole('button', { name: 'Clear' }));
 
     expect(getByRole('textbox', { name: 'Search label' })).toHaveValue('');
 
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+      },
+      { timeout: 600 }
+    );
   });
 
   describe('blur behavior', () => {

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -46,14 +46,13 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await waitFor(
-      () => {
-        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
-          'michka'
-        );
-      },
-      { timeout: 600 }
-    ); // Wait for debounce (500ms) + buffer
+    await user.keyboard('[Enter]');
+
+    const searchString = getByRole('listitem').textContent ?? '';
+    const searchParams = new URLSearchParams(searchString);
+
+    expect(searchParams.has('_q')).toBe(true);
+    expect(searchParams.get('_q')).toBe('michka');
   });
 
   it('should clear value and update query params', async () => {
@@ -74,25 +73,15 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await waitFor(
-      () => {
-        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').get('_q')).toBe(
-          'michka'
-        );
-      },
-      { timeout: 600 }
-    );
+    await user.keyboard('[Enter]');
+
+    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
 
     await user.click(getByRole('button', { name: 'Clear' }));
 
     expect(getByRole('textbox', { name: 'Search label' })).toHaveValue('');
 
-    await waitFor(
-      () => {
-        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
-      },
-      { timeout: 600 }
-    );
+    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
   });
 
   describe('blur behavior', () => {

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -14,6 +14,14 @@ const LocationDisplay = () => {
 };
 
 describe('SearchInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should render an icon button by default', () => {
     const { getByRole } = render(<SearchInput label="Search label" />);
 
@@ -46,7 +54,7 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
+    jest.advanceTimersByTime(600);
 
     const searchString = getByRole('listitem').textContent ?? '';
     const searchParams = new URLSearchParams(searchString);
@@ -73,7 +81,7 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    await user.keyboard('[Enter]');
+    jest.advanceTimersByTime(600);
 
     expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
 
@@ -108,7 +116,7 @@ describe('SearchInput', () => {
       // Type the value if any
       if (inputValue) {
         await user.type(textbox, inputValue);
-        await user.keyboard('[Enter]');
+        jest.advanceTimersByTime(600);
       }
 
       // Simulate blur

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -14,14 +14,6 @@ const LocationDisplay = () => {
 };
 
 describe('SearchInput', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   it('should render an icon button by default', () => {
     const { getByRole } = render(<SearchInput label="Search label" />);
 
@@ -54,12 +46,18 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    jest.advanceTimersByTime(600);
+    // Wait for the debounce delay (500ms) to trigger the search
+    await waitFor(
+      () => {
+        const searchString = getByRole('listitem').textContent ?? '';
+        const searchParams = new URLSearchParams(searchString);
+        expect(searchParams.has('_q')).toBe(true);
+      },
+      { timeout: 1000 }
+    );
 
     const searchString = getByRole('listitem').textContent ?? '';
     const searchParams = new URLSearchParams(searchString);
-
-    expect(searchParams.has('_q')).toBe(true);
     expect(searchParams.get('_q')).toBe('michka');
   });
 
@@ -81,9 +79,12 @@ describe('SearchInput', () => {
 
     await user.type(getByRole('textbox', { name: 'Search label' }), 'michka');
 
-    jest.advanceTimersByTime(600);
-
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(true);
+      },
+      { timeout: 1000 }
+    );
 
     await user.click(getByRole('button', { name: 'Clear' }));
 
@@ -116,7 +117,14 @@ describe('SearchInput', () => {
       // Type the value if any
       if (inputValue) {
         await user.type(textbox, inputValue);
-        jest.advanceTimersByTime(600);
+        await waitFor(
+          () => {
+            const searchString = getByRole('listitem').textContent ?? '';
+            const searchParams = new URLSearchParams(searchString);
+            expect(searchParams.has('_q')).toBe(true);
+          },
+          { timeout: 1000 }
+        );
       }
 
       // Simulate blur

--- a/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/SearchInput.test.tsx
@@ -90,7 +90,12 @@ describe('SearchInput', () => {
 
     expect(getByRole('textbox', { name: 'Search label' })).toHaveValue('');
 
-    expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+    await waitFor(
+      () => {
+        expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(false);
+      },
+      { timeout: 1000 }
+    );
   });
 
   describe('blur behavior', () => {
@@ -106,7 +111,18 @@ describe('SearchInput', () => {
         expectedToBeInDocument: true,
       },
     ])('$name', async ({ inputValue, expectedToBeInDocument }) => {
-      const { user, getByRole, queryByRole } = render(<SearchInput label="Search label" />);
+      const { user, getByRole, queryByRole } = render(<SearchInput label="Search label" />, {
+        renderOptions: {
+          wrapper({ children }) {
+            return (
+              <>
+                {children}
+                <LocationDisplay />
+              </>
+            );
+          },
+        },
+      });
 
       // Open the search input
       await user.click(getByRole('button', { name: 'Search' }));
@@ -119,9 +135,9 @@ describe('SearchInput', () => {
         await user.type(textbox, inputValue);
         await waitFor(
           () => {
-            const searchString = getByRole('listitem').textContent ?? '';
-            const searchParams = new URLSearchParams(searchString);
-            expect(searchParams.has('_q')).toBe(true);
+            expect(new URLSearchParams(getByRole('listitem').textContent ?? '').has('_q')).toBe(
+              true
+            );
           },
           { timeout: 1000 }
         );

--- a/tests/e2e/tests/search/content-type.spec.ts
+++ b/tests/e2e/tests/search/content-type.spec.ts
@@ -16,7 +16,7 @@ function createSearchTest(testFunction, description, searchTerm) {
     // Search
     await page.getByRole('button', { name: 'Search', exact: true }).click();
     await page.fill('input[name="search"]', searchTerm);
-    await page.locator('input[name="search"]').press('Enter');
+    await page.waitForTimeout(600);
 
     // Assert
     const tableWithProduct = page.locator('table:has-text("' + searchTerm + '")');


### PR DESCRIPTION
### What does it do?

Removes the need to press Enter to search on CTM by searching by typing with 500ms debounce.

### Why is it needed?

It'll match the behavior between the CTM menu and the search input, it's also a better UX IMO.

### How to test it?

1. Open CTM
2. Type something in the search input


https://github.com/user-attachments/assets/cd41b0bd-d8e8-4d6e-8880-e656bf7a2af2



### Related issue(s)/PR(s)

Closes https://github.com/strapi/strapi/issues/21358
