### PR TITLE
removed extra x icon at url(http://localhost:1337/admin/plugins/uploa…

### DIFF
--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/ConfigureTheView.tsx
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/ConfigureTheView.tsx
@@ -118,7 +118,6 @@ export const ConfigureTheView = ({ config }: ConfigureTheViewProps) => {
               onChange={handleChange}
             />
           </Layouts.Content>
-          x
           <Dialog.Root open={showWarningSubmit} onOpenChange={toggleWarningSubmit}>
             <ConfirmDialog onConfirm={handleConfirm} variant="default">
               {formatMessage({


### PR DESCRIPTION
…d/configuration\?sort\=createdAt:DESC\&page\=1\&pageSize\=10)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Just wanted to remove the extra "X" on http://localhost:1337/admin/plugins/upload/configuration?sort=createdAt:DESC&page=1&pageSize=10. this url so removed it 

### Why is it needed?

no needed, was a ui bug!

### How to test it?

1.Run yarn develop
2.Go to Admin -> Plugins -> Upload -> Configuration
3.Confirm no extra "x" at left sidebar

### Related issue(s)/PR(s)
issue no: #24306

Let us know if this is related to any issue/pull request
