### PR TITLE
fix: pagination count on query with locale=*

### DIFF
--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -272,7 +272,7 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       DP.defaultStatus(contentType),
       DP.statusToLookup(contentType),
       i18n.defaultLocale(contentType),
-      i18n.localeToLookup(contentType),
+      i18n.multiLocaleToLookup(contentType),
       transformParamsToQuery(uid)
     )(params);
 

--- a/tests/api/core/strapi/document-service/find-many.test.api.ts
+++ b/tests/api/core/strapi/document-service/find-many.test.api.ts
@@ -130,5 +130,24 @@ describe('Document Service', () => {
       const count = await strapi.documents(ARTICLE_UID).count(params);
       expect(count).toBe(articles.length);
     });
+
+    it('Find all documents with locale="*"', async () => {
+      const params = {
+        locale: '*',
+      } as const;
+
+      const articles = await findArticles(params);
+
+      // Should return articles from all locales
+      expect(articles.length).toBeGreaterThan(0);
+
+      // Verify we have articles from different locales
+      const locales = [...new Set(articles.map((article) => article.locale))];
+      expect(locales.length).toBeGreaterThan(1);
+
+      // expect count to be the same as findMany
+      const count = await strapi.documents(ARTICLE_UID).count(params);
+      expect(count).toBe(articles.length);
+    });
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
* Modify the function called to query all locales to get the correct count

### Why is it needed?
Pagination returned total amount to 0 when querying with all locales despite having more than 0 entries.

_BEFORE_
<img width="1800" height="1015" alt="Capture d’écran 2025-10-27 à 10 23 21" src="https://github.com/user-attachments/assets/dc4f1934-aaf3-4de2-8d48-5671cf96a443" />

_AFTER_
<img width="1800" height="1015" alt="Capture d’écran 2025-10-27 à 10 17 40" src="https://github.com/user-attachments/assets/372ed4f0-ad79-4437-9a6b-24256be376f2" />

### How to test it?
* Create at least two entries in a Content Type in at least 2 locales
* Fetch the request using the param `?locale=*`
* See the correct _total_ count

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/22673
