### PR TITLE
docs: added Community Help section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,10 @@ See for yourself what's under the hood by getting access to a [hosted Strapi pro
 ## License
 
 See the [LICENSE](./LICENSE) file for licensing information.
+## 💡 Community Help
+
+If you need help or want to share ideas, you can reach us at:
+- 🗣 [Strapi Forum](https://forum.strapi.io/)
+- 💬 [Strapi Discord](https://discord.strapi.io/)
+- 📘 [Official Documentation](https://docs.strapi.io/)
+


### PR DESCRIPTION
Added a 'Community Help' section in the README with links to the Strapi Forum, Discord, and Docs for better accessibility.
