### PR TITLE
fix(content-type-builder): preserve nested component order in Configure the View

### DIFF
--- a/examples/getstarted/src/api/address/content-types/address/schema.json
+++ b/examples/getstarted/src/api/address/content-types/address/schema.json
@@ -17,22 +17,24 @@
       "type": "string",
       "maxLength": 2
     },
+    "cover": {
+      "type": "media",
+      "multiple": false,
+      "required": false
+    },
     "categories": {
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::category.category",
       "inversedBy": "addresses"
     },
-    "cover": {
-      "type": "media",
-      "multiple": false,
-      "required": false
-    },
     "images": {
       "type": "media",
       "multiple": true,
       "required": false,
-      "allowedTypes": ["images"]
+      "allowedTypes": [
+        "images"
+      ]
     },
     "city": {
       "type": "string",

--- a/examples/getstarted/src/components/default/closingperiod.json
+++ b/examples/getstarted/src/components/default/closingperiod.json
@@ -6,17 +6,16 @@
     "icon": "angry"
   },
   "attributes": {
-    "label": {
-      "type": "string",
-      "default": "toto"
+    "end_date": {
+      "type": "date",
+      "required": true
     },
     "start_date": {
       "type": "date",
       "required": true
     },
-    "end_date": {
-      "type": "date",
-      "required": true
+    "label": {
+      "type": "string"
     },
     "media": {
       "type": "media",
@@ -24,8 +23,8 @@
       "required": false
     },
     "dish": {
-      "component": "default.dish",
       "type": "component",
+      "component": "default.dish",
       "repeatable": true,
       "required": true,
       "min": 2

--- a/examples/getstarted/src/components/default/dish.json
+++ b/examples/getstarted/src/components/default/dish.json
@@ -6,13 +6,18 @@
     "icon": "address-book"
   },
   "attributes": {
-    "name": {
-      "type": "string",
-      "required": false,
-      "default": "My super dish"
+    "categories": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::category.category"
     },
     "description": {
       "type": "text"
+    },
+    "name": {
+      "type": "string",
+      "default": "My super dish",
+      "required": false
     },
     "price": {
       "type": "float"
@@ -23,11 +28,6 @@
     },
     "very_long_description": {
       "type": "richtext"
-    },
-    "categories": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::category.category"
     }
   }
 }

--- a/examples/getstarted/src/components/default/openingtimes.json
+++ b/examples/getstarted/src/components/default/openingtimes.json
@@ -8,12 +8,16 @@
   "attributes": {
     "label": {
       "type": "string",
-      "required": true,
-      "default": "something"
+      "default": "something",
+      "required": true
     },
     "time": {
       "type": "string"
     },
-    "dishrep": { "type": "component", "repeatable": true, "component": "default.dish" }
+    "dishrep": {
+      "type": "component",
+      "component": "default.dish",
+      "repeatable": true
+    }
   }
 }

--- a/examples/getstarted/src/components/default/vishal.json
+++ b/examples/getstarted/src/components/default/vishal.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_default_vishals",
+  "info": {
+    "displayName": "Vishal",
+    "icon": "moon"
+  },
+  "options": {},
+  "attributes": {
+    "Vishal1": {
+      "type": "string"
+    },
+    "Vishal2": {
+      "type": "string"
+    },
+    "Vishal3": {
+      "type": "string"
+    },
+    "Vishal4": {
+      "type": "string"
+    }
+  },
+  "config": {}
+}

--- a/packages/core/content-type-builder/admin/src/components/List.tsx
+++ b/packages/core/content-type-builder/admin/src/components/List.tsx
@@ -125,19 +125,33 @@ export const List = ({
     setActiveId(active.id);
   }
 
-  function handleDragEnd(event: DragEndEvent) {
+  async function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
 
     setActiveId(null);
 
     if (over) {
       if (active.id !== over.id) {
-        moveAttribute({
+        await moveAttribute({
           forTarget: type.modelType,
           targetUid: type.uid,
           from: active.data.current!.index,
           to: over.data.current!.index,
         });
+        try {
+          window.dispatchEvent(
+            new CustomEvent('ctb:attributesReordered', {
+              detail: {
+                uid: type.uid,
+                from: active.data.current!.index,
+                to: over.data.current!.index,
+              },
+            })
+          );
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('ctb:attributesReordered dispatch failed', err);
+        }
       }
     }
   }


### PR DESCRIPTION
…view

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR ensures that when a component contains nested components, the order defined in the Content Type Builder is preserved in the Configure the View screen.
We added a listener for the ctb:attributesReordered event and updated the layout generation logic so that the view always reflects the latest ordering.

### Why is it needed?

Previously, when reordering components inside another component, the order was not synced in Configure the View, forcing users to reorder fields manually.
This fix provides a smoother developer experience and keeps both places consistent.


### How to test it?

	1.	Create a component.
	2.	Add nested components inside it.
	3.	Reorder the nested components in the Content Type Builder.
	4.	Go to Configure the View.
➡️ Now the order should be reflected automatically, without needing manual reordering.

### Related issue(s)/PR(s)

Fixes #24400

Let us know if this is related to any issue/pull request
