### PR TITLE
fix: invalidate all documents cache after a release publish

### DIFF
--- a/packages/core/content-releases/admin/src/services/release.ts
+++ b/packages/core/content-releases/admin/src/services/release.ts
@@ -366,8 +366,8 @@ const releaseApi = adminApi
               method: 'POST',
             };
           },
-          invalidatesTags: () => [
-            { type: 'Release', id: 'LIST' },
+          invalidatesTags: (result, error, arg) => [
+            { type: 'Release', id: arg.id },
             { type: 'Document' },
             'UpcomingReleasesList',
           ],

--- a/tests/e2e/tests/content-releases/document-status.spec.ts
+++ b/tests/e2e/tests/content-releases/document-status.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { clickAndWait, describeOnCondition, findAndClose, navToHeader } from '../../utils/shared';
+import { waitForRestart } from '../../utils/restart';
+import { resetFiles } from '../../utils/file-reset';
+import { sharedSetup } from '../../utils/setup';
+
+const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+describeOnCondition(edition === 'EE')('Releases - Document status', () => {
+  test.beforeEach(async ({ page }) => {
+    await sharedSetup('history-spec', page, {
+      login: true,
+      resetFiles: true,
+      importData: 'with-admin.tar',
+      resetAlways: true, // NOTE: this makes tests extremely slow, but it's necessary to ensure isolation between tests
+    });
+  });
+
+  test.afterAll(async () => {
+    await resetFiles();
+  });
+
+  test('should update the document status when a release is published', async ({ page }) => {
+    const releaseName = 'Trent Crimm: The Independent';
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await page.getByRole('button', { name: /publish/i }).click();
+    await findAndClose(page, 'Published document');
+    await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
+
+    await expect(
+      page.getByRole('row').nth(1).getByRole('status', { name: 'published' })
+    ).toBeVisible();
+    await expect(page.getByRole('row').nth(2).getByRole('status', { name: 'draft' })).toBeVisible();
+
+    await page.getByRole('row').nth(2).getByRole('button', { name: 'Row actions' }).click();
+    await page.getByRole('menuitem', { name: 'Add to release' }).click();
+    await page.getByRole('combobox', { name: 'Select a release' }).click();
+    await page.getByRole('option', { name: releaseName }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await navToHeader(page, ['Releases'], 'Releases');
+    await clickAndWait(page, page.getByRole('link', { name: releaseName }));
+    await expect(page.getByRole('heading', { name: releaseName })).toBeVisible();
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish', exact: true }));
+
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await expect(page.getByRole('row').nth(1).getByRole('status', { name: 'draft' })).toBeVisible();
+    await expect(
+      page.getByRole('row').nth(2).getByRole('status', { name: 'published' })
+    ).toBeVisible();
+
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
### What does it do?

The status of a document on the edit view page wasn't correctly updated after publishing a release.
We were clearing the list query cache but not for all single documents requests.

### Why is it needed?

The status not updated in the edit view page could be very confusing for a content editor that just published a release. This is important to have the correct status showed on the page.

### How to test it?

- Create a release
- Go to the content manager and create a new entry
- Click save to create a draft
- Add the entry to the release and select "Publish" (to change the status from Draft to Publish after release)
- Go in releases and publish the release
- Click on the content manager again and see the status updated on the entry in the list
- Click on the row to display the edit view page
-> The status should be also updated and now be "Published" instead of "Draft"

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/21369

🚀