### PR TITLE
feat: add AI upload modal

### DIFF
--- a/packages/core/upload/admin/src/ai/components/AIAssetCard.tsx
+++ b/packages/core/upload/admin/src/ai/components/AIAssetCard.tsx
@@ -1,0 +1,374 @@
+import * as React from 'react';
+
+import {
+  Box,
+  Card,
+  CardAction,
+  CardAsset,
+  CardBadge,
+  CardBody,
+  CardContent,
+  CardHeader,
+  CardSubtitle,
+  CardTitle,
+  CardTimer,
+  Field,
+  Flex,
+  Grid,
+  TextInput,
+  Typography,
+} from '@strapi/design-system';
+import { Sparkle } from '@strapi/icons';
+import { useIntl } from 'react-intl';
+import { styled } from 'styled-components';
+
+import { AudioPreview } from '../../components/AssetCard/AudioPreview';
+import { VideoPreview } from '../../components/AssetCard/VideoPreview';
+import { AssetType } from '../../constants';
+import {
+  formatBytes,
+  formatDuration,
+  getFileExtension,
+  getTrad,
+  prefixFileUrlWithBackendUrl,
+} from '../../utils';
+import { typeFromMime } from '../../utils/typeFromMime';
+
+import type { File } from '../../../../shared/contracts/files';
+
+const CardActionsContainer = styled(CardAction)`
+  opacity: 0;
+  z-index: 1;
+
+  &:focus-within {
+    opacity: 1;
+  }
+`;
+
+const CardContainer = styled(Box)`
+  background: ${({ theme }) => theme.colors.neutral0};
+  border: 1px solid ${({ theme }) => theme.colors.neutral150};
+  border-radius: ${({ theme }) => theme.borderRadius};
+
+  &:hover {
+    ${CardActionsContainer} {
+      opacity: 1;
+    }
+  }
+`;
+
+/* -------------------------------------------------------------------------------------------------
+ * Asset
+ * -----------------------------------------------------------------------------------------------*/
+
+interface AssetProps {
+  assetType: AssetType;
+  thumbnailUrl: string;
+  assetUrl: string;
+  asset: File;
+}
+
+interface AssetCardProps {
+  asset: File;
+  onCaptionChange: (caption: string) => void;
+  onAltTextChange: (altText: string) => void;
+}
+
+const Extension = styled.span`
+  text-transform: uppercase;
+`;
+
+const VideoPreviewWrapper = styled(Box)`
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+
+  canvas,
+  video {
+    display: block;
+    pointer-events: none;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: ${({ theme }) => theme.borderRadius};
+  }
+`;
+
+const VideoTimerOverlay = styled(CardTimer)`
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+`;
+
+const AudioPreviewWrapper = styled(Box)`
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  canvas,
+  audio {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+  }
+`;
+
+const Asset = ({ assetType, thumbnailUrl, assetUrl, asset }: AssetProps) => {
+  const [duration, setDuration] = React.useState<number>();
+  const formattedDuration = duration ? formatDuration(duration) : undefined;
+
+  switch (assetType) {
+    case AssetType.Image:
+      return <CardAsset src={thumbnailUrl} size="S" alt={asset.alternativeText || asset.name} />;
+    case AssetType.Video:
+      return (
+        <CardAsset size="S">
+          <VideoPreviewWrapper>
+            <VideoPreview
+              url={assetUrl}
+              mime={asset.mime || 'video/mp4'}
+              onLoadDuration={setDuration}
+              alt={asset.alternativeText || asset.name}
+            />
+            {formattedDuration && <VideoTimerOverlay>{formattedDuration}</VideoTimerOverlay>}
+          </VideoPreviewWrapper>
+        </CardAsset>
+      );
+    case AssetType.Audio:
+      return (
+        <CardAsset size="S">
+          <AudioPreviewWrapper>
+            <AudioPreview url={assetUrl} alt={asset.alternativeText || asset.name} />
+          </AudioPreviewWrapper>
+        </CardAsset>
+      );
+    default:
+      return <CardAsset src={thumbnailUrl} size="S" alt={asset.alternativeText || asset.name} />;
+  }
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * AssetCard
+ * -----------------------------------------------------------------------------------------------*/
+
+const StyledCardBody = styled(CardBody)`
+  display: flex;
+  padding: ${({ theme }) => theme.spaces[2]} ${({ theme }) => theme.spaces[1]};
+`;
+
+const StyledCard = styled(Card)`
+  width: 100%;
+  height: 100%;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding: 0;
+`;
+
+const getAssetBadgeLabel = (assetType: AssetType) => {
+  switch (assetType) {
+    case AssetType.Image:
+      return { id: getTrad('settings.section.image.label'), defaultMessage: 'IMAGE' };
+    case AssetType.Video:
+      return { id: getTrad('settings.section.video.label'), defaultMessage: 'VIDEO' };
+    case AssetType.Audio:
+      return { id: getTrad('settings.section.audio.label'), defaultMessage: 'AUDIO' };
+    default:
+      return { id: getTrad('settings.section.doc.label'), defaultMessage: 'DOC' };
+  }
+};
+
+export const AIAssetCard = ({ asset, onCaptionChange, onAltTextChange }: AssetCardProps) => {
+  const { formatMessage } = useIntl();
+
+  const handleCaptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onCaptionChange(event.target.value);
+  };
+
+  const handleAltTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onAltTextChange(event.target.value);
+  };
+
+  const assetType = typeFromMime(asset.mime || '');
+  const thumbnailUrl =
+    prefixFileUrlWithBackendUrl(asset?.formats?.thumbnail?.url || asset.url) || '';
+  const assetUrl = prefixFileUrlWithBackendUrl(asset.url) || '';
+  const subtitle = asset.height && asset.width ? ` - ${asset.width}x${asset.height}` : '';
+  const formattedSize = asset.size ? formatBytes(asset.size) : '';
+  const fullSubtitle = `${subtitle}${subtitle && formattedSize ? ' - ' : ''}${formattedSize}`;
+
+  return (
+    <CardContainer>
+      <Grid.Root>
+        <Grid.Item col={5} alignItems="stretch">
+          <StyledCard width="100%" height="100%" shadow="none" borderRadius={0} padding={0}>
+            <CardHeader style={{ borderStyle: 'none' }}>
+              <Asset
+                assetType={assetType}
+                thumbnailUrl={thumbnailUrl}
+                assetUrl={assetUrl}
+                asset={asset}
+              />
+            </CardHeader>
+            <StyledCardBody>
+              <CardContent width="100%">
+                <Flex justifyContent="space-between" alignItems="start">
+                  <Typography tag="h2">
+                    <CardTitle tag="span">{asset.name}</CardTitle>
+                  </Typography>
+                  <CardBadge>{formatMessage(getAssetBadgeLabel(assetType))}</CardBadge>
+                </Flex>
+                <Flex>
+                  <CardSubtitle>
+                    <Extension>{getFileExtension(asset.ext)}</Extension>
+                    {fullSubtitle}
+                  </CardSubtitle>
+                </Flex>
+              </CardContent>
+            </StyledCardBody>
+          </StyledCard>
+        </Grid.Item>
+
+        <Grid.Item col={7} flex={1}>
+          <Flex direction="column" height="100%" alignItems="stretch" flex={1} padding={4} gap={2}>
+            <Field.Root name="caption">
+              <Flex alignItems="center" gap={2}>
+                <Field.Label>
+                  {formatMessage({
+                    id: getTrad('form.input.label.file-caption'),
+                    defaultMessage: 'Caption',
+                  })}
+                </Field.Label>
+              </Flex>
+              <TextInput
+                value={asset.caption || ''}
+                onChange={handleCaptionChange}
+                placeholder={formatMessage({
+                  id: getTrad('form.input.placeholder.file-caption'),
+                  defaultMessage: 'Enter caption',
+                })}
+                endAction={<Sparkle width="16px" height="16px" fill="#AC73E6" />}
+              />
+            </Field.Root>
+
+            <Field.Root
+              name="alternativeText"
+              hint={formatMessage({
+                id: getTrad('form.input.description.file-alt'),
+                defaultMessage: "This text will be displayed if the asset can't be shown.",
+              })}
+            >
+              <Flex alignItems="center" gap={2}>
+                <Field.Label>
+                  {formatMessage({
+                    id: getTrad('form.input.label.file-alt'),
+                    defaultMessage: 'Alternative text',
+                  })}
+                </Field.Label>
+              </Flex>
+
+              <TextInput
+                value={asset.alternativeText || ''}
+                onChange={handleAltTextChange}
+                placeholder={formatMessage({
+                  id: getTrad('form.input.placeholder.file-alt'),
+                  defaultMessage: 'Enter alternative text',
+                })}
+                endAction={<Sparkle width="16px" height="16px" fill="#AC73E6" />}
+              />
+              <Field.Hint />
+            </Field.Root>
+          </Flex>
+        </Grid.Item>
+      </Grid.Root>
+    </CardContainer>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * AssetCardSkeletons
+ * -----------------------------------------------------------------------------------------------*/
+
+const SkeletonBox = styled(Box)<{ width?: string; height?: string }>`
+  background: linear-gradient(
+    90deg,
+    ${({ theme }) => theme.colors.neutral100} 25%,
+    ${({ theme }) => theme.colors.neutral150} 50%,
+    ${({ theme }) => theme.colors.neutral100} 75%
+  );
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+  border-radius: ${({ theme }) => theme.borderRadius};
+  width: ${({ width }) => width || '100%'};
+  height: ${({ height }) => height || '1rem'};
+
+  @keyframes loading {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+`;
+
+export const AIAssetCardSkeletons = ({ count = 1 }: { count?: number }) => {
+  const skeletons = Array.from({ length: count }, (_, i) => i);
+
+  return skeletons.map((index) => (
+    <Box
+      key={index}
+      background="neutral0"
+      borderColor="neutral150"
+      borderStyle="solid"
+      borderWidth="1px"
+      borderRadius="4px"
+      marginBottom={4}
+    >
+      <Grid.Root>
+        <Grid.Item col={5} alignItems="stretch">
+          <Card
+            height="100%"
+            width="100%"
+            borderStyle="none"
+            shadow="none"
+            borderRadius={0}
+            padding={2}
+          >
+            <Box height="150px" padding={2}>
+              <SkeletonBox height="100%" />
+            </Box>
+            <CardBody style={{ display: 'flex', padding: '8px 4px' }}>
+              <CardContent width="100%">
+                <Flex justifyContent="space-between" alignItems="start" marginBottom={1}>
+                  <SkeletonBox width="60%" height="18px" />
+                  <SkeletonBox width="40px" height="16px" />
+                </Flex>
+                <SkeletonBox width="80%" height="14px" />
+              </CardContent>
+            </CardBody>
+          </Card>
+        </Grid.Item>
+
+        <Grid.Item col={7} flex={1}>
+          <Flex direction="column" height="100%" alignItems="stretch" flex={1} padding={4} gap={2}>
+            <Box>
+              <SkeletonBox width="60px" height="16px" marginBottom={1} />
+              <SkeletonBox height="32px" />
+            </Box>
+
+            <Box>
+              <SkeletonBox width="100px" height="16px" marginBottom={1} />
+              <SkeletonBox height="32px" />
+              <Box marginTop={1}>
+                <SkeletonBox width="70%" height="12px" />
+              </Box>
+            </Box>
+          </Flex>
+        </Grid.Item>
+      </Grid.Root>
+    </Box>
+  ));
+};

--- a/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
+++ b/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+
+import { Button, Flex, Modal } from '@strapi/design-system';
+import { useIntl } from 'react-intl';
+import { styled } from 'styled-components';
+
+import {
+  AddAssetStep,
+  FileWithRawFile,
+} from '../../components/UploadAssetDialog/AddAssetStep/AddAssetStep';
+import { useUpload } from '../../hooks/useUpload';
+import { getTrad } from '../../utils';
+
+import { AIAssetCard, AIAssetCardSkeletons } from './AIAssetCard';
+
+import type { File } from '../../../../shared/contracts/files';
+
+/* -------------------------------------------------------------------------------------------------
+ * ModalBody
+ * -----------------------------------------------------------------------------------------------*/
+
+const StyledModalBody = styled(Modal.Body)`
+  padding: 0;
+  display: flex;
+  justify-content: center;
+
+  [data-radix-scroll-area-viewport] {
+    padding-top: ${({ theme }) => theme.spaces[6]};
+    padding-bottom: ${({ theme }) => theme.spaces[6]};
+    padding-left: ${({ theme }) => theme.spaces[7]};
+    padding-right: ${({ theme }) => theme.spaces[7]};
+  }
+`;
+
+const ModalContent = ({ onClose }: Pick<AIUploadModalProps, 'onClose'>) => {
+  const { formatMessage } = useIntl();
+  const [uploadedAssets, setUploadedAssets] = React.useState<File[]>([]);
+  const [assetsToUploadLength, setAssetsToUploadLength] = React.useState(0);
+  const { upload, isLoading } = useUpload();
+
+  const handleCaptionChange = (assetId: number, caption: string) => {
+    setUploadedAssets((prev) =>
+      prev.map((asset) => (asset.id === assetId ? { ...asset, caption } : asset))
+    );
+  };
+
+  const handleAltTextChange = (assetId: number, altText: string) => {
+    setUploadedAssets((prev) =>
+      prev.map((asset) => (asset.id === assetId ? { ...asset, alternativeText: altText } : asset))
+    );
+  };
+
+  const resetState = () => {
+    setUploadedAssets([]);
+  };
+
+  const handleDone = () => {
+    resetState();
+    // TODO: Bulk update assets after upload if the user manually updates the caption or alt text
+    onClose();
+  };
+
+  const handleCancel = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleUpload = async (assets: FileWithRawFile[]) => {
+    setAssetsToUploadLength(assets.length);
+
+    try {
+      const uploadPromises = assets.map(async (asset) => {
+        const assetForUpload = {
+          ...asset,
+          id: asset.id ? Number(asset.id) : undefined,
+        };
+        return upload(assetForUpload, null);
+      });
+
+      const results = await Promise.all(uploadPromises);
+      const uploadedFiles = results.flat().filter(Boolean);
+      setUploadedAssets(uploadedFiles);
+    } catch (error) {
+      // TODO: toast error
+      console.error('Upload failed:', error);
+    }
+  };
+
+  if (assetsToUploadLength === 0) {
+    return (
+      <Modal.Content>
+        <AddAssetStep onClose={onClose} onAddAsset={handleUpload} />
+      </Modal.Content>
+    );
+  }
+
+  if (isLoading || (assetsToUploadLength > 0 && uploadedAssets.length === 0)) {
+    return (
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title>
+            {formatMessage({
+              id: getTrad('ai.modal.uploading.title'),
+              defaultMessage: 'Uploading and processing with AI...',
+            })}
+          </Modal.Title>
+        </Modal.Header>
+        <StyledModalBody>
+          <AIAssetCardSkeletons count={assetsToUploadLength} />
+        </StyledModalBody>
+      </Modal.Content>
+    );
+  }
+
+  return (
+    <Modal.Content>
+      <Modal.Header>
+        <Modal.Title>
+          {formatMessage(
+            {
+              id: getTrad('ai.modal.title'),
+              defaultMessage:
+                '{count, plural, one {# Asset uploaded} other {# Assets uploaded}} time to review AI generated content',
+            },
+            { count: uploadedAssets.length }
+          )}
+        </Modal.Title>
+      </Modal.Header>
+
+      <StyledModalBody>
+        <Flex gap={6} direction="column" alignItems="stretch">
+          {uploadedAssets.map((asset) => (
+            <AIAssetCard
+              key={asset.id}
+              asset={asset}
+              onCaptionChange={(caption: string) =>
+                asset.id && handleCaptionChange(asset.id, caption)
+              }
+              onAltTextChange={(altText: string) =>
+                asset.id && handleAltTextChange(asset.id, altText)
+              }
+            />
+          ))}
+        </Flex>
+      </StyledModalBody>
+
+      <Modal.Footer>
+        <Button onClick={handleCancel} variant="tertiary">
+          {formatMessage({ id: 'cancel', defaultMessage: 'Cancel' })}
+        </Button>
+        <Button onClick={handleDone}>
+          {formatMessage({ id: 'global.done', defaultMessage: 'Done' })}
+        </Button>
+      </Modal.Footer>
+    </Modal.Content>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * UploadModal
+ * -----------------------------------------------------------------------------------------------*/
+
+interface AIUploadModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const AIUploadModal = ({ open, onClose }: AIUploadModalProps) => {
+  return (
+    <Modal.Root open={open} onOpenChange={onClose}>
+      <ModalContent onClose={onClose} />
+    </Modal.Root>
+  );
+};

--- a/packages/core/upload/admin/src/hooks/useAiAvailability.ts
+++ b/packages/core/upload/admin/src/hooks/useAiAvailability.ts
@@ -1,0 +1,7 @@
+export const useAIAvailability = (): boolean => {
+  const isAiEnabled = window.strapi.ai?.enabled !== false;
+  // @ts-expect-error - incorrect window types
+  const isEE = window.strapi?.isEE;
+
+  return !!isEE && isAiEnabled;
+};

--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
@@ -25,6 +25,7 @@ import { useIntl } from 'react-intl';
 import { Link as ReactRouterLink, useNavigate, useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { AIUploadModal } from '../../../ai/components/AIUploadModal';
 import { AssetGridList } from '../../../components/AssetGridList/AssetGridList';
 import { EditAssetDialog } from '../../../components/EditAssetDialog/EditAssetContent';
 import { EditFolderDialog } from '../../../components/EditFolderDialog/EditFolderDialog';
@@ -37,6 +38,7 @@ import { SortPicker } from '../../../components/SortPicker/SortPicker';
 import { TableList } from '../../../components/TableList/TableList';
 import { UploadAssetDialog } from '../../../components/UploadAssetDialog/UploadAssetDialog';
 import { localStorageKeys, viewOptions } from '../../../constants';
+import { useAIAvailability } from '../../../hooks/useAiAvailability';
 import { useAssets } from '../../../hooks/useAssets';
 import { useFolder } from '../../../hooks/useFolder';
 import { useFolders } from '../../../hooks/useFolders';
@@ -87,6 +89,7 @@ export const MediaLibrary = () => {
     canConfigureView,
     isLoading: permissionsLoading,
   } = useMediaLibraryPermissions();
+  const isAiAvailable = useAIAvailability();
   const currentFolderToEditRef = React.useRef<HTMLDivElement>();
   const { formatMessage } = useIntl();
   const { pathname } = useLocation();
@@ -519,14 +522,17 @@ export const MediaLibrary = () => {
           </Pagination.Root>
         </Layouts.Content>
       </Page.Main>
-      {showUploadAssetDialog && (
-        <UploadAssetDialog
-          open={showUploadAssetDialog}
-          onClose={toggleUploadAssetDialog}
-          trackedLocation="upload"
-          folderId={query?.folder as string | number | null | undefined}
-        />
-      )}
+      {showUploadAssetDialog &&
+        (isAiAvailable ? (
+          <AIUploadModal open={showUploadAssetDialog} onClose={toggleUploadAssetDialog} />
+        ) : (
+          <UploadAssetDialog
+            open={showUploadAssetDialog}
+            onClose={toggleUploadAssetDialog}
+            trackedLocation="upload"
+            folderId={query?.folder as string | number | null | undefined}
+          />
+        ))}
       {showEditFolderDialog && (
         <EditFolderDialog
           open={showEditFolderDialog}

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -12,6 +12,7 @@
   "control-card.crop": "Crop",
   "control-card.download": "Download",
   "control-card.edit": "Edit",
+  "control-card.remove-selection": "Remove from selection",
   "control-card.replace-media": "Replace Media",
   "control-card.save": "Save",
   "control-card.stop-crop": "Stop cropping",
@@ -20,6 +21,7 @@
   "form.input.description.file-alt": "This text will be displayed if the asset can’t be shown.",
   "form.input.label.file-alt": "Alternative text",
   "form.input.label.file-caption": "Caption",
+  "form.input.placeholder.file-caption": "Enter caption",
   "form.input.label.file-name": "File name",
   "form.upload-url.error.url.invalid": "One URL is invalid",
   "form.upload-url.error.url.invalids": "{number} URLs are invalids",
@@ -105,6 +107,7 @@
   "settings.form.videoPreview.description": "It will generate a six-second preview of the video (GIF)",
   "settings.form.videoPreview.label": "Preview",
   "settings.header.label": "Media Library",
+  "settings.section.audio.label": "Audio",
   "settings.section.doc.label": "Doc",
   "settings.section.image.label": "Image",
   "settings.section.video.label": "Video",
@@ -136,5 +139,7 @@
   "config.note": "Note: You can override this value in the media library.",
   "config.popUpWarning.warning.updateAllSettings": "This will modify all your settings",
   "view-switch.list": "List View",
-  "view-switch.grid": "Grid View"
+  "view-switch.grid": "Grid View",
+  "ai.modal.uploading.title": "Uploading and processing with AI...",
+  "ai.modal.title": "{count, plural, one {# Asset uploaded} other {# Assets uploaded}} time to review AI generated content"
 }


### PR DESCRIPTION
⚠️ Merge after or into https://github.com/strapi/strapi/pull/24365 ⚠️ 

### What does it do?

- Create a dedicated space ai related components
- Adds a new AIUploadModal and AIAssetCard component
- Requests upload and ai metadate generation immediately when adding asests

### Why is it needed?

To generate metadata automagically ✨ 

### How to test it?

- Go to the MediaLibrary
- Click Add new assets
- Drag and drop or use file picker to choose some images
- After upload the uploaded assets should appear with generated alt text and caption

### Related issue(s)/PR(s)

Depends on https://github.com/strapi/strapi/pull/24365
resolves https://github.com/strapi/content-squad/issues/84
resolves https://github.com/strapi/content-squad/issues/85


### TODO

- The images don't always span the full width of their container
- Handle errors
