### PR TITLE
fix: incorrect config won't run app

### DIFF
--- a/examples/empty/config/admin.ts
+++ b/examples/empty/config/admin.ts
@@ -1,20 +1,19 @@
-export default ({ env }) => ({
+const adminConfig = ({ env }) => ({
   auth: {
-    secret: env('ADMIN_JWT_SECRET'),
+    secret: env('ADMIN_JWT_SECRET', 'example-token'),
   },
   apiToken: {
-    salt: env('API_TOKEN_SALT'),
+    salt: env('API_TOKEN_SALT', 'example-salt'),
   },
   transfer: {
     token: {
-      salt: env('TRANSFER_TOKEN_SALT'),
+      salt: env('TRANSFER_TOKEN_SALT', 'example-salt'),
     },
-  },
-  secrets: {
-    encryptionKey: env('ENCRYPTION_KEY'),
   },
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
   },
 });
+
+export default adminConfig;

--- a/examples/empty/config/server.ts
+++ b/examples/empty/config/server.ts
@@ -1,7 +1,9 @@
-export default ({ env }) => ({
+const serverConfig = ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
-    keys: env.array('APP_KEYS'),
+    keys: env.array('APP_KEYS', ['toBeModified1', 'toBeModified2']),
   },
 });
+
+export default serverConfig;

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -34,7 +34,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "c3b7bbc6-92d4-49f6-8455-8d7b795ef90f",
-    "installId": "f2f4e378c0dd971296c943faa0c1eeda550631a4621de9ebbf52efe36fd8c0be"
+    "uuid": "strapi_examples_empty"
   }
 }

--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -40,6 +40,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "getstarted"
+    "uuid": "strapi_examples_getstarted"
   }
 }

--- a/examples/kitchensink-ts/package.json
+++ b/examples/kitchensink-ts/package.json
@@ -27,6 +27,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "getstarted"
+    "uuid": "strapi_examples_kitchensink-ts"
   }
 }

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -32,6 +32,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "getstarted"
+    "uuid": "strapi_examples_kitchensink"
   }
 }

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -10,7 +10,9 @@ import { buildFilesPlugin } from './plugins';
 
 const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
-  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid === 'getstarted';
+  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid.startsWith(
+    'strapi_examples_'
+  );
 
   return {
     root: ctx.cwd,

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -10,7 +10,7 @@ import { buildFilesPlugin } from './plugins';
 
 const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
-  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid.startsWith(
+  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid?.startsWith(
     'strapi_examples_'
   );
 


### PR DESCRIPTION
### What does it do?

Adds config with default env vars

### Why is it needed?

The example app won't start without them

### How to test it?

Run `examples/empty` it should work
