### PR TITLE
feat: implement session management system with generaterefreshtoken

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -84,6 +84,7 @@
     "@radix-ui/react-context": "1.0.1",
     "@radix-ui/react-toolbar": "1.0.4",
     "@reduxjs/toolkit": "1.9.7",
+    "@strapi/core": "5.19.0",
     "@strapi/design-system": "2.0.0-rc.29",
     "@strapi/icons": "2.0.0-rc.29",
     "@strapi/permissions": "5.20.0",

--- a/packages/core/admin/server/src/content-types/index.ts
+++ b/packages/core/admin/server/src/content-types/index.ts
@@ -5,6 +5,7 @@ import apiToken from './api-token';
 import apiTokenPermission from './api-token-permission';
 import transferToken from './transfer-token';
 import transferTokenPermission from './transfer-token-permission';
+import session from './session';
 
 export default {
   permission: { schema: Permission },
@@ -14,4 +15,5 @@ export default {
   'api-token-permission': { schema: apiTokenPermission },
   'transfer-token': { schema: transferToken },
   'transfer-token-permission': { schema: transferTokenPermission },
+  session: { schema: session },
 };

--- a/packages/core/admin/server/src/content-types/session.ts
+++ b/packages/core/admin/server/src/content-types/session.ts
@@ -1,0 +1,70 @@
+export default {
+  collectionName: 'admin_sessions',
+  info: {
+    name: 'Session',
+    description: 'Admin user session management',
+    singularName: 'session',
+    pluralName: 'sessions',
+    displayName: 'Session',
+  },
+  pluginOptions: {
+    'content-manager': {
+      visible: false,
+    },
+    'content-type-builder': {
+      visible: false,
+    },
+  },
+  attributes: {
+    user: {
+      type: 'string',
+      required: true,
+      configurable: false,
+      private: true,
+    },
+    sessionId: {
+      type: 'string',
+      unique: true,
+      required: true,
+      configurable: false,
+      private: true,
+    },
+    deviceId: {
+      type: 'string',
+      required: true,
+      configurable: false,
+      private: true,
+    },
+    origin: {
+      type: 'string',
+      required: true,
+      configurable: false,
+      private: true,
+    },
+    expiresAt: {
+      type: 'datetime',
+      required: true,
+      configurable: false,
+      private: true,
+    },
+  },
+  config: {
+    attributes: {
+      user: {
+        hidden: true,
+      },
+      sessionId: {
+        hidden: true,
+      },
+      deviceId: {
+        hidden: true,
+      },
+      origin: {
+        hidden: true,
+      },
+      expiresAt: {
+        hidden: true,
+      },
+    },
+  },
+};

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -83,6 +83,7 @@
     "inquirer": "8.2.5",
     "is-docker": "2.2.1",
     "json-logic-js": "2.0.5",
+    "jsonwebtoken": "9.0.0",
     "koa": "2.16.1",
     "koa-body": "6.0.1",
     "koa-compose": "4.1.0",

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -138,6 +138,10 @@ class Strapi extends Container implements Core.Strapi {
     return this.get('telemetry');
   }
 
+  get sessionManager(): Modules.SessionManager.SessionManagerService {
+    return this.get('sessionManager');
+  }
+
   get store(): Modules.CoreStore.CoreStore {
     return this.get('coreStore');
   }

--- a/packages/core/core/src/providers/index.ts
+++ b/packages/core/core/src/providers/index.ts
@@ -2,9 +2,18 @@ import admin from './admin';
 import coreStore from './coreStore';
 import cron from './cron';
 import registries from './registries';
+import sessionManager from './sessionManager';
 import telemetry from './telemetry';
 import webhooks from './webhooks';
 
 import type { Provider } from './provider';
 
-export const providers: Provider[] = [registries, admin, coreStore, webhooks, telemetry, cron];
+export const providers: Provider[] = [
+  registries,
+  admin,
+  coreStore,
+  sessionManager,
+  webhooks,
+  telemetry,
+  cron,
+];

--- a/packages/core/core/src/providers/sessionManager.ts
+++ b/packages/core/core/src/providers/sessionManager.ts
@@ -1,0 +1,34 @@
+import { defineProvider } from './provider';
+import { createSessionManager } from '../services/session-manager';
+
+interface AdminAuthConfig {
+  secret?: string;
+  options?: Record<string, unknown>;
+}
+
+export default defineProvider({
+  init(strapi) {
+    // Get JWT secret from admin auth settings (same as admin token service)
+    const adminAuth = strapi.config.get<AdminAuthConfig>('admin.auth', {});
+    const jwtSecret = adminAuth.secret;
+
+    if (!jwtSecret) {
+      throw new Error(
+        'Missing admin.auth.secret configuration. The SessionManager requires a JWT secret'
+      );
+    }
+
+    const config = {
+      jwtSecret,
+      refreshTokenLifespan: 30 * 24 * 60 * 60, // 30 days in seconds
+      accessTokenLifespan: 60 * 60, // 1 hour in seconds
+    };
+
+    strapi.add('sessionManager', () =>
+      createSessionManager({
+        db: strapi.db,
+        config,
+      })
+    );
+  },
+});

--- a/packages/core/core/src/services/__tests__/session-manager.test.ts
+++ b/packages/core/core/src/services/__tests__/session-manager.test.ts
@@ -1,0 +1,287 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import {
+  createSessionManager,
+  createDatabaseProvider,
+  SessionProvider,
+  SessionData,
+  SessionManagerConfig,
+} from '../session-manager';
+
+jest.mock('crypto');
+jest.mock('jsonwebtoken');
+
+const mockCrypto = crypto as jest.Mocked<typeof crypto>;
+const mockJwt = jwt as jest.Mocked<typeof jwt>;
+
+describe('SessionManager Factory', () => {
+  let mockDb: any;
+  let mockQuery: any;
+  let config: SessionManagerConfig;
+  let sessionManager: any;
+
+  beforeEach(() => {
+    mockQuery = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    mockDb = {
+      query: jest.fn().mockReturnValue(mockQuery),
+    };
+
+    config = {
+      jwtSecret: 'test-secret',
+      refreshTokenLifespan: 30 * 24 * 60 * 60, // 30 days
+      accessTokenLifespan: 60 * 60, // 1 hour
+    };
+
+    sessionManager = createSessionManager({ db: mockDb, config });
+
+    mockCrypto.randomBytes.mockReturnValue(Buffer.from('abcdef1234567890', 'hex') as any);
+    mockJwt.sign.mockReturnValue('test-jwt-token' as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateSessionId', () => {
+    it('should generate a random session ID', () => {
+      const sessionId = sessionManager.generateSessionId();
+
+      expect(mockCrypto.randomBytes).toHaveBeenCalledWith(16);
+      expect(sessionId).toBe('abcdef1234567890');
+    });
+  });
+
+  describe('generateRefreshToken', () => {
+    const userId = 'user123';
+    const deviceId = 'device456';
+    const origin = 'admin';
+
+    it('should clean up expired sessions first', async () => {
+      await sessionManager.generateRefreshToken(userId, deviceId, origin);
+
+      expect(mockQuery.delete).toHaveBeenCalledWith({
+        where: { expiresAt: { $lt: expect.any(Date) } },
+      });
+    });
+
+    it('should create session in database with correct data', async () => {
+      mockQuery.create.mockResolvedValue({
+        user: userId,
+        sessionId: 'abcdef1234567890',
+        deviceId,
+        origin,
+        expiresAt: expect.any(Date),
+      });
+
+      await sessionManager.generateRefreshToken(userId, deviceId, origin);
+
+      expect(mockQuery.create).toHaveBeenCalledWith({
+        data: {
+          user: userId,
+          sessionId: 'abcdef1234567890',
+          deviceId,
+          origin,
+          expiresAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('should calculate correct expiration date', async () => {
+      const startTime = Date.now();
+
+      await sessionManager.generateRefreshToken(userId, deviceId, origin);
+
+      const createCall = mockQuery.create.mock.calls[0][0];
+      const expiresAt = createCall.data.expiresAt.getTime();
+      const expectedExpiration = startTime + config.refreshTokenLifespan * 1000;
+
+      // Allow for small timing differences (within 1 second)
+      expect(Math.abs(expiresAt - expectedExpiration)).toBeLessThan(1000);
+    });
+
+    it('should generate JWT with correct payload', async () => {
+      await sessionManager.generateRefreshToken(userId, deviceId, origin);
+
+      const expectedPayload = {
+        userId,
+        sessionId: 'abcdef1234567890',
+        type: 'refresh',
+      };
+
+      expect(mockJwt.sign).toHaveBeenCalledWith(expectedPayload, config.jwtSecret, {
+        expiresIn: config.refreshTokenLifespan,
+      });
+    });
+
+    it('should return token and sessionId', async () => {
+      const result = await sessionManager.generateRefreshToken(userId, deviceId, origin);
+
+      expect(result).toEqual({
+        token: 'test-jwt-token',
+        sessionId: 'abcdef1234567890',
+      });
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const error = new Error('Database connection failed');
+      mockQuery.create.mockRejectedValue(error);
+
+      await expect(sessionManager.generateRefreshToken(userId, deviceId, origin)).rejects.toThrow(
+        'Database connection failed'
+      );
+    });
+  });
+
+  describe('createSessionManager factory', () => {
+    it('should create session manager with database provider', () => {
+      const manager = createSessionManager({ db: mockDb, config });
+
+      expect(manager).toBeDefined();
+      expect(typeof manager.generateRefreshToken).toBe('function');
+      expect(typeof manager.generateSessionId).toBe('function');
+    });
+  });
+});
+
+describe('DatabaseSessionProvider', () => {
+  let mockDb: any;
+  let mockQuery: any;
+  let provider: SessionProvider;
+  const contentType = 'admin::session';
+
+  beforeEach(() => {
+    mockQuery = {
+      create: jest.fn(),
+      findOne: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    mockDb = {
+      query: jest.fn().mockReturnValue(mockQuery),
+    };
+
+    provider = createDatabaseProvider(mockDb, contentType);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create session and return result', async () => {
+      const sessionData: SessionData = {
+        user: 'user123',
+        sessionId: 'session456',
+        deviceId: 'device789',
+        origin: 'admin',
+        expiresAt: new Date(),
+      };
+
+      const expectedResult = { ...sessionData, id: '1' };
+      mockQuery.create.mockResolvedValue(expectedResult);
+
+      const result = await provider.create(sessionData);
+
+      expect(mockDb.query).toHaveBeenCalledWith(contentType);
+      expect(mockQuery.create).toHaveBeenCalledWith({ data: sessionData });
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('findBySessionId', () => {
+    it('should find session by sessionId', async () => {
+      const sessionId = 'session123';
+      const expectedResult = {
+        id: '1',
+        user: 'user123',
+        sessionId,
+        deviceId: 'device456',
+        origin: 'admin',
+        expiresAt: new Date(),
+      };
+
+      mockQuery.findOne.mockResolvedValue(expectedResult);
+
+      const result = await provider.findBySessionId(sessionId);
+
+      expect(mockQuery.findOne).toHaveBeenCalledWith({ where: { sessionId } });
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('should return null when session not found', async () => {
+      mockQuery.findOne.mockResolvedValue(null);
+
+      const result = await provider.findBySessionId('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByIdentifier', () => {
+    it('should find sessions by user identifier', async () => {
+      const userId = 'user123';
+      const expectedResults = [
+        {
+          id: '1',
+          user: userId,
+          sessionId: 'session1',
+          deviceId: 'device1',
+          origin: 'admin',
+          expiresAt: new Date(),
+        },
+        {
+          id: '2',
+          user: userId,
+          sessionId: 'session2',
+          deviceId: 'device2',
+          origin: 'admin',
+          expiresAt: new Date(),
+        },
+      ];
+
+      mockQuery.findMany.mockResolvedValue(expectedResults);
+
+      const result = await provider.findByIdentifier(userId);
+
+      expect(mockQuery.findMany).toHaveBeenCalledWith({ where: { user: userId } });
+      expect(result).toEqual(expectedResults);
+    });
+  });
+
+  describe('deleteBySessionId', () => {
+    it('should delete session by sessionId', async () => {
+      const sessionId = 'session123';
+
+      await provider.deleteBySessionId(sessionId);
+
+      expect(mockQuery.delete).toHaveBeenCalledWith({ where: { sessionId } });
+    });
+  });
+
+  describe('deleteByIdentifier', () => {
+    it('should delete sessions by user identifier', async () => {
+      const userId = 'user123';
+
+      await provider.deleteByIdentifier(userId);
+
+      expect(mockQuery.delete).toHaveBeenCalledWith({ where: { user: userId } });
+    });
+  });
+
+  describe('deleteExpired', () => {
+    it('should delete expired sessions', async () => {
+      await provider.deleteExpired();
+
+      expect(mockQuery.delete).toHaveBeenCalledWith({
+        where: { expiresAt: { $lt: expect.any(Date) } },
+      });
+    });
+  });
+});

--- a/packages/core/core/src/services/session-manager.ts
+++ b/packages/core/core/src/services/session-manager.ts
@@ -1,0 +1,154 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import type { Database } from '@strapi/database';
+
+export interface SessionProvider {
+  create(session: SessionData): Promise<SessionData>;
+  findBySessionId(sessionId: string): Promise<SessionData | null>;
+  findByIdentifier(userId: string): Promise<SessionData[]>;
+  deleteBySessionId(sessionId: string): Promise<void>;
+  deleteByIdentifier(userId: string): Promise<void>;
+  deleteExpired(): Promise<void>;
+}
+
+export interface SessionData {
+  id?: string;
+  user: string; // User ID stored as string (key-value store)
+  sessionId: string;
+  deviceId: string;
+  origin: string;
+  expiresAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface RefreshTokenPayload {
+  userId: string;
+  sessionId: string;
+  type: 'refresh';
+  exp: number;
+  iat: number;
+}
+
+export interface AccessTokenPayload {
+  userId: string;
+  sessionId: string;
+  type: 'access';
+  exp: number;
+  iat: number;
+}
+
+export type TokenPayload = RefreshTokenPayload | AccessTokenPayload;
+
+class DatabaseSessionProvider implements SessionProvider {
+  private db: Database;
+
+  private contentType: string;
+
+  constructor(db: Database, contentType: string) {
+    this.db = db;
+    this.contentType = contentType;
+  }
+
+  async create(session: SessionData): Promise<SessionData> {
+    const result = await this.db.query(this.contentType).create({
+      data: session,
+    });
+    return result as SessionData;
+  }
+
+  async findBySessionId(sessionId: string): Promise<SessionData | null> {
+    const result = await this.db.query(this.contentType).findOne({
+      where: { sessionId },
+    });
+    return result as SessionData | null;
+  }
+
+  async findByIdentifier(userId: string): Promise<SessionData[]> {
+    const results = await this.db.query(this.contentType).findMany({
+      where: { user: userId },
+    });
+    return results as SessionData[];
+  }
+
+  async deleteBySessionId(sessionId: string): Promise<void> {
+    await this.db.query(this.contentType).delete({
+      where: { sessionId },
+    });
+  }
+
+  async deleteByIdentifier(userId: string): Promise<void> {
+    await this.db.query(this.contentType).delete({
+      where: { user: userId },
+    });
+  }
+
+  async deleteExpired(): Promise<void> {
+    await this.db.query(this.contentType).delete({
+      where: { expiresAt: { $lt: new Date() } },
+    });
+  }
+}
+
+export interface SessionManagerConfig {
+  jwtSecret: string;
+  refreshTokenLifespan: number; // default 30 days
+  accessTokenLifespan: number; // default 1 hour
+}
+
+class SessionManager {
+  private provider: SessionProvider;
+
+  private config: SessionManagerConfig;
+
+  constructor(provider: SessionProvider, config: SessionManagerConfig) {
+    this.provider = provider;
+    this.config = config;
+  }
+
+  generateSessionId(): string {
+    return crypto.randomBytes(16).toString('hex');
+  }
+
+  async generateRefreshToken(
+    userId: string,
+    deviceId: string,
+    origin: string
+  ): Promise<{ token: string; sessionId: string }> {
+    await this.provider.deleteExpired();
+
+    const sessionId = this.generateSessionId();
+    const expiresAt = new Date(Date.now() + this.config.refreshTokenLifespan * 1000);
+
+    await this.provider.create({
+      user: userId,
+      sessionId,
+      deviceId,
+      origin,
+      expiresAt,
+    });
+
+    const payload: Omit<RefreshTokenPayload, 'iat' | 'exp'> = {
+      userId,
+      sessionId,
+      type: 'refresh',
+    };
+
+    const token = jwt.sign(payload, this.config.jwtSecret, {
+      expiresIn: this.config.refreshTokenLifespan,
+    });
+
+    return { token, sessionId };
+  }
+}
+
+const createDatabaseProvider = (db: Database, contentType: string): SessionProvider => {
+  return new DatabaseSessionProvider(db, contentType);
+};
+
+const createSessionManager = ({ db, config }: { db: Database; config: SessionManagerConfig }) => {
+  const provider = createDatabaseProvider(db, 'admin::session');
+  return new SessionManager(provider, config);
+};
+
+export { createSessionManager, createDatabaseProvider };

--- a/packages/core/types/src/modules/index.ts
+++ b/packages/core/types/src/modules/index.ts
@@ -14,6 +14,7 @@ export type * as Features from './features';
 export type * as Fetch from './fetch';
 export type * as Metrics from './metrics';
 export type * as RequestContext from './request-context';
+export type * as SessionManager from './session-manager';
 export type * as Sanitizers from './sanitizers';
 export type * as Server from './server';
 export type * as Validators from './validators';

--- a/packages/core/types/src/modules/session-manager.ts
+++ b/packages/core/types/src/modules/session-manager.ts
@@ -1,0 +1,8 @@
+export interface SessionManagerService {
+  generateSessionId(): string;
+  generateRefreshToken(
+    userId: string,
+    deviceId: string,
+    origin: string
+  ): Promise<{ token: string; sessionId: string }>;
+}

--- a/tests/api/core/admin/session-manager.test.api.ts
+++ b/tests/api/core/admin/session-manager.test.api.ts
@@ -1,0 +1,182 @@
+'use strict';
+
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createUtils } from 'api-tests/utils';
+
+const contentTypeUID = 'admin::session';
+
+describe('SessionManager API Integration', () => {
+  let strapi: any;
+  let utils: any;
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance();
+    utils = createUtils(strapi);
+  });
+
+  afterAll(async () => {
+    await strapi.db.query(contentTypeUID).deleteMany({});
+    await strapi.destroy();
+  });
+
+  describe('SessionManager Service Integration', () => {
+    const testUserId = 'test-user-123';
+    const testDeviceId = 'test-device-456';
+    const testOrigin = 'admin';
+
+    afterEach(async () => {
+      await strapi.db.query(contentTypeUID).deleteMany({
+        where: { user: testUserId },
+      });
+    });
+
+    describe('strapi.sessionManager access', () => {
+      it('should be accessible via strapi.sessionManager', () => {
+        expect(strapi.sessionManager).toBeDefined();
+        expect(typeof strapi.sessionManager.generateRefreshToken).toBe('function');
+        expect(typeof strapi.sessionManager.generateSessionId).toBe('function');
+      });
+    });
+
+    describe('generateRefreshToken', () => {
+      it('should create a session in the database', async () => {
+        const result = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          testDeviceId,
+          testOrigin
+        );
+
+        expect(result).toMatchObject({
+          token: expect.any(String),
+          sessionId: expect.any(String),
+        });
+
+        // Verify session was created in database
+        const session = await strapi.db.query(contentTypeUID).findOne({
+          where: { sessionId: result.sessionId },
+        });
+
+        expect(session).toMatchObject({
+          user: testUserId,
+          sessionId: result.sessionId,
+          deviceId: testDeviceId,
+          origin: testOrigin,
+          expiresAt: expect.any(String),
+        });
+      });
+
+      it('should generate a valid JWT token', async () => {
+        const result = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          testDeviceId,
+          testOrigin
+        );
+
+        expect(result.token).toBeTruthy();
+        expect(typeof result.token).toBe('string');
+      });
+
+      it('should clean up expired sessions before creating new ones', async () => {
+        const expiredSessionId = 'expired-session-123';
+        await strapi.db.query(contentTypeUID).create({
+          data: {
+            user: testUserId,
+            sessionId: expiredSessionId,
+            deviceId: 'old-device',
+            origin: testOrigin,
+            expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 1 day ago
+          },
+        });
+
+        // Generate new refresh token (should clean up expired one)
+        await strapi.sessionManager.generateRefreshToken(testUserId, testDeviceId, testOrigin);
+
+        const expiredSession = await strapi.db.query(contentTypeUID).findOne({
+          where: { sessionId: expiredSessionId },
+        });
+        expect(expiredSession).toBeNull();
+      });
+
+      it('should allow multiple active sessions for different devices', async () => {
+        const device1 = 'device-1';
+        const device2 = 'device-2';
+
+        const result1 = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          device1,
+          testOrigin
+        );
+        const result2 = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          device2,
+          testOrigin
+        );
+
+        expect(result1.sessionId).not.toBe(result2.sessionId);
+
+        const sessions = await strapi.db.query(contentTypeUID).findMany({
+          where: { user: testUserId },
+        });
+
+        expect(sessions).toHaveLength(2);
+        expect(sessions.map((s) => s.deviceId)).toEqual(expect.arrayContaining([device1, device2]));
+      });
+
+      it('should allow multiple active sessions for different origins', async () => {
+        const origin1 = 'admin';
+        const origin2 = 'users-permissions';
+
+        const result1 = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          testDeviceId,
+          origin1
+        );
+        const result2 = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          testDeviceId,
+          origin2
+        );
+
+        expect(result1.sessionId).not.toBe(result2.sessionId);
+
+        const sessions = await strapi.db.query(contentTypeUID).findMany({
+          where: { user: testUserId },
+        });
+
+        expect(sessions).toHaveLength(2);
+        expect(sessions.map((s) => s.origin)).toEqual(expect.arrayContaining([origin1, origin2]));
+      });
+
+      it('should set correct expiration time (30 days)', async () => {
+        const startTime = Date.now();
+        const result = await strapi.sessionManager.generateRefreshToken(
+          testUserId,
+          testDeviceId,
+          testOrigin
+        );
+
+        const session = await strapi.db.query(contentTypeUID).findOne({
+          where: { sessionId: result.sessionId },
+        });
+
+        const expectedExpiration = startTime + 30 * 24 * 60 * 60 * 1000;
+        const actualExpiration = new Date(session.expiresAt).getTime();
+
+        expect(Math.abs(actualExpiration - expectedExpiration)).toBeLessThan(1_000);
+      });
+    });
+
+    describe('generateSessionId', () => {
+      it('should generate unique session IDs', () => {
+        const sessionId1 = strapi.sessionManager.generateSessionId();
+        const sessionId2 = strapi.sessionManager.generateSessionId();
+
+        expect(sessionId1).toBeTruthy();
+        expect(sessionId2).toBeTruthy();
+        expect(sessionId1).not.toBe(sessionId2);
+        expect(typeof sessionId1).toBe('string');
+        expect(typeof sessionId2).toBe('string');
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8628,6 +8628,83 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@strapi/admin@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/admin@npm:5.19.0"
+  dependencies:
+    "@casl/ability": "npm:6.5.0"
+    "@internationalized/date": "npm:3.5.4"
+    "@radix-ui/react-context": "npm:1.0.1"
+    "@radix-ui/react-toolbar": "npm:1.0.4"
+    "@reduxjs/toolkit": "npm:1.9.7"
+    "@strapi/design-system": "npm:2.0.0-rc.29"
+    "@strapi/icons": "npm:2.0.0-rc.29"
+    "@strapi/permissions": "npm:5.19.0"
+    "@strapi/types": "npm:5.19.0"
+    "@strapi/typescript-utils": "npm:5.19.0"
+    "@strapi/utils": "npm:5.19.0"
+    "@testing-library/dom": "npm:10.1.0"
+    "@testing-library/react": "npm:15.0.7"
+    "@testing-library/user-event": "npm:14.5.2"
+    axios: "npm:1.8.4"
+    bcryptjs: "npm:2.4.3"
+    boxen: "npm:5.1.2"
+    chalk: "npm:^4.1.2"
+    codemirror5: "npm:codemirror@^5.65.11"
+    cross-env: "npm:^7.0.3"
+    date-fns: "npm:2.30.0"
+    execa: "npm:5.1.1"
+    fast-deep-equal: "npm:3.1.3"
+    formik: "npm:2.4.5"
+    fractional-indexing: "npm:3.2.0"
+    fs-extra: "npm:11.2.0"
+    highlight.js: "npm:^10.4.1"
+    immer: "npm:9.0.21"
+    inquirer: "npm:8.2.5"
+    invariant: "npm:^2.2.4"
+    is-localhost-ip: "npm:2.0.0"
+    json-logic-js: "npm:2.0.5"
+    jsonwebtoken: "npm:9.0.0"
+    koa: "npm:2.16.1"
+    koa-compose: "npm:4.1.0"
+    koa-passport: "npm:6.0.0"
+    koa-static: "npm:5.0.0"
+    koa2-ratelimit: "npm:^1.1.3"
+    lodash: "npm:4.17.21"
+    node-schedule: "npm:2.1.1"
+    ora: "npm:5.4.1"
+    p-map: "npm:4.0.0"
+    passport-local: "npm:1.0.0"
+    pluralize: "npm:8.0.0"
+    punycode: "npm:2.3.1"
+    qs: "npm:6.11.1"
+    react-dnd: "npm:16.0.1"
+    react-dnd-html5-backend: "npm:16.0.1"
+    react-intl: "npm:6.6.2"
+    react-is: "npm:^18.2.0"
+    react-query: "npm:3.39.3"
+    react-redux: "npm:8.1.3"
+    react-select: "npm:5.8.0"
+    react-window: "npm:1.8.10"
+    rimraf: "npm:5.0.5"
+    sanitize-html: "npm:2.13.0"
+    scheduler: "npm:0.23.0"
+    semver: "npm:7.5.4"
+    sift: "npm:16.0.1"
+    typescript: "npm:5.4.4"
+    use-context-selector: "npm:1.4.1"
+    yup: "npm:0.32.9"
+    zod: "npm:3.24.2"
+  peerDependencies:
+    "@strapi/data-transfer": ^5.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.0.0
+    styled-components: ^6.0.0
+  checksum: 10c0/9bf71eb7d7e431e4bbf0497c196f04b439863555967634a4555ec739e7f493c52fcf5818ebe25e8694f3d478e4873f5843a962e4702ee86d368ffede26255e00
+  languageName: node
+  linkType: hard
+
 "@strapi/admin@npm:5.20.0, @strapi/admin@workspace:packages/core/admin":
   version: 0.0.0-use.local
   resolution: "@strapi/admin@workspace:packages/core/admin"
@@ -8638,6 +8715,7 @@ __metadata:
     "@radix-ui/react-toolbar": "npm:1.0.4"
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/admin-test-utils": "npm:5.20.0"
+    "@strapi/core": "npm:5.19.0"
     "@strapi/data-transfer": "npm:5.20.0"
     "@strapi/design-system": "npm:2.0.0-rc.29"
     "@strapi/icons": "npm:2.0.0-rc.29"
@@ -8920,6 +8998,67 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@strapi/core@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/core@npm:5.19.0"
+  dependencies:
+    "@koa/cors": "npm:5.0.0"
+    "@koa/router": "npm:12.0.2"
+    "@paralleldrive/cuid2": "npm:2.2.2"
+    "@strapi/admin": "npm:5.19.0"
+    "@strapi/database": "npm:5.19.0"
+    "@strapi/generators": "npm:5.19.0"
+    "@strapi/logger": "npm:5.19.0"
+    "@strapi/permissions": "npm:5.19.0"
+    "@strapi/types": "npm:5.19.0"
+    "@strapi/typescript-utils": "npm:5.19.0"
+    "@strapi/utils": "npm:5.19.0"
+    bcryptjs: "npm:2.4.3"
+    boxen: "npm:5.1.2"
+    chalk: "npm:4.1.2"
+    ci-info: "npm:4.0.0"
+    cli-table3: "npm:0.6.2"
+    commander: "npm:8.3.0"
+    configstore: "npm:5.0.1"
+    copyfiles: "npm:2.4.1"
+    debug: "npm:4.3.4"
+    delegates: "npm:1.0.0"
+    dotenv: "npm:16.4.5"
+    execa: "npm:5.1.1"
+    fs-extra: "npm:11.2.0"
+    glob: "npm:10.3.10"
+    global-agent: "npm:3.0.0"
+    http-errors: "npm:2.0.0"
+    inquirer: "npm:8.2.5"
+    is-docker: "npm:2.2.1"
+    json-logic-js: "npm:2.0.5"
+    koa: "npm:2.16.1"
+    koa-body: "npm:6.0.1"
+    koa-compose: "npm:4.1.0"
+    koa-compress: "npm:5.1.1"
+    koa-favicon: "npm:2.1.0"
+    koa-helmet: "npm:7.0.2"
+    koa-ip: "npm:^2.1.3"
+    koa-session: "npm:6.4.0"
+    koa-static: "npm:5.0.0"
+    lodash: "npm:4.17.21"
+    mime-types: "npm:2.1.35"
+    node-schedule: "npm:2.1.1"
+    open: "npm:8.4.0"
+    ora: "npm:5.4.1"
+    package-json: "npm:7.0.0"
+    pkg-up: "npm:3.1.0"
+    qs: "npm:6.11.1"
+    resolve.exports: "npm:2.0.2"
+    semver: "npm:7.5.4"
+    statuses: "npm:2.0.1"
+    typescript: "npm:5.4.4"
+    undici: "npm:6.21.2"
+    yup: "npm:0.32.9"
+  checksum: 10c0/5ef22b70ae1fd32b393f3f40dc2b1170ffac19b5d7d5ed9cb2069c5c4e24a7978acfb94d08806c94567ac8ff0ad2678817b199874fec4b22a8e99f713717a2c6
+  languageName: node
+  linkType: hard
+
 "@strapi/core@npm:5.20.0, @strapi/core@workspace:packages/core/core":
   version: 0.0.0-use.local
   resolution: "@strapi/core@workspace:packages/core/core"
@@ -8975,6 +9114,7 @@ __metadata:
     inquirer: "npm:8.2.5"
     is-docker: "npm:2.2.1"
     json-logic-js: "npm:2.0.5"
+    jsonwebtoken: "npm:9.0.0"
     koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     koa-compose: "npm:4.1.0"
@@ -9043,6 +9183,24 @@ __metadata:
     ws: "npm:8.17.1"
   languageName: unknown
   linkType: soft
+
+"@strapi/database@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/database@npm:5.19.0"
+  dependencies:
+    "@paralleldrive/cuid2": "npm:2.2.2"
+    "@strapi/utils": "npm:5.19.0"
+    ajv: "npm:8.16.0"
+    date-fns: "npm:2.30.0"
+    debug: "npm:4.3.4"
+    fs-extra: "npm:11.2.0"
+    knex: "npm:3.0.1"
+    lodash: "npm:4.17.21"
+    semver: "npm:7.5.4"
+    umzug: "npm:3.8.1"
+  checksum: 10c0/44ea4fa8b94b41a1eca042c72138e1bc8685c6925c6b0561bfc105ad000d0e2577290c45322959c9cbf484601412c9549de0a955f030a15f6ea1a556198e9d72
+  languageName: node
+  linkType: hard
 
 "@strapi/database@npm:5.20.0, @strapi/database@workspace:packages/core/database":
   version: 0.0.0-use.local
@@ -9169,6 +9327,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@strapi/generators@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/generators@npm:5.19.0"
+  dependencies:
+    "@sindresorhus/slugify": "npm:1.1.0"
+    "@strapi/typescript-utils": "npm:5.19.0"
+    "@strapi/utils": "npm:5.19.0"
+    chalk: "npm:4.1.2"
+    copyfiles: "npm:2.4.1"
+    fs-extra: "npm:11.2.0"
+    handlebars: "npm:4.7.7"
+    plop: "npm:4.0.1"
+    pluralize: "npm:8.0.0"
+  checksum: 10c0/b0df97dfa5de48a87ba9a0f65cf8c6d7517efd97b0876a72982dcf84c7d6301de325eefd23fb0c8035450f55f322cb1d1fd23f9e0c1ef9082d3bbf6ae45b41ae
+  languageName: node
+  linkType: hard
+
 "@strapi/generators@npm:5.20.0, @strapi/generators@workspace:packages/generators/generators":
   version: 0.0.0-use.local
   resolution: "@strapi/generators@workspace:packages/generators/generators"
@@ -9235,6 +9410,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@strapi/logger@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/logger@npm:5.19.0"
+  dependencies:
+    lodash: "npm:4.17.21"
+    winston: "npm:3.10.0"
+  checksum: 10c0/ede5012c366b855951d20b37e6e16e7ea3a8c9c2b752c081c8324f097e4733ff3dade699bcd9e85bd35f94f5f768298aa9be4283e5b099d53776a01fd539e560
+  languageName: node
+  linkType: hard
+
 "@strapi/logger@npm:5.20.0, @strapi/logger@workspace:packages/utils/logger":
   version: 0.0.0-use.local
   resolution: "@strapi/logger@workspace:packages/utils/logger"
@@ -9286,6 +9471,19 @@ __metadata:
   bin:
     pack-up: bin/pack-up.js
   checksum: 10c0/bac2042d4074871bb1cf7bd47c4fec06df868bd83d7e5d9681656d966768b76c67491282748a792e4073abe5e0981e9cb7b034c0a3ef8ff96f8cef3fe99608af
+  languageName: node
+  linkType: hard
+
+"@strapi/permissions@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/permissions@npm:5.19.0"
+  dependencies:
+    "@casl/ability": "npm:6.5.0"
+    "@strapi/utils": "npm:5.19.0"
+    lodash: "npm:4.17.21"
+    qs: "npm:6.11.1"
+    sift: "npm:16.0.1"
+  checksum: 10c0/be23a59104961903c7159f57fe0beadb1413ffe5adf0efe1ce94006ec489cb8bf68cb483dac1da843862a5e828957435b4f345782fbfa0b56e31637c736e6ad8
   languageName: node
   linkType: hard
 
@@ -9770,6 +9968,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@strapi/types@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/types@npm:5.19.0"
+  dependencies:
+    "@casl/ability": "npm:6.5.0"
+    "@koa/cors": "npm:5.0.0"
+    "@koa/router": "npm:12.0.2"
+    "@strapi/database": "npm:5.19.0"
+    "@strapi/logger": "npm:5.19.0"
+    "@strapi/permissions": "npm:5.19.0"
+    "@strapi/utils": "npm:5.19.0"
+    commander: "npm:8.3.0"
+    json-logic-js: "npm:2.0.5"
+    koa: "npm:2.16.1"
+    koa-body: "npm:6.0.1"
+    node-schedule: "npm:2.1.1"
+    typedoc: "npm:0.25.10"
+    typedoc-github-wiki-theme: "npm:1.1.0"
+    typedoc-plugin-markdown: "npm:3.17.1"
+  checksum: 10c0/107489e82777146f6bc8f292ffa98a37340cec0d41e29e8003f7821ad58cb9fbce64e90260f21ef3e8261a524acdffa5b819506167f4a248b9f8b52c7eba83e6
+  languageName: node
+  linkType: hard
+
 "@strapi/types@npm:5.20.0, @strapi/types@workspace:packages/core/types":
   version: 0.0.0-use.local
   resolution: "@strapi/types@workspace:packages/core/types"
@@ -9803,6 +10024,20 @@ __metadata:
     zod: "npm:3.25.67"
   languageName: unknown
   linkType: soft
+
+"@strapi/typescript-utils@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/typescript-utils@npm:5.19.0"
+  dependencies:
+    chalk: "npm:4.1.2"
+    cli-table3: "npm:0.6.5"
+    fs-extra: "npm:11.2.0"
+    lodash: "npm:4.17.21"
+    prettier: "npm:3.3.3"
+    typescript: "npm:5.4.4"
+  checksum: 10c0/e7728599edcc6f455d810b13a0a256e7eb1d5453c74cb3f9037f01a9e65e0015b839ab071e51609e43fe654bb82a3b7b87244d3cd504804bd03b4f89d1266df8
+  languageName: node
+  linkType: hard
 
 "@strapi/typescript-utils@npm:5.20.0, @strapi/typescript-utils@workspace:packages/utils/typescript":
   version: 0.0.0-use.local
@@ -9934,6 +10169,24 @@ __metadata:
     styled-components: ^6.0.0
   languageName: unknown
   linkType: soft
+
+"@strapi/utils@npm:5.19.0":
+  version: 5.19.0
+  resolution: "@strapi/utils@npm:5.19.0"
+  dependencies:
+    "@sindresorhus/slugify": "npm:1.1.0"
+    date-fns: "npm:2.30.0"
+    execa: "npm:5.1.1"
+    http-errors: "npm:2.0.0"
+    lodash: "npm:4.17.21"
+    node-machine-id: "npm:1.1.12"
+    p-map: "npm:4.0.0"
+    preferred-pm: "npm:3.1.2"
+    yup: "npm:0.32.9"
+    zod: "npm:3.24.2"
+  checksum: 10c0/20d2a718dc1d4131ca20abc60f5ad7ba9f3e2e6f57a4b5dadfc5f861c3a473f5984fecd055d93dbe190a2b0c812fd1612059d5de1b2bd4564368c9cfc7b855de
+  languageName: node
+  linkType: hard
 
 "@strapi/utils@npm:5.20.0, @strapi/utils@workspace:packages/core/utils":
   version: 0.0.0-use.local
@@ -32054,6 +32307,13 @@ __metadata:
   peerDependencies:
     zod: ^3.18.0
   checksum: 10c0/e8e8a0af64092dfb3388d759bf10fb7cf5358bc1bdb365771b8ac1944b1fb014ccbc8e60fbd69627961ea5873c5694e5c3fe730341c9842312fbb91661a1f451
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.24.2":
+  version: 3.24.2
+  resolution: "zod@npm:3.24.2"
+  checksum: 10c0/c638c7220150847f13ad90635b3e7d0321b36cce36f3fc6050ed960689594c949c326dfe2c6fa87c14b126ee5d370ccdebd6efb304f41ef5557a4aaca2824565
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

- Implements that start of a session management system with JWT-based refresh tokens
- Adds database-backed session storage with a new `admin::session` content type
- Device ID, origin, and expiration management
- Integrates SessionManager service into the core Strapi instance accessible via `strapi.sessionManager`
- Includes automatic cleanup of expired sessions

### Why is it needed?

- Enables secure session management for admin users with proper token lifecycle control
- Creates foundation for enhanced authentication and authorization features
- Provides device-based session tracking

### How to test it?

- Run the new API integration tests: `yarn test:api tests/api/core/admin/session-manager.test.api.ts`
- Test session creation and token generation through the SessionManager service
- Verify database sessions are properly stored in the `admin_sessions` table
- Test automatic cleanup of expired sessions
- Verify the service is accessible via `strapi.sessionManager` in your application

### Related issue(s)/PR(s)

DX-1987
DX-2141
