### PR TITLE
feat(audit-log): implement comprehensive audit logging system

### DIFF
--- a/templates/website/src/plugins/audit-log/DESIGN_NOTE.md
+++ b/templates/website/src/plugins/audit-log/DESIGN_NOTE.md
@@ -1,0 +1,61 @@
+## 🎯 Objective
+Design a scalable, configurable, and maintainable audit logging system for Strapi that automatically records all content changes and exposes them via a secure REST API.
+
+---
+
+## 🏗️ Design Approach
+
+### 1. Non-Intrusive Integration
+The system leverages **Strapi lifecycle events** rather than modifying core services — making it upgrade-safe and modular. 
+
+Lifecycle hooks were selected over an EventHub-based implementation to ensure tighter coupling with Strapi’s internal data persistence layer and reduce architectural overhead. This approach allows the audit plugin to intercept core CRUD operations directly at the ORM level, ensuring deterministic and synchronous logging of state changes. While an EventHub would enable more scalable, asynchronous event handling across distributed systems, lifecycle hooks provide stronger data consistency guarantees and simplify deployment by eliminating the need for additional message brokers or event infrastructure. This trade-off favors integrity and maintainability within a single-instance Strapi deployment.
+
+### 2. Centralized Service Layer
+All logging logic resides in the `audit-log` service, allowing:
+- Unified creation, filtering, and pagination
+- Easy testing and extension
+
+### 3. Data Model
+Each `audit_log` record stores:
+- Content type name  
+- Record ID  
+- Action  
+- Timestamp  
+- Diff or payload  
+- Relational link to user
+
+This ensures query flexibility and performance (index-friendly fields).
+
+### 4. Access Control
+Middleware checks for `read_audit_logs` permission, isolating log access from other users and preserving security boundaries.
+
+### 5. Configurability
+Admins can globally disable audit logging or exclude sensitive content types (`user`, `admin::role`, etc.) via `config/default.ts`.
+
+---
+
+## 🧠 Trade-offs and Reasoning
+
+| Decision | Trade-off |
+|-----------|------------|
+| Store diffs as JSON | Simpler to implement; may grow storage over time |
+| Use lifecycle hooks | Minimal intrusion but slightly harder to trace in debugging |
+| REST endpoint only | Simpler to evaluate; GraphQL could be added later |
+| One-to-one user relation | Keeps queries efficient; avoids denormalization |
+
+---
+
+## 🧩 Extensibility
+- Could easily emit events to message queues (e.g., Kafka, AWS SNS)
+- Ready for future admin dashboard UI for audit review
+- Schema can evolve with additional metadata (e.g., IP, User-Agent)
+
+---
+
+## ✅ Summary
+This design ensures:
+- **Seamless integration** into Strapi
+- **Configurable and secure** audit data collection
+- **Scalable structure** for future reporting and analytics
+
+By centralizing logic in a dedicated plugin and leveraging Strapi’s event hooks, the system remains robust, modular, and easy to maintain.

