### PR TITLE
chore: revert uuid in examples

### DIFF
--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -34,6 +34,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "strapi_examples_empty"
+    "uuid": "getstarted"
   }
 }

--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -40,6 +40,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "strapi_examples_getstarted"
+    "uuid": "getstarted"
   }
 }

--- a/examples/kitchensink-ts/package.json
+++ b/examples/kitchensink-ts/package.json
@@ -27,6 +27,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "strapi_examples_kitchensink-ts"
+    "uuid": "getstarted"
   }
 }

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -32,6 +32,6 @@
     "npm": ">=6.0.0"
   },
   "strapi": {
-    "uuid": "strapi_examples_kitchensink"
+    "uuid": "getstarted"
   }
 }

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -10,9 +10,7 @@ import { buildFilesPlugin } from './plugins';
 
 const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
-  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid?.startsWith(
-    'strapi_examples_'
-  );
+  const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid === 'getstarted';
 
   return {
     root: ctx.cwd,


### PR DESCRIPTION
### What does it do?

Reverts the prefix on uuids

### Why is it needed?

Apparently they should all be getstarted fro analytics

### How to test it?

https://github.com/strapi/strapi/pull/24063