### PR TITLE
[Session Manager] Fix SSO

### DIFF
--- a/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
+++ b/packages/core/admin/ee/server/src/controllers/authentication-utils/middlewares.ts
@@ -2,6 +2,12 @@ import type { Core } from '@strapi/types';
 import passport from 'koa-passport';
 import { getService } from '../../utils';
 import utils from './utils';
+import {
+  REFRESH_COOKIE_NAME,
+  buildCookieOptionsWithExpiry,
+  getSessionManager,
+  generateDeviceId,
+} from '../../../../../shared/utils/session-auth';
 
 const defaultConnectionError = () => new Error('Invalid connection payload');
 
@@ -91,25 +97,61 @@ const nonExistingUserScenario: Core.MiddlewareHandler =
     return next();
   };
 
-export const redirectWithAuth: Core.MiddlewareHandler = (ctx) => {
+export const redirectWithAuth: Core.MiddlewareHandler = async (ctx) => {
   const {
     params: { provider },
   } = ctx;
   const redirectUrls = utils.getPrefixedRedirectUrls();
-  const domain: string | undefined = strapi.config.get('admin.auth.domain');
   const { user } = ctx.state;
 
-  const jwt = getService('token').createJwtToken(user);
+  try {
+    const sessionManager = getSessionManager();
+    if (!sessionManager) {
+      strapi.log.error('SessionManager not available for SSO authentication');
+      return ctx.redirect(redirectUrls.error);
+    }
 
-  const isProduction = strapi.config.get('environment') === 'production';
+    const userId = String(user.id);
+    const deviceId = generateDeviceId();
 
-  const cookiesOptions = { httpOnly: false, secure: isProduction, overwrite: true, domain };
+    const { token: refreshToken, absoluteExpiresAt } = await sessionManager(
+      'admin'
+    ).generateRefreshToken(userId, deviceId, {
+      type: 'refresh',
+    });
 
-  const sanitizedUser = getService('user').sanitizeUser(user);
-  strapi.eventHub.emit('admin.auth.success', { user: sanitizedUser, provider });
+    const cookieOptions = buildCookieOptionsWithExpiry('refresh', absoluteExpiresAt);
+    ctx.cookies.set(REFRESH_COOKIE_NAME, refreshToken, cookieOptions);
 
-  ctx.cookies.set('jwtToken', jwt, cookiesOptions);
-  ctx.redirect(redirectUrls.success);
+    const accessResult = await sessionManager('admin').generateAccessToken(refreshToken);
+    if ('error' in accessResult) {
+      strapi.log.error('Failed to generate access token for SSO user');
+      return ctx.redirect(redirectUrls.error);
+    }
+
+    const { token: accessToken } = accessResult;
+
+    const isProduction = strapi.config.get('environment') === 'production';
+    const domain: string | undefined = strapi.config.get('admin.auth.domain');
+    ctx.cookies.set('jwtToken', accessToken, {
+      httpOnly: false,
+      secure: isProduction,
+      overwrite: true,
+      domain,
+    });
+
+    const sanitizedUser = getService('user').sanitizeUser(user);
+    strapi.eventHub.emit('admin.auth.success', { user: sanitizedUser, provider });
+
+    ctx.redirect(redirectUrls.success);
+  } catch (error) {
+    strapi.log.error('SSO authentication failed during token generation', error);
+    strapi.eventHub.emit('admin.auth.error', {
+      error: error instanceof Error ? error : new Error('Unknown SSO error'),
+      provider,
+    });
+    return ctx.redirect(redirectUrls.error);
+  }
 };
 
 export default {

--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -6,6 +6,12 @@ import { getTokenOptions, expiresInToSeconds } from './services/token';
 import adminActions from './config/admin-actions';
 import adminConditions from './config/admin-conditions';
 import constants from './services/constants';
+import {
+  DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN,
+  DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN,
+  DEFAULT_MAX_SESSION_LIFESPAN,
+  DEFAULT_IDLE_SESSION_LIFESPAN,
+} from '../../shared/utils/session-auth';
 
 const defaultAdminAuthSettings = {
   providers: {
@@ -100,7 +106,10 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   // Fallback for backward compatibility: if the new maxRefreshTokenLifespan is not set,
   // reuse the legacy admin.auth.options.expiresIn value (previously the sole JWT lifespan)
   const { options } = getTokenOptions();
-  const legacyMaxRefreshFallback = expiresInToSeconds(options?.expiresIn) ?? 30 * 24 * 60 * 60; // default 30 days
+  const legacyMaxRefreshFallback =
+    expiresInToSeconds(options?.expiresIn) ?? DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN;
+  const legacyMaxSessionFallback =
+    expiresInToSeconds(options?.expiresIn) ?? DEFAULT_MAX_SESSION_LIFESPAN;
 
   // Warn if using deprecated legacy expiresIn for new session settings
   const hasLegacyExpires = options?.expiresIn != null;
@@ -122,13 +131,16 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
     ),
     idleRefreshTokenLifespan: strapi.config.get(
       'admin.auth.sessions.idleRefreshTokenLifespan',
-      7 * 24 * 60 * 60
+      DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN
     ),
     maxSessionLifespan: strapi.config.get(
       'admin.auth.sessions.maxSessionLifespan',
-      legacyMaxRefreshFallback
+      legacyMaxSessionFallback
     ),
-    idleSessionLifespan: strapi.config.get('admin.auth.sessions.idleSessionLifespan', 60 * 60),
+    idleSessionLifespan: strapi.config.get(
+      'admin.auth.sessions.idleSessionLifespan',
+      DEFAULT_IDLE_SESSION_LIFESPAN
+    ),
   });
 
   await registerAdminConditions();

--- a/packages/core/admin/server/src/services/constants.ts
+++ b/packages/core/admin/server/src/services/constants.ts
@@ -48,12 +48,6 @@ const constants = {
     DAYS_30: 30 * DAY_IN_MS,
     DAYS_90: 90 * DAY_IN_MS,
   },
-  // Admin session/token default lifespans (seconds)
-  DEFAULT_ACCESS_TOKEN_LIFESPAN: 10 * 60,
-  DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN: 30 * 24 * 60 * 60,
-  DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN: 14 * 24 * 60 * 60,
-  DEFAULT_MAX_SESSION_LIFESPAN: 1 * 24 * 60 * 60,
-  DEFAULT_IDLE_SESSION_LIFESPAN: 2 * 60 * 60,
 };
 
 export default constants;

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -1,0 +1,97 @@
+import crypto from 'crypto';
+import type { Modules } from '@strapi/types';
+
+export const REFRESH_COOKIE_NAME = 'strapi_admin_refresh';
+
+const DEFAULT_ACCESS_TOKEN_LIFESPAN = 10 * 60;
+const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;
+const DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN = 14 * 24 * 60 * 60;
+const DEFAULT_MAX_SESSION_LIFESPAN = 1 * 24 * 60 * 60;
+const DEFAULT_IDLE_SESSION_LIFESPAN = 2 * 60 * 60;
+
+export const getRefreshCookieOptions = () => {
+  const isProduction = strapi.config.get('environment') === 'production';
+  const domain: string | undefined =
+    strapi.config.get('admin.auth.cookie.domain') || strapi.config.get('admin.auth.domain');
+  const path: string = strapi.config.get('admin.auth.cookie.path', '/admin');
+
+  const sameSite: boolean | 'lax' | 'strict' | 'none' =
+    strapi.config.get('admin.auth.cookie.sameSite') ?? 'lax';
+
+  return {
+    httpOnly: true,
+    secure: isProduction,
+    overwrite: true,
+    domain,
+    path,
+    sameSite,
+    maxAge: undefined,
+  };
+};
+
+const getLifespansForType = (
+  type: 'refresh' | 'session'
+): { idleSeconds: number; maxSeconds: number } => {
+  if (type === 'refresh') {
+    const idleSeconds = Number(
+      strapi.config.get(
+        'admin.auth.sessions.idleRefreshTokenLifespan',
+        DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN
+      )
+    );
+    const maxSeconds = Number(
+      strapi.config.get(
+        'admin.auth.sessions.maxRefreshTokenLifespan',
+        DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN
+      )
+    );
+
+    return { idleSeconds, maxSeconds };
+  }
+
+  const idleSeconds = Number(
+    strapi.config.get('admin.auth.sessions.idleSessionLifespan', DEFAULT_IDLE_SESSION_LIFESPAN)
+  );
+  const maxSeconds = Number(
+    strapi.config.get('admin.auth.sessions.maxSessionLifespan', DEFAULT_MAX_SESSION_LIFESPAN)
+  );
+
+  return { idleSeconds, maxSeconds };
+};
+
+export const buildCookieOptionsWithExpiry = (
+  type: 'refresh' | 'session',
+  absoluteExpiresAtISO?: string
+) => {
+  const base = getRefreshCookieOptions();
+  if (type === 'session') {
+    return base;
+  }
+
+  const { idleSeconds } = getLifespansForType('refresh');
+  const now = Date.now();
+  const idleExpiry = now + idleSeconds * 1000;
+  const absoluteExpiry = absoluteExpiresAtISO
+    ? new Date(absoluteExpiresAtISO).getTime()
+    : idleExpiry;
+  const chosen = new Date(Math.min(idleExpiry, absoluteExpiry));
+
+  return { ...base, expires: chosen, maxAge: Math.max(0, chosen.getTime() - now) };
+};
+
+export const getSessionManager = (): Modules.SessionManager.SessionManagerService | null => {
+  const manager = strapi.sessionManager as Modules.SessionManager.SessionManagerService | undefined;
+  return manager ?? null;
+};
+
+export const generateDeviceId = (): string => crypto.randomUUID();
+
+export const extractDeviceParams = (
+  requestBody: unknown
+): { deviceId: string; rememberMe: boolean } => {
+  const body = (requestBody ?? {}) as { deviceId?: string; rememberMe?: boolean };
+  const deviceId = body.deviceId || generateDeviceId();
+  const rememberMe = Boolean(body.rememberMe);
+
+  return { deviceId, rememberMe };
+};

