### PR TITLE
fix: add missing translation for email template title

### DIFF
--- a/packages/plugins/users-permissions/admin/src/translations/en.json
+++ b/packages/plugins/users-permissions/admin/src/translations/en.json
@@ -17,6 +17,7 @@
   "EditPage.form.roles": "Role details",
   "Email.template.data.loaded": "Email templates has been loaded",
   "Email.template.email_confirmation": "Email address confirmation",
+  "Email.template.reset_password": "Reset password",
   "Email.template.form.edit.label": "Edit a template",
   "Email.template.table.action.label": "action",
   "Email.template.table.icon.label": "icon",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Adds the missing translation for the "Reset Password" email template.

_Before_
<img width="1906" height="957" alt="Before" src="https://github.com/user-attachments/assets/c82a3c05-701c-41c4-b5ce-c9c40c33e883" />

_After_
<img width="1906" height="957" alt="After" src="https://github.com/user-attachments/assets/fe319f1a-9897-4935-9748-f3bedf99aa8b" />

### Why is it needed?
The key for the translation is no longer shown, instead a default value is.

### How to test it?
* Go the Settings
* Click on "Email templates" under the Users & Permissions Plugin tab
* Click on "Reset Password"
* The modal opens with the correct translation value 

### Related issue(s)/PR(s)
Fixes this [issue](https://github.com/strapi/strapi/issues/20315)

