### PR TITLE
fix: guided tour adds paddings to pages instead of using offset

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
@@ -32,7 +32,7 @@ const tours = {
     {
       name: 'Introduction',
       content: (Step) => (
-        <Step.Root side="bottom" withArrow={false}>
+        <Step.Root side="bottom" sideOffset={33} withArrow={false}>
           <Step.Title
             id="tours.contentTypeBuilder.Introduction.title"
             defaultMessage="Content-Type Builder"
@@ -118,7 +118,7 @@ const tours = {
       name: 'Introduction',
       when: (completedActions) => completedActions.includes('didCreateContentTypeSchema'),
       content: (Step) => (
-        <Step.Root side="top" withArrow={false}>
+        <Step.Root side="top" sideOffset={33} withArrow={false}>
           <Step.Title
             id="tours.contentManager.Introduction.title"
             defaultMessage="Content manager"

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -143,7 +143,7 @@ const EditViewPage = () => {
       {isSingleType && (
         <tours.contentManager.Introduction>
           {/* Invisible Anchor */}
-          <Box paddingTop={5} />
+          <Box />
         </tours.contentManager.Introduction>
       )}
       <Form

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -232,7 +232,7 @@ const ListViewPage = () => {
       <>
         <tours.contentManager.Introduction>
           {/* Invisible Anchor */}
-          <Box paddingTop={5} />
+          <Box />
         </tours.contentManager.Introduction>
         <Page.Main>
           <Page.Title>{`${contentTypeTitle}`}</Page.Title>
@@ -304,7 +304,7 @@ const ListViewPage = () => {
     <>
       <tours.contentManager.Introduction>
         {/* Invisible Anchor */}
-        <Box paddingTop={5} />
+        <Box />
       </tours.contentManager.Introduction>
       <Page.Main>
         <Page.Title>{`${contentTypeTitle}`}</Page.Title>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/EmptyState.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/EmptyState.tsx
@@ -16,7 +16,7 @@ export const EmptyState = () => {
     <>
       <tours.contentTypeBuilder.Introduction>
         {/* Invisible Anchor */}
-        <Box paddingTop={5} />
+        <Box />
       </tours.contentTypeBuilder.Introduction>
       <Flex justifyContent="center" alignItems="center" height="100%" direction="column">
         <Typography variant="alpha">{pluginName}</Typography>

--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -145,7 +145,7 @@ const ListView = () => {
     <>
       <tours.contentTypeBuilder.Introduction>
         {/* Invisible Anchor */}
-        <Box paddingTop={5} />
+        <Box />
       </tours.contentTypeBuilder.Introduction>
       {isDeleted && (
         <Flex background="danger100" justifyContent={'center'} padding={4}>


### PR DESCRIPTION
### What does it do?

- Removes padding on the invisible anchor for guided tour tooltip
- Uses sideOffset instead 

### Why is it needed?

It causes the whole page to shift down

### How to test it?

It should only be impacting CTB and CM list view page
Ensure both of these pages have no added padding coming from GuidedTourTooltip


