### PR TITLE
chore: replace singleselect by combobox for better ux

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
+++ b/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
@@ -15,13 +15,13 @@ import {
   Box,
   Button,
   ButtonProps,
+  Combobox,
+  ComboboxOption,
   Divider,
   Field,
   Flex,
   Grid,
   Modal,
-  SingleSelect,
-  SingleSelectOption,
   Tabs,
   Typography,
   useId,
@@ -399,19 +399,13 @@ const EnumerationInput = ({
   return (
     <Field.Root error={error} hint={hint} name={name} required={required}>
       <Field.Label>{label}</Field.Label>
-      <SingleSelect
-        disabled={disabled}
-        // @ts-expect-error – This will dissapear when the DS removes support for numbers to be returned by SingleSelect.
-        onChange={handleChange}
-        placeholder={placeholder}
-        value={value}
-      >
+      <Combobox disabled={disabled} onChange={handleChange} placeholder={placeholder} value={value}>
         {options.map((option) => (
-          <SingleSelectOption value={option.value} key={option.value}>
+          <ComboboxOption value={option.value} key={option.value}>
             {option.label}
-          </SingleSelectOption>
+          </ComboboxOption>
         ))}
-      </SingleSelect>
+      </Combobox>
       <Field.Error />
       <Field.Hint />
     </Field.Root>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Replace SingleSelect for Combobox to select a locale more easily since the list is very long. 

_**BEFORE**_
https://github.com/user-attachments/assets/e551f6bc-824e-4fe4-81c6-185486fe3cb0
<img width="888" height="469" alt="Capture d’écran 2025-11-03 à 11 13 44" src="https://github.com/user-attachments/assets/6bef8c9f-eed4-4561-963a-26240649a51a" />

_**AFTER**_
https://github.com/user-attachments/assets/39eedf28-78e0-4c60-b9fb-2a6eed4a9e3f
<img width="932" height="480" alt="Capture d’écran 2025-11-03 à 11 14 05" src="https://github.com/user-attachments/assets/def4ca4f-54e5-4ec6-951f-7c4273acddf3" />

### Why is it needed?
Allows user to type the locale and find it more easily.

### How to test it?
* Go the Internationalization Settings page
* Click on "Add new locale"
* Type in the locale you want.
* Select the locale.
* Click Save and see the locale added.


