### PR TITLE
fix: configure ai ctb csp middleware without overriding user or default config

### DIFF
--- a/packages/core/content-type-builder/server/src/register.ts
+++ b/packages/core/content-type-builder/server/src/register.ts
@@ -1,67 +1,63 @@
-import { mergeWith } from 'lodash/fp';
-
 /**
- * Utility to extend Strapi configuration middlewares. Mainly used to extend the CSP directives from the security middleware.
+ * This file ensures that the Strapi security middleware's Content Security Policy (CSP)
+ * allows images and media from both the default sources ("'self'", 'data:', 'blob:')
+ * and the required S3 domains for AI features. It checks for existing 'img-src' and 'media-src'
+ * directives and adds the S3 domains if not present. If no directives exist but useDefaults is true,
+ * it adds the defaults plus the S3 domains. This guarantees that all required sources are allowed
+ * without overwriting user configuration.
  */
-const extendMiddlewareConfiguration = (middleware = { name: '', config: {} }) => {
-  const middlewares = strapi.config.get('middlewares') as (string | object)[];
+export default async () => {
+  const s3Domains = [
+    'strapi-ai-staging.s3.us-east-1.amazonaws.com',
+    'strapi-ai-production.s3.us-east-1.amazonaws.com',
+  ];
+  const defaults = ["'self'", 'data:', 'blob:'];
+  const middlewares = strapi.config.get('middlewares') as (
+    | string
+    | { name?: string; config?: any }
+  )[];
 
   const configuredMiddlewares = middlewares.map((m) => {
-    let currentMiddleware = m as any;
-    if (currentMiddleware === middleware.name) {
-      // Use the new config object if the middleware has no config property yet
-      currentMiddleware = {
-        name: 'strapi::security',
+    if (typeof m === 'object' && m.name === 'strapi::security') {
+      const config = m.config || {};
+      const csp = config.contentSecurityPolicy || {};
+      const directives = csp.directives || {};
+      // img-src
+      let imgSrc = directives['img-src'];
+      if (!imgSrc && csp.useDefaults) {
+        imgSrc = [...defaults];
+      }
+      if (!imgSrc) {
+        imgSrc = [];
+      }
+      imgSrc = Array.from(new Set([...imgSrc, ...s3Domains]));
+      // media-src
+      let mediaSrc = directives['media-src'];
+      if (!mediaSrc && csp.useDefaults) {
+        mediaSrc = [...defaults];
+      }
+      if (!mediaSrc) {
+        mediaSrc = [];
+      }
+      mediaSrc = Array.from(new Set([...mediaSrc, ...s3Domains]));
+      // Set back
+      return {
+        ...m,
         config: {
-          useDefaults: true,
+          ...config,
           contentSecurityPolicy: {
+            ...csp,
             directives: {
-              'img-src': ["'self'", 'data:', 'blob:'],
-              'media-src': ["'self'", 'data:', 'blob:'],
-              upgradeInsecureRequests: null,
+              ...directives,
+              'img-src': imgSrc,
+              'media-src': mediaSrc,
             },
           },
         },
       };
     }
-
-    if (currentMiddleware.name === middleware.name) {
-      // Deep merge (+ concat arrays) the new config with the current middleware config
-      return mergeWith(
-        (objValue, srcValue) => {
-          if (Array.isArray(objValue)) {
-            return objValue.concat(srcValue);
-          }
-
-          return undefined;
-        },
-        currentMiddleware,
-        middleware
-      );
-    }
-
-    return currentMiddleware;
+    return m;
   });
 
   strapi.config.set('middlewares', configuredMiddlewares);
-};
-
-export default async (/* { strapi }: { strapi: Core.Strapi } */) => {
-  extendMiddlewareConfiguration({
-    name: 'strapi::security',
-    config: {
-      contentSecurityPolicy: {
-        directives: {
-          'img-src': [
-            'strapi-ai-staging.s3.us-east-1.amazonaws.com',
-            'strapi-ai-production.s3.us-east-1.amazonaws.com',
-          ],
-          'media-src': [
-            'strapi-ai-staging.s3.us-east-1.amazonaws.com',
-            'strapi-ai-production.s3.us-east-1.amazonaws.com',
-          ],
-        },
-      },
-    },
-  });
 };


### PR DESCRIPTION
### What does it do?

- removes general middleware extend logic, and focuses on adding additional CSP configs properly for CTB AI
without overriding defaults or changing user configs

### Why is it needed?

- breaks CSP middleware configs

### How to test it?

- run getstarted, you should be able to see assets added to the library

