### PR TITLE
fix(core): max length on short text

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/types.ts
@@ -8,6 +8,7 @@ import { toRegressedEnumValue } from '../../../utils/toRegressedEnumValue';
 
 import {
   alreadyUsedAttributeNames,
+  createStringShape,
   createTextShape,
   isMinSuperiorThanMax,
   isNameAllowed,
@@ -351,7 +352,7 @@ export const attributeTypes = {
     return yup.object(shape);
   },
   string(usedAttributeNames: Array<string>, reservedNames: Array<string>) {
-    const shape = createTextShape(usedAttributeNames, reservedNames);
+    const shape = createStringShape(usedAttributeNames, reservedNames);
 
     return yup.object(shape);
   },

--- a/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/attributes/validation/common.ts
@@ -77,6 +77,13 @@ const validators = {
       })
       .nullable(),
   maxLength: () => yup.number().integer().positive(getTrad('error.validation.positive')).nullable(),
+  maxLengthString: () =>
+    yup
+      .number()
+      .integer()
+      .positive(getTrad('error.validation.positive'))
+      .max(255, 'Maximum length for short text fields is 255 characters')
+      .nullable(),
   minLength: () =>
     yup
       .number()
@@ -131,6 +138,34 @@ const createTextShape = (usedAttributeNames: Array<string>, reservedNames: Array
   return shape;
 };
 
+const createStringShape = (usedAttributeNames: Array<string>, reservedNames: Array<string>) => {
+  const shape = {
+    name: validators.name(usedAttributeNames, reservedNames),
+    type: validators.type(),
+    default: validators.default(),
+    unique: validators.unique(),
+    required: validators.required(),
+    maxLength: validators.maxLengthString(),
+    minLength: validators.minLength(),
+    regex: yup
+      .string()
+      .test({
+        name: 'isValidRegExpPattern',
+        message: getTrad('error.validation.regex'),
+        test(value) {
+          try {
+            return new RegExp(value || '') !== null;
+          } catch (e) {
+            return false;
+          }
+        },
+      })
+      .nullable(),
+  };
+
+  return shape;
+};
+
 type GenericIsMinSuperiorThanMax<T extends (string | null) | number> = yup.TestConfig<
   T | undefined,
   Record<string, unknown>
@@ -162,6 +197,7 @@ const isMinSuperiorThanMax = <
 
 export {
   alreadyUsedAttributeNames,
+  createStringShape,
   createTextShape,
   getUsedContentTypeAttributeNames,
   isMinSuperiorThanMax,

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/types.test.ts
@@ -39,6 +39,56 @@ describe('Type validators', () => {
     expect(validator.isValidSync(attributes.title)).toBe(true);
   });
 
+  describe('String field maxLength validation', () => {
+    test('maxLength cannot be over 255', () => {
+      const attributes = {
+        title: {
+          type: 'string',
+          maxLength: 256,
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.title, {
+        types: ['string'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.title)).toBe(false);
+    });
+
+    test('maxLength of 255 is allowed', () => {
+      const attributes = {
+        title: {
+          type: 'string',
+          maxLength: 255,
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.title, {
+        types: ['string'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.title)).toBe(true);
+    });
+
+    test('maxLength less than 255 is allowed', () => {
+      const attributes = {
+        title: {
+          type: 'string',
+          maxLength: 100,
+        },
+      } satisfies Struct.SchemaAttributes;
+
+      const validator = getTypeValidator(attributes.title, {
+        types: ['string'],
+        attributes,
+      });
+
+      expect(validator.isValidSync(attributes.title)).toBe(true);
+    });
+  });
+
   describe('Dynamiczone type validator', () => {
     test('Components cannot be empty', () => {
       const attributes = {

--- a/packages/core/content-type-builder/server/src/controllers/validation/types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/types.ts
@@ -113,7 +113,16 @@ const getTypeShape = (attribute: Schema.Attribute.AnyAttribute, { attributes }: 
     /**
      * scalar types
      */
-    case 'string':
+    case 'string': {
+      return {
+        default: yup.string(),
+        required: validators.required,
+        unique: validators.unique,
+        minLength: validators.minLength,
+        maxLength: validators.maxLength.max(255).test(maxLengthIsGreaterThanOrEqualToMinLength),
+        regex: yup.string().test(isValidRegExpPattern),
+      };
+    }
     case 'text': {
       return {
         default: yup.string(),


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Limits the Maximum length for Short text fields to 255 and shows a validation error if a higher value is entered.

### Why is it needed?

Short text maps to `VARCHAR(255)` in the database. Allowing larger values is misleading and can cause inconsistencies.

### How to test it?

1. Go to Content Type Builder
2. Create (or edit) a text field
3. Choose Short text as the type
4. Enter a value greater than 255 in the Maximum length field
5. A validation error message should be displayed

<img width="1666" height="1342" alt="image" src="https://github.com/user-attachments/assets/6165381a-eef4-4f97-acce-ed5700bb15b5" />


### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/24642
