### PR TITLE
chore: set up ai i18n future flag

### DIFF
--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,1 +1,5 @@
-module.exports = ({ env }) => ({});
+module.exports = ({ env }) => ({
+  future: {
+    unstableAILocalizations: true,
+  },
+});

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,5 +1,7 @@
 export interface FeaturesConfig {
-  future?: Record<string, unknown>;
+  future?: {
+    unstableAILocalizations?: boolean;
+  };
 }
 
 export interface FeaturesService {

--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -1,0 +1,30 @@
+import type { Core } from '@strapi/types';
+
+const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
+  return {
+    // Async to avoid changing the signature later (there will be a db check in the future)
+    async isEnabled() {
+      // Check if future flag is enabled
+      const isFutureFlagEnabled = strapi.features.future.isEnabled('unstableAILocalizations');
+      if (!isFutureFlagEnabled) {
+        return false;
+      }
+
+      // Check if user disabled AI features globally
+      const isAIEnabled = strapi.config.get('admin.ai.enabled', true);
+      if (!isAIEnabled) {
+        return false;
+      }
+
+      // Check if the user's license grants access to AI features
+      const hasAccess = strapi.ee.features.isEnabled('cms-ai');
+      if (!hasAccess) {
+        return false;
+      }
+
+      return true;
+    },
+  };
+};
+
+export { createAILocalizationsService };

--- a/packages/plugins/i18n/server/src/services/index.ts
+++ b/packages/plugins/i18n/server/src/services/index.ts
@@ -5,6 +5,7 @@ import locales from './locales';
 import isoLocales from './iso-locales';
 import contentTypes from './content-types';
 import sanitize from './sanitize';
+import { createAILocalizationsService } from './ai-localizations';
 
 export default {
   permissions,
@@ -14,4 +15,5 @@ export default {
   sanitize,
   'iso-locales': isoLocales,
   'content-types': contentTypes,
+  aiLocalizations: createAILocalizationsService,
 };


### PR DESCRIPTION
### What does it do?

- sets up AI i18n future flag so we can work safely on develop
- create ai localizations service with isEnabled method

see https://github.com/strapi/content-squad/issues/92
