### PR TITLE
fix: single type publish permission error

### DIFF
--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -209,17 +209,17 @@ export default {
       let document = await findDocument(sanitizedQuery, model, { locale, status: 'draft' });
 
       // If document exists and user can update it, update it before publishing
-      if (document && permissionChecker.can.update(document)) {
+      const shouldUpdate = document && permissionChecker.can.update(document);
+      // If document doesn't exist and user can create it, create it before publishing
+      const shouldCreate = !document && permissionChecker.can.create();
+      if (shouldUpdate || shouldCreate) {
         document = await createOrUpdateDocument(ctx, { populate });
       } else if (!document) {
-        // Document doesn't exist, try to create it
-        if (permissionChecker.cannot.create()) {
-          throw new errors.ForbiddenError();
-        }
-        document = await createOrUpdateDocument(ctx, { populate });
+        // Document doesn't exist and user can't create it
+        throw new errors.ForbiddenError();
       }
-      // Else: document exists but user can't update it, just publish the existing draft
 
+      // If document doesn't exist, throw an error
       if (!document) {
         throw new errors.NotFoundError();
       }

--- a/packages/core/content-manager/server/src/preview/services/preview.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview.ts
@@ -22,7 +22,8 @@ const createPreviewService = ({ strapi }: { strapi: Core.Strapi }) => {
 
       try {
         // Try to get the preview URL from the user-defined handler
-        return await handler(uid, params);
+        const url = await handler(uid, params);
+        return url;
       } catch (error) {
         // Log the error and throw a generic error
         strapi.log.error(`Failed to get preview URL: ${error}`);


### PR DESCRIPTION
## What does it do?

Fixes the permission check in the single-type `publish` controller to allow users with only `publish` permission (without `update` or `create`) to publish existing drafts.

The controller now follows the same logic as `collection-types`:
- If the user has `update` permission on the document → updates then publishes
- If the user only has `publish` permission → publishes the existing draft without updating it
- If the document doesn't exist and user has `create` permission → creates then publishes

## Why is it needed?

Previously, users with `read` + `publish` permissions (but without `update` or `create`) would get a 403 Forbidden error when trying to publish a single type. This was caused by the `publish` method always calling `createOrUpdateDocument`, which requires either `update` or `create` permissions.

This bug prevented implementing proper editorial workflows where some users can only approve and publish content created by others, without being able to modify it.

## How to test it?

1. Create a role with only `read` and `publish` permissions for a single type (without `update` or `create`)
2. Create a user with that role
3. As an admin, create a draft for the single type
4. Log in as the restricted user
5. Navigate to the single type
6. Click the "Publish" button
7. Verify the document is published successfully without a 403 error

## Related issue(s)/PR(s)
Fix [#23603](https://github.com/strapi/strapi/issues/23603)