### PR TITLE
fix: contentTypes generation fails on negative number

### DIFF
--- a/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/schemas/utils.test.js
@@ -168,10 +168,16 @@ describe('Utils', () => {
     });
 
     test('Number', () => {
-      const node = toTypeLiteral(42);
+      const nodePositive = toTypeLiteral(42);
+      const nodeNegative = toTypeLiteral(-42);
 
-      expect(node.kind).toBe(ts.SyntaxKind.FirstLiteralToken);
-      expect(node.text).toBe('42');
+      expect(nodePositive.kind).toBe(ts.SyntaxKind.FirstLiteralToken);
+      expect(nodePositive.text).toBe('42');
+
+      expect(nodeNegative.kind).toBe(ts.SyntaxKind.PrefixUnaryExpression);
+      expect(nodeNegative.operator).toBe(ts.SyntaxKind.MinusToken);
+      expect(nodeNegative.operand.kind).toBe(ts.SyntaxKind.FirstLiteralToken);
+      expect(nodeNegative.operand.text).toBe('42');
     });
 
     test('Boolean', () => {

--- a/packages/utils/typescript/lib/generators/common/models/utils.js
+++ b/packages/utils/typescript/lib/generators/common/models/utils.js
@@ -92,7 +92,12 @@ const toTypeLiteral = (data) => {
   }
 
   if (isNumber(data)) {
-    return factory.createNumericLiteral(data);
+    return data < 0
+      ? factory.createPrefixUnaryExpression(
+          ts.SyntaxKind.MinusToken,
+          factory.createNumericLiteral(-data)
+        )
+      : factory.createNumericLiteral(data);
   }
 
   if (isBoolean(data)) {


### PR DESCRIPTION
### What does it do?

Fix #23463 

### Why is it needed?

ContentTypes generation fails on negative number

### How to test it?

Run Unit Tests.

### Related issue(s)/PR(s)

#23463
