### PR TITLE
feat: adding Claude as a reviewer

### DIFF
--- a/.github/workflows/pr-reviewer.yaml
+++ b/.github/workflows/pr-reviewer.yaml
@@ -1,0 +1,72 @@
+name: PR Review with Progress Tracking
+
+# This example demonstrates how to use the track_progress feature to get
+# visual progress tracking for PR reviews, similar to v0.x agent mode.
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  review-with-tracking:
+    if: ${{ github.event.label.name == 'AI Review' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Your custom review instructions
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
+
+          # Tools for comprehensive PR review
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+# When track_progress is enabled:
+# - Creates a tracking comment with progress checkboxes
+# - Includes all PR context (comments, attachments, images)
+# - Updates progress as the review proceeds
+# - Marks as completed when done


### PR DESCRIPTION
# Description

This will add a PR review done by Claude when a PR has the label 'AI Review' added to it

## Type of change

Nothing changes on the functionality of the Cloud, only on the github PR reviewing process

# How Has This Been Tested?

I have tested already on a private repository within the same organisation

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have added e2e tests that prove my fix is effective or that my feature works
- [ ] I have manually tested it on my local environment
- [X] I have tested on QA environment
- [X] I have performed tests that verify no regressions on all the code paths impacted by my changes

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added comments to my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation