### PR TITLE
fix: clear values of conditionally hidden fields to prevent UI inconsistencies

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -63,6 +63,32 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
     });
   };
 
+  // Compute a masked copy of values that excludes fields that are hidden, so
+  // dependent fields don't evaluate against stale values. We do NOT mutate the
+  // form state to avoid toggling the modified flag.
+  const maskedValues = React.useMemo(() => {
+    const schema = document.schema;
+    if (!schema) return fieldValues;
+
+    const hidden = new Set<string>();
+    // First pass: determine hidden fields at the top level
+    for (const [name, attr] of Object.entries(schema.attributes ?? {})) {
+      const condition = (attr as any)?.conditions?.visible;
+      if (condition) {
+        const isVisible = rulesEngine.evaluate(condition, fieldValues);
+        if (!isVisible) hidden.add(name);
+      }
+    }
+
+    if (hidden.size === 0) return fieldValues;
+
+    const copy: Record<string, unknown> = { ...fieldValues };
+    for (const key of hidden) {
+      if (key in copy) delete (copy as any)[key];
+    }
+    return copy;
+  }, [document.schema, fieldValues, rulesEngine]);
+
   return (
     <Flex direction="column" alignItems="stretch" gap={6}>
       {layout.map((panel, index) => {
@@ -73,7 +99,7 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
           const condition = attribute?.conditions?.visible;
 
           if (condition) {
-            const isVisible = rulesEngine.evaluate(condition, fieldValues);
+            const isVisible = rulesEngine.evaluate(condition, maskedValues);
             if (!isVisible) {
               return null; // Skip rendering the dynamic zone if the condition is not met
             }
@@ -101,7 +127,7 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
                   const condition = attribute?.conditions?.visible;
 
                   if (condition) {
-                    return rulesEngine.evaluate(condition, fieldValues);
+                    return rulesEngine.evaluate(condition, maskedValues);
                   }
 
                   return true;


### PR DESCRIPTION
### What does it do?

This PR fixes an issue where conditionally hidden fields in the Content Manager retain their old values, causing dependent fields to remain visible incorrectly.  

**Technical changes:**
- Added a `maskedValues` memoized object that excludes values of fields currently hidden by visibility conditions.
- Updated all conditional visibility checks (`rulesEngine.evaluate`) to use `maskedValues` instead of the raw `fieldValues`.
- This ensures that dependent field conditions are evaluated without stale hidden field data, without mutating form state (so the modified flag is unaffected).

---

### Why is it needed?

Previously, when a field became hidden due to a condition no longer being met, its stored value persisted in `fieldValues`.  
Because other field visibility conditions could still read this stale value, dependent fields would stay visible even though the triggering field was hidden.  

This fix ensures hidden fields are effectively ignored in visibility evaluations, preventing inconsistent UI behavior in the content editor.  

**Fixes:** #24120

---

### How to test it?
1. Add the example schema from the issue description (with `type`, `linkTo`, and `page` fields, each having visibility conditions).
2. Select `"internal-link"` for `type` and `"Pages"` for `linkTo`.
3. Change `type` to `"external-link"`.
4. **Before fix:** `page` remains visible because `linkTo` still holds `"Pages"`.
5. **After fix:** `page` correctly hides as soon as `linkTo` becomes hidden.

---

### A screen recording demonstrating **before** and **after** behavior is included in this PR.

#### Before:
https://github.com/user-attachments/assets/bf5167b2-f584-4fcc-97e4-b33226379324

#### After:

https://github.com/user-attachments/assets/f3c60f08-1851-40b3-839a-671f55d2200c

---

### Related issue(s)/PR(s)

Fixes #24120
