### PR TITLE
fix: cache invalidation for locales in key stats widget

### DIFF
--- a/packages/core/admin/admin/src/components/Widgets.tsx
+++ b/packages/core/admin/admin/src/components/Widgets.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@strapi/admin/strapi-admin';
 import { Avatar, Badge, Box, Flex, Typography } from '@strapi/design-system';
 import { Earth, Images, User, Key, Files, Layout, Graph, Webhooks } from '@strapi/icons';
 import { useIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { useGetCountDocumentsQuery, useGetKeyStatisticsQuery } from '../services/homepage';
@@ -78,6 +79,11 @@ const formatNumber = ({ locale, number }: { locale: string; number: number }) =>
   }).format(number);
 };
 
+const LinkCell = styled(Link)`
+  text-decoration: none;
+  padding: 12px;
+`;
+
 const KeyStatisticsWidget = () => {
   const { formatMessage, locale } = useIntl();
   const { data: countDocuments, isLoading: isLoadingCountDocuments } = useGetCountDocumentsQuery();
@@ -103,6 +109,7 @@ const KeyStatisticsWidget = () => {
         background: 'primary100',
         color: 'primary600',
       },
+      link: '/content-manager',
     },
     assets: {
       label: {
@@ -114,6 +121,7 @@ const KeyStatisticsWidget = () => {
         background: 'warning100',
         color: 'warning600',
       },
+      link: '/plugins/upload',
     },
     contentTypes: {
       label: {
@@ -125,6 +133,7 @@ const KeyStatisticsWidget = () => {
         background: 'secondary100',
         color: 'secondary600',
       },
+      link: '/plugins/content-type-builder',
     },
     components: {
       label: {
@@ -136,6 +145,7 @@ const KeyStatisticsWidget = () => {
         background: 'alternative100',
         color: 'alternative600',
       },
+      link: '/plugins/content-type-builder',
     },
     locales: {
       label: {
@@ -147,6 +157,7 @@ const KeyStatisticsWidget = () => {
         background: 'success100',
         color: 'success600',
       },
+      link: '/settings/internationalization',
     },
     admins: {
       label: {
@@ -158,6 +169,7 @@ const KeyStatisticsWidget = () => {
         background: 'danger100',
         color: 'danger600',
       },
+      link: '/settings/users?pageSize=10&page=1&sort=firstname',
     },
     webhooks: {
       label: {
@@ -169,6 +181,7 @@ const KeyStatisticsWidget = () => {
         background: 'alternative100',
         color: 'alternative600',
       },
+      link: '/settings/webhooks',
     },
     apiTokens: {
       label: {
@@ -180,6 +193,7 @@ const KeyStatisticsWidget = () => {
         background: 'neutral100',
         color: 'neutral600',
       },
+      link: '/settings/api-tokens?sort=name:ASC',
     },
   };
 
@@ -197,7 +211,12 @@ const KeyStatisticsWidget = () => {
         const value = countKeyStatistics?.[key as keyof typeof countKeyStatistics];
         return (
           value !== null && (
-            <GridCell key={`key-statistics-${key}`} padding={3} data-testid={`stat-${key}`}>
+            <GridCell
+              as={LinkCell}
+              to={item.link}
+              key={`key-statistics-${key}`}
+              data-testid={`stat-${key}`}
+            >
               <Flex alignItems="center" gap={2}>
                 <Flex
                   padding={2}

--- a/packages/core/content-manager/admin/src/services/api.ts
+++ b/packages/core/content-manager/admin/src/services/api.ts
@@ -13,6 +13,7 @@ const contentManagerApi = adminApi.enhanceEndpoints({
     'RecentDocumentList',
     'GuidedTourMeta',
     'CountDocuments',
+    'UpcomingReleasesList',
   ],
 });
 

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -45,7 +45,12 @@ const documentApi = contentManagerApi.injectEndpoints({
           return [];
         }
 
-        return [{ type: 'Document', id: `${model}_LIST` }, 'RecentDocumentList', 'CountDocuments'];
+        return [
+          { type: 'Document', id: `${model}_LIST` },
+          'RecentDocumentList',
+          'CountDocuments',
+          'UpcomingReleasesList',
+        ];
       },
     }),
     cloneDocument: builder.mutation<
@@ -68,6 +73,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         { type: 'UidAvailability', id: model },
         'RecentDocumentList',
         'CountDocuments',
+        'UpcomingReleasesList',
       ],
     }),
     /**
@@ -95,6 +101,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         { type: 'UidAvailability', id: model },
         'RecentDocumentList',
         'CountDocuments',
+        'UpcomingReleasesList',
       ],
       transformResponse: (response: Create.Response, meta, arg): Create.Response => {
         /**
@@ -136,6 +143,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         { type: 'Document', id: collectionType !== SINGLE_TYPES ? `${model}_LIST` : model },
         'RecentDocumentList',
         'CountDocuments',
+        'UpcomingReleasesList',
       ],
     }),
     deleteManyDocuments: builder.mutation<
@@ -154,6 +162,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         { type: 'Document', id: `${model}_LIST` },
         'RecentDocumentList',
         'CountDocuments',
+        'UpcomingReleasesList',
       ],
     }),
     discardDocument: builder.mutation<
@@ -186,6 +195,7 @@ const documentApi = contentManagerApi.injectEndpoints({
           { type: 'UidAvailability', id: model },
           'RecentDocumentList',
           'CountDocuments',
+          'UpcomingReleasesList',
         ];
       },
     }),
@@ -341,6 +351,7 @@ const documentApi = contentManagerApi.injectEndpoints({
           'RecentDocumentList',
           'GuidedTourMeta',
           'CountDocuments',
+          'UpcomingReleasesList',
         ];
       },
     }),
@@ -361,6 +372,7 @@ const documentApi = contentManagerApi.injectEndpoints({
           ...documentIds.map((id) => ({ type: 'Document' as const, id: `${model}_${id}` })),
           'RecentDocumentList',
           'CountDocuments',
+          'UpcomingReleasesList',
         ];
       },
     }),
@@ -391,6 +403,7 @@ const documentApi = contentManagerApi.injectEndpoints({
           { type: 'UidAvailability', id: model },
           'RecentDocumentList',
           'CountDocuments',
+          'UpcomingReleasesList',
         ];
       },
       async onQueryStarted({ data, ...patch }, { dispatch, queryFulfilled }) {
@@ -453,6 +466,7 @@ const documentApi = contentManagerApi.injectEndpoints({
           },
           'RecentDocumentList',
           'CountDocuments',
+          'UpcomingReleasesList',
         ];
       },
     }),
@@ -475,6 +489,7 @@ const documentApi = contentManagerApi.injectEndpoints({
         ...documentIds.map((id) => ({ type: 'Document' as const, id: `${model}_${id}` })),
         'RecentDocumentList',
         'CountDocuments',
+        'UpcomingReleasesList',
       ],
     }),
   }),

--- a/packages/core/content-releases/admin/src/components/tests/Widgets.test.tsx
+++ b/packages/core/content-releases/admin/src/components/tests/Widgets.test.tsx
@@ -15,11 +15,22 @@ const mockReleases = [
   {
     id: 1,
     documentId: '123456',
-    name: 'Test Release',
+    name: 'Test Scheduled Release',
     status: 'ready',
-    updatedAt: '2024-07-18T12:00:00Z',
-    publishedAt: '2024-07-18T12:00:00Z',
+    updatedAt: '2025-07-31T00:00:00Z',
+    publishedAt: '2025-07-31T00:00:00Z',
     scheduledAt,
+    timezone: 'Europe/Paris',
+    locale: null,
+  },
+  {
+    id: 2,
+    documentId: '234567',
+    name: 'Test No Date Release',
+    status: 'blocked',
+    updatedAt: '2025-07-31T00:00:00Z',
+    publishedAt: '2025-07-31T00:00:00Z',
+    scheduledAt: null,
     timezone: 'Europe/Paris',
     locale: null,
   },
@@ -39,11 +50,14 @@ describe('ChartEntriesWidget', () => {
     });
 
     render(<UpcomingReleasesWidget />);
-    expect(screen.getByText(/test release/i)).toBeInTheDocument();
+    expect(screen.getByText('Test Scheduled Release')).toBeInTheDocument();
     expect(screen.getByText(/ready/i)).toBeInTheDocument();
     expect(screen.getByText(/tomorrow/i)).toBeInTheDocument();
+    expect(screen.getByText('Test No Date Release')).toBeInTheDocument();
+    expect(screen.getByText(/blocked/i)).toBeInTheDocument();
+    expect(screen.getByText(/not scheduled/i)).toBeInTheDocument();
 
-    const editLink = screen.getByRole('link', { name: /Edit/i });
+    const editLink = screen.getAllByRole('link', { name: /Edit/i })[0];
     expect(editLink).toBeInTheDocument();
     expect(editLink).toHaveAttribute('href');
     expect(editLink).toHaveAttribute(

--- a/packages/core/content-releases/server/src/services/homepage.ts
+++ b/packages/core/content-releases/server/src/services/homepage.ts
@@ -9,8 +9,8 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     async getUpcomingReleases(): Promise<GetUpcomingReleases.Response['data']> {
       const releases = await strapi.db.query('plugin::content-releases.release').findMany({
         filters: {
-          status: {
-            $notIn: ['done', 'failed'],
+          releasedAt: {
+            $notNull: false,
           },
         },
         orderBy: [{ scheduledAt: 'asc' }],

--- a/packages/core/content-releases/server/src/services/homepage.ts
+++ b/packages/core/content-releases/server/src/services/homepage.ts
@@ -9,11 +9,8 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     async getUpcomingReleases(): Promise<GetUpcomingReleases.Response['data']> {
       const releases = await strapi.db.query('plugin::content-releases.release').findMany({
         filters: {
-          scheduledAt: {
-            $gte: new Date(),
-          },
           status: {
-            $ne: 'done',
+            $notIn: ['done', 'failed'],
           },
         },
         orderBy: [{ scheduledAt: 'asc' }],

--- a/packages/plugins/i18n/admin/src/services/locales.ts
+++ b/packages/plugins/i18n/admin/src/services/locales.ts
@@ -16,14 +16,14 @@ const localesApi = i18nApi.injectEndpoints({
         method: 'POST',
         data,
       }),
-      invalidatesTags: [{ type: 'Locale', id: 'LIST' }, 'KeyStatistics'],
+      invalidatesTags: [{ type: 'Locale', id: 'LIST' }, 'HomepageKeyStatistics'],
     }),
     deleteLocale: builder.mutation<DeleteLocale.Response, DeleteLocale.Params['id']>({
       query: (id) => ({
         url: `/i18n/locales/${id}`,
         method: 'DELETE',
       }),
-      invalidatesTags: (result, error, id) => [{ type: 'Locale', id }, 'KeyStatistics'],
+      invalidatesTags: (result, error, id) => [{ type: 'Locale', id }, 'HomepageKeyStatistics'],
     }),
     getLocales: builder.query<GetLocales.Response, void>({
       query: () => '/i18n/locales',

--- a/tests/e2e/tests/content-releases/home-widgets.spec.ts
+++ b/tests/e2e/tests/content-releases/home-widgets.spec.ts
@@ -12,16 +12,24 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     await login({ page });
   });
 
-  test('a user should see the entries chart widget', async ({ page }) => {
+  test('a user should see the list of upcoming releases', async ({ page }) => {
     const upcomingReleasesWidget = page.getByLabel(/upcoming releases/i, { exact: true });
     await expect(upcomingReleasesWidget).toBeVisible();
-    await expect(upcomingReleasesWidget).toHaveText(/No releases/i);
 
-    // Create a new release in the future
+    // Check that the not scheduled release is displayed
+    const firstReleaseRow = upcomingReleasesWidget.getByRole('row').nth(0);
+    await expect(firstReleaseRow).toBeVisible();
+    await expect(
+      firstReleaseRow.getByRole('gridcell', { name: /trent crimm: the independent/i })
+    ).toBeVisible();
+    await expect(firstReleaseRow.getByRole('gridcell', { name: /not scheduled/i })).toBeVisible();
+
+    // Create a new scheduled release in the future
     await navToHeader(page, ['Releases'], 'Releases');
 
+    const nextReleaseName = 'Next release';
     await page.getByRole('button', { name: /new release/i }).click();
-    await page.getByRole('textbox', { name: /name/i }).fill('Next release');
+    await page.getByRole('textbox', { name: /name/i }).fill(nextReleaseName);
 
     const date = new Date();
     const hours = date.getHours();
@@ -48,11 +56,27 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
 
     // Go back to the homepage
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const upcomingReleasesList = upcomingReleasesWidget.getByRole('row').nth(0);
-    await expect(upcomingReleasesList).toBeVisible();
-    await expect(
-      upcomingReleasesList.getByRole('gridcell', { name: /Next release/i })
-    ).toBeVisible();
-    await expect(upcomingReleasesList.getByRole('gridcell', { name: /empty/i })).toBeVisible();
+    const nextReleaseRow = upcomingReleasesWidget.getByRole('row').nth(1);
+    await expect(nextReleaseRow).toBeVisible();
+    await expect(nextReleaseRow.getByRole('gridcell', { name: nextReleaseName })).toBeVisible();
+    await expect(nextReleaseRow.getByRole('gridcell', { name: /empty/i })).toBeVisible();
+
+    // Add an entry to the release
+    await navToHeader(page, ['Content Manager', 'Cat'], 'Cat');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
+    await page.getByRole('textbox', { name: /age/i }).fill('1');
+    await page.getByRole('button', { name: /save/i }).click();
+    await page.getByRole('button', { name: 'More document actions' }).click();
+    await page.getByRole('menuitem', { name: 'Add to release' }).click();
+    const addToReleaseDialog = await page.getByRole('dialog', { name: 'Add to release' });
+    await expect(addToReleaseDialog).toBeVisible();
+    await page.getByRole('combobox', { name: 'Select a release' }).click();
+    await page.getByRole('option', { name: nextReleaseName }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await findAndClose(page, 'Entry added to release');
+
+    // Go back to the homepage and check that the widget was updated
+    await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
+    await expect(nextReleaseRow.getByRole('gridcell', { name: /blocked/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
fix: added links to cells in key stats widget<!--

### What does it do?

After the Blitz session on the homepage widgets, there are some adjustments that need to be made:
- Project Statistics Widget
  - Add links to the cells of the widget to be able to access quickly to each page
  - Fix the cache invalidation of the locales (when creating / deleting a locale from Settings, the count wasn't refreshing on the homepage, it needed a hard refresh)
- Upcoming Releases Widget
  - Fix the cache invalidation of the upcoming releases whenever an action is performed on an entry (create, update, delete) because it could change the status of a release (blocked, ready, empty...)

### Why is it needed?

To fix some bugs and improve the experience on the newly created widgets of the homepage.

### How to test it?

- Project Statistics Widget
  - Add links to the cells of the widget to be able to access quickly to each page
    - Go to the admin homepage
      -> You should be able to click on each cell of the widget to be redirected to the corresponding page
  - Fix the cache invalidation of the locales (when creating / deleting a locale from Settings, the count wasn't refreshing on the homepage, it needed a hard refresh)
    - Go to the admin homepage and check the number of locales in the widget
    - Go to Settings > Internationalization
    - Create or Delete a locale
    - Go back to the homepage
      -> The count of locales should be updated 
- Upcoming Releases Widget
  - Fix the cache invalidation of the upcoming releases whenever an action is performed on an entry (create, update, delete) because it could change the status of a release (blocked, ready, empty...)
    - Go to the admin homepage
    - Go to Releases
    - Create a new release (not matter if scheduled or not, just make sure it will appear in the widget)
    - Go to the homepage
      -> The status should be Empty 
    - Go to the Content Manager
    - Create or Edit and existing entry (needs to be a collection type with draftAndPublish enabled)
    - Click Save
    - Add it to the release you created
    - Go back to the homepage
      -> The status should have changed to either Ready or Blocked (depending on what you filled in your entry)

🚀