### PR TITLE
Fix/22733 make boolean nullable

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, memo } from 'react';
 
-import { Toggle, useComposedRefs, Field, Flex } from '@strapi/design-system';
-// import { Toggle, useComposedRefs, Field, Button } from '@strapi/design-system';
+import { Toggle, useComposedRefs, Field } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { useFocusInputField } from '../../hooks/useFocusInputField';
@@ -17,70 +16,12 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
 
     const composedRefs = useComposedRefs(ref, fieldRef);
 
-    const handleToggleChange = () => {
-      let newValue;
-      if (field.value === null || field.value === undefined) {
-        newValue = true;
-      } else {
-        newValue = !field.value;
-      }
-      field.onChange(name, newValue);
-    };
-
-    const handleSetFalseClick = () => {
-      field.onChange(name, false);
-    };
-
-    const handleSetTrueClick = () => {
-      field.onChange(name, true);
-    };
-
-    // The key change is here: We check if the cleared value matches the initial value.
-    const handleClear = () => {
-      // The `useField` hook provides an `initialValue` property.
-      // We check if the field's initial value was `undefined` or `null`.
-      // If it was, we set the value back to that specific initial value.
-      const initialValue = field.initialValue;
-      if (initialValue === null || initialValue === undefined) {
-        field.onChange(name, initialValue);
-      } else {
-        // If the initial value was a boolean, we set it back to null to "clear" it.
-        field.onChange(name, null);
-      }
-    };
-
     return (
       <Field.Root error={field.error} name={name} hint={hint} required={required} maxWidth="320px">
-        <Flex justifyContent={'space-between'}>
-          <Field.Label action={labelAction}>{label}</Field.Label>
-          {(field.value === true || field.value === false) && (
-            <div
-              onClick={handleClear}
-              role="button"
-              tabIndex={0}
-              style={{ cursor: 'pointer', fontSize: '1.2rem' }}
-            >
-              <a href="#" style={{ textDecoration: 'none', color: '#7b79ff' }}>
-                {formatMessage({
-                  id: 'app.components.Boolean.clear',
-                  defaultMessage: 'Clear',
-                })}
-              </a>
-            </div>
-          )}
-        </Flex>
-        {/* <Field.Label action={labelAction}>{label}</Field.Label>
-        {(field.value === true || field.value === false) && (
-          <Button variant="tertiary" size="S" onClick={() => field.onChange(name, null)}>
-            {formatMessage({
-              id: 'app.components.Boolean.clear',
-              defaultMessage: 'Clear',
-            })}
-          </Button>
-        )} */}
+        <Field.Label action={labelAction}>{label}</Field.Label>
         <Toggle
           ref={composedRefs}
-          checked={field.value === false ? false : field.value === true ? true : null}
+          checked={field.value === null ? null : field.value || false}
           offLabel={formatMessage({
             id: 'app.components.ToggleCheckbox.off-label',
             defaultMessage: 'False',
@@ -89,37 +30,9 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
             id: 'app.components.ToggleCheckbox.on-label',
             defaultMessage: 'True',
           })}
-          onChange={handleToggleChange}
+          onChange={field.onChange}
           {...props}
         />
-
-        {(field.value === null || field.value === undefined) && (
-          <div style={{ position: 'relative', top: '-36px', width: '100%', height: '36px' }}>
-            <div
-              style={{
-                position: 'absolute',
-                left: '0',
-                top: '0',
-                width: '50%',
-                height: '100%',
-                cursor: 'pointer',
-              }}
-              onClick={handleSetFalseClick}
-            />
-            <div
-              style={{
-                position: 'absolute',
-                right: '0',
-                top: '0',
-                width: '50%',
-                height: '100%',
-                cursor: 'pointer',
-              }}
-              onClick={handleSetTrueClick}
-            />
-          </div>
-        )}
-
         <Field.Hint />
         <Field.Error />
       </Field.Root>

--- a/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, memo } from 'react';
 
