### PR TITLE
fix: optional chaining in getRetentionDays function

### DIFF
--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -46,7 +46,7 @@ const getEventMap = (defaultEvents: any) => {
 const getRetentionDays = (strapi: Core.Strapi) => {
   const featureConfig = strapi.ee.features.get('audit-logs');
   const licenseRetentionDays =
-    typeof featureConfig === 'object' && featureConfig?.options.retentionDays;
+    typeof featureConfig === 'object' && featureConfig?.options?.retentionDays;
   const userRetentionDays = strapi.config.get('admin.auditLogs.retentionDays');
 
   // For enterprise plans, use 90 days by default, but allow users to override it


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds an optional chain operator to the retention days check for audit logs to avoid errors when it's not there.

### Why is it needed?

<img width="2374" height="616" alt="image" src="https://github.com/user-attachments/assets/615647d4-526d-4401-8979-9f3d66d5038a" />


### How to test it?

N/A

### Related issue(s)/PR(s)

TID 4495