### PR TITLE
chore: change close stale issue github action to target label 

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -19,16 +19,17 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Close stale old issues
+      - name: Close stale issues
         uses: actions/stale@v3
         with:
+          debug-only: true # Dry run to confirm the workflow is working
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-labels: 'stale-before-2021' # Only process issues with this label
+          only-labels: 'stale-before-2021' # Only process issues with this label
           exempt-issue-labels: 'issue: security,severity: critical,severity: high' # Don't close issues with this label
           exempt-all-milestones: true # Don't close issues that are part of a milestone
           days-before-stale: 0 # Mark as stale immediately
           days-before-close: 0 # Close immediately
-          operations-per-run: 100
+          operations-per-run: 5
           stale-issue-message: |
             👋 Hello there!
 


### PR DESCRIPTION
This PR is the followup step of the [RFC [Github] Proposal of a process to close stale issues](https://www.notion.so/strapi/Github-Proposal-of-a-process-to-close-stale-issues-2088f359807480b7aa03e17f5b40605d).

# What does it do?
- Issues from before 2021 have been labeled 'stale-before-2021' by the previous github action introduced in this [PR](https://github.com/strapi/strapi/pull/24098).
- This action updates the Close_stale_issue action to target only this label. 

Changes:
- added a dry run so we can test safely. 
- changed the parameter needed to target a specific issue.
- limited operations-per-run to 5. 
