### PR TITLE
future: create preview overlay div with highlights

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -130,7 +130,7 @@ const PreviewComponent = () => {
                           {key}
                         </Typography>
                         <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                          <Typography>
+                          <Typography data-strapi-source={key}>
                             {typeof value === 'object' && value !== null
                               ? JSON.stringify(value, null, 2)
                               : String(value)}

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -40,10 +40,7 @@ const previewScript = (shouldRun = true) => {
   const createOverlaySystem = () => {
     // Clean up before creating a new overlay so we can safely call previewScript multiple times
     window.__strapi_previewCleanup?.();
-    const existingOverlay = document.getElementById(OVERLAY_ID);
-    if (existingOverlay) {
-      existingOverlay.remove();
-    }
+    document.getElementById(OVERLAY_ID)?.remove();
 
     const overlay = document.createElement('div');
     overlay.id = OVERLAY_ID;
@@ -241,7 +238,6 @@ const previewScript = (shouldRun = true) => {
   const highlightManager = createHighlightManager(overlay);
   const observers = setupObservers(highlightManager);
   const eventHandlers = setupEventHandlers(highlightManager);
-
   createCleanupSystem(overlay, observers, eventHandlers);
 };
 

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -2,7 +2,7 @@
 declare global {
   interface Window {
     __strapi_previewCleanup?: () => void;
-    __strapi_HIGHLIGHT_HOVER_COLOR?: string;
+    STRAPI_HIGHLIGHT_HOVER_COLOR?: string;
   }
 }
 
@@ -17,7 +17,7 @@ const previewScript = (shouldRun = true) => {
    * Params
    * ---------------------------------------------------------------------------------------------*/
   const HIGHLIGHT_PADDING = 2; // in pixels
-  const HIGHLIGHT_HOVER_COLOR = window.__strapi_HIGHLIGHT_HOVER_COLOR ?? '#4945ff'; // dark primary500
+  const HIGHLIGHT_HOVER_COLOR = window.STRAPI_HIGHLIGHT_HOVER_COLOR ?? '#4945ff'; // dark primary500
   const SOURCE_ATTRIBUTE = 'data-strapi-source';
   const OVERLAY_ID = 'strapi-preview-overlay';
   const INTERNAL_EVENTS = {
@@ -69,7 +69,7 @@ const previewScript = (shouldRun = true) => {
     const highlights: HTMLElement[] = [];
     const eventListeners: EventListenersList = [];
 
-    const drawOverlay = (target: Element, highlight: HTMLElement) => {
+    const drawHighlight = (target: Element, highlight: HTMLElement) => {
       if (!highlight) return;
 
       const rect = target.getBoundingClientRect();
@@ -82,7 +82,7 @@ const previewScript = (shouldRun = true) => {
       highlights.forEach((highlight, index) => {
         const element = elements[index];
         if (element && highlight) {
-          drawOverlay(element, highlight);
+          drawHighlight(element, highlight);
         }
       });
     };
@@ -135,7 +135,7 @@ const previewScript = (shouldRun = true) => {
         highlights.push(highlight);
         overlay.appendChild(highlight);
 
-        drawOverlay(element, highlight);
+        drawHighlight(element, highlight);
       }
     });
 
@@ -163,10 +163,10 @@ const previewScript = (shouldRun = true) => {
       highlightManager.updateAllHighlights();
     };
 
-    // Find all scrollable ancestors for all tracked elements
     const scrollableElements = new Set<Element | Window>();
-    scrollableElements.add(window); // Add window as a special case
+    scrollableElements.add(window);
 
+    // Find all scrollable ancestors for all tracked elements
     highlightManager.elements.forEach((element) => {
       let parent = element.parentElement;
       while (parent) {

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -2,8 +2,7 @@
 declare global {
   interface Window {
     __strapi_previewCleanup?: () => void;
-    __strapi_HIGHLIGHT_COLOR?: string;
-    __strapi_DISABLE_STEGA_DECODING?: boolean;
+    __strapi_HIGHLIGHT_HOVER_COLOR?: string;
   }
 }
 
@@ -14,9 +13,11 @@ declare global {
  * To get a better overview of everything previewScript does, go to the orchestration part at its end.
  */
 const previewScript = (shouldRun = true) => {
+  /* -----------------------------------------------------------------------------------------------
+   * Params
+   * ---------------------------------------------------------------------------------------------*/
   const HIGHLIGHT_PADDING = 2; // in pixels
-  const HIGHLIGHT_HOVER_COLOR = window.__strapi_HIGHLIGHT_COLOR ?? '#4945ff'; // dark primary500
-  const HIGHLIGHT_ACTIVE_COLOR = window.__strapi_HIGHLIGHT_COLOR ?? '#7b79ff'; // dark primary600
+  const HIGHLIGHT_HOVER_COLOR = window.__strapi_HIGHLIGHT_HOVER_COLOR ?? '#4945ff'; // dark primary500
   const SOURCE_ATTRIBUTE = 'data-strapi-source';
   const OVERLAY_ID = 'strapi-preview-overlay';
   const INTERNAL_EVENTS = {
@@ -32,11 +33,13 @@ const previewScript = (shouldRun = true) => {
     return { INTERNAL_EVENTS };
   }
 
-  // Live Preview logic will go here.
-  // eslint-disable-next-line no-console
-  console.log('Preview script running');
+  /* -----------------------------------------------------------------------------------------------
+   * Functionality pieces
+   * ---------------------------------------------------------------------------------------------*/
 
   const createOverlaySystem = () => {
+    // Clean up before creating a new overlay so we can safely call previewScript multiple times
+    window.__strapi_previewCleanup?.();
     const existingOverlay = document.getElementById(OVERLAY_ID);
     if (existingOverlay) {
       existingOverlay.remove();
@@ -58,7 +61,143 @@ const previewScript = (shouldRun = true) => {
     return overlay;
   };
 
-  createOverlaySystem();
+  const createHighlightManager = (overlay: HTMLElement) => {
+    const elements = window.document.querySelectorAll(`[${SOURCE_ATTRIBUTE}]`);
+    const highlights: HTMLElement[] = [];
+
+    const drawOverlay = (target: Element, highlight: HTMLElement) => {
+      if (!highlight) return;
+
+      const rect = target.getBoundingClientRect();
+      highlight.style.width = `${rect.width + HIGHLIGHT_PADDING * 2}px`;
+      highlight.style.height = `${rect.height + HIGHLIGHT_PADDING * 2}px`;
+      highlight.style.transform = `translate(${rect.left - HIGHLIGHT_PADDING}px, ${rect.top - HIGHLIGHT_PADDING}px)`;
+    };
+
+    const updateAllHighlights = () => {
+      highlights.forEach((highlight, index) => {
+        const element = elements[index];
+        if (element && highlight) {
+          drawOverlay(element, highlight);
+        }
+      });
+    };
+
+    elements.forEach((element) => {
+      if (element instanceof HTMLElement) {
+        const highlight = document.createElement('div');
+        highlight.style.cssText = `
+          position: absolute;
+          outline: 2px solid transparent;
+          pointer-events: auto;
+          border-radius: 2px;
+          background-color: transparent;
+          will-change: transform;
+          transition: outline-color 0.1s ease-in-out;
+        `;
+
+        highlight.addEventListener('mouseenter', () => {
+          highlight.style.outlineColor = HIGHLIGHT_HOVER_COLOR;
+        });
+
+        highlight.addEventListener('mouseleave', () => {
+          highlight.style.outlineColor = 'transparent';
+        });
+
+        highlights.push(highlight);
+        overlay.appendChild(highlight);
+
+        drawOverlay(element, highlight);
+      }
+    });
+
+    return {
+      elements,
+      updateAllHighlights,
+    };
+  };
+
+  type HighlightManager = ReturnType<typeof createHighlightManager>;
+
+  const setupObservers = (highlightManager: HighlightManager) => {
+    const resizeObserver = new ResizeObserver(() => {
+      highlightManager.updateAllHighlights();
+    });
+
+    highlightManager.elements.forEach((element: Element) => {
+      resizeObserver.observe(element);
+    });
+
+    resizeObserver.observe(document.documentElement);
+
+    const updateOnScroll = () => {
+      highlightManager.updateAllHighlights();
+    };
+
+    // Find all scrollable ancestors for all tracked elements
+    const scrollableElements = new Set<Element | Window>();
+    scrollableElements.add(window); // Add window as a special case
+
+    highlightManager.elements.forEach((element) => {
+      let parent = element.parentElement;
+      while (parent) {
+        const computedStyle = window.getComputedStyle(parent);
+        const overflow = computedStyle.overflow + computedStyle.overflowX + computedStyle.overflowY;
+
+        if (overflow.includes('scroll') || overflow.includes('auto')) {
+          scrollableElements.add(parent);
+        }
+
+        parent = parent.parentElement;
+      }
+    });
+
+    // Add scroll listeners to all scrollable elements
+    scrollableElements.forEach((element) => {
+      if (element === window) {
+        window.addEventListener('scroll', updateOnScroll);
+        window.addEventListener('resize', updateOnScroll);
+      } else {
+        (element as Element).addEventListener('scroll', updateOnScroll);
+      }
+    });
+
+    return {
+      resizeObserver,
+      updateOnScroll,
+      scrollableElements,
+    };
+  };
+
+  const createCleanupSystem = (
+    overlay: HTMLElement,
+    observers: ReturnType<typeof setupObservers>
+  ) => {
+    window.__strapi_previewCleanup = () => {
+      observers.resizeObserver.disconnect();
+
+      // Remove all scroll listeners
+      observers.scrollableElements.forEach((element) => {
+        if (element === window) {
+          window.removeEventListener('scroll', observers.updateOnScroll);
+          window.removeEventListener('resize', observers.updateOnScroll);
+        } else {
+          (element as Element).removeEventListener('scroll', observers.updateOnScroll);
+        }
+      });
+
+      overlay.remove();
+    };
+  };
+
+  /* -----------------------------------------------------------------------------------------------
+   * Orchestration
+   * ---------------------------------------------------------------------------------------------*/
+
+  const overlay = createOverlaySystem();
+  const highlightManager = createHighlightManager(overlay);
+  const observers = setupObservers(highlightManager);
+  createCleanupSystem(overlay, observers);
 };
 
 export { previewScript };

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -1,6 +1,10 @@
 // NOTE: This override is for the properties on _user's site_, it's not about Strapi Admin.
 declare global {
-  interface Window {}
+  interface Window {
+    __strapi_previewCleanup?: () => void;
+    __strapi_HIGHLIGHT_COLOR?: string;
+    __strapi_DISABLE_STEGA_DECODING?: boolean;
+  }
 }
 
 /**
@@ -10,6 +14,11 @@ declare global {
  * To get a better overview of everything previewScript does, go to the orchestration part at its end.
  */
 const previewScript = (shouldRun = true) => {
+  const HIGHLIGHT_PADDING = 2; // in pixels
+  const HIGHLIGHT_HOVER_COLOR = window.__strapi_HIGHLIGHT_COLOR ?? '#4945ff'; // dark primary500
+  const HIGHLIGHT_ACTIVE_COLOR = window.__strapi_HIGHLIGHT_COLOR ?? '#7b79ff'; // dark primary600
+  const SOURCE_ATTRIBUTE = 'data-strapi-source';
+  const OVERLAY_ID = 'strapi-preview-overlay';
   const INTERNAL_EVENTS = {
     DUMMY_EVENT: 'dummyEvent',
   } as const;
@@ -26,6 +35,30 @@ const previewScript = (shouldRun = true) => {
   // Live Preview logic will go here.
   // eslint-disable-next-line no-console
   console.log('Preview script running');
+
+  const createOverlaySystem = () => {
+    const existingOverlay = document.getElementById(OVERLAY_ID);
+    if (existingOverlay) {
+      existingOverlay.remove();
+    }
+
+    const overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.style.cssText = `
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      z-index: 9999;
+    `;
+
+    window.document.body.appendChild(overlay);
+    return overlay;
+  };
+
+  createOverlaySystem();
 };
 
 export { previewScript };


### PR DESCRIPTION
### What does it do?

⚠️ this doesn't affect production users, it can be ignored for pre-release QA

Adds actual functionality into the preview script from #24111

- creates an overlay div over the whole page that doesn't affect user interactions
- tracks elements that have a data-source-strapi tag
- displays a "highlight" (blue box) on top of these elements. their position is dynamic, will react to scroll and resize events
- unregisters all its logic, listeners and observers so the script can be called multiple times safely
- handles double clicks on higlights (see console log)
- lets users customize the color of highlights via a window property

### Why is it needed?

for live preview / visual editing

### How to test it?

open a preview page in getstarted. hover elements that display strapi content. you should see the highlights. double click them and see the console log. Then resize, scroll, etc., the highlight positioning should remain right
### Related issue(s)/PR(s)

fixes https://github.com/strapi/content-squad/issues/60