### PR TITLE
fix: accessible responsive left menu

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Divider, Flex, FlexComponent, useCollator } from '@strapi/design-system';
+import { Box, Divider, Flex, FlexComponent, IconButton, useCollator } from '@strapi/design-system';
 import { Cross, List } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
@@ -185,21 +185,23 @@ const LeftMenu = ({
             large: 'none',
           }}
         >
-          <Flex
-            height="3.2rem"
-            width="3.2rem"
-            justifyContent="center"
-            alignItems="center"
-            onClick={() => setIsBurgerMenuShown(!isBurgerMenuShown)}
+          <IconButton
+            onClick={() => setIsBurgerMenuShown((prev) => !prev)}
+            style={{ border: 'none' }}
+            label="Menu"
+            type="button"
+            aria-expanded={isBurgerMenuShown}
+            aria-controls="burger-menu"
           >
-            {!isBurgerMenuShown ? <List /> : <Cross />}
-          </Flex>
+            {!isBurgerMenuShown ? <List fill="neutral1000" /> : <Cross fill="neutral1000" />}
+          </IconButton>
         </Box>
       </MainNav>
       <NavBurgerMenu
         isShown={isBurgerMenuShown}
         listLinks={burgerMobileNavigationLinks}
         handleClickOnLink={handleClickOnLink}
+        onClose={() => setIsBurgerMenuShown(false)}
       />
     </>
   );

