### PR TITLE
fix: find published relations on components

### DIFF
--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -127,7 +127,7 @@ const validateStatus = (
   const sourceModel = strapi.getModel(sourceUid);
 
   const isDP = contentTypes.hasDraftAndPublish;
-  const isSourceDP = isDP(sourceModel)
+  const isSourceDP = isDP(sourceModel);
 
   // Default to draft if not set
   if (!isSourceDP && sourceModel.modelType === 'contentType') {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

FIx https://github.com/strapi/strapi/issues/24363

### Why is it needed?

get findExisting relations in the publishedTab sends a status=published that wasn't properly accepted when the relation is on a component (it doesn't have dp but still should load dp relations)

### How to test it?

Follow the steps shared in the issue (and check the published tab instead of the api response)

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
