### PR TITLE
feat(homepage): add endpoints for widget move and resize actions

### DIFF
--- a/packages/core/admin/admin/src/services/homepage.ts
+++ b/packages/core/admin/admin/src/services/homepage.ts
@@ -32,16 +32,16 @@ const homepageService = adminApi
     }),
   });
 
-  const {
-    useGetKeyStatisticsQuery,
-    useGetCountDocumentsQuery,
-    useGetHomepageLayoutQuery,
-    useUpdateHomepageLayoutMutation,
-  } = homepageService;
-  
-  export {
-    useGetKeyStatisticsQuery,
-    useGetCountDocumentsQuery,
-    useGetHomepageLayoutQuery,
-    useUpdateHomepageLayoutMutation,
-  };
+const {
+  useGetKeyStatisticsQuery,
+  useGetCountDocumentsQuery,
+  useGetHomepageLayoutQuery,
+  useUpdateHomepageLayoutMutation,
+} = homepageService;
+
+export {
+  useGetKeyStatisticsQuery,
+  useGetCountDocumentsQuery,
+  useGetHomepageLayoutQuery,
+  useUpdateHomepageLayoutMutation,
+};

--- a/packages/core/admin/admin/src/services/homepage.ts
+++ b/packages/core/admin/admin/src/services/homepage.ts
@@ -18,9 +18,30 @@ const homepageService = adminApi
         transformResponse: (response: Homepage.GetCountDocuments.Response) => response.data,
         providesTags: (_, _err) => ['CountDocuments'],
       }),
+      getHomepageLayout: builder.query<Homepage.GetHomepageLayout.Response['data'], void>({
+        query: () => '/admin/homepage/layout',
+        transformResponse: (r: Homepage.GetHomepageLayout.Response) => r.data,
+      }),
+      updateHomepageLayout: builder.mutation<
+        Homepage.UpdateHomepageLayout.Response['data'],
+        Homepage.UpdateHomepageLayout.Request['body']
+      >({
+        query: (body) => ({ url: '/admin/homepage/layout', method: 'PUT', body }),
+        transformResponse: (r: Homepage.UpdateHomepageLayout.Response) => r.data,
+      }),
     }),
   });
 
-const { useGetKeyStatisticsQuery, useGetCountDocumentsQuery } = homepageService;
-
-export { useGetKeyStatisticsQuery, useGetCountDocumentsQuery };
+  const {
+    useGetKeyStatisticsQuery,
+    useGetCountDocumentsQuery,
+    useGetHomepageLayoutQuery,
+    useUpdateHomepageLayoutMutation,
+  } = homepageService;
+  
+  export {
+    useGetKeyStatisticsQuery,
+    useGetCountDocumentsQuery,
+    useGetHomepageLayoutQuery,
+    useUpdateHomepageLayoutMutation,
+  };

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'koa';
 import { getService } from '../utils';
