### PR TITLE
feat: add a disable config for AI features

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -31,4 +31,7 @@ module.exports = ({ env }) => ({
       },
     },
   },
+  ai: {
+    disable: false,
+  },
 });

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -29,6 +29,9 @@ interface BrowserStrapi {
   projectType: 'Community' | 'Enterprise';
   telemetryDisabled: boolean;
   aiLicenseKey?: string;
+  ai: {
+    disable: boolean;
+  };
 }
 
 declare global {

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -57,6 +57,9 @@ const renderAdmin = async (
       nps: false,
       promoteEE: true,
     },
+    ai: {
+      disable: false,
+    },
   };
 
   const { get } = getFetchClient();
@@ -67,12 +70,15 @@ const renderAdmin = async (
     features: {
       name: string;
     }[];
+    ai: {
+      disable: boolean;
+    };
   }
 
   try {
     const {
       data: {
-        data: { isEE, isTrial, features, flags },
+        data: { isEE, isTrial, features, flags, ai },
       },
     } = await get<{ data: ProjectType }>('/admin/project-type');
 
@@ -85,6 +91,7 @@ const renderAdmin = async (
     };
     window.strapi.projectType = isEE ? 'Enterprise' : 'Community';
     window.strapi.aiLicenseKey = process.env.STRAPI_ADMIN_AI_API_KEY;
+    window.strapi.ai = ai;
   } catch (err) {
     /**
      * If this fails, we simply don't activate any EE features.

--- a/packages/core/admin/ee/server/src/controllers/admin.ts
+++ b/packages/core/admin/ee/server/src/controllers/admin.ts
@@ -6,6 +6,7 @@ export default {
   // NOTE: Overrides CE admin controller
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
+    const ai = strapi.config.get('admin.ai', {});
     try {
       return {
         data: {
@@ -14,6 +15,7 @@ export default {
           features: strapi.ee.features.list(),
           flags,
           type: strapi.ee.type,
+          ai,
         },
       };
     } catch (err) {

--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -38,7 +38,8 @@ export default {
   // This returns an empty feature list for CE
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
-    return { data: { isEE: false, features: [], flags } };
+    const ai = strapi.config.get('admin.ai', {});
+    return { data: { isEE: false, features: [], flags, ai } };
   },
 
   async init() {

--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
@@ -151,11 +151,12 @@ export const BaseChatProvider = ({
       });
     }
   }, [chat.status, messages, trackUsage]);
+  const isAiDisabled = window.strapi.ai?.disable;
 
   return (
     <ChatContext.Provider
       value={{
-        isChatEnabled: !!STRAPI_AI_TOKEN,
+        isChatEnabled: !!STRAPI_AI_TOKEN && !isAiDisabled,
         ...chat,
         messages,
         rawMessages: chat.messages,

--- a/packages/core/types/src/core/strapi.ts
+++ b/packages/core/types/src/core/strapi.ts
@@ -39,6 +39,9 @@ export interface Strapi extends Container {
   app: any;
   EE?: boolean;
   aiLicenseKey?: string;
+  ai?: {
+    disable: boolean;
+  };
   ee: {
     seats: number | null | undefined;
     type: string | null | undefined;


### PR DESCRIPTION
### What does it do?

- Loads an AI config to the window strapi object in the browser
- incase it AI was disabled, the AI Chat is not rendered

### Why is it needed?

- Allows users to disable AI features if they want to

### How to test it?

- Add 
```
ai:{
   disable:true
}
```
to the admin config, navigate to the CTB, no AI chat should be present

### Related issue(s)/PR(s)

DX-2064