-import { Toggle, useComposedRefs, Field } from '@strapi/design-system';
+import { Toggle, useComposedRefs, Field, Flex } from '@strapi/design-system';
+// import { Toggle, useComposedRefs, Field, Button } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { useFocusInputField } from '../../hooks/useFocusInputField';
@@ -15,13 +16,72 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
     const fieldRef = useFocusInputField<HTMLInputElement>(name);
 
     const composedRefs = useComposedRefs(ref, fieldRef);
+    // handling the toggle change manually when the toggle value is null or undefined
+    const handleToggleChange = () => {
+      let newValue;
+      if (field.value === null || field.value === undefined) {
+        newValue = true;
+      } else {
+        newValue = !field.value;
+      }
+      field.onChange(name, newValue);
+    };
+
+    const handleSetFalseClick = () => {
+      field.onChange(name, false);
+    };
+
+    const handleSetTrueClick = () => {
+      field.onChange(name, true);
+    };
+
+    // Checking if the cleared value matches the initial value.
+    const handleClear = () => {
+      // Using `initialValue` property provided by the `useField` hook.
+      // Checking if the field's initial value was `undefined` or `null`,
+      // if so, setting the value back to the specific initial value
+      const initialValue = field.initialValue;
+      if (initialValue === null || initialValue === undefined) {
+        field.onChange(name, initialValue);
+      } else {
+        // setting it back to null, if the initial value is a boolean,
+        field.onChange(name, null);
+      }
+    };
 
     return (
       <Field.Root error={field.error} name={name} hint={hint} required={required} maxWidth="320px">
-        <Field.Label action={labelAction}>{label}</Field.Label>
+        <Flex justifyContent={'space-between'}>
+          <Field.Label action={labelAction}>{label}</Field.Label>
+          {(field.value === true || field.value === false) && (
+            <div
+              onClick={handleClear}
+              role="button"
+              tabIndex={0}
+              style={{ cursor: 'pointer', fontSize: '1.2rem' }}
+            >
+              <a href="#" style={{ textDecoration: 'none', color: '#7b79ff' }}>
+                {formatMessage({
+                  id: 'app.components.Boolean.clear',
+                  defaultMessage: 'Clear',
+                })}
+              </a>
+            </div>
+          )}
+        </Flex>
+        {/* Alternate version of the clear button */}
+        {/* <Field.Label action={labelAction}>{label}</Field.Label>
+        {(field.value === true || field.value === false) && (
+          <Button variant="tertiary" size="S" onClick={handleClear}>
+            {formatMessage({
+              id: 'app.components.Boolean.clear',
+              defaultMessage: 'Clear',
+            })}
+          </Button>
+        )} */}
         <Toggle
           ref={composedRefs}
-          checked={field.value === null ? null : field.value || false}
+          checked={field.value === false ? false : field.value === true ? true : null}
           offLabel={formatMessage({
             id: 'app.components.ToggleCheckbox.off-label',
             defaultMessage: 'False',
@@ -30,9 +90,37 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
             id: 'app.components.ToggleCheckbox.on-label',
             defaultMessage: 'True',
           })}
-          onChange={field.onChange}
+          onChange={handleToggleChange}
           {...props}
         />
+        {/* Invisible Click Areas for Null/Undefined State */}
+        {(field.value === null || field.value === undefined) && (
+          <div style={{ position: 'relative', top: '-42px', width: '100%', height: '36px' }}>
+            <div
+              style={{
+                position: 'absolute',
+                left: '0',
+                top: '0',
+                width: '50%',
+                height: '100%',
+                cursor: 'pointer',
+              }}
+              onClick={handleSetFalseClick}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                right: '0',
+                top: '0',
+                width: '50%',
+                height: '100%',
+                cursor: 'pointer',
+              }}
+              onClick={handleSetTrueClick}
+            />
+          </div>
+        )}
+
         <Field.Hint />
         <Field.Error />
       </Field.Root>

--- a/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Boolean.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, memo } from 'react';
 
