### PR TITLE
fix: display specific icons for CSV, XLS, and ZIP files in media library

### DIFF
--- a/packages/core/upload/admin/src/components/AssetCard/DocAssetCard.tsx
+++ b/packages/core/upload/admin/src/components/AssetCard/DocAssetCard.tsx
@@ -1,5 +1,6 @@
 import { Flex, Typography } from '@strapi/design-system';
-import { File, FilePdf } from '@strapi/icons';
+import { File, FileCsv, FilePdf, FileXls, FileZip } from '@strapi/icons';
+
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
@@ -27,6 +28,16 @@ export const DocAssetCard = ({
   ...restProps
 }: DocAssetCardProps) => {
   const { formatMessage } = useIntl();
+
+  const DOC_ICON_MAP: Record<string, typeof File> = {
+    pdf: FilePdf,
+    csv: FileCsv,
+    xls: FileXls,
+    zip: FileZip,
+  };
+
+  const DocIcon = DOC_ICON_MAP[extension] || File;
+
   return (
     <AssetCardBase
       name={name}
@@ -37,11 +48,7 @@ export const DocAssetCard = ({
     >
       <CardAsset width="100%" height={size === 'S' ? `8.8rem` : `16.4rem`} justifyContent="center">
         <Flex gap={2} direction="column" alignItems="center">
-          {extension === 'pdf' ? (
-            <FilePdf aria-label={name} fill="neutral500" width={24} height={24} />
-          ) : (
-            <File aria-label={name} fill="neutral500" width={24} height={24} />
-          )}
+          <DocIcon aria-label={name} fill="neutral500" width={24} height={24} />
 
           <Typography textColor="neutral500" variant="pi">
             {formatMessage({

--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import MuxPlayer from '@mux/mux-player-react';
 import { Box, Flex, Typography } from '@strapi/design-system';
-import { File, FilePdf } from '@strapi/icons';
+import { File, FileCsv, FilePdf, FileXls, FileZip } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { styled, useTheme } from 'styled-components';
 
@@ -54,27 +54,22 @@ export const AssetPreview = React.forwardRef<
     );
   }
 
-  if (mime.includes('pdf')) {
-    return (
-      <CardAsset width="100%" justifyContent="center" {...props}>
-        <Flex gap={2} direction="column" alignItems="center">
-          <FilePdf aria-label={name} fill="neutral500" width={24} height={24} />
-          <Typography textColor="neutral500" variant="pi">
-            {formatMessage({
-              id: 'noPreview',
-              defaultMessage: 'No preview available',
-            })}
-          </Typography>
-        </Flex>
-      </CardAsset>
-    );
-  }
+  const DOC_ICON_MAP: Record<string, typeof File> = {
+    pdf: FilePdf,
+    csv: FileCsv,
+    xls: FileXls,
+    'vnd.ms-excel': FileXls,
+    'vnd.openxmlformats-officedocument.spreadsheetml.sheet': FileXls,
+    zip: FileZip,
+  };
+
+  const fileExt = mime.split('/').pop()?.toLowerCase();
+  const DocIcon = fileExt ? DOC_ICON_MAP[fileExt] || File : File;
 
   return (
     <CardAsset width="100%" justifyContent="center" {...props}>
       <Flex gap={2} direction="column" alignItems="center">
-        <File aria-label={name} fill="neutral500" width={24} height={24} />
-
+        <DocIcon aria-label={name} fill="neutral500" width={24} height={24} />
         <Typography textColor="neutral500" variant="pi">
           {formatMessage({
             id: 'noPreview',

--- a/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryInput/Carousel/CarouselAsset.tsx
@@ -1,9 +1,9 @@
 import { Box, Flex } from '@strapi/design-system';
-import { File, FilePdf } from '@strapi/icons';
+import { File, FileCsv, FilePdf, FileXls, FileZip } from '@strapi/icons';
 import { styled } from 'styled-components';
 
 import { AssetType } from '../../../constants';
-import { createAssetUrl } from '../../../utils';
+import { createAssetUrl, getFileExtension } from '../../../utils';
 import { AudioPreview } from '../../AssetCard/AudioPreview';
 import { VideoPreview } from '../../AssetCard/VideoPreview';
 
@@ -73,13 +73,19 @@ export const CarouselAsset = ({ asset }: { asset: FileAsset }) => {
     );
   }
 
+  const DOC_ICON_MAP: Record<string, typeof File> = {
+    pdf: FilePdf,
+    csv: FileCsv,
+    xls: FileXls,
+    zip: FileZip,
+  };
+
+  const fileExtension = getFileExtension(asset.ext);
+  const DocIcon = fileExtension ? DOC_ICON_MAP[fileExtension] || File : File;
+
   return (
     <DocAsset width="100%" height="100%" justifyContent="center" hasRadius>
-      {asset.ext?.includes('pdf') ? (
-        <FilePdf aria-label={asset.alternativeText || asset.name} width="24px" height="32px" />
-      ) : (
-        <File aria-label={asset.alternativeText || asset.name} width="24px" height="32px" />
-      )}
+      <DocIcon aria-label={asset.alternativeText || asset.name} width="24px" height="32px" />
     </DocAsset>
   );
 };


### PR DESCRIPTION
## What does it do?

This PR adds support for displaying specific file type icons (CSV, XLS, ZIP) in the media library, similar to how PDF files already show a dedicated icon.

Updated 3 components in the upload plugin to use an icon map that displays:
- `FileCsv` for .csv files
- `FileXls` for .xls files
- `FileZip` for .zip files
- `FilePdf` for .pdf files (existing)
- `File` icon for all other types (fallback)

## Why is it needed?

Resolves #22076

The FileCsv, FileXls, and FileZip icons from Phosphor are already available in `@strapi/icons`, but were not being used in the media library. This provides better visual distinction for different file types.

## How to test it?

1. Start the Strapi admin panel
2. Go to Media Library
3. Upload CSV, XLS, ZIP, and PDF files
4. Verify that each file type shows its specific icon in:
   - Grid/Card view
   - List/Table view
   - Preview dialog
   - Carousel/Media picker

## Related issue(s)/PR(s)

Fixes #22076