### PR TITLE
fix: track only the api requests

### DIFF
--- a/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/middleware.test.ts
@@ -3,14 +3,21 @@ import createMiddleware from '../middleware';
 describe('Metrics middleware', () => {
   const originalDateNow = Date.now;
 
+  const mockStrapi = {
+    config: {
+      get: jest.fn().mockReturnValue('/api'),
+    },
+  } as any;
+
   afterEach(() => {
     Date.now = originalDateNow;
+    jest.clearAllMocks();
   });
 
   test('Ignores request with extension in them', async () => {
     const sendEvent = jest.fn();
 
-    const middleware = createMiddleware({ sendEvent });
+    const middleware = createMiddleware({ sendEvent, strapi: mockStrapi });
 
     await middleware(
       {
@@ -28,7 +35,7 @@ describe('Metrics middleware', () => {
   test.each(['OPTIONS', 'HEAD'])('Ignores %s method', async (method) => {
     const sendEvent = jest.fn();
 
-    const middleware = createMiddleware({ sendEvent });
+    const middleware = createMiddleware({ sendEvent, strapi: mockStrapi });
 
     await middleware(
       {
@@ -45,14 +52,14 @@ describe('Metrics middleware', () => {
 
   test('Stops sending after 1000 events', async () => {
     const sendEvent = jest.fn();
-    const middleware = createMiddleware({ sendEvent });
+    const middleware = createMiddleware({ sendEvent, strapi: mockStrapi });
 
     for (let i = 0; i < 2000; i += 1) {
       await middleware(
         {
           request: {
             method: 'GET',
-            url: 'api/',
+            url: '/api/articles',
           },
         } as any,
         jest.fn()
@@ -66,14 +73,14 @@ describe('Metrics middleware', () => {
     const sendEvent = jest.fn();
     Date.now = () => new Date('2021-01-01T00:00:00Z').getTime();
 
-    const middleware = createMiddleware({ sendEvent });
+    const middleware = createMiddleware({ sendEvent, strapi: mockStrapi });
 
     for (let i = 0; i < 2000; i += 1) {
       await middleware(
         {
           request: {
             method: 'GET',
-            url: 'api/',
+            url: '/api/articles',
           },
         } as any,
         jest.fn()
@@ -86,7 +93,7 @@ describe('Metrics middleware', () => {
       {
         request: {
           method: 'GET',
-          url: 'api/',
+          url: '/api/articles',
         },
       } as any,
       jest.fn()

--- a/packages/core/core/src/services/metrics/index.ts
+++ b/packages/core/core/src/services/metrics/index.ts
@@ -41,7 +41,7 @@ const createTelemetryInstance = (strapi: Core.Strapi) => {
           },
         });
 
-        strapi.server.use(createMiddleware({ sendEvent }));
+        strapi.server.use(createMiddleware({ sendEvent, strapi }));
       }
     },
 

--- a/packages/core/core/src/services/metrics/middleware.ts
+++ b/packages/core/core/src/services/metrics/middleware.ts
@@ -10,7 +10,7 @@ function nextResetDate(): number {
   return Date.now() + 24 * 60 * 60 * 1000; // Now + 24 hours.
 }
 
-const createMiddleware = ({ sendEvent }: { sendEvent: Sender }) => {
+const createMiddleware = ({ sendEvent, strapi }: { sendEvent: Sender; strapi: Core.Strapi }) => {
   const state: State = {
     expires: nextResetDate(),
     counter: 0,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
It limits the tracking to the Content api requests

### Why is it needed?
Right now, the tracking system event sends the `didReceiveRequest` event to the admin operations and actions, which is not the purpose of this tracking event.

### How to test it?
With a lot of patience.
