### PR TITLE
chore: implement a new prompt to enable A/B test and track the event

### DIFF
--- a/packages/cli/create-strapi-app/src/create-strapi.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi.ts
@@ -257,7 +257,7 @@ async function createApp(scope: Scope) {
   }
 
   if (isABTestEnabled) {
-    await trackUsage({ event: 'didEnabledABTest', scope });
+    await trackUsage({ event: 'didEnableABTest', scope });
   }
 }
 

--- a/packages/cli/create-strapi-app/src/create-strapi.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi.ts
@@ -41,6 +41,7 @@ async function createApp(scope: Scope) {
     packageManager,
     gitInit,
     runApp,
+    isABTestEnabled,
   } = scope;
 
   const shouldRunSeed = useExample && installDependencies;
@@ -253,6 +254,10 @@ async function createApp(scope: Scope) {
 
       logger.fatal('Failed to start your Strapi application');
     }
+  }
+
+  if (isABTestEnabled) {
+    await trackUsage({ event: 'didEnabledABTest', scope });
   }
 }
 

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -161,6 +161,7 @@ async function run(args: string[]): Promise<void> {
       'styled-components': '^6.0.0',
     },
     shouldCreateGrowthSsoTrial,
+    isABTestEnabled: false
   };
 
   if (options.template !== undefined) {
@@ -206,6 +207,8 @@ async function run(args: string[]): Promise<void> {
   } else {
     scope.gitInit = await prompts.gitInit();
   }
+
+  scope.isABTestEnabled = await prompts.enableABTests();
 
   addDatabaseDependencies(scope);
 

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -161,7 +161,7 @@ async function run(args: string[]): Promise<void> {
       'styled-components': '^6.0.0',
     },
     shouldCreateGrowthSsoTrial,
-    isABTestEnabled: false
+    isABTestEnabled: false,
   };
 
   if (options.template !== undefined) {

--- a/packages/cli/create-strapi-app/src/prompts.ts
+++ b/packages/cli/create-strapi-app/src/prompts.ts
@@ -75,4 +75,19 @@ async function installDependencies(packageManager: string) {
   return installDependencies;
 }
 
-export { directory, typescript, example, gitInit, installDependencies };
+async function enableABTests() {
+  const { enableABTests } = await inquirer.prompt<{
+    enableABTests: boolean;
+  }>([
+    {
+      type: 'confirm',
+      name: 'enableABTests',
+      message: `Participate in anonymous A/B testing (to improve Strapi)?`,
+      default: false,
+    },
+  ]);
+
+  return enableABTests;
+}
+
+export { directory, typescript, example, gitInit, installDependencies, enableABTests };

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -64,6 +64,7 @@ export interface Scope {
   useExample?: boolean;
   gitInit?: boolean;
   shouldCreateGrowthSsoTrial: boolean;
+  isABTestEnabled: boolean;
 }
 
 export type ClientName = 'mysql' | 'postgres' | 'sqlite';


### PR DESCRIPTION
### What does it do?

Implement a new prompt in the CLI at then end asking if a user is interested in participating in A/B test.
If yes, we send an event to track the percentage of users interested and then take the decisiong to implement or not A/B tests.

### Why is it needed?

To potentially propose A/B tests on the product so we can easily improve the product.

### How to test it?

- Run the following command: `node packages/cli/create-strapi-app/bin/index.js`
- You should get asked to enable A/B test. By default it is false.
- An event should be sent. 
