### PR TITLE
poc: custom blocks implementation

### DIFF
--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -1,16 +1,167 @@
 import React from 'react';
+import styled from 'styled-components';
+import { Editor, Transforms } from 'slate';
 
-import { Button } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system';
 
 import { registerPreviewRoute } from './preview';
+import { Information } from '@strapi/icons';
 
 const config = {
   locales: ['it', 'es', 'en', 'en-GB'],
 };
 
+// Styled callout container
+const CalloutContainer = styled.div.attrs({ role: 'note' })`
+  background: ${({ theme }) => theme.colors.primary100};
+  border: 1px solid ${({ theme }) => theme.colors.primary200};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  padding: ${({ theme }) => theme.spaces[4]};
+  margin: ${({ theme }) => theme.spaces[2]} 0;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: ${({ theme }) => theme.colors.primary600};
+    border-radius: ${({ theme }) => theme.borderRadius} 0 0 ${({ theme }) => theme.borderRadius};
+  }
+`;
+
+const CalloutContent = styled.div`
+  padding-left: ${({ theme }) => theme.spaces[1]};
+
+  p {
+    margin: 0;
+    color: ${({ theme }) => theme.colors.neutral700};
+    line-height: 1.6;
+  }
+
+  strong,
+  b {
+    font-weight: ${({ theme }) => theme.fontWeights.semiBold};
+  }
+
+  em,
+  i {
+    font-style: italic;
+  }
+`;
+
+const CalloutIcon = styled.div`
+  color: ${({ theme }) => theme.colors.primary600};
+  margin-right: ${({ theme }) => theme.spaces[2]};
+  flex-shrink: 0;
+  margin-top: 2px;
+`;
+
+// Callout component
+const Callout = (props) => (
+  <CalloutContainer {...props.attributes}>
+    <Flex alignItems="flex-start">
+      <CalloutIcon>
+        <Information width="16px" height="16px" />
+      </CalloutIcon>
+      <CalloutContent>{props.children}</CalloutContent>
+    </Flex>
+  </CalloutContainer>
+);
+
+// Utility function for block conversion (simplified version of baseHandleConvert)
+const convertToCallout = (editor) => {
+  if (!editor.selection) {
+    const [_, lastNodePath] = Editor.last(editor, []);
+
+    // Find the current block node
+    const entry = Editor.above(editor, {
+      match: (node) => !Editor.isEditor(node) && node.type !== 'text' && node.type !== 'link',
+      at: lastNodePath,
+    });
+
+    if (entry && !Editor.isEditor(entry[0])) {
+      const [, elementPath] = entry;
+      Transforms.setNodes(editor, { type: 'callout' }, { at: elementPath });
+    }
+    return;
+  }
+
+  // Find the current block node at selection
+  const entry = Editor.above(editor, {
+    match: (node) => !Editor.isEditor(node) && node.type !== 'text' && node.type !== 'link',
+  });
+
+  if (entry && !Editor.isEditor(entry[0])) {
+    const [, elementPath] = entry;
+    Transforms.setNodes(editor, { type: 'callout' }, { at: elementPath });
+  }
+};
+
+// Handle enter key behavior
+const handleCalloutEnter = (editor) => {
+  if (!editor.selection) return;
+
+  const nodeEntry = Editor.above(editor, {
+    match: (node) => !Editor.isEditor(node) && node.type === 'callout',
+  });
+
+  if (!nodeEntry) return;
+
+  const [node, nodePath] = nodeEntry;
+  const isNodeEnd = Editor.isEnd(editor, editor.selection.anchor, nodePath);
+
+  // Check if we're at the end and the last text is empty or ends with newline
+  const lastChild = node.children[node.children.length - 1];
+  const isEmpty =
+    lastChild &&
+    lastChild.type === 'text' &&
+    (lastChild.text === '' || lastChild.text.endsWith('\n'));
+
+  if (isNodeEnd && isEmpty && lastChild.text.endsWith('\n')) {
+    // Remove the trailing newline and exit the callout
+    Transforms.delete(editor, { distance: 1, unit: 'character', reverse: true });
+    Transforms.insertNodes(editor, {
+      type: 'paragraph',
+      children: [{ type: 'text', text: '' }],
+    });
+    return;
+  }
+
+  // Insert a line break within the callout
+  Transforms.insertText(editor, '\n');
+
+  // Remove formatting at the end of lines
+  if (isNodeEnd) {
+    ['bold', 'italic', 'underline', 'strikethrough', 'code'].forEach((modifier) => {
+      Editor.removeMark(editor, modifier);
+    });
+  }
+};
+
 export default {
   config,
   register: (app) => {
+    app.getPlugin('content-manager').apis.addBlocks([
+      {
+        key: 'callout',
+        renderElement: (props) => <Callout {...props} />,
+        icon: Information,
+        label: { id: 'blocks.callout', defaultMessage: 'Callout' },
+        matchNode: (node) => node.type === 'callout',
+        isInBlocksSelector: true,
+        handleConvert(editor) {
+          convertToCallout(editor);
+        },
+        handleEnterKey(editor) {
+          handleCalloutEnter(editor);
+        },
+        snippets: [':::callout'],
+        dragHandleTopMargin: '10px',
+      },
+    ]);
     registerPreviewRoute(app);
   },
 };

