### PR TITLE
future(preview): add content source maps service

### DIFF
--- a/examples/getstarted/config/middlewares.js
+++ b/examples/getstarted/config/middlewares.js
@@ -12,6 +12,8 @@ module.exports = [
         useDefaults: true,
         directives: {
           'frame-src': ["'self'"], // URLs that will be loaded in an iframe (e.g. Content Preview)
+          // Needed to load the `@vercel/stega` lib on the dummy-preview page
+          'script-src': ["'self'", "'unsafe-inline'", 'https://cdn.jsdelivr.net'],
         },
       },
     },

--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -7,19 +7,10 @@ import { registerPreviewRoute } from './preview';
 const config = {
   locales: ['it', 'es', 'en', 'en-GB'],
 };
-const bootstrap = (app) => {
-  app.getPlugin('content-manager').injectComponent('editView', 'right-links', {
-    name: 'PreviewButton',
-    Component: () => (
-      <Button onClick={() => window.alert('Not here, The preview is.')}>Preview</Button>
-    ),
-  });
-};
 
 export default {
   config,
   register: (app) => {
     registerPreviewRoute(app);
   },
-  bootstrap,
 };

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useParams, useLoaderData, useRevalidator } from 'react-router-dom';
 
-// @ts-ignore
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
 import { Grid, Flex, Typography, JSONInput, Box } from '@strapi/design-system';
 
