### PR TITLE
Nps survey responsiveness

### DIFF
--- a/packages/core/admin/admin/src/components/NpsSurvey.tsx
+++ b/packages/core/admin/admin/src/components/NpsSurvey.tsx
@@ -270,7 +270,7 @@ const NpsSurvey = () => {
               left="50%"
               transform="translateX(-50%)"
               zIndex="200"
-              width="50%"
+              minWidth={{ initial: '100%', medium: '50%' }}
             >
               <Flex
                 hasRadius


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

NPS Survey container is currently broken on mobile and tablet because of the width. 


| Before | After |
|-------|-------|
| <img width="666" height="337" alt="Screenshot 2025-10-28 at 17 22 30" src="https://github.com/user-attachments/assets/248512cb-0909-4178-87e9-6c4f83fc3c6e" /> | <img width="666" height="337" alt="Screenshot 2025-10-28 at 17 23 42" src="https://github.com/user-attachments/assets/4de5bfce-e79d-4d3e-a5bd-0ef3bcf5879b" /> |

| Before | After |
|-------|-------|
| <img width="402" height="329" alt="Screenshot 2025-10-28 at 17 22 36" src="https://github.com/user-attachments/assets/3cc8165b-9f9f-413a-a1f6-b07bef11edd9" /> | <img width="437" height="336" alt="Screenshot 2025-10-28 at 17 23 51" src="https://github.com/user-attachments/assets/46b016c1-0f90-46c4-8118-480dc7675b22" /> |

