### PR TITLE
fix: search in Content-type builder doesn't return all results

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/useContentTypeBuilderMenu.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useTracking } from '@strapi/admin/strapi-admin';
-import { useCollator, useFilter } from '@strapi/design-system';
+import { useCollator } from '@strapi/design-system';
 import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
 
@@ -49,10 +49,6 @@ export const useContentTypeBuilderMenu = () => {
   const [searchValue, setSearchValue] = useState('');
   const { onOpenModalCreateSchema } = useFormModalNavigation();
   const { locale } = useIntl();
-
-  const { startsWith } = useFilter(locale, {
-    sensitivity: 'base',
-  });
 
   const formatter = useCollator(locale, {
     sensitivity: 'base',
@@ -178,7 +174,11 @@ export const useContentTypeBuilderMenu = () => {
         ...section,
         links: section.links.reduce((acc, link) => {
           const filteredLinks =
-            'links' in link ? link.links.filter((link) => startsWith(link.title, searchValue)) : [];
+            'links' in link
+              ? link.links.filter((link) =>
+                  link.title.toLowerCase().includes(searchValue.toLowerCase())
+                )
+              : [];
 
           if (filteredLinks.length === 0) {
             return acc;
@@ -198,7 +198,7 @@ export const useContentTypeBuilderMenu = () => {
     }
 
     const filteredLinks = section.links
-      .filter((link) => startsWith(link.title, searchValue))
+      .filter((link) => link.title.toLowerCase().includes(searchValue.toLowerCase()))
       .sort((a, b) => formatter.compare(a.title, b.title));
 
     return {


### PR DESCRIPTION
### What does it do?

This PR changes the search logic in the Content-Type Builder. Instead of filtering by names that start with the search query, it now filters by names that contain the query.

### Why is it needed?

The previous search functionality in the Content-Type Builder was too restrictive, only returning components whose names began with the search term. This made it difficult for users to find components by a middle or end word, reducing the search bar's usefulness. This fix ensures a more intuitive and effective search experience.

### How to test it?

1. Navigate to the Content-Type Builder.

2. Use the search bar to look for a component by a term that is not the first word of its name (e.g., search for "link" to find a component named "common link").

3. Confirm that the search results include all components that contain the query anywhere in their title.

### Screenshot demonstrating the fix:
<img width="286" height="453" alt="image" src="https://github.com/user-attachments/assets/2a30c9bb-25d1-4f71-8768-4e76e21146fc" />

### Related issue(s)/PR(s)

Fixes #24112
