### PR TITLE
fix: saving deletion of optional components not working

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,16 +6,16 @@ As of September 2025 (and until this document is updated), only the v4.x.x and v
 
 **Note**: The v4.x.x LTS version will only receive high/critical severity fixes until April 2026. Any Medium/Low severity issues will not be fixed unless specific exceptions are made.
 
-| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes                          |
-| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------------------------ |
-| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS                            |
-| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life                    |
-| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life                    |
-| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life                    |
-| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | Maintanence Period             |
-| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life                    |
-| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life                    |
-| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life                    |
+| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes              |
+| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------------ |
+| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS                |
+| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life        |
+| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life        |
+| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life        |
+| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | Maintanence Period |
+| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life        |
+| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life        |
+| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life        |
 
 ## Reporting a Vulnerability
 
@@ -54,13 +54,13 @@ Pursuant to the [CNA Operational Rules](https://www.cve.org/resourcessupport/all
   > 4.1.3 Well-documented or commonly understood non-default configuration or runtime changes made by an authorized user SHOULD NOT be determined to be Vulnerabilities.
 - Conditions or behaviors that do not lead to a security impact (CNA Operational Rule 4.1.2)
   > 4.1.2 Conditions or behaviors that do not lead to a security impact SHOULD NOT be determined to be Vulnerabilities. Examples of security impacts include an increase in access for an attacker, a decrease in availability of a target, or another violation of security policy.
-  
+
 In addition to the above stated rules, we will also apply some generic rules as well:
 
 - Any intentions to make threats against any team member, employee, or representative of Strapi or its partners
 - Any intentions to extort or otherwise blackmail a team member, employee, or representative of Strapi or its partners
 - Any vulnerability report made with malicious intent (such as overwhelming security resource personnel)
-  
+
 If any of these cases apply to a vulnerability report then the report will be immediately rejected and closed. In cases where applicable we will also report these people to any applicable authorities or security program groups.
 
 ## Security Process Summary

--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -32,9 +32,7 @@
       "type": "media",
       "multiple": true,
       "required": false,
-      "allowedTypes": [
-        "images"
-      ]
+      "allowedTypes": ["images"]
     },
     "city": {
       "type": "string",

--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -15,7 +15,6 @@
   "attributes": {
     "postal_code": {
       "type": "string",
-      "pluginOptions": {},
       "maxLength": 2
     },
     "categories": {
@@ -27,48 +26,48 @@
     "cover": {
       "type": "media",
       "multiple": false,
-      "required": false,
-      "pluginOptions": {}
+      "required": false
     },
     "images": {
       "type": "media",
       "multiple": true,
       "required": false,
-      "allowedTypes": ["images"],
-      "pluginOptions": {}
+      "allowedTypes": [
+        "images"
+      ]
     },
     "city": {
       "type": "string",
-      "required": true,
       "maxLength": 200,
-      "pluginOptions": {}
+      "required": true
     },
     "json": {
-      "type": "json",
-      "pluginOptions": {}
+      "type": "json"
     },
     "slug": {
       "type": "uid"
     },
     "notrepeat_req": {
       "type": "component",
-      "repeatable": false,
-      "pluginOptions": {},
       "component": "blog.test-como",
+      "repeatable": false,
       "required": true
+    },
+    "notrepeat_optional": {
+      "type": "component",
+      "component": "blog.test-como",
+      "repeatable": false
     },
     "repeat_req": {
       "type": "component",
-      "repeatable": true,
-      "pluginOptions": {},
       "component": "blog.test-como",
+      "repeatable": true,
       "required": true
     },
     "repeat_req_min": {
       "type": "component",
-      "repeatable": true,
-      "pluginOptions": {},
       "component": "blog.test-como",
+      "repeatable": true,
       "required": false,
       "min": 2
     }

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -277,7 +277,7 @@ const handleInvisibleAttributes = (
     // 🔹 Handle components
     if (attrDef.type === 'component') {
       const compSchema = components[attrDef.component];
-      const value = currentValue ?? initialValue;
+      const value = currentValue === undefined ? initialValue : currentValue;
 
       if (!value) {
         result[attrName] = attrDef.repeatable ? [] : null;

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
@@ -174,7 +174,7 @@ describe('data', () => {
                 repeatable: true,
                 required: false,
                 min: 2,
-              }
+              },
             },
           },
           initialValues: {

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
@@ -1,5 +1,5 @@
 import { testData } from '../../../../tests/data';
-import { removeProhibitedFields } from '../data';
+import { handleInvisibleAttributes, removeProhibitedFields } from '../data';
 
 const defaultFieldsValues = {
   name: 'name',
@@ -105,6 +105,122 @@ describe('data', () => {
           },
         ],
         updatedAt: '2020-04-28T13:22:13.033Z',
+      });
+    });
+  });
+
+  describe('handleInvisibleAttributes', () => {
+    it('should remove deleted components', () => {
+      const result = handleInvisibleAttributes(
+        {
+          documentId: 'xfwixs09jhwes2rw77cib73o',
+          notrepeat_req: {
+            id: 1,
+            name: 'toto',
+          },
+          notrepeat_optional: null,
+          repeat_req: [
+            {
+              id: 3,
+              name: 'foobar',
+            },
+          ],
+          repeat_req_min: [],
+        },
+        {
+          schema: {
+            uid: 'api::foo.bar',
+            kind: 'collectionType',
+            modelType: 'contentType',
+            modelName: 'bar',
+            globalId: 'FooBar',
+            info: {
+              displayName: 'FooBar',
+              singularName: 'foobar',
+              pluralName: 'foobars',
+              description: '',
+            },
+            options: {
+              draftAndPublish: false,
+            },
+            pluginOptions: {},
+            attributes: {
+              documentId: {
+                type: 'string',
+              },
+              id: {
+                type: 'integer',
+              },
+              notrepeat_req: {
+                type: 'component',
+                component: 'blog.test-como',
+                repeatable: false,
+                required: true,
+              },
+              notrepeat_optional: {
+                type: 'component',
+                component: 'blog.test-como',
+                repeatable: false,
+              },
+              repeat_req: {
+                type: 'component',
+                component: 'blog.test-como',
+                repeatable: true,
+                required: true,
+              },
+              repeat_req_min: {
+                type: 'component',
+                component: 'blog.test-como',
+                repeatable: true,
+                required: false,
+                min: 2,
+              }
+            },
+          },
+          initialValues: {
+            documentId: 'xfwixs09jhwes2rw77cib73o',
+            city: 'city x',
+            categories: {
+              connect: [],
+              disconnect: [],
+            },
+            notrepeat_req: {
+              id: 1,
+              name: 'toto',
+            },
+            notrepeat_optional: {
+              id: 4,
+              name: 'I will be deleted',
+            },
+            repeat_req: [
+              {
+                id: 3,
+                name: 'wow',
+              },
+            ],
+            repeat_req_min: [],
+          },
+          components: {},
+        }
+      );
+
+      expect(result).toEqual({
+        data: {
+          documentId: 'xfwixs09jhwes2rw77cib73o',
+          notrepeat_req: {
+            id: 1,
+            name: 'toto',
+          },
+          notrepeat_optional: null,
+          repeat_req: [
+            {
+              id: 3,
+              name: 'foobar',
+            },
+          ],
+          repeat_req_min: [],
+        },
+        removedAttributes: [],
       });
     });
   });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes an issue in v5.23.3 where deleted optional components reappeared after saving. Restores ability to save deletions correctly.

| Before fix | After fix |
| --- | --- |
| https://github.com/user-attachments/assets/d0b177d2-fff9-4489-995f-ba1673033e10 | https://github.com/user-attachments/assets/7966b6d1-d2c7-4a14-8dcc-cf805bc0ca03 |

### Why is it needed?

Because it should be possible to remove optional components. Behavior in Strapi content manager was broken.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/24315
