### PR TITLE
fix: limit i18n population on list view

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -143,8 +143,14 @@ export default {
 
     // OPTIMIZATION: For list view, avoid deep-populating localizations to prevent heavy payloads
     // Only expose minimal fields needed for locale badges/metadata
+    // @ts-expect-error ignored - There is an issue with the type because this does exist
+    const isLocalized = strapi.contentTypes[model]?.pluginOptions?.i18n?.localized;
     if (populate && typeof populate === 'object') {
-      (populate as any).localizations = { fields: ['id', 'locale', 'documentId'] };
+      if (isLocalized === true) {
+        populate.localizations = {
+          fields: ['id', 'locale', 'documentId'],
+        };
+      }
     }
 
     const { locale, status } = await getDocumentLocaleAndStatus(query, model);


### PR DESCRIPTION
### What does it do?

Checks within the population to see if it's trying to populate localization and limits the population to only the `id`, `locale`, and `documentID` and does not deeply populate data that isn't rendered within the list view

### Why is it needed?

Solving performance issue in loading the list view

### How to test it?

Compare two applications with deeply nested localized relations

### Related issue(s)/PR(s)

fixes: #24504
