### PR TITLE
test(ts-front): fix types in test

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/tests/SettingsPage.test.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/tests/SettingsPage.test.tsx
@@ -6,6 +6,8 @@ import { StrapiAppContextValue, StrapiAppProvider } from '../../../features/Stra
 import { useSettingsMenu } from '../../../hooks/useSettingsMenu';
 import { Layout } from '../Layout';
 
+import type { Widget } from '../../../core/apis/Widgets';
+
 jest.mock('../../../hooks/useSettingsMenu');
 
 jest.mock('../../../../../ee/admin/src/hooks/useLicenseLimits', () => ({
@@ -32,7 +34,7 @@ const render = (settings: StrapiAppContextValue['settings']) =>
             components={{}}
             fields={{}}
             widgets={{
-              widgets: {},
+              widgets: {} as Record<string, Widget>,
               register: jest.fn(),
               getAll: jest.fn(),
             }}

--- a/packages/core/admin/admin/tests/utils.tsx
+++ b/packages/core/admin/admin/tests/utils.tsx
@@ -41,6 +41,8 @@ import { adminApi } from '../src/services/api';
 import { server } from './server';
 import { initialState } from './store';
 
+import type { Widget } from '../src/core/apis/Widgets';
+
 setLogger({
   log: () => {},
   warn: () => {},
@@ -111,7 +113,7 @@ const Providers = ({ children, initialEntries, storeConfig, permissions = [] }: 
             components={{}}
             rbac={new RBAC()}
             widgets={{
-              widgets: {},
+              widgets: {} as Record<string, Widget>,
               getAll: jest.fn(),
               register: jest.fn(),
             }}


### PR DESCRIPTION
NOTE: this is targeting `main` to fix a test issue; it doesn't change any Strapi code

### What does it do?

Fix the types so that tests pass on `main`

### Why is it needed?

ts:front tests are failing on main: https://github.com/strapi/strapi/actions/runs/16491888963/job/46632150370?pr=24017

I don't have the issue locally, so this will warrant investigation later to see why CI and local do not have the exact same configuration

### How to test it?

All the tests should pass here

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
