### PR TITLE
fix: add error notification when AI metadata save fails

### DIFF
--- a/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
+++ b/packages/core/upload/admin/src/ai/components/AIUploadModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { createContext } from '@strapi/admin/strapi-admin';
+import { createContext, useNotification } from '@strapi/admin/strapi-admin';
 import { Alert, Button, Flex, Modal } from '@strapi/design-system';
 import { produce } from 'immer';
 import { useIntl } from 'react-intl';
@@ -44,6 +44,7 @@ const StyledAlert = styled(Alert)`
 
 const ModalContent = ({ onClose }: Pick<AIUploadModalProps, 'onClose'>) => {
   const { formatMessage } = useIntl();
+  const { toggleNotification } = useNotification();
   const state = useAIUploadModalContext('ModalContent', (s) => s.state);
   const dispatch = useAIUploadModalContext('ModalContent', (s) => s.dispatch);
   const folderId = useAIUploadModalContext('ModalContent', (s) => s.folderId);
@@ -105,7 +106,12 @@ const ModalContent = ({ onClose }: Pick<AIUploadModalProps, 'onClose'>) => {
           await edit(updates);
           dispatch({ type: 'clear_unsaved_changes' });
         } catch (err) {
-          console.error('Failed to save asset changes:', err);
+          toggleNotification({
+            type: 'danger',
+            message:
+              (err instanceof Error ? err.message : null) ||
+              formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
+          });
           return; // Don't close modal on error
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes a UX issue where errors during AI metadata saves fail silently in the Media Library.

Closes #24610

## The Problem

When users generate AI captions/alt text and try to save their edits, if something goes wrong (network error, API failure, etc.), the error only appears in the browser console. There's no visible notification to let the user know their changes didn't save.

This is frustrating because users might think everything worked fine, close the modal, and later wonder why their changes disappeared.

## The Solution

I've updated the error handling to use `toggleNotification` (the same pattern used throughout the admin panel) instead of `console.error()`. Now users will see a clear red error notification at the top of the page when something goes wrong.

This is very similar to the fix I made in #24596 for the Upload Settings page - same issue, same solution, just a different part of the upload plugin.

## Changes Made

- Imported `useNotification` hook in the AI Upload Modal component
- Replaced the silent `console.error()` with a proper `toggleNotification` call
- Added TypeScript type guard to safely handle error messages

## Testing

✅ Code formatting passes (Prettier)  
✅ No ESLint errors from my changes  
✅ Follows the same error handling pattern used elsewhere in the codebase  
✅ Modal stays open on error (existing behavior preserved)

The two ESLint warnings visible are pre-existing (lines 83, 87) and unrelated to this change.