### PR TITLE
fix(admin): add `origin` to doc hooks

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocument.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocument.ts
@@ -272,6 +272,7 @@ const useDoc = () => {
     collectionType,
     model: slug,
     id: returnId,
+    origin,
     ...document,
   };
 };

--- a/packages/core/content-manager/admin/src/hooks/useDocumentContext.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentContext.ts
@@ -48,12 +48,17 @@ function useDocumentContext(consumerName: string): DocumentContextValue {
   );
 
   // Then try to get the same state from the URL
-  const { collectionType, model, id: documentId } = useDoc();
+  const { collectionType, model, id: documentId, origin } = useDoc();
   const [{ query }] = useQueryParams();
 
   // TODO: look into why we never seem to pass any params
   const params = React.useMemo(() => buildValidParams(query ?? {}), [query]);
-  const urlDocumentMeta: DocumentMeta = { collectionType, model, documentId: documentId!, params };
+  const urlDocumentMeta: DocumentMeta = {
+    collectionType,
+    model,
+    documentId: documentId! || origin,
+    params,
+  };
   const urlDocument = useDocument(urlDocumentMeta);
 
   /**


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

When cloning a document on
`/admin/content-manager/collection-types/:slug/clone/:origin`, we do not set the document id to the origin document id since this is the creation of a new document. But a document id is required to query relations and without it, the field is kept empty.

This updates the `useDoc` hook to pass the `origin` string and use that as an alternative document id.

### Why is it needed?

This allows relations to be correctly set on clone documents

### How to test it?

- Open a document in edit view on admin, something like /admin/content-manager/collection-types/api::event.event/dzahzj4dixny3nqfv56fxgzq 
- Insert `clone` in the URL to land on the clone page, eg. /admin/content-manager/collection-types/api::event.event/**clone**/dzahzj4dixny3nqfv56fxgzq (this is where we are redirected if auto-clone failed)

https://github.com/user-attachments/assets/91967b65-67e6-43b9-a02e-3a5cd7450c94


### Related issue(s)/PR(s)

Resolves #24814 
