### PR TITLE
fix(content-type-builder): fix schema validation when max is equal to…

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+import { maxGreaterThanMin, maxLengthGreaterThanMinLength } from '../schema';
+
+describe('Schema', () => {
+  let ctx: z.RefinementCtx & { addIssue: jest.Mock };
+  let expectAddIssue: (shouldAddIssue: boolean) => void;
+
+  beforeEach(() => {
+    ctx = {
+      addIssue: jest.fn(),
+    } as unknown as z.RefinementCtx & { addIssue: jest.Mock };
+
+    expectAddIssue = (shouldAddIssue: boolean) => {
+      if (shouldAddIssue) {
+        expect(ctx.addIssue).toHaveBeenCalled();
+      } else {
+        expect(ctx.addIssue).not.toHaveBeenCalled();
+      }
+
+      // so it can be ran many time inside the same test
+      ctx.addIssue.mockClear();
+    };
+  });
+
+  describe('maxLengthGreaterThanMinLength', () => {
+    let expectError: (value: Record<string, unknown>, shouldError: boolean) => void;
+
+    beforeEach(() => {
+      expectError = (value: Record<string, unknown>, shouldError: boolean) => {
+        maxLengthGreaterThanMinLength(value, ctx);
+        expectAddIssue(shouldError);
+      };
+    });
+
+    test('should not add error if maxLength is strictly greater than min', () => {
+      expectError({ minLength: 1, maxLength: 2 }, false);
+      expectError({ minLength: 0, maxLength: 1 }, false);
+      expectError({ minLength: -1, maxLength: 0 }, false);
+    });
+
+    test('should not add error if maxLength is equals to minLength', () => {
+      expectError({ minLength: 1, maxLength: 1 }, false);
+      expectError({ minLength: 0, maxLength: 0 }, false);
+      expectError({ minLength: -1, maxLength: -1 }, false);
+    });
+
+    test('should add error if maxLength is strictly less than minLength', () => {
+      expectError({ minLength: 2, maxLength: 1 }, true);
+      expectError({ minLength: 1, maxLength: 0 }, true);
+      expectError({ minLength: 0, maxLength: -1 }, true);
+    });
+  });
+
+  describe('maxGreaterThanMin', () => {
+    let expectError: (value: Record<string, unknown>, shouldError: boolean) => void;
+
+    beforeEach(() => {
+      expectError = (value: Record<string, unknown>, shouldError: boolean) => {
+        maxGreaterThanMin(value, ctx);
+        expectAddIssue(shouldError);
+      };
+    });
+
+    test('should not add error if max is strictly greater than min', () => {
+      expectError({ min: 1, max: 2 }, false);
+      expectError({ min: 0, max: 1 }, false);
+      expectError({ min: -1, max: 0 }, false);
+    });
+
+    test('should not add error if max is equals to min', () => {
+      expectError({ min: 1, max: 1 }, false);
+      expectError({ min: 0, max: 0 }, false);
+      expectError({ min: -1, max: -1 }, false);
+    });
+
+    test('should add error if max is strictly less than min', () => {
+      expectError({ min: 2, max: 1 }, true);
+      expectError({ min: 1, max: 0 }, true);
+      expectError({ min: 0, max: -1 }, true);
+    });
+
+    test('should not add error if either max or min are not numbers', () => {
+      // missing
+      expectError({ max: 1 }, false);
+      expectError({ min: 1 }, false);
+
+      // undefined
+      expectError({ max: 1, min: undefined }, false);
+      expectError({ max: undefined, min: 1 }, false);
+
+      // not a number
+      expectError({ max: 1, min: 'hello' }, false);
+      expectError({ max: 'hello', min: 1 }, false);
+    });
+  });
+});

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -88,14 +88,17 @@ const verifySingularAndPluralNames: z.SuperRefinement<Record<string, unknown>> =
   }
 };
 
-const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unknown>> = (value, ctx) => {
+export const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unknown>> = (
+  value,
+  ctx
+) => {
   if (
     !isNil(value.maxLength) &&
     !isNil(value.minLength) &&
     isNumber(value.maxLength) &&
     isNumber(value.minLength)
   ) {
-    if (value.maxLength <= value.minLength) {
+    if (value.maxLength < value.minLength) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'maxLength must be greater or equal to minLength',
@@ -105,9 +108,9 @@ const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unknown>> 
   }
 };
 
-const maxGreaterThanMin: z.SuperRefinement<Record<string, unknown>> = (value, ctx) => {
+export const maxGreaterThanMin: z.SuperRefinement<Record<string, unknown>> = (value, ctx) => {
   if (!isNil(value.max) && !isNil(value.min) && isNumber(value.max) && isNumber(value.min)) {
-    if (value.max <= value.min) {
+    if (value.max < value.min) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'max must be greater or equal to min',


### PR DESCRIPTION
… min

Validation of the update schema was rejecting when we would  pass a max value equal to the min value. The error message clearly stated the intention: "max must be greater or  EQUAL to min".

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes a validation rule that enforce max being greater or equal than min. This PR allows a max value to be equal to the min value. 

### Why is it needed?

I would say it's the expected behavior when there is no option to choose between a "strictly" and "greater or equal" comparator. Reason is , with a "strictly" you cannot implement the behavior "value must be exactly x".

Also the error messge says `max must be greater or  equal to min`.


### How to test it?

- Create a dynamic zone
- go to `Advanced Settings`
- set  a `Minimum value` and `Maximum value` to `1`
- Hit Save, it should not reject the update 

<img width="826" height="465" alt="Screenshot 2025-07-25 at 17 51 07" src="https://github.com/user-attachments/assets/5db530da-6bbf-41a7-a462-1e19116bbf00" />
