### PR TITLE
fix: do not overwrite modified names in create ct modal

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/PluralName.tsx
+++ b/packages/core/content-type-builder/admin/src/components/PluralName.tsx
@@ -50,14 +50,8 @@ export const PluralName = ({
         // If pluralize fails, use the base value
       }
 
-      // Only update if the field is empty or matches the previous auto-generated value
-      if (
-        !value ||
-        (previousValue.current && value === pluralize(nameToSlug(previousDisplayName.current), 2))
-      ) {
-        onChangeRef.current({ target: { name, value: newValue } });
-        previousValue.current = newValue;
-      }
+      onChangeRef.current({ target: { name, value: newValue } });
+      previousValue.current = newValue;
       previousDisplayName.current = displayName;
     } else if (!displayName) {
       onChangeRef.current({ target: { name, value: '' } });

--- a/packages/core/content-type-builder/admin/src/components/SingularName.tsx
+++ b/packages/core/content-type-builder/admin/src/components/SingularName.tsx
@@ -35,11 +35,8 @@ export const SingularName = ({
   useEffect(() => {
     if (displayName && displayName !== previousDisplayName.current) {
       const newValue = nameToSlug(displayName);
-      // Only update if the field is empty or matches the previous auto-generated value
-      if (!value || (previousValue.current && value === nameToSlug(previousDisplayName.current))) {
-        onChangeRef.current({ target: { name, value: newValue } });
-        previousValue.current = newValue;
-      }
+      onChangeRef.current({ target: { name, value: newValue } });
+      previousValue.current = newValue;
       previousDisplayName.current = displayName;
     } else if (!displayName) {
       onChangeRef.current({ target: { name, value: '' } });


### PR DESCRIPTION
### What does it do?

Ensures that singularName and pluralNames that have been modified do not get accidentally replaced when switching tabs in modal

### Why is it needed?

switching between tabs in FormModal caused the singularName and pluralName to be lost

### How to test it?

- Create a content type in the CTB
- add a displayName
- modify either of singularName + pluralName
- switch between tabs of the modal
- when you come back, your modifications should still be there

### Related issue(s)/PR(s)

DX-2136