--- a/packages/core/admin/admin/src/components/MainNav/MainNavLinks.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/MainNavLinks.tsx
@@ -106,13 +106,9 @@ const MainNavIcons = ({
         return isDesktop || (!isDesktop && linkMobile) ? (
           <Flex tag="li" key={link.to}>
             <GuidedTourTooltip to={link.to}>
-              {isDesktop ? (
-                <NavLink.Tooltip label={labelValue}>
-                  <LinkElement />
-                </NavLink.Tooltip>
-              ) : (
+              <NavLink.Tooltip position={isDesktop ? 'right' : 'bottom'} label={labelValue}>
                 <LinkElement />
-              )}
+              </NavLink.Tooltip>
             </GuidedTourTooltip>
           </Flex>
         ) : null;

--- a/packages/core/admin/admin/src/components/MainNav/NavBurgerMenu.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavBurgerMenu.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
-import { Box, ScrollArea } from '@strapi/design-system';
+import { Box, FocusTrap, Portal, ScrollArea } from '@strapi/design-system';
+import { motion, AnimatePresence } from 'motion/react';
 import { styled } from 'styled-components';
 
 import { HEIGHT_TOP_NAVIGATION } from '../../constants/theme';
@@ -14,53 +13,71 @@ interface NavBurgerMenuProps {
   listLinks: MenuItem[];
   handleClickOnLink: (value: string) => void;
   mobile?: boolean;
+  onClose: () => void;
 }
 
-const NavBurgerMenuWrapper = styled(Box)<{ $isShown: boolean }>`
+const MotionLayer = styled(motion.div)`
   position: fixed;
   top: calc(${HEIGHT_TOP_NAVIGATION} + 1px);
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 3;
-  background-color: ${({ theme }) => theme.colors.neutral0};
-  transform: ${({ $isShown }) => ($isShown ? 'translateY(0)' : 'translateY(-100%)')};
-  transition: transform 0.2s ease-in-out;
 
   ${({ theme }) => theme.breakpoints.large} {
     display: none;
   }
 `;
 
-const NavBurgerMenu = ({ isShown, handleClickOnLink, listLinks }: NavBurgerMenuProps) => (
-  <NavBurgerMenuWrapper $isShown={isShown}>
-    <ScrollArea>
-      <Box
-        tag="ul"
-        paddingLeft={{
-          initial: 4,
-          medium: 6,
-        }}
-        paddingRight={{
-          initial: 4,
-          medium: 6,
-        }}
-        paddingTop={{
-          initial: 1,
-          medium: 3,
-        }}
-        paddingBottom={{
-          initial: 4,
-          medium: 6,
-        }}
-      >
-        <MainNavBurgerMenuLinks listLinks={listLinks} handleClickOnLink={handleClickOnLink} />
-        <Box paddingTop={4} tag="li">
-          <NavUser showDisplayName />
-        </Box>
-      </Box>
-    </ScrollArea>
-  </NavBurgerMenuWrapper>
-);
+const Surface = styled(Box)`
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.neutral0};
+`;
 
-export { NavBurgerMenu };
+export const NavBurgerMenu = ({
+  isShown,
+  handleClickOnLink,
+  onClose,
+  listLinks,
+}: NavBurgerMenuProps) => {
+  return (
+    <Portal>
+      <AnimatePresence>
+        {isShown && (
+          <FocusTrap onEscape={onClose}>
+            <MotionLayer
+              key="burger"
+              role="dialog"
+              aria-modal="true"
+              initial={{ y: '-100%' }}
+              animate={{ y: 0 }}
+              exit={{ y: '-100%' }}
+              transition={{ duration: 0.2, ease: 'easeInOut' }}
+              id="burger-menu"
+            >
+              <Surface>
+                <ScrollArea>
+                  <Box
+                    tag="ul"
+                    paddingLeft={{ initial: 4, medium: 6 }}
+                    paddingRight={{ initial: 4, medium: 6 }}
+                    paddingTop={{ initial: 1, medium: 3 }}
+                    paddingBottom={{ initial: 4, medium: 6 }}
+                  >
+                    <MainNavBurgerMenuLinks
+                      listLinks={listLinks}
+                      handleClickOnLink={handleClickOnLink}
+                    />
+                    <Box paddingTop={4} tag="li">
+                      <NavUser showDisplayName />
+                    </Box>
+                  </Box>
+                </ScrollArea>
+              </Surface>
+            </MotionLayer>
+          </FocusTrap>
+        )}
+      </AnimatePresence>
+    </Portal>
+  );
+};

--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -32,6 +32,7 @@ const MainSubNav = styled(DSSubNav)`
   z-index: 2;
 
   ${({ theme }) => theme.breakpoints.medium} {
+    width: 23.2rem;
     position: sticky;
     top: 0;
     border-right: 1px solid ${({ theme }) => theme.colors.neutral150};

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -118,6 +118,7 @@
     "koa-static": "5.0.0",
     "koa2-ratelimit": "^1.1.3",
     "lodash": "4.17.21",
+    "motion": "12.23.24",
     "ora": "5.4.1",
     "p-map": "4.0.0",
     "passport-local": "1.0.0",

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -543,6 +543,7 @@ border:1px solid #eaeaef .c22:focus-within .c27 {
 
 @media (min-width: 768px) {
   .c3 {
+    width: 23.2rem;
     position: sticky;
     top: 0;
     border-right: 1px solid #eaeaef;

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -95,6 +95,7 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
               'slate',
               'slate-history',
               'slate-react',
+              'motion',
             ]
           : []),
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9149,6 +9149,7 @@ __metadata:
     koa-static: "npm:5.0.0"
     koa2-ratelimit: "npm:^1.1.3"
     lodash: "npm:4.17.21"
+    motion: "npm:12.23.24"
     msw: "npm:1.3.0"
     ora: "npm:5.4.1"
     p-map: "npm:4.0.0"
@@ -19497,6 +19498,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^12.23.24":
+  version: 12.23.24
+  resolution: "framer-motion@npm:12.23.24"
+  dependencies:
+    motion-dom: "npm:^12.23.23"
+    motion-utils: "npm:^12.23.6"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/716addd9fa85dd2c1475ab848e14c4e6d3246ced041de84afc19b1d6534c897256c8f2878864cf057039116e56f5ca1b87a4cbb943f0b1cf37199ef7174c3cf8
+  languageName: node
+  linkType: hard
+
 "fresh@npm:0.5.2, fresh@npm:~0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
@@ -25472,6 +25495,43 @@ __metadata:
   version: 1.0.1
   resolution: "modify-values@npm:1.0.1"
   checksum: 10c0/6acb1b82aaf7a02f9f7b554b20cbfc159f223a79c66b0a257511c5933d50b85e12ea1220b0a90a2af6f80bc29ff784f929a52a51881867a93ae6a12ce87a729a
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^12.23.23":
+  version: 12.23.23
+  resolution: "motion-dom@npm:12.23.23"
+  dependencies:
+    motion-utils: "npm:^12.23.6"
+  checksum: 10c0/139705731085063519b88f23fcc5b1c13e15707a4ff3365da02ef9a4bf2a2d8ebed9a151c57e7f215ccd9e822365d93c16e28e619fbf25611f61dcff5ee81d75
+  languageName: node
+  linkType: hard
+
+"motion-utils@npm:^12.23.6":
+  version: 12.23.6
+  resolution: "motion-utils@npm:12.23.6"
+  checksum: 10c0/c058e8ba6423b3baa63e985bcc669877ee7d9579d938f5348b4e60c5ea1b4b33dd7f4877434436a4a5807f3cf00370d3fd4079a6fdd6309c5c87aa62b311a897
+  languageName: node
+  linkType: hard
+
+"motion@npm:12.23.24":
+  version: 12.23.24
+  resolution: "motion@npm:12.23.24"
+  dependencies:
+    framer-motion: "npm:^12.23.24"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/d937ddaf50816f97e4e7121f323104fd655045ef122bd03d433370649c00129a5dd928cbe54efe9add22a05b2a9b84b7cfda1fd5c5b1e9c6245cd94e1c24e823
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR fixes the keyboard and focus issues when trying to open the burger menu drawer when you work on small screen.

### Why is it needed?

Needed for keyboard navigation and a11y.

### How to test it?

- Open the admin in a small screen to render the burger menu button
- Navigate with the keyboard by pressing Tab
- You should now be able to focus the burger menu button
- Open it with "Space" or "Enter"
- On open, the first link of the menu should be focused
- The focus is now trapped in the menu.
- To quit the focus trap, you can close the menu with "Escape" or "Enter" on a link.
- The focus should be restored to the burger menu button when you press "Escape".

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
