### PR TITLE
fix: run orphan removal for the 'related_type' column

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -457,6 +457,7 @@ class Strapi extends Container implements Core.Strapi {
     // // if schemas have changed, run repairs
     if (status === 'CHANGED') {
       await this.db.repair.removeOrphanMorphType({ pivot: 'component_type' });
+      await this.db.repair.removeOrphanMorphType({ pivot: 'related_type' });
     }
 
     // const alreadyRanComponentRepair = await this.store.get({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It cleans up orphans in the `files_related_mph` database table after deleting a content type.

### Why is it needed?

To solve an issue similar to this one https://github.com/strapi/strapi/issues/22641, where orphaned morph types remain in the database after deleting parts of the schema:

### How to test it?

1. Create 2 content types which both have a media field
2. Create 1 media item
3. Create an entry for each content-type with a reference to the same media item
4. Remove 1 of the content types
5. Try to call the API on the other content type whilst populating it's media field
6. Witness the error

### Related issue(s)/PR(s)

A similar issue was resolved for components in PR https://github.com/strapi/strapi/pull/22267. I expect this issue was just more vocal for components because of the way dynamic zones work. That being said I was able to use the same repair script used to fix that issue, so good job on that one @innerdvations!
