### PR TITLE
future: sync preview to side editor forms

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 
 import {
   Page,
-  Blocker,
   Form,
-  useForm,
   useRBAC,
   useNotification,
   useQueryParams,
@@ -25,6 +23,7 @@ import { useOnce } from '../../hooks/useOnce';
 import { getTranslation } from '../../utils/translations';
 import { createYupSchema } from '../../utils/validation';
 
+import { Blocker } from './components/Blocker';
 import { FormLayout } from './components/FormLayout';
 import { Header } from './components/Header';
 import { Panels } from './components/Panels';
@@ -33,15 +32,6 @@ import { handleInvisibleAttributes } from './utils/data';
 /* -------------------------------------------------------------------------------------------------
  * EditViewPage
  * -----------------------------------------------------------------------------------------------*/
-
-// Needs to be wrapped in a component to have access to the form context via a hook.
-// Using the Form component's render prop instead would cause unnecessary re-renders of Form children
-const BlockerWrapper = () => {
-  const resetForm = useForm('BlockerWrapper', (state) => state.resetForm);
-
-  // We reset the form to the published version to avoid errors like – https://strapi-inc.atlassian.net/browse/CONTENT-2284
-  return <Blocker onProceed={resetForm} />;
-};
 
 const EditViewPage = () => {
   const location = useLocation();
@@ -219,7 +209,7 @@ const EditViewPage = () => {
               </Grid.Item>
             </Grid.Root>
           </Tabs.Root>
-          <BlockerWrapper />
+          <Blocker />
         </>
       </Form>
     </Main>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/Blocker.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Blocker.tsx
@@ -1,0 +1,15 @@
+// Needs to be wrapped in a component to have access to the form context via a hook.
+
+import { Blocker as BaseBlocker, useForm } from '@strapi/admin/strapi-admin';
+
+/**
+ * Prevents users from leaving the page with unsaved form changes
+ */
+const Blocker = () => {
+  const resetForm = useForm('Blocker', (state) => state.resetForm);
+
+  // We reset the form to the published version to avoid errors like – https://strapi-inc.atlassian.net/browse/CONTENT-2284
+  return <BaseBlocker onProceed={resetForm} />;
+};
+
+export { Blocker };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -14,6 +14,7 @@ import { type UseDocument } from '../../../hooks/useDocument';
 import { useDocumentContext } from '../../../hooks/useDocumentContext';
 import { useDocumentLayout } from '../../../hooks/useDocumentLayout';
 import { useLazyComponents } from '../../../hooks/useLazyComponents';
+import { usePreviewInputManager } from '../../../preview/hooks/usePreviewInputManager';
 
 import { BlocksInput } from './FormInputs/BlocksInput/BlocksInput';
 import { ComponentInput } from './FormInputs/Component/Input';
@@ -39,7 +40,12 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
  * the complete EditFieldLayout and will handle RBAC conditions and rendering CM specific
  * components such as Blocks / Relations.
  */
-const InputRenderer = ({ visible, hint: providedHint, document, ...props }: InputRendererProps) => {
+const InputRenderer = ({
+  visible,
+  hint: providedHint,
+  document,
+  ...inputProps
+}: InputRendererProps) => {
   const { currentDocumentMeta } = useDocumentContext('DynamicComponent');
   const {
     edit: { components },
@@ -63,6 +69,10 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
 
   const editableFields = idToCheck ? canUpdateFields : canCreateFields;
   const readableFields = idToCheck ? canReadFields : canCreateFields;
+
+  // Everything preview related
+  const previewProps = usePreviewInputManager(inputProps.name);
+  const props = { ...inputProps, ...previewProps };
 
   /**
    * Component fields are always readable and editable,
@@ -103,13 +113,23 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
     const CustomInput = lazyComponentStore[props.attribute.customField];
 
     if (CustomInput) {
-      // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
-      return <CustomInput {...props} {...field} hint={hint} disabled={fieldIsDisabled} />;
+      return (
+        <>
+          <CustomInput
+            {...props}
+            {...field}
+            // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
+            hint={hint}
+            disabled={fieldIsDisabled}
+          />
+        </>
+      );
     }
 
     return (
       <FormInputRenderer
         {...props}
+        {...previewProps}
         hint={hint}
         // @ts-expect-error – this workaround lets us display that the custom field is missing.
         type={props.attribute.customField}
@@ -124,8 +144,16 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
   const addedInputTypes = Object.keys(fields);
   if (!attributeHasCustomFieldProperty(props.attribute) && addedInputTypes.includes(props.type)) {
     const CustomInput = fields[props.type];
-    // @ts-expect-error – TODO: fix this type error in the useLibrary hook.
-    return <CustomInput {...props} hint={hint} disabled={fieldIsDisabled} />;
+    return (
+      <>
+        <CustomInput
+          {...props}
+          // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
+          hint={hint}
+          disabled={fieldIsDisabled}
+        />
+      </>
+    );
   }
 
   /**
@@ -143,7 +171,7 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
           layout={components[props.attribute.component].layout}
           disabled={fieldIsDisabled}
         >
-          {(inputProps) => <InputRenderer {...inputProps} />}
+          {(componentInputProps) => <InputRenderer {...componentInputProps} />}
         </ComponentInput>
       );
     case 'dynamiczone':
@@ -161,6 +189,7 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
       return (
         <FormInputRenderer
           {...props}
+          {...previewProps}
           hint={hint}
           options={props.attribute.enum.map((value) => ({ value }))}
           // @ts-expect-error – Temp workaround so we don't forget custom-fields don't work!
@@ -174,6 +203,7 @@ const InputRenderer = ({ visible, hint: providedHint, document, ...props }: Inpu
       return (
         <FormInputRenderer
           {...restProps}
+          {...previewProps}
           hint={hint}
           // @ts-expect-error – Temp workaround so we don't forget custom-fields don't work!
           type={props.customField ? 'custom-field' : props.type}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -114,15 +114,13 @@ const InputRenderer = ({
 
     if (CustomInput) {
       return (
-        <>
-          <CustomInput
-            {...props}
-            {...field}
-            // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
-            hint={hint}
-            disabled={fieldIsDisabled}
-          />
-        </>
+        <CustomInput
+          {...props}
+          {...field}
+          // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
+          hint={hint}
+          disabled={fieldIsDisabled}
+        />
       );
     }
 
@@ -145,14 +143,12 @@ const InputRenderer = ({
   if (!attributeHasCustomFieldProperty(props.attribute) && addedInputTypes.includes(props.type)) {
     const CustomInput = fields[props.type];
     return (
-      <>
-        <CustomInput
-          {...props}
-          // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
-          hint={hint}
-          disabled={fieldIsDisabled}
-        />
-      </>
+      <CustomInput
+        {...props}
+        // @ts-expect-error – TODO: fix this type error in the useLazyComponents hook.
+        hint={hint}
+        disabled={fieldIsDisabled}
+      />
     );
   }
 

--- a/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+import { createContext } from '@strapi/admin/strapi-admin';
+import { Box, Popover } from '@strapi/design-system';
+
+import { type UseDocument } from '../../hooks/useDocument';
+import { InputRenderer } from '../../pages/EditView/components/InputRenderer';
+import { usePreviewContext } from '../pages/Preview';
+
+/**
+ * No need for actual data in the context. It's just to let children check if they're rendered
+ * inside of a preview InputPopover without relying on prop drilling.
+ */
+interface InputPopoverContextValue {}
+
+const [InputPopoverProvider, useInputPopoverContext] =
+  createContext<InputPopoverContextValue>('InputPopover');
+
+const InputPopover = ({ documentResponse }: { documentResponse: ReturnType<UseDocument> }) => {
+  const iframeRef = usePreviewContext('VisualEditingPopover', (state) => state.iframeRef);
+  const popoverField = usePreviewContext('VisualEditingPopover', (state) => state.popoverField);
+  const setPopoverField = usePreviewContext(
+    'VisualEditingPopover',
+    (state) => state.setPopoverField
+  );
+
+  if (!popoverField || !documentResponse.schema || !iframeRef.current) {
+    return null;
+  }
+
+  const iframeRect = iframeRef.current.getBoundingClientRect();
+
+  return (
+    <>
+      {popoverField && (
+        <Box
+          position={'fixed'}
+          top={iframeRect.top + 'px'}
+          left={iframeRect.left + 'px'}
+          width={iframeRect.width + 'px'}
+          height={iframeRect.height + 'px'}
+          zIndex={4}
+        />
+      )}
+      <InputPopoverProvider>
+        <Popover.Root
+          open={popoverField != null}
+          onOpenChange={(open) => !open && setPopoverField(null)}
+        >
+          <Popover.Trigger>
+            <Box
+              id="popover-trigger"
+              position="fixed"
+              width={popoverField.position.width + 'px'}
+              height={popoverField.position.height + 'px'}
+              top={iframeRect.top + popoverField.position.top + 'px'}
+              left={iframeRect.left + popoverField.position.left + 'px'}
+            />
+          </Popover.Trigger>
+          <Popover.Content sideOffset={4}>
+            <Box padding={4} width="400px">
+              <InputRenderer
+                document={documentResponse}
+                attribute={documentResponse.schema.attributes[popoverField.path] as any}
+                label={popoverField.path}
+                name={popoverField.path}
+                type={documentResponse.schema.attributes[popoverField.path].type}
+                visible={true}
+              />
+            </Box>
+          </Popover.Content>
+        </Popover.Root>
+      </InputPopoverProvider>
+    </>
+  );
+};
+
+function useHasInputPopoverParent() {
+  const context = useInputPopoverContext('useHasInputPopoverParent', () => true, false);
+
+  // useContext will return undefined if the called is not wrapped in the provider
+  return context !== undefined;
+}
+
+export { InputPopover, useHasInputPopoverParent };

--- a/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
@@ -32,29 +32,29 @@ const InputPopover = ({ documentResponse }: { documentResponse: ReturnType<UseDo
 
   return (
     <>
-      {popoverField && (
-        <Box
-          position={'fixed'}
-          top={iframeRect.top + 'px'}
-          left={iframeRect.left + 'px'}
-          width={iframeRect.width + 'px'}
-          height={iframeRect.height + 'px'}
-          zIndex={4}
-        />
-      )}
+      {/**
+       * Overlay an empty div on top of the iframe while the popover is open so it can
+       * intercept clicks. Without it, we wouldn't be able to close the popover by clicking outside,
+       * because the click would be detected by the iframe window, not by the admin.
+       **/}
+      <Box
+        position={'fixed'}
+        top={iframeRect.top + 'px'}
+        left={iframeRect.left + 'px'}
+        width={iframeRect.width + 'px'}
+        height={iframeRect.height + 'px'}
+        zIndex={4}
+      />
       <InputPopoverProvider>
-        <Popover.Root
-          open={popoverField != null}
-          onOpenChange={(open) => !open && setPopoverField(null)}
-        >
+        <Popover.Root open={true} onOpenChange={(open) => !open && setPopoverField(null)}>
           <Popover.Trigger>
             <Box
-              id="popover-trigger"
               position="fixed"
               width={popoverField.position.width + 'px'}
               height={popoverField.position.height + 'px'}
-              top={iframeRect.top + popoverField.position.top + 'px'}
-              left={iframeRect.left + popoverField.position.left + 'px'}
+              top={0}
+              left={0}
+              transform={`translate(${iframeRect.left + popoverField.position.left}px, ${iframeRect.top + popoverField.position.top}px)`}
             />
           </Popover.Trigger>
           <Popover.Content sideOffset={4}>

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import { useField } from '@strapi/admin/strapi-admin';
+
+import { usePreviewContext } from '../pages/Preview';
+import { INTERNAL_EVENTS } from '../utils/constants';
+import { getSendMessage } from '../utils/getSendMessage';
+
+type PreviewInputProps = Pick<
+  Required<React.InputHTMLAttributes<HTMLInputElement>>,
+  'onFocus' | 'onBlur'
+>;
+
+export function usePreviewInputManager(name: string): PreviewInputProps {
+  const iframe = usePreviewContext('usePreviewInputManager', (state) => state.iframeRef, false);
+  const setPopoverField = usePreviewContext(
+    'usePreviewInputManager',
+    (state) => state.setPopoverField,
+    false
+  );
+  const isSideEditorOpen = usePreviewContext(
+    'usePreviewInputManager',
+    (state) => state.isSideEditorOpen,
+    false
+  );
+  const { value } = useField(name);
+
+  const isUsingPreview = Boolean(iframe?.current);
+
+  React.useEffect(() => {
+    if (!isUsingPreview || !iframe) {
+      return;
+    }
+
+    const sendMessage = getSendMessage(iframe);
+    sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_TYPING, { field: name, value });
+  }, [name, value, isUsingPreview, iframe]);
+
+  React.useEffect(() => {
+    if (!isUsingPreview) {
+      return;
+    }
+
+    const handleMessage = ({ data }: MessageEvent) => {
+      if (data?.type === INTERNAL_EVENTS.WILL_EDIT_FIELD && data.payload?.path === name) {
+        setPopoverField?.(data.payload);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    return () => window.removeEventListener('message', handleMessage);
+  }, [name, setPopoverField, isUsingPreview]);
+
+  const sendMessage = getSendMessage(iframe);
+
+  return {
+    onFocus: () => {
+      // If side editor is open, input renderers are inside popovers in the right location,
+      // so no need for focus highlights as it's clear where the field is used.
+      if (!isSideEditorOpen) return;
+
+      sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_FOCUS, { field: name });
+    },
+    onBlur: () => {
+      // If side editor is open, input renderers are inside popovers in the right location,
+      // so no need for focus highlights as it's clear where the field is used.
+      if (!isSideEditorOpen) return;
+
+      setPopoverField?.(null);
+      sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_BLUR, { field: name });
+    },
+  };
+}

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -22,32 +22,14 @@ export function usePreviewInputManager(name: string): PreviewInputProps {
   const hasInputPopoverParent = useHasInputPopoverParent();
   const { value } = useField(name);
 
-  const isUsingPreview = Boolean(iframe?.current);
-
   React.useEffect(() => {
-    if (!isUsingPreview || !iframe) {
+    if (!iframe) {
       return;
     }
 
     const sendMessage = getSendMessage(iframe);
     sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_TYPING, { field: name, value });
-  }, [name, value, isUsingPreview, iframe]);
-
-  React.useEffect(() => {
-    if (!isUsingPreview) {
-      return;
-    }
-
-    const handleMessage = ({ data }: MessageEvent) => {
-      if (data?.type === INTERNAL_EVENTS.WILL_EDIT_FIELD && data.payload?.path === name) {
-        setPopoverField?.(data.payload);
-      }
-    };
-
-    window.addEventListener('message', handleMessage);
-
-    return () => window.removeEventListener('message', handleMessage);
-  }, [name, setPopoverField, isUsingPreview]);
+  }, [name, value, iframe]);
 
   const sendMessage = getSendMessage(iframe);
 

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { useField } from '@strapi/admin/strapi-admin';
 
+import { useHasInputPopoverParent } from '../components/InputPopover';
 import { usePreviewContext } from '../pages/Preview';
 import { INTERNAL_EVENTS } from '../utils/constants';
 import { getSendMessage } from '../utils/getSendMessage';
@@ -18,11 +19,7 @@ export function usePreviewInputManager(name: string): PreviewInputProps {
     (state) => state.setPopoverField,
     false
   );
-  const isSideEditorOpen = usePreviewContext(
-    'usePreviewInputManager',
-    (state) => state.isSideEditorOpen,
-    false
-  );
+  const hasInputPopoverParent = useHasInputPopoverParent();
   const { value } = useField(name);
 
   const isUsingPreview = Boolean(iframe?.current);
@@ -56,16 +53,12 @@ export function usePreviewInputManager(name: string): PreviewInputProps {
 
   return {
     onFocus: () => {
-      // If side editor is open, input renderers are inside popovers in the right location,
-      // so no need for focus highlights as it's clear where the field is used.
-      if (!isSideEditorOpen) return;
+      if (hasInputPopoverParent) return;
 
       sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_FOCUS, { field: name });
     },
     onBlur: () => {
-      // If side editor is open, input renderers are inside popovers in the right location,
-      // so no need for focus highlights as it's clear where the field is used.
-      if (!isSideEditorOpen) return;
+      if (hasInputPopoverParent) return;
 
       setPopoverField?.(null);
       sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_BLUR, { field: name });

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -28,7 +28,7 @@ export function usePreviewInputManager(name: string): PreviewInputProps {
     }
 
     const sendMessage = getSendMessage(iframe);
-    sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_TYPING, { field: name, value });
+    sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_CHANGE, { field: name, value });
   }, [name, value, iframe]);
 
   const sendMessage = getSendMessage(iframe);

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -146,7 +146,7 @@ const PreviewPage = () => {
         sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
       }
 
-      if (event.data?.type === INTERNAL_EVENTS.WILL_EDIT_FIELD) {
+      if (event.data?.type === INTERNAL_EVENTS.STRAPI_FIELD_FOCUS_INTENT) {
         setPopoverField?.(event.data.payload);
       }
     };

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -34,7 +34,7 @@ import { createYupSchema } from '../../utils/validation';
 import { InputPopover } from '../components/InputPopover';
 import { PreviewHeader } from '../components/PreviewHeader';
 import { useGetPreviewUrlQuery } from '../services/preview';
-import { PUBLIC_EVENTS } from '../utils/constants';
+import { PUBLIC_EVENTS, INTERNAL_EVENTS } from '../utils/constants';
 import { getSendMessage } from '../utils/getSendMessage';
 import { previewScript } from '../utils/previewScript';
 
@@ -144,6 +144,10 @@ const PreviewPage = () => {
         const script = `(${previewScript.toString()})()`;
         const sendMessage = getSendMessage(iframeRef);
         sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
+      }
+
+      if (event.data?.type === INTERNAL_EVENTS.WILL_EDIT_FIELD) {
+        setPopoverField?.(event.data.payload);
       }
     };
 

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -6,7 +6,6 @@ import {
   useRBAC,
   createContext,
   Form as FormContext,
-  Blocker,
 } from '@strapi/admin/strapi-admin';
 import {
   Box,
@@ -27,6 +26,7 @@ import { COLLECTION_TYPES } from '../../constants/collections';
 import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { type UseDocument, useDocument } from '../../hooks/useDocument';
 import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
+import { Blocker } from '../../pages/EditView/components/Blocker';
 import { FormLayout } from '../../pages/EditView/components/FormLayout';
 import { handleInvisibleAttributes } from '../../pages/EditView/utils/data';
 import { buildValidParams } from '../../utils/api';
@@ -297,109 +297,107 @@ const PreviewPage = () => {
             return yupSchema.validate(cleanedValues, { abortEarly: false });
           }}
         >
-          {({ resetForm }) => (
-            <Flex direction="column" height="100%" alignItems="stretch">
-              <Blocker onProceed={resetForm} />
-              <PreviewHeader />
-              <InputPopover documentResponse={documentResponse} />
-              <Flex flex={1} overflow="auto" alignItems="stretch">
-                {hasAdvancedPreview && (
-                  <Box
-                    overflow="auto"
-                    width={isSideEditorOpen ? '50%' : 0}
-                    borderWidth="0 1px 0 0"
-                    borderColor="neutral150"
-                    paddingTop={6}
-                    paddingBottom={6}
-                    // Remove horizontal padding when the editor is closed or it won't fully disappear
-                    paddingLeft={isSideEditorOpen ? 6 : 0}
-                    paddingRight={isSideEditorOpen ? 6 : 0}
-                    transition="all 0.2s ease-in-out"
-                  >
-                    <FormLayout
-                      layout={documentLayoutResponse.edit.layout}
-                      document={documentResponse}
-                      hasBackground={false}
-                    />
-                  </Box>
-                )}
-                <Flex
-                  direction="column"
-                  alignItems="stretch"
-                  flex={1}
-                  height="100%"
-                  overflow="hidden"
+          <Flex direction="column" height="100%" alignItems="stretch">
+            <Blocker />
+            <PreviewHeader />
+            <InputPopover documentResponse={documentResponse} />
+            <Flex flex={1} overflow="auto" alignItems="stretch">
+              {hasAdvancedPreview && (
+                <Box
+                  overflow="auto"
+                  width={isSideEditorOpen ? '50%' : 0}
+                  borderWidth="0 1px 0 0"
+                  borderColor="neutral150"
+                  paddingTop={6}
+                  paddingBottom={6}
+                  // Remove horizontal padding when the editor is closed or it won't fully disappear
+                  paddingLeft={isSideEditorOpen ? 6 : 0}
+                  paddingRight={isSideEditorOpen ? 6 : 0}
+                  transition="all 0.2s ease-in-out"
                 >
-                  <Flex
-                    direction="row"
-                    background="neutral0"
-                    padding={2}
-                    borderWidth="0 0 1px 0"
-                    borderColor="neutral150"
-                  >
-                    {hasAdvancedPreview && (
-                      <IconButton
-                        variant="ghost"
-                        label={formatMessage(
-                          isSideEditorOpen
-                            ? {
-                                id: 'content-manager.preview.content.close-editor',
-                                defaultMessage: 'Close editor',
-                              }
-                            : {
-                                id: 'content-manager.preview.content.open-editor',
-                                defaultMessage: 'Open editor',
-                              }
-                        )}
-                        onClick={() => setIsSideEditorOpen((prev) => !prev)}
-                      >
-                        <AnimatedArrow $isSideEditorOpen={isSideEditorOpen} />
-                      </IconButton>
-                    )}
-                    <Flex justifyContent="center" flex={1}>
-                      <SingleSelect
-                        value={deviceName}
-                        onChange={(name) => setDeviceName(name.toString())}
-                        aria-label={formatMessage({
-                          id: 'content-manager.preview.device.select',
-                          defaultMessage: 'Select device type',
-                        })}
-                      >
-                        {DEVICES.map((deviceOption) => (
-                          <SingleSelectOption key={deviceOption.name} value={deviceOption.name}>
-                            {formatMessage(deviceOption.label)}
-                          </SingleSelectOption>
-                        ))}
-                      </SingleSelect>
-                    </Flex>
-                  </Flex>
-                  <Flex direction="column" justifyContent="center" background="neutral0" flex={1}>
-                    <Box
-                      data-testid="preview-iframe"
-                      ref={iframeRef}
-                      src={previewUrl}
-                      /**
-                       * For some reason, changing an iframe's src tag causes the browser to add a new item in the
-                       * history stack. This is an issue for us as it means clicking the back button will not let us
-                       * go back to the edit view. To fix it, we need to trick the browser into thinking this is a
-                       * different iframe when the preview URL changes. So we set a key prop to force React
-                       * to mount a different node when the src changes.
-                       */
-                      key={previewUrl}
-                      title={formatMessage({
-                        id: 'content-manager.preview.panel.title',
-                        defaultMessage: 'Preview',
+                  <FormLayout
+                    layout={documentLayoutResponse.edit.layout}
+                    document={documentResponse}
+                    hasBackground={false}
+                  />
+                </Box>
+              )}
+              <Flex
+                direction="column"
+                alignItems="stretch"
+                flex={1}
+                height="100%"
+                overflow="hidden"
+              >
+                <Flex
+                  direction="row"
+                  background="neutral0"
+                  padding={2}
+                  borderWidth="0 0 1px 0"
+                  borderColor="neutral150"
+                >
+                  {hasAdvancedPreview && (
+                    <IconButton
+                      variant="ghost"
+                      label={formatMessage(
+                        isSideEditorOpen
+                          ? {
+                              id: 'content-manager.preview.content.close-editor',
+                              defaultMessage: 'Close editor',
+                            }
+                          : {
+                              id: 'content-manager.preview.content.open-editor',
+                              defaultMessage: 'Open editor',
+                            }
+                      )}
+                      onClick={() => setIsSideEditorOpen((prev) => !prev)}
+                    >
+                      <AnimatedArrow $isSideEditorOpen={isSideEditorOpen} />
+                    </IconButton>
+                  )}
+                  <Flex justifyContent="center" flex={1}>
+                    <SingleSelect
+                      value={deviceName}
+                      onChange={(name) => setDeviceName(name.toString())}
+                      aria-label={formatMessage({
+                        id: 'content-manager.preview.device.select',
+                        defaultMessage: 'Select device type',
                       })}
-                      width={device.width}
-                      height={device.height}
-                      borderWidth={0}
-                      tag="iframe"
-                    />
+                    >
+                      {DEVICES.map((deviceOption) => (
+                        <SingleSelectOption key={deviceOption.name} value={deviceOption.name}>
+                          {formatMessage(deviceOption.label)}
+                        </SingleSelectOption>
+                      ))}
+                    </SingleSelect>
                   </Flex>
+                </Flex>
+                <Flex direction="column" justifyContent="center" background="neutral0" flex={1}>
+                  <Box
+                    data-testid="preview-iframe"
+                    ref={iframeRef}
+                    src={previewUrl}
+                    /**
+                     * For some reason, changing an iframe's src tag causes the browser to add a new item in the
+                     * history stack. This is an issue for us as it means clicking the back button will not let us
+                     * go back to the edit view. To fix it, we need to trick the browser into thinking this is a
+                     * different iframe when the preview URL changes. So we set a key prop to force React
+                     * to mount a different node when the src changes.
+                     */
+                    key={previewUrl}
+                    title={formatMessage({
+                      id: 'content-manager.preview.panel.title',
+                      defaultMessage: 'Preview',
+                    })}
+                    width={device.width}
+                    height={device.height}
+                    borderWidth={0}
+                    tag="iframe"
+                  />
                 </Flex>
               </Flex>
             </Flex>
-          )}
+          </Flex>
         </FormContext>
       </PreviewProvider>
     </>

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -13,7 +13,6 @@ import {
   Flex,
   FocusTrap,
   IconButton,
-  Popover,
   Portal,
   SingleSelect,
   SingleSelectOption,
@@ -29,13 +28,13 @@ import { DocumentRBAC } from '../../features/DocumentRBAC';
 import { type UseDocument, useDocument } from '../../hooks/useDocument';
 import { type EditLayout, useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { FormLayout } from '../../pages/EditView/components/FormLayout';
-import { InputRenderer } from '../../pages/EditView/components/InputRenderer';
 import { handleInvisibleAttributes } from '../../pages/EditView/utils/data';
 import { buildValidParams } from '../../utils/api';
 import { createYupSchema } from '../../utils/validation';
+import { InputPopover } from '../components/InputPopover';
 import { PreviewHeader } from '../components/PreviewHeader';
 import { useGetPreviewUrlQuery } from '../services/preview';
-import { INTERNAL_EVENTS, PUBLIC_EVENTS } from '../utils/constants';
+import { PUBLIC_EVENTS } from '../utils/constants';
 import { getSendMessage } from '../utils/getSendMessage';
 import { previewScript } from '../utils/previewScript';
 
@@ -83,78 +82,12 @@ interface PreviewContextValue {
   schema: NonNullable<ReturnType<UseDocument>['schema']>;
   layout: EditLayout;
   onPreview: () => void;
-  isSideEditorOpen: boolean;
   iframeRef: React.RefObject<HTMLIFrameElement>;
   popoverField: PopoverField | null;
   setPopoverField: (value: PopoverField | null) => void;
 }
 
 const [PreviewProvider, usePreviewContext] = createContext<PreviewContextValue>('PreviewPage');
-
-/* -------------------------------------------------------------------------------------------------
- * VisualEditingPopover
- * -----------------------------------------------------------------------------------------------*/
-
-const VisualEditingPopover = ({
-  documentResponse,
-}: {
-  documentResponse: ReturnType<UseDocument>;
-}) => {
-  const iframeRef = usePreviewContext('VisualEditingPopover', (state) => state.iframeRef);
-  const popoverField = usePreviewContext('VisualEditingPopover', (state) => state.popoverField);
-  const setPopoverField = usePreviewContext(
-    'VisualEditingPopover',
-    (state) => state.setPopoverField
-  );
-
-  if (!popoverField || !documentResponse.schema || !iframeRef.current) {
-    return null;
-  }
-
-  const iframeRect = iframeRef.current.getBoundingClientRect();
-
-  return (
-    <>
-      {popoverField && (
-        <Box
-          position={'fixed'}
-          top={iframeRect.top + 'px'}
-          left={iframeRect.left + 'px'}
-          width={iframeRect.width + 'px'}
-          height={iframeRect.height + 'px'}
-          zIndex={4}
-        />
-      )}
-      <Popover.Root
-        open={popoverField != null}
-        onOpenChange={(open) => !open && setPopoverField(null)}
-      >
-        <Popover.Trigger>
-          <Box
-            id="popover-trigger"
-            position="fixed"
-            width={popoverField.position.width + 'px'}
-            height={popoverField.position.height + 'px'}
-            top={iframeRect.top + popoverField.position.top + 'px'}
-            left={iframeRect.left + popoverField.position.left + 'px'}
-          />
-        </Popover.Trigger>
-        <Popover.Content sideOffset={4}>
-          <Box padding={4} width="400px">
-            <InputRenderer
-              document={documentResponse}
-              attribute={documentResponse.schema.attributes[popoverField.path] as any}
-              label={popoverField.path}
-              name={popoverField.path}
-              type={documentResponse.schema.attributes[popoverField.path].type}
-              visible={true}
-            />
-          </Box>
-        </Popover.Content>
-      </Popover.Root>
-    </>
-  );
-};
 
 /* -------------------------------------------------------------------------------------------------
  * PreviewPage
@@ -330,7 +263,6 @@ const PreviewPage = () => {
         schema={documentResponse.schema}
         layout={documentLayoutResponse.edit}
         onPreview={onPreview}
-        isSideEditorOpen={isSideEditorOpen}
         iframeRef={iframeRef}
         popoverField={popoverField}
         setPopoverField={setPopoverField}
@@ -369,7 +301,7 @@ const PreviewPage = () => {
             <Flex direction="column" height="100%" alignItems="stretch">
               <Blocker onProceed={resetForm} />
               <PreviewHeader />
-              <VisualEditingPopover documentResponse={documentResponse} />
+              <InputPopover documentResponse={documentResponse} />
               <Flex flex={1} overflow="auto" alignItems="stretch">
                 {hasAdvancedPreview && (
                   <Box

--- a/packages/core/content-manager/admin/src/preview/utils/getSendMessage.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/getSendMessage.ts
@@ -1,0 +1,27 @@
+import type { INTERNAL_EVENTS, PUBLIC_EVENTS } from './constants';
+
+type MessageType =
+  | (typeof INTERNAL_EVENTS)[keyof typeof INTERNAL_EVENTS]
+  | (typeof PUBLIC_EVENTS)[keyof typeof PUBLIC_EVENTS];
+
+/**
+ * A function factory so we can generate a new sendMessage everytime we need one.
+ * We can't store and reuse a single sendMessage because it needs to have a stable identity
+ * as it used in a useEffect function. And we can't rely on useCallback because we need the
+ * up-to-date iframe ref, and this would make it stale (refs don't trigger callback reevaluations).
+ */
+export function getSendMessage(iframe: React.RefObject<HTMLIFrameElement> | undefined) {
+  return (type: MessageType, payload?: unknown) => {
+    if (!iframe?.current) return;
+
+    const { origin } = new URL(iframe.current.src);
+
+    iframe.current.contentWindow?.postMessage(
+      {
+        type,
+        ...(payload !== undefined && { payload }),
+      },
+      origin
+    );
+  };
+}

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -26,8 +26,8 @@ const previewScript = (shouldRun = true) => {
   const INTERNAL_EVENTS = {
     STRAPI_FIELD_FOCUS: 'strapiFieldFocus',
     STRAPI_FIELD_BLUR: 'strapiFieldBlur',
-    STRAPI_FIELD_TYPING: 'strapiFieldTyping',
-    WILL_EDIT_FIELD: 'willEditField',
+    STRAPI_FIELD_CHANGE: 'strapiFieldChange',
+    STRAPI_FIELD_FOCUS_INTENT: 'strapiFieldFocusIntent',
   } as const;
 
   /**
@@ -130,7 +130,7 @@ const previewScript = (shouldRun = true) => {
           const sourceAttribute = element.getAttribute(SOURCE_ATTRIBUTE);
           if (sourceAttribute) {
             const rect = element.getBoundingClientRect();
-            sendMessage(INTERNAL_EVENTS.WILL_EDIT_FIELD, {
+            sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_FOCUS_INTENT, {
               path: sourceAttribute,
               position: {
                 top: rect.top,
@@ -224,7 +224,7 @@ const previewScript = (shouldRun = true) => {
         window.addEventListener('scroll', updateOnScroll);
         window.addEventListener('resize', updateOnScroll);
       } else {
-        (element as Element).addEventListener('scroll', updateOnScroll);
+        element.addEventListener('scroll', updateOnScroll);
       }
     });
 
@@ -237,7 +237,7 @@ const previewScript = (shouldRun = true) => {
 
   const setupEventHandlers = (highlightManager: HighlightManager) => {
     const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === INTERNAL_EVENTS.STRAPI_FIELD_TYPING) {
+      if (event.data?.type === INTERNAL_EVENTS.STRAPI_FIELD_CHANGE) {
         const { field, value } = event.data.payload;
         if (field) {
           const matchingElements = document.querySelectorAll(`[${SOURCE_ATTRIBUTE}="${field}"]`);
@@ -284,7 +284,7 @@ const previewScript = (shouldRun = true) => {
 
     // Add the message handler to the cleanup list
     const messageEventListener = {
-      element: window as any,
+      element: window,
       type: 'message' as keyof HTMLElementEventMap,
       handler: handleMessage as EventListener,
     };


### PR DESCRIPTION
### What does it do?

Adds all the interactions we want to enable live/visual editing on Preview:
- highlighting elements matching the focused input in the preview
- double clicking on a highlight triggers a popover with the input for that field
- editing a field (both in side editor and in popover) reflects the changes in real time in the preview

⚠️ not handling nested fields yet, I'll look at that as part of the stega/encoding task
⚠️ not handling yet inputs that require more space than the popover offers, e.g. markdown
ℹ️ an e2e test suite and some contributor docs will come in separate PRs

### How to test it?

Open any preview page in getstarted, click around, edit stuff
