### PR TITLE
test(api): add test for viewable api tokens

### DIFF
--- a/tests/api/core/admin/admin-api-token-crud.test.api.ts
+++ b/tests/api/core/admin/admin-api-token-crud.test.api.ts
@@ -968,6 +968,7 @@ describe('Admin API Token v2 CRUD (api)', () => {
     });
 
     expect(getRes.statusCode).toBe(200);
-    expect(getRes.body.data.accessKey).toBe(createRes.body.data.accessKey);
+    expect(getRes.body.data.accessKey).toBe(decryptedKey); // Verify API sends decrypted token
+    expect(getRes.body.data.accessKey).toBe(createRes.body.data.accessKey); // Verify it matches original
   });
 });

--- a/tests/api/core/admin/admin-api-token-crud.test.api.ts
+++ b/tests/api/core/admin/admin-api-token-crud.test.api.ts
@@ -23,6 +23,9 @@ describe('Admin API Token v2 CRUD (api)', () => {
   // Initialization Actions
   beforeAll(async () => {
     strapi = await createStrapiInstance();
+
+    // Set up encryption key for API token encryption; without this, we can't test viewable tokens
+    strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key-for-api-tokens');
     rq = await createAuthRequest({ strapi });
     // To eliminate latency in the request and predict the expiry timestamp, we freeze Date.now()
     now = Date.now();
@@ -930,4 +933,41 @@ describe('Admin API Token v2 CRUD (api)', () => {
   });
 
   test.todo('Custom token can only be created with valid permissions that exist');
+
+  test('Supports viewable API tokens', async () => {
+    // Create a token
+    const body = {
+      name: 'api-token_tests-viewable',
+      description: 'Testing viewable token functionality',
+      type: 'read-only',
+    };
+
+    // Create the token and get back the viewable token
+    const createRes = await rq({
+      url: '/admin/api-tokens',
+      method: 'POST',
+      body,
+    });
+
+    expect(createRes.statusCode).toBe(201);
+    expect(createRes.body.data.accessKey).toBeDefined();
+
+    // Verify the token is stored encrypted but can be decrypted
+    const storedToken = await strapi.db.query('admin::api-token').findOne({
+      where: { id: createRes.body.data.id },
+      select: ['encryptedKey'],
+    });
+
+    const decryptedKey = strapi.service('admin::encryption').decrypt(storedToken.encryptedKey);
+    expect(decryptedKey).toBe(createRes.body.data.accessKey);
+
+    // Verify retrieving the token returns the decrypted value
+    const getRes = await rq({
+      url: `/admin/api-tokens/${createRes.body.data.id}`,
+      method: 'GET',
+    });
+
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.body.data.accessKey).toBe(createRes.body.data.accessKey);
+  });
 });


### PR DESCRIPTION
### What does it do?

Tests that the viewable api tokens works correctly

### Why is it needed?

tests weren't missing

specifically, it will prevent a regression of the critical bug solved in https://github.com/strapi/strapi/pull/23477

### How to test it?

See the CI, or to run it manually, make sure you have a mysql and postgres running on your system (matching the config found in `run-api-tests.js`) and run:

`yarn test:api:clean`
`yarn test:api --db=mysql admin-api-token-crud` 
`yarn test:api --db=postgres admin-api-token-crud`

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23477

DX-2009