--- a/templates/website/src/plugins/audit-log/README.md
+++ b/templates/website/src/plugins/audit-log/README.md
@@ -1,0 +1,351 @@
+# Audit Logging for Strapi
+
+## 🧾 Overview
+This feature adds **Automated Audit Logging** to Strapi, enabling the system to record all content changes (create, update, delete) performed through the Content API.
+
+Each change is logged in a dedicated collection — `audit_logs` — along with metadata about the user, content type, action type, timestamps, and data differences.
+
+This solution integrates seamlessly with Strapi’s event-driven architecture and respects existing configurations and access control.
+
+---
+
+## ⚙️ Key Features
+
+✅ Automatically logs all **create**, **update**, and **delete** actions from the Content API.  
+✅ Stores contextual metadata:
+- Content type name  
+- Record ID  
+- Action type  
+- Timestamp  
+- Authenticated user (relation to `plugin::users-permissions.user`)  
+- Changed fields or payload diff  
+✅ Provides a REST endpoint `/audit-logs` with:
+- Filtering by content type, user, action type, and date range  
+- Pagination and sorting  
+✅ Role-based access control:
+- Only users with permission `read_audit_logs` can view logs  
+✅ Configurable via `config/default.ts`:
+```ts
+export default {
+  auditLog: {
+    enabled: true,
+    excludeContentTypes: ['plugin::users-permissions.user', 'admin::user'],
+  },
+};
+```
+
+## 🚀 Setup Instructions
+
+- Copy the audit-log folder into src/plugins/ of your Strapi project.
+
+- Enable the plugin in config/plugins.ts:
+
+```
+export default {
+  'audit-log': { enabled: true },
+};
+```
+- Restart your Strapi server — the plugin will create the audit_logs collection automatically.
+
+
+## 🏗️ Architectural Overview
+
+### 1. Integration Points
+
+The **Audit Log system** hooks into Strapi’s lifecycle events and **Content API layer**.
+
+- On every **create**, **update**, or **delete** action,  
+  the system triggers a `createLog()` call from the audit-log service.
+- This call saves a record in `audit_logs` via Strapi’s ORM,  
+  including the linked user and metadata.
+
+
+---
+
+### 📁 Plugin Structure
+
+Located under `src/plugins/audit-log/`:
+
+ ```
+├── server/
+│   ├── index.ts
+│   ├── content-types/
+│   │   └── audit-log/schema.json
+│   ├── controllers/
+│   │   └── audit-log.ts
+│   ├── routes/
+│   │   └── audit-log.ts
+│   ├── policies/
+│   │   └── can-read-audit-logs.ts
+│   ├── services/
+│   │   └── audit-log.ts
+│   └── config/
+│       └── default.ts
+
+```
+
+---
+
+## 🧩 Implementation Details
+
+### 1. Schema Definition
+
+`audit_logs` is a new collection with proper indexing and relationships:
+
+```json
+{
+  "kind": "collectionType",
+  "collectionName": "audit_logs",
+  "info": {
+    "singularName": "audit-log",
+    "pluralName": "audit-logs",
+    "displayName": "Audit Log"
+  },
+  "attributes": {
+    "contentType": { "type": "string", "required": true },
+    "recordId": { "type": "string", "required": true },
+    "action": {
+      "type": "enumeration",
+      "enum": ["create", "update", "delete"],
+      "required": true
+    },
+    "user": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "plugin::users-permissions.user"
+    },
+    "timestamp": { "type": "datetime", "required": true },
+    "diff": { "type": "json" }
+  }
+}
+```
+
+### 2. Lifecycle Hook (Bootstrap)
+
+`index.ts` attaches to Strapi’s event bus:
+
+```
+import { Core } from '@strapi/strapi';
+import _default from '../server/config/default.js';
+
+const CONFIG_KEY = 'plugin.audit-log';
+const config = strapi.config.get(CONFIG_KEY, _default);
+
+
+export default async ({ strapi }: { strapi: Core.Strapi }) => {
+
+  if (!config.auditLog.enabled) {
+    strapi.log.info('Audit logging disabled via configuration.');
+    return;
+  }
+
+  strapi.log.info('Audit logging initialized.');
+
+  // Hook into Strapi content events
+  strapi.db.lifecycles.subscribe({
+    async afterCreate(event) {
+      await createAuditLog(strapi, event, 'create');
+    },
+    async afterUpdate(event) {
+      await createAuditLog(strapi, event, 'update');
+    },
+    async afterDelete(event) {
+      await createAuditLog(strapi, event, 'delete');
+    },
+  });
+};
+
+// helper
+async function createAuditLog(
+  strapi: Core.Strapi,
+  event: any,
+  action: 'create' | 'update' | 'delete'
+) {
+
+
+  const { model, result, params } = event;
+  if (config.auditLog.excludeContentTypes?.includes(model.uid)) return;
+
+  const user = params?.user ?? null;
+
+  await strapi.db.query('plugin::audit-log.audit-log').create({
+    data: {
+      contentType: model.uid,
+      recordId: result.id,
+      action,
+      user: user?.id || null,
+      timestamp: new Date(),
+      payload: JSON.stringify(result),
+    },
+  });
+}
+
+```
+### 3. Audit Log Service
+
+```
+import type { Core } from '@strapi/strapi';
+import type { AuditLogEntry, AuditLogQuery } from '../types/audit-log.d.ts';
+import _default from '../config/default.js';
+
+const CONFIG_KEY = 'plugin.audit-log';
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  /**
+   * Find audit logs with filters and pagination
+   */
+  async findWithFilters(query: AuditLogQuery) {
+    const {
+      page = 1,
+      pageSize = 10,
+      contentType,
+      user,
+      action,
+      startDate,
+      endDate,
+    } = query;
+
+    const filters: any = {};
+    if (contentType) filters.contentType = contentType;
+    if (user) filters.user = user;
+    if (action) filters.action = action;
+    if (startDate || endDate) {
+      filters.timestamp = {};
+      if (startDate) filters.timestamp.$gte = new Date(startDate);
+      if (endDate) filters.timestamp.$lte = new Date(endDate);
+    }
+
+    const [entries, total] = await Promise.all([
+      strapi.db.query('plugin::audit-log.audit-log').findMany({
+        where: filters,
+        orderBy: { timestamp: 'DESC' },
+        limit: pageSize,
+        offset: (page - 1) * pageSize,
+      }),
+      strapi.db.query('plugin::audit-log.audit-log').count({ where: filters }),
+    ]);
+
+    return {
+      entries,
+      pagination: {
+        page,
+        pageSize,
+        pageCount: Math.ceil(total / pageSize),
+        total,
+      },
+    };
+  },
+
+  /**
+   * Create a new audit log entry for a content change
+   */
+  async createLog(params: {
+    contentType: string;
+    recordId: string | number;
+    action: 'create' | 'update' | 'delete';
+    userId?: number;
+    diff?: Record<string, any>;
+  }) {
+    const { contentType, recordId, action, userId, diff } = params;
+    const config = strapi.config.get(CONFIG_KEY, _default);
+
+    // Skip logging if disabled or excluded
+    if (!config.auditLog.enabled) return;
+    if (config.auditLog.excludeContentTypes?.includes(contentType)) return;
+
+    const entry: AuditLogEntry = {
+      contentType,
+      recordId: recordId.toString(),
+      action,
+      timestamp: new Date(),
+      diff: diff || {},
+    };
+
+    if (userId) {
+      entry.user = userId;
+    }
+
+    try {
+      await strapi.db.query('plugin::audit-log.audit-log').create({
+        data: entry,
+      });
+    } catch (error) {
+      strapi.log.error('Failed to create audit log:', error);
+    }
+  },
+});
+
+```
+
+### 4. Controller
+
+```
+import { Core } from '@strapi/strapi';
+import { Context } from 'koa';
+import { AuditLogQuery } from '../types/audit-log';
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  async find(ctx: Context) {
+    const query = ctx.request.query as unknown as AuditLogQuery;
+
+    const data = await strapi
+      .plugin('audit-log')
+      .service('audit-log')
+      .findWithFilters(query);
+
+    ctx.body = data;
+  },
+});
+```
+
+### 5. Access Control Middleware
+
+`can-read-audit-logs.ts` add role-based access control:
+
+```
+import { Core } from '@strapi/strapi';
+import { Context, Next } from 'koa';
+
+export default async (ctx: Context, next: Next) => {
+  const user = ctx.state.user;
+  if (!user) {
+    return ctx.unauthorized('You must be logged in.');
+  }
+
+  // permission check for read_audit_logs
+  const hasPermission = await strapi
+    .plugin('users-permissions')
+    .service('user')
+    .hasPermission(user.id, 'read_audit_logs');
+
+  if (!hasPermission) {
+    return ctx.forbidden('You are not allowed to read audit logs.');
+  }
+
+  await next();
+};
+
+```
+
+## 🧮 Query Examples
+
+### Get All Audit Logs
+```http
+GET /audit-logs?page=1&pageSize=10
+```
+### Filter by User
+```http
+GET /audit-logs?startDate=2025-10-01&endDate=2025-10-26
+```
+
+## 🧰 Configuration Options
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `auditLog.enabled` | `boolean` | Enables or disables logging globally |
+| `auditLog.excludeContentTypes` | `string[]` | Content types to exclude from logging |
+
+## 🔐 Access Control
+
+Only users with the read_audit_logs permission can query /audit-logs.
+All other users will receive a 403 Forbidden response.

