### PR TITLE
enhancement: remove default notification title

### DIFF
--- a/packages/core/admin/admin/src/features/Notifications.tsx
+++ b/packages/core/admin/admin/src/features/Notifications.tsx
@@ -148,38 +148,18 @@ const Notification = ({
     }
   }, [blockTransition, handleClose, timeout]);
 
-  let variant: AlertVariant;
-  let alertTitle: string;
-
-  if (type === 'info') {
-    variant = 'default';
-    alertTitle = formatMessage({
-      id: 'notification.default.title',
-      defaultMessage: 'Information:',
-    });
-  } else if (type === 'danger') {
-    variant = 'danger';
-    alertTitle = formatMessage({
-      id: 'notification.warning.title',
-      defaultMessage: 'Warning:',
-    });
-  } else if (type === 'warning') {
-    variant = 'warning';
-    alertTitle = formatMessage({
-      id: 'notification.warning.title',
-      defaultMessage: 'Warning:',
-    });
-  } else {
-    variant = 'success';
-    alertTitle = formatMessage({
-      id: 'notification.success.title',
-      defaultMessage: 'Success:',
-    });
-  }
-
-  if (title) {
-    alertTitle = title;
-  }
+  const getVariant = (): AlertVariant => {
+    switch (type) {
+      case 'info':
+        return 'default';
+      case 'danger':
+        return 'danger';
+      case 'warning':
+        return 'warning';
+      default:
+        return 'success';
+    }
+  };
 
   return (
     <Alert
@@ -195,8 +175,8 @@ const Notification = ({
         id: 'global.close',
         defaultMessage: 'Close',
       })}
-      title={alertTitle}
-      variant={variant}
+      title={title}
+      variant={getVariant()}
     >
       {message}
     </Alert>

--- a/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
+++ b/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
@@ -130,7 +130,7 @@ const CreateModal = ({ onClose }: ModalCreateProps) => {
         type: 'success',
         message: formatMessage({
           id: getTranslation('Settings.locales.modal.create.success'),
-          defaultMessage: 'Created locale',
+          defaultMessage: 'Locale successfully added',
         }),
       });
 

--- a/packages/plugins/i18n/admin/src/components/EditLocale.tsx
+++ b/packages/plugins/i18n/admin/src/components/EditLocale.tsx
@@ -114,7 +114,7 @@ const EditModal = ({ id, code, isDefault, name, open, onOpenChange }: EditModalP
         type: 'success',
         message: formatMessage({
           id: getTranslation('Settings.locales.modal.edit.success'),
-          defaultMessage: 'Updated locale',
+          defaultMessage: 'Locale successfully edited',
         }),
       });
 

