### PR TITLE
chore: close stale issue starts from oldest issue

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -24,12 +24,13 @@ jobs:
         with:
           debug-only: true # Dry run to confirm the workflow is working
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ascending: true # Start with oldest issues first
           only-labels: 'stale-before-2021' # Only process issues with this label
           exempt-issue-labels: 'issue: security,severity: critical,severity: high' # Don't close issues with this label
           exempt-all-milestones: true # Don't close issues that are part of a milestone
           days-before-stale: 0 # Mark as stale immediately
           days-before-close: 0 # Close immediately
-          operations-per-run: 5
+          operations-per-run: 100
           stale-issue-message: |
             👋 Hello there!
 


### PR DESCRIPTION
This PR is the followup step of the [RFC [Github] Proposal of a process to close stale issues](https://www.notion.so/strapi/Github-Proposal-of-a-process-to-close-stale-issues-2088f359807480b7aa03e17f5b40605d).

- change to start with the oldest issues first instead of running through the whole set. 
- update `operations-per-run` to 100 to that it can close up to 33 issues (3 actions required: tag, comment, close)