### PR TITLE
fix: fill from other locale creates empty components

### DIFF
--- a/packages/plugins/i18n/admin/src/utils/clean.ts
+++ b/packages/plugins/i18n/admin/src/utils/clean.ts
@@ -85,9 +85,9 @@ const recursiveRemoveFieldTypes = (
             __temp_key__: index + 1,
           };
         });
-      } else {
+      } else if (data[current]) {
         const { id: _, ...rest } = recursiveRemoveFieldTypes(
-          data[current] ?? {},
+          data[current],
           components[component],
           components,
           fields


### PR DESCRIPTION
### What does it do?

When creating another locale for a document and click on "Fill in from another locale", it creates empty components if they weren't provided at all in the locale to copy data from.
The correct behaviour should be to reproduce the exact same content from the source locale. If the component doesn't exist, then it shouldn't exist either after copying content.

### Why is it needed?

It's a weird issue that doesn't makes sense and could lead to validation error when submitting the form.

### How to test it?

- Go to the content manager and choose a collection type that has a component (not repeatable) and has internationalization enabled
- Create a new entry in a locale and leave the component empty
- Switch to another locale (with the locale selector of the edit view) to create a new document
- Click on "Fill in from another locale" icon
-> The component should stay empty and not having all its fields appearing

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/22449

🚀