### PR TITLE
fix(upload): file-type does not support commonjs

### DIFF
--- a/packages/core/upload/server/src/utils/mime-validation.ts
+++ b/packages/core/upload/server/src/utils/mime-validation.ts
@@ -49,6 +49,11 @@ export async function detectMimeType(file: any): Promise<string | undefined> {
   }
 
   try {
+    /**
+     * Use dynamic import to support file-type which is ESM-only
+     * Static imports fail during CommonJS build since bundler can't transform ESM-only packages
+     * @see https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+     */
     const { fileTypeFromBuffer } = await import('file-type');
 
     const result = await fileTypeFromBuffer(new Uint8Array(buffer));


### PR DESCRIPTION
### What does it do?

Replace static import with dynamic import for file-type package to support ESM-only modules in both CommonJS/ESM builds.

The maintainer mentions this approach here: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

### Why is it needed?

file-type is ESM-only and lacks CommonJS exports. When Strapi builds its CommonJS output, the bundler fails to transform the static import to require(). This breaks app startup on Node.js < 22, which has stricter ESM/CommonJS interop. Dynamic imports work at runtime in both module formats.

### How to test it?

You will need to be able to switch node versions with something like https://github.com/nvm-sh/nvm

Switch to node 20 (`nvm install 20` if it's not already installed. `nvm use 20` to use it, `node -v` to confirm)
Create a strapi app with `npx create-strapi-app@0.0.0-experimental.f9ca9ac9518346cac58a4a3a576bc9d9d795570d test-fix --quickstart`
Update the config in `config/plugins.js`:

```
upload: {
    config: {
      security: {
        deniedTypes: ['video/*'],
      }
    }
  }
```
Run `npm run develop` there should NOT be an error
Go to the media library and try to upload a video, it should be rejected
Try to upload other file types not in the deniedTypes list, it should work


Test the same for all node versions up to 24

### Related issue(s)/PR(s)

Resolves https://github.com/strapi/strapi/issues/24829
