### PR TITLE
fix: uncomment component cleanup script

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -37,7 +37,7 @@ import { createContentSourceMapsService } from './services/content-source-maps';
 import { coreStoreModel } from './services/core-store';
 import { createConfigProvider } from './services/config';
 
-// import { cleanComponentJoinTable } from './services/document-service/utils/clean-component-join-table';
+import { cleanComponentJoinTable } from './services/document-service/utils/clean-component-join-table';
 
 class Strapi extends Container implements Core.Strapi {
   app: any;
@@ -459,19 +459,19 @@ class Strapi extends Container implements Core.Strapi {
       await this.db.repair.removeOrphanMorphType({ pivot: 'component_type' });
     }
 
-    // const alreadyRanComponentRepair = await this.store.get({
-    //   type: 'strapi',
-    //   key: 'unidirectional-join-table-repair-ran',
-    // });
+    const alreadyRanComponentRepair = await this.store.get({
+      type: 'strapi',
+      key: 'unidirectional-join-table-repair-ran',
+    });
 
-    // if (!alreadyRanComponentRepair) {
-    //   await this.db.repair.processUnidirectionalJoinTables(cleanComponentJoinTable);
-    //   await this.store.set({
-    //     type: 'strapi',
-    //     key: 'unidirectional-join-table-repair-ran',
-    //     value: true,
-    //   });
-    // }
+    if (!alreadyRanComponentRepair) {
+      await this.db.repair.processUnidirectionalJoinTables(cleanComponentJoinTable);
+      await this.store.set({
+        type: 'strapi',
+        key: 'unidirectional-join-table-repair-ran',
+        value: true,
+      });
+    }
 
     if (this.EE) {
       await utils.ee.checkLicense({ strapi: this });


### PR DESCRIPTION
### What does it do?

- Uncomment component cleanup script, so it can run automatically in projects again

### Why is it needed?

- for projects that had this issue #23858  we need to cleanup the corrupted data

### How to test it?

- create a strapi app, fill it with relations different types of  relation data, between draft and publish contentTypes, and non draft and publish contentTypes, in components, DZ...
- then run the script and check if it removes anything it shouldn't remove

### Related issue(s)/PR(s)

#24316 #24227 #24467 