--- a/examples/getstarted/src/index.js
+++ b/examples/getstarted/src/index.js
@@ -7,7 +7,25 @@ module.exports = {
    *
    * This gives you an opportunity to extend code.
    */
-  register({ strapi }) {},
+  register({ strapi }) {
+    // Register the callout custom block for backend validation
+    const { yup } = require('@strapi/utils');
+
+    // Register the callout block with a function-based validator
+    strapi.customBlocks.register({
+      name: 'callout',
+      validator: ({ inlineNodeValidator }) => {
+        return yup.object().shape({
+          type: yup.string().equals(['callout']).required(),
+          children: yup
+            .array()
+            .of(inlineNodeValidator)
+            .min(1, 'Callout must have at least one child element')
+            .required(),
+        });
+      },
+    });
+  },
 
   /**
    * An asynchronous bootstrap function that runs before

--- a/packages/core/content-manager/admin/src/content-manager.ts
+++ b/packages/core/content-manager/admin/src/content-manager.ts
@@ -1,6 +1,7 @@
 /* eslint-disable check-file/filename-naming-convention */
 import { INJECTION_ZONES } from './components/InjectionZone';
 import { PLUGIN_ID } from './constants/plugin';
+import { BlocksRegistry, type CustomBlockConfig } from './core/BlocksRegistry';
 import {
   DEFAULT_ACTIONS,
   type DocumentActionPosition,
@@ -129,6 +130,7 @@ class ContentManagerPlugin {
   ];
   editViewSidePanels: PanelComponent[] = [ActionsPanel];
   headerActions: HeaderActionComponent[] = [];
+  blocksRegistry = new BlocksRegistry();
 
   constructor() {}
 
@@ -200,6 +202,10 @@ class ContentManagerPlugin {
     }
   }
 
+  addBlocks(blocks: CustomBlockConfig | CustomBlockConfig[]) {
+    this.blocksRegistry.register(blocks);
+  }
+
   get config() {
     return {
       id: PLUGIN_ID,
@@ -210,6 +216,7 @@ class ContentManagerPlugin {
         addDocumentAction: this.addDocumentAction.bind(this),
         addDocumentHeaderAction: this.addDocumentHeaderAction.bind(this),
         addEditViewSidePanel: this.addEditViewSidePanel.bind(this),
+        addBlocks: this.addBlocks.bind(this),
         getBulkActions: () => this.bulkActions,
         getDocumentActions: (position?: DocumentActionPosition) => {
           /**
@@ -229,6 +236,7 @@ class ContentManagerPlugin {
         },
         getEditViewSidePanels: () => this.editViewSidePanels,
         getHeaderActions: () => this.headerActions,
+        getBlocksRegistry: () => this.blocksRegistry,
       },
     } satisfies PluginConfig;
   }

--- a/packages/core/content-manager/admin/src/core/BlocksRegistry.ts
+++ b/packages/core/content-manager/admin/src/core/BlocksRegistry.ts
@@ -1,0 +1,181 @@
+/* eslint-disable check-file/filename-naming-convention */
+import { ComponentType } from 'react';
+
+import invariant from 'invariant';
+import { Editor } from 'slate';
+import { type RenderElementProps } from 'slate-react';
+
+import type { Internal, Schema, Utils } from '@strapi/types';
+import type { MessageDescriptor, PrimitiveType } from 'react-intl';
+import type { CSSProperties } from 'styled-components';
+
+type CustomBlockUID = Utils.String.Suffix<
+  | Internal.Namespace.WithSeparator<Internal.Namespace.Plugin>
+  | Internal.Namespace.WithSeparator<Internal.Namespace.Global>,
+  string
+>;
+
+/**
+ * Base interface for custom blocks
+ */
+interface BaseCustomBlock {
+  renderElement: (props: RenderElementProps) => React.JSX.Element;
+  matchNode: (node: Schema.Attribute.BlocksNode) => boolean;
+  handleConvert?: (editor: Editor) => void | (() => React.JSX.Element);
+  handleEnterKey?: (editor: Editor) => void;
+  handleBackspaceKey?: (editor: Editor, event: React.KeyboardEvent<HTMLElement>) => void;
+  handleTab?: (editor: Editor) => void;
+  snippets?: string[];
+  dragHandleTopMargin?: CSSProperties['marginTop'];
+}
+
+/**
+ * Custom block that appears in the blocks selector dropdown
+ */
+interface SelectorCustomBlock extends BaseCustomBlock {
+  isInBlocksSelector: true;
+  icon: ComponentType;
+  label: MessageDescriptor & {
+    values?: Record<string, PrimitiveType>;
+  };
+}
+
+/**
+ * Custom block that doesn't appear in the blocks selector dropdown
+ */
+interface NonSelectorCustomBlock extends BaseCustomBlock {
+  isInBlocksSelector: false;
+}
+
+/**
+ * Configuration for registering a custom block
+ */
+interface CustomBlock {
+  /**
+   * Unique key for the block
+   */
+  key: string;
+  /**
+   * Plugin ID - if not provided, defaults to global namespace
+   */
+  pluginId?: string;
+}
+
+type CustomBlockConfig = CustomBlock & (SelectorCustomBlock | NonSelectorCustomBlock);
+
+/**
+ * Registry for managing custom blocks in the blocks editor
+ *
+ * @example
+ * ```typescript
+ * // In a plugin's admin/src/index.ts
+ * export default {
+ *   register(app) {
+ *     app.getPlugin('content-manager').apis.addBlocks([
+ *       {
+ *         key: 'callout',
+ *         renderElement: (props) => <CalloutBlock {...props} />,
+ *         icon: AlertTriangle,
+ *         label: { id: 'blocks.callout', defaultMessage: 'Callout' },
+ *         matchNode: (node) => node.type === 'callout',
+ *         isInBlocksSelector: true,
+ *         handleConvert(editor) {
+ *           // Block conversion logic
+ *         },
+ *         snippets: [':::callout']
+ *       }
+ *     ]);
+ *   }
+ * }
+ * ```
+ */
+class BlocksRegistry {
+  private customBlocks: Record<string, CustomBlockConfig>;
+
+  constructor() {
+    this.customBlocks = {};
+  }
+
+  /**
+   * Register one or more custom blocks
+   */
+  register = (blocks: CustomBlockConfig | CustomBlockConfig[]) => {
+    if (Array.isArray(blocks)) {
+      // If several custom blocks are passed, register them one by one
+      blocks.forEach((block) => {
+        this.register(block);
+      });
+    } else {
+      // Handle individual custom block
+      const { key, pluginId, renderElement, matchNode, isInBlocksSelector } = blocks;
+
+      // Ensure required attributes are provided
+      invariant(key, 'A key must be provided');
+      invariant(renderElement, 'A renderElement function must be provided');
+      invariant(matchNode, 'A matchNode function must be provided');
+      invariant(typeof isInBlocksSelector === 'boolean', 'isInBlocksSelector must be a boolean');
+
+      // For selector blocks, ensure icon and label are provided
+      if (isInBlocksSelector) {
+        const selectorBlock = blocks as CustomBlock & SelectorCustomBlock;
+        invariant(selectorBlock.icon, 'An icon must be provided for blocks in selector');
+        invariant(selectorBlock.label, 'A label must be provided for blocks in selector');
+      }
+
+      // Ensure key has no special characters
+      const isValidObjectKey = /^(?![0-9])[a-zA-Z0-9$_-]+$/g;
+      invariant(isValidObjectKey.test(key), `Custom block key: '${key}' is not a valid object key`);
+
+      // When no plugin is specified, default to the global namespace
+      const uid: CustomBlockUID = pluginId ? `plugin::${pluginId}.${key}` : `global::${key}`;
+
+      // Ensure the uid is unique
+      const uidAlreadyUsed = Object.prototype.hasOwnProperty.call(this.customBlocks, uid);
+      invariant(!uidAlreadyUsed, `Custom block: '${uid}' has already been registered`);
+
+      this.customBlocks[uid] = blocks;
+    }
+  };
+
+  /**
+   * Get all registered custom blocks
+   */
+  getAll = () => {
+    return this.customBlocks;
+  };
+
+  /**
+   * Get a specific custom block by UID
+   */
+  get = (uid: string): CustomBlockConfig | undefined => {
+    return this.customBlocks[uid];
+  };
+
+  /**
+   * Get all registered blocks formatted for the BlocksEditor
+   */
+  getBlocksForEditor = () => {
+    const blocks: Record<string, SelectorCustomBlock | NonSelectorCustomBlock> = {};
+
+    Object.entries(this.customBlocks).forEach(([_uid, blockConfig]) => {
+      // Use the block key (not the full UID) as the editor block key
+      const blockKey = blockConfig.key;
+
+      // Transform the block config to match BlocksEditor expectations
+      const { key: _key, pluginId: _pluginId, ...editorBlock } = blockConfig;
+
+      blocks[blockKey] = editorBlock;
+    });
+
+    return blocks;
+  };
+}
+
+export { BlocksRegistry };
+export type {
+  CustomBlockConfig,
+  CustomBlockUID,
+  SelectorCustomBlock,
+  NonSelectorCustomBlock,
+  BaseCustomBlock,
+};

--- a/packages/core/content-manager/admin/src/exports.ts
+++ b/packages/core/content-manager/admin/src/exports.ts
@@ -39,3 +39,10 @@ export type {
   HeaderActionDescription,
   HeaderActionProps,
 } from './content-manager';
+
+export type {
+  CustomBlockConfig,
+  SelectorCustomBlock,
+  NonSelectorCustomBlock,
+  BaseCustomBlock,
+} from './core/BlocksRegistry';

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { createContext, type FieldValue } from '@strapi/admin/strapi-admin';
+import { createContext, type FieldValue, useStrapiApp } from '@strapi/admin/strapi-admin';
 import { IconButton, Divider, VisuallyHidden } from '@strapi/design-system';
 import { Expand } from '@strapi/icons';
 import { MessageDescriptor, useIntl } from 'react-intl';
@@ -55,7 +55,7 @@ interface SelectorBlock extends BaseBlock {
 
 type NonSelectorBlockKey = 'list-item' | 'link';
 
-const selectorBlockKeys = [
+const defaultSelectorBlockKeys = [
   'paragraph',
   'heading-one',
   'heading-two',
@@ -70,16 +70,26 @@ const selectorBlockKeys = [
   'code',
 ] as const;
 
-type SelectorBlockKey = (typeof selectorBlockKeys)[number];
+type DefaultSelectorBlockKey = (typeof defaultSelectorBlockKeys)[number];
+type SelectorBlockKey = DefaultSelectorBlockKey | string;
 
-const isSelectorBlockKey = (key: unknown): key is SelectorBlockKey => {
-  return typeof key === 'string' && selectorBlockKeys.includes(key as SelectorBlockKey);
+const isSelectorBlockKey = (key: unknown, blocks: BlocksStore): key is SelectorBlockKey => {
+  if (typeof key !== 'string') return false;
+
+  // Check if it's a default selector block key
+  if (defaultSelectorBlockKeys.includes(key as DefaultSelectorBlockKey)) return true;
+
+  // Check if it's a custom block that should be in selector
+  const block = blocks[key];
+  return block?.isInBlocksSelector === true;
 };
 
 type BlocksStore = {
-  [K in SelectorBlockKey]: SelectorBlock;
+  [K in DefaultSelectorBlockKey]: SelectorBlock;
 } & {
   [K in NonSelectorBlockKey]: NonSelectorBlock;
+} & {
+  [key: string]: SelectorBlock | NonSelectorBlock;
 };
 
 interface BlocksEditorContextValue {
@@ -166,9 +176,49 @@ interface BlocksEditorProps
   name: string;
 }
 
+const getDefaultBlocks = () => ({
+  ...paragraphBlocks,
+  ...headingBlocks,
+  ...listBlocks,
+  ...linkBlocks,
+  ...imageBlocks,
+  ...quoteBlocks,
+  ...codeBlocks,
+});
+
+const useBlocks = (): BlocksStore => {
+  const getPlugin = useStrapiApp('BlocksEditor', (state) => state.getPlugin);
+
+  return React.useMemo(() => {
+    const defaultBlocks = getDefaultBlocks();
+
+    try {
+      // Since we're in the content-manager, we can access our own plugin instance
+      // by using the context directly instead of going through getPlugin
+      if (typeof getPlugin === 'function') {
+        const contentManagerPlugin = getPlugin('content-manager');
+        if (
+          contentManagerPlugin?.apis?.getBlocksRegistry &&
+          typeof contentManagerPlugin.apis.getBlocksRegistry === 'function'
+        ) {
+          const blocksRegistry = contentManagerPlugin.apis.getBlocksRegistry();
+          const customBlocks = blocksRegistry.getBlocksForEditor();
+          return { ...defaultBlocks, ...customBlocks } as BlocksStore;
+        }
+      }
+    } catch (error) {
+      // If plugin isn't available or there's an error, just use default blocks
+      console.warn('Failed to load custom blocks:', error);
+    }
+
+    return defaultBlocks as BlocksStore;
+  }, [getPlugin]);
+};
+
 const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
   ({ disabled = false, name, onChange, value, error, ...contentProps }, forwardedRef) => {
     const { formatMessage } = useIntl();
+    const blocks = useBlocks();
     const [editor] = React.useState(() =>
       pipe(withHistory, withImages, withStrapiSchema, withReact, withLinks)(createEditor())
     );
@@ -239,19 +289,6 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
       }
     }, [editor, value]);
 
-    const blocks = React.useMemo(
-      () => ({
-        ...paragraphBlocks,
-        ...headingBlocks,
-        ...listBlocks,
-        ...linkBlocks,
-        ...imageBlocks,
-        ...quoteBlocks,
-        ...codeBlocks,
-      }),
-      []
-    ) satisfies BlocksStore;
-
     return (
       <>
         <VisuallyHidden id={ariaDescriptionId}>
@@ -310,6 +347,8 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
 export {
   type BlocksStore,
   type SelectorBlockKey,
+  type SelectorBlock,
+  type NonSelectorBlock,
   BlocksEditor,
   BlocksEditorProvider,
   useBlocksEditorContext,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -22,6 +22,7 @@ import { EditorToolbarObserver, type ObservedComponent } from '../../EditorToolb
 import {
   type BlocksStore,
   type SelectorBlockKey,
+  type SelectorBlock,
   isSelectorBlockKey,
   useBlocksEditorContext,
 } from './BlocksEditor';
@@ -173,7 +174,7 @@ const BlocksDropdown = () => {
   const [blockSelected, setBlockSelected] = React.useState<SelectorBlockKey>('paragraph');
 
   const handleSelect = (optionKey: unknown) => {
-    if (!isSelectorBlockKey(optionKey)) {
+    if (!isSelectorBlockKey(optionKey, blocks)) {
       return;
     }
 
@@ -284,7 +285,8 @@ const BlocksDropdown = () => {
     }
   }, [editor.selection, editor, blocks, blockSelected]);
 
-  const Icon = blocks[blockSelected].icon;
+  const selectedBlock = blocks[blockSelected] as SelectorBlock;
+  const Icon = selectedBlock.icon;
 
   return (
     <>
@@ -292,7 +294,7 @@ const BlocksDropdown = () => {
         <SingleSelect
           startIcon={<Icon />}
           onChange={handleSelect}
-          placeholder={formatMessage(blocks[blockSelected].label)}
+          placeholder={formatMessage(selectedBlock.label)}
           value={blockSelected}
           onCloseAutoFocus={preventSelectFocus}
           aria-label={formatMessage({
@@ -301,15 +303,18 @@ const BlocksDropdown = () => {
           })}
           disabled={disabled}
         >
-          {blockKeysToInclude.map((key) => (
-            <BlockOption
-              key={key}
-              value={key}
-              label={blocks[key].label}
-              icon={blocks[key].icon}
-              blockSelected={blockSelected}
-            />
-          ))}
+          {blockKeysToInclude.map((key) => {
+            const block = blocks[key] as SelectorBlock;
+            return (
+              <BlockOption
+                key={key}
+                value={key}
+                label={block.label}
+                icon={block.icon}
+                blockSelected={blockSelected}
+              />
+            );
+          })}
         </SingleSelect>
       </SelectWrapper>
       {modalElement}

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -76,6 +76,7 @@
     "fractional-indexing": "3.2.0",
     "highlight.js": "^10.4.1",
     "immer": "9.0.21",
+    "invariant": "^2.2.4",
     "koa": "2.16.1",
     "lodash": "4.17.21",
     "markdown-it": "^13.0.2",

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -27,6 +27,7 @@ import entityValidator from './services/entity-validator';
 import requestContext from './services/request-context';
 import createAuth from './services/auth';
 import createCustomFields from './services/custom-fields';
+import createCustomBlocks from './services/custom-blocks';
 import createContentAPI from './services/content-api';
 import getNumberOfDynamicZones from './services/utils/dynamic-zones';
 import getNumberOfConditionalFields from './services/utils/conditional-fields';
@@ -86,6 +87,10 @@ class Strapi extends Container implements Core.Strapi {
 
   get customFields(): Modules.CustomFields.CustomFields {
     return this.get('customFields');
+  }
+
+  get customBlocks(): Modules.CustomBlocks.CustomBlocks {
+    return this.get('customBlocks');
   }
 
   get entityValidator(): Modules.EntityValidator.EntityValidator {
@@ -269,6 +274,7 @@ class Strapi extends Container implements Core.Strapi {
       .add('features', () => createFeaturesService(this))
       .add('requestContext', requestContext)
       .add('customFields', createCustomFields(this))
+      .add('customBlocks', createCustomBlocks(this))
       .add('entityValidator', entityValidator)
       .add('entityService', () => createEntityService({ strapi: this, db: this.db }))
       .add('documents', () => createDocumentService(this))

--- a/packages/core/core/src/providers/registries.ts
+++ b/packages/core/core/src/providers/registries.ts
@@ -19,6 +19,7 @@ export default defineProvider({
       .add('modules', () => registries.modules(strapi))
       .add('plugins', () => registries.plugins(strapi))
       .add('custom-fields', () => registries.customFields(strapi))
+      .add('custom-blocks', () => registries.customBlocks(strapi))
       .add('apis', () => registries.apis(strapi))
       .add('models', () => registries.models())
       .add('sanitizers', registries.sanitizers())

--- a/packages/core/core/src/registries/custom-blocks.ts
+++ b/packages/core/core/src/registries/custom-blocks.ts
@@ -1,0 +1,73 @@
+import { has } from 'lodash/fp';
+import { yup } from '@strapi/utils';
+
+import type { Core } from '@strapi/types';
+
+export interface CustomBlockServerOptions {
+  /**
+   * The name of the custom block type
+   */
+  name: string;
+
+  /**
+   * The name of the plugin creating the custom block
+   */
+  plugin?: string;
+
+  /**
+   * Function that returns a Yup validation schema for the block.
+   * Receives helper validators that can be reused for common node types.
+   */
+  validator: (helpers: { inlineNodeValidator: any }) => ReturnType<typeof yup.object>;
+}
+
+const customBlocksRegistry = (strapi: Core.Strapi) => {
+  const customBlocks: Record<string, CustomBlockServerOptions> = {};
+
+  return {
+    getAll() {
+      return customBlocks;
+    },
+    get(customBlock: string) {
+      const registeredCustomBlock = customBlocks[customBlock];
+      if (!registeredCustomBlock) {
+        throw new Error(`Could not find Custom Block: ${customBlock}`);
+      }
+
+      return registeredCustomBlock;
+    },
+    add(customBlock: CustomBlockServerOptions | CustomBlockServerOptions[]) {
+      const customBlockList = Array.isArray(customBlock) ? customBlock : [customBlock];
+
+      for (const cb of customBlockList) {
+        if (!has('name', cb) || !has('validator', cb)) {
+          throw new Error(`Custom blocks require a 'name' and 'validator' key`);
+        }
+
+        const { name, plugin, validator } = cb;
+
+        // Validate that the validator is a function
+        if (!validator || typeof validator !== 'function') {
+          throw new Error(`Custom block validator must be a function that returns a Yup schema`);
+        }
+
+        const isValidObjectKey = /^(?![0-9])[a-zA-Z0-9$_-]+$/g;
+        if (!isValidObjectKey.test(name)) {
+          throw new Error(`Custom block name: '${name}' is not a valid object key`);
+        }
+
+        // When no plugin is specified, or it isn't found in Strapi, default to global
+        const uid =
+          plugin && strapi.plugin(plugin) ? `plugin::${plugin}.${name}` : `global::${name}`;
+
+        if (has(uid, customBlocks)) {
+          throw new Error(`Custom block: '${uid}' has already been registered`);
+        }
+
+        customBlocks[uid] = cb;
+      }
+    },
+  };
+};
+
+export default customBlocksRegistry;

--- a/packages/core/core/src/registries/index.ts
+++ b/packages/core/core/src/registries/index.ts
@@ -8,6 +8,7 @@ export { default as controllers } from './controllers';
 export { default as modules } from './modules';
 export { default as plugins } from './plugins';
 export { default as customFields } from './custom-fields';
+export { default as customBlocks } from './custom-blocks';
 export { default as apis } from './apis';
 export { default as sanitizers } from './sanitizers';
 export { default as validators } from './validators';

--- a/packages/core/core/src/services/custom-blocks.ts
+++ b/packages/core/core/src/services/custom-blocks.ts
@@ -1,0 +1,11 @@
+import type { Core, Modules } from '@strapi/types';
+
+const createCustomBlocks = (strapi: Core.Strapi): Modules.CustomBlocks.CustomBlocks => {
+  return {
+    register(customBlock: Parameters<Modules.CustomBlocks.CustomBlocks['register']>[0]) {
+      strapi.get('custom-blocks').add(customBlock);
+    },
+  };
+};
+
+export default createCustomBlocks;

--- a/packages/core/types/src/core/strapi.ts
+++ b/packages/core/types/src/core/strapi.ts
@@ -31,6 +31,7 @@ export interface Strapi extends Container {
   telemetry: Modules.Metrics.TelemetryService;
   requestContext: Modules.RequestContext.RequestContext;
   customFields: Modules.CustomFields.CustomFields;
+  customBlocks: Modules.CustomBlocks.CustomBlocks;
   fetch: Modules.Fetch.Fetch;
   dirs: StrapiDirectories;
   admin: Core.Module;

--- a/packages/core/types/src/modules/custom-blocks.ts
+++ b/packages/core/types/src/modules/custom-blocks.ts
@@ -1,0 +1,28 @@
+import type { yup } from '@strapi/utils';
+
+export interface CustomBlockServerOptions {
+  /**
+   * The name of the custom block type
+   */
+  name: string;
+
+  /**
+   * The name of the plugin creating the custom block
+   */
+  plugin?: string;
+
+  /**
+   * Function that returns a Yup validation schema for the block.
+   * Receives helper validators that can be reused for common node types.
+   */
+  validator: (helpers: {
+    textNodeValidator: ReturnType<typeof yup.object>;
+    linkNodeValidator: ReturnType<typeof yup.object>;
+    inlineNodeValidator: any;
+    checkValidLink: (link: string) => boolean;
+  }) => ReturnType<typeof yup.object>;
+}
+
+export interface CustomBlocks {
+  register: (customBlocks: CustomBlockServerOptions[] | CustomBlockServerOptions) => void;
+}

--- a/packages/core/types/src/modules/index.ts
+++ b/packages/core/types/src/modules/index.ts
@@ -8,6 +8,7 @@ export type * as ContentAPI from './content-api';
 export type * as CoreStore from './core-store';
 export type * as Cron from './cron';
 export type * as CustomFields from './custom-fields';
+export type * as CustomBlocks from './custom-blocks';
 export type * as EntityValidator from './entity-validator';
 export type * as EventHub from './event-hub';
 export type * as Features from './features';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8799,6 +8799,7 @@ __metadata:
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
+    invariant: "npm:^2.2.4"
     koa: "npm:2.16.1"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.17.21"


### PR DESCRIPTION
### What does it do?

- adds a new custom blocks API to the plugin API
- creates a sample "callout" block in getstarted to try out the API

TODO

- replace yup by zod for the validations, since it will be exposed to the users and we're moving everything to zod already
- probably a fix needed in the React renderer repo since custom blocks would not match the BlocksContent TS type
- add unit tests

### Why is it needed?

https://feedback.strapi.io/customization/p/add-ability-to-extend-strapis-rich-text-editor-with-custom-slate-elements
### How to test it?

Open a kitchensink entry in getstarted. It has a blocks editor. Use the callout block.
