### PR TITLE
docs(README.md): Correct Node Requirements for v5.0.0 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Strapi only supports maintenance and LTS versions of Node.js. Please refer to th
 
 | Strapi Version  | Recommended | Minimum |
 | --------------- | ----------- | ------- |
-| 5.0.0 and up    | 20.x        | 18.x    |
+| 5.0.0 and up    | 22.x        | 20.x    |
 | 4.14.5 and up   | 20.x        | 18.x    |
 | 4.11.0 and up   | 18.x        | 16.x    |
 | 4.3.9 to 4.10.x | 18.x        | 14.x    |


### PR DESCRIPTION
### What does it do?

Update this repositories `README.md` to state correct Node requirements for Strapi v5.0.0

### Why is it needed?

Documentation should be correct.

### How to test it?

See https://docs.strapi.io/cms/quick-start

> [Node.js](https://nodejs.org/): Only [Active LTS or Maintenance LTS versions](https://nodejs.org/en/about/previous-releases) are supported (currently v20 and v22). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v21, v23).

### Related issue(s)/PR(s)

It is not
