### PR TITLE
chore: gitignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,11 @@ tests/e2e/.env
 tests/cli/.env
 
 ############################
+# AI tools
+############################
+CLAUDE.local.md
+
+############################
 # Strapi
 ############################
 examples/**/types/generated


### PR DESCRIPTION
### What does it do?

Gitignores the CLAUDE.local.md file, as per the Claude guidelines. So we have a convenient way to experiment with Claude instructions and memory

https://www.anthropic.com/engineering/claude-code-best-practices
