### PR TITLE
fix: hide edit IconButton when media field is disabled

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -93,7 +93,7 @@ export const CarouselAssets = React.forwardRef(
                 asset={currentAsset}
                 onDeleteAsset={disabled ? undefined : onDeleteAsset}
                 onAddAsset={disabled ? undefined : onAddAsset}
-                onEditAsset={onEditAsset ? () => setIsEditingAsset(true) : undefined}
+                onEditAsset={onEditAsset && !disabled ? () => setIsEditingAsset(true) : undefined}
               />
             ) : undefined
           }


### PR DESCRIPTION
### What does it do?

Hides the "Edit" IconButton in the media input when the field is disabled.

### Why is it needed?

Previously, the "Edit" IconButton was visible and allowed editing even when the media field was disabled. This caused confusion and did not match the expected behavior as shown in the issue video.

### How to test it?

- Go to any content type with a media input.
- Fill the required content and upload media.
- Publish the content type.
- The "Edit" IconButton should not be visible in the published version but should be visible in the draft version of it.

### Related issue(s)/PR(s)

Fixes #23102 
