### PR TITLE
feat(upload): fixing ordering issue

### DIFF
--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -126,7 +126,7 @@ export default {
         .map((info) => {
           return filesArray.find((file) => file.originalFilename === info.name);
         })
-        .filter(Boolean) as import('formidable').File[];
+        .filter(Boolean) as any[];
 
       filesArray = alignedFilesArray;
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes a bug causing file name mismatches during bulk uploads in the Media Library.

### Why is it needed?

When performing a bulk upload in Media Library, the uploaded files are reordered during the upload process, causing a mismatch between the original file names (from the frontend) and the files stored in Strapi.
For instance, uploading 10 images at once results in all files being successfully uploaded and having AI metadata generated, but their names no longer match the original local files.


Here is an example of
Uploaded files in Media Library:
<img width="821" height="908" alt="image" src="https://github.com/user-attachments/assets/ee52900d-9016-4eae-88b9-4d5a029fa4a5" />

VS

Files on local machine:
<img width="448" height="242" alt="image" src="https://github.com/user-attachments/assets/007cbdab-1b90-4436-b9a3-654ac90fdde5" />

As you can see, pic1.jpeg differs between the local folder and the Media Library.
This mismatch occurs randomly — it's not always the first file that differs, but the naming can change unpredictably during bulk uploads.

**Root Cause**
This issue appears to be related to Koa's internal handling of multipart form data.
During parsing, Koa may reorder files within the request before they reach the upload controller. As a result, the backend receives the files in a different order than the one sent from the frontend, which leads to mismatched file-name-to-metadata associations.

### How to test it?

- Upload multiple files at once in the Media Library.
- Verify that the uploaded files order, names, and metadata match the original local files.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
