### PR TITLE
enhancement: add unrelated data to dummy preview

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -138,9 +138,26 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
   );
 };
 
+const Entry = ({ data }) => {
+  return (
+    <Grid.Root gap={5} tag="dl">
+      {filterAttributes(data).map(([key, value]) => (
+        <Grid.Item key={key} col={6} s={12} direction="column" alignItems="start">
+          <Typography variant="sigma" textColor="neutral600" tag="dt">
+            {key}
+          </Typography>
+          <Flex gap={3} direction="column" alignItems="start" tag="dd">
+            <NestedValue value={value} fieldName={key} />
+          </Flex>
+        </Grid.Item>
+      ))}
+    </Grid.Root>
+  );
+};
+
 const PreviewComponent = () => {
   const { apiName, documentId, locale, status: documentStatus } = useParams();
-  const data = useLoaderData();
+  const { main, unrelated } = useLoaderData();
   const revalidator = useRevalidator();
 
   React.useEffect(() => {
@@ -168,16 +185,12 @@ const PreviewComponent = () => {
 
     window.addEventListener('message', handleMessage);
 
+    window.parent?.postMessage({ type: 'previewReady' }, '*');
+
     return () => {
       window.removeEventListener('message', handleMessage);
     };
   }, []);
-
-  React.useEffect(() => {
-    if (data) {
-      window.parent?.postMessage({ type: 'previewReady' }, '*');
-    }
-  }, [data]);
 
   return (
     <Box
@@ -249,24 +262,21 @@ const PreviewComponent = () => {
                 Rest API data
               </Typography>
               {revalidator.state === 'loading' && <Typography>Refreshing data...</Typography>}
-              {data ? (
+              {main ? (
                 <>
-                  <Grid.Root gap={5} tag="dl">
-                    {filterAttributes(data).map(([key, value]) => (
-                      <Grid.Item key={key} col={6} s={12} direction="column" alignItems="start">
-                        <Typography variant="sigma" textColor="neutral600" tag="dt">
-                          {key}
-                        </Typography>
-                        <Flex gap={3} direction="column" alignItems="start" tag="dd">
-                          <NestedValue value={value} fieldName={key} />
-                        </Flex>
-                      </Grid.Item>
-                    ))}
-                  </Grid.Root>
-                  <JSONInput value={JSON.stringify(data, null, 2)} disabled />
+                  <Entry data={main} />
+                  <JSONInput value={JSON.stringify(main, null, 2)} disabled />
                 </>
               ) : (
                 <Typography textColor="neutral600">No data found</Typography>
+              )}
+              {unrelated && (
+                <>
+                  <Typography variant="delta" tag="h3">
+                    Unrelated API data
+                  </Typography>
+                  <Entry data={unrelated} />
+                </>
               )}
             </Flex>
           </Layouts.Content>

--- a/examples/getstarted/src/admin/preview/index.jsx
+++ b/examples/getstarted/src/admin/preview/index.jsx
@@ -34,16 +34,30 @@ const previewLoader = async ({ params }) => {
     });
     const route = collectionType === 'collection-types' ? `${apiName}/${documentId}` : apiName;
 
-    const response = await fetch(`/api/${route}?${searchParams.toString()}`, {
-      headers,
-    });
+    // Make both fetch requests in parallel
+    const [mainResponse, unrelatedResponse] = await Promise.all([
+      fetch(`/api/${route}?${searchParams.toString()}`, { headers }),
+      fetch(`/api/homepage?status=draft`, { headers }),
+    ]);
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+    if (!mainResponse.ok) {
+      throw new Error(`HTTP error! status: ${mainResponse.status}`);
     }
 
-    const result = await response.json();
-    return result.data;
+    if (!unrelatedResponse.ok) {
+      throw new Error(`HTTP error! status: ${unrelatedResponse.status}`);
+    }
+
+    // Process both responses in parallel
+    const [mainResult, unrelatedResult] = await Promise.all([
+      mainResponse.json(),
+      unrelatedResponse.json(),
+    ]);
+
+    return {
+      main: mainResult.data,
+      unrelated: unrelatedResult.data,
+    };
   } catch (error) {
     console.error('Error fetching preview data:', error);
     throw error;


### PR DESCRIPTION
### What does it do?

Updates the dummy-preview page (the page we use as the preview within getstarted) so that it also fetches and displays content from another entry. This simulates better real websites that usually fetch content from multiple sources in Strapi at once.

⚠️ this PR only affects the testing environment we created for Preview in examples/getstarted. No need to do pre-release QA for it.

### Why is it needed?

Having this in getstarted is useful because:
- we display a "This field comes from a different document" toast when the user double clicks on a highlight that's from a different document. Now we can test this behavior.
- at some point we'll actually support editing things from different documents (see this [internal poc](https://strapihq.slack.com/archives/C092SNX8FB6/p1757922405127179)). At that point we'll be happy to have the environment ready to test it

### How to test it?

- Open preview for any entry
- Scroll to the bottom of the preview, see the "unrelated api data" section
- Double click on the title field to edit it: you should see a toast saying "This field comes from a different document"