### PR TITLE
fix(content-type-builder): resolve "An error occurred" when creating collection types with plural display names

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -333,7 +333,7 @@ export const FormModal = () => {
     get(modifiedData, 'createComponent', false) || isCreatingComponentWhileAddingAField;
   const isInFirstComponentStep = step === '1';
   const isPickingAttribute = modalType === 'chooseAttribute';
-  const uid = createUid(modifiedData.displayName || '');
+  const uid = createUid(modifiedData.singularName || '');
   const attributes = get(type, ['attributes'], null) as {
     name: string;
   }[];

--- a/packages/core/content-type-builder/admin/src/components/PluralName.tsx
+++ b/packages/core/content-type-builder/admin/src/components/PluralName.tsx
@@ -41,7 +41,21 @@ export const PluralName = ({
 
   useEffect(() => {
     if (displayName && displayName !== previousDisplayName.current) {
-      const baseValue = nameToSlug(displayName);
+      // Always start from singular form of display name, then pluralize
+      let singularDisplayName = displayName;
+      
+      try {
+        // Convert display name to singular first
+        if (pluralize.isPlural(displayName)) {
+          singularDisplayName = pluralize.singular(displayName);
+        }
+      } catch (err) {
+        // If pluralize fails, use the original display name
+        singularDisplayName = displayName;
+      }
+      
+      // Convert to slug and then pluralize
+      const baseValue = nameToSlug(singularDisplayName);
       let newValue = baseValue;
 
       try {

--- a/packages/core/content-type-builder/admin/src/components/SingularName.tsx
+++ b/packages/core/content-type-builder/admin/src/components/SingularName.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { Field, TextInput } from '@strapi/design-system';
+import pluralize from 'pluralize';
 import { useIntl } from 'react-intl';
 
 import { nameToSlug } from '../utils/nameToSlug';
@@ -34,7 +35,21 @@ export const SingularName = ({
 
   useEffect(() => {
     if (displayName && displayName !== previousDisplayName.current) {
-      const newValue = nameToSlug(displayName);
+      // Always convert display name to singular form, then to slug
+      let singularDisplayName = displayName;
+      
+      try {
+        // Check if the display name is plural and convert to singular
+        if (pluralize.isPlural(displayName)) {
+          singularDisplayName = pluralize.singular(displayName);
+        }
+        // If it's already singular, use as-is
+      } catch (err) {
+        // If pluralize fails, use the original display name
+        singularDisplayName = displayName;
+      }
+      
+      const newValue = nameToSlug(singularDisplayName);
       onChangeRef.current({ target: { name, value: newValue } });
       previousValue.current = newValue;
       previousDisplayName.current = displayName;


### PR DESCRIPTION
   Fix #24406
 
 ### What does it do?

  - Fixes auto-generation logic in Content-Type Builder to properly singularize plural display names
  - Updates SingularName component to use `pluralize.isPlural()` and `pluralize.singular()` for real-time conversion
  - Enhances PluralName component to ensure consistent pluralization from singular base
  - Corrects UID generation to use `singularName` instead of `displayName` to prevent invalid UIDs

  ### Why is it needed?

  Users were unable to create collection types when using plural display names (e.g., "Members", "Cities", "Categories"). The auto-generation algorithm incorrectly generated identical singular and plural IDs, causing backend validation failures and 400 Bad Request errors. This prevented users from using natural naming patterns for their content types.

  ### How to test it?

  Environment: Fresh Strapi installation (5.23.5+)

  Test steps:
  1. Navigate to Content-Type Builder in admin panel
  2. Create new collection type with plural display name: "Members"
  3. Verify real-time generation shows: Singular: "member", Plural: "members"
  4. Click save - should succeed without 400 error
  5. Test with other plural names: "Cities", "Categories", "Products"

  Before: Plural display names generated same singular/plural IDs causing server crashes
  After: All display names (singular or plural) generate correct singular/plural pairs and save successfully



