### PR TITLE
fix: don't trigger translations with no translateable content

### DIFF
--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -11,7 +11,7 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
   const aiServerUrl = process.env.STRAPI_AI_URL || 'https://strapi-ai.apps.strapi.io';
   const aiLocalizationJobsService = getService('ai-localization-jobs');
 
-  const UNSUPPORTED_ATTRIBUTE_TYPES: Schema.Attribute.Kind[] = ['media', 'relation'];
+  const UNSUPPORTED_ATTRIBUTE_TYPES: Schema.Attribute.Kind[] = ['media', 'relation', 'boolean'];
   const IGNORED_FIELDS = [
     'id',
     'documentId',


### PR DESCRIPTION
### What does it do?

- avoids sending a request to the ai server with no content, which would throw a 400
- don't translate booleans

### How to test it?

Create or update a content type that is localized but that has no localized field. You should see no success or error notification, but a log in the terminal instead
