### PR TITLE
feat(packages/core/upload): improved disabled state for carousel input

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAssets.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { CarouselInput, CarouselSlide } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
+import { useTheme } from 'styled-components';
 
 import { getTrad } from '../../../utils/getTrad';
 import { EditAssetDialog } from '../../EditAssetDialog/EditAssetContent';
@@ -66,10 +67,28 @@ export const CarouselAssets = React.forwardRef(
 
     const currentAsset = assets[selectedAssetIndex];
 
+    const internalRef = React.useRef<HTMLDivElement>(null);
+    const parentRef = forwardedRef
+      ? (forwardedRef as React.RefObject<HTMLDivElement>)
+      : internalRef;
+
+    const theme = useTheme();
+
+    React.useEffect(() => {
+      if (parentRef.current) {
+        const firstChild = parentRef.current.firstElementChild as HTMLElement | null;
+        if (firstChild) {
+          firstChild.style.backgroundColor = disabled ? theme.colors.neutral150 : '';
+          firstChild.style.border = disabled ? theme.colors.neutral200 : '';
+        }
+      }
+    }, [disabled, parentRef, theme.colors.neutral150, theme.colors.neutral200]);
+
     return (
       <>
         <CarouselInput
-          ref={forwardedRef as React.Ref<HTMLDivElement>}
+          style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}
+          ref={parentRef}
           label={label}
           labelAction={labelAction}
           secondaryLabel={currentAsset?.name}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes two issues in the asset carousel component without touching the @strapi/design-system package:

 1. Overrides the background and border color applied by a nested child element so the disabled state displays correctly.
    - I used DOM manipulation to target the nested child element responsible for the background and border color, which avoids the need of direct change to @strapi/design-system

2. Makes the cursor change to not-allowed when the carousel input is filled.
   - Previously, the cursor style was applied in EmptyStateAsset.tsx. I applied this logic (style={{ cursor: disabled ? 'not-allowed' : 'pointer' }}) into CarouselAsset.tsx also, ensuring that the cursor correctly switches to the disabled form when the input is filled.
   
 Result - 
 

https://github.com/user-attachments/assets/cb408c83-a749-4723-b848-3199ac8737c1



### Why is it needed?

Without this we were facing two major issues - 

 - The carousel input doesn't use the disabled colors as the other ones.
 -  On a filled carousel input, the cursor doesn't change to it's disabled form.

### How to test it?

1. Run and login to a strapi admin panel (eg. /examples/gestarted).
2. Create a role "readOnly" with only read permissions on any collection or single type having a carousel input (eg. getstarted > singleType > Homepage > image input).
4. assign that "readOnly" role to another test user and login to that test account
5. Try to hover on the fields (eg. multiple image, single image etc) with and without asset filled to see the changes in action on the disabled carousel input field.

### Related issue(s)/PR(s)

#23308

