### PR TITLE
fix: show error notification when upload settings save fails

### DIFF
--- a/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/core/upload/admin/src/pages/SettingsPage/SettingsPage.tsx
@@ -59,8 +59,11 @@ export const SettingsPage = () => {
           message: formatMessage({ id: 'notification.form.success.fields' }),
         });
       },
-      onError(err) {
-        console.error(err);
+      onError(err: any) {
+        toggleNotification({
+          type: 'danger',
+          message: err.message || formatMessage({ id: 'notification.error' }),
+        });
       },
     }
   );


### PR DESCRIPTION
## What does it do?

Fixes a bug where the Upload Settings page (`Settings > Global Settings > Media Library`) does not display error notifications when the save operation fails. 

Previously, errors were only logged to the console using `console.error()`, leaving users unaware that their settings changes weren't saved. Now, the page properly shows a danger notification using the `toggleNotification` hook.

## Why is it needed?

Fixes #24595 

**The Problem:**
When users try to save upload settings and the request fails (due to network issues, server errors, etc.), they receive no visual feedback. The error is silently logged to the console, and users assume their changes were saved successfully.

**The Solution:**
This PR updates the mutation's `onError` callback to display a user-facing error notification, making it consistent with how errors are handled throughout the admin panel and other parts of the upload plugin (e.g., `hooks/useRemoveAsset.ts`).

## How to test it?

1. Start Strapi in development mode
2. Go to `Settings > Global Settings > Media Library`
3. Open browser DevTools > Network tab
4. Set network to "Offline"
5. Toggle any setting (e.g., "Responsive friendly upload")
6. Click "Save"
7. **Expected:** A red error notification appears at the top of the page
8. **Before this fix:** No notification appeared (error only in console)

You can also test with a real server error by temporarily modifying the endpoint or breaking the API.

## Screenshots


<img width="902" height="842" alt="Screenshot 2025-10-15 213449" src="https://github.com/user-attachments/assets/c7d9bfcd-3ff1-479d-9c0c-2538f8f43904" />

https://github.com/user-attachments/assets/f3dfbbf6-f844-41b1-9db7-6eb61869f338

