### PR TITLE
fix(admin): ai admin config can be set to true for non growth license

### DIFF
--- a/packages/core/admin/ee/server/src/controllers/admin.ts
+++ b/packages/core/admin/ee/server/src/controllers/admin.ts
@@ -10,7 +10,9 @@ export default {
   // NOTE: Overrides CE admin controller
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
-    const ai = strapi.config.get('admin.ai', {});
+    const isAIConfigured = strapi.config.get('admin.ai', { enabled: false });
+    const isAILicense = strapi.ee.features.isEnabled('cms-ai');
+
     try {
       return {
         data: {
@@ -19,11 +21,13 @@ export default {
           features: strapi.ee.features.list(),
           flags,
           type: strapi.ee.type,
-          ai,
+          ai: {
+            enabled: isAILicense && isAIConfigured.enabled,
+          },
         },
       };
     } catch (err) {
-      return { data: { isEE: false, features: [], flags } };
+      return { data: { isEE: false, features: [], flags, ai: { enabled: false } } };
     }
   },
 

--- a/packages/core/admin/server/src/controllers/admin.ts
+++ b/packages/core/admin/server/src/controllers/admin.ts
@@ -38,8 +38,7 @@ export default {
   // This returns an empty feature list for CE
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
-    const ai = strapi.config.get('admin.ai', {});
-    return { data: { isEE: false, features: [], flags, ai } };
+    return { data: { isEE: false, features: [], flags, ai: { enabled: false } } };
   },
 
   async init() {


### PR DESCRIPTION
### What does it do?

- Always return ai license enabled as false for community edition
- Determine if EE license is Growth by first checking the license for the `cms-ai` feature _then_ checking if the user has it configured. (Should always be false for a non-growth EE license)

### Why is it needed?

Currently an EE license with config in `admin.js`:

```
ai: {
 enabled: true,
}
```
But this is not correct, it should only return true if the license actually has AI

### How to test it?

Run the app with an EE license, a growth license, and in CE
Check the guided tour works in EE with and without AI
General QA of all licenses with and without AI

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
