### PR TITLE
fix: support wildcards in arrays of origins

### DIFF
--- a/packages/core/core/src/middlewares/__tests__/cors.test.ts
+++ b/packages/core/core/src/middlewares/__tests__/cors.test.ts
@@ -1,0 +1,218 @@
+import { matchOrigin } from '../cors';
+
+describe('CORS middleware', () => {
+  describe('matchOrigin function', () => {
+    describe('Exact string origin matching', () => {
+      it('should allow exact origin match', async () => {
+        const result = await matchOrigin('https://example.com:3000', 'https://example.com:3000');
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should block origin with different port', async () => {
+        const result = await matchOrigin('https://example.com:3001', 'https://example.com:3000');
+        expect(result).toBe('');
+      });
+
+      it('should block origin with different protocol', async () => {
+        const result = await matchOrigin('http://example.com:3000', 'https://example.com:3000');
+        expect(result).toBe('');
+      });
+
+      it('should block origin with different subdomain', async () => {
+        const result = await matchOrigin(
+          'https://api.example.com:3000',
+          'https://example.com:3000'
+        );
+        expect(result).toBe('');
+      });
+
+      it('should block origin with different domain', async () => {
+        const result = await matchOrigin(
+          'https://otherdomain.com:3000',
+          'https://example.com:3000'
+        );
+        expect(result).toBe('');
+      });
+
+      it('should block origin with different port even if domain matches', async () => {
+        const result = await matchOrigin('https://example.com:3001', 'https://example.com:3000');
+        expect(result).toBe('');
+      });
+    });
+
+    describe('Array of origins', () => {
+      it('should allow origin that exists in array', async () => {
+        const result = await matchOrigin('https://example.com:3000', [
+          'https://example.com:3000',
+          'https://api.example.com:3000',
+        ]);
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should block origin that does not exist in array', async () => {
+        const result = await matchOrigin('https://otherdomain.com:3000', [
+          'https://example.com:3000',
+          'https://api.example.com:3000',
+        ]);
+        expect(result).toBe('');
+      });
+
+      it('should block origin with different port even if domain matches', async () => {
+        const result = await matchOrigin('https://example.com:3001', [
+          'https://example.com:3000',
+          'https://api.example.com:3000',
+        ]);
+        expect(result).toBe('');
+      });
+    });
+
+    describe('Comma-separated string of origins', () => {
+      it('should allow origin that exists in comma-separated string', async () => {
+        const result = await matchOrigin(
+          'https://example.com:3000',
+          'https://example.com:3000, https://api.example.com:3000'
+        );
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should block origin that does not exist in comma-separated string', async () => {
+        const result = await matchOrigin(
+          'https://otherdomain.com:3000',
+          'https://example.com:3000, https://api.example.com:3000'
+        );
+        expect(result).toBe('');
+      });
+
+      it('should handle whitespace in comma-separated string', async () => {
+        const result = await matchOrigin(
+          'https://api.example.com:3000',
+          'https://example.com:3000,https://api.example.com:3000'
+        );
+        expect(result).toBe('https://api.example.com:3000');
+      });
+
+      it('should handle single origin in comma-separated string', async () => {
+        const result = await matchOrigin('https://example.com:3000', 'https://example.com:3000');
+        expect(result).toBe('https://example.com:3000');
+      });
+    });
+
+    describe('Function-based origin', () => {
+      it('should allow origin based on function return', async () => {
+        const originFunction = (ctx: any) => {
+          const origin = ctx.get('Origin');
+          return origin === 'https://example.com:3000' ? origin : '';
+        };
+
+        const mockCtx = {
+          get(header: string) {
+            if (header === 'Origin') return 'https://example.com:3000';
+            return undefined;
+          },
+        };
+
+        const result = await matchOrigin('https://example.com:3000', originFunction, mockCtx);
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should block origin based on function return', async () => {
+        const originFunction = (ctx: any) => {
+          const origin = ctx.get('Origin');
+          return origin === 'https://example.com:3000' ? origin : '';
+        };
+
+        const mockCtx = {
+          get(header: string) {
+            if (header === 'Origin') return 'https://otherdomain.com:3000';
+            return undefined;
+          },
+        };
+
+        const result = await matchOrigin('https://otherdomain.com:3000', originFunction, mockCtx);
+        expect(result).toBe('');
+      });
+
+      it('should handle async function-based origin', async () => {
+        const originFunction = async (ctx: any) => {
+          const origin = ctx.get('Origin');
+          return origin === 'https://example.com:3000' ? origin : '';
+        };
+
+        const mockCtx = {
+          get(header: string) {
+            if (header === 'Origin') return 'https://example.com:3000';
+            return undefined;
+          },
+        };
+
+        const result = await matchOrigin('https://example.com:3000', originFunction, mockCtx);
+        expect(result).toBe('https://example.com:3000');
+      });
+    });
+
+    describe('Default behavior', () => {
+      it('should return * when no Origin header is present', async () => {
+        const result = await matchOrigin(undefined, 'https://example.com:3000');
+        expect(result).toBe('*');
+      });
+
+      it('should return * when requestOrigin is empty string', async () => {
+        const result = await matchOrigin('', 'https://example.com:3000');
+        expect(result).toBe('*');
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should handle wildcard origin configuration', async () => {
+        const result = await matchOrigin('https://example.com:3000', '*');
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should handle empty array of origins', async () => {
+        const result = await matchOrigin('https://example.com:3000', []);
+        expect(result).toBe('');
+      });
+
+      it('should handle empty string origin configuration', async () => {
+        const result = await matchOrigin('https://example.com:3000', '');
+        expect(result).toBe('');
+      });
+
+      it('should handle function that returns empty string', async () => {
+        const originFunction = () => '';
+        const result = await matchOrigin('https://example.com:3000', originFunction);
+        expect(result).toBe('');
+      });
+
+      it('should handle function that returns array', async () => {
+        const originFunction = () => ['https://example.com:3000', 'https://api.example.com:3000'];
+        const result = await matchOrigin('https://example.com:3000', originFunction);
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should handle wildcard in array of origins', async () => {
+        const result = await matchOrigin('https://example.com:3000', [
+          'https://api.example.com:3000',
+          '*',
+        ]);
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should handle wildcard in comma-separated string of origins', async () => {
+        const result = await matchOrigin(
+          'https://example.com:3000',
+          'https://api.example.com:3000, *'
+        );
+        expect(result).toBe('https://example.com:3000');
+      });
+
+      it('should handle wildcard in comma-separated string without spaces', async () => {
+        const result = await matchOrigin(
+          'https://example.com:3000',
+          'https://api.example.com:3000,*'
+        );
+        expect(result).toBe('https://example.com:3000');
+      });
+    });
+  });
+});

