### PR TITLE
chore: label and close actions for stale 2024 q1q2 issues

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -5,42 +5,45 @@ on:
 permissions:
   issues: write # Required to close issues and post comments
   contents: read # Needed by most GitHub Actions
-  pull-requests: read # Needed to access PR data
 
 jobs:
   close-inactive:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Close stale issues
-        uses: actions/stale@v3
+        uses: actions/stale@v9
         with:
-          # debug-only: true # Dry run to confirm the workflow is working
+          debug-only: true # Dry run to confirm the workflow is working
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true # Start with oldest issues first
-          only-labels: 'stale-before-2024' # Only process issues with this label
+          only-labels: 'stale-q1-q2-2024' # Only process issues with this label
           exempt-issue-labels: 'issue: security,severity: critical,severity: high' # Don't close issues with this label
           exempt-all-milestones: true # Don't close issues that are part of a milestone
           exempt-all-assignees: false # Close even if they are assigned
           days-before-stale: 0 # Mark as stale immediately
-          days-before-close: 0 # Close immediately
+          days-before-close: 14 # Close in 14 days
           days-before-pr-stale: -1 # dont apply to PRs
           days-before-pr-close: -1 # PRs disabled
           operations-per-run: 100
           stale-issue-message: |
-            👋 Hello there!
+            stale-issue-message: |
+              👋 Hello, and thank you for helping us to make Strapi better!
 
-            We noticed this issue was created before 2024. As part of our efforts to keep our issue tracker current and actionable, we are closing older issues that have been inactive.
+              As part of our effort to keep the issue tracker focused and manageable, we are reviewing older reports.  
+              This issue has been inactive for a while. To ensure we spend our limited resources effectively, we are prioritizing:
+              - Active issues related to Strapi v5
+              - Issues with recent engagement
+              - Issues that are not duplicates of others
 
-            This issue has been automatically closed due to inactivity. If this issue is still relevant:
-            - Please add a comment to let us know and we will reopen it.
-            - Share any updates or additional context.
+              This issue will be automatically closed in **14 days** unless there is new activity.  
+              👉 If this is still relevant:
+              - Please add a comment with any updates.
+              - If the problem also exists in **Strapi v5**, we encourage you to open (or link to) a v5 issue.
 
-            Thank you for your contribution to making Strapi better! 🙏
+              Thank you for helping us improve Strapi! 🙏
+          close-issue-message: |
+            This issue has been closed due to inactivity as part of our backlog review.  
+
+            If the problem is still relevant (especially in **Strapi v5**), please let us know or open a new issue. 
+            We truly appreciate your input and contributions 💜

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,4 +1,4 @@
-name: Close Pre-2023 Issues
+name: Close Pre-2024 Issues
 on:
   workflow_dispatch: # Allows manual triggering from the Github UI
 
@@ -25,7 +25,7 @@ jobs:
           # debug-only: true # Dry run to confirm the workflow is working
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true # Start with oldest issues first
-          only-labels: 'stale-before-2023' # Only process issues with this label
+          only-labels: 'stale-before-2024' # Only process issues with this label
           exempt-issue-labels: 'issue: security,severity: critical,severity: high' # Don't close issues with this label
           exempt-all-milestones: true # Don't close issues that are part of a milestone
           exempt-all-assignees: false # Close even if they are assigned

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -1,11 +1,10 @@
-name: Label Pre-2024 Issues
+name: Label Q1 Q2 2024 Issues
 on:
   workflow_dispatch: # Allows manual triggering from the Github UI
 
 permissions:
   issues: write # Required to close issues and post comments
   contents: read # Needed by most GitHub Actions
-  pull-requests: read # Needed to access PR data
 
 jobs:
   close-inactive:
@@ -13,18 +12,19 @@ jobs:
     steps:
       - name: Label old issues
         run: |
-          # Set the cutoff date (issues created before this date will be labeled)
-          CUTOFF_DATE="2024-01-01"
-          LABEL="stale-before-2024"
+          # issues last updated between 01/01/2024 and 06/01/2024 will be labeled
+          DATE1="2024-01-01"
+          DATE2="2024-06-01"
+          LABEL="stale-q1-q2-2024"
 
-          echo "Labeling issues created before $CUTOFF_DATE with $LABEL"
+          echo "Labeling issues updated between $DATE1 and $DATE2 with $LABEL"
 
-          # Get all open issues created before the cutoff date
+          # Get all issues last updated between the two dates
           # Exclude issues with 'severity: high' or 'severity: critical' and 'issue: security' label and issues in milestones
           # NOTE: This will only process the first 100 issues due to pagination limitation
           curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/search/issues?q=repo:${{ github.repository }}+is:issue+is:open+created:%3C$CUTOFF_DATE+no:milestone+-label:%22severity:%20high%22+-label:%22severity:%20critical%22+-label:%22issue:%20security%22&per_page=100" | \
+            "https://api.github.com/search/issues?q=repo:${{ github.repository }}+is:issue+is:open+updated:${DATE1}..${DATE2}+no:milestone+-label:%22severity:%20high%22+-label:%22severity:%20critical%22+-label:%22issue:%20security%22&per_page=100" | \
             jq -r --arg label "$LABEL" ' 
               .items[] | 
               select(any(.labels[]?; .name == $label) | not) |

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -1,4 +1,4 @@
-name: Label Pre-2023 Issues
+name: Label Pre-2024 Issues
 on:
   workflow_dispatch: # Allows manual triggering from the Github UI
 
@@ -14,8 +14,8 @@ jobs:
       - name: Label old issues
         run: |
           # Set the cutoff date (issues created before this date will be labeled)
-          CUTOFF_DATE="2023-01-01"
-          LABEL="stale-before-2023"
+          CUTOFF_DATE="2024-01-01"
+          LABEL="stale-before-2024"
 
           echo "Labeling issues created before $CUTOFF_DATE with $LABEL"
 


### PR DESCRIPTION
in both actions: 
- removed permissions to PRs to speed up the process.

For Close stable actions script: 
- bumped to actions/stale@v9 so the default close reason is `not planned` instead.
- updated messages and timeline for closing. 