### PR TITLE
fix: include invisible relations in the getDeepPopulate utility

### DIFF
--- a/packages/core/core/src/services/document-service/utils/populate.ts
+++ b/packages/core/core/src/services/document-service/utils/populate.ts
@@ -1,5 +1,4 @@
 import type { UID } from '@strapi/types';
-import { contentTypes } from '@strapi/utils';
 
 interface Options {
   /**
@@ -7,8 +6,6 @@ interface Options {
    */
   relationalFields?: string[];
 }
-
-const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = contentTypes.constants;
 
 // We want to build a populate object based on the schema
 export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
@@ -24,14 +21,7 @@ export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
           break;
         }
 
-        // Ignore not visible fields other than createdBy and updatedBy
-        const isVisible = contentTypes.isVisibleAttribute(model, attributeName);
-        const isCreatorField = [CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE].includes(attributeName);
-
-        if (isVisible || isCreatorField) {
-          acc[attributeName] = { select: opts.relationalFields };
-        }
-
+        acc[attributeName] = { select: opts.relationalFields };
         break;
       }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes the exclusion of invisible relation attributes from the `getDeepPopulate` utility in the document service.

### Why is it needed?

Currently we're facing a bug because invisible relations are not copied over from the source entry. The reason being that they are excluded in the `getDeepPopulate`. This PR would solve that.

### How to test it?

I hope we can confirm that all tests are still passing. Apart from that you could try to reproduce any of the related issues, and confirm that this PR will solve that.

I expect the exclusion was added as a performance optimization. Other than that I couldn't find a reason why we should exclude the invisible relations here.

### Related issue(s)/PR(s)

Fixes #23039
Fixes #22975
