### PR TITLE
fix(i18n): locale selector does not sort default locale first

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -261,7 +261,7 @@ const LocalePickerAction = ({
                   entryExists={entryWithLocaleExists}
                 />
               </SingleSelectOption>
-              {index === 0 && (
+              {localesSortingDefaultFirst.length > 1 && index === 0 && (
                 <Box paddingRight={4} paddingLeft={4} paddingTop={2} paddingBottom={2}>
                   <Typography variant="sigma">
                     {formatMessage({


### PR DESCRIPTION
### What does it do?

Sorts the default locale first

### Why is it needed?

The default locale should always be at the top

### How to test it?

With AND without a license containing AI

Go to a localized content type
Click the locale selector to see your locales, the default locale should be first
Change the default locale and test again


https://github.com/user-attachments/assets/9a2f369d-5fd4-4374-bde4-c033c581e109

<img width="290" height="240" alt="Screenshot 2025-10-29 at 09 56 08" src="https://github.com/user-attachments/assets/42dd440e-e849-4718-b11f-2e3a9c871ad0" />


### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