--- a/templates/website/src/plugins/audit-log/package.json
+++ b/templates/website/src/plugins/audit-log/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "audit-logs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@strapi/strapi": "^5.0.0",
+    "@types/node": "^24.9.1",
+    "fast-deep-equal": "^3.1.3",
+    "lodash": "^4.17.21",
+    "typescript": "^5.9.3"
+  }
+}

--- a/templates/website/src/plugins/audit-log/server/config/default.ts
+++ b/templates/website/src/plugins/audit-log/server/config/default.ts
@@ -1,0 +1,6 @@
+export default {
+  auditLog: {
+    enabled: true,
+    excludeContentTypes: ['plugin::users-permissions.user', 'admin::user'],
+  },
+};

--- a/templates/website/src/plugins/audit-log/server/content-types/audit-log/schema.json
+++ b/templates/website/src/plugins/audit-log/server/content-types/audit-log/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "audit_logs",
+  "info": {
+    "singularName": "audit-log",
+    "pluralName": "audit-logs",
+    "displayName": "Audit Log",
+    "description": "Stores automated audit records for content changes"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "contentType": { "type": "string", "required": true },
+    "recordId": { "type": "string", "required": true },
+    "action": {
+      "type": "enumeration",
+      "enum": ["create", "update", "delete"],
+      "required": true
+    },
+    "user": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "plugin::users-permissions.user"
+    },
+    "timestamp": { "type": "datetime", "required": true },
+    "diff": { "type": "json" }
+  }
+}

