### PR TITLE
fix: ai settings show up for licenses without ai

### DIFF
--- a/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
+++ b/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
@@ -168,7 +168,7 @@ const ModalContent = ({ onClose }: Pick<AIUploadModalProps, 'onClose'>) => {
     {
       id: getTrad('ai.modal.title'),
       defaultMessage:
-        '{count, plural, one {# Asset uploaded} other {# Assets uploaded}} time to review AI generated content',
+        '{count, plural, one {# asset uploaded} other {# assets uploaded}}, review AI generated metadata',
     },
     { count: state.uploadedAssets.length }
   );

--- a/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import { Page, useNotification, useFetchClient, Layouts } from '@strapi/admin/strapi-admin';
+import { useAIAvailability } from '@strapi/admin/strapi-admin/ee';
 import { Box, Button, Flex, Grid, Toggle, Typography, Field } from '@strapi/design-system';
 import { Check, Sparkle } from '@strapi/icons';
 import isEqual from 'lodash/isEqual';
@@ -26,6 +27,7 @@ export const SettingsPage = () => {
   const [{ initialData, modifiedData }, dispatch] = React.useReducer(reducer, initialState, init);
 
   const { data, isLoading, refetch } = useSettings();
+  const isAIAvailable = useAIAvailability();
 
   React.useEffect(() => {
     if (data) {
@@ -125,61 +127,64 @@ export const SettingsPage = () => {
         <Layouts.Content>
           <Layouts.Root>
             <Flex direction="column" alignItems="stretch" gap={4}>
-              <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
-                <Flex direction="column" alignItems="stretch" gap={1}>
-                  <Grid.Root gap={6}>
-                    <Grid.Item col={8} s={12} direction="column" alignItems="stretch">
-                      <Flex gap={2}>
-                        <Box color="alternative700">
-                          <Sparkle />
-                        </Box>
-                        <Typography variant="delta" tag="h2">
-                          {formatMessage({
-                            id: getTrad('settings.form.aiMetadata.label'),
-                            defaultMessage:
-                              'Generate AI captions and alt texts automatically on upload!',
-                          })}
-                        </Typography>
-                      </Flex>
-                      <Flex paddingTop={1}>
-                        <Typography variant="pi" textColor="neutral600">
-                          {formatMessage({
-                            id: getTrad('settings.form.aiMetadata.description'),
-                            defaultMessage:
-                              'Enable this feature to save time, optimize your SEO and increase accessibility by letting our AI generate captions and alternative texts for you.',
-                          })}
-                        </Typography>
-                      </Flex>
-                    </Grid.Item>
-                    <Grid.Item
-                      col={4}
-                      s={12}
-                      direction="column"
-                      alignItems="end"
-                      justifyContent={'center'}
-                    >
-                      <Field.Root name="aiMetadata" width={'158px'}>
-                        <Toggle
-                          checked={modifiedData?.aiMetadata}
-                          offLabel={formatMessage({
-                            id: 'app.components.ToggleCheckbox.off-label',
-                            defaultMessage: 'Disabled',
-                          })}
-                          onLabel={formatMessage({
-                            id: 'app.components.ToggleCheckbox.on-label',
-                            defaultMessage: 'Enabled',
-                          })}
-                          onChange={(e) => {
-                            handleChange({
-                              target: { name: 'aiMetadata', value: e.target.checked },
-                            });
-                          }}
-                        />
-                      </Field.Root>
-                    </Grid.Item>
-                  </Grid.Root>
-                </Flex>
-              </Box>
+              {isAIAvailable && (
+                <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
+                  <Flex direction="column" alignItems="stretch" gap={1}>
+                    <Grid.Root gap={6}>
+                      <Grid.Item col={8} s={12} direction="column" alignItems="stretch">
+                        <Flex gap={2}>
+                          <Box color="alternative700">
+                            <Sparkle />
+                          </Box>
+                          <Typography variant="delta" tag="h2">
+                            {formatMessage({
+                              id: getTrad('settings.form.aiMetadata.label'),
+                              defaultMessage:
+                                'Generate AI captions and alt texts automatically on upload!',
+                            })}
+                          </Typography>
+                        </Flex>
+                        <Flex paddingTop={1}>
+                          <Typography variant="pi" textColor="neutral600">
+                            {formatMessage({
+                              id: getTrad('settings.form.aiMetadata.description'),
+                              defaultMessage:
+                                'Enable this feature to save time, optimize your SEO and increase accessibility by letting our AI generate captions and alternative texts for you.',
+                            })}
+                          </Typography>
+                        </Flex>
+                      </Grid.Item>
+                      <Grid.Item
+                        col={4}
+                        s={12}
+                        direction="column"
+                        alignItems="end"
+                        justifyContent={'center'}
+                      >
+                        <Field.Root name="aiMetadata" width={'158px'}>
+                          <Toggle
+                            checked={modifiedData?.aiMetadata}
+                            offLabel={formatMessage({
+                              id: 'app.components.ToggleCheckbox.off-label',
+                              defaultMessage: 'Disabled',
+                            })}
+                            onLabel={formatMessage({
+                              id: 'app.components.ToggleCheckbox.on-label',
+                              defaultMessage: 'Enabled',
+                            })}
+                            onChange={(e) => {
+                              handleChange({
+                                target: { name: 'aiMetadata', value: e.target.checked },
+                              });
+                            }}
+                          />
+                        </Field.Root>
+                      </Grid.Item>
+                    </Grid.Root>
+                  </Flex>
+                </Box>
+              )}
+
               <Box background="neutral0" padding={6} shadow="filterShadow" hasRadius>
                 <Flex direction="column" alignItems="stretch" gap={4}>
                   <Flex>

--- a/packages/core/upload/admin/src/pages/SettingsPage/tests/SettingsPage.test.tsx
+++ b/packages/core/upload/admin/src/pages/SettingsPage/tests/SettingsPage.test.tsx
@@ -1,5 +1,11 @@
 // TODO: find a better naming convention for the file that was an index file before
+import { useAIAvailability } from '@strapi/admin/strapi-admin/ee';
 import { render, waitFor } from '@tests/utils';
+
+jest.mock('@strapi/admin/strapi-admin/ee', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin/ee'),
+  useAIAvailability: jest.fn(),
+}));
 
 import { SettingsPage } from '../SettingsPage';
 
@@ -29,5 +35,33 @@ describe('SettingsPage', () => {
     expect(getByRole('checkbox', { name: 'Responsive friendly upload' })).toBeChecked();
     expect(getByRole('checkbox', { name: 'Size optimization' })).toBeChecked();
     expect(getByRole('checkbox', { name: 'Auto orientation' })).toBeChecked();
+  });
+
+  it('shows AI metadata section when AI is available', async () => {
+    (useAIAvailability as jest.Mock).mockReturnValue(true);
+
+    const { getByRole, queryByText } = render(<SettingsPage />);
+
+    await waitFor(() => expect(queryByText('Loading content.')).not.toBeInTheDocument());
+
+    expect(
+      getByRole('heading', {
+        name: 'Generate AI captions and alt texts automatically on upload!',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('hides AI metadata section when AI is not available', async () => {
+    (useAIAvailability as jest.Mock).mockReturnValue(false);
+
+    const { queryByRole, queryByText } = render(<SettingsPage />);
+
+    await waitFor(() => expect(queryByText('Loading content.')).not.toBeInTheDocument());
+
+    expect(
+      queryByRole('heading', {
+        name: 'Generate AI captions and alt texts automatically on upload!',
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -141,6 +141,6 @@
   "view-switch.list": "List View",
   "view-switch.grid": "Grid View",
   "ai.modal.uploading.title": "Uploading and processing with AI...",
-  "ai.modal.title": "{count, plural, one {# Asset uploaded} other {# Assets uploaded}} time to review AI generated content",
+  "ai.modal.title": "{count, plural, one {# asset uploaded} other {# assets uploaded}}, time to review AI generated content",
   "ai.modal.error": "Could not generate AI metadata for the uploaded files."
 }

--- a/packages/core/upload/admin/src/translations/en.json
+++ b/packages/core/upload/admin/src/translations/en.json
@@ -141,6 +141,6 @@
   "view-switch.list": "List View",
   "view-switch.grid": "Grid View",
   "ai.modal.uploading.title": "Uploading and processing with AI...",
-  "ai.modal.title": "{count, plural, one {# asset uploaded} other {# assets uploaded}}, time to review AI generated content",
+  "ai.modal.title": "{count, plural, one {# asset uploaded} other {# assets uploaded}}, review AI generated metadata",
   "ai.modal.error": "Could not generate AI metadata for the uploaded files."
 }


### PR DESCRIPTION
### What does it do?

- Conditionally renders the media lib ai settings based on whether or not the app has ai available
- Updates the upload modal header text to:  'X assets uploaded, review AI generated metadata'

### Why is it needed?

We shouldn't see ai related settings if there is no AI

### How to test it?

With CE or an EE license that does NOT have AI 
Go to the settings page for media library
You should NOT see any settings related to AI

With a growth license or license with AI
You should see the AI settings

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
