### PR TITLE
fix: unique index recreation

### DIFF
--- a/packages/core/database/src/schema/index.ts
+++ b/packages/core/database/src/schema/index.ts
@@ -6,7 +6,7 @@ import createSchemaStorage from './storage';
 import { metadataToSchema } from './schema';
 
 import type { Database } from '..';
-import { SchemaDiff } from './types';
+import { SchemaDiff, Schema } from './types';
 
 export type * from './types';
 
@@ -17,7 +17,7 @@ export interface SchemaProvider {
   schemaDiff: ReturnType<typeof createSchemaDiff>;
   schemaStorage: ReturnType<typeof createSchemaStorage>;
   sync(): Promise<SchemaDiff['status']>;
-  syncSchema(): Promise<SchemaDiff['status']>;
+  syncSchema(schema?: Schema): Promise<SchemaDiff['status']>;
   reset(): Promise<void>;
   create(): Promise<void>;
   drop(): Promise<void>;
@@ -61,12 +61,12 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       await this.create();
     },
 
-    async syncSchema(): Promise<SchemaDiff['status']> {
+    async syncSchema(oldSchema?: Schema): Promise<SchemaDiff['status']> {
       debug('Synchronizing database schema');
 
-      const DBSchema = await db.dialect.schemaInspector.getSchema();
+      const currentSchema = oldSchema ?? (await db.dialect.schemaInspector.getSchema());
 
-      const { status, diff } = await this.schemaDiff.diff(DBSchema, schema);
+      const { status, diff } = await this.schemaDiff.diff(currentSchema, schema);
 
       if (status === 'CHANGED') {
         await this.builder.updateSchema(diff);
@@ -101,7 +101,7 @@ export const createSchemaProvider = (db: Database): SchemaProvider => {
       if (oldHash !== hash) {
         debug('Schema changed');
 
-        return this.syncSchema();
+        return this.syncSchema(oldSchema.schema);
       }
 
       debug('Schema unchanged');


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix #24421 

### Why is it needed?

Describe the issue you are solving.

- It uses the previous schema stored in the `strapi_database_schema` table to compare changes to not recreate indexes as the order of the columns array is the same. It also avoids doing a lot of queries to the database to know the current schema if it was already stored in the `strapi_database_schema` table.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

- It can be reproduced by following the steps in issue #24421 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request

- #24421 