### PR TITLE
fix(content-manager): compute document status per-locale to prevent cross-locale state bleed

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -154,9 +154,18 @@ export default {
 
     const setStatus = (document: any) => {
       // Available status of document
-      const availableStatuses = documentsAvailableStatus.filter(
-        (d: any) => d.documentId === document.documentId
-      );
+      // Scope by documentId and, when present, by the same locale to avoid cross-locale state
+      const availableStatuses = documentsAvailableStatus.filter((d: any) => {
+        if (d.documentId !== document.documentId) {
+          return false;
+        }
+        // If the document has a locale, only consider statuses from the same locale
+        if (document.locale) {
+          return d.locale === document.locale;
+        }
+        // If no locale on the document, keep all
+        return true;
+      });
       // Compute document version status
       document.status = documentMetadata.getStatus(document, availableStatuses);
       return document;

--- a/packages/core/content-manager/server/src/services/__tests__/document-metadata.locale-status.test.ts
+++ b/packages/core/content-manager/server/src/services/__tests__/document-metadata.locale-status.test.ts
@@ -1,0 +1,114 @@
+import documentMetadataLoader from '../document-metadata';
+
+describe('document-metadata.getStatus locale awareness', () => {
+  const createService = () => {
+    // getStatus does not rely on strapi in its current implementation
+    // Provide a minimal shape to satisfy the factory signature.
+    const service = (documentMetadataLoader as any)({ strapi: {} });
+    return service as {
+      getStatus: (
+        version: {
+          id?: string | number;
+          documentId: string;
+          locale?: string | null;
+          updatedAt?: string | Date | null;
+          publishedAt?: string | Date | null;
+        },
+        other?: Array<{
+          id?: string | number;
+          documentId: string;
+          locale?: string | null;
+          updatedAt?: string | Date | null;
+          publishedAt?: string | Date | null;
+        }>
+      ) => 'draft' | 'published' | 'modified';
+    };
+  };
+
+  test('does not mark a locale as modified based on other locales (published EN, modified draft EN-GB)', () => {
+    const { getStatus } = createService();
+
+    const enPublished = {
+      documentId: 'doc-1',
+      locale: 'en',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      publishedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    const enGbDraftNewer = {
+      documentId: 'doc-1',
+      locale: 'en-GB',
+      updatedAt: '2024-02-01T00:00:00.000Z',
+      publishedAt: null,
+    };
+
+    const status = getStatus(enPublished, [enGbDraftNewer]);
+
+    expect(status).toBe('published');
+  });
+
+  test('returns modified when the same-locale draft is newer than its published version', () => {
+    const { getStatus } = createService();
+
+    const enPublished = {
+      documentId: 'doc-1',
+      locale: 'en',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      publishedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    const enDraftNewer = {
+      documentId: 'doc-1',
+      locale: 'en',
+      updatedAt: '2024-03-01T00:00:00.000Z',
+      publishedAt: null,
+    };
+
+    const status = getStatus(enPublished, [enDraftNewer]);
+
+    expect(status).toBe('modified');
+  });
+
+  test('returns draft when only other-locale published exists', () => {
+    const { getStatus } = createService();
+
+    const enDraft = {
+      documentId: 'doc-1',
+      locale: 'en',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      publishedAt: null,
+    };
+
+    const enGbPublished = {
+      documentId: 'doc-1',
+      locale: 'en-GB',
+      updatedAt: '2024-02-01T00:00:00.000Z',
+      publishedAt: '2024-02-01T00:00:00.000Z',
+    };
+
+    const status = getStatus(enDraft, [enGbPublished]);
+
+    expect(status).toBe('draft');
+  });
+
+  test('when no locale on version, falls back to first counterpart', () => {
+    const { getStatus } = createService();
+
+    const noLocaleDraft = {
+      documentId: 'doc-1',
+      updatedAt: '2024-03-01T00:00:00.000Z',
+      publishedAt: null,
+    };
+
+    const publishedCounterpart = {
+      documentId: 'doc-1',
+      locale: 'en',
+      updatedAt: '2024-02-01T00:00:00.000Z',
+      publishedAt: '2024-02-01T00:00:00.000Z',
+    };
+
+    const status = getStatus(noLocaleDraft as any, [publishedCounterpart]);
+
+    expect(status).toBe('modified');
+  });
+});

--- a/packages/core/content-manager/server/src/services/document-metadata.ts
+++ b/packages/core/content-manager/server/src/services/document-metadata.ts
@@ -186,7 +186,22 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       draftVersion = version;
     }
 
-    const otherVersion = otherDocumentStatuses?.at(0);
+    // Prefer the counterpart from the same locale if a locale is set.
+    // This avoids cross-locale state bleed (e.g. en-GB draft affecting en status).
+    let otherVersion: DocumentVersion | undefined;
+    if (Array.isArray(otherDocumentStatuses) && otherDocumentStatuses.length > 0) {
+      if (version.locale != null) {
+        otherVersion = (otherDocumentStatuses as DocumentVersion[]).find(
+          (v) => v.locale === version.locale
+        );
+        // If a locale is defined but no counterpart exists for that locale,
+        // ignore other locales entirely.
+      } else {
+        // When no locale is defined, fall back to the first counterpart
+        otherVersion = (otherDocumentStatuses as DocumentVersion[]).at(0);
+      }
+    }
+
     if (otherVersion?.publishedAt) {
       publishedVersion = otherVersion;
     } else if (otherVersion) {


### PR DESCRIPTION
### What does it do?

Scopes Content Manager document status computation by locale to prevent cross-locale state bleed.

Technical changes:
- Server
  - document-metadata.getStatus():
    - When a locale is provided, prefer the counterpart (draft/published) of the same locale among localizations.
    - Ignore other locales when deciding if an entry is published/modified/draft for the current locale.
    - Fall back to the first available counterpart only if no same-locale version exists.
  - controllers/collection-types.find():
    - Filter availableStatuses by the requested locale before computing setStatus for each returned item.
- Tests
  - Added locale-aware status unit tests:
    - packages/core/content-manager/server/src/services/__tests__/document-metadata.locale-status.test.ts

### Why is it needed?

Previously, changing/publishing an entry in one locale could inadvertently flip the status of entries with the same documentId in other locales (e.g., editing en-GB made the en version look “modified”). This fix ensures the status reflects only the state of the current locale’s version.

Scenarios addressed:
- Published EN and modified draft EN-GB no longer marks EN as modified.
- Modified draft EN compared to published EN returns “modified” as expected.
- If only another-locale published exists, current-locale draft remains “draft.”
- If a version has no locale metadata, fallback remains preserved.

### How to test it?

Automated
- Run package unit tests for Content Manager:
  - yarn workspace @strapi/content-manager run test:unit
- The new tests are located at:
  - packages/core/content-manager/server/src/services/__tests__/document-metadata.locale-status.test.ts

Manual (Admin UI with i18n and Draft & Publish enabled)
1) Create a collection-type with i18n enabled (e.g., Article).
2) Create an entry in EN, publish it.
3) Switch to EN-GB, create/edit the localized version (leave as draft or modify after publishing).
4) Verify in the list view:
   - EN stays “published” unless its own draft changed in EN.
   - EN-GB shows “modified” only when EN-GB’s draft is newer than its own published version.
   - Changing EN-GB does not alter EN’s status, and vice versa.

### Related issue(s)/PR(s)

N/A (please link an issue if one exists)