### PR TITLE
fix: responsive subnav

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -101,7 +101,7 @@ const Link = (
           <Typography
             tag="div"
             lineHeight="32px"
-            width="100%"
+            width={{ initial: '80dvw', medium: '100%' }}
             overflow="hidden"
             style={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
           >
@@ -139,10 +139,16 @@ const Header = ({ label }: { label: string }) => {
   );
 };
 
-const Sections = ({ children, ...props }: { children: React.ReactNode[]; [key: string]: any }) => {
+const Sections = ({
+  children,
+  ...props
+}: {
+  children: React.ReactNode[];
+  [key: string]: unknown;
+}) => {
   return (
-    <Box paddingTop={4} paddingBottom={4}>
-      <Flex tag="ol" gap="5" direction="column" alignItems="stretch" {...props}>
+    <Box paddingTop={4} paddingBottom={4} maxWidth={{ initial: '100%', medium: '23.2rem' }}>
+      <Flex tag="ul" gap="5" direction="column" alignItems="stretch" {...props}>
         {children.map((child, index) => {
           return <li key={index}>{child}</li>;
         })}
@@ -313,26 +319,24 @@ const SubSection = ({ label, children }: { label: string; children: React.ReactN
           </Box>
         </SubSectionHeader>
       </Flex>
-      {
-        <Flex
-          tag="ul"
-          id={listId}
-          direction="column"
-          gap="2px"
-          alignItems={'stretch'}
-          style={{
-            maxHeight: isOpen ? '1000px' : 0,
-            overflow: 'hidden',
-            transition: isOpen
-              ? 'max-height 1s ease-in-out'
-              : 'max-height 0.5s cubic-bezier(0, 1, 0, 1)',
-          }}
-        >
-          {children.map((child, index) => {
-            return <SubSectionLinkWrapper key={index}>{child}</SubSectionLinkWrapper>;
-          })}
-        </Flex>
-      }
+      <Flex
+        tag="ul"
+        id={listId}
+        direction="column"
+        gap="2px"
+        alignItems={'stretch'}
+        style={{
+          maxHeight: isOpen ? '1000px' : 0,
+          overflow: 'hidden',
+          transition: isOpen
+            ? 'max-height 1s ease-in-out'
+            : 'max-height 0.5s cubic-bezier(0, 1, 0, 1)',
+        }}
+      >
+        {children.map((child, index) => {
+          return <SubSectionLinkWrapper key={index}>{child}</SubSectionLinkWrapper>;
+        })}
+      </Flex>
     </Box>
   );
 };

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 .c30 {
   padding-block-start: 16px;
   padding-block-end: 16px;
+  max-width: 100%;
 }
 
 .c33 {
@@ -81,7 +82,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 }
 
 .c48 {
-  width: 100%;
+  width: 80dvw;
   overflow: hidden;
 }
 
@@ -503,10 +504,22 @@ border:1px solid #eaeaef .c22:focus-within .c27 {
   }
 }
 
+@media (min-width: 768px) {
+  .c30 {
+    max-width: 23.2rem;
+  }
+}
+
 @media (min-width: 1080px) {
   .c41 {
     margin-inline-start: 8px;
     margin-inline-end: 8px;
+  }
+}
+
+@media (min-width: 768px) {
+  .c48 {
+    width: 100%;
   }
 }
 
@@ -671,7 +684,7 @@ border:1px solid #eaeaef .c22:focus-within .c27 {
           <div
             class="c30"
           >
-            <ol
+            <ul
               class="c31"
             >
               <li>
@@ -1116,7 +1129,7 @@ border:1px solid #eaeaef .c22:focus-within .c27 {
                   </ol>
                 </div>
               </li>
-            </ol>
+            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Set the subnav width to the previous max-width (23.2rem) It fixes the subnav when link title are too long on desktop and tablet

### Why is it needed?

Describe the issue you are solving.

### How to test it?

- Change the link name too a long one directly from your browser inspector (subnav should have a 23.2rem max-width and you should be able to see ellipsis on the long link.
- Should not change on mobile.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/24606