### PR TITLE
fix(upload): disable the edit button on media input if disabled

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -65,6 +65,7 @@ export const CarouselAssets = React.forwardRef(
     const [isEditingAsset, setIsEditingAsset] = React.useState(false);
 
     const currentAsset = assets[selectedAssetIndex];
+    const canEditMedia = !disabled && onEditAsset;
 
     return (
       <>
@@ -93,9 +94,7 @@ export const CarouselAssets = React.forwardRef(
                 asset={currentAsset}
                 onDeleteAsset={disabled ? undefined : onDeleteAsset}
                 onAddAsset={disabled ? undefined : onAddAsset}
-                onEditAsset={
-                  disabled ? undefined : onEditAsset ? () => setIsEditingAsset(true) : undefined
-                }
+                onEditAsset={canEditMedia ? () => setIsEditingAsset(true) : undefined}
               />
             ) : undefined
           }

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -93,7 +93,9 @@ export const CarouselAssets = React.forwardRef(
                 asset={currentAsset}
                 onDeleteAsset={disabled ? undefined : onDeleteAsset}
                 onAddAsset={disabled ? undefined : onAddAsset}
-                onEditAsset={onEditAsset ? () => setIsEditingAsset(true) : undefined}
+                onEditAsset={
+                  disabled ? undefined : onEditAsset ? () => setIsEditingAsset(true) : undefined
+                }
               />
             ) : undefined
           }

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/tests/CarouselAssets.test.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/tests/CarouselAssets.test.tsx
@@ -104,4 +104,10 @@ describe('MediaLibraryInput | Carousel | CarouselAssets', () => {
 
     expect(getByText('localized')).toBeInTheDocument();
   });
+
+  it.only('should not render the edit button if disabled', () => {
+    const { queryByRole } = setup({ disabled: true });
+
+    expect(queryByRole('button', { name: 'edit' })).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### What does it do?

If the media library field is disabled (e.g. the user doesn't have permission to edit the content), it should not display the edit button.

### Why is it needed?

This aligns with the permissions given to the user. If a user can read the content without updating, they shouldn't be able to modify the media fields

### How to test it?

1. Create a new permission and give them access to only read and publish a content type
2. Create a content type with the media fields as a part of the schema
3. Login using the user with the new permission and head to the content
4. You will find that field without the edit button

### Screenshots

Before the fix:
<img width="470" height="210" alt="image" src="https://github.com/user-attachments/assets/69dc6158-50e3-44c5-a6c8-292ebacfa328" />

After the fix:
<img width="465" height="211" alt="image" src="https://github.com/user-attachments/assets/b01370c5-9e3e-4055-b718-e9f5603c398d" />

### Related issue(s)/PR(s)

Fixes #24262 