### PR TITLE
feat: allow to override relations to display in admin

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -214,6 +214,8 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           attribute.target === props.attribute.target
       ).length > 0;
 
+    const relationsToDisplay: number = props.attribute?.relationsToDisplay || RELATIONS_TO_DISPLAY;
+
     const { data, isLoading, isFetching } = useGetRelationsQuery(
       {
         model,
@@ -222,7 +224,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         id,
         params: {
           ...currentDocumentMeta.params,
-          pageSize: RELATIONS_TO_DISPLAY,
+          pageSize: relationsToDisplay,
           page: currentPage,
         },
       },
@@ -383,6 +385,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           serverData={data.results}
           disabled={isDisabled}
           name={props.name}
+          relationsToDisplay={relationsToDisplay}
           isLoading={isFetchingMoreRelations}
           relationType={props.attribute.relation}
           // @ts-expect-error – targetModel does exist on the attribute. But it's not typed.
@@ -794,6 +797,7 @@ interface RelationsListProps extends Pick<RelationsFieldProps, 'disabled' | 'nam
    * The existing relations connected on the server. We need these to diff against.
    */
   serverData: RelationResult[];
+  relationsToDisplay: number;
   targetModel: string;
   mainField?: MainField;
 }
@@ -805,6 +809,7 @@ const RelationsList = ({
   name,
   isLoading,
   relationType,
+  relationsToDisplay,
   targetModel,
   mainField,
 }: RelationsListProps) => {
@@ -817,7 +822,7 @@ const RelationsList = ({
   const field = useField(name);
 
   React.useEffect(() => {
-    if (data.length <= RELATIONS_TO_DISPLAY) {
+    if (data.length <= relationsToDisplay) {
       return setOverflow(undefined);
     }
 
@@ -993,10 +998,10 @@ const RelationsList = ({
   const canReorder = !ONE_WAY_RELATIONS.includes(relationType);
 
   const dynamicListHeight =
-    data.length > RELATIONS_TO_DISPLAY
-      ? Math.min(data.length, RELATIONS_TO_DISPLAY) * (RELATION_ITEM_HEIGHT + RELATION_GUTTER) +
+    data.length > relationsToDisplay
+      ? Math.min(data.length, relationsToDisplay) * (RELATION_ITEM_HEIGHT + RELATION_GUTTER) +
         RELATION_ITEM_HEIGHT / 2
-      : Math.min(data.length, RELATIONS_TO_DISPLAY) * (RELATION_ITEM_HEIGHT + RELATION_GUTTER);
+      : Math.min(data.length, relationsToDisplay) * (RELATION_ITEM_HEIGHT + RELATION_GUTTER);
 
   return (
     <ShadowBox $overflowDirection={overflow}>

--- a/packages/core/types/src/schema/attribute/definitions/relation.ts
+++ b/packages/core/types/src/schema/attribute/definitions/relation.ts
@@ -68,6 +68,7 @@ export type RelationOptions = Intersect<
     Attribute.VisibleOption,
     Attribute.RequiredOption,
     { useJoinTable?: boolean },
+    { relationsToDisplay?: number }
   ]
 >;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR add new feature for realtion input in strapi admin in order to allow user to manipulate more that 5 entities in relation field. Keep the hardcoded 5 by default but allow to override it is optional field

### Why is it needed?

For a strapi we handle with my team, we have a page with a field which is a one-to-may relation field to a list of speaker for a conference.
Contribution team have some issue to contribute this field.
- We have about 70 Speakers in this fields (seeing only 5 and need to loadMore X times in annoying)
- Sorting speakers in a tiny 5 items list view in complex with drag and drop

### How to test it?

Add new field in entity schema for relation, you should see new height and item display

```json
{
 "attributes": {
    "speakers": {
      "type": "relation",
      "relation": "oneToMany",
      "target": "api::speaker.speaker",
	  "relationsToDisplay": 100
    }
  }
}
```

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request


### Todo

- [ ] is there a way to implement test on this ? 
- [ ] did not touch the documentation part, if PR is accepted, tell me where I should add some documentation and I will
- [ ] did nothing to be able to edit it in strapi admin UI, waiting for your feedback
