### PR TITLE
fix(i18n): update Simplified Chinese translations in zh-Hans.json for content-type-builder

### DIFF
--- a/packages/core/content-type-builder/admin/src/translations/zh-Hans.json
+++ b/packages/core/content-type-builder/admin/src/translations/zh-Hans.json
@@ -41,7 +41,7 @@
   "button.single-types.create": "创建新单一类型",
   "media.multiple": "多个",
   "component.repeatable": "可重复",
-  "components.SelectComponents.displayed-value": "{number, plural, =0 {# 个组件} one {# 个组件} other {# 个组件}} 已选择",
+  "components.SelectComponents.displayed-value": "已选择 {number, plural, =0 {# components} 一个 {# component} 其他 {# components}}",
   "components.componentSelect.no-component-available": "您已经添加了所有组件",
   "components.componentSelect.no-component-available.with-search": "没有与搜索匹配的组件",
   "components.componentSelect.value-component": "{number} 个组件已选择（输入以搜索组件）",


### PR DESCRIPTION
### What does it do?

Fix wrong translations in [packages/core/content-type-builder/admin/src/translations/zh-Hans.json](packages/core/content-type-builder/admin/src/translations/zh-Hans.json)

### Why is it needed?

The current [zh-Hans.json](packages/core/content-type-builder/admin/src/translations/zh-Hans.json) file actually contains Traditional Chinese, so the file needs to be updated.

<img width="2754" height="1188" alt="image" src="https://github.com/user-attachments/assets/70118eda-1d8e-4b29-9ca2-5ab47e9b228c" />
