### PR TITLE
feat(packages): adding new field row

### DIFF
--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -7,6 +7,7 @@ const WidgetEntrySchema = z
   .object({
     uid: z.string().nonempty(),
     width: WidthSchema,
+    row: z.number().int().min(0).default(0),
   })
   .strict();
 

--- a/packages/core/admin/server/src/services/__tests__/homepage.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/homepage.test.ts
@@ -37,8 +37,8 @@ describe('homepageService', () => {
       const stored = {
         version: 1,
         widgets: [
-          { uid: 'w-1', width: 6 },
-          { uid: 'w-2', width: 12 },
+          { uid: 'w-1', width: 6, row: 0 },
+          { uid: 'w-2', width: 12, row: 0 },
         ],
         updatedAt: new Date().toISOString(),
       };
@@ -65,16 +65,16 @@ describe('homepageService', () => {
       const service = homepageService({ strapi: mockStrapi });
       const next = await service.updateHomepageLayout(5, {
         widgets: [
-          { uid: 'a', width: 4 },
-          { uid: 'b', width: 8 },
+          { uid: 'a', width: 4, row: 0 },
+          { uid: 'b', width: 8, row: 0 },
         ],
       });
 
       expect(next.version).toBe(1);
       expect(Array.isArray(next.widgets)).toBe(true);
       expect(next.widgets).toEqual([
-        { uid: 'a', width: 4 },
-        { uid: 'b', width: 8 },
+        { uid: 'a', width: 4, row: 0 },
+        { uid: 'b', width: 8, row: 0 },
       ]);
       expect(typeof next.updatedAt).toBe('string');
       expect(Number.isNaN(Date.parse(next.updatedAt))).toBe(false);
@@ -89,8 +89,11 @@ describe('homepageService', () => {
       const existing = {
         version: 1,
         widgets: [
-          { uid: 'x', width: 6 },
-          { uid: 'y', width: 12 },
+          { uid: 'x', width: 6, row: 0 },
+          { uid: 'y', width: 12, row: 0 },
+          { uid: 'z', width: 6, row: 1 },
+          { uid: 'a', width: 12, row: 1 },
+          { uid: 'b', width: 6, row: 2 },
         ],
         updatedAt: new Date().toISOString(),
       };
@@ -103,16 +106,22 @@ describe('homepageService', () => {
       const updatedAt = new Date().toISOString();
       const updated = await service.updateHomepageLayout(9, {
         widgets: [
-          { uid: 'x', width: 4 },
-          { uid: 'y', width: 8 },
+          { uid: 'x', width: 6, row: 0 },
+          { uid: 'y', width: 6, row: 0 },
+          { uid: 'z', width: 6, row: 1 },
+          { uid: 'a', width: 6, row: 1 },
+          { uid: 'b', width: 12, row: 2 },
         ],
         updatedAt,
       });
 
       expect(updated.version).toBe(1);
       expect(updated.widgets).toEqual([
-        { uid: 'x', width: 4 },
-        { uid: 'y', width: 8 },
+          { uid: 'x', width: 6, row: 0 },
+          { uid: 'y', width: 6, row: 0 },
+          { uid: 'z', width: 6, row: 1 },
+          { uid: 'a', width: 6, row: 1 },
+          { uid: 'b', width: 12, row: 2 },
       ]);
       expect(updated.updatedAt).toBe(updatedAt);
 

--- a/packages/core/admin/server/src/services/__tests__/homepage.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/homepage.test.ts
@@ -117,11 +117,11 @@ describe('homepageService', () => {
 
       expect(updated.version).toBe(1);
       expect(updated.widgets).toEqual([
-          { uid: 'x', width: 6, row: 0 },
-          { uid: 'y', width: 6, row: 0 },
-          { uid: 'z', width: 6, row: 1 },
-          { uid: 'a', width: 6, row: 1 },
-          { uid: 'b', width: 12, row: 2 },
+        { uid: 'x', width: 6, row: 0 },
+        { uid: 'y', width: 6, row: 0 },
+        { uid: 'z', width: 6, row: 1 },
+        { uid: 'a', width: 6, row: 1 },
+        { uid: 'b', width: 12, row: 2 },
       ]);
       expect(updated.updatedAt).toBe(updatedAt);
 

--- a/packages/core/admin/server/src/services/homepage.ts
+++ b/packages/core/admin/server/src/services/homepage.ts
@@ -71,6 +71,7 @@ export const homepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       return {
         uid: w.uid,
         width: w.width ?? prev?.width ?? DEFAULT_WIDTH,
+        row: w.row ?? prev?.row ?? 0,
       };
     });
 


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds new field row.

### Why is it needed?

The admin homepage now allows dynamic widget resizing and reordering. Backend persistence ensures user preferences survive refreshes and sessions.

### How to test it?

1. Run the Strapi.
2. Log in with an authenticated admin user.
3. Call (you can use curl, Postman, or any other HTTP client):

#### GET  
```
GET /admin/homepage/layout
Authorization: Bearer <your-admin-token>

Example of response when layout exists:
{
  "version": 1,
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6, "row": 0 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 6, "row": 0 }
  ],
  "updatedAt": "2025-09-11T12:34:56.000Z"
}
Response when no layout exists yet:
null
```

#### PUT
```
PUT /admin/homepage/layout
Authorization: Bearer <your-admin-token>

Request body:
{
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6, "row": 0 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 6, "row": 0 }
  ]
}

Response:
{
  "version": 1,
  "widgets": [
    { "uid": "plugin::content-manager.last-published-entries", "width": 6,  "row": 0 },
    { "uid": "plugin::content-manager.last-edited-entries", "width": 6, "row": 0 }
  ],
  "updatedAt": "2025-09-12T09:45:00.000Z"
}
```

Notes:
version (defaults to 1), row (defaults to 0), updatedAt (set automatically on the backend to the current datetime) are optional in the request.

### Related issue(s)/PR(s)

https://github.com/strapi/content-squad/issues/77
