### PR TITLE
proof of concept: soft reset after ctb changes

### DIFF
--- a/packages/core/core/src/core-api/controller/transform.ts
+++ b/packages/core/core/src/core-api/controller/transform.ts
@@ -121,7 +121,8 @@ function transformEntry(
     const attribute = type && type.attributes[key];
 
     if (attribute && attribute.type === 'relation' && isEntry(property) && 'target' in attribute) {
-      const data = transformEntry(property, strapi.contentType(attribute.target));
+      const targetType = strapi.contentType(attribute.target);
+      const data = transformEntry(property, targetType ?? undefined);
 
       attributeValues[key] = { data };
     } else if (attribute && attribute.type === 'component' && isEntry(property)) {
@@ -135,7 +136,8 @@ function transformEntry(
         return transformComponent(subProperty, strapi.components[subProperty.__component]);
       });
     } else if (attribute && attribute.type === 'media' && isEntry(property)) {
-      const data = transformEntry(property, strapi.contentType('plugin::upload.file'));
+      const fileType = strapi.contentType('plugin::upload.file');
+      const data = transformEntry(property, fileType ?? undefined);
 
       attributeValues[key] = { data };
     } else {

--- a/packages/core/core/src/domain/module/index.ts
+++ b/packages/core/core/src/domain/module/index.ts
@@ -9,6 +9,7 @@ interface LifecyclesState {
   bootstrap?: boolean;
   register?: boolean;
   destroy?: boolean;
+  softReset?: boolean;
 }
 
 export interface RawModule {
@@ -22,12 +23,14 @@ export interface RawModule {
   bootstrap?: (params: { strapi: Core.Strapi }) => Promise<void>;
   register?: (params: { strapi: Core.Strapi }) => Promise<void>;
   destroy?: (params: { strapi: Core.Strapi }) => Promise<void>;
+  softReset?: (params: { strapi: Core.Strapi }) => Promise<void>;
 }
 
 export interface Module {
   bootstrap: () => Promise<void>;
   register: () => Promise<void>;
   destroy: () => Promise<void>;
+  softReset: () => Promise<void>;
   load: () => void;
   routes: Core.Module['routes'];
   config<T = unknown>(key: PropertyPath, defaultVal?: T): T; // TODO: this mirrors ConfigProvider.get, we should use it directly
@@ -81,6 +84,13 @@ export const createModule = (
       }
       called.bootstrap = true;
       await (rawModule.bootstrap && rawModule.bootstrap({ strapi }));
+    },
+    async softReset() {
+      if (called.softReset) {
+        return;
+      }
+      called.softReset = true;
+      await (rawModule.softReset && rawModule.softReset({ strapi }));
     },
     async register() {
       if (called.register) {

--- a/packages/core/core/src/domain/module/validation.ts
+++ b/packages/core/core/src/domain/module/validation.ts
@@ -6,6 +6,7 @@ const strapiServerSchema = yup
     bootstrap: yup.mixed().isFunction(),
     destroy: yup.mixed().isFunction(),
     register: yup.mixed().isFunction(),
+    softReset: yup.mixed().isFunction(),
     config: yup.object(),
     routes: yup.lazy((value) => {
       if (Array.isArray(value)) {

--- a/packages/core/core/src/loaders/admin.ts
+++ b/packages/core/core/src/loaders/admin.ts
@@ -3,11 +3,13 @@ import type { Core, Struct } from '@strapi/types';
 import { getGlobalId } from '../domain/content-type';
 
 export default async function loadAdmin(strapi: Core.Strapi) {
-  strapi.get('services').add(`admin::`, strapi.admin?.services);
-  strapi.get('controllers').add(`admin::`, strapi.admin?.controllers);
-  strapi.get('content-types').add(`admin::`, formatContentTypes(strapi.admin?.contentTypes ?? {}));
-  strapi.get('policies').add(`admin::`, strapi.admin?.policies);
-  strapi.get('middlewares').add(`admin::`, strapi.admin?.middlewares);
+  strapi.get('services').add(`admin::`, strapi.admin?.services, { force: true });
+  strapi.get('controllers').add(`admin::`, strapi.admin?.controllers, { force: true });
+  strapi
+    .get('content-types')
+    .add(`admin::`, formatContentTypes(strapi.admin?.contentTypes ?? {}), { force: true });
+  strapi.get('policies').add(`admin::`, strapi.admin?.policies, { force: true });
+  strapi.get('middlewares').add(`admin::`, strapi.admin?.middlewares, { force: true });
 
   const userAdminConfig = strapi.config.get('admin');
   strapi.get('config').set('admin', _.merge(strapi.admin?.config, userAdminConfig));

--- a/packages/core/core/src/loaders/apis.ts
+++ b/packages/core/core/src/loaders/apis.ts
@@ -58,7 +58,7 @@ export default async function loadAPIs(strapi: Core.Strapi) {
   validateContentTypesUnicity(apis);
 
   for (const apiName of Object.keys(apis)) {
-    strapi.get('apis').add(apiName, apis[apiName]);
+    strapi.get('apis').add(apiName, apis[apiName], { force: true });
   }
 }
 

--- a/packages/core/core/src/loaders/components.ts
+++ b/packages/core/core/src/loaders/components.ts
@@ -61,5 +61,5 @@ export default async function loadComponents(strapi: Core.Strapi) {
     return acc;
   }, {} as ComponentMap);
 
-  strapi.get('components').add(components);
+  strapi.get('components').add(components, { force: true });
 }

--- a/packages/core/core/src/loaders/middlewares.ts
+++ b/packages/core/core/src/loaders/middlewares.ts
@@ -8,8 +8,15 @@ import { middlewares as internalMiddlewares } from '../middlewares';
 export default async function loadMiddlewares(strapi: Core.Strapi) {
   const localMiddlewares = await loadLocalMiddlewares(strapi);
 
-  strapi.get('middlewares').add(`global::`, localMiddlewares);
-  strapi.get('middlewares').add(`strapi::`, internalMiddlewares);
+  strapi.log.debug(
+    `loadMiddlewares: adding global middlewares: ${Object.keys(localMiddlewares).join(', ')}`
+  );
+  strapi.get('middlewares').add(`global::`, localMiddlewares, { force: true });
+
+  strapi.log.debug(
+    `loadMiddlewares: adding strapi middlewares: ${Object.keys(internalMiddlewares).join(', ')}`
+  );
+  strapi.get('middlewares').add(`strapi::`, internalMiddlewares, { force: true });
 }
 
 const loadLocalMiddlewares = async (strapi: Core.Strapi) => {

--- a/packages/core/core/src/loaders/plugins/index.ts
+++ b/packages/core/core/src/loaders/plugins/index.ts
@@ -136,7 +136,7 @@ export default async function loadPlugins(strapi: Core.Strapi) {
   await applyUserExtension(plugins);
 
   for (const pluginName of Object.keys(plugins)) {
-    strapi.get('plugins').add(pluginName, plugins[pluginName]);
+    strapi.get('plugins').add(pluginName, plugins[pluginName], { force: true });
   }
 }
 

--- a/packages/core/core/src/loaders/policies.ts
+++ b/packages/core/core/src/loaders/policies.ts
@@ -25,5 +25,6 @@ export default async function loadPolicies(strapi: Core.Strapi) {
     }
   }
 
-  strapi.get('policies').add(`global::`, policies);
+  strapi.log.debug(`loadPolicies: adding global policies: ${Object.keys(policies).join(', ')}`);
+  strapi.get('policies').add(`global::`, policies, { force: true });
 }

--- a/packages/core/core/src/registries/apis.ts
+++ b/packages/core/core/src/registries/apis.ts
@@ -11,8 +11,8 @@ const apisRegistry = (strapi: Core.Strapi) => {
     getAll() {
       return apis;
     },
-    add(apiName: string, apiConfig: unknown) {
-      if (has(apiName, apis)) {
+    add(apiName: string, apiConfig: unknown, options?: { force?: boolean }) {
+      if (has(apiName, apis) && !options?.force) {
         throw new Error(`API ${apiName} has already been registered.`);
       }
 
@@ -21,6 +21,36 @@ const apisRegistry = (strapi: Core.Strapi) => {
       apis[apiName] = api;
 
       return apis[apiName];
+    },
+
+    /**
+     * Removes a given API namespace; used to rebuild from disk
+     */
+    remove(apiName: string) {
+      delete apis[apiName];
+      return this;
+    },
+
+    /**
+     * Clears all APIs
+     */
+    clear() {
+      for (const key of Object.keys(apis)) {
+        delete apis[key];
+      }
+      return this;
+    },
+
+    /**
+     * Removes APIs whose name starts with the given prefix
+     */
+    removePrefix(prefix: string) {
+      for (const key of Object.keys(apis)) {
+        if (key.startsWith(prefix)) {
+          delete apis[key];
+        }
+      }
+      return this;
     },
   };
 };

--- a/packages/core/core/src/registries/components.ts
+++ b/packages/core/core/src/registries/components.ts
@@ -29,8 +29,8 @@ const componentsRegistry = () => {
     /**
      * Registers a component
      */
-    set(uid: UID.Component, component: Struct.ComponentSchema) {
-      if (has(uid, components)) {
+    set(uid: UID.Component, component: Struct.ComponentSchema, options?: { force?: boolean }) {
+      if (has(uid, components) && !options?.force) {
         throw new Error(`Component ${uid} has already been registered.`);
       }
 
@@ -42,10 +42,23 @@ const componentsRegistry = () => {
     /**
      * Registers a map of components for a specific namespace
      */
-    add(newComponents: Record<UID.Component, Struct.ComponentSchema>) {
+    add(
+      newComponents: Record<UID.Component, Struct.ComponentSchema>,
+      options?: { force?: boolean }
+    ) {
       for (const uid of Object.keys(newComponents) as UID.Component[]) {
-        this.set(uid, newComponents[uid]);
+        this.set(uid, newComponents[uid], { force: options?.force });
       }
+    },
+
+    /**
+     * Removes all components (used for rebuilding from disk)
+     */
+    clear() {
+      for (const uid of Object.keys(components) as UID.Component[]) {
+        delete components[uid];
+      }
+      return this;
     },
   };
 };

--- a/packages/core/core/src/registries/content-types.ts
+++ b/packages/core/core/src/registries/content-types.ts
@@ -46,7 +46,15 @@ const contentTypesRegistry = () => {
     /**
      * Registers a contentType
      */
-    set(uid: UID.ContentType, contentType: Struct.ContentTypeSchema) {
+    set(
+      uid: UID.ContentType,
+      contentType: Struct.ContentTypeSchema,
+      options?: { force?: boolean }
+    ) {
+      if (has(uid, contentTypes) && !options?.force) {
+        throw new Error(`Content-type ${uid} has already been registered.`);
+      }
+
       contentTypes[uid] = contentType;
       return this;
     },
@@ -54,13 +62,13 @@ const contentTypesRegistry = () => {
     /**
      * Registers a map of contentTypes for a specific namespace
      */
-    add(namespace: string, newContentTypes: ContentTypesInput) {
+    add(namespace: string, newContentTypes: ContentTypesInput, options?: { force?: boolean }) {
       validateKeySameToSingularName(newContentTypes);
 
       for (const rawCtName of Object.keys(newContentTypes)) {
         const uid = addNamespace(rawCtName, namespace);
 
-        if (has(uid, contentTypes)) {
+        if (has(uid, contentTypes) && !options?.force) {
           throw new Error(`Content-type ${uid} has already been registered.`);
         }
 
@@ -79,6 +87,19 @@ const contentTypesRegistry = () => {
       }
 
       extendFn(currentContentType);
+
+      return this;
+    },
+
+    /**
+     * Removes all content types for a specific namespace (e.g. api::blog)
+     */
+    removeNamespace(namespace: string) {
+      for (const uid of Object.keys(contentTypes)) {
+        if (hasNamespace(uid, namespace)) {
+          delete contentTypes[uid];
+        }
+      }
 
       return this;
     },

--- a/packages/core/core/src/registries/modules.ts
+++ b/packages/core/core/src/registries/modules.ts
@@ -14,8 +14,8 @@ const modulesRegistry = (strapi: Core.Strapi) => {
     getAll(prefix = '') {
       return pickBy<ModuleMap>((mod, namespace) => namespace.startsWith(prefix))(modules);
     },
-    add(namespace: string, rawModule: RawModule) {
-      if (has(namespace, modules)) {
+    add(namespace: string, rawModule: RawModule, options?: { force?: boolean }) {
+      if (has(namespace, modules) && !options?.force) {
         throw new Error(`Module ${namespace} has already been registered.`);
       }
 
@@ -38,6 +38,35 @@ const modulesRegistry = (strapi: Core.Strapi) => {
       for (const mod of Object.values(modules)) {
         await mod.destroy();
       }
+    },
+    async softReset() {
+      for (const mod of Object.values(modules)) {
+        await mod.softReset?.();
+      }
+    },
+
+    /**
+     * Removes modules whose namespace starts with the given prefix (e.g. 'plugin::', 'api::')
+     */
+    removePrefix(prefix: string) {
+      for (const namespace of Object.keys(modules)) {
+        if (namespace.startsWith(prefix)) {
+          delete modules[namespace];
+        }
+      }
+
+      return this;
+    },
+
+    /**
+     * Clears all modules
+     */
+    clear() {
+      for (const namespace of Object.keys(modules)) {
+        delete modules[namespace];
+      }
+
+      return this;
     },
   };
 };

--- a/packages/core/core/src/registries/plugins.ts
+++ b/packages/core/core/src/registries/plugins.ts
@@ -14,8 +14,8 @@ const pluginsRegistry = (strapi: Core.Strapi) => {
     getAll() {
       return plugins;
     },
-    add(name: string, pluginConfig: Core.Plugin) {
-      if (has(name, plugins)) {
+    add(name: string, pluginConfig: Core.Plugin, options?: { force?: boolean }) {
+      if (has(name, plugins) && !options?.force) {
         throw new Error(`Plugin ${name} has already been registered.`);
       }
 
@@ -23,6 +23,24 @@ const pluginsRegistry = (strapi: Core.Strapi) => {
       plugins[name] = pluginModule;
 
       return plugins[name];
+    },
+
+    /**
+     * Removes a plugin by name
+     */
+    remove(name: string) {
+      delete plugins[name];
+      return this;
+    },
+
+    /**
+     * Clears all plugins
+     */
+    clear() {
+      for (const key of Object.keys(plugins)) {
+        delete plugins[key];
+      }
+      return this;
     },
   };
 };

--- a/packages/core/core/src/registries/policies.ts
+++ b/packages/core/core/src/registries/policies.ts
@@ -115,7 +115,10 @@ const policiesRegistry = () => {
     /**
      * Registers a policy
      */
-    set(uid: string, policy: Core.Policy) {
+    set(uid: string, policy: Core.Policy, options?: { force?: boolean }) {
+      if (policies.has(uid) && !options?.force) {
+        throw new Error(`Policy ${uid} has already been registered.`);
+      }
       policies.set(uid, policy);
       return this;
     },
@@ -123,12 +126,16 @@ const policiesRegistry = () => {
     /**
      * Registers a map of policies for a specific namespace
      */
-    add(namespace: string, newPolicies: Record<string, Core.Policy>) {
+    add(
+      namespace: string,
+      newPolicies: Record<string, Core.Policy>,
+      options?: { force?: boolean }
+    ) {
       for (const policyName of Object.keys(newPolicies)) {
         const policy = newPolicies[policyName];
         const uid = addNamespace(policyName, namespace);
 
-        if (has(uid, policies)) {
+        if (policies.has(uid) && !options?.force) {
           throw new Error(`Policy ${uid} has already been registered.`);
         }
 
@@ -148,6 +155,19 @@ const policiesRegistry = () => {
           config: (typeof policyConfig === 'object' && policyConfig.config) || {},
         };
       });
+    },
+
+    /**
+     * Removes all policies for a specific namespace
+     */
+    removeNamespace(namespace: string) {
+      for (const uid of Array.from(policies.keys())) {
+        if (hasNamespace(uid, namespace)) {
+          policies.delete(uid);
+        }
+      }
+
+      return this;
     },
   };
 };

--- a/packages/plugins/graphql/server/src/index.ts
+++ b/packages/plugins/graphql/server/src/index.ts
@@ -1,9 +1,30 @@
+import type { Core } from '@strapi/types';
 import { config } from './config';
 import { bootstrap } from './bootstrap';
 import { services } from './services';
 
+async function softReset({ strapi }: { strapi: Core.Strapi }) {
+  try {
+    // Stop existing Apollo server if available
+    if (typeof (strapi.plugin('graphql') as any).destroy === 'function') {
+      await (strapi.plugin('graphql') as any).destroy();
+    }
+
+    // Rebuild GraphQL schema
+    const contentApi = strapi.plugin('graphql').service('content-api');
+    contentApi.buildSchema();
+
+    // Re-register GraphQL route handlers without touching app-level middlewares
+    await bootstrap({ strapi });
+  } catch (e) {
+    strapi.log.warn('GraphQL softReset failed');
+    strapi.log.warn(e as any);
+  }
+}
+
 export default {
   config,
   bootstrap,
+  softReset,
   services,
 };

--- a/packages/plugins/i18n/server/src/controllers/content-types.ts
+++ b/packages/plugins/i18n/server/src/controllers/content-types.ts
@@ -32,6 +32,9 @@ const controller = {
     } = strapi.service('admin::constants');
 
     const modelDef = strapi.contentType(model);
+    if (!modelDef) {
+      return ctx.notFound(`Content type ${model} not found`);
+    }
     const attributesToPopulate = getNestedPopulateOfNonLocalizedAttributes(model);
 
     if (!isLocalizedContentType(modelDef)) {


### PR DESCRIPTION
### What does it do?

Just an experiment to eliminate the server restarts after CTB changes, something to look into for Strapi 6

- Breaking change: user code and plugins that perform any setup in bootstrap or init relying on routes or content types will not work until they add a 'softReset' method that will be called to inform them of updates

This current implementation "somewhat properly" handles the database sync, rebuilding routes and content types, adds blocking to avoid race conditions while routes are being rebuilt, and handles softReset in graphql. basically enough to more-or-less work on our end (with some hacky code), but would wreak havoc on a real system with plugins 😆 There may also be some issues with middleware.

### Why is it needed?

Reduces the lengthy server restart to under 1 second, eliminating the need for a front-end "please wait..." screen

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
