### PR TITLE
chore: label and close issues before 2022

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,4 +1,4 @@
-name: Close Pre-2021 Issues
+name: Close Pre-2022 Issues
 on:
   workflow_dispatch: # Allows manual triggering from the Github UI
 
@@ -25,7 +25,7 @@ jobs:
           # debug-only: true # Dry run to confirm the workflow is working
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true # Start with oldest issues first
-          only-labels: 'stale-before-2021' # Only process issues with this label
+          only-labels: 'stale-before-2022' # Only process issues with this label
           exempt-issue-labels: 'issue: security,severity: critical,severity: high' # Don't close issues with this label
           exempt-all-milestones: true # Don't close issues that are part of a milestone
           exempt-all-assignees: false # Close even if they are assigned

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -1,4 +1,4 @@
-name: Label Pre-2021 Issues
+name: Label Pre-2022 Issues
 on:
   workflow_dispatch: # Allows manual triggering from the Github UI
 
@@ -14,8 +14,8 @@ jobs:
       - name: Label old issues
         run: |
           # Set the cutoff date (issues created before this date will be labeled)
-          CUTOFF_DATE="2021-01-01"
-          LABEL="stale-before-2021"
+          CUTOFF_DATE="2022-01-01"
+          LABEL="stale-before-2022"
 
           echo "Labeling issues created before $CUTOFF_DATE with $LABEL"
 


### PR DESCRIPTION
Rinse and repeat: updated script to target issues before 2022!
I will do another PR for before 2023 and 2024 then I will change the method a little. 

We'll change the method for issues post 2024 and create scripts that will run daily for upkeep.