### PR TITLE
feat: enhance JWT handling with configurable algorithms

### DIFF
--- a/packages/core/admin/server/src/services/token.ts
+++ b/packages/core/admin/server/src/services/token.ts
@@ -1,12 +1,14 @@
 import crypto from 'crypto';
 import _ from 'lodash';
 import jwt from 'jsonwebtoken';
+import type { Algorithm, VerifyOptions } from 'jsonwebtoken';
 import type { AdminUser } from '../../../shared/contracts/shared';
 
 const defaultJwtOptions = { expiresIn: '30d' };
 
 export type TokenOptions = {
   expiresIn?: string;
+  algorithm?: Algorithm;
   [key: string]: unknown;
 };
 
@@ -56,10 +58,14 @@ const createJwtToken = (user: { id: AdminUser['id'] }) => {
 const decodeJwtToken = (
   token: string
 ): { payload: TokenPayload; isValid: true } | { payload: null; isValid: false } => {
-  const { secret } = getTokenOptions();
+  const { secret, options } = getTokenOptions();
 
   try {
-    const payload = jwt.verify(token, secret) as TokenPayload;
+    const verifyOptions: VerifyOptions = options?.algorithm
+      ? { algorithms: [options.algorithm] }
+      : {};
+
+    const payload = jwt.verify(token, secret, verifyOptions) as TokenPayload;
     return { payload, isValid: true };
   } catch (err) {
     return { payload: null, isValid: false };

--- a/packages/core/core/src/providers/sessionManager.ts
+++ b/packages/core/core/src/providers/sessionManager.ts
@@ -1,9 +1,13 @@
+import type { Algorithm } from 'jsonwebtoken';
 import { defineProvider } from './provider';
 import { createSessionManager } from '../services/session-manager';
 
 interface AdminAuthConfig {
   secret?: string;
-  options?: Record<string, unknown>;
+  options?: {
+    algorithm?: Algorithm;
+    [key: string]: unknown;
+  };
 }
 
 export default defineProvider({
@@ -31,6 +35,7 @@ export default defineProvider({
       jwtSecret,
       refreshTokenLifespan,
       accessTokenLifespan,
+      algorithm: adminAuth.options?.algorithm,
     };
 
     strapi.add('sessionManager', () =>

--- a/packages/core/core/src/services/__tests__/session-manager.test.ts
+++ b/packages/core/core/src/services/__tests__/session-manager.test.ts
@@ -188,7 +188,9 @@ describe('SessionManager Factory', () => {
 
       const result = await sessionManager.validateRefreshToken('valid-token');
 
-      expect(mockJwt.verify).toHaveBeenCalledWith('valid-token', config.jwtSecret);
+      expect(mockJwt.verify).toHaveBeenCalledWith('valid-token', config.jwtSecret, {
+        algorithms: ['HS256'],
+      });
       expect(mockQuery.findOne).toHaveBeenCalledWith({ where: { sessionId } });
 
       expect(result).toEqual({

--- a/packages/plugins/users-permissions/server/services/jwt.js
+++ b/packages/plugins/users-permissions/server/services/jwt.js
@@ -39,10 +39,13 @@ module.exports = ({ strapi }) => ({
 
   verify(token) {
     return new Promise((resolve, reject) => {
+      const jwtConfig = strapi.config.get('plugin::users-permissions.jwt', {});
+      const algorithms = jwtConfig && jwtConfig.algorithm ? [jwtConfig.algorithm] : undefined;
+
       jwt.verify(
         token,
         strapi.config.get('plugin::users-permissions.jwtSecret'),
-        {},
+        algorithms ? { algorithms } : {},
         (err, tokenPayload = {}) => {
           if (err) {
             return reject(new Error('Invalid token.'));


### PR DESCRIPTION
To address https://github.com/strapi/strapi/pull/24133#discussion_r2304231650 in the base branch

```
// Admin (config/admin.js or .ts)
module.exports = ({ env }) => ({
  auth: {
    secret: env('ADMIN_JWT_SECRET'),
    options: {
      algorithm: 'HS256',
      // ...
    },
  },
});

// Users-permissions (config/plugins.js)
module.exports = ({ env }) => ({
  'users-permissions': {
    config: {
      jwtSecret: env('JWT_SECRET'),
      jwt: {
        algorithm: 'HS256',
        // ...
      },
    },
  },
});
```