### PR TITLE
Add setting crossOrigin attribute to 'anonymus' in image asset preview

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
@@ -36,7 +36,7 @@ export const AssetPreview = React.forwardRef<
 
   if (mime.includes(AssetType.Image)) {
     return (
-      <img ref={ref as React.ForwardedRef<HTMLImageElement>} src={url} alt={name} {...props} />
+      <img ref={ref as React.ForwardedRef<HTMLImageElement>} src={url} alt={name} {...props} crossOrigin="anonymous" />
     );
   }
 

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetContent.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetContent.test.tsx.snap
@@ -774,6 +774,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   >
                     <img
                       alt="Screenshot 2.png"
+                      crossorigin="anonymous"
                       src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
                     />
                   </div>

--- a/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.tsx.snap
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/tests/__snapshots__/EditAssetDialog.test.tsx.snap
@@ -774,6 +774,7 @@ exports[`<EditAssetDialog /> renders and matches the snapshot 1`] = `
                   >
                     <img
                       alt="Screenshot 2.png"
+                      crossorigin="anonymous"
                       src="http://localhost:1337/uploads/thumbnail_Screenshot_2_5d4a574d61.png"
                     />
                   </div>


### PR DESCRIPTION
### What does it do?

Adds the crossOrigin="anonymous" attribute to the <img> element in the AssetPreview component.

### Why is it needed?

When using upload providers such as AWS S3, edited images could not be saved because the canvas was marked as tainted by the browser.
This resulted in the following error during image export:
```
Uncaught (in promise) SecurityError: Failed to execute 'toBlob' on 'HTMLCanvasElement': 
Tainted canvases may not be exported.
```
Adding crossOrigin="anonymous" ensures that images are loaded in a way that keeps the canvas exportable when valid CORS headers are present.

### How to test it?

1. Configure Strapi to use the AWS S3 upload provider.
2. Upload an image asset.
3. Open the asset in the media library and try to edit/crop it.
4. Save the image.
5. ✅ The image should save successfully without errors.

### Regression risk / Breaking change
This change only adds a crossOrigin="anonymous" attribute to <img> elements in the asset preview.
It does not affect the rendering or functionality of images that are already being served from Strapi’s local provider.
No breaking changes are expected.

### Related issue(s) / PR(s)
Fixes: https://github.com/strapi/strapi/issues/22745
Related: https://github.com/strapi/strapi/issues/23742
Related: https://github.com/strapi/strapi/issues/21074