### PR TITLE
AI media lib bulk update

### DIFF
--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -48,14 +48,14 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
     mockGetService.mockImplementation((serviceName: string) => {
       if (serviceName === 'aiMetadata') return mockAiMetadataService;
-      if (serviceName === 'upload') return uploadService as any;
+      if (serviceName === 'upload') return uploadService;
       if (serviceName === 'file') {
         return {
           upload: jest.fn().mockResolvedValue([{}]),
           signFileUrls: jest.fn((f: any) => Promise.resolve(f)),
         };
       }
-      return {} as any;
+      return {};
     });
 
     const pm = {
@@ -63,7 +63,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
     };
 
-    (global as any).strapi = {
+    global.strapi = {
       service: jest.fn().mockReturnValue({
         createPermissionsManager: jest.fn().mockReturnValue(pm),
       }),
@@ -79,11 +79,11 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
     mockValidateUploadBody.mockResolvedValue({
       fileInfo: { name: 'test.jpg', alternativeText: '', caption: '', folder: null },
-    } as any);
+    });
 
     mockValidateBulkUpdateBody.mockResolvedValue({
       updates: [],
-    } as any);
+    });
 
     mockFindEntityAndCheckPermissions.mockResolvedValue({
       pm: {
@@ -102,7 +102,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
     ctxBulk = {
       state: { userAbility: {}, user: { id: 42 } },
-      request: { body: {} } as any,
+      request: { body: {} },
     } as any;
   });
 
@@ -189,7 +189,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
       expect(mockFindEntityAndCheckPermissions).toHaveBeenCalledTimes(2);
 
-      expect((ctxBulk as any).body).toEqual([
+      expect(ctxBulk.body).toEqual([
         { id: 1, caption: 'A', cleaned: true },
         { id: 2, alternativeText: 'B', cleaned: true },
       ]);
@@ -200,7 +200,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
 
       await adminUploadController.bulkUpdateFileInfo(ctxBulk as Context);
 
-      expect((ctxBulk as any).body).toEqual([]);
+      expect(ctxBulk.body).toEqual([]);
       expect(uploadService.updateFileInfo).not.toHaveBeenCalled();
       expect(mockFindEntityAndCheckPermissions).not.toHaveBeenCalled();
     });
@@ -239,7 +239,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
         { id: 10, caption: 'X' },
         { action: ACTIONS.read }
       );