--- a/templates/website/src/plugins/audit-log/server/controllers/audit-log.ts
+++ b/templates/website/src/plugins/audit-log/server/controllers/audit-log.ts
@@ -1,0 +1,19 @@
+import { Core } from '@strapi/strapi';
+import { Context } from 'koa';
+import { AuditLogQuery } from '../types/audit-log';
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  async find(ctx: Context) {
+    try {
+      const query = ctx.request.query as unknown as AuditLogQuery;
+      const data = await strapi
+        .plugin('audit-log')
+        .service('audit-log')
+        .findWithFilters(query);
+
+      ctx.body = data;
+    } catch (error) {
+      ctx.throw(500, 'Failed to retrieve audit logs');
+    }
+  },
+});

--- a/templates/website/src/plugins/audit-log/server/index.ts
+++ b/templates/website/src/plugins/audit-log/server/index.ts
@@ -1,0 +1,54 @@
+import { Core } from '@strapi/strapi';
+import _default from '../server/config/default.js';
+
+const CONFIG_KEY = 'plugin.audit-log';
+const config = strapi.config.get(CONFIG_KEY, _default);
+
+
+export default async ({ strapi }: { strapi: Core.Strapi }) => {
+
+  if (!config.auditLog.enabled) {
+    strapi.log.info('Audit logging disabled via configuration.');
+    return;
+  }
+
+  strapi.log.info('Audit logging initialized.');
+
+  // Hook into Strapi content events
+  strapi.db.lifecycles.subscribe({
+    async afterCreate(event) {
+      await createAuditLog(strapi, event, 'create');
+    },
+    async afterUpdate(event) {
+      await createAuditLog(strapi, event, 'update');
+    },
+    async afterDelete(event) {
+      await createAuditLog(strapi, event, 'delete');
+    },
+  });
+};
+
+// helper
+async function createAuditLog(
+  strapi: Core.Strapi,
+  event: any,
+  action: 'create' | 'update' | 'delete'
+) {
+
+
+  const { model, result, params } = event;
+  if (config.auditLog.excludeContentTypes?.includes(model.uid)) return;
+
+  const user = params?.user ?? null;
+
+  await strapi.db.query('plugin::audit-log.audit-log').create({
+    data: {
+      contentType: model.uid,
+      recordId: result.id,
+      action,
+      user: user?.id || null,
+      timestamp: new Date(),
+      payload: JSON.stringify(result),
+    },
+  });
+}

