### PR TITLE
New workflow to tag issues before 2021 to prepare for cleanup

### DIFF
--- a/.github/workflows/cleanup_issues_before_2021.yml
+++ b/.github/workflows/cleanup_issues_before_2021.yml
@@ -1,0 +1,60 @@
+name: Close Pre-2021 Issues
+on:
+  # schedule:
+    # - cron: '35 15 * * *'  # Runs daily at 3:30 PM - stop after first run
+  workflow_dispatch: # Allows manual triggering from the Github UI
+
+permissions:
+  issues: write  # Required to close issues and post comments
+  contents: read  # Needed by most GitHub Actions
+  pull-requests: read  # Needed to access PR data
+
+jobs:
+  close-inactive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Label old issues
+        run: |
+          # Set the cutoff date (issues created before this date will be labeled)
+          CUTOFF_DATE="2021-01-01"
+          LABEL="stale-before-2021"
+          
+          echo "Labeling issues created before $CUTOFF_DATE with $LABEL"
+          
+          # Get all open issues created before the cutoff date
+          # Exclude issues with 'severity: high' or 'severity: critical' and 'issue: security' label and issues in milestones
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&per_page=100" | \
+            jq -r --arg cutoff "$CUTOFF_DATE" '
+              .[] | 
+              select(.created_at < $cutoff) |
+              select(.pull_request == null) |
+              select(any(.labels[]?; .name == "severity: high") | not) |
+              select(any(.labels[]?; .name == "severity: critical") | not) |
+              select(any(.labels[]?; .name == "issue: security") | not) |
+              select(.milestone == null) |
+              select(any(.labels[]?; .name == $label) | not) |
+              .number
+            ' | while read issue_number; do
+              if [ ! -z "$issue_number" ]; then
+                echo "Labeling issue #$issue_number with $label" 
+                
+                # Add the stale-before-2021 label
+                curl -s -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number/labels" \
+                  -d "{\"labels\": [\"$label\"]}"
+                
+                echo "Labeled issue #$issue_number"
+              fi
+            done


### PR DESCRIPTION
This PR is the very first step of the [RFC [Github] Proposal of a process to close stale issues](https://www.notion.so/strapi/Github-Proposal-of-a-process-to-close-stale-issues-2088f359807480b7aa03e17f5b40605d).

## What does it do?
This PR introduces a new github workflow that will add a "stale-before-2021" tag to all issues created before 2021 that do not carry any of these labels:
- "severity: high"
- "severity: critical"
- "issue: security"

## Why is it needed?
The original workflow had several issues:

- Incorrect GitHub Actions expression syntax (${{ TAG }}) for shell variables
- Inconsistent variable naming (TAG vs label in different contexts)
- Unclear documentation about which issues are being excluded
- The workflow would fail to properly label issues due to these syntax errors

## How to test it?

1. Manual testing: Trigger the workflow manually via GitHub Actions UI using the workflow_dispatch trigger
2. Verify the changes:
- Check that [issues created before 2021-01-01](https://github.com/strapi/strapi/issues?q=is:issue%20is:open%20created:2010-01-01..2021-01-01) are properly labeled with "stale-before-2021"
- Confirm that issues with "severity: high", "severity: critical", or "issue: security" labels have not been tagged.
- Verify that issues with milestones are excluded.
- Ensure issues already labeled with "stale-before-2021" are not processed again.

## What's next?

Next, I will add a step to this workflow to close these issues with a specific message. 