--- a/packages/core/admin/shared/utils/session-auth.ts
+++ b/packages/core/admin/shared/utils/session-auth.ts
@@ -3,11 +3,10 @@ import type { Modules } from '@strapi/types';
 
 export const REFRESH_COOKIE_NAME = 'strapi_admin_refresh';
 
-const DEFAULT_ACCESS_TOKEN_LIFESPAN = 10 * 60;
-const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;
-const DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN = 14 * 24 * 60 * 60;
-const DEFAULT_MAX_SESSION_LIFESPAN = 1 * 24 * 60 * 60;
-const DEFAULT_IDLE_SESSION_LIFESPAN = 2 * 60 * 60;
+export const DEFAULT_MAX_REFRESH_TOKEN_LIFESPAN = 30 * 24 * 60 * 60;
+export const DEFAULT_IDLE_REFRESH_TOKEN_LIFESPAN = 14 * 24 * 60 * 60;
+export const DEFAULT_MAX_SESSION_LIFESPAN = 1 * 24 * 60 * 60;
+export const DEFAULT_IDLE_SESSION_LIFESPAN = 2 * 60 * 60;
 
 export const getRefreshCookieOptions = () => {
   const isProduction = strapi.config.get('environment') === 'production';

--- a/tests/api/core/admin/session-manager.test.api.ts
+++ b/tests/api/core/admin/session-manager.test.api.ts
@@ -201,7 +201,7 @@ describe('SessionManager API Integration', () => {
         expect(sessions.map((s) => s.origin)).toEqual(expect.arrayContaining([origin1, origin2]));
       });
 
-      it('should set refresh idle expiration (default 7 days) for refresh family', async () => {
+      it('should set refresh idle expiration (default 14 days) for refresh family', async () => {
         const startTime = Date.now();
         const result = await strapi
           .sessionManager('admin')
@@ -211,7 +211,7 @@ describe('SessionManager API Integration', () => {
           where: { sessionId: result.sessionId },
         });
 
-        const expectedExpiration = startTime + 7 * 24 * 60 * 60 * 1000;
+        const expectedExpiration = startTime + 14 * 24 * 60 * 60 * 1000;
         const actualExpiration = new Date(session.expiresAt).getTime();
 
         expect(Math.abs(actualExpiration - expectedExpiration)).toBeLessThan(1_000);
@@ -536,8 +536,8 @@ describe('SessionManager API Integration', () => {
           .sessionManager('admin')
           .generateRefreshToken(testUserId, testDeviceId);
 
-        // Make createdAt older than idleRefreshTokenLifespan (7d) by 1 minute
-        const past = new Date(Date.now() - (7 * 24 * 60 * 60 * 1000 + 60 * 1000));
+        // Make createdAt older than idleRefreshTokenLifespan (14d) by 1 minute
+        const past = new Date(Date.now() - (14 * 24 * 60 * 60 * 1000 + 60 * 1000));
         await strapi.db.query(contentTypeUID).update({
           where: { sessionId: r.sessionId },
           data: { createdAt: past },


### PR DESCRIPTION
### What does it do?

- Fixes **SSO login flow** using the new session manager:
- Adds a **shared session/auth utils module**:

### Why is it needed?

- SSO previously didn’t create a proper session/refresh token

### How to test it?

1. Configure an SSO provider (e.g., GitHub/Google).
2. Login via SSO → check cookies:
   - `strapi_admin_refresh` is present, with correct expiry (absolute/idle or session).
   - `jwtToken` is present and usable in the Admin UI.
3. Verify refresh token rotation and logout clear cookies correctly.

### Related issue(s)/PR(s)
