### PR TITLE
chore: update security policy for strapi version 4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,16 +6,16 @@ As of October 2025 (and until this document is updated), v5.x.x _GA_ or _STABLE_
 
 **Note**: The v4.x.x LTS version will only receive high/critical severity **SECURITY** fixes until April 2026. No further bug fixes releases will be made.
 
-| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes              |
-| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------------ |
-| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS                |
-| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life        |
-| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life        |
-| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life        |
-| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | Security Only      |
-| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life        |
-| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life        |
-| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life        |
+| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes         |
+| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------- |
+| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS           |
+| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life   |
+| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life   |
+| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life   |
+| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | Security Only |
+| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life   |
+| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life   |
+| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life   |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
### What does it do?

Updates the Security policy to specify that v4 is now security fix only

### Why is it needed?

Bug fix support on v4 has ended

### How to test it?

N/A

### Related issue(s)/PR(s)

N/A
