### PR TITLE
future: set up preview injected script

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -46,10 +46,10 @@ const PreviewComponent = () => {
   }, []);
 
   React.useEffect(() => {
-    if (document) {
+    if (data) {
       window.parent?.postMessage({ type: 'previewReady' }, '*');
     }
-  }, [document]);
+  }, [data]);
 
   return (
     <Box

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -11,7 +11,7 @@ const filterAttributes = (item) => {
 };
 
 const PreviewComponent = () => {
-  const { apiName, documentId, locale, status: documentStatus, collectionType } = useParams();
+  const { apiName, documentId, locale, status: documentStatus } = useParams();
   const data = useLoaderData();
   const revalidator = useRevalidator();
 

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -31,6 +31,10 @@ const PreviewComponent = () => {
       if (data?.type === 'strapiUpdate') {
         // The data is stale, force a refetch
         revalidator.revalidate();
+      } else if (data?.type === 'strapiScript') {
+        const script = window.document.createElement('script');
+        script.textContent = data.payload.script;
+        window.document.head.appendChild(script);
       }
     };
 
@@ -40,6 +44,12 @@ const PreviewComponent = () => {
       window.removeEventListener('message', handleMessage);
     };
   }, []);
+
+  React.useEffect(() => {
+    if (document) {
+      window.parent?.postMessage({ type: 'previewReady' }, '*');
+    }
+  }, [document]);
 
   return (
     <Box

--- a/packages/core/content-manager/admin/src/preview/utils/constants.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/constants.ts
@@ -1,0 +1,20 @@
+import { previewScript } from './previewScript';
+
+const scriptResponse = previewScript(false);
+
+/**
+ * These events can be changed safely. They're used by the content manager admin on one side, and by
+ * the preview script on the other. We own both ends, and they're not documented to users, so we can
+ * do what we want with them.
+ */
+export const INTERNAL_EVENTS = scriptResponse!.INTERNAL_EVENTS;
+
+/**
+ * These events are documented to users, and will be hardcoded in their frontends.
+ * Changing any of these would be a breaking change.
+ */
+export const PUBLIC_EVENTS = {
+  PREVIEW_READY: 'previewReady',
+  STRAPI_UPDATE: 'strapiUpdate',
+  STRAPI_SCRIPT: 'strapiScript',
+} as const;

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -1,0 +1,31 @@
+// NOTE: This override is for the properties on _user's site_, it's not about Strapi Admin.
+declare global {
+  interface Window {}
+}
+
+/**
+ * previewScript will be injected into the preview iframe after being stringified.
+ * Therefore it CANNOT use any imports, or refer to any variables outside of its own scope.
+ * It's why many functions are defined within previewScript, it's the only way to avoid going full spaghetti.
+ * To get a better overview of everything previewScript does, go to the orchestration part at its end.
+ */
+const previewScript = (shouldRun = true) => {
+  const INTERNAL_EVENTS = {
+    DUMMY_EVENT: 'dummyEvent',
+  } as const;
+
+  /**
+   * Calling the function in no-run mode lets us retrieve the constants from other files and keep
+   * a single source of truth for them. It's the only way to do this because this script can't
+   * refer to any variables outside of its own scope, because it's stringified before it's run.
+   */
+  if (!shouldRun) {
+    return { INTERNAL_EVENTS };
+  }
+
+  // Live Preview logic will go here.
+  // eslint-disable-next-line no-console
+  console.log('Preview script running');
+};
+
+export { previewScript };


### PR DESCRIPTION
### What does it do?

sets up the boilerplate needed to get code that lives in the content manager to run on the websites of users.
### Why is it needed?

we need to own a script that runs in the websites of users for the next preview improvements
### How to test it?

open the preview for any entry in getstarted, open your console, you should see a log from within the preview page

### Related issue(s)/PR(s)

fixes https://github.com/strapi/content-squad/issues/59