### PR TITLE
ci: use bitnamilegacy images for mysql

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -372,7 +372,7 @@ jobs:
         shard: [1/4, 2/4, 3/4, 4/4]
     services:
       mysql:
-        image: bitnami/mysql:latest
+        image: bitnamilegacy/mysql:latest
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi
@@ -480,7 +480,7 @@ jobs:
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
-        image: bitnami/mysql:latest
+        image: bitnamilegacy/mysql:latest
         env:
           MYSQL_ROOT_PASSWORD: strapi
           MYSQL_USER: strapi


### PR DESCRIPTION
### What does it do?

switch from bitnami/mysql to bitnamilegacy/mysql

### Why is it needed?

our API tests are sometimes not able to run mysql, I believe because [Bitnami have deprecated the images](https://hub.docker.com/r/bitnami/mysql) causing docker to fail to find the image

This is a quick-fix until we move to a different image maintainer.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
