### PR TITLE
fix: reset selection when folder changes to hide bulk actions

### DIFF
--- a/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
+++ b/packages/core/upload/admin/src/pages/App/MediaLibrary/MediaLibrary.tsx
@@ -157,10 +157,14 @@ export const MediaLibrary = () => {
   const [showEditFolderDialog, setShowEditFolderDialog] = React.useState(false);
   const [assetToEdit, setAssetToEdit] = React.useState<Asset | undefined>(undefined);
   const [folderToEdit, setFolderToEdit] = React.useState<FolderRow | undefined | null>(undefined);
-  const [selected, { selectOne, selectAll }] = useSelectionState<FolderRow | FileRow>(
-    ['type', 'id'],
-    []
-  );
+  const [selected, { selectOne, selectAll, setSelections }] = useSelectionState<
+    FolderRow | FileRow
+  >(['type', 'id'], []);
+  // reset selection when folder changes to hide bulk actions
+  React.useEffect(() => {
+    setSelections([]);
+  }, [query.folder, setSelections]);
+
   const indeterminateBulkSelect =
     selected?.length > 0 && selected?.length !== assetCount + folderCount;
   const toggleUploadAssetDialog = () => setShowUploadAssetDialog((prev) => !prev);


### PR DESCRIPTION
closes #24256

### What does it do?

I added an effect to watch for the change in `query.folder`. If the directory changes, the selection of the folders in the media gallery is restted and eventually the bulk actions buttons are hidden.

### Why is it needed?

Because without it, if a user selected a folders/files then navigated to another folder, the bulk actions can be applied to the items added previously leading to potential troubles.

### How to test it?

1. Open the media manager
2. Click the checkbox on a folder or an item, the bulk actions bar will appear
3. Change the directory

The bulk actions bar will be hidden.

Check the video on the first issue [here](https://github.com/strapi/strapi/issues/24256#issuecomment-3241890361)

### Related issue(s)/PR(s)

#24256