### PR TITLE
fix: fixed subnav`s height when there are more elements than for 1000px

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -338,9 +338,7 @@ const SubSection = ({ label, children }: { label: string; children: React.ReactN
         style={{
           maxHeight: isOpen ? `${contentHeight}px` : 0,
           overflow: 'hidden',
-          transition: isOpen
-            ? 'max-height 1s ease-in-out'
-            : 'max-height 0.5s cubic-bezier(0, 1, 0, 1)',
+          transition: 'max-height 0.5s cubic-bezier(0, 1, 0, 1)',
         }}
       >
         {children.map((child, index) => {

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -998,7 +998,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                         <ul
                           class="c40"
                           id=":r9:"
-                          style="max-height: 1000px; overflow: hidden; transition: max-height 1s ease-in-out;"
+                          style="max-height: 0px; overflow: hidden; transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);"
                         >
                           <li
                             class="c52"
@@ -1072,7 +1072,7 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
                         <ul
                           class="c40"
                           id=":ra:"
-                          style="max-height: 1000px; overflow: hidden; transition: max-height 1s ease-in-out;"
+                          style="max-height: 0px; overflow: hidden; transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);"
                         >
                           <li
                             class="c52"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes hardcoded "magic number" that setting height of SubNav`s lists and makes it calculated by children height when UI is changing.

### Why is it needed?

When there are a lot of components created in single category in Content Type Builder, they appears hidden because height of block contains them is hardcoded to certain "magic number" and 'overflow' CSS property is set to 'hidden'. Overflows behavior is OK to be consistent in UI, but magic number is limiting space for big count of components to be seen.

### How to test it?

You can add many components (for example against "magic number" you should have >30 components) in Content Type Builder and see that height of list dynamically changes to fit all the items.

### Related issue(s)/PR(s)

Resolves:
https://github.com/strapi/strapi/issues/24674
https://github.com/strapi/strapi/issues/23918

Offers more flexible solution that provided in this PR: https://github.com/strapi/strapi/pull/24679