### PR TITLE
future(upload): generate image metadata on file upload

### DIFF
--- a/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
@@ -77,7 +77,7 @@ describe('Authenticated User Controller', () => {
         'AI token request failed. Check server logs for details.'
       );
 
-      expect(mockUserService.getAiToken).toHaveBeenCalledWith(mockUser);
+      expect(mockUserService.getAiToken).toHaveBeenCalledWith();
     });
 
     test('Should successfully return AI token when service succeeds', async () => {
@@ -92,7 +92,7 @@ describe('Authenticated User Controller', () => {
 
       await authenticatedUserController.getAiToken(ctx as any);
 
-      expect(mockUserService.getAiToken).toHaveBeenCalledWith(mockUser);
+      expect(mockUserService.getAiToken).toHaveBeenCalledWith();
       expect(ctx.body).toEqual({
         data: tokenData,
       });

--- a/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/authenticated-user.test.ts
@@ -3,11 +3,26 @@
 import createContext from '../../../../../../../tests/helpers/create-context';
 import authenticatedUserController from '../authenticated-user';
 
+// Mock the getService function
+const mockUserService = {
+  getAiToken: jest.fn(),
+};
+
+jest.mock('../../utils', () => ({
+  getService: jest.fn((serviceName: string) => {
+    if (serviceName === 'user') {
+      return mockUserService;
+    }
+    return {};
+  }),
+}));
+
 describe('Authenticated User Controller', () => {
   const ORIGINAL_ENV = process.env;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUserService.getAiToken.mockReset();
     process.env = { ...ORIGINAL_ENV }; // fresh copy for each test
 
     // Reset global fetch
@@ -42,60 +57,19 @@ describe('Authenticated User Controller', () => {
       );
     };
 
-    const createMockStrapi = (config = {}) => {
-      return {
-        ee: { isEE: true },
-        dirs: { app: { root: '/app' } },
-        config: {
-          get: jest.fn((key, defaultValue) => {
-            if (key === 'uuid') return 'test-project-id';
-            return defaultValue;
-          }),
-        },
-        log: {
-          info: jest.fn(),
-          error: jest.fn(),
-          http: jest.fn(),
-        },
-        ...config,
-      };
-    };
-
-    // Helper to setup standard valid environment
-    const setupValidEnvironment = () => {
-      process.env.STRAPI_LICENSE = 'test-license';
-      process.env.STRAPI_AI_URL = 'http://ai-server.com';
-    };
-
-    // Helper to create successful AI server response
-    const createSuccessfulFetch = (responseData = {}) => {
-      const defaultResponse = {
-        jwt: 'test-jwt-token',
-        expiresAt: '2025-01-01T12:00:00Z',
-      };
-
-      return jest.fn().mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({ ...defaultResponse, ...responseData }),
-      });
-    };
-
     test('Should return unauthorized when user is not authenticated', async () => {
       const ctx = createMockContext(null);
-      global.strapi = createMockStrapi() as any;
 
       await authenticatedUserController.getAiToken(ctx as any);
 
       expect(ctx.unauthorized).toHaveBeenCalledWith('Authentication required');
     });
 
-    test('Should return internal server error when no EE license is found', async () => {
+    test('Should return internal server error when service throws error', async () => {
       const ctx = createMockContext();
-      const mockStrapi = createMockStrapi() as any;
-      global.strapi = mockStrapi;
 
-      // Ensure no license is available
-      delete process.env.STRAPI_LICENSE;
+      // Mock service to throw an error
+      mockUserService.getAiToken.mockRejectedValueOnce(new Error('Service error'));
 
       await authenticatedUserController.getAiToken(ctx as any);
 
@@ -103,88 +77,24 @@ describe('Authenticated User Controller', () => {
         'AI token request failed. Check server logs for details.'
       );
 
-      // Check that the specific error was logged
-      expect(mockStrapi.log.error).toHaveBeenCalledWith(
-        'AI token request failed: No EE license found. Please ensure STRAPI_LICENSE environment variable is set or license.txt file exists.'
-      );
+      expect(mockUserService.getAiToken).toHaveBeenCalledWith(mockUser);
     });
 
-    test('Should return internal server error when AI server URL is not configured', async () => {
+    test('Should successfully return AI token when service succeeds', async () => {
       const ctx = createMockContext();
-      const mockStrapi = createMockStrapi() as any;
-      global.strapi = mockStrapi;
-
-      process.env.STRAPI_LICENSE = 'test-license';
-      delete process.env.STRAPI_AI_URL;
-      delete process.env.STRAPI_ADMIN_AI_URL;
-
-      await authenticatedUserController.getAiToken(ctx as any);
-
-      expect(ctx.internalServerError).toHaveBeenCalledWith(
-        'AI token request failed. Check server logs for details.'
-      );
-
-      // Check that the specific error was logged
-      expect(mockStrapi.log.error).toHaveBeenCalledWith(
-        'AI token request failed: AI server URL not configured. Please set STRAPI_ADMIN_AI_URL or STRAPI_AI_URL environment variable.'
-      );
-    });
-
-    test('Should return internal server error when project ID is not configured', async () => {
-      const ctx = createMockContext();
-      const mockStrapi = createMockStrapi({
-        config: {
-          get: jest.fn((key) => (key === 'uuid' ? null : 'default-value')),
-        },
-      }) as any;
-      global.strapi = mockStrapi;
-      setupValidEnvironment();
-
-      await authenticatedUserController.getAiToken(ctx as any);
-
-      expect(ctx.internalServerError).toHaveBeenCalledWith(
-        'AI token request failed. Check server logs for details.'
-      );
-
-      // Check that the specific error was logged
-      expect(mockStrapi.log.error).toHaveBeenCalledWith(
-        'AI token request failed: Project ID not configured'
-      );
-    });
-
-    test('Should successfully return AI token when all conditions are met', async () => {
-      const ctx = createMockContext();
-      const mockStrapi = createMockStrapi() as any;
-      global.strapi = mockStrapi;
-      setupValidEnvironment();
-
-      global.fetch = createSuccessfulFetch();
-
-      await authenticatedUserController.getAiToken(ctx as any);
-
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://ai-server.com/auth/getAiJWT',
-        expect.objectContaining({
-          method: 'POST',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
-          }),
-          body: expect.stringContaining('test-license'),
-        })
-      );
-
-      expect(ctx.body).toEqual({
-        data: {
-          token: 'test-jwt-token',
-          expiresAt: '2025-01-01T12:00:00Z',
-        },
-      });
-
-      // Check that the appropriate log messages were called
-      expect(mockStrapi.log.http).toHaveBeenCalledWith('Contacting AI Server for token generation');
-      expect(mockStrapi.log.info).toHaveBeenCalledWith('AI token generated successfully', {
-        userId: 1,
+      const tokenData = {
+        token: 'test-jwt-token',
         expiresAt: '2025-01-01T12:00:00Z',
+      };
+
+      // Mock service to return successful result
+      mockUserService.getAiToken.mockResolvedValueOnce(tokenData);
+
+      await authenticatedUserController.getAiToken(ctx as any);
+
+      expect(mockUserService.getAiToken).toHaveBeenCalledWith(mockUser);
+      expect(ctx.body).toEqual({
+        data: tokenData,
       });
     });
   });

--- a/packages/core/admin/server/src/controllers/authenticated-user.ts
+++ b/packages/core/admin/server/src/controllers/authenticated-user.ts
@@ -1,7 +1,4 @@
 import type { Context } from 'koa';
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
 import type { AdminUser } from '../../../shared/contracts/shared';
 
 import { getService } from '../utils';
@@ -57,146 +54,23 @@ export default {
   },
 
   async getAiToken(ctx: Context) {
-    const ERROR_PREFIX = 'AI token request failed:';
-    const USER_ERROR_MESSAGE = 'AI token request failed. Check server logs for details.';
-
     try {
       // Security check: Ensure user is authenticated and has proper permissions
       if (!ctx.state.user) {
         return ctx.unauthorized('Authentication required');
       }
 
-      // Check if EE features are enabled first
-      if (!strapi.ee?.isEE) {
-        strapi.log.error(`${ERROR_PREFIX} Enterprise Edition features are not enabled`);
-        return ctx.internalServerError(USER_ERROR_MESSAGE);
-      }
-
-      // Get the EE license
-      // First try environment variable, then try reading from file
-      let eeLicense = process.env.STRAPI_LICENSE;
-
-      if (!eeLicense) {
-        try {
-          const licensePath = path.join(strapi.dirs.app.root, 'license.txt');
-          eeLicense = fs.readFileSync(licensePath).toString();
-        } catch (error) {
-          // License file doesn't exist or can't be read
-        }
-      }
-
-      if (!eeLicense) {
-        strapi.log.error(
-          `${ERROR_PREFIX} No EE license found. Please ensure STRAPI_LICENSE environment variable is set or license.txt file exists.`
-        );
-        return ctx.internalServerError(USER_ERROR_MESSAGE);
-      }
-
-      const aiServerUrl = process.env.STRAPI_ADMIN_AI_URL || process.env.STRAPI_AI_URL;
-
-      if (!aiServerUrl) {
-        strapi.log.error(
-          `${ERROR_PREFIX} AI server URL not configured. Please set STRAPI_ADMIN_AI_URL or STRAPI_AI_URL environment variable.`
-        );
-        return ctx.internalServerError(USER_ERROR_MESSAGE);
-      }
-
-      // Get the current user
+      const userService = getService('user');
       const user = ctx.state.user as AdminUser;
 
-      // Create a secure user identifier using only user ID
-      const userIdentifier = user.id.toString();
+      const tokenData = await userService.getAiToken(user);
 
-      // Get project ID
-      const projectId = strapi.config.get('uuid');
-      if (!projectId) {
-        strapi.log.error(`${ERROR_PREFIX} Project ID not configured`);
-        return ctx.internalServerError(USER_ERROR_MESSAGE);
-      }
-
-      strapi.log.http('Contacting AI Server for token generation');
-
-      try {
-        // Call the AI server's getAiJWT endpoint
-        const response = await fetch(`${aiServerUrl}/auth/getAiJWT`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            // No authorization header needed for public endpoint
-            // Add request ID for tracing
-            'X-Request-Id': crypto.randomUUID(),
-          },
-          body: JSON.stringify({
-            eeLicense,
-            userIdentifier,
-            projectId,
-          }),
-        });
-
-        if (!response.ok) {
-          let errorData;
-          let errorText;
-          try {
-            errorText = await response.text();
-            errorData = JSON.parse(errorText);
-          } catch {
-            errorData = { error: errorText || 'Failed to parse error response' };
-          }
-
-          strapi.log.error(`${ERROR_PREFIX} ${errorData?.error || 'Unknown error'}`, {
-            status: response.status,
-            statusText: response.statusText,
-            error: errorData,
-            errorText,
-            projectId,
-          });
-
-          return ctx.internalServerError(USER_ERROR_MESSAGE);
-        }
-
-        let data;
-        try {
-          data = (await response.json()) as {
-            jwt: string;
-            expiresAt?: string;
-          };
-        } catch (parseError) {
-          strapi.log.error(`${ERROR_PREFIX} Failed to parse AI server response`, parseError);
-          return ctx.internalServerError(USER_ERROR_MESSAGE);
-        }
-
-        if (!data.jwt) {
-          strapi.log.error(`${ERROR_PREFIX} Invalid response: missing JWT token`);
-          return ctx.internalServerError(USER_ERROR_MESSAGE);
-        }
-
-        strapi.log.info('AI token generated successfully', {
-          userId: user.id,
-          expiresAt: data.expiresAt,
-        });
-
-        // Return the AI JWT with metadata
-        // Note: Token expires in 1 hour, client should handle refresh
-        ctx.body = {
-          data: {
-            token: data.jwt,
-            expiresAt: data.expiresAt, // 1 hour from generation
-          },
-        } satisfies GetAiToken.Response;
-      } catch (fetchError) {
-        if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-          strapi.log.error(`${ERROR_PREFIX} Request to AI server timed out`);
-          return ctx.internalServerError(USER_ERROR_MESSAGE);
-        }
-
-        throw fetchError;
-      }
+      ctx.body = {
+        data: tokenData,
+      } satisfies GetAiToken.Response;
     } catch (error) {
-      strapi.log.error(
-        `${ERROR_PREFIX} ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error
-      );
-      return ctx.internalServerError(USER_ERROR_MESSAGE);
+      const errorMessage = 'AI token request failed. Check server logs for details.';
+      return ctx.internalServerError(errorMessage);
     }
   },
 };

--- a/packages/core/admin/server/src/controllers/authenticated-user.ts
+++ b/packages/core/admin/server/src/controllers/authenticated-user.ts
@@ -60,10 +60,7 @@ export default {
         return ctx.unauthorized('Authentication required');
       }
 
-      const userService = getService('user');
-      const user = ctx.state.user as AdminUser;
-
-      const tokenData = await userService.getAiToken(user);
+      const tokenData = await getService('user').getAiToken();
 
       ctx.body = {
         data: tokenData,

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -401,10 +401,9 @@ const getLanguagesInUse = async (): Promise<string[]> => {
 };
 
 /**
- * Generate an AI token for the given user
- * @param user - The user to generate the token for
+ * Generate an AI token for the user performing the request
  */
-const getAiToken = async (user: AdminUser): Promise<{ token: string; expiresAt?: string }> => {
+const getAiToken = async (): Promise<{ token: string; expiresAt?: string }> => {
   const ERROR_PREFIX = 'AI token request failed:';
 
   // Check if EE features are enabled first
@@ -443,6 +442,12 @@ const getAiToken = async (user: AdminUser): Promise<{ token: string; expiresAt?:
   }
 
   // Create a secure user identifier using only user ID
+  const user = strapi.requestContext.get()?.state?.user as AdminUser | undefined;
+  if (!user) {
+    strapi.log.error(`${ERROR_PREFIX} No authenticated user in request context`);
+    throw new Error('AI token request failed. Check server logs for details.');
+  }
+
   const userIdentifier = user.id.toString();
 
   // Get project ID

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -3,6 +3,9 @@ import _ from 'lodash';
 import { defaults } from 'lodash/fp';
 import { arrays, errors } from '@strapi/utils';
 import type { Data } from '@strapi/types';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 import { createUser, hasSuperAdminRole } from '../domain/user';
 import type {
   AdminUser,
@@ -397,6 +400,135 @@ const getLanguagesInUse = async (): Promise<string[]> => {
   return users.map((user) => user.preferedLanguage || 'en');
 };
 
+/**
+ * Generate an AI token for the given user
+ * @param user - The user to generate the token for
+ */
+const getAiToken = async (user: AdminUser): Promise<{ token: string; expiresAt?: string }> => {
+  const ERROR_PREFIX = 'AI token request failed:';
+
+  // Check if EE features are enabled first
+  if (!strapi.ee?.isEE) {
+    strapi.log.error(`${ERROR_PREFIX} Enterprise Edition features are not enabled`);
+    throw new Error('AI token request failed. Check server logs for details.');
+  }
+
+  // Get the EE license
+  // First try environment variable, then try reading from file
+  let eeLicense = process.env.STRAPI_LICENSE;
+
+  if (!eeLicense) {
+    try {
+      const licensePath = path.join(strapi.dirs.app.root, 'license.txt');
+      eeLicense = fs.readFileSync(licensePath).toString();
+    } catch (error) {
+      // License file doesn't exist or can't be read
+    }
+  }
+
+  if (!eeLicense) {
+    strapi.log.error(
+      `${ERROR_PREFIX} No EE license found. Please ensure STRAPI_LICENSE environment variable is set or license.txt file exists.`
+    );
+    throw new Error('AI token request failed. Check server logs for details.');
+  }
+
+  const aiServerUrl = process.env.STRAPI_ADMIN_AI_URL || process.env.STRAPI_AI_URL;
+
+  if (!aiServerUrl) {
+    strapi.log.error(
+      `${ERROR_PREFIX} AI server URL not configured. Please set STRAPI_ADMIN_AI_URL or STRAPI_AI_URL environment variable.`
+    );
+    throw new Error('AI token request failed. Check server logs for details.');
+  }
+
+  // Create a secure user identifier using only user ID
+  const userIdentifier = user.id.toString();
+
+  // Get project ID
+  const projectId = strapi.config.get('uuid');
+  if (!projectId) {
+    strapi.log.error(`${ERROR_PREFIX} Project ID not configured`);
+    throw new Error('AI token request failed. Check server logs for details.');
+  }
+
+  strapi.log.http('Contacting AI Server for token generation');
+
+  try {
+    // Call the AI server's getAiJWT endpoint
+    const response = await fetch(`${aiServerUrl}/auth/getAiJWT`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // No authorization header needed for public endpoint
+        // Add request ID for tracing
+        'X-Request-Id': crypto.randomUUID(),
+      },
+      body: JSON.stringify({
+        eeLicense,
+        userIdentifier,
+        projectId,
+      }),
+    });
+
+    if (!response.ok) {
+      let errorData;
+      let errorText;
+      try {
+        errorText = await response.text();
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = { error: errorText || 'Failed to parse error response' };
+      }
+
+      strapi.log.error(`${ERROR_PREFIX} ${errorData?.error || 'Unknown error'}`, {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorData,
+        errorText,
+        projectId,
+      });
+
+      throw new Error('AI token request failed. Check server logs for details.');
+    }
+
+    let data;
+    try {
+      data = (await response.json()) as {
+        jwt: string;
+        expiresAt?: string;
+      };
+    } catch (parseError) {
+      strapi.log.error(`${ERROR_PREFIX} Failed to parse AI server response`, parseError);
+      throw new Error('AI token request failed. Check server logs for details.');
+    }
+
+    if (!data.jwt) {
+      strapi.log.error(`${ERROR_PREFIX} Invalid response: missing JWT token`);
+      throw new Error('AI token request failed. Check server logs for details.');
+    }
+
+    strapi.log.info('AI token generated successfully', {
+      userId: user.id,
+      expiresAt: data.expiresAt,
+    });
+
+    // Return the AI JWT with metadata
+    // Note: Token expires in 1 hour, client should handle refresh
+    return {
+      token: data.jwt,
+      expiresAt: data.expiresAt, // 1 hour from generation
+    };
+  } catch (fetchError) {
+    if (fetchError instanceof Error && fetchError.name === 'AbortError') {
+      strapi.log.error(`${ERROR_PREFIX} Request to AI server timed out`);
+      throw new Error('AI token request failed. Check server logs for details.');
+    }
+
+    throw fetchError;
+  }
+};
+
 export default {
   create,
   updateById,
@@ -416,4 +548,5 @@ export default {
   resetPasswordByEmail,
   getLanguagesInUse,
   isFirstSuperAdminUser,
+  getAiToken,
 };

--- a/packages/core/admin/shared/contracts/users.ts
+++ b/packages/core/admin/shared/contracts/users.ts
@@ -45,24 +45,6 @@ export declare namespace UpdateMe {
 }
 
 /**
- * GET /users/me/getAiToken - Get an AI token for the current admin user
- */
-export declare namespace GetAiToken {
-  export interface Request {
-    query: {};
-    body: {};
-  }
-
-  export interface Response {
-    data: {
-      token: string;
-      expiresAt?: string;
-    };
-    error?: errors.ApplicationError;
-  }
-}
-
-/**
  * GET /users/me/permissions - Get the permissions of the current admin user
  */
 export declare namespace GetOwnPermissions {

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -1,0 +1,109 @@
+import type { Context } from 'koa';
+
+import adminUploadController from '../admin-upload';
+import { getService } from '../../utils';
+import { validateUploadBody } from '../validation/admin/upload';
+
+jest.mock('../../utils');
+jest.mock('../validation/admin/upload');
+
+const mockGetService = getService as jest.MockedFunction<typeof getService>;
+const mockValidateUploadBody = validateUploadBody as jest.MockedFunction<typeof validateUploadBody>;
+
+describe('Admin Upload Controller - AI Service Connection', () => {
+  let mockContext: Partial<Context>;
+  let mockAiMetadataService: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAiMetadataService = {
+      isEnabled: jest.fn(),
+      processFiles: jest.fn(),
+    };
+
+    mockGetService.mockImplementation((serviceName: string) => {
+      if (serviceName === 'aiMetadata') {
+        return mockAiMetadataService;
+      }
+      return {
+        upload: jest.fn().mockResolvedValue([{}]),
+        signFileUrls: jest.fn((file) => Promise.resolve(file)),
+      };
+    });
+
+    global.strapi = {
+      service: jest.fn().mockReturnValue({
+        createPermissionsManager: jest.fn().mockReturnValue({
+          isAllowed: true,
+          sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
+        }),
+      }),
+      admin: {
+        services: {
+          permission: {
+            createPermissionsManager: jest.fn().mockReturnValue({
+              isAllowed: true,
+              sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
+            }),
+          },
+        },
+      },
+      log: {
+        warn: jest.fn(),
+      },
+    } as any;
+
+    mockContext = {
+      state: {
+        userAbility: {},
+        user: { id: 1 },
+      },
+      request: {
+        body: {},
+        files: { files: { filepath: '/tmp/test.jpg', mimetype: 'image/jpeg' } },
+      } as any,
+      forbidden: jest.fn(),
+    } as any;
+
+    mockValidateUploadBody.mockResolvedValue({
+      fileInfo: { name: 'test.jpg', alternativeText: '', caption: '', folder: null },
+    } as any);
+  });
+
+  describe('uploadFiles - AI Service Connection', () => {
+    it('should call AI processFiles when service is enabled', async () => {
+      mockAiMetadataService.isEnabled.mockReturnValue(true);
+      mockAiMetadataService.processFiles.mockResolvedValue([{}]);
+
+      await adminUploadController.uploadFiles(mockContext as Context);
+
+      expect(mockAiMetadataService.processFiles).toHaveBeenCalledWith([
+        expect.objectContaining({
+          filepath: '/tmp/test.jpg',
+          mimetype: 'image/jpeg',
+        }),
+      ]);
+    });
+
+    it('should not call AI processFiles when service is disabled', async () => {
+      mockAiMetadataService.isEnabled.mockReturnValue(false);
+
+      await adminUploadController.uploadFiles(mockContext as Context);
+
+      expect(mockAiMetadataService.processFiles).not.toHaveBeenCalled();
+    });
+
+    it('should handle AI service errors gracefully', async () => {
+      mockAiMetadataService.isEnabled.mockReturnValue(true);
+      mockAiMetadataService.processFiles.mockRejectedValue(new Error('AI service unavailable'));
+
+      await adminUploadController.uploadFiles(mockContext as Context);
+
+      expect(strapi.log.warn).toHaveBeenCalledWith(
+        'AI metadata generation failed, proceeding without AI enhancements',
+        { error: 'AI service unavailable' }
+      );
+    });
+  });
+});

--- a/packages/core/upload/server/src/services/__tests__/ai-metadata.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/ai-metadata.test.ts
@@ -1,0 +1,233 @@
+import { readFile } from 'node:fs/promises';
+import { createAIMetadataService } from '../ai-metadata';
+import type { InputFile } from '../../types';
+
+// Mock dependencies
+jest.mock('node:fs/promises');
+const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
+
+// Mock fetch globally
+global.fetch = jest.fn();
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+// Mock FormData
+global.FormData = jest.fn().mockImplementation(() => ({
+  append: jest.fn(),
+}));
+
+// Mock Blob
+global.Blob = jest.fn().mockImplementation((parts, options) => ({
+  parts,
+  type: options?.type,
+}));
+
+describe('AI Metadata Service', () => {
+  let mockStrapi: any;
+  let aiMetadataService: ReturnType<typeof createAIMetadataService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockStrapi = {
+      config: {
+        get: jest.fn(),
+      },
+      ee: {
+        isEE: true,
+      },
+      service: jest.fn().mockReturnValue({
+        getAiToken: jest.fn().mockResolvedValue({ token: 'mock-token' }),
+      }),
+      log: {
+        http: jest.fn(),
+        warn: jest.fn(),
+      },
+    };
+
+    // Set default environment
+    process.env.STRAPI_AI_URL = 'https://ai.strapi.com';
+
+    aiMetadataService = createAIMetadataService({ strapi: mockStrapi });
+  });
+
+  afterEach(() => {
+    delete process.env.STRAPI_AI_URL;
+    delete process.env.STRAPI_ADMIN_AI_URL;
+  });
+
+  describe('isEnabled', () => {
+    it('should return true when AI is enabled and EE is available', () => {
+      mockStrapi.config.get.mockReturnValue(true);
+      mockStrapi.ee.isEE = true;
+
+      expect(aiMetadataService.isEnabled()).toBe(true);
+      expect(mockStrapi.config.get).toHaveBeenCalledWith('admin.ai.enabled', false);
+    });
+
+    it('should return false when AI is disabled but EE is available', () => {
+      mockStrapi.config.get.mockReturnValue(false);
+      mockStrapi.ee.isEE = true;
+
+      expect(aiMetadataService.isEnabled()).toBe(false);
+    });
+
+    it('should return false when AI is enabled but EE is not available', () => {
+      mockStrapi.config.get.mockReturnValue(true);
+      mockStrapi.ee.isEE = false;
+
+      expect(aiMetadataService.isEnabled()).toBe(false);
+    });
+
+    it('should return false when both AI and EE are disabled', () => {
+      mockStrapi.config.get.mockReturnValue(false);
+      mockStrapi.ee.isEE = false;
+
+      expect(aiMetadataService.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('processFiles', () => {
+    const mockImageFile: InputFile = {
+      filepath: '/tmp/image.jpg',
+      mimetype: 'image/jpeg',
+      originalFilename: 'image.jpg',
+      size: 1024,
+    } as InputFile;
+
+    const mockPdfFile: InputFile = {
+      filepath: '/tmp/document.pdf',
+      mimetype: 'application/pdf',
+      originalFilename: 'document.pdf',
+      size: 2048,
+    } as InputFile;
+
+    beforeEach(() => {
+      // Mock service as enabled by default
+      mockStrapi.config.get.mockReturnValue(true);
+      mockStrapi.ee.isEE = true;
+
+      // Mock readFile to return proper Buffer with .buffer property
+      const mockBuffer = Buffer.from('image-data');
+      mockReadFile.mockResolvedValue(mockBuffer);
+    });
+
+    describe('error cases', () => {
+      it('should throw error when service is disabled', async () => {
+        mockStrapi.config.get.mockReturnValue(false);
+
+        await expect(aiMetadataService.processFiles([mockImageFile])).rejects.toThrow(
+          'AI Metadata service is not enabled'
+        );
+      });
+    });
+
+    describe('non-image file handling', () => {
+      it('should return array of nulls for non-image files', async () => {
+        const result = await aiMetadataService.processFiles([mockPdfFile]);
+
+        expect(result).toEqual([null]);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should return proper sparse array for mixed file types', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            results: [{ altText: 'image alt', caption: 'image caption' }],
+          }),
+        } as any);
+
+        const files = [mockPdfFile, mockImageFile, mockPdfFile];
+        const result = await aiMetadataService.processFiles(files);
+
+        expect(result).toEqual([null, { altText: 'image alt', caption: 'image caption' }, null]);
+      });
+    });
+
+    describe('image file processing', () => {
+      it('should process single image file correctly', async () => {
+        const expectedMetadata = { altText: 'A beautiful image', caption: 'Image caption' };
+
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            results: [expectedMetadata],
+          }),
+        } as any);
+
+        const result = await aiMetadataService.processFiles([mockImageFile]);
+
+        expect(result).toEqual([expectedMetadata]);
+        expect(mockReadFile).toHaveBeenCalledWith('/tmp/image.jpg');
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://ai.strapi.com/media-library/generate-metadata',
+          {
+            method: 'POST',
+            body: expect.any(Object),
+            headers: {
+              Authorization: 'Bearer mock-token',
+            },
+          }
+        );
+      });
+
+      it('should process multiple image files correctly', async () => {
+        const mockImageFile2: InputFile = {
+          filepath: '/tmp/image2.png',
+          mimetype: 'image/png',
+          originalFilename: 'image2.png',
+          size: 2048,
+        } as InputFile;
+
+        const expectedMetadata = [
+          { altText: 'First image', caption: 'First caption' },
+          { altText: 'Second image', caption: 'Second caption' },
+        ];
+
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            results: expectedMetadata,
+          }),
+        } as any);
+
+        const result = await aiMetadataService.processFiles([mockImageFile, mockImageFile2]);
+
+        expect(result).toEqual(expectedMetadata);
+        expect(mockReadFile).toHaveBeenCalledTimes(2);
+      });
+
+      it('should handle mixed file types with correct sparse array mapping', async () => {
+        const mockImageFile2: InputFile = {
+          filepath: '/tmp/image2.png',
+          mimetype: 'image/png',
+          originalFilename: 'image2.png',
+          size: 2048,
+        } as InputFile;
+
+        const expectedMetadata = [
+          { altText: 'First image', caption: 'First caption' },
+          { altText: 'Second image', caption: 'Second caption' },
+        ];
+
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            results: expectedMetadata,
+          }),
+        } as any);
+
+        // Order: image, pdf, image, pdf
+        const files = [mockImageFile, mockPdfFile, mockImageFile2, mockPdfFile];
+        const result = await aiMetadataService.processFiles(files);
+
+        expect(result).toEqual([
+          expectedMetadata[0], // first image
+          null, // pdf
+          expectedMetadata[1], // second image
+          null, // pdf
+        ]);
+      });
+    });
+  });
+});

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -1,0 +1,16 @@
+import type { Core } from '@strapi/types';
+
+const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
+  return {
+    isEnabled() {
+      const isAIEnabled = strapi.config.get('admin.ai.enabled', false);
+
+      // TODO replace by a specific feature check once it's set up in the license registry
+      const { isEE } = strapi.ee;
+
+      return isAIEnabled && isEE;
+    },
+  };
+};
+
+export { createAIMetadataService };

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -16,11 +16,28 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
       return isAIEnabled && isEE;
     },
 
-    async processFiles(files: InputFile[]) {
-      const userService = strapi.service('admin::user');
+    async processFiles(
+      files: InputFile[]
+    ): Promise<Array<{ altText: string; caption: string } | null>> {
+      if (!this.isEnabled() || !aiServerUrl) {
+        throw new Error('AI Metadata service is not enabled');
+      }
+
+      // Filter for image files only and track their original positions
+      // We need to maintain the original indices so we can map AI results back correctly
+      const imageFiles = files
+        .map((file, index) => ({ file, originalIndex: index }))
+        .filter(({ file }) => file.mimetype?.startsWith('image/'));
+
+      // If no image files, return sparse array with all nulls to avoid calling the AI server
+      // This maintains the same array length as input files for proper index alignment
+      if (imageFiles.length === 0) {
+        return new Array(files.length).fill(null);
+      }
+
       const formData = new FormData();
 
-      for (const file of files) {
+      for (const { file } of imageFiles) {
         const fileBuffer = await readFile(file.filepath);
         const blob = new Blob([fileBuffer.buffer as ArrayBuffer], {
           type: file.mimetype || undefined,
@@ -28,8 +45,7 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
         formData.append('files', blob);
       }
 
-      // TODO: move user retrieval within getAiToken
-      const { token } = await userService.getAiToken();
+      const { token } = await strapi.service('admin::user').getAiToken();
 
       strapi.log.http('Contacting AI Server for media metadata generation');
       const res = await fetch(`${aiServerUrl}/media-library/generate-metadata`, {
@@ -54,8 +70,16 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
       });
 
       const { results } = responseSchema.parse(await res.json());
-      strapi.log.http('Media metadata generated successfully');
-      return results;
+      strapi.log.http(`Media metadata generated successfully for ${results.length} files`);
+
+      // Create sparse array with results at original indices
+      // Example: files=[img1, pdf, img2] -> imageFiles=[{img1, index:0}, {img2, index:2}]
+      // AI results=[meta1, meta2] -> sparse=[meta1, null, meta2]
+      // This ensures metadata[i] corresponds to files[i], with null for non-images
+      return imageFiles.reduce((sparseResults, { originalIndex }, resultIndex) => {
+        sparseResults[originalIndex] = results[resultIndex];
+        return sparseResults;
+      }, new Array(files.length).fill(null));
     },
   };
 };

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -1,6 +1,11 @@
 import type { Core } from '@strapi/types';
+import { readFile } from 'node:fs/promises';
+import type { File } from 'formidable';
+import { z } from 'zod';
 
 const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
+  const aiServerUrl = process.env.STRAPI_ADMIN_AI_URL || process.env.STRAPI_AI_URL;
+
   return {
     isEnabled() {
       const isAIEnabled = strapi.config.get('admin.ai.enabled', false);
@@ -9,6 +14,48 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
       const { isEE } = strapi.ee;
 
       return isAIEnabled && isEE;
+    },
+
+    async processFiles(files: File[]) {
+      const userService = strapi.service('admin::user');
+      const formData = new FormData();
+
+      for (const file of files) {
+        const fileBuffer = await readFile(file.filepath);
+        const blob = new Blob([fileBuffer.buffer as ArrayBuffer], {
+          type: file.mimetype || undefined,
+        });
+        formData.append('files', blob);
+      }
+
+      // TODO: move user retrieval within getAiToken
+      const { token } = await userService.getAiToken();
+
+      strapi.log.http('Contacting AI Server for media metadata generation');
+      const res = await fetch(`${aiServerUrl}/media-library/generate-metadata`, {
+        method: 'POST',
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        throw Error(`AI metadata generation failed`, { cause: await res.text() });
+      }
+
+      const responseSchema = z.object({
+        results: z.array(
+          z.object({
+            altText: z.string(),
+            caption: z.string(),
+          })
+        ),
+      });
+
+      const { results } = responseSchema.parse(await res.json());
+      strapi.log.http('Media metadata generated successfully');
+      return results;
     },
   };
 };

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -1,7 +1,7 @@
 import type { Core } from '@strapi/types';
 import { readFile } from 'node:fs/promises';
-import type { File } from 'formidable';
 import { z } from 'zod';
+import { InputFile } from '../types';
 
 const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
   const aiServerUrl = process.env.STRAPI_ADMIN_AI_URL || process.env.STRAPI_AI_URL;
@@ -16,7 +16,7 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
       return isAIEnabled && isEE;
     },
 
-    async processFiles(files: File[]) {
+    async processFiles(files: InputFile[]) {
       const userService = strapi.service('admin::user');
       const formData = new FormData();
 

--- a/packages/core/upload/server/src/services/index.ts
+++ b/packages/core/upload/server/src/services/index.ts
@@ -7,6 +7,7 @@ import weeklyMetrics from './weekly-metrics';
 import metrics from './metrics';
 import apiUploadFolder from './api-upload-folder';
 import extensions from './extensions';
+import { createAIMetadataService } from './ai-metadata';
 
 export const services = {
   provider,
@@ -18,4 +19,5 @@ export const services = {
   'image-manipulation': imageManipulation,
   'api-upload-folder': apiUploadFolder,
   extensions,
+  aiMetadata: createAIMetadataService,
 };

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -240,7 +240,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const fileInfoArray = Array.isArray(fileInfo) ? fileInfo : [fileInfo];
 
       const doUpload = async (file: InputFile, fileInfo: FileInfo) => {
-        console.log('file info', fileInfo);
         const fileData = await enhanceAndValidateFile(file, fileInfo, metas);
         return uploadFileAndPersist(fileData, { user });
       };

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -223,7 +223,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       files,
     }: {
       data: Record<string, unknown>;
-      files: InputFile[];
+      files: InputFile | InputFile[];
     },
     opts?: CommonOptions
   ) {

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -223,7 +223,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       files,
     }: {
       data: Record<string, unknown>;
-      files: InputFile | InputFile[];
+      files: InputFile[];
     },
     opts?: CommonOptions
   ) {
@@ -240,6 +240,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const fileInfoArray = Array.isArray(fileInfo) ? fileInfo : [fileInfo];
 
       const doUpload = async (file: InputFile, fileInfo: FileInfo) => {
+        console.log('file info', fileInfo);
         const fileData = await enhanceAndValidateFile(file, fileInfo, metas);
         return uploadFileAndPersist(fileData, { user });
       };

--- a/packages/core/upload/server/src/utils/index.ts
+++ b/packages/core/upload/server/src/utils/index.ts
@@ -7,6 +7,7 @@ import type file from '../services/file';
 import type weeklyMetrics from '../services/weekly-metrics';
 import type metrics from '../services/metrics';
 import type extensions from '../services/extensions';
+import type { createAIMetadataService } from '../services/ai-metadata';
 
 type Services = {
   upload: ReturnType<typeof upload>;
@@ -18,6 +19,7 @@ type Services = {
   metrics: ReturnType<typeof metrics>;
   'api-upload-folder': typeof apiUploadFolder;
   extensions: typeof extensions;
+  aiMetadata: ReturnType<typeof createAIMetadataService>;
 };
 
 export const getService = <TName extends keyof Services>(name: TName): Services[TName] => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- moves the admin's getAiToken into a service (so we can retrieve the token from the upload plugin)
- create an aiMetadata service on the upload plugin with:
  - isEnabled method: check if feature should be on
  - processFiles method: takes files, sends them to the ai server, returns the metadata
- hooks the upload controller to this processFiles method.

### How to test it?

- Check that getAiToken is not broken. For this, clear session storage, refresh and open the CTB chat.
- Upload an image from the media library page. Then click on the pen icon to edit its metadata. You should see the AI-generated caption and alt text already there
- Upload multiple files at once. Some that are images, some that are not. Only the images should get AI metadata. Make sure the metadata is for the right images
 and do it again
