### PR TITLE
Added the functionality to unindent using shift+tab key

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -512,8 +512,13 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
       return;
     }
 
-    if (selectedBlock.handleTab) {
-      event.preventDefault();
+    event.preventDefault();
+
+    if (event.shiftKey && selectedBlock.handleShiftTab) {
+      // Handle Shift+Tab (unindent)
+      selectedBlock.handleShiftTab(editor);
+    } else if (!event.shiftKey && selectedBlock.handleTab) {
+      // Handle Tab (indent)
       selectedBlock.handleTab(editor);
     }
   };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -39,6 +39,7 @@ interface BaseBlock {
   handleEnterKey?: (editor: Editor) => void;
   handleBackspaceKey?: (editor: Editor, event: React.KeyboardEvent<HTMLElement>) => void;
   handleTab?: (editor: Editor) => void;
+  handleShiftTab?: (editor: Editor) => void;
   snippets?: string[];
   dragHandleTopMargin?: CSSProperties['marginTop'];
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Created `handleShiftTabOnList` to add functionality to unindent using shift+tab key.

https://github.com/user-attachments/assets/d111dce4-0bbd-4514-8588-0c1633d9c889



### Why is it needed?

Most wysiwg editors have the functionality to indent using tab and unindent using shift+tab, this PR resolve the unavailability of the latter, bringing it in line with common editor behaviour.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #20933 
