### PR TITLE
fix: update openapi package with correct build configuration

### DIFF
--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -56,7 +56,6 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
-    "@strapi/types": "5.20.0",
     "debug": "4.3.4",
     "openapi-types": "12.1.3",
     "zod": "3.25.67"

--- a/packages/core/openapi/rollup.config.mjs
+++ b/packages/core/openapi/rollup.config.mjs
@@ -1,3 +1,7 @@
 import { baseConfig } from '../../../rollup.utils.mjs';
 
-export default baseConfig(import.meta.dirname);
+export default baseConfig({
+  input: './src/index.ts',
+  outDir: './dist',
+  rootDir: './src',
+});


### PR DESCRIPTION
### What does it do?

- Remove duplicate dependency form package.json `@strapi/types`
- Provide correct config for rollup

### Why is it needed?

- removes warning when building packages 
```(!) You have passed an unrecognized option
Unknown input options: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54. Allowed options: cache, context, experimentalCacheExpiry, experimentalLogSideEffects, external, input, jsx, logLevel, makeAbsoluteExternalsRelative, maxParallelFileOps, moduleContext, onLog, onwarn, perf, plugins, preserveEntrySignatures, preserveSymlinks, shimMissingExports, strictDeprecations, treeshake, watch
```
- Prevents error in release process where the duplicate dependency does not get it's version updated

