### PR TITLE
fix: formatErrorMessages array values formatting

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -78,32 +78,26 @@ export const formatErrorMessages = (
   Object.entries(errors).forEach(([key, value]) => {
     const currentKey = parentKey ? `${parentKey}.${key}` : key;
 
-    if (Array.isArray(value)) {
-      messages.push(...formatErrorMessages(value, currentKey, formatMessage));
-    } else if (
-      value !== null &&
-      typeof value === 'object' &&
-      'id' in value &&
-      'defaultMessage' in value
-    ) {
+    if (!value) return;
+    const isErrorMessageDescriptor =
+      typeof value === 'object' && 'id' in value && 'defaultMessage' in value;
+    if (isErrorMessageDescriptor || typeof value === 'string') {
+      const id = isErrorMessageDescriptor ? value.id : value;
+      const defaultMessage = isErrorMessageDescriptor
+        ? (value.defaultMessage as string)
+        : (value as string);
       messages.push(
         formatMessage(
           {
-            id: `${value.id}.withField`,
-            defaultMessage: value.defaultMessage as string,
+            id: `${id}.withField`,
+            defaultMessage,
           },
           { field: currentKey }
         )
       );
     } else {
       messages.push(
-        formatMessage(
-          {
-            id: `${value}.withField`,
-            defaultMessage: value as string,
-          },
-          { field: currentKey }
-        )
+        ...formatErrorMessages(value as unknown as FormErrors, currentKey, formatMessage)
       );
     }
   });

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/tests/formatErrorMessages.test.ts
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/tests/formatErrorMessages.test.ts
@@ -1,7 +1,159 @@
 import { formatErrorMessages } from '../PublishAction';
 
+/**
+ * A minimal formatMessage stub: returns the defaultMessage as-is.
+ * For cases where we want to assert the field is forwarded we inspect the
+ * second argument via a spy instead.
+ */
+const fmt = (msg: { defaultMessage: string }) => msg.defaultMessage;
+
 describe('formatErrorMessages', () => {
-  it('should format error messages correctly', () => {
+  // -------------------------------------------------------------------------
+  // Leaf value: MessageDescriptor  { id, defaultMessage }
+  // -------------------------------------------------------------------------
+  it('formats a single MessageDescriptor leaf at the root', () => {
+    const errors = {
+      title: { id: 'error.required', defaultMessage: 'This value is required.' },
+    };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual(['This value is required.']);
+  });
+
+  it('formats a single MessageDescriptor leaf with a parent key', () => {
+    const errors = {
+      name: { id: 'error.required', defaultMessage: 'This value is required.' },
+    };
+
+    const calls: Array<[{ id: string; defaultMessage: string }, { field: string }]> = [];
+    const spy = (msg: any, values: any) => {
+      calls.push([msg, values]);
+      return msg.defaultMessage;
+    };
+
+    formatErrorMessages(errors, 'component', spy as any);
+
+    expect(calls[0][1]).toEqual({ field: 'component.name' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Leaf value: plain string
+  // -------------------------------------------------------------------------
+  it('formats a plain-string error value', () => {
+    const errors = { slug: 'This field must be unique.' };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual(['This field must be unique.']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Falsy / nullish values are skipped
+  // -------------------------------------------------------------------------
+  it('skips null values', () => {
+    const errors = { title: null };
+    expect(formatErrorMessages(errors as any, '', fmt)).toEqual([]);
+  });
+
+  it('skips undefined values', () => {
+    const errors = { title: undefined };
+    expect(formatErrorMessages(errors as any, '', fmt)).toEqual([]);
+  });
+
+  it('returns empty array for null errors argument', () => {
+    expect(formatErrorMessages(null as any, '', fmt)).toEqual([]);
+  });
+
+  it('returns empty array for undefined errors argument', () => {
+    expect(formatErrorMessages(undefined as any, '', fmt)).toEqual([]);
+  });
+
+  it('returns empty array for empty errors object', () => {
+    expect(formatErrorMessages({}, '', fmt)).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Nested objects (components, dynamic zones)
+  // -------------------------------------------------------------------------
+  it('recurses into a nested plain object', () => {
+    const errors = {
+      address: {
+        street: { id: 'error.required', defaultMessage: 'Street is required.' },
+      },
+    };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual(['Street is required.']);
+  });
+
+  it('builds a dotted path when recursing through nested objects', () => {
+    const errors = {
+      address: {
+        city: { id: 'error.required', defaultMessage: 'City is required.' },
+      },
+    };
+
+    const calls: Array<{ field: string }> = [];
+    const spy = (msg: any, values: any) => {
+      calls.push(values);
+      return msg.defaultMessage;
+    };
+
+    formatErrorMessages(errors, '', spy as any);
+
+    expect(calls[0].field).toBe('address.city');
+  });
+
+  it('builds a dotted path from a non-empty parentKey', () => {
+    const errors = {
+      street: { id: 'error.required', defaultMessage: 'Street is required.' },
+    };
+
+    const calls: Array<{ field: string }> = [];
+    const spy = (msg: any, values: any) => {
+      calls.push(values);
+      return msg.defaultMessage;
+    };
+
+    formatErrorMessages(errors, 'address', spy as any);
+
+    expect(calls[0].field).toBe('address.street');
+  });
+
+  it('recurses deeply through multiple levels', () => {
+    const errors = {
+      section: {
+        block: {
+          title: { id: 'error.required', defaultMessage: 'Title is required.' },
+        },
+      },
+    };
+
+    const calls: Array<{ field: string }> = [];
+    const spy = (msg: any, values: any) => {
+      calls.push(values);
+      return msg.defaultMessage;
+    };
+
+    formatErrorMessages(errors, '', spy as any);
+
+    expect(calls[0].field).toBe('section.block.title');
+  });
+
+  // -------------------------------------------------------------------------
+  // Arrays (repeatable components, dynamic zones)
+  // -------------------------------------------------------------------------
+  it('recurses into array-like indexed objects (repeatable components)', () => {
+    const errors = {
+      cards: {
+        0: { id: 'error.required', defaultMessage: 'Card title is required.' },
+        1: { id: 'error.required', defaultMessage: 'Card title is required.' },
+      },
+    };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual([
+      'Card title is required.',
+      'Card title is required.',
+    ]);
+  });
+
+  it('builds correct dotted paths for array-indexed entries', () => {
     const errors = {
       'Content.0.cards': {
         id: 'components.Input.error.validation.required',
@@ -9,8 +161,62 @@ describe('formatErrorMessages', () => {
       },
     };
 
-    const formattedMessages = formatErrorMessages(errors, '', (msg) => msg.defaultMessage);
+    const calls: Array<{ field: string }> = [];
+    const spy = (msg: any, values: any) => {
+      calls.push(values);
+      return msg.defaultMessage;
+    };
 
-    expect(formattedMessages).toEqual(['This value is required.']);
+    formatErrorMessages(errors, '', spy as any);
+
+    expect(calls[0].field).toBe('Content.0.cards');
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple errors at the same level
+  // -------------------------------------------------------------------------
+  it('collects multiple errors at the same level', () => {
+    const errors = {
+      title: { id: 'error.required', defaultMessage: 'Title is required.' },
+      slug: { id: 'error.unique', defaultMessage: 'Slug must be unique.' },
+    };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual([
+      'Title is required.',
+      'Slug must be unique.',
+    ]);
+  });
+
+  it('collects errors from both leaf and nested keys at the same level', () => {
+    const errors = {
+      title: { id: 'error.required', defaultMessage: 'Title is required.' },
+      meta: {
+        description: { id: 'error.required', defaultMessage: 'Description is required.' },
+      },
+    };
+
+    expect(formatErrorMessages(errors, '', fmt)).toEqual([
+      'Title is required.',
+      'Description is required.',
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // formatMessage receives the correct id suffix (.withField)
+  // -------------------------------------------------------------------------
+  it('appends .withField to the id when calling formatMessage', () => {
+    const calls: Array<{ id: string }> = [];
+    const spy = (msg: any) => {
+      calls.push(msg);
+      return msg.defaultMessage;
+    };
+
+    formatErrorMessages(
+      { name: { id: 'error.required', defaultMessage: 'Required.' } },
+      '',
+      spy as any
+    );
+
+    expect(calls[0].id).toBe('error.required.withField');
   });
 });


### PR DESCRIPTION
Fix #23606 
Fix #18810 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the formatting of error messages in `PublishAction` when errors are a nested array.

### Why is it needed?

Formatting of errors is broken for nested arrays of errors.

### How to test it?

Try bulk-publishing entries containing dynamic zones which have content with validation errors.

### Related issue(s)/PR(s)

#23606, #18810 