### PR TITLE
fix: Unable to click on the last row in Media Library modal

### DIFF
--- a/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
+++ b/packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx
@@ -459,7 +459,7 @@ export const BrowseStep = ({
           paddingTop={4}
           position="relative"
           zIndex={1}
-          style={{ overflow: 'hidden' }}
+          overflow="hidden"
         >
           <PageSize
             pageSize={queryObject.pageSize! as number}


### PR DESCRIPTION
## Fix: Media library pagination blocking hover on bottom assets

### Issue

In the Media Library dialog, the pagination footer at the bottom was blocking hover interactions on assets positioned near it. Users couldn't hover over or interact with the last row of assets in the grid view.

### Root Cause

The pagination container had `position="relative"` and `zIndex={1}` (required for the PageSize dropdown to display correctly), which created a stacking context that was blocking pointer events to elements visually positioned behind it.

### Solution

Added the `style` property of the pagination `Flex` container from:

```typescript
style={{ overflow: 'hidden' }}
```

**Location:**
`packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx` (line 462)

### Testing

1. Open Media Library dialog
2. Navigate to a folder with many assets (enough to show pagination)
3. Hover over assets in the last row near the pagination footer
4. **Expected:** Hover effects work correctly on all assets

### Files Changed

- `packages/core/upload/admin/src/components/AssetDialog/BrowseStep/BrowseStep.tsx`

Fix [#24084](https://github.com/strapi/strapi/issues/24084)
