### PR TITLE
fix: Markdown editor cannot bold with shortcut or add images from clipboard

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
@@ -92,21 +92,15 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
       editorRef.current.on('change', changeHandler);
 
       // Handle paste event to detect images
-      const handlePaste = (_cm: CodeMirror.Editor, event: ClipboardEvent) => {
+      const handlePaste = (editor: CodeMirror.Editor, event: ClipboardEvent) => {
         const items = event.clipboardData?.items;
         if (!items) return;
 
         // Collect all image files
-        const imageFiles: File[] = [];
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
-          if (item.type.indexOf('image') !== -1) {
-            const file = item.getAsFile();
-            if (file) {
-              imageFiles.push(file);
-            }
-          }
-        }
+        const imageFiles: File[] = Array.from(items)
+          .filter((item) => item.type.includes('image'))
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => file !== null);
 
         // If we found images, prevent default and upload them
         if (imageFiles.length > 0) {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Editor.tsx
@@ -5,6 +5,7 @@ import { styled } from 'styled-components';
 
 import { PreviewWysiwyg } from './PreviewWysiwyg';
 import { newlineAndIndentContinueMarkdownList } from './utils/continueList';
+import { markdownHandler } from './utils/utils';
 
 import type { FieldValue, InputProps } from '@strapi/admin/strapi-admin';
 
@@ -20,6 +21,7 @@ interface EditorProps extends Omit<FieldValue, 'initialValue'>, Omit<InputProps,
   isPreviewMode?: boolean;
   isExpandMode?: boolean;
   textareaRef: React.RefObject<HTMLTextAreaElement>;
+  onPasteImage?: (files: File[]) => void;
 }
 
 const Editor = React.forwardRef<EditorApi, EditorProps>(
@@ -35,10 +37,16 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
       placeholder,
       textareaRef,
       value,
+      onPasteImage,
     },
     forwardedRef
   ) => {
     const onChangeRef = React.useRef(onChange);
+    const onPasteImageRef = React.useRef(onPasteImage);
+
+    React.useEffect(() => {
+      onPasteImageRef.current = onPasteImage;
+    }, [onPasteImage]);
 
     React.useEffect(() => {
       if (editorRef.current) {
@@ -52,6 +60,14 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
           Enter: 'newlineAndIndentContinueMarkdownList',
           Tab: false,
           'Shift-Tab': false,
+          'Cmd-B': 'bold',
+          'Ctrl-B': 'bold',
+          'Cmd-I': 'italic',
+          'Ctrl-I': 'italic',
+          'Cmd-U': 'underline',
+          'Ctrl-U': 'underline',
+          'Cmd-K': 'link',
+          'Ctrl-K': 'link',
         },
         readOnly: false,
         smartIndent: false,
@@ -60,12 +76,55 @@ const Editor = React.forwardRef<EditorApi, EditorProps>(
         inputStyle: 'contenteditable',
       });
 
-      // @ts-expect-error – doesn't think command exists?
+      // Register custom commands for markdown formatting
       CodeMirror.commands.newlineAndIndentContinueMarkdownList =
         newlineAndIndentContinueMarkdownList;
-      editorRef.current.on('change', (doc) => {
+
+      CodeMirror.commands.bold = () => markdownHandler(editorRef, 'Bold');
+      CodeMirror.commands.italic = () => markdownHandler(editorRef, 'Italic');
+      CodeMirror.commands.underline = () => markdownHandler(editorRef, 'Underline');
+      CodeMirror.commands.link = () => markdownHandler(editorRef, 'Link');
+
+      const changeHandler = (doc: CodeMirror.Editor) => {
         onChangeRef.current(name, doc.getValue());
-      });
+      };
+
+      editorRef.current.on('change', changeHandler);
+
+      // Handle paste event to detect images
+      const handlePaste = (_cm: CodeMirror.Editor, event: ClipboardEvent) => {
+        const items = event.clipboardData?.items;
+        if (!items) return;
+
+        // Collect all image files
+        const imageFiles: File[] = [];
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          if (item.type.indexOf('image') !== -1) {
+            const file = item.getAsFile();
+            if (file) {
+              imageFiles.push(file);
+            }
+          }
+        }
+
+        // If we found images, prevent default and upload them
+        if (imageFiles.length > 0) {
+          event.preventDefault();
+          if (onPasteImageRef.current) {
+            onPasteImageRef.current(imageFiles);
+          }
+        }
+      };
+
+      editorRef.current.on('paste', handlePaste);
+
+      return () => {
+        if (editorRef.current) {
+          editorRef.current.off('change', changeHandler);
+          editorRef.current.off('paste', handlePaste);
+        }
+      };
     }, [editorRef, textareaRef, name, placeholder]);
 
     React.useEffect(() => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
 
-import { useField, useStrapiApp, type InputProps } from '@strapi/admin/strapi-admin';
+import {
+  useField,
+  useStrapiApp,
+  useFetchClient,
+  useNotification,
+  type InputProps,
+} from '@strapi/admin/strapi-admin';
 import { Field, Flex } from '@strapi/design-system';
 import { EditorFromTextArea } from 'codemirror5';
+import { useIntl } from 'react-intl';
 
 import { prefixFileUrlWithBackendUrl } from '../../../../../utils/urls';
 
@@ -29,7 +36,11 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
     const [isPreviewMode, setIsPreviewMode] = React.useState(false);
     const [mediaLibVisible, setMediaLibVisible] = React.useState(false);
     const [isExpandMode, setIsExpandMode] = React.useState(false);
+    const [isUploading, setIsUploading] = React.useState(false);
     const components = useStrapiApp('ImageDialog', (state) => state.components);
+    const { post } = useFetchClient();
+    const { toggleNotification } = useNotification();
+    const { formatMessage } = useIntl();
 
     const MediaLibraryDialog = components['media-library'];
 
@@ -40,7 +51,7 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
       setIsExpandMode((prev) => !prev);
     };
 
