### PR TITLE
fix(content-manager): filter invalid fields in homepage recent-documents query

### DIFF
--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -189,6 +189,13 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
             ...additionalQueryParams,
           });
 
+          // minimal fix: ensure fields is an array of non-empty strings
+          if (permissionQuery && Array.isArray((permissionQuery as any).fields)) {
+            (permissionQuery as any).fields = (permissionQuery as any).fields.filter(
+              (f: unknown): f is string => typeof f === 'string' && f.length > 0
+            );
+          }
+
           const docs = await strapi.documents(meta.uid).findMany(permissionQuery);
           const populate = additionalQueryParams?.populate as string[];
 


### PR DESCRIPTION
Prevents "Invalid fields parameter. Expected a string or an array of strings" 500 error in the admin homepage “Last edited entries / Recent documents” widget.

Relates to #24040

What does it do?

In packages/core/content-manager/server/homepage/services/homepage.ts, inside queryLastDocuments, it filters permissionQuery.fields (after sanitizedQuery.read) to ensure it is an array of non-empty strings before calling findMany()

`// minimal fix: ensure fields is an array of non-empty strings
if (permissionQuery && Array.isArray((permissionQuery as any).fields)) {
  (permissionQuery as any).fields = (permissionQuery as any).fields.filter(
    (f: unknown): f is string => typeof f === 'string' && f.length > 0
  );
}`

Why is it needed?

After migration from v4 → v5, the homepage “Recent documents” query can include a fields array where some entries become null after permission sanitization (e.g., when a field like provider is not permitted on plugin::users-permissions.user).
The document service validator expects fields to be a string or an array of strings; any non-string entry (like null) causes a 500 with:
`Invalid fields parameter. Expected a string or an array of strings`
Normalizing the array prevents the crash without changing any other query behavior (sorting, filters, populate, or permissions).

How to test it?
	1.	Use a Strapi v5 app where the admin dashboard “Recent documents” widget is enabled.
	•	Migrated app from v4 → v5 can reproduce more easily.
	2.	Ensure you have content types including plugin::users-permissions.user (or another model where a field may be stripped by permissions).
	3.	Open the admin dashboard → Home.
	4.	Before fix: Server logs show the 500 and the error above from convert-query-params.
	5.	Apply this patch, rebuild/run.
	6.	After fix: Dashboard loads the widget successfully; logs show no 500.

Environment verified:
	•	Node v20.x
	•	Strapi v5.29.0 (also reproduced on 5.18.0 before upgrading)
	•	DB: (e.g., SQLite locally; reporter also observed on MySQL)
	•	OS: macOS

Related issue(s)/PR(s)
	•	Relates to #24040 (admin homepage “Last edited entries” error after migration to v5)

Notes
	•	This is a minimal, defensive guard local to the homepage service.
	•	It doesn’t modify permission logic or other query params.
	•	Tests welcome: a unit test could assert that queryLastDocuments does not throw when fields contains [ 'documentId', 'updatedAt', null ] after permission sanitization.