### PR TITLE
chore: improve getstarted dummy preview page

### DIFF
--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -25,9 +25,14 @@ module.exports = ({ env }) => ({
     enabled: env.bool('PREVIEW_ENABLED', true),
     config: {
       handler: (uid, { documentId, locale, status }) => {
-        const kind =
-          strapi.contentType(uid).kind === 'collectionType' ? 'collection-types' : 'single-types';
-        return `/admin/preview/${kind}/${uid}/${documentId}/${locale}/${status}`;
+        const contentType = strapi.contentType(uid);
+        const kind = contentType.kind === 'collectionType' ? 'collection-types' : 'single-types';
+        const apiName =
+          contentType.kind === 'collectionType'
+            ? contentType.info.pluralName
+            : contentType.info.singularName;
+
+        return `/admin/preview/${kind}/${apiName}/${documentId}/${locale}/${status}`;
       },
     },
   },

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -1,97 +1,138 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLoaderData, useRevalidator } from 'react-router-dom';
 
 // @ts-ignore
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
-import { unstable_useDocument as useDocument } from '@strapi/content-manager/strapi-admin';
-import { Grid, Flex, Typography, JSONInput } from '@strapi/design-system';
+import { Grid, Flex, Typography, JSONInput, Box } from '@strapi/design-system';
+
+const filterAttributes = (item) => {
+  const excludedKeys = ['documentId', 'id', 'createdAt', 'updatedAt', 'publishedAt'];
+  return Object.entries(item).filter(([key]) => !excludedKeys.includes(key));
+};
 
 const PreviewComponent = () => {
-  const { uid: model, documentId, locale, status, collectionType } = useParams();
-  const { document, refetch } = useDocument({
-    model,
-    documentId,
-    params: {
-      locale,
-      status,
-      populate: '*',
-    },
-    collectionType,
-  });
+  const { apiName, documentId, locale, status: documentStatus, collectionType } = useParams();
+  const data = useLoaderData();
+  const revalidator = useRevalidator();
 
   React.useEffect(() => {
-    const handleStrapiUpdate = (event) => {
-      if (event.data?.type === 'strapiUpdate') {
-        refetch();
+    const handleMessage = (event) => {
+      const { origin, data } = event;
+
+      if (origin !== 'http://localhost:1337') {
+        return;
+      }
+
+      if (data?.type === 'strapiUpdate') {
+        // The data is stale, force a refetch
+        revalidator.revalidate();
       }
     };
 
-    window.addEventListener('message', handleStrapiUpdate);
+    window.addEventListener('message', handleMessage);
 
     return () => {
-      window.removeEventListener('message', handleStrapiUpdate);
+      window.removeEventListener('message', handleMessage);
     };
   }, []);
 
   return (
-    <Layouts.Root>
-      <Page.Main>
-        <Page.Title>{`Previewing ${model}`}</Page.Title>
-        <Layouts.Header title="Static Preview" subtitle="Dummy preview for getstarted app" />
-        <Layouts.Content>
-          <Flex
-            direction="column"
-            alignItems="stretch"
-            gap={4}
-            hasRadius
-            background="neutral0"
-            shadow="tableShadow"
-            paddingTop={6}
-            paddingBottom={6}
-            paddingRight={7}
-            paddingLeft={7}
-          >
-            <Typography variant="delta" tag="h3">
-              Details
-            </Typography>
-
-            <Grid.Root gap={5} tag="dl">
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Content Type
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{model}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Document Id
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{documentId}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Status
-                </Typography>
-                <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                  <Typography>{status}</Typography>
-                </Flex>
-              </Grid.Item>
-              <Grid.Item col={6} s={12} direction="column" alignItems="start">
-                <Typography variant="sigma" textColor="neutral600" tag="dt">
-                  Locale
-                </Typography>
-                <Typography tag="dd">{locale}</Typography>
-              </Grid.Item>
-            </Grid.Root>
-            {document && <JSONInput value={JSON.stringify(document, null, 2)} disabled />}
-          </Flex>
-        </Layouts.Content>
-      </Page.Main>
-    </Layouts.Root>
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={100}
+      background="neutral100"
+      overflow="auto"
+    >
+      <Layouts.Root>
+        <Page.Main>
+          <Page.Title>{`Previewing ${apiName}`}</Page.Title>
+          <Layouts.Header
+            title="Static Preview"
+            subtitle="Dummy frontend so we can test Preview in getstarted"
+          />
+          <Layouts.Content>
+            <Flex
+              direction="column"
+              alignItems="stretch"
+              gap={4}
+              hasRadius
+              background="neutral0"
+              shadow="tableShadow"
+              paddingTop={6}
+              paddingBottom={6}
+              paddingRight={7}
+              paddingLeft={7}
+            >
+              <Typography variant="delta" tag="h3">
+                URL metadata
+              </Typography>
+              <Grid.Root gap={5} tag="dl">
+                <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                  <Typography variant="sigma" textColor="neutral600" tag="dt">
+                    Content Type
+                  </Typography>
+                  <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                    <Typography>{apiName}</Typography>
+                  </Flex>
+                </Grid.Item>
+                <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                  <Typography variant="sigma" textColor="neutral600" tag="dt">
+                    Document Id
+                  </Typography>
+                  <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                    <Typography>{documentId}</Typography>
+                  </Flex>
+                </Grid.Item>
+                <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                  <Typography variant="sigma" textColor="neutral600" tag="dt">
+                    Status
+                  </Typography>
+                  <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                    <Typography>{documentStatus}</Typography>
+                  </Flex>
+                </Grid.Item>
+                <Grid.Item col={6} s={12} direction="column" alignItems="start">
+                  <Typography variant="sigma" textColor="neutral600" tag="dt">
+                    Locale
+                  </Typography>
+                  <Typography tag="dd">{locale}</Typography>
+                </Grid.Item>
+              </Grid.Root>
+              <Typography variant="delta" tag="h3">
+                Rest API data
+              </Typography>
+              {revalidator.state === 'loading' && <Typography>Refreshing data...</Typography>}
+              {!data && <Typography textColor="neutral600">No data found</Typography>}
+              {data && (
+                <>
+                  <Grid.Root gap={5} tag="dl">
+                    {filterAttributes(data).map(([key, value]) => (
+                      <Grid.Item key={key} col={6} s={12} direction="column" alignItems="start">
+                        <Typography variant="sigma" textColor="neutral600" tag="dt">
+                          {key}
+                        </Typography>
+                        <Flex gap={3} direction="column" alignItems="start" tag="dd">
+                          <Typography>
+                            {typeof value === 'object' && value !== null
+                              ? JSON.stringify(value, null, 2)
+                              : String(value)}
+                          </Typography>
+                        </Flex>
+                      </Grid.Item>
+                    ))}
+                  </Grid.Root>
+                  <JSONInput value={JSON.stringify(data, null, 2)} disabled />
+                </>
+              )}
+            </Flex>
+          </Layouts.Content>
+        </Page.Main>
+      </Layouts.Root>
+    </Box>
   );
 };
 

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -8,13 +8,54 @@ const Preview = lazy(() =>
   }))
 );
 
+// Pre-fetch the preview data before the route renders
+const previewLoader = async ({ params }) => {
+  const { apiName, documentId, locale, status, collectionType } = params;
+  const apiToken = process.env.STRAPI_ADMIN_API_TOKEN;
+
+  if (!documentId) {
+    throw new Error('Document ID is required');
+  }
+
+  if (!apiToken) {
+    throw new Error('STRAPI_ADMIN_API_TOKEN is not set');
+  }
+
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiToken}`,
+    };
+    const searchParams = new URLSearchParams({
+      locale,
+      status,
+    });
+    const route = collectionType === 'collection-types' ? `${apiName}/${documentId}` : apiName;
+
+    const response = await fetch(`/api/${route}?${searchParams.toString()}`, {
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result = await response.json();
+    return result.data;
+  } catch (error) {
+    console.error('Error fetching preview data:', error);
+    throw error;
+  }
+};
+
 export const registerPreviewRoute = (app) => {
   app.router.addRoute({
     path: 'preview/*',
     children: [
       {
-        path: ':collectionType/:uid/:documentId/:locale/:status',
+        path: ':collectionType/:apiName/:documentId/:locale/:status',
         element: <Preview />,
+        loader: previewLoader,
       },
     ],
   });

--- a/examples/getstarted/src/api/address/controllers/address.js
+++ b/examples/getstarted/src/api/address/controllers/address.js
@@ -1,9 +1,5 @@
+'use strict';
+
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::address.address', {
-  async find(ctx) {
-    const { results } = await strapi.service('api::address.address').find();
-
-    ctx.body = await this.sanitizeOutput(results, ctx);
-  },
-});
+module.exports = createCoreController('api::address.address');


### PR DESCRIPTION
### What does it do?

ℹ️ this is only a meta PR about our dev environment, it can be ignored for pre-release QA

Makes changes in the getstarted example app:
- hides the admin sidebar in the dummy-preview
- makes dummy-preview consume the public content API
- makes dummy-preview require a STRAPI_ADMIN_API_TOKEN env variable
- changes the URL pattern of the dummy page, because the content API can't use the model uid, it needs the plural name
- refactors dummy-preview data fetching to use react router loader
- removes the controller override that was in the address content type

### Why is it needed?

To make it easier to test the preview improvements that are coming up.

### How to test it?

Set a read-only API token in the .env of your getstarted app. Then open up the preview page for different content types. Make sure to try both single and collection types
### Related issue(s)/PR(s)

fixes https://github.com/strapi/content-squad/issues/57