@@ -130,7 +129,7 @@ const PreviewComponent = () => {
                           {key}
                         </Typography>
                         <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                          <Typography data-strapi-source={key}>
+                          <Typography>
                             {typeof value === 'object' && value !== null
                               ? JSON.stringify(value, null, 2)
                               : String(value)}

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -29,6 +29,7 @@ const previewLoader = async ({ params }) => {
     const searchParams = new URLSearchParams({
       locale,
       status,
+      encodeSourceMaps: 'true',
     });
     const route = collectionType === 'collection-types' ? `${apiName}/${documentId}` : apiName;
 

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -25,11 +25,11 @@ const previewLoader = async ({ params }) => {
     const headers = {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiToken}`,
+      'encode-source-maps': 'true',
     };
     const searchParams = new URLSearchParams({
       locale,
       status,
-      encodeSourceMaps: 'true',
     });
     const route = collectionType === 'collection-types' ? `${apiName}/${documentId}` : apiName;
 

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -64,6 +64,7 @@
     "@strapi/types": "5.22.0",
     "@strapi/typescript-utils": "5.22.0",
     "@strapi/utils": "5.22.0",
+    "@vercel/stega": "0.1.2",
     "bcryptjs": "2.4.3",
     "boxen": "5.1.2",
     "chalk": "4.1.2",

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -32,6 +32,7 @@ import getNumberOfDynamicZones from './services/utils/dynamic-zones';
 import getNumberOfConditionalFields from './services/utils/conditional-fields';
 import { FeaturesService, createFeaturesService } from './services/features';
 import { createDocumentService } from './services/document-service';
+import { createContentSourceMapsService } from './services/content-source-maps';
 
 import { coreStoreModel } from './services/core-store';
 import { createConfigProvider } from './services/config';
@@ -287,7 +288,8 @@ class Strapi extends Container implements Core.Strapi {
           })
         );
       })
-      .add('reload', () => createReloader(this));
+      .add('reload', () => createReloader(this))
+      .add('content-source-maps', () => createContentSourceMapsService(this));
   }
 
   sendStartupTelemetry() {

--- a/packages/core/core/src/core-api/controller/index.ts
+++ b/packages/core/core/src/core-api/controller/index.ts
@@ -32,6 +32,7 @@ function createController({
       return transformResponse(data, meta, {
         contentType,
         useJsonAPIFormat: ctx?.headers?.['strapi-response-format'] === 'v4',
+        encodeSourceMaps: ctx?.query?.encodeSourceMaps === 'true',
       });
     },
 

--- a/packages/core/core/src/core-api/controller/index.ts
+++ b/packages/core/core/src/core-api/controller/index.ts
@@ -32,7 +32,7 @@ function createController({
       return transformResponse(data, meta, {
         contentType,
         useJsonAPIFormat: ctx?.headers?.['strapi-response-format'] === 'v4',
-        encodeSourceMaps: ctx?.query?.encodeSourceMaps === 'true',
+        encodeSourceMaps: ctx?.headers?.['encode-source-maps'] === 'true',
       });
     },
 

--- a/packages/core/core/src/core-api/controller/transform.ts
+++ b/packages/core/core/src/core-api/controller/transform.ts
@@ -32,13 +32,15 @@ interface TransformOptions {
    * @deprecated this option is deprecated and will be removed in the next major version
    */
   useJsonAPIFormat?: boolean;
+  encodeSourceMaps?: boolean;
 }
 
-const transformResponse = (
+const transformResponse = async (
   resource: any,
   meta: unknown = {},
   opts: TransformOptions = {
     useJsonAPIFormat: false,
+    encodeSourceMaps: false,
   }
 ) => {
   if (isNil(resource)) {
@@ -49,8 +51,15 @@ const transformResponse = (
     throw new Error('Entry must be an object or an array of objects');
   }
 
+  const data = opts.useJsonAPIFormat ? transformEntry(resource, opts?.contentType) : resource;
+
+  // Apply source map encoding if requested and content type is provided
+  if (opts.encodeSourceMaps && opts.contentType) {
+    await strapi.get('content-source-maps').encodeSourceMaps(data, opts.contentType);
+  }
+
   return {
-    data: opts.useJsonAPIFormat ? transformEntry(resource, opts?.contentType) : resource,
+    data,
     meta,
   };
 };

--- a/packages/core/core/src/services/content-source-maps.ts
+++ b/packages/core/core/src/services/content-source-maps.ts
@@ -1,0 +1,150 @@
+import { vercelStegaCombine } from '@vercel/stega';
+import type { Core, Struct } from '@strapi/types';
+
+const ENCODABLE_TYPES = [
+  'string',
+  'text',
+  'richtext',
+  'uid',
+  'enumeration',
+  'email',
+  'date',
+  'datetime',
+  'time',
+  'timestamp',
+];
+
+const EXCLUDED_FIELDS = [
+  'id',
+  'documentId',
+  'locale',
+  'localizations',
+  'created_by',
+  'updated_by',
+  'created_at',
+  'updated_at',
+  'publishedAt',
+];
+
+const createContentSourceMapsService = (strapi: Core.Strapi) => {
+  return {
+    encodeField(text: string, key: string): string {
+      const res = vercelStegaCombine(text, {
+        // TODO: smarter metadata than just the key
+        key,
+      });
+      return res;
+    },
+
+    async encodeEntry(entryRootId: any, entryRootModel: string, entryData: any, model: any) {
+      if (typeof entryData !== 'object' || entryData === null || entryData === undefined) {
+        return;
+      }
+
+      Object.keys(entryData).forEach((key) => {
+        const value = entryData[key];
+
+        // Skip encoding if the value is null or undefined
+        if (value === null || value === undefined) {
+          return;
+        }
+
+        const attribute = model.attributes[key];
+
+        if (!attribute || EXCLUDED_FIELDS.includes(key)) {
+          return;
+        }
+
+        if (ENCODABLE_TYPES.includes(attribute.type)) {
+          entryData[key] = this.encodeField(
+            value,
+            // TODO: smarter metadata than just the key
+            key
+          );
+
+          return;
+        }
+
+        if (attribute.type === 'component') {
+          const componentModel = strapi.getModel(attribute.component);
+
+          if (Array.isArray(value)) {
+            return value.forEach((item) => {
+              return this.encodeEntry(entryRootId, entryRootModel, item, componentModel);
+            });
+          }
+
+          return this.encodeEntry(entryRootId, entryRootModel, value, componentModel);
+        }
+
+        if (attribute.type === 'dynamiczone' && Array.isArray(value)) {
+          return value.forEach((item) => {
+            return this.encodeEntry(
+              entryRootId,
+              entryRootModel,
+              item,
+              strapi.getModel(item.__component)
+            );
+          });
+        }
+
+        if (attribute.type === 'relation') {
+          const relatedModel = strapi.getModel(attribute.target);
+
+          if (Array.isArray(value)) {
+            return value.forEach((item: any) => {
+              return this.encodeEntry(
+                item.id,
+                relatedModel.uid,
+                item,
+                strapi.getModel(attribute.target)
+              );
+            });
+          }
+
+          return this.encodeEntry(
+            value.id,
+            relatedModel.uid,
+            value,
+            strapi.getModel(attribute.target)
+          );
+        }
+
+        if (attribute.type === 'media') {
+          const fileModel = strapi.getModel('plugin::upload.file');
+
+          if (Array.isArray(value.data)) {
+            return value.data.forEach((item: any) => {
+              return this.encodeEntry(entryRootId, entryRootModel, item, fileModel);
+            });
+          }
+
+          return this.encodeEntry(entryRootId, entryRootModel, value.data, fileModel);
+        }
+      });
+    },
+
+    async encodeSourceMaps(
+      data: any,
+      contentType: Struct.ContentTypeSchema,
+      rootId?: any,
+      rootModel?: string
+    ): Promise<void> {
+      if (Array.isArray(data)) {
+        data.forEach((item) => this.encodeSourceMaps(item, contentType));
+        return;
+      }
+
+      if (typeof data !== 'object' || data === null) {
+        return;
+      }
+
+      const actualRootId = rootId || data.id;
+      const actualRootModel = rootModel || contentType.uid;
+
+      await this.encodeEntry(actualRootId, actualRootModel, data, contentType);
+    },
+  };
+};
+
+export { createContentSourceMapsService };

--- a/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
+++ b/packages/core/utils/src/sanitize/visitors/remove-restricted-relations.ts
@@ -24,6 +24,10 @@ export default (auth: unknown): Visitor =>
     const handleMorphRelation = async () => {
       const elements: any = (data as Record<string, MorphArray>)[key];
 
+      if (!elements) {
+        return;
+      }
+
       if ('connect' in elements || 'set' in elements || 'disconnect' in elements) {
         const newValue: Record<string, unknown> = {};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8955,6 +8955,7 @@ __metadata:
     "@types/node": "npm:18.19.24"
     "@types/node-schedule": "npm:2.1.7"
     "@types/statuses": "npm:2.0.1"
+    "@vercel/stega": "npm:0.1.2"
     bcryptjs: "npm:2.4.3"
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
@@ -12068,6 +12069,13 @@ __metadata:
   bin:
     ncc: dist/ncc/cli.js
   checksum: 10c0/430f506d7243155d85b8f99d46f46159b9dea58190ae4c28eadebe6b1b90e350e9861c7accc4f3b2dcb603f47fbe7cc947c56af396c96ba1059419f1b4f20928
+  languageName: node
+  linkType: hard
+
+"@vercel/stega@npm:0.1.2":
+  version: 0.1.2
+  resolution: "@vercel/stega@npm:0.1.2"
+  checksum: 10c0/66eb80f286d46806004a2eacd215af80ad3cd443e7a96a6070d390dbb3f4d1f6e063013ec0d196c7fe852721d5dbe62e23b44c32975e36b18cda30e5e0728e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

- Creates a content-source-maps service. It traverses entries to attach field sourcemaps as stega encoded data when possible in the content API. This only runs when the `encode-source-maps` header is passed.
- Adds the logic in our previewScript to detect fields with encoded data, and write that data to the data-attributes so we can show our highlight overlays for them

Known issues:
- not all fields are handled, only the string-based ones. 
- the actual data we encode is quite dumb, improving that will be the next PR

I used 2 references for inspiration:
- Alex's [v4 sourcemaps plugin](https://github.com/strapi/plugin-content-source-map/blob/main/server/src/encoder.ts) (RIP) for the actual encoding logic
- the v4 `strapi-response-format` functionality to see how to transform the content API responses based on a header

### Why is it needed?

This metadata powers our new Live Preview

### How to test it?

The most convenient way is to open the preview page for any entry on getstarted, and scroll down in the preview to the code block. This should let you see the weird invisible characters:
<img width="1410" height="1078" alt="screenshot 2025-08-20 at 18 35 48@2x" src="https://github.com/user-attachments/assets/f34e2137-afd2-4871-b2f6-193b90282e61" />

