### PR TITLE
fix: reordering newly created components in dz cause error on save

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -317,10 +317,13 @@ const handleInvisibleAttributes = (
           removedAttributes
         ).data;
 
-        return {
-          __component: compUID,
-          ...cleaned,
-        };
+        // For newly created components, we want to be sure that the id is undefined (in case of reordering items)
+        const processedItem =
+          dzItem.id === undefined || dzItem.id === null
+            ? { __component: compUID, ...cleaned, id: undefined }
+            : { __component: compUID, ...cleaned };
+
+        return processedItem;
       });
 
       continue;


### PR DESCRIPTION
### What does it do?

When creating a new component in a dynamic zone (when editing an entry), if we reorder the component in the list and try to save the updates, there's an error message that says `Some of the provided components in components are not related to the entity`.

Thanks a lot to @JanMikes (https://github.com/strapi/strapi/issues/23909#issuecomment-3104993847) for the video that shows the issue:

https://github.com/user-attachments/assets/f3944c87-07e3-40e7-8792-b8b1134af321

It's also doing the same thing when creating a component not at the end of the list:

https://github.com/user-attachments/assets/1ca6a9c6-80a3-4c96-82c3-131e022bcc77


### Why is it needed?

The user can't save the entry in that specific case and would cause loss of data or to open a new window and do a workaround to make it work.
The only workaround is to create the component, filling it (or not, it's not mandatory at this point) and save. Then once saved, it's possible to reorder the items in the list.

### How to test it?

Prepare:
- Go to the admin interface
- Go to the Content Manager
- Select a collection type that has a dynamic zone set with components
- Create or edit an entry
- If there's no component in the list of DZ, add at least two and click Save
  -> At this point, it should succeed

1. Reorder components
- In the same entry, try now to create a new component in the DZ and drag it between the two existing other
- Click save
  -> The error would occur (if testing on this branch, it should be fixed)

3. Add component above / below an existing one
- In the same entry, try now to create a new component in the DZ by clicking on the three dots of either the first component and "Add component below" or the last component and "Add component above"
- Click save
  -> The error would occur (if testing on this branch, it should be fixed)

### Related issue(s)/PR(s)

Resolves #23909

🚀