### PR TITLE
chore: remove unstableAILocalizations future flag

### DIFF
--- a/examples/getstarted/config/features.js
+++ b/examples/getstarted/config/features.js
@@ -1,5 +1,3 @@
 module.exports = ({ env }) => ({
-  future: {
-    unstableAILocalizations: true,
-  },
+  future: {},
 });

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,7 +1,5 @@
 export interface FeaturesConfig {
-  future?: {
-    unstableAILocalizations?: boolean;
-  };
+  future?: object;
 }
 
 export interface FeaturesService {

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -234,11 +234,7 @@ const LocalePickerAction = ({
 
       const permissionsToCheck = currentLocaleDoc ? canRead : canCreate;
 
-      if (
-        window.strapi.future.isEnabled('unstableAILocalizations') &&
-        isAiAvailable &&
-        settings?.data?.aiLocalizations
-      ) {
+      if (isAiAvailable && settings?.data?.aiLocalizations) {
         return {
           _render: () => (
             <React.Fragment key={index}>
@@ -381,8 +377,7 @@ const AITranslationStatusAction = ({ documentId, model, collectionType }: Header
   }
 
   // Do not display this action when AI is not available
-  const hasAIFutureFlag = window.strapi.future.isEnabled('unstableAILocalizations');
-  if (!isAIAvailable || !hasAIFutureFlag) {
+  if (!isAIAvailable) {
     return null;
   }
 
@@ -506,8 +501,7 @@ const FillFromAnotherLocaleAction = ({
   }
 
   // Do not display this action when AI is available and AI translations are enabled
-  const hasAIFutureFlag = window.strapi.future.isEnabled('unstableAILocalizations');
-  if (hasAIFutureFlag && isAIAvailable && isAISettingEnabled) {
+  if (isAIAvailable && isAISettingEnabled) {
     return null;
   }
 

--- a/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
+++ b/packages/plugins/i18n/admin/src/pages/SettingsPage.tsx
@@ -112,7 +112,7 @@ const SettingsPage = () => {
         })}
       />
       <Layouts.Content>
-        {isAIAvailable && window.strapi.future.isEnabled('unstableAILocalizations') && (
+        {isAIAvailable && (
           <Flex background="neutral0" padding={6} marginBottom={6} shadow="filterShadow" hasRadius>
             <Flex direction="column" alignItems="stretch" gap={1} flex={1}>
               <Flex gap={1}>

--- a/packages/plugins/i18n/admin/src/pages/tests/SettingsPage.test.tsx
+++ b/packages/plugins/i18n/admin/src/pages/tests/SettingsPage.test.tsx
@@ -60,9 +60,6 @@ describe('Settings Page', () => {
   it('should display AI translations section when AI is available', async () => {
     (useAIAvailability as jest.Mock).mockReturnValue(true);
 
-    // TODO: remove mocked future flag after stable release
-    window.strapi.future.isEnabled = jest.fn((flag: string) => flag === 'unstableAILocalizations');
-
     render(<SettingsPage />);
 
     // Wait for the page to load completely
@@ -79,9 +76,6 @@ describe('Settings Page', () => {
 
   it('should not display AI translations section when AI is not available', async () => {
     (useAIAvailability as jest.Mock).mockReturnValue(false);
-
-    // TODO: remove mocked future flag after stable release
-    window.strapi.future.isEnabled = jest.fn((flag: string) => flag === 'unstableAILocalizations');
 
     render(<SettingsPage />);
 

--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -24,12 +24,6 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
   return {
     // Async to avoid changing the signature later (there will be a db check in the future)
     async isEnabled() {
-      // Check if future flag is enabled
-      const isFutureFlagEnabled = strapi.features.future.isEnabled('unstableAILocalizations');
-      if (!isFutureFlagEnabled) {
-        return false;
-      }
-
       // Check if user disabled AI features globally
       const isAIEnabled = strapi.config.get('admin.ai.enabled', true);
       if (!isAIEnabled) {

--- a/tests/e2e/app-template/config/features.js
+++ b/tests/e2e/app-template/config/features.js
@@ -1,5 +1,3 @@
 module.exports = ({ env }) => ({
-  future: {
-    unstableAILocalizations: env.bool('STRAPI_FEATURES_UNSTABLE_AI_LOCALIZATIONS', false),
-  },
+  future: {},
 });


### PR DESCRIPTION
### What does it do?

Removes the future flag for AI localizations
### Why is it needed?

- so we're ready for launch
- so it's easier to the testers tomorrow, now that we have a feature branch anyway
