### PR TITLE
Add the user ID to amplitude events

### DIFF
--- a/packages/cli/cloud/src/bin.ts
+++ b/packages/cli/cloud/src/bin.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { createLogger } from './services';
+import { getContext, setContext } from './services/context';
 import { CLIContext } from './types';
 import { buildStrapiCloudCommands } from './index';
 
@@ -18,10 +19,13 @@ function loadStrapiCloudCommand(argv = process.argv, command = new Command()) {
 
   const logger = createLogger({ debug: hasDebug, silent: hasSilent, timestamp: false });
 
-  const ctx = {
+  setContext({
+    user: { id: '' },
     cwd,
     logger,
-  } satisfies CLIContext;
+  });
+
+  const ctx: CLIContext = getContext();
 
   buildStrapiCloudCommands({ command, ctx, argv });
 }

--- a/packages/cli/cloud/src/create-growth-sso-trial/action.ts
+++ b/packages/cli/cloud/src/create-growth-sso-trial/action.ts
@@ -1,4 +1,5 @@
 import { cloudApiFactory, tokenServiceFactory } from '../services';
+import { getContext } from '../services/context';
 import { createLogger } from '../services/logger';
 import { trackEvent } from '../utils/analytics';
 
@@ -36,7 +37,9 @@ export default async ({
   try {
     const response = await cloudApiService.createTrial({ strapiVersion: strapiVersion || '' });
 
-    await trackEvent({ logger, cwd: process.cwd() }, cloudApiService, 'didCreateGrowthSsoTrial', {
+    const ctx = getContext();
+
+    await trackEvent(ctx, cloudApiService, 'didCreateGrowthSsoTrial', {
       strapiVersion: strapiVersion || '',
     });
 

--- a/packages/cli/cloud/src/login/action.ts
+++ b/packages/cli/cloud/src/login/action.ts
@@ -5,6 +5,7 @@ import { tokenServiceFactory, cloudApiFactory } from '../services';
 import type { CloudCliConfig, CLIContext } from '../types';
 import { apiConfig } from '../config/api';
 import { trackEvent } from '../utils/analytics';
+import { setContext } from '../services/context';
 
 const openModule = import('open');
 
@@ -39,6 +40,7 @@ export default async function loginAction(
       try {
         const userInfo = await cloudApiService.getUserInfo();
         const { email } = userInfo.data.data;
+        setContext({ ...ctx, user: userInfo.data.data });
         if (email) {
           logger.log(`You are already logged into your account (${email}).`);
         } else {

--- a/packages/cli/cloud/src/services/cli-api.ts
+++ b/packages/cli/cloud/src/services/cli-api.ts
@@ -6,6 +6,7 @@ import type { CLIContext, CloudCliConfig, TrackPayload } from '../types';
 import { getLocalConfig } from '../config/local';
 
 import packageJson from '../../package.json';
+import { getContext } from './context';
 
 export const VERSION = 'v3';
 
@@ -307,6 +308,10 @@ export async function cloudApiFactory(
     },
 
     track(event, payload = {}) {
+      const ctx = getContext();
+      if (ctx?.user?.id) {
+        axiosCloudAPI.defaults.headers['x-user-id'] = ctx.user.id;
+      }
       return axiosCloudAPI.post<void>('/track', {
         event,
         payload,

--- a/packages/cli/cloud/src/services/context.ts
+++ b/packages/cli/cloud/src/services/context.ts
@@ -1,0 +1,13 @@
+// This file will manage the CLI context state.
+
+import { CLIContext } from '../types';
+
+let ctx: CLIContext;
+
+export function setContext(newCtx: CLIContext): void {
+  ctx = newCtx;
+}
+
+export function getContext(): CLIContext {
+  return ctx;
+}

--- a/packages/cli/cloud/src/types.ts
+++ b/packages/cli/cloud/src/types.ts
@@ -53,7 +53,12 @@ export interface CLIContext {
   cwd: string;
   logger: Logger;
   promptExperiment?: string;
+  user?: User;
 }
+
+export type User = {
+  id: string;
+};
 
 export type StrapiCloudCommand = (params: {
   command: Command;
@@ -74,4 +79,5 @@ export type StrapiCloudCommandInfo = {
 
 export type TrackPayload = Record<string, unknown>;
 
+// eslint-disable-next-line import/no-cycle
 export type * from './services/cli-api';

--- a/packages/cli/create-strapi-app/src/cloud.ts
+++ b/packages/cli/create-strapi-app/src/cloud.ts
@@ -53,6 +53,7 @@ export async function handleCloudLogin(): Promise<boolean> {
 
   if (!userChoice.toLowerCase().includes('skip')) {
     const cliContext = {
+      user: { id: '' }, // This will be set later when the user logs in
       logger,
       cwd: process.cwd(),
       ...(cloudApiConfig.projectCreation?.reference && {


### PR DESCRIPTION
### What does it do?

We updated the ContextCLI interface to include a new user field, allowing us to associate Amplitude events with the correct user context.

### Why is it needed?

We were missing user data in Amplitude events. This has now been resolved by properly initializing the userId field.

### How to test it?

1. Create a new project.
2. Log in.
3. Complete the onboarding steps.
4. Check amplitude
  4.1. Locate your event (e.g. `didCreateGrowthSsoTrial`) 
  4.2. Ensure that the event includes your user ID under the userId field

### Related issue(s)/PR(s)

[JIRA CBA-1200](https://strapi-inc.atlassian.net/browse/CBA-1200)
