### PR TITLE
fix: remove extra 'x' in the template

### DIFF
--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/ConfigureTheView.tsx
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/ConfigureTheView.tsx
@@ -118,7 +118,6 @@ export const ConfigureTheView = ({ config }: ConfigureTheViewProps) => {
               onChange={handleChange}
             />
           </Layouts.Content>
-          x
           <Dialog.Root open={showWarningSubmit} onOpenChange={toggleWarningSubmit}>
             <ConfirmDialog onConfirm={handleConfirm} variant="default">
               {formatMessage({


### PR DESCRIPTION
closes #24306

Before:

<img width="4570" height="850" alt="image" src="https://github.com/user-attachments/assets/fb5f5129-bb9b-4823-85d0-3d693785d464" />

After:

<img width="1679" height="478" alt="image" src="https://github.com/user-attachments/assets/74e922e6-49ff-447f-92af-3fa009ba031e" />