-    const handleSelectAssets = (files: any[]) => {
+    const handleSelectAssets = (files: Array<Record<string, string>>) => {
       const formattedFiles = files.map((f) => ({
         alt: f.alternativeText || f.name,
         url: prefixFileUrlWithBackendUrl(f.url),
@@ -49,6 +60,97 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
 
       insertFile(editorRef, formattedFiles);
       setMediaLibVisible(false);
+    };
+
+    const handlePasteImage = async (files: File[]) => {
+      if (isUploading || files.length === 0) return;
+
+      setIsUploading(true);
+
+      try {
+        // Create FormData for the upload
+        const formData = new FormData();
+
+        // Add all files
+        files.forEach((file) => {
+          formData.append('files', file);
+        });
+
+        // Add fileInfo for each file
+        files.forEach((file) => {
+          formData.append(
+            'fileInfo',
+            JSON.stringify({
+              name: file.name,
+              alternativeText: file.name.split('.')[0],
+            })
+          );
+        });
+
+        // Upload the files
+        const message =
+          files.length === 1
+            ? formatMessage({
+                id: 'content-manager.components.Wysiwyg.uploading',
+                defaultMessage: 'Uploading image...',
+              })
+            : formatMessage(
+                {
+                  id: 'content-manager.components.Wysiwyg.uploading-multiple',
+                  defaultMessage: 'Uploading {count} images...',
+                },
+                { count: files.length }
+              );
+
+        toggleNotification({
+          type: 'info',
+          message,
+        });
+
+        const response = await post<Array<Record<string, string>>>('/upload', formData);
+
+        if (response.data && response.data.length > 0) {
+          // Format all uploaded files for insertion
+          const formattedFiles = response.data.map((uploadedFile) => ({
+            alt: uploadedFile.alternativeText || uploadedFile.name,
+            url: prefixFileUrlWithBackendUrl(uploadedFile.url),
+            mime: uploadedFile.mime,
+          }));
+
+          // Insert all images into the editor
+          insertFile(editorRef, formattedFiles);
+
+          const successMessage =
+            files.length === 1
+              ? formatMessage({
+                  id: 'content-manager.components.Wysiwyg.upload-success',
+                  defaultMessage: 'Image uploaded and inserted successfully',
+                })
+              : formatMessage(
+                  {
+                    id: 'content-manager.components.Wysiwyg.upload-success-multiple',
+                    defaultMessage: '{count} images uploaded and inserted successfully',
+                  },
+                  { count: files.length }
+                );
+
+          toggleNotification({
+            type: 'success',
+            message: successMessage,
+          });
+        }
+      } catch (error) {
+        console.error('Error uploading pasted image:', error);
+        toggleNotification({
+          type: 'danger',
+          message: formatMessage({
+            id: 'content-manager.components.Wysiwyg.upload-error',
+            defaultMessage: 'Error uploading image',
+          }),
+        });
+      } finally {
+        setIsUploading(false);
+      }
     };
 
     return (
@@ -81,6 +183,7 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
               placeholder={placeholder}
               textareaRef={textareaRef}
               value={field.value}
+              onPasteImage={handlePasteImage}
               ref={forwardedRef}
             />
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
@@ -88,19 +88,13 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
         });
 
         // Upload the files
-        const message =
-          files.length === 1
-            ? formatMessage({
-                id: 'content-manager.components.Wysiwyg.uploading',
-                defaultMessage: 'Uploading image...',
-              })
-            : formatMessage(
-                {
-                  id: 'content-manager.components.Wysiwyg.uploading-multiple',
-                  defaultMessage: 'Uploading {count} images...',
-                },
-                { count: files.length }
-              );
+        const message = formatMessage(
+          {
+            id: 'content-manager.components.Wysiwyg.uploading',
+            defaultMessage: 'Uploading {count, plural, one {# image} other {# images}}...',
+          },
+          { count: files.length }
+        );
 
         toggleNotification({
           type: 'info',
@@ -120,19 +114,14 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
           // Insert all images into the editor
           insertFile(editorRef, formattedFiles);
 
-          const successMessage =
-            files.length === 1
-              ? formatMessage({
-                  id: 'content-manager.components.Wysiwyg.upload-success',
-                  defaultMessage: 'Image uploaded and inserted successfully',
-                })
-              : formatMessage(
-                  {
-                    id: 'content-manager.components.Wysiwyg.upload-success-multiple',
-                    defaultMessage: '{count} images uploaded and inserted successfully',
-                  },
-                  { count: files.length }
-                );
+          const successMessage = formatMessage(
+            {
+              id: 'content-manager.components.Wysiwyg.upload-success',
+              defaultMessage:
+                '{count, plural, one {Image uploaded and inserted successfully} other {# images uploaded and inserted successfully}}',
+            },
+            { count: files.length }
+          );
 
           toggleNotification({
             type: 'success',
@@ -143,10 +132,13 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
         console.error('Error uploading pasted image:', error);
         toggleNotification({
           type: 'danger',
-          message: formatMessage({
-            id: 'content-manager.components.Wysiwyg.upload-error',
-            defaultMessage: 'Error uploading image',
-          }),
+          message: formatMessage(
+            {
+              id: 'content-manager.components.Wysiwyg.upload-error',
+              defaultMessage: 'Error uploading {count, plural, one {image} other {images}}',
+            },
+            { count: files.length }
+          ),
         });
       } finally {
         setIsUploading(false);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/Field.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import {
   useField,
   useStrapiApp,
-  useFetchClient,
   useNotification,
   type InputProps,
 } from '@strapi/admin/strapi-admin';
 import { Field, Flex } from '@strapi/design-system';
+import { useUpload, type Asset } from '@strapi/upload/strapi-admin';
 import { EditorFromTextArea } from 'codemirror5';
 import { useIntl } from 'react-intl';
 
@@ -36,9 +36,8 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
     const [isPreviewMode, setIsPreviewMode] = React.useState(false);
     const [mediaLibVisible, setMediaLibVisible] = React.useState(false);
     const [isExpandMode, setIsExpandMode] = React.useState(false);
-    const [isUploading, setIsUploading] = React.useState(false);
     const components = useStrapiApp('ImageDialog', (state) => state.components);
-    const { post } = useFetchClient();
+    const { upload, isLoading: isUploading } = useUpload();
     const { toggleNotification } = useNotification();
     const { formatMessage } = useIntl();
 
@@ -65,69 +64,50 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
     const handlePasteImage = async (files: File[]) => {
       if (isUploading || files.length === 0) return;
 
-      setIsUploading(true);
-
       try {
-        // Create FormData for the upload
-        const formData = new FormData();
-
-        // Add all files
-        files.forEach((file) => {
-          formData.append('files', file);
-        });
-
-        // Add fileInfo for each file
-        files.forEach((file) => {
-          formData.append(
-            'fileInfo',
-            JSON.stringify({
-              name: file.name,
-              alternativeText: file.name.split('.')[0],
-            })
-          );
-        });
-
-        // Upload the files
-        const message = formatMessage(
-          {
-            id: 'content-manager.components.Wysiwyg.uploading',
-            defaultMessage: 'Uploading {count, plural, one {# image} other {# images}}...',
-          },
-          { count: files.length }
-        );
-
         toggleNotification({
           type: 'info',
-          message,
+          message: formatMessage(
+            {
+              id: 'content-manager.components.Wysiwyg.uploading',
+              defaultMessage: 'Uploading {count, plural, one {# image} other {# images}}...',
+            },
+            { count: files.length }
+          ),
         });
 
-        const response = await post<Array<Record<string, string>>>('/upload', formData);
+        // Prepare assets for upload using the upload plugin's expected format
+        const assets: Asset[] = files.map((file) => ({
+          name: file.name,
+          alternativeText: file.name.split('.')[0],
+          rawFile: file,
+        }));
 
-        if (response.data && response.data.length > 0) {
-          // Format all uploaded files for insertion
-          const formattedFiles = response.data.map((uploadedFile) => ({
-            alt: uploadedFile.alternativeText || uploadedFile.name,
-            url: prefixFileUrlWithBackendUrl(uploadedFile.url),
-            mime: uploadedFile.mime,
-          }));
+        // Use the upload hook to handle the upload
+        const uploadedFiles = await upload(assets, null);
 
-          // Insert all images into the editor
-          insertFile(editorRef, formattedFiles);
+        // Format uploaded files for insertion into the editor
+        const formattedFiles = uploadedFiles.map((uploadedFile: Asset) => ({
+          alt: uploadedFile.alternativeText || uploadedFile.name,
+          url: prefixFileUrlWithBackendUrl(uploadedFile.url!),
+          mime: uploadedFile.mime,
+        }));
 
-          const successMessage = formatMessage(
+        // Insert all images into the editor
+        insertFile(editorRef, formattedFiles);
+
+        // Show success notification
+        toggleNotification({
+          type: 'success',
+          message: formatMessage(
             {
               id: 'content-manager.components.Wysiwyg.upload-success',
               defaultMessage:
                 '{count, plural, one {Image uploaded and inserted successfully} other {# images uploaded and inserted successfully}}',
             },
             { count: files.length }
-          );
-
-          toggleNotification({
-            type: 'success',
-            message: successMessage,
-          });
-        }
+          ),
+        });
       } catch (error) {
         console.error('Error uploading pasted image:', error);
         toggleNotification({
@@ -140,8 +120,6 @@ const Wysiwyg = React.forwardRef<EditorApi, WysiwygProps>(
             { count: files.length }
           ),
         });
-      } finally {
-        setIsUploading(false);
       }
     };
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/codemirror.d.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/codemirror.d.ts
@@ -1,0 +1,11 @@
+import 'codemirror5';
+
+declare module 'codemirror5' {
+  interface CommandActions {
+    bold: () => void;
+    italic: () => void;
+    underline: () => void;
+    link: () => void;
+    newlineAndIndentContinueMarkdownList: (cm: Editor) => void;
+  }
+}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/tests/Field.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Wysiwyg/tests/Field.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@strapi/admin/strapi-admin';
-import { render as renderRTL } from '@tests/utils';
+import { render as renderRTL, waitFor } from '@tests/utils';
 
 import { Wysiwyg, WysiwygProps } from '../Field';
 
@@ -246,6 +246,44 @@ describe('Wysiwyg render and actions buttons', () => {
     await user.click(getByRole('button', { name: /Preview/ }));
 
     expect(getByRole('combobox', { name: 'Headings' })).toHaveAttribute('aria-disabled', 'true');
+  });
+});
+
+describe('Wysiwyg keyboard shortcuts', () => {
+  const originalWarn = console.warn;
+
+  beforeAll(() => {
+    console.warn = jest.fn();
+  });
+
+  afterAll(() => {
+    console.warn = originalWarn;
+  });
+
+  it('should register CodeMirror commands for keyboard shortcuts', async () => {
+    const { container } = render();
+
+    // Wait for the editor to be rendered
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      expect(container.querySelector('.CodeMirror')).toBeInTheDocument();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const CodeMirror = require('codemirror5');
+
+    // Verify that CodeMirror commands are registered
+    expect(CodeMirror.commands.bold).toBeDefined();
+    expect(typeof CodeMirror.commands.bold).toBe('function');
+
+    expect(CodeMirror.commands.italic).toBeDefined();
+    expect(typeof CodeMirror.commands.italic).toBe('function');
+
+    expect(CodeMirror.commands.underline).toBeDefined();
+    expect(typeof CodeMirror.commands.underline).toBe('function');
+
+    expect(CodeMirror.commands.link).toBeDefined();
+    expect(typeof CodeMirror.commands.link).toBe('function');
   });
 });
 

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -317,5 +317,10 @@
   "widget.last-edited.single-type": "Single-Type",
   "widget.last-edited.no-data": "No edited entries",
   "widget.last-published.title": "Last published entries",
-  "widget.last-published.no-data": "No published entries"
+  "widget.last-published.no-data": "No published entries",
+  "components.Wysiwyg.uploading": "Uploading image...",
+  "components.Wysiwyg.uploading-multiple": "Uploading {count} images...",
+  "components.Wysiwyg.upload-success": "Image uploaded and inserted successfully",
+  "components.Wysiwyg.upload-success-multiple": "{count} images uploaded and inserted successfully",
+  "components.Wysiwyg.upload-error": "Error uploading image"
 }

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -318,9 +318,7 @@
   "widget.last-edited.no-data": "No edited entries",
   "widget.last-published.title": "Last published entries",
   "widget.last-published.no-data": "No published entries",
-  "components.Wysiwyg.uploading": "Uploading image...",
-  "components.Wysiwyg.uploading-multiple": "Uploading {count} images...",
-  "components.Wysiwyg.upload-success": "Image uploaded and inserted successfully",
-  "components.Wysiwyg.upload-success-multiple": "{count} images uploaded and inserted successfully",
-  "components.Wysiwyg.upload-error": "Error uploading image"
+  "components.Wysiwyg.uploading": "Uploading {count, plural, one {# image} other {# images}}...",
+  "components.Wysiwyg.upload-success": "{count, plural, one {Image uploaded and inserted successfully} other {# images uploaded and inserted successfully}}",
+  "components.Wysiwyg.upload-error": "Error uploading {count, plural, one {image} other {images}}"
 }

--- a/packages/core/content-manager/admin/src/translations/es.json
+++ b/packages/core/content-manager/admin/src/translations/es.json
@@ -187,9 +187,7 @@
   "widget.chart-entries.title": "Entradas",
   "widget.chart-entries.count.label": "{count, plural, =0 {Entradas} one {Entrada} other {Entradas}}",
   "widget.chart-entries.tooltip": "{count} {label}",
-  "components.Wysiwyg.uploading": "Subiendo imagen...",
-  "components.Wysiwyg.uploading-multiple": "Subiendo {count} imágenes...",
-  "components.Wysiwyg.upload-success": "Imagen subida e insertada correctamente",
-  "components.Wysiwyg.upload-success-multiple": "{count} imágenes subidas e insertadas correctamente",
-  "components.Wysiwyg.upload-error": "Error al subir la imagen"
+  "components.Wysiwyg.uploading": "Subiendo {count, plural, one {# imagen} other {# imágenes}}...",
+  "components.Wysiwyg.upload-success": "{count, plural, one {Imagen subida e insertada correctamente} other {# imágenes subidas e insertadas correctamente}}",
+  "components.Wysiwyg.upload-error": "Error al subir {count, plural, one {la imagen} other {las imágenes}}"
 }

--- a/packages/core/content-manager/admin/src/translations/es.json
+++ b/packages/core/content-manager/admin/src/translations/es.json
@@ -186,5 +186,10 @@
   "popUpwarning.warning.has-draft-relations.button-confirm": "Si, publicar",
   "widget.chart-entries.title": "Entradas",
   "widget.chart-entries.count.label": "{count, plural, =0 {Entradas} one {Entrada} other {Entradas}}",
-  "widget.chart-entries.tooltip": "{count} {label}"
+  "widget.chart-entries.tooltip": "{count} {label}",
+  "components.Wysiwyg.uploading": "Subiendo imagen...",
+  "components.Wysiwyg.uploading-multiple": "Subiendo {count} imágenes...",
+  "components.Wysiwyg.upload-success": "Imagen subida e insertada correctamente",
+  "components.Wysiwyg.upload-success-multiple": "{count} imágenes subidas e insertadas correctamente",
+  "components.Wysiwyg.upload-error": "Error al subir la imagen"
 }

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -106,6 +106,7 @@
   "devDependencies": {
     "@strapi/admin": "5.30.0",
     "@strapi/database": "5.30.0",
+    "@strapi/upload": "5.30.0",
     "@testing-library/react": "15.0.7",
     "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191",

--- a/packages/core/upload/admin/src/exports.ts
+++ b/packages/core/upload/admin/src/exports.ts
@@ -1,0 +1,7 @@
+/**
+ * This file keeps track of the exports from the upload plugin admin side.
+ * This allows other plugins to import and use upload functionality.
+ */
+
+export { useUpload } from './hooks/useUpload';
+export type { Asset } from './hooks/useUpload';

--- a/packages/core/upload/admin/src/hooks/useUpload.ts
+++ b/packages/core/upload/admin/src/hooks/useUpload.ts
@@ -9,7 +9,7 @@ import { pluginId } from '../pluginId';
 
 const endpoint = `/${pluginId}`;
 
-interface Asset extends Omit<File, 'id' | 'hash'> {
+export interface Asset extends Omit<File, 'id' | 'hash'> {
   rawFile?: RawFile;
   id?: File['id'];
   hash?: File['hash'];

--- a/packages/core/upload/admin/src/index.ts
+++ b/packages/core/upload/admin/src/index.ts
@@ -84,3 +84,5 @@ const admin: Plugin.Config.AdminInput = {
 
 // eslint-disable-next-line import/no-default-export
 export default admin;
+
+export * from './exports';


### PR DESCRIPTION
# Markdown Editor Improvements

## What does it do?

This PR fix two issues in the Markdown editor:

### 1. Keyboard Shortcuts for Text Formatting

- **Cmd+B / Ctrl+B**: Bold
- **Cmd+I / Ctrl+I**: Italic
- **Cmd+U / Ctrl+U**: Underline
- **Cmd+K / Ctrl+K**: Link

The shortcuts work just like the toolbar buttons - wrapping selected text or inserting 
markdown with proper cursor positioning.

### 2. Automatic Upload of Pasted Images

- Detects when users paste images from clipboard (Cmd+V / Ctrl+V)
- Automatically uploads images to the server via `/upload` endpoint
- Inserts the uploaded images as markdown in the editor
- Supports single or multiple images at once
- Shows translated notifications with upload progress

## Why is it needed?

The Markdown editor previously lacked common keyboard shortcuts and required a manual 
workflow for adding images, creating friction in the content editing experience.

## How to test it?

### Testing Keyboard Shortcuts

1. Open any content type with a Markdown field
2. Type some text or select existing text
3. Press the shortcuts:
   - **Cmd+B** (Mac) or **Ctrl+B** (Windows/Linux) → Text should be wrapped with 
     `**bold**`
   - **Cmd+I** or **Ctrl+I** → Text should be wrapped with `_italic_`
   - **Cmd+U** or **Ctrl+U** → Text should be wrapped with `<u>underline</u>`
   - **Cmd+K** or **Ctrl+K** → Text should be wrapped with `[text](link)`

### Testing Image Paste

1. Take a screenshot or copy an image from any source
2. Click inside the Markdown editor
3. Paste with **Cmd+V** or **Ctrl+V**
4. Verify:
   - Notification appears: "Uploading image..."
   - Image uploads to the server
   - Success notification: "Image uploaded and inserted successfully"
   - Image markdown is inserted in the editor: `![alt](url)`
5. Test multiple images:
   - Copy multiple images (e.g., from Finder/Explorer)
   - Paste in editor
   - Verify notification: "Uploading X images..."
   - All images should be uploaded and inserted

## Related issue(s)/PR(s)

Fix [#24742](https://github.com/strapi/strapi/issues/24742)