### PR TITLE
fix: remove circular structure in content-api route

### DIFF
--- a/packages/core/core/src/services/content-api/index.ts
+++ b/packages/core/core/src/services/content-api/index.ts
@@ -45,17 +45,15 @@ const createContentAPI = (strapi: Core.Strapi) => {
         .filter(filterContentAPI);
 
       if (routes.length === 0) {
-        return;
+        const apiPrefix = strapi.config.get('api.rest.prefix');
+        routesMap[`api::${apiName}`] = routes.map((route) =>
+          // Apply clean for all routes
+          cleanRouteForSerialization({
+            ...route,
+            path: `${apiPrefix}${route.path}`,
+          })
+        );
       }
-
-      const apiPrefix = strapi.config.get('api.rest.prefix');
-      routesMap[`api::${apiName}`] = routes.map((route) =>
-        // Apply clean for all routes
-        cleanRouteForSerialization({
-          ...route,
-          path: `${apiPrefix}${route.path}`,
-        })
-      );
     });
 
     Object.entries(strapi.plugins).forEach(([pluginName, plugin]) => {
@@ -70,18 +68,16 @@ const createContentAPI = (strapi: Core.Strapi) => {
           .filter(filterContentAPI);
       }
 
-      if (routes.length === 0) {
-        return;
+      if (routes.length > 0) {
+        const apiPrefix = strapi.config.get('api.rest.prefix');
+        routesMap[`plugin::${pluginName}`] = routes.map((route) =>
+          // Apply clean for all routes
+          cleanRouteForSerialization({
+            ...route,
+            path: `${apiPrefix}${route.path}`,
+          })
+        );
       }
-
-      const apiPrefix = strapi.config.get('api.rest.prefix');
-      routesMap[`plugin::${pluginName}`] = routes.map((route) =>
-        // Apply clean for all routes
-        cleanRouteForSerialization({
-          ...route,
-          path: `${apiPrefix}${route.path}`,
-        })
-      );
     });
 
     return routesMap;


### PR DESCRIPTION
### What does it do?

When going to API tokens page in settings, we have a 500 error when calling the endpoint /content-api/routes because of a circular structure in the routes objects.
We need to get rid of the `request` and `response` attributes in the data sent to avoid this circular structure.

### Why is it needed?

Routes aren't correctly retrieved in the API tokens creation / edit page.

### How to test it?

- Go to the admin and show the console
- Go to Settings > API Tokens
- Click on Create new API Token
  -> The 500 error while calling /content-api/routes should appear in the console before this fix

### Related issue(s)/PR(s)

Resolves #21478

🚀