### PR TITLE
Fix double go back links and header size on mobile

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -173,7 +173,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
       ],
     };
 
-    setQuery({ filters: newFilterQuery, page: 1 });
+    setQuery({ filters: newFilterQuery, page: 1 }, 'push', true);
     setOpen(false);
   };
 

--- a/packages/core/admin/admin/src/components/Table.tsx
+++ b/packages/core/admin/admin/src/components/Table.tsx
@@ -187,9 +187,13 @@ const HeaderCell = <TData, THead>({ name, label, sortable }: TableHeader<TData, 
 
   const handleClickSort = () => {
     if (sortable) {
-      setQuery({
-        sort: `${name}:${isSorted && sortOrder === 'ASC' ? 'DESC' : 'ASC'}`,
-      });
+      setQuery(
+        {
+          sort: `${name}:${isSorted && sortOrder === 'ASC' ? 'DESC' : 'ASC'}`,
+        },
+        'push',
+        true
+      );
     }
   };
 

--- a/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
+++ b/packages/core/admin/admin/src/pages/Marketplace/MarketplacePage.tsx
@@ -102,26 +102,34 @@ const MarketplacePage = () => {
     const hasTabQuery = tabQuery[selectedTab] && Object.keys(tabQuery[selectedTab]).length;
 
     if (hasTabQuery) {
-      setQuery({
-        // Keep filters and search
-        ...tabQuery[selectedTab],
-        search: query?.search || '',
-        // Set tab and reset page
-        npmPackageType: selectedTab,
-        page: 1,
-      });
+      setQuery(
+        {
+          // Keep filters and search
+          ...tabQuery[selectedTab],
+          search: query?.search || '',
+          // Set tab and reset page
+          npmPackageType: selectedTab,
+          page: 1,
+        },
+        'push',
+        true
+      );
     } else {
-      setQuery({
-        // Set tab
-        npmPackageType: selectedTab,
-        // Clear filters
-        collections: [],
-        categories: [],
-        sort: 'name:asc',
-        page: 1,
-        // Keep search
-        search: query?.search || '',
-      });
+      setQuery(
+        {
+          // Set tab
+          npmPackageType: selectedTab,
+          // Clear filters
+          collections: [],
+          categories: [],
+          sort: 'name:asc',
+          page: 1,
+          // Keep search
+          search: query?.search || '',
+        },
+        'push',
+        true
+      );
     }
   };
 

--- a/packages/core/admin/admin/src/pages/Settings/Layout.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/Layout.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@strapi/design-system';
+import { Box } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { Navigate, Outlet, useMatch } from 'react-router-dom';
 
@@ -21,7 +21,6 @@ const Layout = () => {
   const { formatMessage } = useIntl();
   const { isLoading } = useSettingsMenu();
   const isMobile = useIsMobile();
-  const hasSubPage = Boolean(match?.params['*']);
 
   // Since the useSettingsMenu hook can make API calls in order to check the links permissions
   // We need to add a loading state to prevent redirecting the user while permissions are being checked
@@ -60,16 +59,14 @@ const Layout = () => {
           defaultMessage: 'Settings',
         })}
       </Page.Title>
-      {!hasSubPage && (
-        <Box
-          display={{ initial: 'block', medium: 'none' }}
-          paddingLeft={RESPONSIVE_DEFAULT_SPACING}
-          paddingRight={RESPONSIVE_DEFAULT_SPACING}
-          paddingTop={RESPONSIVE_DEFAULT_SPACING}
-        >
-          <BackButton fallback="/settings" />
-        </Box>
-      )}
+      <Box
+        display={{ initial: 'block', medium: 'none' }}
+        paddingLeft={RESPONSIVE_DEFAULT_SPACING}
+        paddingRight={RESPONSIVE_DEFAULT_SPACING}
+        paddingTop={RESPONSIVE_DEFAULT_SPACING}
+      >
+        <BackButton fallback="/settings" />
+      </Box>
       <Outlet />
     </Layouts.Root>
   );