-import { UserLayout, UserLayoutWrite } from './validation/schema';
+import { HomepageLayout, HomepageLayoutWrite } from './validation/schema';
 
 export default {
   async getKeyStatistics(): Promise<{
@@ -9,22 +9,19 @@ export default {
     const homepageService = getService('homepage');
     return { data: await homepageService.getKeyStatistics() };
   },
-  async getUserLayout(ctx: Context): Promise<{ data: UserLayout } | null> {
+  async getHomepageLayout(ctx: Context): Promise<{ data: HomepageLayout | null }> {
     const homepageService = getService('homepage');
     const userId = ctx.state.user?.id;
-    if (!userId) ctx.throw(401, 'Unauthorized');
 
-    const data = await homepageService.getUserLayout(userId);
-    if (!data) return null;
+    const data = await homepageService.getHomepageLayout(userId);
     return { data };
   },
-  async updateUserLayout(ctx: Context): Promise<{ data: UserLayout }> {
+  async updateHomepageLayout(ctx: Context): Promise<{ data: HomepageLayout }> {
     const homepageService = getService('homepage');
     const userId = ctx.state.user?.id;
-    if (!userId) ctx.throw(401, 'Unauthorized');
 
-    const body = ctx.request.body as UserLayoutWrite;
-    const data = await homepageService.updateUserLayout(userId, body);
+    const body = ctx.request.body as HomepageLayoutWrite;
+    const data = await homepageService.updateHomepageLayout(userId, body);
     return { data };
   },
 };

--- a/packages/core/admin/server/src/controllers/homepage.ts
+++ b/packages/core/admin/server/src/controllers/homepage.ts
@@ -1,4 +1,6 @@
+import type { Context } from 'koa';
 import { getService } from '../utils';
+import { UserLayout, UserLayoutWrite } from './validation/schema';
 
 export default {
   async getKeyStatistics(): Promise<{
@@ -6,5 +8,23 @@ export default {
   }> {
     const homepageService = getService('homepage');
     return { data: await homepageService.getKeyStatistics() };
+  },
+  async getUserLayout(ctx: Context): Promise<{ data: UserLayout } | null> {
+    const homepageService = getService('homepage');
+    const userId = ctx.state.user?.id;
+    if (!userId) ctx.throw(401, 'Unauthorized');
+
+    const data = await homepageService.getUserLayout(userId);
+    if (!data) return null;
+    return { data };
+  },
+  async updateUserLayout(ctx: Context): Promise<{ data: UserLayout }> {
+    const homepageService = getService('homepage');
+    const userId = ctx.state.user?.id;
+    if (!userId) ctx.throw(401, 'Unauthorized');
+
+    const body = ctx.request.body as UserLayoutWrite;
+    const data = await homepageService.updateUserLayout(userId, body);
+    return { data };
   },
 };

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -10,17 +10,19 @@ export const WidthSchema = z.union([
   z.literal(12),
 ]);
 
-export const UserLayoutSchema = z.object({
-  version: z.number().int().min(0),
+const widthsFieldSchema = z.record(WidgetUIDSchema, WidthSchema);
+
+export const HomepageLayoutSchema = z.object({
+  version: z.number().int().min(1),
   order: z.array(WidgetUIDSchema).max(100),
-  widths: z.record(WidgetUIDSchema, WidthSchema),
+  widths: widthsFieldSchema,
   updatedAt: z.string().datetime(),
 }).strict();
 
-export type UserLayout = z.infer<typeof UserLayoutSchema>;
+export type WidthsField = z.infer<typeof widthsFieldSchema>;
+export type HomepageLayout = z.infer<typeof HomepageLayoutSchema>;
 
-// PATCH accepts partial changes
-export const UserLayoutWriteSchema = z.object({
+export const HomepageLayoutWriteSchema = z.object({
   order: z.array(WidgetUIDSchema).max(100).optional(),
   widths: z.record(WidgetUIDSchema, WidthSchema).optional(),
 })
@@ -29,4 +31,4 @@ export const UserLayoutWriteSchema = z.object({
     message: "At least one of 'order' or 'widths' is required",
   });
 
-export type UserLayoutWrite = z.infer<typeof UserLayoutWriteSchema>;
+export type HomepageLayoutWrite = z.infer<typeof HomepageLayoutWriteSchema>;

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -1,37 +1,3 @@
-/*import { z } from "zod";
-
-export const WidgetUIDSchema = z.string().min(1);
-export const WidthSchema = z.number().int().min(1).max(12);
-
-// Incoming payload from the client (no version/updatedAt).
-// We also PRUNE widths whose keys are not present in `order`.
-export const UserLayoutWriteSchema = z
-  .object({
-    order: z.array(WidgetUIDSchema).max(100),
-    widths: z.record(WidgetUIDSchema, WidthSchema),
-  })
-  .strict()
-  // TODO Araks: do we need to delete orphaned widths?
-  .transform((data) => {
-    const allowed = new Set(data.order);
-    const pruned: Record<string, number> = {};
-    for (const [uid, w] of Object.entries(data.widths)) {
-      if (allowed.has(uid)) pruned[uid] = w;
-    }
-    return { ...data, widths: pruned };
-  });
-
-export const UserLayoutSchema = z
-  .object({
-    version: z.number().int().min(0),
-    order: z.array(WidgetUIDSchema).max(100),
-    widths: z.record(WidgetUIDSchema, WidthSchema),
-    updatedAt: z.string().datetime(),
-  })
-  .strict();
-
-export type UserLayoutWrite = z.infer<typeof UserLayoutWriteSchema>;
-export type UserLayout = z.infer<typeof UserLayoutSchema>;*/
 import { z } from "zod";
 
 export const WidgetUIDSchema = z.string().min(1);

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -24,8 +24,8 @@ export const HomepageLayoutWriteSchema = z
   .object({
     version: z.number().int().min(1).optional(),
     widgets: z.array(WidgetEntrySchema).max(100),
+    updatedAt: z.string().datetime().optional(),
   })
   .strict();
-
 
 export type HomepageLayoutWrite = z.infer<typeof HomepageLayoutWriteSchema>;

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -1,0 +1,66 @@
+/*import { z } from "zod";
+
+export const WidgetUIDSchema = z.string().min(1);
+export const WidthSchema = z.number().int().min(1).max(12);
+
+// Incoming payload from the client (no version/updatedAt).
+// We also PRUNE widths whose keys are not present in `order`.
+export const UserLayoutWriteSchema = z
+  .object({
+    order: z.array(WidgetUIDSchema).max(100),
+    widths: z.record(WidgetUIDSchema, WidthSchema),
+  })
+  .strict()
+  // TODO Araks: do we need to delete orphaned widths?
+  .transform((data) => {
+    const allowed = new Set(data.order);
+    const pruned: Record<string, number> = {};
+    for (const [uid, w] of Object.entries(data.widths)) {
+      if (allowed.has(uid)) pruned[uid] = w;
+    }
+    return { ...data, widths: pruned };
+  });
+
+export const UserLayoutSchema = z
+  .object({
+    version: z.number().int().min(0),
+    order: z.array(WidgetUIDSchema).max(100),
+    widths: z.record(WidgetUIDSchema, WidthSchema),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+export type UserLayoutWrite = z.infer<typeof UserLayoutWriteSchema>;
+export type UserLayout = z.infer<typeof UserLayoutSchema>;*/
+import { z } from "zod";
+
+export const WidgetUIDSchema = z.string().min(1);
+
+// widths must be one of 4, 6, 8, 12
+export const WidthSchema = z.union([
+  z.literal(4),
+  z.literal(6),
+  z.literal(8),
+  z.literal(12),
+]);
+
+export const UserLayoutSchema = z.object({
+  version: z.number().int().min(0),
+  order: z.array(WidgetUIDSchema).max(100),
+  widths: z.record(WidgetUIDSchema, WidthSchema),
+  updatedAt: z.string().datetime(),
+}).strict();
+
+export type UserLayout = z.infer<typeof UserLayoutSchema>;
+
+// PATCH accepts partial changes
+export const UserLayoutWriteSchema = z.object({
+  order: z.array(WidgetUIDSchema).max(100).optional(),
+  widths: z.record(WidgetUIDSchema, WidthSchema).optional(),
+})
+  .strict()
+  .refine((v) => v.order || v.widths, {
+    message: "At least one of 'order' or 'widths' is required",
+  });
+
+export type UserLayoutWrite = z.infer<typeof UserLayoutWriteSchema>;

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -1,34 +1,31 @@
-import { z } from "zod";
-
-export const WidgetUIDSchema = z.string().min(1);
+import { z } from 'zod';
 
 // widths must be one of 4, 6, 8, 12
-export const WidthSchema = z.union([
-  z.literal(4),
-  z.literal(6),
-  z.literal(8),
-  z.literal(12),
-]);
+export const WidthSchema = z.union([z.literal(4), z.literal(6), z.literal(8), z.literal(12)]);
 
-const widthsFieldSchema = z.record(WidgetUIDSchema, WidthSchema);
+const WidgetEntrySchema = z
+  .object({
+    uid: z.string().nonempty(),
+    width: WidthSchema,
+  })
+  .strict();
 
-export const HomepageLayoutSchema = z.object({
-  version: z.number().int().min(1),
-  order: z.array(WidgetUIDSchema).max(100),
-  widths: widthsFieldSchema,
-  updatedAt: z.string().datetime(),
-}).strict();
+export const HomepageLayoutSchema = z
+  .object({
+    version: z.number().int().min(1),
+    widgets: z.array(WidgetEntrySchema).max(100),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
 
-export type WidthsField = z.infer<typeof widthsFieldSchema>;
 export type HomepageLayout = z.infer<typeof HomepageLayoutSchema>;
 
-export const HomepageLayoutWriteSchema = z.object({
-  order: z.array(WidgetUIDSchema).max(100).optional(),
-  widths: z.record(WidgetUIDSchema, WidthSchema).optional(),
-})
-  .strict()
-  .refine((v) => v.order || v.widths, {
-    message: "At least one of 'order' or 'widths' is required",
-  });
+export const HomepageLayoutWriteSchema = z
+  .object({
+    version: z.number().int().min(1).optional(),
+    widgets: z.array(WidgetEntrySchema).max(100),
+  })
+  .strict();
+
 
 export type HomepageLayoutWrite = z.infer<typeof HomepageLayoutWriteSchema>;

--- a/packages/core/admin/server/src/routes/homepage.ts
+++ b/packages/core/admin/server/src/routes/homepage.ts
@@ -10,13 +10,13 @@ export default [
   {
     method: 'GET',
     path: '/homepage/layout',
-    handler: 'homepage.getUserLayout',
+    handler: 'homepage.getHomepageLayout',
     config: { policies: ['admin::isAuthenticatedAdmin'] },
   },
   {
     method: 'PUT',
     path: '/homepage/layout',
-    handler: 'homepage.updateUserLayout',
+    handler: 'homepage.updateHomepageLayout',
     config: { policies: ['admin::isAuthenticatedAdmin'] },
   },
 ];

--- a/packages/core/admin/server/src/routes/homepage.ts
+++ b/packages/core/admin/server/src/routes/homepage.ts
@@ -7,4 +7,16 @@ export default [
       policies: ['admin::isAuthenticatedAdmin'],
     },
   },
+  {
+    method: 'GET',
+    path: '/homepage/layout',
+    handler: 'homepage.getUserLayout',
+    config: { policies: ['admin::isAuthenticatedAdmin'] },
+  },
+  {
+    method: 'PUT',
+    path: '/homepage/layout',
+    handler: 'homepage.updateUserLayout',
+    config: { policies: ['admin::isAuthenticatedAdmin'] },
+  },
 ];

--- a/packages/core/admin/server/src/services/__tests__/homepage.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/homepage.test.ts
@@ -106,7 +106,7 @@ describe('homepageService', () => {
           { uid: 'x', width: 4 },
           { uid: 'y', width: 8 },
         ],
-        updatedAt
+        updatedAt,
       });
 
       expect(updated.version).toBe(1);

--- a/packages/core/admin/server/src/services/__tests__/homepage.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/homepage.test.ts
@@ -1,0 +1,123 @@
+import type { Core } from '@strapi/types';
+import { homepageService } from '../homepage';
+
+const createMockAdminStore = (initialValue?: any) => {
+  let storedValue = initialValue;
+  return {
+    get: jest.fn(async () => {
+      return storedValue;
+    }),
+    set: jest.fn(async ({ value }: { value: any }) => {
+      storedValue = value;
+    }),
+  };
+};
+
+describe('homepageService', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useRealTimers();
+  });
+
+  describe('getHomepageLayout', () => {
+    test('returns null when nothing stored', async () => {
+      const mockStore = createMockAdminStore(undefined);
+      const mockStrapi = {
+        store: () => mockStore,
+      } as unknown as Core.Strapi;
+
+      const service = homepageService({ strapi: mockStrapi });
+      const result = await service.getHomepageLayout(42);
+
+      expect(result).toBeNull();
+      expect(mockStore.get).toHaveBeenCalledWith({ key: 'homepage-layout:42' });
+    });
+
+    test('returns parsed layout when stored value exists', async () => {
+      const stored = {
+        version: 1,
+        widgets: [
+          { uid: 'w-1', width: 6 },
+          { uid: 'w-2', width: 12 },
+        ],
+        updatedAt: new Date().toISOString(),
+      };
+      const mockStore = createMockAdminStore(stored);
+      const mockStrapi = {
+        store: () => mockStore,
+      } as unknown as Core.Strapi;
+
+      const service = homepageService({ strapi: mockStrapi });
+      const result = await service.getHomepageLayout(7);
+
+      expect(result).toEqual(stored);
+      expect(mockStore.get).toHaveBeenCalledWith({ key: 'homepage-layout:7' });
+    });
+  });
+
+  describe('updateHomepageLayout', () => {
+    test('creates new layout when none exists', async () => {
+      const mockStore = createMockAdminStore(undefined);
+      const mockStrapi = {
+        store: () => mockStore,
+      } as unknown as Core.Strapi;
+
+      const service = homepageService({ strapi: mockStrapi });
+      const next = await service.updateHomepageLayout(5, {
+        widgets: [
+          { uid: 'a', width: 4 },
+          { uid: 'b', width: 8 },
+        ],
+      });
+
+      expect(next.version).toBe(1);
+      expect(Array.isArray(next.widgets)).toBe(true);
+      expect(next.widgets).toEqual([
+        { uid: 'a', width: 4 },
+        { uid: 'b', width: 8 },
+      ]);
+      expect(typeof next.updatedAt).toBe('string');
+      expect(Number.isNaN(Date.parse(next.updatedAt))).toBe(false);
+
+      expect(mockStore.set).toHaveBeenCalledWith({
+        key: 'homepage-layout:5',
+        value: next,
+      });
+    });
+
+    test('updates existing layout and persists provided widths', async () => {
+      const existing = {
+        version: 1,
+        widgets: [
+          { uid: 'x', width: 6 },
+          { uid: 'y', width: 12 },
+        ],
+        updatedAt: new Date().toISOString(),
+      };
+      const mockStore = createMockAdminStore(existing);
+      const mockStrapi = {
+        store: () => mockStore,
+      } as unknown as Core.Strapi;
+
+      const service = homepageService({ strapi: mockStrapi });
+      const updatedAt = new Date().toISOString();
+      const updated = await service.updateHomepageLayout(9, {
+        widgets: [
+          { uid: 'x', width: 4 },
+          { uid: 'y', width: 8 },
+        ],
+        updatedAt
+      });
+
+      expect(updated.version).toBe(1);
+      expect(updated.widgets).toEqual([
+        { uid: 'x', width: 4 },
+        { uid: 'y', width: 8 },
+      ]);
+      expect(updated.updatedAt).toBe(updatedAt);
+
+      expect(mockStore.get).toHaveBeenCalledWith({ key: 'homepage-layout:9' });
+      expect(mockStore.set).toHaveBeenCalledWith({ key: 'homepage-layout:9', value: updated });
+    });
+  });
+});

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -9,12 +9,12 @@ import {
 
 const DEFAULT_WIDTH = 6 as const;
 const keyFor = (userId: number) => `homepage-layout:${userId}`;
-const adminStore = strapi.store({ type: 'core', name: 'admin' });
 
 const isContentTypeVisible = (model: any) =>
   model?.pluginOptions?.['content-type-builder']?.visible !== false;
 
 export const homepageService = ({ strapi }: { strapi: Core.Strapi }) => {
+  const adminStore = strapi.store({ type: 'core', name: 'admin' });
   const getKeyStatistics = async () => {
     const contentTypes = Object.entries(strapi.contentTypes).filter(([, contentType]) => {
       return isContentTypeVisible(contentType);
@@ -63,7 +63,6 @@ export const homepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       ? HomepageLayoutSchema.parse(currentRaw)
       : null;
 
-    // Final order: replace only if provided
     const widgetsNext = write.widgets ?? current?.widgets ?? [];
 
     // Normalize widths (fill defaults where missing)
@@ -76,9 +75,9 @@ export const homepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     });
 
     const next: HomepageLayout = {
-      version: 1,
+      version: write.version ?? 1,
       widgets: normalizedWidgets,
-      updatedAt: new Date().toISOString(),
+      updatedAt: write.updatedAt ?? new Date().toISOString(),
     };
 
     await adminStore.set({ key, value: next });

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -5,7 +5,7 @@ import {
   HomepageLayoutSchema,
   HomepageLayoutWrite,
   HomepageLayoutWriteSchema,
-} from '../../src/controllers/validation/schema';
+} from '../controllers/validation/schema';
 
 const DEFAULT_WIDTH = 6 as const;
 const keyFor = (userId: number) => `homepage-layout:${userId}`;

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -1,5 +1,10 @@
 import { Core } from '@strapi/types';
 import { getService } from '../utils';
+import { UserLayout, UserLayoutSchema, UserLayoutWrite, UserLayoutWriteSchema } from '../../src/controllers/validation/schema';
+
+const STORE = { type: "core", name: "admin" } as const;
+const DEFAULT_WIDTH = 6 as const;
+const keyFor = (userId: number) => `homepage-layout:${userId}`;
 
 const isContentTypeVisible = (model: any) =>
   model?.pluginOptions?.['content-type-builder']?.visible !== false;
@@ -32,7 +37,59 @@ export const homepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     };
   };
 
+  const getUserLayout = async (
+    userId: number
+  ): Promise<UserLayout | null> => {
+    const store = await strapi.store(STORE);
+    const key = keyFor(userId);
+
+    const value = (await store.get({ key })) as unknown;
+    if (!value) {
+      // nothing saved yet
+      return null;
+    }
+
+    return UserLayoutSchema.parse(value);
+  };
+
+  const updateUserLayout = async (
+    userId: number,
+    input: unknown
+  ): Promise<UserLayout> => {
+    const write: UserLayoutWrite = UserLayoutWriteSchema.parse(input);
+
+    const store = await strapi.store(STORE);
+    const key = keyFor(userId);
+
+    const currentRaw = (await store.get({ key })) as unknown;
+    const current: UserLayout | null = currentRaw
+      ? UserLayoutSchema.parse(currentRaw)
+      : null;
+
+    // Final order: replace only if provided
+    const orderNext = write.order ?? current?.order ?? [];
+
+    // Build widths ONLY for UIDs present in the final order (prunes removed)
+    const widthsNext = {} as any;
+    for (const uid of orderNext) {
+      const incoming = write.widths?.[uid];
+      const existing = current?.widths[uid];
+      widthsNext[uid] = (incoming ?? existing ?? DEFAULT_WIDTH);
+    }
+
+    const next: UserLayout = {
+      version: (current?.version ?? 0) + 1,
+      order: orderNext,
+      widths: widthsNext,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await store.set({ key, value: next });
+    return next;
+  };
   return {
     getKeyStatistics,
+    getUserLayout,
+    updateUserLayout,
   };
 };

--- a/packages/core/admin/shared/contracts/homepage.ts
+++ b/packages/core/admin/shared/contracts/homepage.ts
@@ -61,3 +61,36 @@ export declare namespace GetCountDocuments {
     error?: errors.ApplicationError;
   }
 }
+
+export declare namespace Homepage {
+  export type WidgetUID = string;
+  export type Width = 4 | 6 | 8 | 12;
+
+  export interface Layout {
+    version: number;
+    order: WidgetUID[];
+    widths: Record<WidgetUID, Width>;
+    updatedAt: string;
+  }
+
+  export interface LayoutWrite {
+    order: WidgetUID[];
+    widths: Record<WidgetUID, Width>;
+  }
+}
+
+export declare namespace GetHomepageLayout {
+  export interface Response {
+    data: Homepage.Layout;
+  }
+}
+
+export declare namespace UpdateHomepageLayout {
+  export interface Request {
+    body: Homepage.LayoutWrite;
+  }
+
+  export interface Response {
+    data: Homepage.Layout;
+  }
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds backend support for persisting and retrieving the homepage layout (widget order and widths) per user.

### Why is it needed?

The admin homepage now allows dynamic widget resizing and reordering. Backend persistence ensures user preferences survive refreshes and sessions.

### How to test it?

1. Run the Strapi.
2. Log in with an authenticated admin user.
3. Call (you can use curl, Postman, or any other HTTP client):

#### GET  
```
GET /admin/homepage/layout
Authorization: Bearer <your-admin-token>

Response when layout exists:
{
  "version": 1,
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 8 }
  ],
  "updatedAt": "2025-09-11T12:34:56.000Z"
}
Response when no layout exists yet:
null
```

#### PUT
```
PUT /admin/homepage/layout
Authorization: Bearer <your-admin-token>

Request body:
{
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 8 }
  ]
}

Response:
{
  "version": 1,
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 8 }
  ],
  "updatedAt": "2025-09-12T09:45:00.000Z"
}
```

Notes:
version (defaults to 1) and updatedAt (set automatically on the backend to the current datetime) are optional in the request.

### Related issue(s)/PR(s)

https://github.com/strapi/content-squad/issues/77
