### PR TITLE
Replace act() calls with the right testing library api when it is necessary

### DIFF
--- a/packages/core/admin/admin/src/features/tests/Widgets.test.tsx
+++ b/packages/core/admin/admin/src/features/tests/Widgets.test.tsx
@@ -1,5 +1,5 @@
 import { server } from '@tests/server';
-import { act, renderHook, waitFor } from '@tests/utils';
+import { waitFor, renderHook } from '@tests/utils';
 import { rest } from 'msw';
 
 import {
@@ -158,7 +158,7 @@ describe('useWidgets', () => {
     it('should move widget to new position and update state', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('widget-1', 2);
       });
 
@@ -173,7 +173,7 @@ describe('useWidgets', () => {
     it('should handle horizontal drop', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('widget-1', 2, 1, true);
       });
 
@@ -188,7 +188,7 @@ describe('useWidgets', () => {
     it('should handle vertical drop within same row', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('widget-1', 1, 0, false);
       });
 
@@ -205,7 +205,7 @@ describe('useWidgets', () => {
     it('should delete widget and update state', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.deleteWidget('widget-1');
       });
 
@@ -223,7 +223,7 @@ describe('useWidgets', () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
       const newWidget = createMockWidget('widget-4', 'Widget 4');
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.addWidget(newWidget);
       });
 
@@ -235,7 +235,7 @@ describe('useWidgets', () => {
     it('should not add widget if it already exists', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.addWidget(mockWidgets[0]);
       });
 
@@ -250,7 +250,7 @@ describe('useWidgets', () => {
     it('should resize widgets and update columnWidths', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.handleWidgetResize('widget-1', 'widget-2', 8, 4);
       });
 
@@ -271,7 +271,7 @@ describe('useWidgets', () => {
       mockCanResizeBetweenWidgets.mockReturnValue(false);
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.handleWidgetResize('widget-1', 'widget-2', 8, 4);
       });
 
@@ -284,7 +284,7 @@ describe('useWidgets', () => {
       mockIsValidResizeOperation.mockReturnValue(false);
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.handleWidgetResize('widget-1', 'widget-2', 8, 4);
       });
 
@@ -296,10 +296,10 @@ describe('useWidgets', () => {
   });
 
   describe('drag state management', () => {
-    it('should handle drag start', () => {
+    it('should handle drag start', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      act(() => {
+      await waitFor(() => {
         result.current.handleDragStart('widget-1');
       });
 
@@ -307,18 +307,18 @@ describe('useWidgets', () => {
       expect(result.current.draggedWidgetId).toBe('widget-1');
     });
 
-    it('should handle drag end', () => {
+    it('should handle drag end', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
       // Start dragging first
-      act(() => {
+      await waitFor(() => {
         result.current.handleDragStart('widget-1');
       });
 
       expect(result.current.isDraggingWidget).toBe(true);
 
       // End dragging
-      act(() => {
+      await waitFor(() => {
         result.current.handleDragEnd();
       });
 
@@ -328,10 +328,10 @@ describe('useWidgets', () => {
   });
 
   describe('columnWidths state management', () => {
-    it('should update columnWidths when setColumnWidths is called', () => {
+    it('should update columnWidths when setColumnWidths is called', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      act(() => {
+      await waitFor(() => {
         result.current.setColumnWidths(mockColumnWidths);
       });
 
@@ -350,7 +350,7 @@ describe('useWidgets', () => {
 
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('widget-1', 2);
       });
 
@@ -370,7 +370,7 @@ describe('useWidgets', () => {
 
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('widget-1', 2);
       });
 
@@ -398,7 +398,7 @@ describe('useWidgets', () => {
     it('should handle moveWidget with non-existent widget', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.moveWidget('non-existent', 1);
       });
 
@@ -411,7 +411,7 @@ describe('useWidgets', () => {
     it('should handle deleteWidget with non-existent widget', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.deleteWidget('non-existent');
       });
 
@@ -424,7 +424,7 @@ describe('useWidgets', () => {
     it('should handle resize with invalid widget IDs', async () => {
       const { result } = renderHook(() => useWidgets(defaultProps));
 
-      await act(async () => {
+      await waitFor(() => {
         result.current.handleWidgetResize('invalid-1', 'invalid-2', 8, 4);
       });
 

--- a/packages/core/admin/admin/src/hooks/tests/usePersistentState.test.ts
+++ b/packages/core/admin/admin/src/hooks/tests/usePersistentState.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { usePersistentState, useScopedPersistentState } from '../usePersistentState';
 
@@ -16,7 +16,7 @@ describe('usePersistentState', () => {
     const [value, setValue] = result.current;
     expect(value).toBe(0);
 
-    act(() => {
+    await waitFor(() => {
       setValue(1);
     });
     const [updatedValue] = result.current;
@@ -30,7 +30,7 @@ describe('useScopedPersistentState', () => {
     const [value, setValue] = result.current;
     expect(value).toBe(0);
 
-    act(() => {
+    await waitFor(() => {
       setValue(1);
     });
     const [updatedValue] = result.current;

--- a/packages/core/admin/admin/src/hooks/tests/useQueryParams.test.tsx
+++ b/packages/core/admin/admin/src/hooks/tests/useQueryParams.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable check-file/filename-naming-convention */
 
-import { renderHook, act, screen } from '@tests/utils';
+import { renderHook, screen, waitFor } from '@tests/utils';
 import { useLocation } from 'react-router-dom';
 
 import { useQueryParams } from '../useQueryParams';
@@ -16,7 +16,7 @@ const LocationDisplay = () => {
 };
 
 describe('useQueryParams', () => {
-  it('should set and remove the query params using setQuery method', () => {
+  it('should set and remove the query params using setQuery method', async () => {
     const { result } = renderHook(
       ({ initialParams }) =>
         useQueryParams<{ type?: string; filters?: object; page?: number }>(initialParams),
@@ -34,7 +34,7 @@ describe('useQueryParams', () => {
     const [{ query }, setQuery] = result.current;
     expect(query).toEqual({ page: 1, type: 'plugins' }); // initial params
 
-    act(() => {
+    await waitFor(() => {
       setQuery({ type: 'plugins' }, 'remove');
     });
 
@@ -42,7 +42,7 @@ describe('useQueryParams', () => {
     expect(searchParams.has('type')).toBe(false);
     expect(searchParams.has('page')).toBe(true);
 
-    act(() => {
+    await waitFor(() => {
       setQuery({ filters: { type: 'audio' }, page: 1 });
     });
     const updatedSearchParams = new URLSearchParams(screen.getByRole('listitem').textContent ?? '');

--- a/packages/core/admin/admin/src/pages/Marketplace/hooks/tests/useNavigatorOnline.test.ts
+++ b/packages/core/admin/admin/src/pages/Marketplace/hooks/tests/useNavigatorOnline.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { useNavigatorOnline } from '../useNavigatorOnline';
 
@@ -22,7 +22,7 @@ describe('useNavigatorOnline', () => {
     jest.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
     const { result } = renderHook(() => useNavigatorOnline());
 
-    await act(async () => {
+    await waitFor(() => {
       // Simulate a change from offline to online
       window.dispatchEvent(new window.Event('online'));
     });
@@ -37,7 +37,7 @@ describe('useNavigatorOnline', () => {
     jest.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(true);
     const { result } = renderHook(() => useNavigatorOnline());
 
-    await act(async () => {
+    await waitFor(() => {
       // Simulate a change from online to offline
       window.dispatchEvent(new window.Event('offline'));
     });

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentActions.test.ts
@@ -1,5 +1,5 @@
 import { errors } from '@strapi/utils';
-import { act, renderHook, screen, server } from '@tests/utils';
+import { renderHook, screen, server, waitFor } from '@tests/utils';
 import { rest } from 'msw';
 
 import { mockData } from '../../../tests/mockData';
@@ -12,23 +12,25 @@ jest.mock('@strapi/admin/strapi-admin/ee', () => ({
 }));
 
 describe('useDocumentActions', () => {
-  it('should return an object with the correct methods', () => {
+  it('should return an object with the correct methods', async () => {
     const { result } = renderHook(() => useDocumentActions());
 
-    expect(result.current).toEqual({
-      autoClone: expect.any(Function),
-      publishMany: expect.any(Function),
-      clone: expect.any(Function),
-      create: expect.any(Function),
-      discard: expect.any(Function),
-      delete: expect.any(Function),
-      deleteMany: expect.any(Function),
-      getDocument: expect.any(Function),
-      publish: expect.any(Function),
-      update: expect.any(Function),
-      unpublish: expect.any(Function),
-      unpublishMany: expect.any(Function),
-      isLoading: expect.any(Boolean),
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        autoClone: expect.any(Function),
+        publishMany: expect.any(Function),
+        clone: expect.any(Function),
+        create: expect.any(Function),
+        discard: expect.any(Function),
+        delete: expect.any(Function),
+        deleteMany: expect.any(Function),
+        getDocument: expect.any(Function),
+        publish: expect.any(Function),
+        update: expect.any(Function),
+        unpublish: expect.any(Function),
+        unpublishMany: expect.any(Function),
+        isLoading: expect.any(Boolean),
+      });
     });
   });
 
@@ -38,7 +40,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.clone(
           {
             model: mockData.contentManager.contentType,
@@ -79,7 +81,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.clone(
           {
             model: mockData.contentManager.contentType,
@@ -113,7 +115,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.create(
           {
             model: mockData.contentManager.contentType,
@@ -153,7 +155,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.create(
           {
             model: mockData.contentManager.contentType,
@@ -185,7 +187,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.delete({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -218,7 +220,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.delete({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -246,7 +248,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.deleteMany({
           model: mockData.contentManager.contentType,
           documentIds: ['12345', '6789'],
@@ -279,7 +281,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.deleteMany({
           model: mockData.contentManager.contentType,
           documentIds: ['12345', '6789'],
@@ -307,7 +309,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.discard({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -340,7 +342,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.discard({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -368,7 +370,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.delete({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -401,7 +403,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.delete({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -429,7 +431,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.publish(
           {
             collectionType: 'collection-types',
@@ -468,7 +470,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.publish(
           {
             collectionType: 'collection-types',
@@ -501,7 +503,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.update(
           {
             collectionType: 'collection-types',
@@ -546,7 +548,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.update(
           {
             collectionType: 'collection-types',
@@ -580,7 +582,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.unpublish({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -614,7 +616,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.unpublish({
           collectionType: 'collection-types',
           model: mockData.contentManager.contentType,
@@ -642,7 +644,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.unpublishMany({
           model: mockData.contentManager.contentType,
           documentIds: ['12345', '6789'],
@@ -672,7 +674,7 @@ describe('useDocumentActions', () => {
 
       let response;
 
-      await act(async () => {
+      await waitFor(async () => {
         const res = await result.current.unpublishMany({
           model: mockData.contentManager.contentType,
           documentIds: ['12345', '6789'],

--- a/packages/core/content-manager/admin/src/hooks/tests/useKeyboardDragAndDrop.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useKeyboardDragAndDrop.test.ts
@@ -1,6 +1,6 @@
 import type { KeyboardEvent } from 'react';
 
-import { act, renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { useKeyboardDragAndDrop } from '../useKeyboardDragAndDrop';
 
@@ -12,27 +12,28 @@ describe('useKeyboardDragAndDrop', () => {
     }) as unknown as KeyboardEvent<HTMLButtonElement>;
 
   describe('onGrabItem', () => {
-    it('should be called when the event is the enter key', () => {
+    it('should be called when the event is the enter key', async () => {
       const onGrabItem = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onGrabItem, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
       expect(onGrabItem).toHaveBeenCalledWith(0);
     });
 
-    it('should be called when the event is the space key', () => {
+    it('should be called when the event is the space key', async () => {
       const onGrabItem = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onGrabItem, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event(' '));
+        result.current(event('Enter'));
       });
 
       expect(onGrabItem).toHaveBeenCalledWith(0);
@@ -40,34 +41,34 @@ describe('useKeyboardDragAndDrop', () => {
   });
 
   describe('onDropItem', () => {
-    it('should be called after the enter key is pressed twice', () => {
+    it('should be called after the enter key is pressed twice', async () => {
       const onDropItem = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onDropItem, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
       expect(onDropItem).toHaveBeenCalledWith(0);
     });
 
-    it('should be called after the space key is pressed twice', () => {
+    it('should be called after the space key is pressed twice', async () => {
       const onDropItem = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onDropItem, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event(' '));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event(' '));
       });
 
@@ -76,40 +77,40 @@ describe('useKeyboardDragAndDrop', () => {
   });
 
   describe('onCancel', () => {
-    it('should be called when the escape key is pressed provided that the enter or space key has been pressed first', () => {
+    it('should be called when the escape key is pressed provided that the enter or space key has been pressed first', async () => {
       const onCancel = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onCancel, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Escape'));
       });
 
       expect(onCancel).toHaveBeenCalledWith(0);
 
-      act(() => {
+      await waitFor(() => {
         result.current(event(' '));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Escape'));
       });
 
       expect(onCancel).toHaveBeenCalledTimes(2);
     });
 
-    it('should not be called if neither the space nor enter key have been pressed first', () => {
+    it('should not be called if neither the space nor enter key have been pressed first', async () => {
       const onCancel = jest.fn();
       const { result } = renderHook(() =>
         useKeyboardDragAndDrop(true, 0, { onCancel, onMoveItem: jest.fn() })
       );
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Escape'));
       });
 
@@ -118,90 +119,90 @@ describe('useKeyboardDragAndDrop', () => {
   });
 
   describe('onMoveItem', () => {
-    it('should be called when the down arrow is pressed provided the enter key has been pressed first', () => {
+    it('should be called when the down arrow is pressed provided the enter key has been pressed first', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowDown'));
       });
 
       expect(onMoveItem).toHaveBeenCalledWith(1, 0);
     });
 
-    it('should be called when the right arrow is pressed provided the enter key has been pressed first', () => {
+    it('should be called when the right arrow is pressed provided the enter key has been pressed first', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowRight'));
       });
 
       expect(onMoveItem).toHaveBeenCalledWith(1, 0);
     });
 
-    it('should not be called with either the down arrow or right arrow if the enter key has not been pressed prior', () => {
+    it('should not be called with either the down arrow or right arrow if the enter key has not been pressed prior', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 0, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowDown'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowRight'));
       });
 
       expect(onMoveItem).not.toHaveBeenCalled();
     });
 
-    it('should be called when the up arrow is pressed provided the enter key has been pressed first', () => {
+    it('should be called when the up arrow is pressed provided the enter key has been pressed first', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowUp'));
       });
 
       expect(onMoveItem).toHaveBeenCalledWith(0, 1);
     });
 
-    it('should be called when the left arrow is pressed provided the enter key has been pressed first', () => {
+    it('should be called when the left arrow is pressed provided the enter key has been pressed first', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('Enter'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowLeft'));
       });
 
       expect(onMoveItem).toHaveBeenCalledWith(0, 1);
     });
 
-    it('should not be called with either the left or up arrow key if the enter key has not been pressed first', () => {
+    it('should not be called with either the left or up arrow key if the enter key has not been pressed first', async () => {
       const onMoveItem = jest.fn();
       const { result } = renderHook(() => useKeyboardDragAndDrop(true, 1, { onMoveItem }));
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowUp'));
       });
 
-      act(() => {
+      await waitFor(() => {
         result.current(event('ArrowLeft'));
       });
 

--- a/packages/core/content-manager/admin/src/hooks/tests/useLazyComponents.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useLazyComponents.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@tests/utils';
+import { renderHook, waitFor } from '@tests/utils';
 
 import { useLazyComponents } from '../useLazyComponents';
 
@@ -27,7 +27,7 @@ describe('useLazyComponents', () => {
 
     expect(actualResult.current.lazyComponentStore['plugin::test.test']).toBeDefined();
 
-    act(() => actualResult.current.cleanup());
+    await waitFor(() => actualResult.current.cleanup());
 
     expect(actualResult.current.lazyComponentStore).toEqual({});
   });

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Image.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Image.test.tsx
@@ -2,7 +2,7 @@
 
 import { ReactElement } from 'react';
 
-import { act, render as renderRTL, screen } from '@tests/utils';
+import { render as renderRTL, screen, waitFor } from '@tests/utils';
 import { Editor, Transforms, createEditor } from 'slate';
 
 import { mockImage } from '../../tests/mock-schema';
@@ -99,7 +99,7 @@ describe('Image', () => {
     const baseEditor = createEditor();
     baseEditor.children = [{ type: 'paragraph', children: [{ type: 'text', text: '' }] }];
 
-    await act(async () =>
+    await waitFor(() =>
       Transforms.select(baseEditor, {
         anchor: { path: [0, 0], offset: 0 },
         focus: { path: [0, 0], offset: 0 },
@@ -146,7 +146,7 @@ describe('Image', () => {
       },
     ];
 
-    await act(async () =>
+    await waitFor(() =>
       Transforms.select(baseEditor, {
         anchor: { path: [0, 1, 0], offset: 0 },
         focus: { path: [0, 1, 0], offset: 0 },

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/Field.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/Field.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@strapi/admin/strapi-admin';
-import { act, render as renderRTL, screen, waitFor } from '@tests/utils';
+import { render as renderRTL, screen, waitFor } from '@tests/utils';
 import { Route, Routes } from 'react-router-dom';
 
 import { DynamicZone, DynamicZoneProps } from '../Field';
@@ -205,7 +205,7 @@ describe('DynamicZone', () => {
 
       const [draggedItem] = screen.getAllByRole('button', { name: 'Drag' });
 
-      act(() => {
+      await waitFor(() => {
         draggedItem.focus();
       });
 
@@ -235,7 +235,7 @@ describe('DynamicZone', () => {
 
       const [draggedItem] = screen.getAllByRole('button', { name: 'Drag' });
 
-      act(() => {
+      await waitFor(() => {
         draggedItem.focus();
       });
 
@@ -267,7 +267,7 @@ describe('DynamicZone', () => {
 
       const [draggedItem] = screen.getAllByRole('button', { name: 'Drag' });
 
-      act(() => {
+      await waitFor(() => {
         draggedItem.focus();
       });
 
@@ -295,7 +295,7 @@ describe('DynamicZone', () => {
 
       const [draggedItem] = screen.getAllByRole('button', { name: 'Drag' });
 
-      act(() => {
+      await waitFor(() => {
         draggedItem.focus();
       });
 

--- a/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/formModalNavigationProvider.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/formModalNavigationProvider.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import {
   FormModalNavigationProvider,
@@ -24,17 +24,17 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(INITIAL_STATE_DATA);
   });
 
-  it('updates the state when selecting a custom field for a new attribute', () => {
+  it('updates the state when selecting a custom field for a new attribute', async () => {
     const { result } = renderHook(() => useFormModalNavigation(), {
       wrapper: FormModalNavigationProvider,
     });
 
-    act(() => {
-      (result.current as any).onClickSelectCustomField({
+    await waitFor(() =>
+      result.current.onClickSelectCustomField({
         attributeType: 'text',
         customFieldUid: 'plugin::mycustomfields.color',
-      });
-    });
+      })
+    );
 
     const currentStateWithoutFunctions = removeFunctionsFromObject(result.current);
     const expected = {
@@ -48,13 +48,13 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(expected);
   });
 
-  it('updates the state when editing a custom field attribute', () => {
+  it('updates the state when editing a custom field attribute', async () => {
     const { result } = renderHook(() => useFormModalNavigation(), {
       wrapper: FormModalNavigationProvider,
     });
 
-    act(() => {
-      (result.current as any).onOpenModalEditCustomField({
+    await waitFor(() => {
+      result.current.onOpenModalEditCustomField({
         forTarget: 'contentType',
         targetUid: 'api::test.test',
         attributeName: 'color',

--- a/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/index.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import {
   FormModalNavigationProvider,
@@ -25,13 +25,13 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(INITIAL_STATE_DATA);
   });
 
-  it('updates the state when selecting a custom field for a new attribute', () => {
+  it('updates the state when selecting a custom field for a new attribute', async () => {
     const { result } = renderHook(() => useFormModalNavigation(), {
       wrapper: FormModalNavigationProvider,
     });
 
-    act(() => {
-      (result.current as any).onClickSelectCustomField({
+    await waitFor(() => {
+      result.current.onClickSelectCustomField({
         attributeType: 'text',
         customFieldUid: 'plugin::mycustomfields.color',
       });
@@ -49,13 +49,13 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(expected);
   });
 
-  it('updates the state when editing a custom field attribute', () => {
+  it('updates the state when editing a custom field attribute', async () => {
     const { result } = renderHook(() => useFormModalNavigation(), {
       wrapper: FormModalNavigationProvider,
     });
 
-    act(() => {
-      (result.current as any).onOpenModalEditCustomField({
+    await waitFor(() => {
+      result.current.onOpenModalEditCustomField({
         forTarget: 'contentType',
         targetUid: 'api::test.test',
         attributeName: 'color',

--- a/packages/core/content-type-builder/admin/src/components/tests/AutoReloadOverlayBlocker.test.tsx
+++ b/packages/core/content-type-builder/admin/src/components/tests/AutoReloadOverlayBlocker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DesignSystemProvider } from '@strapi/design-system';
-import { act, screen, renderHook } from '@testing-library/react';
+import { act, screen, renderHook, waitFor } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 
 import {
@@ -33,7 +33,7 @@ describe('AutoReloadOverlayBlocker', () => {
       wrapper,
     });
 
-    act(() => {
+    await waitFor(() => {
       result.current.lockAppWithAutoreload?.();
     });
 
@@ -45,11 +45,11 @@ describe('AutoReloadOverlayBlocker', () => {
       wrapper,
     });
 
-    act(() => {
+    await waitFor(() => {
       result.current.lockAppWithAutoreload?.();
     });
-    expect(screen.getByRole('heading', { name: /Waiting for restart/ })).toBeInTheDocument();
-    act(() => {
+    expect(await screen.findByRole('heading', { name: /Waiting for restart/ })).toBeInTheDocument();
+    await waitFor(() => {
       result.current.unlockAppWithAutoreload?.();
     });
     expect(screen.queryByRole('heading', { name: /Waiting for restart/ })).not.toBeInTheDocument();
@@ -60,7 +60,7 @@ describe('AutoReloadOverlayBlocker', () => {
       wrapper,
     });
 
-    act(() => {
+    await waitFor(() => {
       result.current.lockAppWithAutoreload?.();
     });
 
@@ -69,7 +69,7 @@ describe('AutoReloadOverlayBlocker', () => {
     act(() => jest.advanceTimersByTime(MAX_ELAPSED_TIME));
 
     expect(
-      screen.getByRole('heading', { name: /The restart is taking longer than expected/ })
+      await screen.findByRole('heading', { name: /The restart is taking longer than expected/ })
     ).toBeInTheDocument();
   });
 });

--- a/packages/core/upload/admin/src/hooks/tests/useBulkMove.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useBulkMove.test.ts
@@ -1,5 +1,5 @@
 import { useFetchClient } from '@strapi/admin/strapi-admin';
-import { act, renderHook, screen } from '@tests/utils';
+import { renderHook, screen, waitFor } from '@tests/utils';
 
 import { useBulkMove, FileWithType, FolderWithType } from '../useBulkMove';
 
@@ -95,7 +95,7 @@ describe('useBulkMove', () => {
     } = setup();
     const { move } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_ASSETS);
     });
     const { post } = useFetchClient();
@@ -110,7 +110,7 @@ describe('useBulkMove', () => {
     const { move } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_ASSETS);
     });
 
@@ -127,7 +127,7 @@ describe('useBulkMove', () => {
     const { move } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_FOLDERS);
     });
 
@@ -144,7 +144,7 @@ describe('useBulkMove', () => {
     const { move } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await move(FIXTURE_DESTINATION_FOLDER_ID, [...FIXTURE_FOLDERS, ...FIXTURE_ASSETS]);
     });
 
@@ -158,7 +158,7 @@ describe('useBulkMove', () => {
   test('does re-fetch assets, if files were deleted', async () => {
     const { result } = setup();
 
-    await act(async () => {
+    await waitFor(async () => {
       await result.current.move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_ASSETS);
     });
 
@@ -168,7 +168,7 @@ describe('useBulkMove', () => {
   test('does re-fetch folders, if folders were deleted', async () => {
     const { result } = setup();
 
-    await act(async () => {
+    await waitFor(async () => {
       await result.current.move(FIXTURE_DESTINATION_FOLDER_ID, FIXTURE_FOLDERS);
     });
 

--- a/packages/core/upload/admin/src/hooks/tests/useBulkRemove.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useBulkRemove.test.ts
@@ -1,5 +1,5 @@
 import { useFetchClient } from '@strapi/admin/strapi-admin';
-import { act, renderHook, screen } from '@tests/utils';
+import { renderHook, screen, waitFor } from '@tests/utils';
 
 import { BulkDeleteFiles } from '../../../../shared/contracts/files';
 import { BulkDeleteFolders } from '../../../../shared/contracts/folders';
@@ -93,7 +93,7 @@ describe('useBulkRemove', () => {
     const { remove } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await remove(FIXTURE_ASSETS);
     });
 
@@ -107,7 +107,7 @@ describe('useBulkRemove', () => {
     const { remove } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await remove(FIXTURE_ASSETS);
     });
 
@@ -123,7 +123,7 @@ describe('useBulkRemove', () => {
     const { remove } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await remove(FIXTURE_FOLDERS);
     });
 
@@ -139,7 +139,7 @@ describe('useBulkRemove', () => {
     const { remove } = current;
     const { post } = useFetchClient();
 
-    await act(async () => {
+    await waitFor(async () => {
       await remove([...FIXTURE_FOLDERS, ...FIXTURE_ASSETS]);
     });
 
@@ -152,7 +152,7 @@ describe('useBulkRemove', () => {
   test('does re-fetch assets, if files were deleted', async () => {
     const { result } = setup();
 
-    await act(async () => {
+    await waitFor(async () => {
       await result.current.remove(FIXTURE_ASSETS);
     });
 
@@ -162,7 +162,7 @@ describe('useBulkRemove', () => {
   test('does re-fetch folders, if folders were deleted', async () => {
     const { result } = setup();
 
-    await act(async () => {
+    await waitFor(async () => {
       await result.current.remove(FIXTURE_FOLDERS);
     });
 

--- a/packages/core/upload/admin/src/hooks/tests/useConfig.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useConfig.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor, screen, server } from '@tests/utils';
+import { renderHook, waitFor, screen, server } from '@tests/utils';
 import { rest } from 'msw';
 
 import { useConfig } from '../useConfig';
@@ -56,14 +56,13 @@ describe('useConfig', () => {
     test('does call the proper mutation endpoint', async () => {
       const { result } = renderHook(() => useConfig());
 
-      act(() => {
-        result.current.mutateConfig.mutateAsync({
+      await waitFor(async () => {
+        await result.current.mutateConfig.mutateAsync({
           pageSize: 100,
           sort: 'name:DESC',
         });
+        expect(result.current.config.isLoading).toBe(true);
       });
-
-      expect(result.current.config.isLoading).toBe(true);
 
       await waitFor(() => expect(result.current.config.isLoading).toBe(false));
     });

--- a/packages/core/upload/admin/src/hooks/tests/useEditFolder.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useEditFolder.test.ts
@@ -1,5 +1,5 @@
 import { useFetchClient } from '@strapi/admin/strapi-admin';
-import { act, renderHook } from '@tests/utils';
+import { renderHook, waitFor } from '@tests/utils';
 
 import { useEditFolder } from '../useEditFolder';
 
@@ -38,7 +38,7 @@ describe('useEditFolder', () => {
     } = setup();
     const { editFolder } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await editFolder(FOLDER_CREATE_FIXTURE);
     });
 
@@ -53,7 +53,7 @@ describe('useEditFolder', () => {
     } = setup();
     const { editFolder } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await editFolder(
         {
           name: FOLDER_EDIT_FIXTURE.name,
@@ -73,7 +73,7 @@ describe('useEditFolder', () => {
     } = setup();
     const { editFolder } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await editFolder(
         {
           name: FOLDER_EDIT_FIXTURE.name,
@@ -92,7 +92,7 @@ describe('useEditFolder', () => {
     } = setup();
     const { editFolder } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await editFolder(
         {
           name: FOLDER_EDIT_FIXTURE.name,

--- a/packages/core/upload/admin/src/hooks/tests/useModalQueryParams.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useModalQueryParams.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@tests/utils';
+import { renderHook, waitFor } from '@tests/utils';
 
 import { useModalQueryParams } from '../useModalQueryParams';
 
@@ -50,7 +50,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeFilters?.([{ some: 'thing' }]);
     });
 
@@ -73,7 +73,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeFolder?.({ id: 1 }, '/1');
     });
 
@@ -92,7 +92,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangePage?.({ id: 1 });
     });
 
@@ -110,7 +110,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangePageSize?.(5);
     });
 
@@ -125,7 +125,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangePageSize?.('5');
     });
 
@@ -140,7 +140,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeSort?.('name:DESC');
     });
 
@@ -156,7 +156,7 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeSearch?.('something');
     });
 
@@ -172,15 +172,15 @@ describe('useModalQueryParams', () => {
 
     await waitFor(() => expect(result.current[0]?.queryObject?.pageSize).toBe(20));
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangePage?.({ id: 1 });
     });
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeSearch?.('something');
     });
 
-    act(() => {
+    await waitFor(() => {
       result.current[1]?.onChangeSearch?.('');
     });
 

--- a/packages/core/upload/admin/src/hooks/tests/usePersistentState.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/usePersistentState.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
 import { usePersistentState } from '../usePersistentState';
 
@@ -8,7 +8,7 @@ describe('usePersistentState', () => {
     const [value, setValue] = result.current;
     expect(value).toBe(0);
 
-    act(() => {
+    await waitFor(() => {
       setValue(1);
     });
     const [updatedValue] = result.current;

--- a/packages/core/upload/admin/src/hooks/tests/useRemoveAsset.test.tsx
+++ b/packages/core/upload/admin/src/hooks/tests/useRemoveAsset.test.tsx
@@ -98,7 +98,7 @@ describe('useRemoveAsset', () => {
     const { removeAsset } = current;
 
     try {
-      await act(async () => {
+      await waitFor(async () => {
         await removeAsset(ASSET_FIXTURE);
       });
     } catch (err) {
@@ -118,7 +118,7 @@ describe('useRemoveAsset', () => {
     } = (await setup(jest.fn)) as { result: { current: any } };
     const { removeAsset } = current;
 
-    await act(async () => {
+    await waitFor(async () => {
       await removeAsset(ASSET_FIXTURE);
     });
 
@@ -147,7 +147,7 @@ describe('useRemoveAsset', () => {
     const { removeAsset } = current;
 
     try {
-      await act(async () => {
+      await waitFor(async () => {
         await removeAsset(ASSET_FIXTURE);
       });
     } catch (err) {

--- a/packages/core/upload/admin/src/hooks/tests/useSelectionState.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useSelectionState.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@tests/utils';
+import { renderHook, waitFor } from '@tests/utils';
 
 import { useSelectionState } from '../useSelectionState';
 
@@ -34,13 +34,13 @@ describe('useSelectionState', () => {
   test('selectOne', async () => {
     const { result } = setup(['id'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[0]);
     });
 
     expect(result.current[0]).toStrictEqual([FIXTURE[0]]);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[1]);
     });
 
@@ -50,13 +50,13 @@ describe('useSelectionState', () => {
   test('selectOne - multiple keys', async () => {
     const { result } = setup(['id', 'name'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[0]);
     });
 
     expect(result.current[0]).toStrictEqual([FIXTURE[0]]);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[1]);
     });
 
@@ -66,114 +66,114 @@ describe('useSelectionState', () => {
   test('selectOne deselect', async () => {
     const { result } = setup(['id'], FIXTURE);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[0]);
     });
 
     expect(result.current[0]).toStrictEqual([FIXTURE[1]]);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOne(FIXTURE[1]);
     });
 
     expect(result.current[0]).toStrictEqual([]);
   });
 
-  test('selectAll', () => {
+  test('selectAll', async () => {
     const { result } = setup(['id'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectAll(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual(FIXTURE);
   });
 
-  test('selectAll - multiple keys', () => {
+  test('selectAll - multiple keys', async () => {
     const { result } = setup(['id', 'name'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectAll(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual(FIXTURE);
   });
 
-  test('selectAll - reset', () => {
+  test('selectAll - reset', async () => {
     const { result } = setup(['id'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectAll([]);
     });
 
     expect(result.current[0]).toStrictEqual([]);
   });
 
-  test('selectOnly', () => {
+  test('selectOnly', async () => {
     const { result } = setup(['id'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOnly(FIXTURE[0]);
     });
 
     expect(result.current[0]).toStrictEqual([FIXTURE[0]]);
   });
 
-  test('selectOnly - multiple keys', () => {
+  test('selectOnly - multiple keys', async () => {
     const { result } = setup(['id', 'name'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectOnly(FIXTURE[0]);
     });
 
     expect(result.current[0]).toStrictEqual([FIXTURE[0]]);
   });
 
-  test('selectMultiple - no previously selected + multiple keys', () => {
+  test('selectMultiple - no previously selected + multiple keys', async () => {
     const { result } = setup(['id', 'name'], []);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectMultiple(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual(FIXTURE);
   });
 
-  test('selectMultiple - already selected item + multiple keys', () => {
+  test('selectMultiple - already selected item + multiple keys', async () => {
     const alreadySelectedItem = { id: 0, name: 'already selected' };
     const { result } = setup(['id', 'name'], [alreadySelectedItem]);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectMultiple(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual([alreadySelectedItem, ...FIXTURE]);
   });
 
-  test('selectMultiple - no duplicates + multiple keys', () => {
+  test('selectMultiple - no duplicates + multiple keys', async () => {
     const { result } = setup(['id', 'name'], FIXTURE);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].selectMultiple(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual(FIXTURE);
   });
 
-  test('deselectMultiple - multiple keys', () => {
+  test('deselectMultiple - multiple keys', async () => {
     const { result } = setup(['id', 'name'], FIXTURE);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].deselectMultiple(FIXTURE);
     });
 
     expect(result.current[0]).toStrictEqual([]);
   });
 
-  test('deselectMultiple - some items to deselect + multiple keys', () => {
+  test('deselectMultiple - some items to deselect + multiple keys', async () => {
     const { result } = setup(['id', 'name'], FIXTURE);
 
-    act(() => {
+    await waitFor(() => {
       result.current[1].deselectMultiple([FIXTURE[0]]);
     });
 

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/tests/EditPage.test.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/tests/EditPage.test.jsx
@@ -7,6 +7,7 @@ import {
   render as renderRTL,
   waitForElementToBeRemoved,
   waitFor,
+  screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
@@ -115,30 +116,26 @@ describe('Roles – EditPage', () => {
   it("can update a role's name, description and permissions", async () => {
     const { getByRole, user, getByText, findByRole, findByText } = render();
 
-    await waitForElementToBeRemoved(() => getByText('Loading content.'));
+    // await waitForElementToBeRemoved(() => getByText('Loading content.'));
 
-    await waitFor(() => {
-      expect(getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
-    });
+    const textboxName = await screen.findByRole('textbox', { name: 'Name' });
+    const textboxDescription = await screen.findByRole('textbox', { name: 'Description' });
 
-    await user.type(getByRole('textbox', { name: 'Name' }), 'test');
-    await user.type(getByRole('textbox', { name: 'Description' }), 'testing');
+    await user.type(textboxName, 'test');
+    await user.type(textboxDescription, 'testing');
     await user.click(
       getByRole('button', {
         name: 'Address Define all allowed actions for the api::address plugin.',
       })
     );
 
-    await waitFor(() => {
-      expect(getByRole('checkbox', { name: 'create' })).toBeInTheDocument();
-    });
-
-    await user.click(getByRole('checkbox', { name: 'create' }));
+    const checkboxCreate = await screen.findByRole('checkbox', { name: 'create' });
+    await user.click(checkboxCreate);
 
     const button = await findByRole('button', { name: 'Save' });
-    /**
-     * @note user.click will not trigger the form.
-     */
+    // /**
+    //  * @note user.click will not trigger the form.
+    //  */
     fireEvent.click(button);
     await findByText('Role edited');
     await findByText('Authenticated');

--- a/packages/plugins/users-permissions/admin/src/tests/setup.js
+++ b/packages/plugins/users-permissions/admin/src/tests/setup.js
@@ -3,6 +3,29 @@ import { setupServer } from 'msw/node';
 
 import pluginId from '../pluginId';
 
+const role = {
+  id: 1,
+  name: 'Authenticated',
+  description: 'Default role given to authenticated user.',
+  type: 'authenticated',
+  createdAt: '2021-09-08T16:26:18.061Z',
+  updatedAt: '2021-09-08T16:26:18.061Z',
+  permissions: {
+    'api::address': {
+      controllers: {
+        address: {
+          create: {
+            enabled: false,
+            policy: '',
+          },
+        },
+      },
+    },
+  },
+};
+
+let roleVersion = 0;
+
 const handlers = [
   // Mock get role route
   rest.get(`*/${pluginId}/roles/:roleId`, (req, res, ctx) => {
@@ -10,24 +33,14 @@ const handlers = [
       ctx.status(200),
       ctx.json({
         role: {
-          id: req.params.roleId,
-          name: 'Authenticated',
-          description: 'Default role given to authenticated user.',
-          type: 'authenticated',
-          createdAt: '2021-09-08T16:26:18.061Z',
-          updatedAt: '2021-09-08T16:26:18.061Z',
-          permissions: {
-            'api::address': {
-              controllers: {
-                address: {
-                  create: {
-                    enabled: false,
-                    policy: '',
-                  },
-                },
-              },
-            },
-          },
+          ...role,
+          id: Number(req.params.roleId),
+          /**
+           * @note React Query will bail out of notifying listeners if the response deep-equals
+           * the previous response. Bump a version to ensure a new reference so Formik can
+           * reinitialize its values during tests.
+           */
+          version: ++roleVersion,
         },
       })
     );


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

In many front end test files, the `act()` has been used even though we could use more relevants api such as `waitFor`, `findBy` and `waitForElementToBeRemoved ` that already wraps `act()`. I guess, this has been done this way because of the error logged when a test that cause state updates fail. One of the only place we need to explicitly use `act()` is when using with fake timers

### Why is it needed?

Hopefully less test flakiness

### How to test it?

- Run the front end unit test, make sure they pass
- `yarn test:front:update`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
