### PR TITLE
chore(i18n): populate media fields

### DIFF
--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -249,7 +249,7 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
             const derivedDoc = await strapi.documents(model).findOne({
               documentId,
               locale,
-              populate: '*',
+              populate: mediaFields,
             });
 
             // Merge AI content and media fields, works only on first level media fields (root level)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Since we only need to update the root-level media fields for derived locales, populating only the `mediaFields` should be sufficient for the `derivedDoc`.

### Why is it needed?

It will have a positive impact on performance.

### How to test it?

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
