### PR TITLE
fix(upload): use absolute server url for file url

### DIFF
--- a/packages/core/upload/server/src/services/__tests__/ai-metadata.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/ai-metadata.test.ts
@@ -155,7 +155,7 @@ describe('AI Metadata Service', () => {
     beforeEach(() => {
       // Mock strapi config
       mockStrapi.config.get.mockImplementation((key: string) => {
-        if (key === 'server.url') return 'test-url';
+        if (key === 'server.absoluteUrl') return 'test-url';
         if (key === 'admin.ai.enabled') return true;
         if (key === 'server.port') return 1337;
         return undefined;

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -51,7 +51,7 @@ const createAIMetadataService = ({ strapi }: { strapi: Core.Strapi }) => {
       for (const { file } of imageFiles) {
         const fullUrl =
           file.provider === 'local'
-            ? strapi.config.get('server.url') + file.filepath
+            ? strapi.config.get('server.absoluteUrl') + file.filepath
             : file.filepath;
 
         const resp = await fetch(fullUrl);


### PR DESCRIPTION
As we found out in testing, `server.url` is not always provided, so `server.absoluteUrl` is the one that can be relied on. I found it by looking up what the startup terminal log used:
<img width="1324" height="642" alt="screenshot 2025-10-07 at 15 48 50@2x" src="https://github.com/user-attachments/assets/2073d23b-6130-4b20-ac6e-259af2d9106d" />
