### PR TITLE
fix: add schema validation for custom fields to prevent #24083

### DIFF
--- a/packages/core/core/src/core-api/routes/validation/attributes.ts
+++ b/packages/core/core/src/core-api/routes/validation/attributes.ts
@@ -97,6 +97,21 @@ export const componentToSchema = (
 };
 
 /**
+ * Converts a customField attribute to a Zod schema.
+ * @param attribute - The CustomField attribute object from the Strapi schema.
+ * @returns A Zod schema representing the custom field.
+ */
+export const customFieldToSchema = (attribute: Schema.Attribute.CustomField): z.Schema => {
+  const { required } = attribute;
+
+  const schema = augmentSchema(z.any(), [
+    maybeRequired(required),
+  ]);
+
+  return schema.describe('A custom field');
+};
+
+/**
  * Converts a date attribute to a Zod schema.
  * @param attribute - The Date attribute object from the Strapi schema.
  * @returns A Zod schema representing the date field.
@@ -454,6 +469,21 @@ export const componentToInputSchema = (
   ]);
 
   return schema.describe('A component field');
+};
+
+/**
+ * Converts a customField attribute to a Zod schema for input validation.
+ * @param attribute - The CustomField attribute object from the Strapi schema.
+ * @returns A Zod schema for input validation of the custom field.
+ */
+export const customFieldToInputSchema = (attribute: Schema.Attribute.CustomField) => {
+  const { required } = attribute;
+
+  const schema = augmentSchema(z.any(), [
+    maybeRequired(required),
+  ]);
+
+  return schema.describe('A custom field');
 };
 
 /**

--- a/packages/core/core/src/core-api/routes/validation/mappers.ts
+++ b/packages/core/core/src/core-api/routes/validation/mappers.ts
@@ -97,6 +97,8 @@ export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): 
       return attributes.booleanToSchema(attribute);
     case 'component':
       return attributes.componentToSchema(attribute);
+    case 'customField':
+      return attributes.customFieldToSchema(attribute);
     case 'date':
       return attributes.dateToSchema(attribute);
     case 'datetime':
@@ -190,6 +192,8 @@ export const mapAttributeToInputSchema = (
       return attributes.booleanToInputSchema(attribute);
     case 'component':
       return attributes.componentToInputSchema(attribute);
+    case 'customField':
+      return attributes.customFieldToInputSchema(attribute);
     case 'date':
       return attributes.dateToInputSchema(attribute);
     case 'datetime':


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the issue as described in #24083 

### How to test it?

Reproduce the issue as described in #24083. Notice that you do not get the error when the changes from this PR are applied.

### Comments

In terms of the schema of a custom field I noticed a custom field can have the following additional attributes:

1. `customField` (required)
2. `required` (optional)
3. `options` (optional)

I noticed the following attributes do not have any effect on custom fields:

1. `writeable`
2. `default`

Taking this in to account, the only schema attribute that says anything about it's validation is the `required` attribute. So that is the only schema validation I've added for custom fields.

Also I've set the field type to `z.any()`, seeing how a custom field can be a variety of types (string, number, json ..)