--- a/templates/website/src/plugins/audit-log/server/policies/can-read-audit-logs.ts
+++ b/templates/website/src/plugins/audit-log/server/policies/can-read-audit-logs.ts
@@ -1,0 +1,32 @@
+import { Context, Next } from 'koa';
+
+interface Permission {
+  action: string;
+  [key: string]: any;
+}
+
+export default async (ctx: Context, next: Next) => {
+  const user = ctx.state.user;
+  if (!user) {
+    return ctx.unauthorized('You must be logged in.');
+  }
+
+  const role = await strapi.db.query('plugin::users-permissions.role').findOne({
+    where: { id: user.role.id },
+    populate: ['permissions'],
+  });
+
+  if (!role) {
+    return ctx.forbidden('Role not found.');
+  }
+
+  const hasPermission = (role.permissions as Permission[]).some(
+    (p: Permission) => p.action === 'plugin::audit-log.read'
+  );
+
+  if (!hasPermission) {
+    return ctx.forbidden('You are not allowed to read audit logs.');
+  }
+
+  await next();
+};

--- a/templates/website/src/plugins/audit-log/server/routes/audit-log.ts
+++ b/templates/website/src/plugins/audit-log/server/routes/audit-log.ts
@@ -1,0 +1,11 @@
+export default [
+  {
+    method: 'GET',
+    path: '/audit-logs',
+    handler: 'audit-log.find',
+    config: {
+      auth: true,
+      policies: ['plugin::audit-log.can-read-audit-logs'],
+    },
+  },
+];

--- a/templates/website/src/plugins/audit-log/server/services/audit-log.ts
+++ b/templates/website/src/plugins/audit-log/server/services/audit-log.ts
@@ -1,0 +1,90 @@
+import type { Core } from '@strapi/strapi';
+import type { AuditLogEntry, AuditLogQuery } from '../types/audit-log.d.ts';
+import _default from '../config/default.js';
+
+const CONFIG_KEY = 'plugin.audit-log';
+
+export default ({ strapi }: { strapi: Core.Strapi }) => ({
+  /**
+   * Find audit logs with filters and pagination
+   */
+  async findWithFilters(query: AuditLogQuery) {
+    const {
+      page = 1,
+      pageSize = 10,
+      contentType,
+      user,
+      action,
+      startDate,
+      endDate,
+    } = query;
+
+    const filters: any = {};
+    if (contentType) filters.contentType = contentType;
+    if (user) filters.user = user;
+    if (action) filters.action = action;
+    if (startDate || endDate) {
+      filters.timestamp = {};
+      if (startDate) filters.timestamp.$gte = new Date(startDate);
+      if (endDate) filters.timestamp.$lte = new Date(endDate);
+    }
+
+    const [entries, total] = await Promise.all([
+      strapi.db.query('plugin::audit-log.audit-log').findMany({
+        where: filters,
+        orderBy: { timestamp: 'DESC' },
+        limit: pageSize,
+        offset: (page - 1) * pageSize,
+      }),
+      strapi.db.query('plugin::audit-log.audit-log').count({ where: filters }),
+    ]);
+
+    return {
+      entries,
+      pagination: {
+        page,
+        pageSize,
+        pageCount: Math.ceil(total / pageSize),
+        total,
+      },
+    };
+  },
+
+  /**
+   * Create a new audit log entry for a content change
+   */
+  async createLog(params: {
+    contentType: string;
+    recordId: string | number;
+    action: 'create' | 'update' | 'delete';
+    userId?: number;
+    diff?: Record<string, any>;
+  }) {
+    const { contentType, recordId, action, userId, diff } = params;
+    const config = strapi.config.get(CONFIG_KEY, _default);
+
+    // Skip logging if disabled or excluded
+    if (!config.auditLog.enabled) return;
+    if (config.auditLog.excludeContentTypes?.includes(contentType)) return;
+
+    const entry: AuditLogEntry = {
+      contentType,
+      recordId: recordId.toString(),
+      action,
+      timestamp: new Date(),
+      diff: diff || {},
+    };
+
+    if (userId) {
+      entry.user = userId;
+    }
+
+    try {
+      await strapi.db.query('plugin::audit-log.audit-log').create({
+        data: entry,
+      });
+    } catch (error) {
+      strapi.log.error('Failed to create audit log:', error);
+    }
+  },
+});

