### PR TITLE
fix: prevent full screen loader regression in preview page

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -148,7 +148,7 @@ const PreviewPage = () => {
 
   const isLoading =
     previewUrlResponse.isLoading || documentLayoutResponse.isLoading || documentResponse.isLoading;
-  if (isLoading) {
+  if (isLoading && (!documentResponse.document?.documentId || previewUrlResponse.isLoading)) {
     return <Page.Loading />;
   }
 


### PR DESCRIPTION
### What does it do

- fixes regression from #23985 that caused a full screen loader when saving an update from the preview side editor. That prevented "live" preview to work because it reloaded the iframe every time
- another attempt at fixing the "no data" flash by adding a more specific condition for the loader

### How to test it

- navigate from the edit view to the preview page. You should not see the "no data" screen, even for a fraction of a second
- make an update in the preview side editor and fix it. There shouldn't be any full screen loader. The preview on the right should directly update to reflect the change instead
