### PR TITLE
fix(content-manager): reflect ordering for nested components in Confi…

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
@@ -26,13 +26,9 @@ import type { EditFieldLayout, EditLayout } from '../../hooks/useDocumentLayout'
  * -----------------------------------------------------------------------------------------------*/
 
 interface ConfigurationFormProps extends Pick<FieldsProps, 'attributes' | 'fieldSizes'> {
-  layout: EditLayout;
+  layout: Pick<EditLayout, 'components' | 'settings' | 'layout' | 'metadatas'>;
   onSubmit: FormProps<ConfigurationFormData>['onSubmit'];
 }
-
-/**
- * Every key in EditFieldLayout is turned to optional never and then we overwrite the ones we are using.
- */
 
 type EditFieldSpacerLayout = {
   [key in keyof Omit<EditFieldLayout, 'name' | 'size'>]?: never;
@@ -48,9 +44,9 @@ interface ConfigurationFormData extends Pick<EditLayout, 'settings'> {
   layout: Array<{
     __temp_key__: string;
     children: Array<
-      | (Pick<EditFieldLayout, 'label' | 'size' | 'name' | 'placeholder' | 'mainField'> & {
-          description: EditFieldLayout['hint'];
-          editable: EditFieldLayout['disabled'];
+      | (Pick<EditFieldLayout, 'name' | 'size' | 'label' | 'mainField' | 'placeholder'> & {
+          description: string | undefined;
+          editable: boolean;
           __temp_key__: string;
         })
       | EditFieldSpacerLayout
@@ -129,11 +125,6 @@ const ConfigurationForm = ({
                         return acc;
                       }
 
-                      /**
-                       * Create the list of attributes from the schema as to which can
-                       * be our `mainField` and dictate the display name of the schema
-                       * we're editing.
-                       */
                       if (!ATTRIBUTE_TYPES_THAT_CANNOT_BE_MAIN_FIELD.includes(attribute.type)) {
                         acc.push({
                           label: key,


### PR DESCRIPTION
…gure the View

Fixes #24400
- Persist nested component ordering
- Update Fields.tsx and Form.tsx

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

What does it do?

This PR ensures that when a component contains nested components, the order defined in the Content Type Builder is preserved in the Configure the View screen.

We added a listener for the ctb:attributesReordered event and updated the layout generation logic so the view always reflects the latest ordering.

⚠️ Note: A global reload is sometimes required before hitting the Configure the View button. While it usually happens automatically, there are cases where a manual reload is needed.

Why is it needed?

Previously, when a component contained nested components, changes to the order were not reflected in the Configure the View screen (Content Manager).

### How to test it?

cd ./examples/getstarted
yarn develop --watch-admin

1. Run the project.
2. Create a component with nested components.
3. Reorder the nested components in the Content Type Builder.
4. Open Configure the View — the new order should now be correctly reflected.

Related issue(s)/PR(s)
Closes #24400
Replaces #24410 (previous PR attempt, now closed)

https://github.com/user-attachments/assets/4c1c1716-a8a0-43d0-b06f-a80d87d47994

