### PR TITLE
fix: get draft relations count from document with locale

### DIFF
--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -318,7 +318,7 @@ export default {
       return ctx.forbidden();
     }
 
-    const document = await findDocument({}, model);
+    const document = await findDocument({}, model, { locale });
     if (!document) {
       return ctx.notFound();
     }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Get `countDraftRelations` from current locale, not just for the document.

### Why is it needed?
If a single type had entries in locale(s) other than the default locale, there was an alert to display the error in fetching the `countDraftRelations` for that document. The goal here is to remove that alert by fetching the relations from the locale, not just the document, so that the correct count is returned for that locale's entry.

⚠️ _Seems like the `countDraftRelations` returns all relations (published are counted as draft relations too) instead of just draft relations for now: https://www.notion.so/strapi/Count-draft-relations-56901b492efb45ab90d42fe975b32bd8 but I'm not touching this here_

**BEFORE**
https://github.com/user-attachments/assets/2587e26f-65c6-4650-8201-a6f63771bafb

**AFTER**
https://github.com/user-attachments/assets/6e438739-c9dd-47ab-a732-6dcbe46cddd4

### How to test it?
* Go to the Settings for the Internationalization and add an additional locale 
* Go to the CTB and create a Single type with at least one field + localization enabled
* Go to the CM and create an entry in an additional locale
* Navigate between the "Create an entry" (in the default locale) and your existing entry, without creating an entry in the default locale => There should be no Alert.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/23450
