### PR TITLE
fix: Markdown editor: <ol> is created with wrong numbers

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.ts
@@ -152,17 +152,19 @@ export const listHandler = (
 
     editor.current.operation(function () {
       selections.forEach(function (selection) {
-        const pos = [selection.head.line, selection.anchor.line].sort();
+        const pos = [selection.head.line, selection.anchor.line].sort((a, b) => a - b);
+        // Will match a bullet point or any number
+        const regexIsItemFromList = /^[*-]\s|^\d+\.\s/;
 
-        // Remove if the first text starts with it
+        // Remove if the first text starts with a bullet point or any number
         if (remove == null) {
-          remove = doc.getLine(pos[0]).startsWith(insertion);
+          remove = doc.getLine(pos[0]).match(regexIsItemFromList) !== null;
         }
 
         for (let i = pos[0]; i <= pos[1]; i++) {
           if (remove) {
-            // Don't remove if we don't start with it
-            if (doc.getLine(i).startsWith(insertion)) {
+            // Don't remove if the line doesn't start with a bullet point or a number
+            if (doc.getLine(i).match(regexIsItemFromList) !== null) {
               doc.replaceRange('', { line: i, ch: 0 }, { line: i, ch: insertion.length });
             }
           } else {


### PR DESCRIPTION
## Fix: Ordered list numbering starts from line index instead of 1

### Issue

When selecting multiple lines to create an ordered list in the Markdown editor, the numbering was based on the absolute line index in the document rather than starting from 1.

**Example:**

```
a
b

c  <- line 3
d  <- line 4
e  <- line 5
```

Selecting lines c, d, e and applying ordered list would produce:

```
4. c
5. d
6. e
```

Instead of the expected:

```
1. c
2. d
3. e
```

### Solution

Changed the line number calculation in `listHandler` function to use relative positioning from the first selected line:

**Before:**

```typescript
const lineInsertion = listType === 'BulletList' ? '- ' : `${i + 1}. `;
```

**After:**

```typescript
const lineInsertion = listType === 'BulletList' ? '- ' : `${i - pos[0] + 1}. `;
```

Where:

- `i` is the current line index
- `pos[0]` is the first selected line index
- `i - pos[0] + 1` calculates the relative position starting from 1

### Files Changed

- `packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.ts`

### Related

Fixes [#24603](https://github.com/strapi/strapi/issues/24603)