### PR TITLE
fix: assert admin.auth.secret on bootstrap instead of init

### DIFF
--- a/packages/core/core/src/providers/index.ts
+++ b/packages/core/core/src/providers/index.ts
@@ -2,7 +2,7 @@ import admin from './admin';
 import coreStore from './coreStore';
 import cron from './cron';
 import registries from './registries';
-import sessionManager from './sessionManager';
+import sessionManager from './session-manager';
 import telemetry from './telemetry';
 import webhooks from './webhooks';
 

--- a/packages/core/core/src/providers/session-manager.ts
+++ b/packages/core/core/src/providers/session-manager.ts
@@ -12,6 +12,14 @@ interface AdminAuthConfig {
 
 export default defineProvider({
   init(strapi) {
+    strapi.add('sessionManager', () =>
+      createSessionManager({
+        db: strapi.db,
+      })
+    );
+  },
+
+  async register(strapi) {
     // Get JWT secret from admin auth settings (same as admin token service)
     const adminAuth = strapi.config.get<AdminAuthConfig>('admin.auth', {});
     const jwtSecret = adminAuth.secret;
@@ -21,11 +29,5 @@ export default defineProvider({
         'Missing admin.auth.secret configuration. The SessionManager requires a JWT secret'
       );
     }
-
-    strapi.add('sessionManager', () =>
-      createSessionManager({
-        db: strapi.db,
-      })
-    );
   },
 });


### PR DESCRIPTION
# Note: this is a hotfix branch

### What does it do?

Moves the assertion for admin.auth.secret to bootstrap instead of init

### Why is it needed?

init is run on build, and the secret is not actually required for build. this causes errors on workflows where different env vars are passed in to build.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