--- a/templates/website/src/plugins/audit-log/server/types/audit-log.d.ts
+++ b/templates/website/src/plugins/audit-log/server/types/audit-log.d.ts
@@ -1,0 +1,45 @@
+export interface AuditLogModel {
+  uid: string;
+  [key: string]: any;
+}
+
+export interface AuditLogUser {
+  id: number;
+  [key: string]: any;
+}
+
+export interface AuditLogEvent extends Event {
+  model: AuditLogModel;
+  result?: Record<string, any>;
+  params?: {
+    user?: AuditLogUser;
+    [key: string]: any;
+  };
+}
+
+export interface AuditLogEntry {
+  id?: number;
+  contentType: string;
+  recordId: string | number;
+  action: 'create' | 'update' | 'delete';
+  user?: number | null;
+  timestamp: Date;
+  payload?: string;
+  diff?: Record<string, any>;
+}
+
+export interface AuditLogQuery {
+  page?: number;
+  pageSize?: number;
+  contentType?: string;
+  user?: string;
+  action?: 'create' | 'update' | 'delete';
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface AuditLogConfig {
+  enabled: boolean;
+  excludeContentTypes?: string[];
+  maxPayloadSize?: number;
+}

--- a/templates/website/src/plugins/audit-log/tsconfig.json
+++ b/templates/website/src/plugins/audit-log/tsconfig.json
@@ -1,0 +1,49 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+     "rootDir": "./server",
+     "outDir": "./dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    // "module": "nodenext",
+    // "target": "esnext",
+    "target": "es2021",
+    "module": "commonjs",
+    "types": [],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    //"verbatimModuleSyntax": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+  },
+    "include": ["server/**/*.ts"]
+
+}


### PR DESCRIPTION
### What does it do?

This PR introduces a custom Audit Logging plugin that captures key lifecycle events (create, update, delete) across selected Strapi content types.
It stores audit trails in a dedicated collection (audit_logs) and provides a REST API for querying logs with pagination, filtering, and access control.

The design leverages Strapi lifecycle hooks for event interception instead of the EventHub, allowing direct coupling with model changes and consistent payload structures across content types.

### Why is it needed?

This implementation demonstrates the ability to extend Strapi’s plugin architecture for operational transparency, compliance, and traceability.
Audit logging is essential for tracking user activities, debugging changes, and maintaining accountability within multi-user environments.

### How to test it?

Run the project

```
npm install
npm run develop
```

Trigger content operations
Perform create, update, or delete operations on any tracked content type (e.g., Articles, Users).

Verify audit logs
Use the endpoint:

`GET /audit-logs?page=1&pageSize=10`


To filter by user: `/audit-logs?user=3`

To filter by date range: `/audit-logs?startDate=2025-10-01&endDate=2025-10-26`

Permissions
Ensure the user has `read_audit_logs` permission; otherwise, requests return 403 Forbidden.

### Related issue(s)/PR(s)

N/A — this is an independent feature implementation for assessment purposes.
