### PR TITLE
feat: add getAiToken endpoint

### DIFF
--- a/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
@@ -26,7 +26,7 @@ describe('Authenticated User Controller', () => {
       lastname: 'User',
     };
 
-    const createMockContext = (user = mockUser, overrides = {}) => {
+    const createMockContext = (user = mockUser as any, overrides = {}) => {
       return createContext(
         {},
         {
@@ -48,7 +48,7 @@ describe('Authenticated User Controller', () => {
         dirs: { app: { root: '/app' } },
         config: {
           get: jest.fn((key, defaultValue) => {
-            if (key === 'uuid') return config.projectId || 'test-project-id';
+            if (key === 'uuid') return 'test-project-id';
             return defaultValue;
           }),
         },

--- a/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
@@ -1,0 +1,158 @@
+// @ts-expect-error - types are not generated for this file
+// eslint-disable-next-line import/no-relative-packages
+import createContext from '../../../../../../../tests/helpers/create-context';
+import authenticatedUserController from '../authenticated-user';
+
+describe('Authenticated User Controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset environment variables
+    delete process.env.STRAPI_LICENSE;
+    delete process.env.STRAPI_ADMIN_AI_URL;
+    delete process.env.STRAPI_AI_URL;
+    delete process.env.NODE_ENV;
+
+    // Reset global fetch
+    delete (global as any).fetch;
+  });
+
+  describe('getAiToken', () => {
+    const mockUser = {
+      id: 1,
+      email: 'test@example.com',
+      firstname: 'Test',
+      lastname: 'User',
+    };
+
+    const createMockContext = (user = mockUser, overrides = {}) => {
+      return createContext(
+        {},
+        {
+          state: { user },
+          unauthorized: jest.fn(),
+          badRequest: jest.fn(),
+          forbidden: jest.fn(),
+          notFound: jest.fn(),
+          internalServerError: jest.fn(),
+          requestTimeout: jest.fn(),
+          ...overrides,
+        }
+      );
+    };
+
+    const createMockStrapi = (config = {}) => {
+      return {
+        ee: { isEE: true },
+        dirs: { app: { root: '/app' } },
+        config: {
+          get: jest.fn((key, defaultValue) => {
+            if (key === 'uuid') return config.projectId || 'test-project-id';
+            return defaultValue;
+          }),
+        },
+        log: {
+          info: jest.fn(),
+          error: jest.fn(),
+        },
+        ...config,
+      };
+    };
+
+    // Helper to setup standard valid environment
+    const setupValidEnvironment = () => {
+      process.env.STRAPI_LICENSE = 'test-license';
+      process.env.STRAPI_AI_URL = 'http://ai-server.com';
+    };
+
+    // Helper to create successful AI server response
+    const createSuccessfulFetch = (responseData = {}) => {
+      const defaultResponse = {
+        jwt: 'test-jwt-token',
+        expiresAt: '2025-01-01T12:00:00Z',
+        projectId: 'test-project-id',
+      };
+
+      return jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ ...defaultResponse, ...responseData }),
+      });
+    };
+
+
+    test('Should return unauthorized when user is not authenticated', async () => {
+      const ctx = createMockContext(null);
+      global.strapi = createMockStrapi() as any;
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(ctx.unauthorized).toHaveBeenCalledWith('Authentication required');
+    });
+
+    test('Should return bad request when no EE license is found', async () => {
+      const ctx = createMockContext();
+      global.strapi = createMockStrapi() as any;
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(ctx.badRequest).toHaveBeenCalledWith(
+        'No EE license found. Please ensure STRAPI_LICENSE environment variable is set or license.txt file exists.'
+      );
+    });
+
+    test('Should return bad request when AI server URL is not configured', async () => {
+      const ctx = createMockContext();
+      global.strapi = createMockStrapi() as any;
+      process.env.STRAPI_LICENSE = 'test-license';
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(ctx.badRequest).toHaveBeenCalledWith(
+        'AI server URL not configured. Please set STRAPI_ADMIN_AI_URL or STRAPI_AI_URL environment variable.'
+      );
+    });
+
+    test('Should return bad request when project ID is not configured', async () => {
+      const ctx = createMockContext();
+      global.strapi = createMockStrapi({
+        config: {
+          get: jest.fn((key) => (key === 'uuid' ? null : 'default-value')),
+        },
+      }) as any;
+      setupValidEnvironment();
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(ctx.badRequest).toHaveBeenCalledWith('Project ID not configured');
+    });
+
+    test('Should successfully return AI token when all conditions are met', async () => {
+      const ctx = createMockContext();
+      global.strapi = createMockStrapi() as any;
+      setupValidEnvironment();
+
+      global.fetch = createSuccessfulFetch();
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://ai-server.com/auth/getAiJWT',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: expect.stringContaining('test-license'),
+        })
+      );
+
+      expect(ctx.body).toEqual({
+        data: {
+          token: 'test-jwt-token',
+          expiresAt: '2025-01-01T12:00:00Z',
+          projectId: 'test-project-id',
+        },
+      });
+    });
+  });
+});