--- a/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/SettingsNav.tsx
@@ -1,4 +1,4 @@
-import { Badge, Divider } from '@strapi/design-system';
+import { Badge, Divider, Typography } from '@strapi/design-system';
 import { Lightning } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';

--- a/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/components/Tokens/FormHead.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, Dialog, Flex, Tooltip } from '@strapi/design-system';
+import { Box, Button, Dialog, Flex, Tooltip } from '@strapi/design-system';
 import { Check, ArrowClockwise, Eye, EyeStriked } from '@strapi/icons';
 import { MessageDescriptor, useIntl } from 'react-intl';
 
@@ -209,7 +209,12 @@ export const FormHead = <TToken extends Token | null>({
           )
         )
       }
-      navigationAction={<BackButton />}
+      navigationAction={
+        // The back link for mobile works differently; it is placed higher up in the DOM.
+        <Box display={{ initial: 'none', medium: 'block' }}>
+          <BackButton />
+        </Box>
+      }
       ellipsis
     />
   );

--- a/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApiTokens/ListView.tsx
@@ -72,7 +72,7 @@ export const ListView = () => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
 
   React.useEffect(() => {
-    navigate({ search: qs.stringify({ sort: 'name:ASC' }, { encode: false }) });
+    navigate({ search: qs.stringify({ sort: 'name:ASC' }, { encode: false }) }, { replace: true });
   }, [navigate]);
 
   const headers = TABLE_HEADERS.map((header) => ({

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/CreatePage.tsx
@@ -220,7 +220,12 @@ const CreatePage = () => {
                   id: 'Settings.roles.create.description',
                   defaultMessage: 'Define the rights given to the role',
                 })}
-                navigationAction={<BackButton fallback="../roles" />}
+                navigationAction={
+                  // The back link for mobile works differently; it is placed higher up in the DOM.
+                  <Box display={{ initial: 'none', medium: 'block' }}>
+                    <BackButton fallback="../roles" />
+                  </Box>
+                }
               />
               <Layouts.Content>
                 <Flex direction="column" alignItems="stretch" gap={6}>

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/EditPage.tsx
@@ -211,7 +211,12 @@ const EditPage = () => {
                 id: 'Settings.roles.create.description',
                 defaultMessage: 'Define the rights given to the role',
               })}
-              navigationAction={<BackButton fallback="../roles" />}
+              navigationAction={
+                // The back link for mobile works differently; it is placed higher up in the DOM.
+                <Box display={{ initial: 'none', medium: 'block' }}>
+                  <BackButton fallback="../roles" />
+                </Box>
+              }
             />
             <Layouts.Content>
               <Flex direction="column" alignItems="stretch" gap={6}>

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
@@ -78,7 +78,7 @@ const ListView = () => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
 
   React.useEffect(() => {
-    navigate({ search: qs.stringify({ sort: 'name:ASC' }, { encode: false }) });
+    navigate({ search: qs.stringify({ sort: 'name:ASC' }, { encode: false }) }, { replace: true });
   }, [navigate]);
 
   useOnce(() => {

--- a/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Users/EditPage.tsx
@@ -205,7 +205,12 @@ const EditPage = () => {
                     name: getDisplayName(initialData),
                   }
                 )}
-                navigationAction={<BackButton fallback="../users" />}
+                navigationAction={
+                  // The back link for mobile works differently; it is placed higher up in the DOM.
+                  <Box display={{ initial: 'none', medium: 'block' }}>
+                    <BackButton fallback="../users" />
+                  </Box>
+                }
               />
               <Layouts.Content>
                 {user?.registrationToken && (

--- a/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Webhooks/components/WebhookForm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Button, Flex, Grid, TextInput } from '@strapi/design-system';
+import { Box, Button, Flex, Grid } from '@strapi/design-system';
 import { Check, Play as Publish } from '@strapi/icons';
 import { IntlShape, useIntl } from 'react-intl';
 import * as yup from 'yup';
@@ -125,7 +125,12 @@ const WebhookForm = ({
                   })
                 : data?.name
             }
