### PR TITLE
fix: update tracking on homepage widgets

### DIFF
--- a/packages/core/admin/admin/src/components/Widgets.tsx
+++ b/packages/core/admin/admin/src/components/Widgets.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from '@strapi/admin/strapi-admin';
+import { useAuth, useTracking } from '@strapi/admin/strapi-admin';
 import { Avatar, Badge, Box, Flex, Typography } from '@strapi/design-system';
 import { Earth, Images, User, Key, Files, Layout, Graph, Webhooks } from '@strapi/icons';
 import { useIntl } from 'react-intl';
@@ -84,7 +84,109 @@ const LinkCell = styled(Link)`
   padding: ${({ theme }) => theme.spaces[3]};
 `;
 
+const keyStatisticsList = {
+  entries: {
+    label: {
+      id: 'widget.key-statistics.list.entries',
+      defaultMessage: 'Entries',
+    },
+    icon: {
+      component: <Files />,
+      background: 'primary100',
+      color: 'primary600',
+    },
+    link: '/content-manager',
+  },
+  assets: {
+    label: {
+      id: 'widget.key-statistics.list.assets',
+      defaultMessage: 'Assets',
+    },
+    icon: {
+      component: <Images />,
+      background: 'warning100',
+      color: 'warning600',
+    },
+    link: '/plugins/upload',
+  },
+  contentTypes: {
+    label: {
+      id: 'widget.key-statistics.list.contentTypes',
+      defaultMessage: 'Content-Types',
+    },
+    icon: {
+      component: <Layout />,
+      background: 'secondary100',
+      color: 'secondary600',
+    },
+    link: '/plugins/content-type-builder',
+  },
+  components: {
+    label: {
+      id: 'widget.key-statistics.list.components',
+      defaultMessage: 'Components',
+    },
+    icon: {
+      component: <Graph />,
+      background: 'alternative100',
+      color: 'alternative600',
+    },
+    link: '/plugins/content-type-builder',
+  },
+  locales: {
+    label: {
+      id: 'widget.key-statistics.list.locales',
+      defaultMessage: 'Locales',
+    },
+    icon: {
+      component: <Earth />,
+      background: 'success100',
+      color: 'success600',
+    },
+    link: '/settings/internationalization',
+  },
+  admins: {
+    label: {
+      id: 'widget.key-statistics.list.admins',
+      defaultMessage: 'Admins',
+    },
+    icon: {
+      component: <User />,
+      background: 'danger100',
+      color: 'danger600',
+    },
+    link: '/settings/users?pageSize=10&page=1&sort=firstname',
+  },
+  webhooks: {
+    label: {
+      id: 'widget.key-statistics.list.webhooks',
+      defaultMessage: 'Webhooks',
+    },
+    icon: {
+      component: <Webhooks />,
+      background: 'alternative100',
+      color: 'alternative600',
+    },
+    link: '/settings/webhooks',
+  },
+  apiTokens: {
+    label: {
+      id: 'widget.key-statistics.list.apiTokens',
+      defaultMessage: 'API Tokens',
+    },
+    icon: {
+      component: <Key />,
+      background: 'neutral100',
+      color: 'neutral600',
+    },
+    link: '/settings/api-tokens?sort=name:ASC',
+  },
+};
+
+type KeyStatisticsItem = keyof typeof keyStatisticsList;
+
 const KeyStatisticsWidget = () => {
+  const { trackUsage } = useTracking();
   const { formatMessage, locale } = useIntl();
   const { data: countDocuments, isLoading: isLoadingCountDocuments } = useGetCountDocumentsQuery();
   const { data: countKeyStatistics, isLoading: isLoadingKeyStatistics } =
@@ -97,105 +199,6 @@ const KeyStatisticsWidget = () => {
   if (!countKeyStatistics || !countDocuments) {
     return <Widget.Error />;
   }
-
-  const keyStatisticsList = {
-    entries: {
-      label: {
-        id: 'widget.key-statistics.list.entries',
-        defaultMessage: 'Entries',
-      },
-      icon: {
-        component: <Files />,
-        background: 'primary100',
-        color: 'primary600',
-      },
-      link: '/content-manager',
-    },
-    assets: {
-      label: {
-        id: 'widget.key-statistics.list.assets',
-        defaultMessage: 'Assets',
-      },
-      icon: {
-        component: <Images />,
-        background: 'warning100',
-        color: 'warning600',
-      },
-      link: '/plugins/upload',
-    },
-    contentTypes: {
-      label: {
-        id: 'widget.key-statistics.list.contentTypes',
-        defaultMessage: 'Content-Types',
-      },
-      icon: {
-        component: <Layout />,
-        background: 'secondary100',
-        color: 'secondary600',
-      },
-      link: '/plugins/content-type-builder',
-    },
-    components: {
-      label: {
-        id: 'widget.key-statistics.list.components',
-        defaultMessage: 'Components',
-      },
-      icon: {
-        component: <Graph />,
-        background: 'alternative100',
-        color: 'alternative600',
-      },
-      link: '/plugins/content-type-builder',
-    },
-    locales: {
-      label: {
-        id: 'widget.key-statistics.list.locales',
-        defaultMessage: 'Locales',
-      },
-      icon: {
-        component: <Earth />,
-        background: 'success100',
-        color: 'success600',
-      },
-      link: '/settings/internationalization',
-    },
-    admins: {
-      label: {
-        id: 'widget.key-statistics.list.admins',
-        defaultMessage: 'Admins',
-      },
-      icon: {
-        component: <User />,
-        background: 'danger100',
-        color: 'danger600',
-      },
-      link: '/settings/users?pageSize=10&page=1&sort=firstname',
-    },
-    webhooks: {
-      label: {
-        id: 'widget.key-statistics.list.webhooks',
-        defaultMessage: 'Webhooks',
-      },
-      icon: {
-        component: <Webhooks />,
-        background: 'alternative100',
-        color: 'alternative600',
-      },
-      link: '/settings/webhooks',
-    },
-    apiTokens: {
-      label: {
-        id: 'widget.key-statistics.list.apiTokens',
-        defaultMessage: 'API Tokens',
-      },
-      icon: {
-        component: <Key />,
-        background: 'neutral100',
-        color: 'neutral600',
-      },
-      link: '/settings/api-tokens?sort=name:ASC',
-    },
-  };
 
   const { draft, published, modified } = countDocuments ?? {
     draft: 0,
@@ -216,6 +219,7 @@ const KeyStatisticsWidget = () => {
               to={item.link}
               key={`key-statistics-${key}`}
               data-testid={`stat-${key}`}
+              onClick={() => trackUsage('didOpenProjectStatisticsWidgetLink', { item: key })}
             >
               <Flex alignItems="center" gap={2}>
                 <Flex

--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -175,7 +175,6 @@ export interface EventWithoutProperties {
     | 'willEditEditLayout'
     | 'willEditEmailTemplates'
     | 'willEditEntryFromButton'
-    | 'willEditEntryFromHome'
     | 'willEditEntryFromList'
     | 'willEditReleaseFromHome'
     | 'willEditFieldOfContentType'
@@ -187,7 +186,7 @@ export interface EventWithoutProperties {
     | 'willEditStage'
     | 'willFilterEntries'
     | 'willInstallPlugin'
-    | 'willOpenAuditLogDetails'
+    | 'willOpenAuditLogDetailsFromHome'
     | 'willUnpublishEntry'
     | 'willSaveComponent'
     | 'willSaveContentType'
@@ -411,6 +410,27 @@ interface DidStartGuidedTour {
   };
 }
 
+interface WillEditEntryFromHome {
+  name: 'willEditEntryFromHome';
+  properties: {
+    type: 'edited' | 'published' | 'assigned';
+  };
+}
+
+interface DidOpenHomeWidgetLink {
+  name: 'didOpenHomeWidgetLink';
+  properties: {
+    widgetUID: string;
+  };
+}
+
+interface DidOpenProjectStatisticsWidgetLink {
+  name: 'didOpenProjectStatisticsWidgetLink';
+  properties: {
+    item: string;
+  };
+}
+
 type EventsWithProperties =
   | CreateEntryEvents
   | PublishEntryEvents
@@ -436,7 +456,10 @@ type EventsWithProperties =
   | DidUpdateCTBSchema
   | DidSkipGuidedTour
   | DidCompleteGuidedTour
-  | DidStartGuidedTour;
+  | DidStartGuidedTour
+  | WillEditEntryFromHome
+  | DidOpenHomeWidgetLink
+  | DidOpenProjectStatisticsWidgetLink;
 
 export type TrackingEvent = EventWithoutProperties | EventsWithProperties;
 export interface UseTrackingReturn {

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -12,6 +12,7 @@ import { Widget } from '../../components/WidgetHelpers';
 import { useEnterprise } from '../../ee';
 import { useAuth } from '../../features/Auth';
 import { useStrapiApp } from '../../features/StrapiApp';
+import { useTracking } from '../../features/Tracking';
 
 import { FreeTrialEndedModal } from './components/FreeTrialEndedModal';
 import { FreeTrialWelcomeModal } from './components/FreeTrialWelcomeModal';
@@ -23,14 +24,20 @@ import type { WidgetType } from '@strapi/admin/strapi-admin';
  * WidgetRoot
  * -----------------------------------------------------------------------------------------------*/
 
-interface WidgetRootProps extends Pick<WidgetType, 'title' | 'icon' | 'permissions' | 'link'> {
+interface WidgetRootProps
+  extends Pick<WidgetType, 'title' | 'icon' | 'permissions' | 'link' | 'uid'> {
   children: React.ReactNode;
 }
 
-export const WidgetRoot = ({ title, icon = PuzzlePiece, children, link }: WidgetRootProps) => {
+export const WidgetRoot = ({ title, icon = PuzzlePiece, children, link, uid }: WidgetRootProps) => {
+  const { trackUsage } = useTracking();
   const { formatMessage } = useIntl();
   const id = React.useId();
   const Icon = icon;
+
+  const handleClickOnLink = () => {
+    trackUsage('didOpenHomeWidgetLink', { widgetUID: uid });
+  };
 
   return (
     <Flex
@@ -61,6 +68,7 @@ export const WidgetRoot = ({ title, icon = PuzzlePiece, children, link }: Widget
             style={{ textDecoration: 'none' }}
             textAlign="right"
             to={link.href}
+            onClick={handleClickOnLink}
           >
             {formatMessage(link.label)}
           </Typography>
@@ -157,7 +165,12 @@ const HomePageCE = () => {
             <Grid.Root gap={5}>
               {filteredWidgets.map((widget) => (
                 <Grid.Item col={6} s={12} key={widget.uid}>
-                  <WidgetRoot title={widget.title} icon={widget.icon} link={widget.link}>
+                  <WidgetRoot
+                    title={widget.title}
+                    icon={widget.icon}
+                    link={widget.link}
+                    uid={widget.uid}
+                  >
                     <WidgetComponent component={widget.component} />
                   </WidgetRoot>
                 </Grid.Item>

--- a/packages/core/admin/ee/admin/src/components/AuditLogs/Widgets.tsx
+++ b/packages/core/admin/ee/admin/src/components/AuditLogs/Widgets.tsx
@@ -30,7 +30,7 @@ const LastActivityTable = ({ items }: { items: AuditLog[] }) => {
   };
 
   const handleRowClick = (document: AuditLog) => () => {
-    trackUsage('willOpenAuditLogDetails');
+    trackUsage('willOpenAuditLogDetailsFromHome');
     const link = getAuditLogDetailsLink(document);
     navigate(link);
   };
@@ -74,7 +74,7 @@ const LastActivityTable = ({ items }: { items: AuditLog[] }) => {
                   <IconButton
                     tag={Link}
                     to={getAuditLogDetailsLink(item)}
-                    onClick={() => trackUsage('willOpenAuditLogDetails')}
+                    onClick={() => trackUsage('willOpenAuditLogDetailsFromHome')}
                     label={formatMessage({
                       id: 'global.details',
                       defaultMessage: 'Details',

--- a/packages/core/content-manager/admin/src/components/Widgets.tsx
+++ b/packages/core/content-manager/admin/src/components/Widgets.tsx
@@ -32,7 +32,13 @@ const CellTypography = styled(Typography)`
   white-space: nowrap;
 `;
 
-const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) => {
+const RecentDocumentsTable = ({
+  documents,
+  type,
+}: {
+  documents: RecentDocument[];
+  type: 'edited' | 'published';
+}) => {
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const navigate = useNavigate();
@@ -46,7 +52,9 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
   };
 
   const handleRowClick = (document: RecentDocument) => () => {
-    trackUsage('willEditEntryFromHome');
+    trackUsage('willEditEntryFromHome', {
+      type,
+    });
     const link = getEditViewLink(document);
     navigate(link);
   };
@@ -95,7 +103,7 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
                 <IconButton
                   tag={Link}
                   to={getEditViewLink(document)}
-                  onClick={() => trackUsage('willEditEntryFromHome')}
+                  onClick={() => trackUsage('willEditEntryFromHome', { type })}
                   label={formatMessage({
                     id: 'content-manager.actions.edit.label',
                     defaultMessage: 'Edit',
@@ -140,7 +148,7 @@ const LastEditedWidget = () => {
     );
   }
 
-  return <RecentDocumentsTable documents={data} />;
+  return <RecentDocumentsTable documents={data} type="edited" />;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -170,7 +178,7 @@ const LastPublishedWidget = () => {
     );
   }
 
-  return <RecentDocumentsTable documents={data} />;
+  return <RecentDocumentsTable documents={data} type="published" />;
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/review-workflows/admin/src/components/Widgets.tsx
+++ b/packages/core/review-workflows/admin/src/components/Widgets.tsx
@@ -19,7 +19,13 @@ const CellTypography = styled(Typography)`
   white-space: nowrap;
 `;
 
-const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) => {
+const RecentDocumentsTable = ({
+  documents,
+  type,
+}: {
+  documents: RecentDocument[];
+  type: 'assigned';
+}) => {
   const { formatMessage } = useIntl();
   const { trackUsage } = useTracking();
   const navigate = useNavigate();
@@ -33,7 +39,7 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
   };
 
   const handleRowClick = (document: RecentDocument) => () => {
-    trackUsage('willEditEntryFromHome');
+    trackUsage('willEditEntryFromHome', { type });
     const link = getEditViewLink(document);
     navigate(link);
   };
@@ -85,7 +91,7 @@ const RecentDocumentsTable = ({ documents }: { documents: RecentDocument[] }) =>
                 <IconButton
                   tag={Link}
                   to={getEditViewLink(document)}
-                  onClick={() => trackUsage('willEditEntryFromHome')}
+                  onClick={() => trackUsage('willEditEntryFromHome', { type })}
                   label={formatMessage({
                     id: 'content-manager.actions.edit.label',
                     defaultMessage: 'Edit',
@@ -130,7 +136,7 @@ const AssignedWidget = () => {
     );
   }
 
-  return <RecentDocumentsTable documents={data} />;
+  return <RecentDocumentsTable documents={data} type="assigned" />;
 };
 
 export { AssignedWidget };


### PR DESCRIPTION
### What does it do?

Updates the tracking events plan for the homepage widgets.

### Why is it needed?

To be able to track engagement on homepage widgets.

### How to test it?

- Go to the homepage
- Open the console > click on Network tab
- If not already enabled, click on the checkbox "Preserve log"
- You can type "track" in the field "Filter" to only display tracking requests
- Click on the following links
-> To see tracking event details, click on track request > Payload, you should see the details of the event (the name and their parameters)
<img width="1108" height="213" alt="Screenshot 2025-08-11 at 18 24 18" src="https://github.com/user-attachments/assets/782a2868-c12c-4d67-85a7-604b6c3615e9" />

- Last Edited Entries
  - ![Screenshot 2025-08-11 at 16.22.45.png](attachment:2096a110-ddad-4114-87f4-7c97239af3a6:Screenshot_2025-08-11_at_16.22.45.png)
  - willEditEntryFromHome + type = edited
  - Click on a row or the pencil icon

- Last Published Entries
  - ![Screenshot 2025-08-11 at 16.23.28.png](attachment:6e9a08c3-0aef-4618-965e-8a2c707d2999:Screenshot_2025-08-11_at_16.23.28.png)
  - willEditEntryFromHome + type = published
  - Click on a row or the pencil icon

- Profile
  - ![Screenshot 2025-08-11 at 16.23.33.png](attachment:9ac686c3-9453-4af3-88d5-528770ea5102:Screenshot_2025-08-11_at_16.23.33.png)
  - didOpenHomeWidgetLink + widgetUID = plugin::admin.profile-info
  - Click on the link on top right of the widget (Profile settings)

- Entries
  - No event to track 🥳 Pour you a cup of coffee ☕️

- Project Statistics
  - ![Screenshot 2025-08-11 at 16.23.43.png](attachment:63ed11f8-f10d-4a46-9342-e853a73cbf8a:Screenshot_2025-08-11_at_16.23.43.png)
  - didOpenProjectStatisticsWidgetLink + item (entries | assets | contentTypes | components | locales | admins | webhooks | apiTokens)
  - Click on each cell of the widget

- Upcoming releases
  - ![Screenshot 2025-08-11 at 16.44.06.png](attachment:39299a2b-7a10-459d-8b5c-dc750665916c:Screenshot_2025-08-11_at_16.44.06.png)
  - didOpenWidgetLink + widgetUID = plugin::content-releases.upcoming-releases
  - Click on Open Releases link

  - ![Screenshot 2025-08-11 at 16.45.42.png](attachment:e97093a9-56e0-4318-8ec9-47402eff9165:Screenshot_2025-08-11_at_16.45.42.png)
  - willEditReleaseFromHome
  - Click on a row or the pencil icon

- Assigned to me
  - ![Screenshot 2025-08-11 at 16.23.51.png](attachment:1c40511b-d8a3-4e17-8c7c-0b106ffd7e5d:Screenshot_2025-08-11_at_16.23.51.png)
  - willEditEntryFromHome + type = assigned

- Last activity
  - ![Screenshot 2025-08-11 at 16.59.19.png](attachment:a70e324c-acd2-4c6e-9e3b-5b28a5f195f7:Screenshot_2025-08-11_at_16.59.19.png)
  - didOpenWidgetLink + widgetUID = plugin::admin.audit-logs
  - Click on Open Audit Logs link

  - ![Screenshot 2025-08-11 at 16.59.19 copy.tiff](attachment:e1b5f7ea-a2f8-4e7f-b8f4-a042e9699e65:Screenshot_2025-08-11_at_16.59.19_copy.tiff)
  - willOpenAuditLogDetailsFromHome
  - Click on a row or the eye icon

🚀