### PR TITLE
fix: syncing components in draft and publish relations

### DIFF
--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -529,8 +529,9 @@ const shouldPropagateComponentRelationToNewVersion = async (
 ): Promise<boolean> => {
   // Get the component ID column name using the actual component model name
   const componentIdColumn = strapi.db.metadata.identifiers.getJoinColumnAttributeIdName(
-    componentSchema.modelName
+    _.snakeCase(componentSchema.modelName)
   );
+
   const componentId = componentRelation[componentIdColumn];
 
   const parent = await findComponentParent(

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -309,10 +309,16 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
     ]);
 
     // Load any unidirectional relation targetting the old published entries
-    const relationsToSync = await unidirectionalRelations.load(uid, {
-      newVersions: draftsToPublish,
-      oldVersions: oldPublishedVersions,
-    });
+    const relationsToSync = await unidirectionalRelations.load(
+      uid,
+      {
+        newVersions: draftsToPublish,
+        oldVersions: oldPublishedVersions,
+      },
+      {
+        shouldPropagateRelation: components.createComponentRelationFilter(),
+      }
+    );
 
     const bidirectionalRelationsToSync = await bidirectionalRelations.load(uid, {
       newVersions: draftsToPublish,
@@ -399,10 +405,16 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
     ]);
 
     // Load any unidirectional relation targeting the old drafts
-    const relationsToSync = await unidirectionalRelations.load(uid, {
-      newVersions: versionsToDraft,
-      oldVersions: oldDrafts,
-    });
+    const relationsToSync = await unidirectionalRelations.load(
+      uid,
+      {
+        newVersions: versionsToDraft,
+        oldVersions: oldDrafts,
+      },
+      {
+        shouldPropagateRelation: components.createComponentRelationFilter(),
+      }
+    );
 
     const bidirectionalRelationsToSync = await bidirectionalRelations.load(uid, {
       newVersions: versionsToDraft,

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -108,8 +108,9 @@ const load = async (
             .whereIn(targetColumnName, ids)
             .transacting(trx);
 
-          let filteredRelations = newVersionsRelations;
 
+          // TODO: Reconsider this name and remove the mutable variable
+          let filteredRelations = newVersionsRelations;
           // Apply custom filtering if provided
           if (options.shouldPropagateRelation) {
             const relationsToPropagate = [];

--- a/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/unidirectional-relations.ts
@@ -108,7 +108,6 @@ const load = async (
             .whereIn(targetColumnName, ids)
             .transacting(trx);
 
-
           // TODO: Reconsider this name and remove the mutable variable
           let filteredRelations = newVersionsRelations;
           // Apply custom filtering if provided


### PR DESCRIPTION
### What does it do?

moves all components logic out of the database layer and into the document service

### Why is it needed?

db layer should not be aware of strapi logic

### How to test it?

see linked issue

### Related issue(s)/PR(s)

Parent PR: https://github.com/strapi/strapi/pull/24227
Issue: https://github.com/strapi/strapi/issues/23858
