### PR TITLE
fix: remove refresh cookie from responses

### DIFF
--- a/packages/core/admin/server/src/controllers/authentication.ts
+++ b/packages/core/admin/server/src/controllers/authentication.ts
@@ -181,7 +181,6 @@ export default {
           data: {
             token: accessToken,
             accessToken,
-            refreshToken,
             user: getService('user').sanitizeUser(ctx.state.user),
           },
         } satisfies Login.Response;
@@ -245,7 +244,6 @@ export default {
         data: {
           token: accessToken,
           accessToken,
-          refreshToken,
           user: getService('user').sanitizeUser(user),
         },
       } satisfies Register.Response;
@@ -315,7 +313,6 @@ export default {
         data: {
           token: accessToken,
           accessToken,
-          refreshToken,
           user: getService('user').sanitizeUser(user),
         },
       };

--- a/packages/core/admin/shared/contracts/authentication.ts
+++ b/packages/core/admin/shared/contracts/authentication.ts
@@ -20,7 +20,6 @@ export declare namespace Login {
       // Primary token for the client to use. This is the short‑lived access token.
       token: string;
       accessToken?: string;
-      refreshToken?: string;
       user: Omit<SanitizedAdminUser, 'permissions'>;
     };
     errors?: errors.ApplicationError | errors.NotImplementedError;
@@ -80,7 +79,6 @@ export declare namespace Register {
     data: {
       token: string;
       accessToken?: string;
-      refreshToken?: string;
       user: Omit<SanitizedAdminUser, 'permissions'>;
     };
     errors?: errors.ApplicationError | errors.YupValidationError;
@@ -102,7 +100,6 @@ export declare namespace RegisterAdmin {
     data: {
       token: string;
       accessToken?: string;
-      refreshToken?: string;
       user: Omit<SanitizedAdminUser, 'permissions'>;
     };
     errors?: errors.ApplicationError | errors.YupValidationError;

--- a/tests/api/core/admin/admin-access-token-exchange.test.api.ts
+++ b/tests/api/core/admin/admin-access-token-exchange.test.api.ts
@@ -73,9 +73,9 @@ describe('Admin Access Token Exchange', () => {
     const loginRes = await rq.post('/admin/login', { body: superAdmin.loginInfo });
     expect(loginRes.statusCode).toBe(200);
 
-    const refreshToken = loginRes.body?.data?.refreshToken as string;
     const refreshCookie = getCookie(loginRes, cookieName)!;
     const pair = refreshCookie.split(';')[0];
+    const refreshToken = pair.split('=')[1];
 
     const payload = decode(refreshToken);
     const sessionId = payload.sessionId as string;
@@ -96,9 +96,9 @@ describe('Admin Access Token Exchange', () => {
     const loginRes = await rq.post('/admin/login', { body: superAdmin.loginInfo });
     expect(loginRes.statusCode).toBe(200);
 
-    const refreshToken = loginRes.body?.data?.refreshToken as string;
     const refreshCookie = getCookie(loginRes, cookieName)!;
     const pair = refreshCookie.split(';')[0];
+    const refreshToken = pair.split('=')[1];
     const payload = decode(refreshToken);
     const sessionId = payload.sessionId as string;
 

--- a/tests/api/core/admin/admin-strategy-sessions.test.api.ts
+++ b/tests/api/core/admin/admin-strategy-sessions.test.api.ts
@@ -78,8 +78,11 @@ describe('admin strategy', () => {
     });
     expect(loginRes.statusCode).toBe(200);
 
-    const refreshToken = loginRes.body?.data?.refreshToken as string;
-    expect(refreshToken).toEqual(expect.any(String));
+    // Extract refresh token from cookie instead of response body
+    const setCookies: string[] = loginRes.headers['set-cookie'] || [];
+    const refreshCookie = setCookies.find((c) => c.startsWith(`strapi_admin_refresh=`));
+    expect(refreshCookie).toBeDefined();
+    const refreshToken = refreshCookie!.split(';')[0].split('=')[1];
 
     const res = await createRequest({ strapi }).setToken(refreshToken).get('/admin/users/me');
     expect(res.statusCode).toBe(401);


### PR DESCRIPTION
### What does it do?

don't send refresh token because it's not needed with httpOnly; this way js doesn't even have access to it

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