--- a/packages/core/admin/server/src/controllers/authenticated-user.ts
+++ b/packages/core/admin/server/src/controllers/authenticated-user.ts
@@ -1,9 +1,12 @@
 import type { Context } from 'koa';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import type { AdminUser } from '../../../shared/contracts/shared';
 
 import { getService } from '../utils';
 import { validateProfileUpdateInput } from '../validation/user';
-import { GetMe, GetOwnPermissions, UpdateMe } from '../../../shared/contracts/users';
+import { GetMe, GetOwnPermissions, UpdateMe, GetAiToken } from '../../../shared/contracts/users';
 
 export default {
   async getMe(ctx: Context) {
@@ -51,5 +54,165 @@ export default {
       // @ts-expect-error - transform response type to sanitized permission
       data: userPermissions.map(sanitizePermission),
     } satisfies GetOwnPermissions.Response;
+  },
+
+  async getAiToken(ctx: Context) {
+    try {
+      // Security check: Ensure user is authenticated and has proper permissions
+      if (!ctx.state.user) {
+        return ctx.unauthorized('Authentication required');
+      }
+
+      // Check if EE features are enabled first
+      if (!strapi.ee?.isEE) {
+        return ctx.badRequest('Enterprise Edition features are not enabled');
+      }
+
+      // Get the EE license
+      // First try environment variable, then try reading from file
+      let eeLicense = process.env.STRAPI_LICENSE;
+
+      if (!eeLicense) {
+        try {
+          const licensePath = path.join(strapi.dirs.app.root, 'license.txt');
+          eeLicense = fs.readFileSync(licensePath).toString();
+        } catch (error) {
+          // License file doesn't exist or can't be read
+        }
+      }
+
+      if (!eeLicense) {
+        return ctx.badRequest(
+          'No EE license found. Please ensure STRAPI_LICENSE environment variable is set or license.txt file exists.'
+        );
+      }
+
+      const aiServerUrl = process.env.STRAPI_ADMIN_AI_URL || process.env.STRAPI_AI_URL;
+
+      if (!aiServerUrl) {
+        return ctx.badRequest(
+          'AI server URL not configured. Please set STRAPI_ADMIN_AI_URL or STRAPI_AI_URL environment variable.'
+        );
+      }
+
+      // Get the current user
+      const user = ctx.state.user as AdminUser;
+
+      // Create a secure user identifier
+      // Using a hash of email + id + internal salt for enhanced privacy
+      const internalSalt = strapi.config.get('uuid', 'default-salt');
+      const userIdentifier = crypto
+        .createHash('sha256')
+        .update(`${user.email}:${user.id}:${internalSalt}`)
+        .digest('hex');
+
+      // Get project ID
+      const projectId = strapi.config.get('uuid');
+      if (!projectId) {
+        return ctx.badRequest('Project ID not configured');
+      }
+
+      strapi.log.info('Making request to AI server:', {
+        url: `${aiServerUrl}/auth/getAiJWT`,
+        projectId,
+        hasEeLicense: !!eeLicense,
+        userEmail: user.email,
+      });
+
+      try {
+        // Call the AI server's getAiJWT endpoint (now on public server)
+        const response = await fetch(`${aiServerUrl}/auth/getAiJWT`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            // No authorization header needed for public endpoint
+            // Add request ID for tracing
+            'X-Request-Id': crypto.randomUUID(),
+          },
+          body: JSON.stringify({
+            eeLicense,
+            userIdentifier,
+            projectId,
+          }),
+        });
+
+        if (!response.ok) {
+          let errorData;
+          let errorText;
+          try {
+            errorText = await response.text();
+            errorData = JSON.parse(errorText);
+          } catch {
+            errorData = { error: errorText || 'Failed to parse error response' };
+          }
+
+          strapi.log.error('AI token request failed:', {
+            status: response.status,
+            statusText: response.statusText,
+            error: errorData,
+            errorText,
+            projectId,
+            aiServerUrl,
+          });
+
+          // Return more specific error messages
+          if (response.status === 401) {
+            // This shouldn't happen with the public endpoint
+            const message =
+              process.env.NODE_ENV === 'development'
+                ? `AI server request failed. Response: ${errorText || 'No response body'}.`
+                : 'AI server request failed.';
+            return ctx.unauthorized(message);
+          }
+          if (response.status === 403) {
+            return ctx.forbidden('License validation failed. Check your EE license.');
+          }
+          if (response.status === 404) {
+            return ctx.notFound(`AI service endpoint not found at ${aiServerUrl}`);
+          }
+
+          // Include more detail in error for debugging
+          return ctx.badRequest(
+            `Failed to obtain AI token. Server responded with: ${response.status} ${errorText || response.statusText}`
+          );
+        }
+
+        const data = (await response.json()) as {
+          jwt: string;
+          expiresAt?: string;
+          projectId?: string;
+        };
+
+        if (!data.jwt) {
+          throw new Error('Invalid response: missing JWT token');
+        }
+
+        strapi.log.info('AI token generated successfully', {
+          userId: user.id,
+          projectId: data.projectId,
+          expiresAt: data.expiresAt,
+        });
+
+        // Return the AI JWT with metadata
+        // Note: Token expires in 1 hour, client should handle refresh
+        ctx.body = {
+          data: {
+            token: data.jwt,
+            expiresAt: data.expiresAt, // 1 hour from generation
+            projectId: data.projectId,
+          },
+        } satisfies GetAiToken.Response;
+      } catch (fetchError) {
+        if (fetchError instanceof Error && fetchError.name === 'AbortError') {
+          strapi.log.error('AI token request timeout');
+          return ctx.requestTimeout('Request to AI server timed out');
+        }
+
+        throw fetchError;
+      }
+    } catch (error) {
+      strapi.log.error('Failed to get AI token:', error);
+      ctx.internalServerError('An unexpected error occurred while obtaining the AI token');
+    }
   },
 };

