### PR TITLE
fix: allow saving invisible fields in the content-manager

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -44,7 +44,7 @@ import {
 } from '../../../services/documents';
 import { isBaseQueryError, buildValidParams } from '../../../utils/api';
 import { getTranslation } from '../../../utils/translations';
-import { AnyData, handleInvisibleAttributes } from '../utils/data';
+import { AnyData } from '../utils/data';
 
 import { useRelationModal } from './FormInputs/Relations/RelationModal';
 
@@ -746,10 +746,6 @@ const PublishAction: DocumentActionComponent = ({
         }
         return;
       }
-      const { data } = handleInvisibleAttributes(transformData(formValues), {
-        schema,
-        components,
-      });
       const res = await publish(
         {
           collectionType,
@@ -757,7 +753,7 @@ const PublishAction: DocumentActionComponent = ({
           documentId,
           params: currentDocumentMeta.params,
         },
-        data
+        transformData(formValues)
       );
 
       // Reset form if successful
@@ -1050,11 +1046,6 @@ const UpdateAction: DocumentActionComponent = ({
           setErrors(formatValidationErrors(res.error));
         }
       } else if (documentId || collectionType === SINGLE_TYPES) {
-        const { data } = handleInvisibleAttributes(transformData(document), {
-          schema: fromRelationModal ? relationalModalSchema : schema,
-          initialValues,
-          components,
-        });
         const res = await update(
           {
             collectionType,
@@ -1062,7 +1053,7 @@ const UpdateAction: DocumentActionComponent = ({
             documentId,
             params: currentDocumentMeta.params,
           },
-          data
+          transformData(document)
         );
 
         if ('error' in res && isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
@@ -1071,17 +1062,12 @@ const UpdateAction: DocumentActionComponent = ({
           resetForm();
         }
       } else {
-        const { data } = handleInvisibleAttributes(transformData(document), {
-          schema: fromRelationModal ? relationalModalSchema : schema,
-          initialValues,
-          components,
-        });
         const res = await create(
           {
             model,
             params: currentDocumentMeta.params,
           },
-          data
+          transformData(document)
         );
 
         if ('data' in res && collectionType !== SINGLE_TYPES) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It allows fields which are marked as `visible: false` to be saved through the content manager.

### Why is it needed?

One might want to mark a field as invisible and afterwards handle the editing of that field in a custom widget in the content-manager sidebar. This PR fixes this use case.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

This was reported as an issue to a community plugin https://github.com/pluginpal/strapi-webtools/issues/334
