### PR TITLE
fix: reordering dynamic zones messes up indexes during validation

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -220,6 +220,25 @@ type HandleOptions = {
 type RemovedFieldPath = string;
 
 /**
+ * @internal
+ * @description Finds the initial value for a component or dynamic zone item (based on its __temp_key__ and not its index).
+ * @param initialValue - The initial values object.
+ * @param item - The item to find the initial value for.
+ * @returns The initial value for the item.
+ */
+const getItemInitialValue = (initialValue: AnyData, item: AnyData) => {
+  if (initialValue && Array.isArray(initialValue)) {
+    const matchingInitialItem = initialValue.find(
+      (initialItem) => initialItem.__temp_key__ === item.__temp_key__
+    );
+    if (matchingInitialItem) {
+      return matchingInitialItem;
+    }
+  }
+  return {};
+};
+
+/**
  * Removes values from the data object if their corresponding attribute has a
  * visibility condition that evaluates to false.
  *
@@ -267,16 +286,7 @@ const handleInvisibleAttributes = (
 
       if (attrDef.repeatable && Array.isArray(value)) {
         result[attrName] = value.map((item) => {
-          // Find the initial value for this component using __temp_key__ instead of index
-          let componentInitialValue = {};
-          if (initialValue && Array.isArray(initialValue)) {
-            const matchingInitialItem = initialValue.find(
-              (initialItem) => initialItem.__temp_key__ === item.__temp_key__
-            );
-            if (matchingInitialItem) {
-              componentInitialValue = matchingInitialItem;
-            }
-          }
+          const componentInitialValue = getItemInitialValue(initialValue, item);
 
           return handleInvisibleAttributes(
             item,
@@ -316,16 +326,7 @@ const handleInvisibleAttributes = (
         const compUID = dzItem?.__component;
         const compSchema = components[compUID];
 
-        // Find the initial value for this component using __temp_key__ instead of index
-        let componentInitialValue = {};
-        if (initialValue && Array.isArray(initialValue)) {
-          const matchingInitialItem = initialValue.find(
-            (item) => item.__temp_key__ === dzItem.__temp_key__
-          );
-          if (matchingInitialItem) {
-            componentInitialValue = matchingInitialItem;
-          }
-        }
+        const componentInitialValue = getItemInitialValue(initialValue, dzItem);
 
         const cleaned = handleInvisibleAttributes(
           dzItem,


### PR DESCRIPTION
### What does it do?

Reordering dynamic zones messes up the data because of an index change and mix the content between the swapped items.
It's happening during the form validation where we use indexes to fetch the initialValue.
See the following video to show the issue:

https://github.com/user-attachments/assets/aa2ebda8-d71e-400e-aee9-34c499e02ed7

### Why is it needed?

It's not saving the actual state of the form and messes up with the data, it could lead to pretty nasty behaviours and loss of data.

### How to test it?

Since the issue is pretty hard to reproduce, see the details in the ticket below.
Reordering dynamic zones will not be enough. The dynamic zone should have repeatable components as children.
For the test, create a first row with a child content (fill some data) + create a new one without anything in it, then swap the two items and save.
You can also see in the payload of the PUT request that the data is incorrect.

### Related issue(s)/PR(s)

Resolves #24186

🚀