### PR TITLE
fix: warn user when CM edit view is unsaved on page reload/close

### DIFF
--- a/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/Provider.tsx
+++ b/packages/core/admin/admin/src/content-manager/components/EditViewDataManagerProvider/Provider.tsx
@@ -23,6 +23,7 @@ import { Prompt, Redirect } from 'react-router-dom';
 import { ValidationError } from 'yup';
 
 import { useTypedDispatch, useTypedSelector } from '../../../core/store/hooks';
+import { useWarnIfUnsavedChanges } from '../../../hooks/useWarnIfUnsavedChanges';
 import { usePrev } from '../../hooks/usePrev';
 import { clearSetModifiedDataOnly } from '../../sharedReducers/crud/actions';
 import { getTranslation } from '../../utils/translations';
@@ -113,6 +114,8 @@ const EditViewDataManagerProvider = ({
   const { lockApp, unlockApp } = useOverlayBlocker();
 
   const currentContentTypeLayout = allLayoutData.contentType;
+
+  useWarnIfUnsavedChanges(!isEqual(modifiedData, initialData) && !isSaving);
 
   const hasDraftAndPublish = React.useMemo(() => {
     return get(currentContentTypeLayout, ['options', 'draftAndPublish'], false);

--- a/packages/core/admin/admin/src/hooks/tests/useWarnIfUnsavedChanges.test.ts
+++ b/packages/core/admin/admin/src/hooks/tests/useWarnIfUnsavedChanges.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+
+import { useWarnIfUnsavedChanges } from '../useWarnIfUnsavedChanges';
+
+const dispatchBeforeUnload = () => {
+  const event = new Event('beforeunload', { cancelable: true }) as any;
+  Object.defineProperty(event, 'returnValue', {
+    value: undefined,
+    writable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+};
+
+describe('useWarnIfUnsavedChanges', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does nothing when disabled', () => {
+    renderHook(() => useWarnIfUnsavedChanges(false));
+
+    const event = dispatchBeforeUnload();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.returnValue).toBeUndefined();
+  });
+
+  test('prevents unload and sets returnValue when enabled', () => {
+    renderHook(() => useWarnIfUnsavedChanges(true));
+
+    const event = dispatchBeforeUnload();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.returnValue).toBe('');
+  });
+
+  test('adds and removes listener correctly when toggling enabled', () => {
+    const { rerender } = renderHook(({ enabled }) => useWarnIfUnsavedChanges(enabled), {
+      initialProps: { enabled: true },
+    });
+
+    let event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(true);
+
+    rerender({ enabled: false });
+    event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(false);
+
+    rerender({ enabled: true });
+    event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('cleans up listener on unmount', () => {
+    const { unmount } = renderHook(() => useWarnIfUnsavedChanges(true));
+
+    unmount();
+
+    const event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('registers and unregisters event listeners', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useWarnIfUnsavedChanges(true));
+
+    expect(addSpy.mock.calls.filter(([type]) => type === 'beforeunload')).toHaveLength(1);
+
+    unmount();
+
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'beforeunload')).toHaveLength(1);
+  });
+});

--- a/packages/core/admin/admin/src/hooks/useWarnIfUnsavedChanges.ts
+++ b/packages/core/admin/admin/src/hooks/useWarnIfUnsavedChanges.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export function useWarnIfUnsavedChanges(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [enabled]);
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

The existing `<Prompt />` we are using in the EditView provided by react-router-dom, only intercepts in-app (client side) route transitions. This component will not intercepts browser actions (reload, tab close, etc). We need to use a custom listener `beforeunload` to handle these use cases.

### Why is it needed?

Prevent data loss when the user reloads the page by mistake

### How to test it?

- Open the admin (v4)
- Start to edit a content type
- Try to close the tab or refresh the page
- A confirm dialog should be triggered to confirm the action.

### Related issue(s)/PR(s)

