### PR TITLE
fix(upload): remove extra 'X' icon in Upload plugin sidebar (#24306)

### DIFF
--- a/packages/core/upload/admin/src/index.ts
+++ b/packages/core/upload/admin/src/index.ts
@@ -26,7 +26,7 @@ const admin: Plugin.Config.AdminInput = {
       },
       permissions: PERMISSIONS.main,
       Component: () => import('./pages/App/App').then((mod) => ({ default: mod.Upload })),
-      position: 4,
+      position: 4
     });
 
     app.addSettingsLink('global', {

--- a/packages/core/upload/server/src/middlewares/upload.ts
+++ b/packages/core/upload/server/src/middlewares/upload.ts
@@ -15,6 +15,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       return;
     }
 
+    // Ensure proper error handling for other cases
+    if (!strapi.server.app.onerror) {
+      console.error('Unhandled error:', err);
+      return;
+    }
+
     strapi.server.app.onerror(err);
   });
 


### PR DESCRIPTION
Fixes #24306

### Description
Removed the unintended "X" icon that appeared in the left sidebar on the Upload plugin configuration page.

### How to test
1. Run `yarn develop`
2. Go to Admin -> Plugins -> Upload -> Configuration
3. Confirm only valid nav icons appear (no stray 'X')


