### PR TITLE
feat: Implement and Add Back to Top button in Layouts

### DIFF
--- a/packages/core/admin/admin/src/components/BackToTop.tsx
+++ b/packages/core/admin/admin/src/components/BackToTop.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import { Box, Button } from "@strapi/design-system";
+
+const BackToTop: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <Box
+      position="fixed"
+      bottom="2rem"
+      right="2rem"
+      zIndex={1000}
+      shadow="filterShadow"
+    >
+      <Button onClick={scrollToTop} variant="secondary" size="L">
+        ↑ Back to Top
+      </Button>
+    </Box>
+  );
+};
+
+export default BackToTop;

--- a/packages/core/admin/admin/src/components/Layouts/Layout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/Layout.tsx
@@ -7,6 +7,8 @@ import { ActionLayout } from './ActionLayout';
 import { ContentLayout } from './ContentLayout';
 import { GridLayout, GridLayoutProps } from './GridLayout';
 import { HeaderLayout, BaseHeaderLayout } from './HeaderLayout';
+import BackToTop from '../BackToTop';
+
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -26,7 +28,10 @@ const RootLayout = ({ sideNav, children }: LayoutProps) => {
   return (
     <GridContainer $hasSideNav={Boolean(sideNav)}>
       {sideNav}
-      <OverflowingItem paddingBottom={10}>{children}</OverflowingItem>
+      <OverflowingItem paddingBottom={10}>
+        {children}
+        <BackToTop />
+      </OverflowingItem>
     </GridContainer>
   );
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds a **Back to Top** button to the Strapi admin panel layout.  
- The button appears at the bottom-right of every page when the user scrolls down.  
- Clicking the button smoothly scrolls the page back to the top.  
- Implemented as a reusable React component `BackToTop.tsx` and integrated into `Layouts.tsx`.

### Why is it needed?

Currently, navigating long pages in the Strapi admin panel requires manual scrolling.  
Adding a **Back to Top** button improves usability and provides a better user experience for admin users.

### How to test it?

- Navigate to any content-type page with scrollable content (e.g., Posts, Media).
- Scroll down → the Back to Top button should appear in the bottom-right corner.
- Click the button → page should smoothly scroll back to the top.

### Related issue(s)/PR(s)

Fixes #24483
