### PR TITLE
ci(scripts): git bisect run helper

### DIFF
--- a/scripts/bisect-helper.js
+++ b/scripts/bisect-helper.js
@@ -111,10 +111,14 @@ async function printFirstBadFromBisectLog() {
       const text = summary.replace(/^#\s*first bad commit:\s*/, '');
       const match = text.match(/^\[([0-9a-f]{7,40})\]\s+(.*)$/i);
       if (match) {
-        const short = match[1].slice(0, 10);
-        const subject = match[2];
+        const fullHash = match[1];
+        const [{ stdout: short }, { stdout: subject }] = await Promise.all([
+          execa('git', ['rev-parse', '--short', fullHash]),
+          execa('git', ['show', '-s', '--format=%s', fullHash]),
+        ]);
         console.log(`FIRST_BAD_COMMIT: ${short} - ${subject}`);
       } else {
+        // Fallback: print as-is from the bisect log
         console.log(`FIRST_BAD_COMMIT: ${text}`);
       }
     }

--- a/scripts/bisect-helper.js
+++ b/scripts/bisect-helper.js
@@ -1,4 +1,29 @@
 #!/usr/bin/env node
+/**
+ * Git Bisect Helper (Node)
+ *
+ * What it does
+ * - Interactively prompts for:
+ *   - Test command to run at each checkout (e.g. `yarn test:unit --selectProjects Strapi -- packages/core/strapi/__tests__/version.test.ts`)
+ *   - Known GOOD ref and BAD ref (Enter to use current commit for either)
+ *   - Setup mode between checkouts: none | build (`yarn build`) | setup (`yarn setup`)
+ * - Generates a temporary bash runner that, on each checkout, runs the chosen setup then executes the test command
+ * - Starts a `git bisect` session with your refs and runs `git bisect run <runner>`
+ * - Leaves the repo in a bisected state. Run `git bisect reset` when finished.
+ *
+ * Requirements
+ * - git, bash, Node.js, and yarn available on PATH
+ *
+ * Usage
+ * - Make sure this file is executable: `chmod +x scripts/bisect-helper.js`
+ * - Run: `./scripts/bisect-helper.js`
+ * - Follow prompts. Press Enter on good/bad if you want to mark the current commit.
+ *
+ * Notes
+ * - The test command is base64-encoded into the runner to avoid quoting issues.
+ * - The runner is created in your system temp folder and its path is printed for reference.
+ * - `git bisect run` expects the runner to exit 0 for GOOD and non-zero for BAD; your test command’s exit code is passed through.
+ */
 'use strict';
 
 const fs = require('fs');

--- a/scripts/bisect-helper.js
+++ b/scripts/bisect-helper.js
@@ -24,17 +24,17 @@ async function promptInputs() {
     {
       type: 'input',
       name: 'goodRef',
-      message: 'Enter the known GOOD commit or tag:',
-      validate(input) {
-        return input && input.trim().length > 0 ? true : 'Good ref is required';
+      message: 'Enter the known GOOD commit or tag (leave blank to use current):',
+      validate() {
+        return true; // allow blank
       },
     },
     {
       type: 'input',
       name: 'badRef',
-      message: 'Enter the known BAD commit or tag:',
-      validate(input) {
-        return input && input.trim().length > 0 ? true : 'Bad ref is required';
+      message: 'Enter the known BAD commit or tag (leave blank to use current):',
+      validate() {
+        return true; // allow blank
       },
     },
     {
@@ -124,8 +124,16 @@ async function runBisect({ goodRef, badRef, runnerPath }) {
   } catch {}
 
   await execa('git', ['bisect', 'start'], { stdio: 'inherit' });
-  await execa('git', ['bisect', 'bad', badRef], { stdio: 'inherit' });
-  await execa('git', ['bisect', 'good', goodRef], { stdio: 'inherit' });
+  if (badRef && badRef.trim().length > 0) {
+    await execa('git', ['bisect', 'bad', badRef.trim()], { stdio: 'inherit' });
+  } else {
+    await execa('git', ['bisect', 'bad'], { stdio: 'inherit' });
+  }
+  if (goodRef && goodRef.trim().length > 0) {
+    await execa('git', ['bisect', 'good', goodRef.trim()], { stdio: 'inherit' });
+  } else {
+    await execa('git', ['bisect', 'good'], { stdio: 'inherit' });
+  }
 
   try {
     await execa('git', ['bisect', 'run', runnerPath], { stdio: 'inherit' });

--- a/scripts/bisect-helper.js
+++ b/scripts/bisect-helper.js
@@ -70,8 +70,8 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 echo "[bisect-runner] Checkout: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-echo "[bisect-runner] Setup mode: ${SETUP_MODE}"
-case "${SETUP_MODE}" in
+echo "[bisect-runner] Setup mode: \${SETUP_MODE}"
+case "\${SETUP_MODE}" in
   build)
     yarn build
     ;;
@@ -98,11 +98,11 @@ decode_b64() {
   fi
 }
 
-TEST_COMMAND=$(printf %s "${TEST_COMMAND_B64}" | decode_b64)
+TEST_COMMAND=$(printf %s "\${TEST_COMMAND_B64}" | decode_b64)
 
-echo "[bisect-runner] Running test command: ${TEST_COMMAND}"
+echo "[bisect-runner] Running test command: \n\${TEST_COMMAND}"
 # Use bash -lc so complex commands, pipes, and env assignments work
-bash -lc "${TEST_COMMAND}"
+bash -lc "\${TEST_COMMAND}"
 `;
 }
 

--- a/scripts/bisect-helper.js
+++ b/scripts/bisect-helper.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+const inquirer = require('inquirer');
+const execa = require('execa');
+
+const writeFile = promisify(fs.writeFile);
+const chmod = promisify(fs.chmod);
+
+async function promptInputs() {
+  const answers = await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'testCommand',
+      message: 'Enter the test command to run at each step (e.g., yarn test:api tests/api/...):',
+      validate(input) {
+        return input && input.trim().length > 0 ? true : 'Test command is required';
+      },
+    },
+    {
+      type: 'input',
+      name: 'goodRef',
+      message: 'Enter the known GOOD commit or tag:',
+      validate(input) {
+        return input && input.trim().length > 0 ? true : 'Good ref is required';
+      },
+    },
+    {
+      type: 'input',
+      name: 'badRef',
+      message: 'Enter the known BAD commit or tag:',
+      validate(input) {
+        return input && input.trim().length > 0 ? true : 'Bad ref is required';
+      },
+    },
+    {
+      type: 'list',
+      name: 'setupMode',
+      message: 'Choose setup to run between checkouts:',
+      default: 'none',
+      choices: [
+        { name: 'none (do nothing)', value: 'none' },
+        { name: "build (run 'yarn build')", value: 'build' },
+        { name: "setup (run 'yarn setup')", value: 'setup' },
+      ],
+    },
+  ]);
+
+  return answers;
+}
+
+function createRunnerScriptContent({ testCommand, setupMode }) {
+  const testCommandB64 = Buffer.from(testCommand, 'utf8').toString('base64');
+
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=
+
+TEST_COMMAND_B64='${testCommandB64}'
+SETUP_MODE='${setupMode}'
+
+# Ensure we run from the repo root (worktree) if available, otherwise stay in current dir
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  cd "$(git rev-parse --show-toplevel)"
+fi
+
+echo "[bisect-runner] Checkout: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "[bisect-runner] Setup mode: ${SETUP_MODE}"
+case "${SETUP_MODE}" in
+  build)
+    yarn build
+    ;;
+  setup)
+    yarn setup
+    ;;
+  none)
+    ;; # no-op
+esac
+
+# Decode base64 in a cross-platform way (GNU/macOS). Fallback to openssl if needed.
+decode_b64() {
+  if command -v base64 >/dev/null 2>&1; then
+    if base64 --help 2>&1 | grep -q -- "--decode"; then
+      base64 --decode
+    else
+      base64 -D
+    fi
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl base64 -d
+  else
+    echo "No base64 decoder found on PATH" >&2
+    exit 2
+  fi
+}
+
+TEST_COMMAND=$(printf %s "${TEST_COMMAND_B64}" | decode_b64)
+
+echo "[bisect-runner] Running test command: ${TEST_COMMAND}"
+# Use bash -lc so complex commands, pipes, and env assignments work
+bash -lc "${TEST_COMMAND}"
+`;
+}
+
+async function createRunnerScript(params) {
+  const content = createRunnerScriptContent(params);
+  const runnerPath = path.join(
+    os.tmpdir(),
+    `git-bisect-runner.${Date.now()}.${Math.random().toString(36).slice(2)}.sh`
+  );
+  await writeFile(runnerPath, content, { encoding: 'utf8' });
+  await chmod(runnerPath, 0o755);
+  return runnerPath;
+}
+
+async function runBisect({ goodRef, badRef, runnerPath }) {
+  // Reset any existing bisect session silently
+  try {
+    await execa('git', ['bisect', 'reset'], { stdio: 'ignore' });
+  } catch {}
+
+  await execa('git', ['bisect', 'start'], { stdio: 'inherit' });
+  await execa('git', ['bisect', 'bad', badRef], { stdio: 'inherit' });
+  await execa('git', ['bisect', 'good', goodRef], { stdio: 'inherit' });
+
+  try {
+    await execa('git', ['bisect', 'run', runnerPath], { stdio: 'inherit' });
+    console.log('\nGit bisect run completed. The first bad commit should be shown above.');
+  } catch (err) {
+    console.error(
+      `\nGit bisect run exited with status ${err.exitCode ?? 'unknown'}. See output above for details.`
+    );
+  }
+
+  console.log('\nNote: Your repository is currently checked out at a commit in the bisect state.');
+  console.log(
+    "      Run 'git bisect reset' when you're done inspecting to return to your previous state."
+  );
+  console.log(`Runner kept at: ${runnerPath}`);
+}
+
+async function main() {
+  console.log('Git Bisect Helper (Node)');
+  const answers = await promptInputs();
+  const runnerPath = await createRunnerScript({
+    testCommand: answers.testCommand,
+    setupMode: answers.setupMode,
+  });
+
+  console.log(`\nGenerated runner script at: ${runnerPath}`);
+  console.log('Starting git bisect session...');
+
+  await runBisect({ goodRef: answers.goodRef, badRef: answers.badRef, runnerPath });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### What does it do?

Adds `scripts/bisect-helper.js`

```
Usage: bisect-helper [options]

Description:
  Interactive helper for `git bisect run`.
  - Prompts for the test command to execute at each checkout
  - Prompts for GOOD and BAD refs (blank = current commit)
  - Prompts for setup step between checkouts: none | build | setup
  - Generates a temporary runner that performs setup then runs your test command
  - Starts `git bisect` and runs `git bisect run <runner>`

CLI Options (any omitted option will be prompted for):
  -t, --test, --test-command   Test command to run at each checkout
  -g, --good                   Known GOOD commit or tag (blank/current if omitted)
  -b, --bad                    Known BAD commit or tag (blank/current if omitted)
  -s, --setup                  Setup between checkouts: none | build | setup
  -h, --help                   Show this help and exit

Environment:
  DEBUG=1           Enable verbose logs from the helper and the runner

Examples:
  ./scripts/bisect-helper.js
  DEBUG=1 ./scripts/bisect-helper.js
  ./scripts/bisect-helper.js -t "yarn test:unit version.test.ts" -g v5.17.0 -b v5.19.0 -s none
```

It accepts (or prompts) for the good commit, bad commit, and test command to run, and then creates the script needed by git bisect and runs the command for you.

So all you have to do is:
- create a new test file to check for the bug you're looking for
- run `node ./scripts/bisect-helper.js`
- answer all the prompts
- wait until the first bad commit is found

### Why is it needed?

To simplify regression finding via `git bisect`

### How to test it?

try using it

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