-import { Toggle, useComposedRefs, Field } from '@strapi/design-system';
+import { Toggle, useComposedRefs, Field, Flex } from '@strapi/design-system';
+// import { Toggle, useComposedRefs, Field, Button } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
 import { useFocusInputField } from '../../hooks/useFocusInputField';
@@ -16,12 +17,70 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
 
     const composedRefs = useComposedRefs(ref, fieldRef);
 
+    const handleToggleChange = () => {
+      let newValue;
+      if (field.value === null || field.value === undefined) {
+        newValue = true;
+      } else {
+        newValue = !field.value;
+      }
+      field.onChange(name, newValue);
+    };
+
+    const handleSetFalseClick = () => {
+      field.onChange(name, false);
+    };
+
+    const handleSetTrueClick = () => {
+      field.onChange(name, true);
+    };
+
+    // The key change is here: We check if the cleared value matches the initial value.
+    const handleClear = () => {
+      // The `useField` hook provides an `initialValue` property.
+      // We check if the field's initial value was `undefined` or `null`.
+      // If it was, we set the value back to that specific initial value.
+      const initialValue = field.initialValue;
+      if (initialValue === null || initialValue === undefined) {
+        field.onChange(name, initialValue);
+      } else {
+        // If the initial value was a boolean, we set it back to null to "clear" it.
+        field.onChange(name, null);
+      }
+    };
+
     return (
       <Field.Root error={field.error} name={name} hint={hint} required={required} maxWidth="320px">
-        <Field.Label action={labelAction}>{label}</Field.Label>
+        <Flex justifyContent={'space-between'}>
+          <Field.Label action={labelAction}>{label}</Field.Label>
+          {(field.value === true || field.value === false) && (
+            <div
+              onClick={handleClear}
+              role="button"
+              tabIndex={0}
+              style={{ cursor: 'pointer', fontSize: '1.2rem' }}
+            >
+              <a href="#" style={{ textDecoration: 'none', color: '#7b79ff' }}>
+                {formatMessage({
+                  id: 'app.components.Boolean.clear',
+                  defaultMessage: 'Clear',
+                })}
+              </a>
+            </div>
+          )}
+        </Flex>
+        {/* <Field.Label action={labelAction}>{label}</Field.Label>
+        {(field.value === true || field.value === false) && (
+          <Button variant="tertiary" size="S" onClick={() => field.onChange(name, null)}>
+            {formatMessage({
+              id: 'app.components.Boolean.clear',
+              defaultMessage: 'Clear',
+            })}
+          </Button>
+        )} */}
         <Toggle
           ref={composedRefs}
-          checked={field.value === null ? null : field.value || false}
+          checked={field.value === false ? false : field.value === true ? true : null}
           offLabel={formatMessage({
             id: 'app.components.ToggleCheckbox.off-label',
             defaultMessage: 'False',
@@ -30,9 +89,37 @@ const BooleanInput = forwardRef<HTMLInputElement, InputProps>(
             id: 'app.components.ToggleCheckbox.on-label',
             defaultMessage: 'True',
           })}
-          onChange={field.onChange}
+          onChange={handleToggleChange}
           {...props}
         />
+
+        {(field.value === null || field.value === undefined) && (
+          <div style={{ position: 'relative', top: '-36px', width: '100%', height: '36px' }}>
+            <div
+              style={{
+                position: 'absolute',
+                left: '0',
+                top: '0',
+                width: '50%',
+                height: '100%',
+                cursor: 'pointer',
+              }}
+              onClick={handleSetFalseClick}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                right: '0',
+                top: '0',
+                width: '50%',
+                height: '100%',
+                cursor: 'pointer',
+              }}
+              onClick={handleSetTrueClick}
+            />
+          </div>
+        )}
+
         <Field.Hint />
         <Field.Error />
       </Field.Root>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Made the Boolean toggle null-able.

https://github.com/user-attachments/assets/5cfe1c36-a235-4844-9e3f-585aa745945e



### Why is it needed?

Currently there is no way to change a toggle to an `unset` state, this PR adds a clear button that brings back the functionality to assign null value to toggle.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #22733 