-      expect((ctxBulk as any).body).toEqual([{ ok: true, id: 10, caption: 'X' }]);
+      expect(ctxBulk.body).toEqual([{ ok: true, id: 10, caption: 'X' }]);
     });
 
     it('passes the authenticated user to updateFileInfo', async () => {

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -4,7 +4,7 @@ import adminUploadController from '../admin-upload';
 import { getService } from '../../utils';
 import { validateBulkUpdateBody, validateUploadBody } from '../validation/admin/upload';
 import * as findEntityAndCheckPermissionsModule from '../utils/find-entity-and-check-permissions';
-import { ACTIONS } from '../../../src/constants';
+import { ACTIONS } from '../../constants';
 
 jest.mock('../../utils');
 jest.mock('../validation/admin/upload');

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -47,7 +47,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
     };
 
     mockGetService.mockImplementation((serviceName: string) => {
-      if (serviceName === 'aiMetadata') return mockAiMetadataService as any;
+      if (serviceName === 'aiMetadata') return mockAiMetadataService;
       if (serviceName === 'upload') return uploadService as any;
       if (serviceName === 'file') {
         return {

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -20,7 +20,7 @@ const mockFindEntityAndCheckPermissions =
     typeof findEntityAndCheckPermissionsModule.findEntityAndCheckPermissions
   >;
 
-describe('Admin Upload Controller', () => {
+describe('Admin Upload Controller - AI Service Connection', () => {
   let mockContext: Partial<Context>;
   let ctxBulk: Partial<Context>;
 
@@ -79,7 +79,6 @@ describe('Admin Upload Controller', () => {
       log: { warn: jest.fn() },
     } as any;
 
-    // --- default validator behavior ---
     mockValidateUploadBody.mockResolvedValue({
       fileInfo: { name: 'test.jpg', alternativeText: '', caption: '', folder: null },
     } as any);
@@ -88,14 +87,12 @@ describe('Admin Upload Controller', () => {
       updates: [],
     } as any);
 
-    // By default, each permission check returns a pm with sanitizeOutput
     mockFindEntityAndCheckPermissions.mockResolvedValue({
       pm: {
         sanitizeOutput: jest.fn((data) => Promise.resolve({ ...data, cleaned: true })),
       },
     } as any);
 
-    // --- contexts ---
     mockContext = {
       state: { userAbility: {}, user: { id: 1 } },
       request: {

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -52,7 +52,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       if (serviceName === 'file') {
         return {
           upload: jest.fn().mockResolvedValue([{}]),
-          signFileUrls: jest.fn((f: any) => Promise.resolve(f)),
+          signFileUrls: jest.fn((file) => Promise.resolve(file)),
         };
       }
       return {};

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -24,10 +24,7 @@ describe('Admin Upload Controller - AI Service Connection', () => {
   let mockContext: Partial<Context>;
   let ctxBulk: Partial<Context>;
 
-  let mockAiMetadataService: {
-    isEnabled: jest.Mock;
-    processFiles: jest.Mock;
-  };
+  let mockAiMetadataService: any;
 
   let uploadService: {
     upload: jest.Mock;
@@ -54,8 +51,9 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       if (serviceName === 'upload') return uploadService as any;
       if (serviceName === 'file') {
         return {
+          upload: jest.fn().mockResolvedValue([{}]),
           signFileUrls: jest.fn((f: any) => Promise.resolve(f)),
-        } as any;
+        };
       }
       return {} as any;
     });

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -2,17 +2,38 @@ import type { Context } from 'koa';
 
 import adminUploadController from '../admin-upload';
 import { getService } from '../../utils';
-import { validateUploadBody } from '../validation/admin/upload';
+import { validateBulkUpdateBody, validateUploadBody } from '../validation/admin/upload';
+import * as findEntityAndCheckPermissionsModule from '../utils/find-entity-and-check-permissions';
+import { ACTIONS } from '../../../src/constants';
 
 jest.mock('../../utils');
 jest.mock('../validation/admin/upload');
+jest.mock('../utils/find-entity-and-check-permissions');
 
 const mockGetService = getService as jest.MockedFunction<typeof getService>;
 const mockValidateUploadBody = validateUploadBody as jest.MockedFunction<typeof validateUploadBody>;
+const mockValidateBulkUpdateBody = validateBulkUpdateBody as jest.MockedFunction<
+  typeof validateBulkUpdateBody
+>;
+const mockFindEntityAndCheckPermissions =
+  findEntityAndCheckPermissionsModule.findEntityAndCheckPermissions as jest.MockedFunction<
+    typeof findEntityAndCheckPermissionsModule.findEntityAndCheckPermissions
+  >;
 
-describe('Admin Upload Controller - AI Service Connection', () => {
+describe('Admin Upload Controller', () => {
   let mockContext: Partial<Context>;
-  let mockAiMetadataService: any;
+  let ctxBulk: Partial<Context>;
+
+  let mockAiMetadataService: {
+    isEnabled: jest.Mock;
+    processFiles: jest.Mock;
+  };
+
+  let uploadService: {
+    upload: jest.Mock;
+    updateFileInfo: jest.Mock;
+    replace: jest.Mock;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -22,43 +43,61 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       processFiles: jest.fn(),
     };
 
+    uploadService = {
+      upload: jest.fn().mockResolvedValue([{}]),
+      updateFileInfo: jest.fn(),
+      replace: jest.fn(),
+    };
+
     mockGetService.mockImplementation((serviceName: string) => {
-      if (serviceName === 'aiMetadata') {
-        return mockAiMetadataService;
+      if (serviceName === 'aiMetadata') return mockAiMetadataService as any;
+      if (serviceName === 'upload') return uploadService as any;
+      if (serviceName === 'file') {
+        return {
+          signFileUrls: jest.fn((f: any) => Promise.resolve(f)),
+        } as any;
       }
-      return {
-        upload: jest.fn().mockResolvedValue([{}]),
-        signFileUrls: jest.fn((file) => Promise.resolve(file)),
-      };
+      return {} as any;
     });
 
-    global.strapi = {
+    const pm = {
+      isAllowed: true,
+      sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
+    };
+
+    (global as any).strapi = {
       service: jest.fn().mockReturnValue({
-        createPermissionsManager: jest.fn().mockReturnValue({
-          isAllowed: true,
-          sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
-        }),
+        createPermissionsManager: jest.fn().mockReturnValue(pm),
       }),
       admin: {
         services: {
           permission: {
-            createPermissionsManager: jest.fn().mockReturnValue({
-              isAllowed: true,
-              sanitizeOutput: jest.fn((data) => Promise.resolve(data)),
-            }),
+            createPermissionsManager: jest.fn().mockReturnValue(pm),
           },
         },
       },
-      log: {
-        warn: jest.fn(),
-      },
+      log: { warn: jest.fn() },
     } as any;
 
-    mockContext = {
-      state: {
-        userAbility: {},
-        user: { id: 1 },
+    // --- default validator behavior ---
+    mockValidateUploadBody.mockResolvedValue({
+      fileInfo: { name: 'test.jpg', alternativeText: '', caption: '', folder: null },
+    } as any);
+
+    mockValidateBulkUpdateBody.mockResolvedValue({
+      updates: [],
+    } as any);
+
+    // By default, each permission check returns a pm with sanitizeOutput
+    mockFindEntityAndCheckPermissions.mockResolvedValue({
+      pm: {
+        sanitizeOutput: jest.fn((data) => Promise.resolve({ ...data, cleaned: true })),
       },
+    } as any);
+
+    // --- contexts ---
+    mockContext = {
+      state: { userAbility: {}, user: { id: 1 } },
       request: {
         body: {},
         files: { files: { filepath: '/tmp/test.jpg', mimetype: 'image/jpeg' } },
@@ -66,9 +105,10 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       forbidden: jest.fn(),
     } as any;
 
-    mockValidateUploadBody.mockResolvedValue({
-      fileInfo: { name: 'test.jpg', alternativeText: '', caption: '', folder: null },
-    } as any);
+    ctxBulk = {
+      state: { userAbility: {}, user: { id: 42 } },
+      request: { body: {} } as any,
+    } as any;
   });
 
   describe('uploadFiles - AI Service Connection', () => {
@@ -103,6 +143,132 @@ describe('Admin Upload Controller - AI Service Connection', () => {
       expect(strapi.log.warn).toHaveBeenCalledWith(
         'AI metadata generation failed, proceeding without AI enhancements',
         { error: 'AI service unavailable' }
+      );
+    });
+  });
+
+  describe('bulkUpdateFileInfo', () => {
+    it('updates multiple files, sanitizes outputs, and returns an array', async () => {
+      mockValidateBulkUpdateBody.mockResolvedValue({
+        updates: [
+          {
+            id: 1,
+            fileInfo: {
+              name: 'fileA.jpg',
+              caption: 'A',
+              alternativeText: 'alternativeA',
+              folder: null,
+            },
+          },
+          {
+            id: 2,
+            fileInfo: {
+              name: 'fileB.jpg',
+              alternativeText: 'alternativeB',
+              caption: 'B',
+              folder: null,
+            },
+          },
+        ],
+      });
+
+      uploadService.updateFileInfo
+        .mockResolvedValueOnce({ id: 1, caption: 'A' })
+        .mockResolvedValueOnce({ id: 2, alternativeText: 'B' });
+
+      await adminUploadController.bulkUpdateFileInfo(ctxBulk as Context);
+
+      expect(mockValidateBulkUpdateBody).toHaveBeenCalledWith({});
+      expect(uploadService.updateFileInfo).toHaveBeenNthCalledWith(
+        1,
+        1,
+        { name: 'fileA.jpg', alternativeText: 'alternativeA', caption: 'A', folder: null },
+        { user: { id: 42 } }
+      );
+      expect(uploadService.updateFileInfo).toHaveBeenNthCalledWith(
+        2,
+        2,
+        { name: 'fileB.jpg', alternativeText: 'alternativeB', caption: 'B', folder: null },
+        { user: { id: 42 } }
+      );
+
+      expect(mockFindEntityAndCheckPermissions).toHaveBeenCalledTimes(2);
+
+      expect((ctxBulk as any).body).toEqual([
+        { id: 1, caption: 'A', cleaned: true },
+        { id: 2, alternativeText: 'B', cleaned: true },
+      ]);
+    });
+
+    it('returns an empty array when no updates provided', async () => {
+      mockValidateBulkUpdateBody.mockResolvedValue({ updates: [] });
+
+      await adminUploadController.bulkUpdateFileInfo(ctxBulk as Context);
+
+      expect((ctxBulk as any).body).toEqual([]);
+      expect(uploadService.updateFileInfo).not.toHaveBeenCalled();
+      expect(mockFindEntityAndCheckPermissions).not.toHaveBeenCalled();
+    });
+
+    it('propagates validation errors from validateBulkUpdateBody', async () => {
+      mockValidateBulkUpdateBody.mockRejectedValue(new Error('Invalid payload'));
+
+      await expect(adminUploadController.bulkUpdateFileInfo(ctxBulk as Context)).rejects.toThrow(
+        'Invalid payload'
+      );
+    });
+
+    it('sanitizes each updated entity with ACTIONS.read', async () => {
+      const sanitizeOutput = jest.fn((data) => Promise.resolve({ ok: true, ...data }));
+      mockFindEntityAndCheckPermissions.mockResolvedValue({ pm: { sanitizeOutput } } as any);
+
+      mockValidateBulkUpdateBody.mockResolvedValue({
+        updates: [
+          {
+            id: 10,
+            fileInfo: {
+              name: 'fileA.jpg',
+              caption: 'X',
+              alternativeText: 'alternativeA',
+              folder: null,
+            },
+          },
+        ],
+      });
+
+      uploadService.updateFileInfo.mockResolvedValue({ id: 10, caption: 'X' });
+
+      await adminUploadController.bulkUpdateFileInfo(ctxBulk as Context);
+
+      expect(sanitizeOutput).toHaveBeenCalledWith(
+        { id: 10, caption: 'X' },
+        { action: ACTIONS.read }
+      );
+      expect((ctxBulk as any).body).toEqual([{ ok: true, id: 10, caption: 'X' }]);
+    });
+
+    it('passes the authenticated user to updateFileInfo', async () => {
+      mockValidateBulkUpdateBody.mockResolvedValue({
+        updates: [
+          {
+            id: 7,
+            fileInfo: {
+              name: 'fileA.jpg',
+              alternativeText: 'hello',
+              caption: 'A',
+            },
+          },
+        ],
+      } as any);
+
+      uploadService.updateFileInfo.mockResolvedValue({ id: 7 });
+
+      await adminUploadController.bulkUpdateFileInfo(ctxBulk as Context);
+
+      expect(uploadService.updateFileInfo).toHaveBeenCalledWith(
+        7,
+        { name: 'fileA.jpg', alternativeText: 'hello', caption: 'A' },
+        { user: { id: 42 } }
       );
     });
   });

--- a/packages/core/upload/server/src/controllers/validation/admin/upload.ts
+++ b/packages/core/upload/server/src/controllers/validation/admin/upload.ts
@@ -41,12 +41,16 @@ export type UploadBody =
   | yup.InferType<typeof multiUploadSchema>;
 
 const bulkUpdatesSchema = yup.object({
-  updates: yup.array().of(
-    yup.object({
-      id: yup.number().required(),
-      fileInfo: fileInfoSchema.required(),
-    })
-  ).min(1).required(),
+  updates: yup
+    .array()
+    .of(
+      yup.object({
+        id: yup.number().required(),
+        fileInfo: fileInfoSchema.required(),
+      })
+    )
+    .min(1)
+    .required(),
 });
 
 export const validateBulkUpdateBody = validateYupSchema(bulkUpdatesSchema);

--- a/packages/core/upload/server/src/controllers/validation/admin/upload.ts
+++ b/packages/core/upload/server/src/controllers/validation/admin/upload.ts
@@ -39,3 +39,14 @@ export { validateUploadBody };
 export type UploadBody =
   | yup.InferType<typeof uploadSchema>
   | yup.InferType<typeof multiUploadSchema>;
+
+const bulkUpdatesSchema = yup.object({
+  updates: yup.array().of(
+    yup.object({
+      id: yup.number().required(),
+      fileInfo: fileInfoSchema.required(),
+    })
+  ).min(1).required(),
+});
+
+export const validateBulkUpdateBody = validateYupSchema(bulkUpdatesSchema);

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -1,221 +1,58 @@
+const isAuthenticated = 'admin::isAuthenticatedAdmin';
+
+const withPermissions = (actions: string[]) => ({
+  name: 'admin::hasPermissions',
+  config: { actions },
+});
+
+// Common policy sets
+const authOnly = [isAuthenticated];
+
+const canReadSettings = [isAuthenticated, withPermissions(['plugin::upload.settings.read'])];
+const canReadAssets = [isAuthenticated, withPermissions(['plugin::upload.read'])];
+const canUpdateAssets = [isAuthenticated, withPermissions(['plugin::upload.assets.update'])];
+const canCreateAssets = [isAuthenticated, withPermissions(['plugin::upload.assets.create'])];
+
+type Route = {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  path: string;
+  handler: string;
+  config: { policies: unknown[] };
+};
+
+const makeRoute = (
+  method: Route['method'],
+  path: string,
+  handler: string,
+  policies: unknown[]
+): Route => ({
+  method,
+  path,
+  handler,
+  config: { policies },
+});
+
 export const routes = {
   type: 'admin',
   routes: [
-    {
-      method: 'GET',
-      path: '/settings',
-      handler: 'admin-settings.getSettings',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.settings.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'PUT',
-      path: '/settings',
-      handler: 'admin-settings.updateSettings',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.settings.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/',
-      handler: 'admin-upload.upload',
-      config: {
-        policies: ['admin::isAuthenticatedAdmin'],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/files',
-      handler: 'admin-file.find',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/files/:id',
-      handler: 'admin-file.findOne',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'DELETE',
-      path: '/files/:id',
-      handler: 'admin-file.destroy',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.update'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/folders/:id',
-      handler: 'admin-folder.findOne',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/folders',
-      handler: 'admin-folder.find',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/folders',
-      handler: 'admin-folder.create',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.create'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'PUT',
-      path: '/folders/:id',
-      handler: 'admin-folder.update',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.update'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'GET',
-      path: '/folder-structure',
-      handler: 'admin-folder.getStructure',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.read'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/actions/bulk-delete',
-      handler: 'admin-folder-file.deleteMany',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.update'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/actions/bulk-move',
-      handler: 'admin-folder-file.moveMany',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.update'],
-            },
-          },
-        ],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/actions/bulk-update',
-      handler: 'admin-upload.bulkUpdateFileInfo',
-      config: {
-        policies: [
-          'admin::isAuthenticatedAdmin',
-          {
-            name: 'admin::hasPermissions',
-            config: {
-              actions: ['plugin::upload.assets.update'],
-            },
-          },
-        ],
-      },
-    },
+    makeRoute('GET', '/settings', 'admin-settings.getSettings', canReadSettings),
+    makeRoute('PUT', '/settings', 'admin-settings.updateSettings', canReadSettings),
+
+    makeRoute('POST', '/', 'admin-upload.upload', authOnly),
+
+    makeRoute('GET', '/files', 'admin-file.find', canReadAssets),
+    makeRoute('GET', '/files/:id', 'admin-file.findOne', canReadAssets),
+    makeRoute('DELETE', '/files/:id', 'admin-file.destroy', canUpdateAssets),
+
+    makeRoute('GET', '/folders/:id', 'admin-folder.findOne', canReadAssets),
+    makeRoute('GET', '/folders', 'admin-folder.find', canReadAssets),
+    makeRoute('POST', '/folders', 'admin-folder.create', canCreateAssets),
+    makeRoute('PUT', '/folders/:id', 'admin-folder.update', canUpdateAssets),
+
+    makeRoute('GET', '/folder-structure', 'admin-folder.getStructure', canReadAssets),
+
+    makeRoute('POST', '/actions/bulk-delete', 'admin-folder-file.deleteMany', canUpdateAssets),
+    makeRoute('POST', '/actions/bulk-move', 'admin-folder-file.moveMany', canUpdateAssets),
+    makeRoute('POST', '/actions/bulk-update', 'admin-upload.bulkUpdateFileInfo', canUpdateAssets),
   ],
 };

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -201,5 +201,21 @@ export const routes = {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/actions/bulk-update',
+      handler: 'admin-upload.bulkUpdateFileInfo',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/core/upload/server/src/routes/admin.ts
+++ b/packages/core/upload/server/src/routes/admin.ts
@@ -1,58 +1,205 @@
-const isAuthenticated = 'admin::isAuthenticatedAdmin';
-
-const withPermissions = (actions: string[]) => ({
-  name: 'admin::hasPermissions',
-  config: { actions },
-});
-
-// Common policy sets
-const authOnly = [isAuthenticated];
-
-const canReadSettings = [isAuthenticated, withPermissions(['plugin::upload.settings.read'])];
-const canReadAssets = [isAuthenticated, withPermissions(['plugin::upload.read'])];
-const canUpdateAssets = [isAuthenticated, withPermissions(['plugin::upload.assets.update'])];
-const canCreateAssets = [isAuthenticated, withPermissions(['plugin::upload.assets.create'])];
-
-type Route = {
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-  path: string;
-  handler: string;
-  config: { policies: unknown[] };
-};
-
-const makeRoute = (
-  method: Route['method'],
-  path: string,
-  handler: string,
-  policies: unknown[]
-): Route => ({
-  method,
-  path,
-  handler,
-  config: { policies },
-});
-
 export const routes = {
   type: 'admin',
   routes: [
-    makeRoute('GET', '/settings', 'admin-settings.getSettings', canReadSettings),
-    makeRoute('PUT', '/settings', 'admin-settings.updateSettings', canReadSettings),
-
-    makeRoute('POST', '/', 'admin-upload.upload', authOnly),
-
-    makeRoute('GET', '/files', 'admin-file.find', canReadAssets),
-    makeRoute('GET', '/files/:id', 'admin-file.findOne', canReadAssets),
-    makeRoute('DELETE', '/files/:id', 'admin-file.destroy', canUpdateAssets),
-
-    makeRoute('GET', '/folders/:id', 'admin-folder.findOne', canReadAssets),
-    makeRoute('GET', '/folders', 'admin-folder.find', canReadAssets),
-    makeRoute('POST', '/folders', 'admin-folder.create', canCreateAssets),
-    makeRoute('PUT', '/folders/:id', 'admin-folder.update', canUpdateAssets),
-
-    makeRoute('GET', '/folder-structure', 'admin-folder.getStructure', canReadAssets),
-
-    makeRoute('POST', '/actions/bulk-delete', 'admin-folder-file.deleteMany', canUpdateAssets),
-    makeRoute('POST', '/actions/bulk-move', 'admin-folder-file.moveMany', canUpdateAssets),
-    makeRoute('POST', '/actions/bulk-update', 'admin-upload.bulkUpdateFileInfo', canUpdateAssets),
+    {
+      method: 'GET',
+      path: '/settings',
+      handler: 'admin-settings.getSettings',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.settings.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/settings',
+      handler: 'admin-settings.updateSettings',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.settings.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/',
+      handler: 'admin-upload.upload',
+      config: {
+        policies: ['admin::isAuthenticatedAdmin'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/files',
+      handler: 'admin-file.find',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/files/:id',
+      handler: 'admin-file.findOne',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'DELETE',
+      path: '/files/:id',
+      handler: 'admin-file.destroy',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/folders/:id',
+      handler: 'admin-folder.findOne',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/folders',
+      handler: 'admin-folder.find',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/folders',
+      handler: 'admin-folder.create',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.create'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'PUT',
+      path: '/folders/:id',
+      handler: 'admin-folder.update',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/folder-structure',
+      handler: 'admin-folder.getStructure',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.read'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/actions/bulk-delete',
+      handler: 'admin-folder-file.deleteMany',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/actions/bulk-move',
+      handler: 'admin-folder-file.moveMany',
+      config: {
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'admin::hasPermissions',
+            config: {
+              actions: ['plugin::upload.assets.update'],
+            },
+          },
+        ],
+      },
+    },
   ],
 };


### PR DESCRIPTION
What does it do?

Adds new route for bulk update.

Why is it needed?

Currently, the media library only allows updating files one by one. This new route makes it possible to update the file information for multiple files at once (bulk update).

How to test it?

Run the Strapi.
Log in with an authenticated admin user.
Call (you can use curl, Postman, or any other HTTP client):

POST /upload/actions/bulk-update
Authorization: Bearer <your-admin-token>

Request body:
{
  "updates": [
    { "id": 3, "fileInfo": {"name": "img3", "alternativeText": "altText1", "caption": "capt3"}},
    {"id": 4, "fileInfo": {"name": "img4", "alternativeText": "altText2"}}
  ]
}

Response:
[
    {
        "id": 3,
        "documentId": "q2t1gpuss2h3s460gc5ufa7m",
        "name": "img3",
        "alternativeText": "altText1",
        "caption": "capt3",
        "width": null,
        "height": null,
        "formats": null,
        ...
    },
    {
        "id": 4,
        "documentId": "mon3o8rjrswcuac3kxjp7r0s",
        "name": "img4",
        "alternativeText": "altText4",
        "caption": "capt4",
        "width": 1024,
        "height": 1024,
        ...
    }
]

Related issue(s)/PR(s)

https://github.com/strapi/content-squad/issues/83