### PR TITLE
fix: allow submitting image messages to AI chat

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/providers/ChatProvider.tsx
@@ -131,8 +131,7 @@ export const BaseChatProvider = ({
     }
 
     const readyAttachments = attachments.filter((a) => a.status !== 'loading');
-
-    if (!input.trim() || readyAttachments.length !== 0) {
+    if (input.trim().length === 0 && attachments.length === 0) {
       return;
     }
 


### PR DESCRIPTION
### What does it do?

- Allows messages with attachments to be sent to AI chat

### Why is it needed?

- Messages with Attachments where not being sent
- a wrong check prevented messages from being sent when attachments where present

### How to test it?

- send an attachment to AI chat, could be an image, figma, code... it should work
