### PR TITLE
fix(i18n): creating a source document does not create translated docu…

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -420,7 +420,7 @@ const AITranslationStatusAction = ({ documentId, model, collectionType }: Header
             {formatMessage({
               id: getTranslation('CMEditViewAITranslation.status-description'),
               defaultMessage:
-                'Our AI translates content in all locales each time you save a modification.',
+                'Our AI translates content in all locales each time you save a modification in the default locale.',
             })}
           </Typography>
           <Link

--- a/packages/plugins/i18n/admin/src/translations/en.json
+++ b/packages/plugins/i18n/admin/src/translations/en.json
@@ -20,7 +20,7 @@
   "CMEditViewBulkLocale.continue-confirmation": "Are you sure you want to continue?",
   "CMEditViewAITranslation.status-aria-label": "AI Translation Status",
   "CMEditViewAITranslation.status-title": "{enabled, select, true {AI translation enabled} false {AI translation disabled} other {AI translation disabled}}",
-  "CMEditViewAITranslation.status-description": "Our AI translates content in all locales each time you save a modification.",
+  "CMEditViewAITranslation.status-description": "Our AI translates content in all locales each time you save a modification in the default locale.",
   "CMEditViewAITranslation.settings-link": "{enabled, select, true {Disable it in settings} false {Enable it in settings} other {Enable it in settings}}",
   "CMEditViewAITranslation.job-completed": "AI translation completed successfully!",
   "CMEditViewAITranslation.job-failed": "AI translation failed. Please try again.",

--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -254,16 +254,10 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
               }
             }
 
-            /**
-             * TODO:
-             * We should use the document service here, however currently,
-             * updating a localized entry marks the source document as modified.
-             * @see https://github.com/strapi/strapi/issues/22924
-             *
-             * Falling back to the query engine to preserve the correct status
-             */
-            await strapi.db.query(model).update({
-              where: { documentId, locale },
+            await strapi.documents(model).update({
+              documentId,
+              locale,
+              fields: [],
               data: mergedData,
             });
 


### PR DESCRIPTION
### What does it do?

- Create the derive document if it does not already exist
- Copy the non-localized content to the derived document on creation
- Updates a translation

### Why is it needed?

Translated documents should be created when the default locale creates a document

### How to test it?


Go to a content type with i18n
Create a new doc in the default locale
It should create and translate for other locales
It should copy over non localized attributes


