### PR TITLE
fix: ios input zoom on focus

### DIFF
--- a/packages/core/admin/admin/src/components/Theme.tsx
+++ b/packages/core/admin/admin/src/components/Theme.tsx
@@ -21,6 +21,11 @@ const Theme = ({ children, themes }: ThemeProps) => {
   const [systemTheme, setSystemTheme] = React.useState<'light' | 'dark'>();
   const { locale } = useIntl();
   const dispatch = useDispatch();
+  const isIos =
+    ['iPad Simulator', 'iPhone Simulator', 'iPod Simulator', 'iPad', 'iPhone', 'iPod'].includes(
+      navigator.platform
+    ) ||
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
 
   // Listen to changes in the system theme
   React.useEffect(() => {
@@ -55,15 +60,41 @@ const Theme = ({ children, themes }: ThemeProps) => {
       theme={themes?.[computedThemeName || 'light']}
     >
       {children}
-      <GlobalStyle />
+      <GlobalStyle $shouldOverrideInputFontSize={isIos} />
     </DesignSystemProvider>
   );
 };
 
-const GlobalStyle = createGlobalStyle`
+const GlobalStyle = createGlobalStyle<{ $shouldOverrideInputFontSize: boolean }>`
   body {
     background: ${({ theme }) => theme.colors.neutral100};
   }
+
+  // Temporary fix override to fix iOS zoom due to the 14px input font size
+  ${({ $shouldOverrideInputFontSize }) =>
+    $shouldOverrideInputFontSize
+      ? `
+    input[type="color"],
+    input[type="date"],
+    input[type="datetime"],
+    input[type="datetime-local"],
+    input[type="email"],
+    input[type="month"],
+    input[type="number"],
+    input[type="password"],
+    input[type="search"],
+    input[type="tel"],
+    input[type="text"],
+    input[type="time"],
+    input[type="url"],
+    input[type="week"],
+    select:focus,
+    textarea {
+      font-size: 16px !important;
+      line-height: 2.4rem !important;
+    }
+  `
+      : undefined}
 `;
 
 export { Theme };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Override the text input font size and line height only on iOS (from 14px to 16px).

### Why is it needed?

When input font size is below 16px, a zoom is automatically done on focus on iOS. To avoid that annoyinh zoom, we are increasing the font-size from 14 to 16. 

⚠️ This is considered as a temporary fix, product designer will work on a permanent solution to avoid breaking the actual 14/20 ratio.

### How to test it?

- Open the admin with an iOS device and focus form inputs.
- There shouldn't be any zoom should 

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
