### PR TITLE
enhancement: add en language for Japan

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -632,6 +632,10 @@
     "name": "English (Jamaica) (en-JM)"
   },
   {
+    "code": "en-JP",
+    "name": "English (Japan) (en-JP)"
+  },
+  {
     "code": "en-JE",
     "name": "English (Jersey) (en-JE)"
   },

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -635,6 +635,10 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "English (Jamaica) (en-JM)",
   },
   {
+    "code": "en-JP",
+    "name": "English (Japan) (en-JP)",
+  },
+  {
     "code": "en-JE",
     "name": "English (Jersey) (en-JE)",
   },


### PR DESCRIPTION
### What does it do?

Added en-JP language for Japan region.

### Why is it needed?

To add support for new locale

### How to test it?

Go to strapi settings page and enable en-JP locale. https://docs.strapi.io/cms/features/internationalization#settings