--- a/packages/core/core/src/middlewares/cors.ts
+++ b/packages/core/core/src/middlewares/cors.ts
@@ -49,36 +49,22 @@ export const matchOrigin = async (
     originList = configuredOrigin;
   }
 
-  // Handle arrays of origins
+  // Normalize originList into an array
+  let normalizedOrigins: string[];
   if (Array.isArray(originList)) {
-    // Check if wildcard is in the array
-    if (originList.includes('*')) {
-      return requestOrigin;
-    }
-    return originList.includes(requestOrigin) ? requestOrigin : '';
+    normalizedOrigins = originList;
+  } else {
+    // Handle comma-separated string of origins
+    normalizedOrigins = originList.split(',').map((origin) => origin.trim());
   }
 
-  // Handle comma-separated string of origins
-  const parsedOrigin = originList.split(',').map((origin) => origin.trim());
-  if (parsedOrigin.length > 1) {
-    // Check if wildcard is in the comma-separated list
-    if (parsedOrigin.includes('*')) {
-      return requestOrigin;
-    }
-    return parsedOrigin.includes(requestOrigin) ? requestOrigin : '';
+  // Check if wildcard is in the normalized origins
+  if (normalizedOrigins.includes('*')) {
+    return requestOrigin;
   }
 
-  // Handle string of one origin with exact match
-  if (typeof originList === 'string') {
-    // Handle wildcard origin
-    if (originList === '*') {
-      return requestOrigin;
-    }
-    return originList === requestOrigin ? requestOrigin : '';
-  }
-
-  // block the request
-  return '';
+  // Check if request origin is in the normalized origins
+  return normalizedOrigins.includes(requestOrigin) ? requestOrigin : '';
 };
 
 export const cors: Core.MiddlewareFactory<Config> = (config) => {

--- a/packages/core/core/src/middlewares/cors.ts
+++ b/packages/core/core/src/middlewares/cors.ts
@@ -4,7 +4,7 @@ import type { Core } from '@strapi/types';
 
 export type Config = {
   enabled?: boolean;
-  origin: string | string[] | ((ctx: any) => string | string[]);
+  origin: string | string[] | ((ctx: any) => string | string[] | Promise<string | string[]>);
   expose?: string | string[];
   maxAge?: number;
   credentials?: boolean;
@@ -20,6 +20,65 @@ const defaults: Config = {
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
   headers: ['Content-Type', 'Authorization', 'Origin', 'Accept'],
   keepHeadersOnError: false,
+};
+
+/**
+ * Determines if a request origin is allowed based on the configured origin list
+ * @param requestOrigin - The origin from the request header
+ * @param configuredOrigin - The origin configuration (string, array, or function)
+ * @param ctx - The Koa context (for function-based origin)
+ * @returns The allowed origin string or empty string if blocked
+ */
+export const matchOrigin = async (
+  requestOrigin: string | undefined,
+  configuredOrigin:
+    | string
+    | string[]
+    | ((ctx: any) => string | string[] | Promise<string | string[]>),
+  ctx?: any
+): Promise<string> => {
+  if (!requestOrigin) {
+    return '*';
+  }
+
+  let originList: string | string[];
+
+  if (typeof configuredOrigin === 'function') {
+    originList = await configuredOrigin(ctx);
+  } else {
+    originList = configuredOrigin;
+  }
+
+  // Handle arrays of origins
+  if (Array.isArray(originList)) {
+    // Check if wildcard is in the array
+    if (originList.includes('*')) {
+      return requestOrigin;
+    }
+    return originList.includes(requestOrigin) ? requestOrigin : '';
+  }
+
+  // Handle comma-separated string of origins
+  const parsedOrigin = originList.split(',').map((origin) => origin.trim());
+  if (parsedOrigin.length > 1) {
+    // Check if wildcard is in the comma-separated list
+    if (parsedOrigin.includes('*')) {
+      return requestOrigin;
+    }
+    return parsedOrigin.includes(requestOrigin) ? requestOrigin : '';
+  }
+
+  // Handle string of one origin with exact match
+  if (typeof originList === 'string') {
+    // Handle wildcard origin
+    if (originList === '*') {
+      return requestOrigin;
+    }
+    return originList === requestOrigin ? requestOrigin : '';
+  }
+
+  // block the request
+  return '';
 };
 
 export const cors: Core.MiddlewareFactory<Config> = (config) => {
@@ -39,37 +98,7 @@ export const cors: Core.MiddlewareFactory<Config> = (config) => {
   return koaCors({
     async origin(ctx) {
       const requestOrigin = ctx.get('Origin');
-
-      if (!requestOrigin) {
-        return '*';
-      }
-
-      let originList: string | string[];
-
-      if (typeof origin === 'function') {
-        originList = await origin(ctx);
-      } else {
-        originList = origin;
-      }
-
-      // Handle arrays of origins
-      if (Array.isArray(originList)) {
-        return originList.includes(requestOrigin) ? requestOrigin : '';
-      }
-
-      // Handle comma-separated string of origins
-      const parsedOrigin = originList.split(',').map((origin) => origin.trim());
-      if (parsedOrigin.length > 1) {
-        return parsedOrigin.includes(requestOrigin) ? requestOrigin : '';
-      }
-
-      // Handle string of one origin with exact match (protocol, subdomain, domain, and port)
-      if (typeof originList === 'string') {
-        return originList === requestOrigin ? requestOrigin : '';
-      }
-
-      // block the request
-      return '';
+      return matchOrigin(requestOrigin, origin, ctx);
     },
     exposeHeaders: expose,
     maxAge,


### PR DESCRIPTION
### What does it do?

Adds support for wildcards in arrays of origins 

### Why is it needed?

They currently aren't supported

### How to test it?

Create a CORS origin array (either array or csv string) that includes a wildcard *
- Without this PR, the wildcard would not be respected
- With this PR, the wildcard is respected

Automated unit tests have been provided

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
