### PR TITLE
fix(admin): ai disabled by default for growth license

### DIFF
--- a/packages/core/admin/ee/server/src/controllers/admin.ts
+++ b/packages/core/admin/ee/server/src/controllers/admin.ts
@@ -10,8 +10,8 @@ export default {
   // NOTE: Overrides CE admin controller
   async getProjectType() {
     const flags = strapi.config.get('admin.flags', {});
-    const isAIConfigured = strapi.config.get('admin.ai', { enabled: false });
     const isAILicense = strapi.ee.features.isEnabled('cms-ai');
+    const isAIConfigured = strapi.config.get('admin.ai', { enabled: isAILicense });
 
     try {
       return {


### PR DESCRIPTION
### What does it do?

Enables AI by default for growth license

### Why is it needed?

It should be enabled by default if the license has AI

### How to test it?

With a growth license 
Ensure you do NOT have the admin config for enabling ai
Run the app and AI should be available in the App
Add the config and set it to false, You should NOT have AI in the app
Set it to true you should have AI again

With an CE/EE license
Run the app, you should NOT have AI regardless of the config

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
