### PR TITLE
fix: Media Library Filter Removal for Complex Filters

### DIFF
--- a/packages/core/upload/admin/src/components/FilterList/FilterList.tsx
+++ b/packages/core/upload/admin/src/components/FilterList/FilterList.tsx
@@ -54,10 +54,15 @@ export const FilterList = ({ appliedFilters, filtersSchema, onRemoveFilter }: Fi
       if (filterName !== undefined) {
         const filterType = Object.keys(filterName)[0];
         const filterValue = filterName[filterType];
+        // Handle string values
         if (typeof filterValue === 'string') {
           const decodedValue = decodeURIComponent(filterValue);
           return prevFilter[name]?.[filterType] !== decodedValue;
         }
+        // Handle complex filters (objects and arrays) by comparing JSON
+        // This handles cases like: { mime: { $not: { $contains: ['image', 'video'] } } }
+        const prevFilterValue = prevFilter[name]?.[filterType];
+        return JSON.stringify(filterValue) !== JSON.stringify(prevFilterValue);
       }
 
       return true;


### PR DESCRIPTION
# Fix: Media Library Filter Removal for Complex Filters

## What does it do?

Fixes a bug where complex filters (like type "file") could not be removed by clicking the X button on the filter tag in the Media Library.

The fix adds proper comparison logic for complex filter structures (objects and arrays) in addition to the existing string comparison.

**Affected filters:**

- Type = file (uses complex nested filter structure)
- Any future filters with non-string values

## Why is it needed?

### The Problem

When users applied the "type = file" filter in the Media Library, they couldn't remove it by clicking the X icon on the filter tag. The filter would remain stuck.

**Root cause:** The filter removal logic in `FilterList.tsx` only handled string values. When the filter value was an object or array, it would always return `true` (keep the filter) instead of comparing and removing it.

**Type = file filter structure:**

```json
{
  "mime": {
    "$not": {
      "$contains": ["image", "video"]
    }
  }
}
```

This complex structure wasn't being compared correctly, so it could never be removed.

## How to test it?

1. Navigate to Media Library
2. Click the "Filters" button
3. Select filter: **Type** = **file**
4. Click "Add filter"
5. **Click the X icon** on the filter tag
6. Filter should be removed and the media library should refresh

## Related issue(s)/PR(s)

Fix [#24737](https://github.com/strapi/strapi/issues/24737)