### PR TITLE
fix: allow audit logs to be increased up to the license maximum

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -55,7 +55,7 @@ const getRetentionDays = (strapi: Core.Strapi) => {
   }
 
   // Allow users to override the license retention days, but not to increase it
-  if (userRetentionDays && userRetentionDays < licenseRetentionDays) {
+  if (userRetentionDays && userRetentionDays <= licenseRetentionDays) {
     return userRetentionDays;
   }
 


### PR DESCRIPTION
### What does it do?

Changes the Audit Logs retention check to allow for increases if the license allows it. 

### Why is it needed?

Previously it would only check that the override was "less than" the license limit but in some cases a few customers have a longer retention based on their license features (greater than 90 days)

### How to test it?

Create a license key with longer than 90 days audit logs retention and manually configure the longer limit, verify that the retention was properly increased

### Related issue(s)/PR(s)

TID 2075
