### PR TITLE
fix(content-manager): export ContentManagerPlugin type for plugin dev…

### DIFF
--- a/packages/core/content-manager/admin/src/exports.ts
+++ b/packages/core/content-manager/admin/src/exports.ts
@@ -27,6 +27,7 @@ export type {
   BulkActionComponent,
   BulkActionComponentProps,
   BulkActionDescription,
+  ContentManagerPlugin,
   DescriptionComponent,
   DescriptionReducer,
   PanelComponentProps,


### PR DESCRIPTION
## What does it do?
  Exports the `ContentManagerPlugin` type from the content-manager package's main export, making it available for plugin developers.

## Why is it needed?
  Plugin developers who want to properly type their integrations with the content-manager (e.g., when using `app.getPlugin('content-manager')`) currently cannot import the `ContentManagerPlugin`
   type, forcing them to use `any` types or create custom interfaces.

## How to test it?
  1. Create a plugin that imports: `import type { ContentManagerPlugin } from '@strapi/content-manager/strapi-admin'`
  2. Verify TypeScript compilation succeeds

## Breaking changes?
  None - this only adds a type export that was already defined but not accessible.

### Related issue(s)/PR(s)

Fix #24148 
