### PR TITLE
fix: include encryption key in javascript template

### DIFF
--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
@@ -10,6 +10,9 @@ module.exports = ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
+  secrets: {
+    encryptionKey: env('ENCRYPTION_KEY'),
+  },
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),


### PR DESCRIPTION
### What does it do?

When the encryption key option was added for automatic API token generation, only the typescript project template was updated to include this by default. This PR adds that option to the javascript template also

### Why is it needed?

So that users don't get a warning in their console when generating a javascript project

### How to test it?

Release an experimental, generate a project using the --js option, ensure there is no encryption key error on startup

### Related issue(s)/PR(s)

N/A