-            navigationAction={<BackButton fallback="../webhooks" />}
+            navigationAction={
+              // The back link for mobile works differently; it is placed higher up in the DOM.
+              <Box display={{ initial: 'none', medium: 'block' }}>
+                <BackButton fallback="../webhooks" />
+              </Box>
+            }
           />
           <Layouts.Content>
             <Flex direction="column" alignItems="stretch" gap={4}>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -126,7 +126,7 @@ const ListPage = () => {
             <Table.Loading />
             <Table.Body>
               {results.map((log) => (
-                <Table.Row key={log.id} onClick={() => setQuery({ id: log.id })}>
+                <Table.Row key={log.id} onClick={() => setQuery({ id: log.id }, 'push', true)}>
                   {headers.map((header) => {
                     const { name, cellFormatter } = header;
 
@@ -175,7 +175,7 @@ const ListPage = () => {
                   <Table.Cell onClick={(e) => e.stopPropagation()}>
                     <Flex justifyContent="end">
                       <IconButton
-                        onClick={() => setQuery({ id: log.id })}
+                        onClick={() => setQuery({ id: log.id }, 'push', true)}
                         withTooltip={false}
                         label={formatMessage(
                           { id: 'app.component.table.view', defaultMessage: '{target} details' },
@@ -199,7 +199,10 @@ const ListPage = () => {
         </Pagination.Root>
       </Layouts.Content>
       {query?.id && (
-        <Modal handleClose={() => setQuery({ id: '' }, 'remove')} logId={query.id.toString()} />
+        <Modal
+          handleClose={() => setQuery({ id: '' }, 'remove', true)}
+          logId={query.id.toString()}
+        />
       )}
     </Page.Main>
   );

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -270,7 +270,6 @@ const ListViewPage = () => {
               <>
                 {list.settings.searchable && (
                   <SearchInput
-                    disabled={results.length === 0}
                     label={formatMessage(
                       { id: 'app.component.search.label', defaultMessage: 'Search for {target}' },
                       { target: contentTypeTitle }
@@ -282,9 +281,7 @@ const ListViewPage = () => {
                     trackedEvent="didSearch"
                   />
                 )}
-                {list.settings.filterable && schema ? (
-                  <Filters disabled={results.length === 0} schema={schema} />
-                ) : null}
+                {list.settings.filterable && schema ? <Filters schema={schema} /> : null}
               </>
             }
           />

--- a/packages/core/review-workflows/admin/src/routes/settings/id.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/id.tsx
@@ -12,7 +12,7 @@ import {
   FormHelpers,
 } from '@strapi/admin/strapi-admin';
 import { useLicenseLimits } from '@strapi/admin/strapi-admin/ee';
-import { Button, Dialog, Flex, Typography } from '@strapi/design-system';
+import { Box, Button, Dialog, Flex, Typography } from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import { useIntl } from 'react-intl';
@@ -347,7 +347,12 @@ const EditPage = () => {
         {({ modified, isSubmitting, values, setErrors }) => (
           <>
             <Layout.Header
-              navigationAction={<BackButton fallback=".." />}
+              navigationAction={
+                // The back link for mobile works differently; it is placed higher up in the DOM.
+                <Box display={{ initial: 'none', medium: 'block' }}>
+                  <BackButton fallback=".." />
+                </Box>
+              }
               primaryAction={
                 canUpdate || canCreate ? (
                   <Button

--- a/packages/core/review-workflows/admin/src/routes/settings/index.tsx
+++ b/packages/core/review-workflows/admin/src/routes/settings/index.tsx
@@ -213,6 +213,7 @@ export const ReviewWorkflowsListView = () => {
                       {canRead || canUpdate ? (
                         <IconButton
                           tag={Link}
+                          onClick={(e) => e.stopPropagation()}
                           to={workflow.id.toString()}
                           label={formatMessage(
                             {

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -165,14 +165,18 @@ const LocalePickerAction = ({
 
   const handleSelect = React.useCallback(
     (value: string) => {
-      setQuery({
-        plugins: {
-          ...query.plugins,
-          i18n: {
-            locale: value,
+      setQuery(
+        {
+          plugins: {
+            ...query.plugins,
+            i18n: {
+              locale: value,
+            },
           },
         },
-      });
+        'push',
+        true
+      );
     },
     [query.plugins, setQuery]
   );

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/CreatePage.jsx
@@ -1,8 +1,24 @@
 import * as React from 'react';
 
-import { Button, Flex, Grid, Textarea, TextInput, Typography, Field } from '@strapi/design-system';
+import {
+  Button,
+  Flex,
+  Grid,
+  Textarea,
+  TextInput,
+  Typography,
+  Field,
+  Box,
+} from '@strapi/design-system';
 import { Check } from '@strapi/icons';
-import { Page, useTracking, useNotification, useFetchClient, Layouts } from '@strapi/strapi/admin';
+import {
+  Page,
+  useTracking,
+  useNotification,
+  useFetchClient,
+  Layouts,
+  BackButton,
+} from '@strapi/strapi/admin';
 import { Formik, Form } from 'formik';
 import { useIntl } from 'react-intl';
 import { useMutation } from 'react-query';
@@ -93,6 +109,12 @@ export const CreatePage = () => {
                 id: 'Settings.roles.create.description',
                 defaultMessage: 'Define the rights given to the role',
               })}
+              navigationAction={
+                // The back link for mobile works differently; it is placed higher up in the DOM.
+                <Box display={{ initial: 'none', medium: 'block' }}>
+                  <BackButton fallback=".." />
+                </Box>
+              }
             />
             <Layouts.Content>
               <Flex

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/EditPage.jsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 
-import { Button, Flex, TextInput, Textarea, Typography, Grid, Field } from '@strapi/design-system';
+import {
+  Button,
+  Flex,
+  TextInput,
+  Textarea,
+  Typography,
+  Grid,
+  Field,
+  Box,
+} from '@strapi/design-system';
 import { Check } from '@strapi/icons';
 import {
   Page,
@@ -110,7 +119,12 @@ export const EditPage = () => {
               }
               title={role.name}
               subtitle={role.description}
-              navigationAction={<BackButton fallback=".." />}
+              navigationAction={
+                // The back link for mobile works differently; it is placed higher up in the DOM.
+                <Box display={{ initial: 'none', medium: 'block' }}>
+                  <BackButton fallback=".." />
+                </Box>
+              }
             />
             <Layouts.Content>
               <Flex

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/tests/EditPage.test.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/tests/EditPage.test.jsx
@@ -62,8 +62,6 @@ describe('Roles – EditPage', () => {
 
     await waitForElementToBeRemoved(() => getByText('Loading content.'));
 
-    expect(getByRole('link', { name: 'Back' })).toBeInTheDocument();
-
     expect(getByRole('heading', { name: 'Authenticated' })).toBeInTheDocument();
     expect(getByRole('heading', { name: 'Role details' })).toBeInTheDocument();
     expect(getByRole('heading', { name: 'Permissions' })).toBeInTheDocument();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove the duplicate go back button and use the default form header on mobile.

### Why is it needed?

This PR fixes the double go back link that can is rendered when opening a setting subpage. It does also fix the header fixed height that we are using for the desktop mode.

### How to test it?

- Open the API token settings page (the header should be displayed normally)
- Open the create new token settings page (you should be able to see the submit button and a single go back link in the form header.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request

| before    | after |
| -------- | ------- |
| <img width="163" height="818" alt="Settings — API Tokens  Strapi" src="https://github.com/user-attachments/assets/f698986b-4f5d-45f0-80ee-d70c7e0175c1" /> | <img width="163" height="818" alt="IMG_3837" src="https://github.com/user-attachments/assets/4adff10b-4bd0-4148-94c1-2ce3065181ab" /> |

| before    | after |
| -------- | ------- |
| <img width="163" height="818" alt="IMG_3835" src="https://github.com/user-attachments/assets/089d8839-7d21-41f1-9658-f1c41d1bf491" /> | <img width="163" height="818" alt="IMG_3836" src="https://github.com/user-attachments/assets/9213d845-96ff-4d8e-8c7a-d32e6ed1d737" /> |