### PR TITLE
fix: change messsaging on i18n AI

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -421,7 +421,7 @@ const AITranslationStatusAction = ({ documentId, model, collectionType }: Header
             {formatMessage({
               id: getTranslation('CMEditViewAITranslation.status-description'),
               defaultMessage:
-                'Our AI translates content in all locales each time you save a modification.',
+                'Our AI translates content in all locales each time you save a modification in the default locale.',
             })}
           </Typography>
           <Link


### PR DESCRIPTION

### What does it do?

Change wording on AI i18n explanation in the CM  popup.

### Why is it needed?

Clearer messaging

### How to test it?

Check the text in this popup has been updated: 
<img width="764" height="378" alt="Screenshot 2025-10-29 at 11 31 51" src="https://github.com/user-attachments/assets/9ee802d9-987a-4c2d-9431-c1753b3009c1" />

1. enable i18n AI
2. Go to a Content type
3. Hover on the sparkle AI button: the new text should be  'Our AI translates content in all locales each time you save a modification in the default locale.'

