### PR TITLE
fix: warn user on page reload/close if edit view has unsaved data

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -15,6 +15,7 @@ import isEqual from 'lodash/isEqual';
 import { useIntl, type MessageDescriptor, type PrimitiveType } from 'react-intl';
 import { useBlocker } from 'react-router-dom';
 
+import { useWarnIfUnsavedChanges } from '../hooks/useWarnIfUnsavedChanges';
 import { getIn, setIn } from '../utils/objects';
 
 import { createContext } from './Context';
@@ -774,6 +775,12 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
   const { formatMessage } = useIntl();
   const modified = useForm('Blocker', (state) => state.modified);
   const isSubmitting = useForm('Blocker', (state) => state.isSubmitting);
+
+  // this is trigering a native browser prompt on page unload
+  // We aren't able to use our Dialog component in that scenario
+  // so we fallback to the native browser one when the user is trying to close/refresh the tab/browser
+  // This hook will be triggered on dev mode because of the live reloads but it's fine as it's only for that scenario
+  useWarnIfUnsavedChanges(modified && !isSubmitting);
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     return (

--- a/packages/core/admin/admin/src/hooks/tests/useWarnIfUnsavedChanges.test.ts
+++ b/packages/core/admin/admin/src/hooks/tests/useWarnIfUnsavedChanges.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+
+import { useWarnIfUnsavedChanges } from '../useWarnIfUnsavedChanges';
+
+const dispatchBeforeUnload = () => {
+  const event = new Event('beforeunload', { cancelable: true }) as any;
+  Object.defineProperty(event, 'returnValue', {
+    value: undefined,
+    writable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+};
+
+describe('useWarnIfUnsavedChanges', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does nothing when disabled', () => {
+    renderHook(() => useWarnIfUnsavedChanges(false));
+
+    const event = dispatchBeforeUnload();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.returnValue).toBeUndefined();
+  });
+
+  test('prevents unload and sets returnValue when enabled', () => {
+    renderHook(() => useWarnIfUnsavedChanges(true));
+
+    const event = dispatchBeforeUnload();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.returnValue).toBe('');
+  });
+
+  test('adds and removes listener correctly when toggling enabled', () => {
+    const { rerender } = renderHook(({ enabled }) => useWarnIfUnsavedChanges(enabled), {
+      initialProps: { enabled: true },
+    });
+
+    let event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(true);
+
+    rerender({ enabled: false });
+    event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(false);
+
+    rerender({ enabled: true });
+    event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('cleans up listener on unmount', () => {
+    const { unmount } = renderHook(() => useWarnIfUnsavedChanges(true));
+
+    unmount();
+
+    const event = dispatchBeforeUnload();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('registers and unregisters event listeners', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useWarnIfUnsavedChanges(true));
+
+    expect(addSpy.mock.calls.filter(([type]) => type === 'beforeunload')).toHaveLength(1);
+
+    unmount();
+
+    expect(removeSpy.mock.calls.filter(([type]) => type === 'beforeunload')).toHaveLength(1);
+  });
+});

--- a/packages/core/admin/admin/src/hooks/useWarnIfUnsavedChanges.ts
+++ b/packages/core/admin/admin/src/hooks/useWarnIfUnsavedChanges.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export function useWarnIfUnsavedChanges(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [enabled]);
+}

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
@@ -5,6 +5,12 @@ import { rest } from 'msw';
 import { mockData } from '../../../tests/mockData';
 import { useDocumentActions } from '../useDocumentActions';
 
+jest.mock('@strapi/admin/strapi-admin/ee', () => ({
+  ...jest.requireActual('@strapi/admin/strapi-admin/ee'),
+  useGetAIFeatureConfigQuery: () => ({ data: undefined }),
+  useAIAvailability: () => false,
+}));
+
 describe('useDocumentActions', () => {
   it('should return an object with the correct methods', () => {
     const { result } = renderHook(() => useDocumentActions());


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Warn the user when CM edit view has unsaved data (on reload, page close)

### Why is it needed?

We are currently warning the user when CM edit view has unsaved data but only on client side navigation update, all the browser actions aren't handled (tab close, browser close, page reload). 

### How to test it?

- Create or edit a content in the Content manager
- Before saving, try to close the tab (a native alert should be visible to confirm the action and warn the user about the unsaved data)
- ⚠️ The alert is different from the other alert (when you have unsaved data and click on a link in the page) and that's normal (`beforeunload` this native browser event we are using to catch these browser actions is displaying a native confirm alert and we don't have the control of it's content)
- Same for page reload from the browser url
- Same for browser close action

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request

Closes #[17731](https://github.com/strapi/strapi/issues/17731)