--- a/packages/core/admin/server/src/controllers/authenticated-user.ts
+++ b/packages/core/admin/server/src/controllers/authenticated-user.ts
@@ -98,13 +98,8 @@ export default {
       // Get the current user
       const user = ctx.state.user as AdminUser;
 
-      // Create a secure user identifier
-      // Using a hash of email + id + internal salt for enhanced privacy
-      const internalSalt = strapi.config.get('uuid', 'default-salt');
-      const userIdentifier = crypto
-        .createHash('sha256')
-        .update(`${user.email}:${user.id}:${internalSalt}`)
-        .digest('hex');
+      // Create a secure user identifier using only user ID
+      const userIdentifier = user.id.toString();
 
       // Get project ID
       const projectId = strapi.config.get('uuid');
@@ -180,7 +175,6 @@ export default {
         const data = (await response.json()) as {
           jwt: string;
           expiresAt?: string;
-          projectId?: string;
         };
 
         if (!data.jwt) {
@@ -189,7 +183,6 @@ export default {
 
         strapi.log.info('AI token generated successfully', {
           userId: user.id,
-          projectId: data.projectId,
           expiresAt: data.expiresAt,
         });
 
@@ -199,7 +192,6 @@ export default {
           data: {
             token: data.jwt,
             expiresAt: data.expiresAt, // 1 hour from generation
-            projectId: data.projectId,
           },
         } satisfies GetAiToken.Response;
       } catch (fetchError) {

--- a/packages/core/admin/server/src/routes/users.ts
+++ b/packages/core/admin/server/src/routes/users.ts
@@ -24,6 +24,14 @@ export default [
     },
   },
   {
+    method: 'GET',
+    path: '/users/me/getAiToken',
+    handler: 'authenticated-user.getAiToken',
+    config: {
+      policies: ['admin::isAuthenticatedAdmin'],
+    },
+  },
+  {
     method: 'POST',
     path: '/users',
     handler: 'user.create',

--- a/packages/core/admin/server/src/routes/users.ts
+++ b/packages/core/admin/server/src/routes/users.ts
@@ -25,7 +25,7 @@ export default [
   },
   {
     method: 'GET',
-    path: '/users/me/getAiToken',
+    path: '/users/me/ai-token',
     handler: 'authenticated-user.getAiToken',
     config: {
       policies: ['admin::isAuthenticatedAdmin'],

--- a/packages/core/admin/shared/contracts/users.ts
+++ b/packages/core/admin/shared/contracts/users.ts
@@ -57,7 +57,6 @@ export declare namespace GetAiToken {
     data: {
       token: string;
       expiresAt?: string;
-      projectId?: string;
     };
     error?: errors.ApplicationError;
   }

--- a/packages/core/admin/shared/contracts/users.ts
+++ b/packages/core/admin/shared/contracts/users.ts
@@ -45,6 +45,25 @@ export declare namespace UpdateMe {
 }
 
 /**
+ * GET /users/me/getAiToken - Get an AI token for the current admin user
+ */
+export declare namespace GetAiToken {
+  export interface Request {
+    query: {};
+    body: {};
+  }
+
+  export interface Response {
+    data: {
+      token: string;
+      expiresAt?: string;
+      projectId?: string;
+    };
+    error?: errors.ApplicationError;
+  }
+}
+
+/**
  * GET /users/me/permissions - Get the permissions of the current admin user
  */
 export declare namespace GetOwnPermissions {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

new endpoint: GET `/users/me/getAiToken`

### Why is it needed?

This endpoint sends user identifier and the EE license to the AI server,  get the AI JWT and return it to the user

### How to test it?

 ## Configuration Required

  ```- STRAPI_LICENSE=your-EE-license-key ```
 ```- STRAPI_ADMIN_AI_URL=http://localhost:3001```
## How to test
  1. Login to Strapi admin and get admin JWT token
  2. launch [Strapi AI server](https://github.com/strapi/strapi-ai)
  3.  run  
  ```
curl -X GET http://localhost:1337/admin/users/me/ai-token" \
-H "Authorization: Bearer YOUR_JWT_TOKEN
```
  5.   Expected API Response:
  ```{
    "data": {
      "token": "eyJhbGciOiJIUzI1NiIs...",
      "expiresAt": "2025-01-01T12:00:00Z",
      "projectId": "uuid"
    }
  }
```

### Related issue(s)/PR(s)

DX-2129