--- a/packages/plugins/i18n/admin/src/components/tests/CreateLocale.test.tsx
+++ b/packages/plugins/i18n/admin/src/components/tests/CreateLocale.test.tsx
@@ -56,7 +56,7 @@ describe('Create Locale', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(await screen.findByText(/Success/)).toBeInTheDocument();
+    expect(await screen.findByText(/locale successfully added/i)).toBeInTheDocument();
   });
 
   it('should show an error if the creation fails', async () => {

--- a/packages/plugins/i18n/admin/src/components/tests/EditLocale.test.tsx
+++ b/packages/plugins/i18n/admin/src/components/tests/EditLocale.test.tsx
@@ -60,7 +60,7 @@ describe('Edit Locale', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(await screen.findByText(/Success/)).toBeInTheDocument();
+    expect(await screen.findByText(/locale successfully edited/i)).toBeInTheDocument();
   });
 
   it('should show an error if the update fails', async () => {

--- a/tests/e2e/tests/content-manager/cloning.spec.ts
+++ b/tests/e2e/tests/content-manager/cloning.spec.ts
@@ -43,7 +43,7 @@ test.describe('Cloning', () => {
     await expect(page.getByRole('button', { name: 'Row actions' }).first()).toBeEnabled();
     await page.getByRole('button', { name: 'Row actions' }).first().click();
     await page.getByRole('menuitem', { name: 'Duplicate' }).click();
-    await findAndClose(page, 'Success:Cloned document');
+    await findAndClose(page, 'Cloned document');
 
     /**
      * Now we should be in our edit view with the new document already saved.
@@ -92,7 +92,7 @@ test.describe('Cloning', () => {
      * Publish the document
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Now we'll go back to the list view to ensure the content has been updated
@@ -117,7 +117,7 @@ test.describe('Cloning', () => {
     await expect(page.getByRole('button', { name: 'Row actions' }).first()).toBeEnabled();
     await page.getByRole('button', { name: 'Row actions' }).first().click();
     await page.getByRole('menuitem', { name: 'Duplicate' }).click();
-    await findAndClose(page, 'Success:Cloned document');
+    await findAndClose(page, 'Cloned document');
 
     /**
      * Now we should be in our edit view with the new document already saved.
@@ -168,7 +168,7 @@ test.describe('Cloning', () => {
     await page.getByRole('textbox', { name: 'slug' }).fill('');
     await page.getByRole('textbox', { name: 'slug' }).fill('hammers-post-match-analysis');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Cloned document');
+    await findAndClose(page, 'Cloned document');
     await page.waitForURL(EDIT_URL_ARTICLE);
 
     /**

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -199,7 +199,7 @@ test.describe('Uniqueness', () => {
         await findAndClose(page, 'Saved document');
 
         await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
-        await expect(page.getByText('Warning:2 errors occurred')).toBeVisible();
+        await findAndClose(page, '2 errors occurred', { role: 'alert' });
 
         await clickAndWait(page, page.getByRole('button', { name: 'Delete' }).nth(1));
       }
@@ -227,7 +227,7 @@ test.describe('Uniqueness', () => {
       await findAndClose(page, 'Saved document');
 
       await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
-      await expect(page.getByText('Warning:This attribute must be unique')).toBeVisible();
+      await findAndClose(page, 'This attribute must be unique', { role: 'alert' });
 
       await navigateToListView(page);
       await changeLocale(page, 'French (fr)');

--- a/tests/e2e/tests/i18n/create-edit.spec.ts
+++ b/tests/e2e/tests/i18n/create-edit.spec.ts
@@ -94,7 +94,7 @@ test.describe('Create and Edit Operations', () => {
      * Publish the document
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Now we'll go back to the list view to ensure the content has been updated
@@ -211,7 +211,7 @@ test.describe('Create and Edit Operations', () => {
      * Publish the document
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Now we'll go back to the list view to ensure the content has been updated

--- a/tests/e2e/tests/i18n/editview.spec.ts
+++ b/tests/e2e/tests/i18n/editview.spec.ts
@@ -105,7 +105,7 @@ test.describe('Edit view', () => {
      * Publish the document
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Now we'll go back to the list view to ensure the content has been updated
@@ -224,7 +224,7 @@ test.describe('Edit view', () => {
      * Publish the document
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Now we'll go back to the list view to ensure the content has been updated
@@ -285,7 +285,7 @@ test.describe('Edit view', () => {
     // header is behind the permissions component.
     await page.evaluate(() => window.scrollTo(0, 0));
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Logout and login as editor
@@ -308,7 +308,7 @@ test.describe('Edit view', () => {
     await page.getByRole('link', { name: 'Create new entry' }).click();
     await page.getByLabel('title').fill('the richmond way');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Verify we cannot create a new entry in the french locale as editors do
@@ -333,7 +333,7 @@ test.describe('Edit view', () => {
     await page.getByRole('link', { name: 'Create new entry' }).click();
     await page.getByLabel('title').fill('trent crimm');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Create a Spanish (es) locale for the entry
@@ -342,7 +342,7 @@ test.describe('Edit view', () => {
     await page.getByRole('option', { name: 'Spanish (es)' }).click();
     await page.getByLabel('title').fill('dani rojas');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Delete the Spanish (es) locale entry
@@ -350,7 +350,7 @@ test.describe('Edit view', () => {
     await page.getByRole('button', { name: 'More actions' }).click();
     await page.getByRole('menuitem', { name: 'Delete entry (Spanish (es))' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
-    await findAndClose(page, 'Success:Deleted');
+    await findAndClose(page, 'Deleted');
 
     /**
      * Navigate to our homepage single-type and create a new entry
@@ -360,7 +360,7 @@ test.describe('Edit view', () => {
     await page.waitForURL(HOMEPAGE_LIST_URL);
     await page.getByLabel('title').fill('football is life');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Create a Spanish (es) locale for the homepage entry
@@ -369,7 +369,7 @@ test.describe('Edit view', () => {
     await page.getByRole('option', { name: 'Spanish (es)' }).click();
     await page.getByLabel('title').fill('el fútbol también es muerte.');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Delete the Spanish (es) locale homepage entry
@@ -377,7 +377,7 @@ test.describe('Edit view', () => {
     await page.getByRole('button', { name: 'More actions' }).click();
     await page.getByRole('menuitem', { name: 'Delete entry (Spanish (es))' }).click();
     await page.getByRole('button', { name: 'Confirm' }).click();
-    await findAndClose(page, 'Success:Deleted');
+    await findAndClose(page, 'Deleted');
   });
 
   test('As a user I want to publish multiple locales of my document', async ({ page, browser }) => {
@@ -427,7 +427,7 @@ test.describe('Edit view', () => {
      * Save the spanish draft
      */
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Open the bulk locale publish modal
@@ -486,7 +486,7 @@ test.describe('Edit view', () => {
      * Publish the english article
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     await page.getByRole('combobox', { name: 'Locales' }).click();
     await page.getByRole('option', { name: 'Spanish (es)' }).click();
@@ -512,13 +512,13 @@ test.describe('Edit view', () => {
      * Save the spanish draft
      */
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Publish the spanish article
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
 
     /**
      * Open the bulk locale unpublish modal

--- a/tests/e2e/tests/i18n/permissions.spec.ts
+++ b/tests/e2e/tests/i18n/permissions.spec.ts
@@ -49,7 +49,7 @@ test.describe('Locale Permissions', () => {
     // header is behind the permissions component.
     await page.evaluate(() => window.scrollTo(0, 0));
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Logout and login as editor
@@ -72,7 +72,7 @@ test.describe('Locale Permissions', () => {
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }));
     await page.getByLabel('title').fill('the richmond way');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Verify we cannot create a new entry in the french locale as editors do
@@ -92,7 +92,7 @@ test.describe('Locale Permissions', () => {
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }));
     await page.getByLabel('title').fill('trent crimm');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Create a Spanish (es) locale for the entry
@@ -101,7 +101,7 @@ test.describe('Locale Permissions', () => {
     await page.getByRole('option', { name: 'Spanish (es)' }).click();
     await page.getByLabel('title').fill('dani rojas');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Delete the Spanish (es) locale entry
@@ -109,7 +109,7 @@ test.describe('Locale Permissions', () => {
     await clickAndWait(page, page.getByRole('button', { name: 'More actions' }));
     await clickAndWait(page, page.getByRole('menuitem', { name: 'Delete entry (Spanish (es))' }));
     await clickAndWait(page, page.getByRole('button', { name: 'Confirm' }));
-    await findAndClose(page, 'Success:Deleted');
+    await findAndClose(page, 'Deleted');
 
     /**
      * Navigate to our homepage single-type and create a new entry
@@ -117,7 +117,7 @@ test.describe('Locale Permissions', () => {
     await navToHeader(page, ['Content Manager', 'Homepage'], 'Homepage');
     await page.getByLabel('title').fill('football is life');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Create a Spanish (es) locale for the homepage entry
@@ -126,7 +126,7 @@ test.describe('Locale Permissions', () => {
     await page.getByRole('option', { name: 'Spanish (es)' }).click();
     await page.getByLabel('title').fill('el fútbol también es muerte.');
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await findAndClose(page, 'Success:Saved');
+    await findAndClose(page, 'Saved');
 
     /**
      * Delete the Spanish (es) locale homepage entry
@@ -134,6 +134,6 @@ test.describe('Locale Permissions', () => {
     await clickAndWait(page, page.getByRole('button', { name: 'More actions' }));
     await clickAndWait(page, page.getByRole('menuitem', { name: 'Delete entry (Spanish (es))' }));
     await clickAndWait(page, page.getByRole('button', { name: 'Confirm' }));
-    await findAndClose(page, 'Success:Deleted');
+    await findAndClose(page, 'Deleted');
   });
 });

--- a/tests/e2e/tests/i18n/settings.spec.ts
+++ b/tests/e2e/tests/i18n/settings.spec.ts
@@ -45,7 +45,7 @@ test.describe('Settings', () => {
     await page.getByRole('option', { name: 'Italian (it)' }).click();
     await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Locale successfully added');
+    await findAndClose(page, 'Locale successfully added');
 
     /**
      * Next, we'll navigate to our shop single type & add the a localised version of this document.
@@ -127,7 +127,7 @@ test.describe('Settings', () => {
      * Successfully publish the entry once the data is valid.
      */
     await page.getByRole('button', { name: 'Publish' }).click();
-    await findAndClose(page, 'Success:Published');
+    await findAndClose(page, 'Published');
   });
 
   test('As a user I want to delete an existing locale and have the content deleted as well', async ({
@@ -158,7 +158,7 @@ test.describe('Settings', () => {
     await page.getByRole('button', { name: 'Delete French (fr) locale' }).click();
 
     await page.getByRole('button', { name: 'Confirm' }).click();
-    await findAndClose(page, 'Success:Locale successfully deleted');
+    await findAndClose(page, 'Locale successfully deleted');
 
     /**
      * Finally, go back to the list view, the english articles should be there,
@@ -206,7 +206,7 @@ test.describe('Settings', () => {
     await page.getByRole('gridcell', { name: 'English (en)', exact: true }).click();
     await page.getByRole('textbox', { name: 'Locale display name' }).fill('UK English');
     await page.getByRole('button', { name: 'Save' }).click();
-    await findAndClose(page, 'Success:Locale successfully edited');
+    await findAndClose(page, 'Locale successfully edited');
 
     /**
      * Lets go back to the list view and assert that the changes are reflected.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes the notification title that was added by default to the text of notifications. We were adding the notification variant as the title, but it looked clunky, and that information is still visible via the color and the toast and the icon.

before:

<img width="1900" height="770" alt="image" src="https://github.com/user-attachments/assets/b456fbe3-c251-418d-be16-5d7da75f33c1" />

after:

<img width="1812" height="904" alt="image" src="https://github.com/user-attachments/assets/00c8221b-e13b-4e54-9c7e-2ab2e22c1c6e" />

When the title is explicitly passed however, then it's still visible.
### Why is it needed?

It was redundant, it looked clunky. @lucasboilly also wanted to remove it.
### How to test it?

do anything that triggers a notification, e.g. updating an entry
