### PR TITLE
fix(content-manager): reflect ordering for nested components in Confi…

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -113,6 +113,130 @@ const Fields = ({ attributes, fieldSizes, components, metadatas = {} }: FieldsPr
   const addFieldRow = useForm('Fields', (state) => state.addFieldRow);
   const removeFieldRow = useForm('Fields', (state) => state.removeFieldRow);
 
+  const attributesRef = React.useRef(attributes);
+  const fieldSizesRef = React.useRef(fieldSizes);
+  const metadatasRef = React.useRef(metadatas);
+
+  React.useEffect(() => {
+    attributesRef.current = attributes;
+  }, [attributes]);
+
+  React.useEffect(() => {
+    fieldSizesRef.current = fieldSizes;
+  }, [fieldSizes]);
+
+  React.useEffect(() => {
+    metadatasRef.current = metadatas;
+  }, [metadatas]);
+
+  // secure key generator using Web Crypto API with a safe fallback
+  const generateSafeKey = (): string => {
+    try {
+      const c = (globalThis as any).crypto;
+      if (c && typeof c.randomUUID === 'function') {
+        return c.randomUUID();
+      }
+
+      if (c && typeof c.getRandomValues === 'function') {
+        const arr = new Uint8Array(8); // 8 bytes -> compact string
+        c.getRandomValues(arr);
+        return Array.from(arr)
+          .map((b) => b.toString(36).padStart(2, '0'))
+          .join('');
+      }
+    } catch (e) {
+      // ignore and fallback to last-resort option below
+    }
+
+    // Last-resort fallback (non-crypto). Very rare in modern runtimes.
+    return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+  };
+
+  const makeKey = React.useCallback(() => generateSafeKey(), []);
+
+  const buildRowForAttribute = React.useCallback(
+    (name: string) => {
+      const attrs = attributesRef.current ?? {};
+      const sizes = fieldSizesRef.current ?? {};
+      const metas = metadatasRef.current ?? {};
+
+      const type = attrs[name]?.type;
+      const size = type ? (sizes[type] ?? GRID_COLUMNS) : GRID_COLUMNS;
+
+      const meta = metas[name] as
+        | Partial<{
+            label?: string;
+            placeholder?: string;
+            mainField?: any;
+            hint?: string;
+            disabled?: boolean;
+          }>
+        | undefined;
+
+      return {
+        name,
+        size: Math.min(size, 6), // Limit size to 6 to allow pairing
+        label: meta?.label ?? name,
+        placeholder: meta?.placeholder ?? '',
+        mainField: meta?.mainField ?? undefined,
+        description: meta?.hint ?? '',
+        editable: meta?.disabled === undefined ? true : !meta.disabled,
+        __temp_key__: makeKey(),
+      };
+    },
+    [makeKey]
+  );
+
+  React.useEffect(() => {
+    const handler = () => {
+      try {
+        const attrs = attributesRef.current ?? {};
+
+        const rows = Object.keys(attrs)
+          .filter((name) => name !== 'id' && !name.startsWith('_'))
+          .map((name) => buildRowForAttribute(name));
+
+        if (rows.length > 0) {
+          onChange('layout', rows);
+        }
+      } catch (err) {
+        console.warn('ctb:attributesReordered handler failed', err);
+      }
+    };
+
+    window.addEventListener('ctb:attributesReordered', handler);
+    return () => window.removeEventListener('ctb:attributesReordered', handler);
+  }, [onChange, buildRowForAttribute]);
+
+  React.useEffect(() => {
+    try {
+      const attrs = attributes ?? {};
+      const rows: ConfigurationFormData['layout'] = [];
+      const fieldNames = Object.keys(attrs)
+
+        .filter((name) => name !== 'id' && !name.startsWith('_'));
+
+      for (let i = 0; i < fieldNames.length; i += 2) {
+        const name1 = fieldNames[i];
+        const name2 = fieldNames[i + 1];
+        const row: ConfigurationFormData['layout'][number] = {
+          __temp_key__: makeKey(),
+          children: [],
+        };
+
+        row.children.push(buildRowForAttribute(name1));
+        if (name2) row.children.push(buildRowForAttribute(name2)); // Add second field if it exists
+
+        rows.push(row);
+      }
+
+      if (rows.length > 0) {
+        onChange('layout', rows as ConfigurationFormData['layout']);
+      }
+    } catch (err) {
+      console.warn('initial layout sync failed', err);
+    }
+  }, [attributes, fieldSizes, metadatas, onChange, makeKey]);
   const existingFields = layout.map((row) => row.children.map((field) => field.name)).flat();
 
   /**

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
@@ -26,13 +26,9 @@ import type { EditFieldLayout, EditLayout } from '../../hooks/useDocumentLayout'
  * -----------------------------------------------------------------------------------------------*/
 
 interface ConfigurationFormProps extends Pick<FieldsProps, 'attributes' | 'fieldSizes'> {
-  layout: EditLayout;
+  layout: Pick<EditLayout, 'components' | 'settings' | 'layout' | 'metadatas'>;
   onSubmit: FormProps<ConfigurationFormData>['onSubmit'];
 }
-
-/**
- * Every key in EditFieldLayout is turned to optional never and then we overwrite the ones we are using.
- */
 
 type EditFieldSpacerLayout = {
   [key in keyof Omit<EditFieldLayout, 'name' | 'size'>]?: never;
@@ -48,9 +44,9 @@ interface ConfigurationFormData extends Pick<EditLayout, 'settings'> {
   layout: Array<{
     __temp_key__: string;
     children: Array<
-      | (Pick<EditFieldLayout, 'label' | 'size' | 'name' | 'placeholder' | 'mainField'> & {
-          description: EditFieldLayout['hint'];
-          editable: EditFieldLayout['disabled'];
+      | (Pick<EditFieldLayout, 'name' | 'size' | 'label' | 'mainField' | 'placeholder'> & {
+          description: string | undefined;
+          editable: boolean;
           __temp_key__: string;
         })
       | EditFieldSpacerLayout
@@ -129,11 +125,6 @@ const ConfigurationForm = ({
                         return acc;
                       }
 
-                      /**
-                       * Create the list of attributes from the schema as to which can
-                       * be our `mainField` and dictate the display name of the schema
-                       * we're editing.
-                       */
                       if (!ATTRIBUTE_TYPES_THAT_CANNOT_BE_MAIN_FIELD.includes(attribute.type)) {
                         acc.push({
                           label: key,


### PR DESCRIPTION
• This PR replaces the previous attempt (#24477).
• Created after 1st October so it counts for Hacktoberfest 🎃

---

## What does it do?
This PR ensures that when a component contains nested components, the order defined in the Content Type Builder (CTB) is preserved in the **Configure the View** screen.

We added a listener for the `ctb:attributesReordered` event and updated the layout generation logic so the view always reflects the latest ordering.

---

## Why is it needed?
Previously, when a component contained nested components, changes to the order were not reflected in the Configure the View screen (Content Manager).

---

## How to test it?
1. `cd ./examples/getstarted`
2. Run: `yarn develop --watch-admin`
3. Create a component with nested components.
4. Reorder the nested components in the Content Type Builder.
5. Open **Configure the View** — the new order should now be correctly reflected.

---

## Related issue(s)/PR(s)
- Closes #24400  
- Supersedes #24477 (pre-Hacktoberfest attempt)  
- Replaces #24410 (previous attempt, now closed)

https://github.com/user-attachments/assets/f2555f9c-9cb6-4e65-92d9-885bdfb9cfd4