### PR TITLE
fix: display name of admin user instead of id in filters

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -66,7 +66,12 @@ const FiltersImpl = ({ disabled, schema }: FiltersProps) => {
 
     const id = value.id.$eq || value.id.$ne;
 
-    if (id && USER_FILTER_ATTRIBUTES.includes(key) && !acc.includes(id)) {
+    // Check if the attribute is a relation to admin::user
+    const attribute = attributes[key];
+    const isAdminUserRelation =
+      attribute?.type === 'relation' && 'target' in attribute && attribute.target === 'admin::user';
+
+    if (id && (isAdminUserRelation || USER_FILTER_ATTRIBUTES.includes(key)) && !acc.includes(id)) {
       acc.push(id);
     }
 


### PR DESCRIPTION
### What does it do?

When adding a relation to an admin user in a collection type, adding a filter in the content manager list view displays the id of the user instead of their name (which is not ideal to understand who is it).

<img width="574" height="538" alt="image" src="https://github.com/user-attachments/assets/fd283eb2-2e47-4a69-84fe-22737875b0f6" />

<img width="925" height="183" alt="image" src="https://github.com/user-attachments/assets/ca8d6418-438f-46d4-ab19-0dfdae3d7c7b" />

### Why is it needed?

Increase the readability and the experience of the content editors when using the filters in the content manager.

### How to test it?

- Go to the content type builder
- Create an "admin user" relation field to any collection type
- Go to the content manager and select the collection type
- Click on Filters and select the newly created relation field
- Select a user
-> The active filter tag should display the name of the selected user and not their id

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/21333

🚀