### PR TITLE
Add additional rate-limits to admin and U&P routes

### DIFF
--- a/packages/core/admin/server/src/routes/authentication.ts
+++ b/packages/core/admin/server/src/routes/authentication.ts
@@ -14,13 +14,17 @@ export default [
     handler: 'authentication.accessToken',
     config: {
       auth: false,
+      middlewares: ['admin::rateLimit'],
     },
   },
   {
     method: 'POST',
     path: '/register-admin',
     handler: 'authentication.registerAdmin',
-    config: { auth: false },
+    config: {
+      auth: false,
+      middlewares: ['admin::rateLimit']
+    },
   },
   {
     method: 'GET',
@@ -32,7 +36,10 @@ export default [
     method: 'POST',
     path: '/register',
     handler: 'authentication.register',
-    config: { auth: false },
+    config: {
+      auth: false,
+      middlewares: ['admin::rateLimit'],
+    },
   },
   {
     method: 'POST',
@@ -47,7 +54,10 @@ export default [
     method: 'POST',
     path: '/reset-password',
     handler: 'authentication.resetPassword',
-    config: { auth: false },
+    config: {
+      auth: false,
+      middlewares: ['plugin::email.rateLimit'],
+    },
   },
   {
     method: 'POST',

--- a/packages/core/admin/server/src/routes/authentication.ts
+++ b/packages/core/admin/server/src/routes/authentication.ts
@@ -14,7 +14,6 @@ export default [
     handler: 'authentication.accessToken',
     config: {
       auth: false,
-      middlewares: ['admin::rateLimit'],
     },
   },
   {

--- a/packages/core/admin/server/src/routes/authentication.ts
+++ b/packages/core/admin/server/src/routes/authentication.ts
@@ -23,7 +23,7 @@ export default [
     handler: 'authentication.registerAdmin',
     config: {
       auth: false,
-      middlewares: ['admin::rateLimit']
+      middlewares: ['admin::rateLimit'],
     },
   },
   {

--- a/packages/plugins/users-permissions/server/routes/content-api/auth.js
+++ b/packages/plugins/users-permissions/server/routes/content-api/auth.js
@@ -94,6 +94,7 @@ module.exports = (strapi) => {
       path: '/auth/send-email-confirmation',
       handler: 'auth.sendEmailConfirmation',
       config: {
+        middlewares: ['plugin::users-permissions.rateLimit'],
         prefix: '',
       },
       request: {
@@ -118,7 +119,10 @@ module.exports = (strapi) => {
       method: 'POST',
       path: '/auth/refresh',
       handler: 'auth.refresh',
-      config: { prefix: '' },
+      config: {
+        middlewares: ['plugin::users-permissions.rateLimit'],
+        prefix: '',
+      },
     },
     {
       method: 'POST',


### PR DESCRIPTION
### What does it do?

Adds the rate-limit middlewares to some additional routes (not strictly required but nice to have)

### Why is it needed?

Customer Ticket ID: 3638

### How to test it?

Attempt to do any of the actions with the additional rate-limits more than the specified limits of the rate-limit and see those actions are blocked

### Related issue(s)/PR(s)

(Closed - Rejected): https://github.com/strapi/strapi/security/advisories/GHSA-ppgv-mp5x-wpj4
