### PR TITLE
fix: LocalePicker not showing all authorized locales

### DIFF
--- a/packages/plugins/i18n/admin/src/hooks/useI18n.ts
+++ b/packages/plugins/i18n/admin/src/hooks/useI18n.ts
@@ -16,6 +16,8 @@ type UseI18n = () => {
   canPublish: string[];
 };
 
+type Action = 'canCreate' | 'canRead' | 'canUpdate' | 'canDelete' | 'canPublish';
+
 /**
  * @alpha
  * @description This hook is used to get the i18n status of a content type.
@@ -33,10 +35,14 @@ const useI18n: UseI18n = () => {
     return permissions.reduce<Omit<ReturnType<UseI18n>, 'hasI18n'>>(
       (acc, permission) => {
         const [actionShorthand] = permission.action.split('.').slice(-1);
+        const key = `can${capitalize(actionShorthand)}` as Action;
+
+        const existingLocales = acc[key] ?? [];
+        const newLocales = permission.properties?.locales ?? [];
 
         return {
           ...acc,
-          [`can${capitalize(actionShorthand)}`]: permission.properties?.locales ?? [],
+          [key]: [...existingLocales, ...newLocales],
         };
       },
       { canCreate: [], canRead: [], canUpdate: [], canDelete: [], canPublish: [] }


### PR DESCRIPTION
## 🐛 Bug Description

The `useI18n` hook in the i18n plugin incorrectly returns only the last locale when a user has permissions for multiple locales on the same action (e.g., read permissions for both `en` and `es`).

## 📋 Current Behavior

When a user has the following permissions:
```json
[
  {
    "action": "plugin::content-manager.explorer.read",
    "subject": "api::article.article",
    "properties": {
      "locales": ["es"]
    }
  },
  {
    "action": "plugin::content-manager.explorer.read",
    "subject": "api::article.article",
    "properties": {
      "locales": ["en"]
    }
  }
]
```

The hook returns:
```javascript
{
  canRead: ["en"],  // ❌ Only the last locale
  canCreate: [],
  canUpdate: [],
  canDelete: [],
  canPublish: []
}
```

## ✅ Expected Behavior

The hook should return **all** locales the user has permissions for:
```javascript
{
  canRead: ["es", "en"],  // ✅ All locales
  canCreate: [],
  canUpdate: [],
  canDelete: [],
  canPublish: []
}
```

## 🔍 Root Cause

In `packages/plugins/i18n/admin/src/hooks/useI18n.ts`, the `reduce` function **overwrites** the locale array instead of **accumulating** values when multiple permissions share the same action:

```typescript
// ❌ Current implementation (line 33-43)
return permissions.reduce(
  (acc, permission) => {
    const [actionShorthand] = permission.action.split('.').slice(-1);

    return {
      ...acc,
      [`can${capitalize(actionShorthand)}`]: permission.properties?.locales ?? []
      // This overwrites previous locales instead of merging them
    };
  },
  { canCreate: [], canRead: [], canUpdate: [], canDelete: [], canPublish: [] }
);
```

### Execution flow:
1. **First iteration** (es): Sets `canRead: ["es"]`
2. **Second iteration** (en): **Overwrites** with `canRead: ["en"]`
3. Result: Only `["en"]` is returned

## 🔧 Proposed Solution

Accumulate locales using the spread operator:

```typescript
return permissions.reduce<Omit<ReturnType<UseI18n>, 'hasI18n'>>(
  (acc, permission) => {
    const [actionShorthand] = permission.action.split('.').slice(-1);
    const key = `can${capitalize(actionShorthand)}` as keyof typeof acc;

    return {
      ...acc,
      [key]: [
        ...acc[key],  // Keep existing locales
        ...(permission.properties?.locales ?? [])  // Add new locales
      ],
    };
  },
  { canCreate: [], canRead: [], canUpdate: [], canDelete: [], canPublish: [] }
);
```

## 🧪 Test Case

```typescript
// Input permissions
const permissions = [
  { action: 'content-manager.explorer.read', properties: { locales: ['es'] } },
  { action: 'content-manager.explorer.read', properties: { locales: ['en'] } },
  { action: 'content-manager.explorer.create', properties: { locales: ['fr'] } }
];

// Expected output
{
  canRead: ['es', 'en'],
  canCreate: ['fr'],
  canUpdate: [],
  canDelete: [],
  canPublish: []
}
```

Fixes [#24324](https://github.com/strapi/strapi/issues/24324)


