### PR TITLE
fix: wrong count for published entries in homepage widget

### DIFF
--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -173,8 +173,8 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       const permittedContentTypes = await getPermittedContentTypes();
       const allowedContentTypeUids = draftAndPublishOnly
         ? permittedContentTypes.filter((uid) => {
-          return contentTypes.hasDraftAndPublish(strapi.contentType(uid));
-        })
+            return contentTypes.hasDraftAndPublish(strapi.contentType(uid));
+          })
         : permittedContentTypes;
       // Fetch the configuration for each content type in a single query
       const configurations = await getConfiguration(allowedContentTypeUids);
@@ -271,21 +271,21 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
             const publishedDocuments = meta.hasDraftAndPublish
               ? await strapiDBConnection(tableName)
-                .countDistinct('draft.document_id as count')
-                .from(`${tableName} as draft`)
-                .join(`${tableName} as published`, function () {
-                  this.on('draft.document_id', '=', 'published.document_id')
-                    .andOn('draft.updated_at', '=', 'published.updated_at')
-                    .andOnNull('draft.published_at')
-                    .andOnNotNull('published.published_at');
-                })
-                .first()
+                  .countDistinct('draft.document_id as count')
+                  .from(`${tableName} as draft`)
+                  .join(`${tableName} as published`, function () {
+                    this.on('draft.document_id', '=', 'published.document_id')
+                      .andOn('draft.updated_at', '=', 'published.updated_at')
+                      .andOnNull('draft.published_at')
+                      .andOnNotNull('published.published_at');
+                  })
+                  .first()
               : await strapiDBConnection(tableName)
-                .select('document_id')
-                .from(`${tableName}`)
-                .countDistinct('document_id as count')
-                .groupBy('document_id')
-                .first();
+                  .select('document_id')
+                  .from(`${tableName}`)
+                  .countDistinct('document_id as count')
+                  .groupBy('document_id')
+                  .first();
             countDocuments.published += Number(publishedDocuments?.count) || 0;
 
             const modifiedDocuments = await strapiDBConnection(tableName)

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -1,3 +1,4 @@
+/* eslint-disable func-names */
 import type { Core, Modules, Schema } from '@strapi/types';
 import { contentTypes } from '@strapi/utils';
 
@@ -172,8 +173,8 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       const permittedContentTypes = await getPermittedContentTypes();
       const allowedContentTypeUids = draftAndPublishOnly
         ? permittedContentTypes.filter((uid) => {
-            return contentTypes.hasDraftAndPublish(strapi.contentType(uid));
-          })
+          return contentTypes.hasDraftAndPublish(strapi.contentType(uid));
+        })
         : permittedContentTypes;
       // Fetch the configuration for each content type in a single query
       const configurations = await getConfiguration(allowedContentTypeUids);
@@ -270,23 +271,21 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
             const publishedDocuments = meta.hasDraftAndPublish
               ? await strapiDBConnection(tableName)
-                  .select('draft.document_id')
-                  .from(`${tableName} as draft`)
-                  .join(`${tableName} as published`, function () {
-                    this.on('draft.document_id', '=', 'published.document_id')
-                      .andOn('draft.updated_at', '=', 'published.updated_at')
-                      .andOnNull('draft.published_at')
-                      .andOnNotNull('published.published_at');
-                  })
-                  .countDistinct('draft.document_id as count')
-                  .groupBy('draft.document_id')
-                  .first()
+                .countDistinct('draft.document_id as count')
+                .from(`${tableName} as draft`)
+                .join(`${tableName} as published`, function () {
+                  this.on('draft.document_id', '=', 'published.document_id')
+                    .andOn('draft.updated_at', '=', 'published.updated_at')
+                    .andOnNull('draft.published_at')
+                    .andOnNotNull('published.published_at');
+                })
+                .first()
               : await strapiDBConnection(tableName)
-                  .select('document_id')
-                  .from(`${tableName}`)
-                  .countDistinct('document_id as count')
-                  .groupBy('document_id')
-                  .first();
+                .select('document_id')
+                .from(`${tableName}`)
+                .countDistinct('document_id as count')
+                .groupBy('document_id')
+                .first();
             countDocuments.published += Number(publishedDocuments?.count) || 0;
 
             const modifiedDocuments = await strapiDBConnection(tableName)


### PR DESCRIPTION
### What does it do?

This PR fixes the query that counts the number of published entries. 

### Why is it needed?

The current implementation just adds 1 for each content type.

### How to test it?

1. Spin up a clean Strapi instance and create some entries
2. Publish some entries, leave others in draft mode
3. Compare the number of published entries and the count in the front page widgets (see image below).

### Related issue(s)/PR(s)

None (yet).

<img width="801" height="421" alt="example-entry-count" src="https://github.com/user-attachments/assets/7bc22a9a-4ef1-4b7f-b198-2550d8861fb3" />

