### PR TITLE
chore: replace deprecated Buffer.slice() with subarray() in encryption utils

### DIFF
--- a/packages/core/data-transfer/src/utils/encryption/decrypt.ts
+++ b/packages/core/data-transfer/src/utils/encryption/decrypt.ts
@@ -12,20 +12,20 @@ const getDecryptionStrategy = (algorithm: Algorithm): EncryptionStrategy => {
     },
     aes128(key: string): Decipheriv {
       const hashedKey = scryptSync(key, '', 32);
-      const initVector: BinaryLike | null = hashedKey.slice(16);
-      const securityKey: CipherKey = hashedKey.slice(0, 16);
+      const initVector: BinaryLike | null = hashedKey.subarray(16);
+      const securityKey: CipherKey = hashedKey.subarray(0, 16);
       return createDecipheriv(algorithm, securityKey, initVector);
     },
     aes192(key: string): Decipheriv {
       const hashedKey = scryptSync(key, '', 40);
-      const initVector: BinaryLike | null = hashedKey.slice(24);
-      const securityKey: CipherKey = hashedKey.slice(0, 24);
+      const initVector: BinaryLike | null = hashedKey.subarray(24);
+      const securityKey: CipherKey = hashedKey.subarray(0, 24);
       return createDecipheriv(algorithm, securityKey, initVector);
     },
     aes256(key: string): Decipheriv {
       const hashedKey = scryptSync(key, '', 48);
-      const initVector: BinaryLike | null = hashedKey.slice(32);
-      const securityKey: CipherKey = hashedKey.slice(0, 32);
+      const initVector: BinaryLike | null = hashedKey.subarray(32);
+      const securityKey: CipherKey = hashedKey.subarray(0, 32);
       return createDecipheriv(algorithm, securityKey, initVector);
     },
   };

--- a/packages/core/data-transfer/src/utils/encryption/encrypt.ts
+++ b/packages/core/data-transfer/src/utils/encryption/encrypt.ts
@@ -12,20 +12,20 @@ const getEncryptionStrategy = (algorithm: Algorithm): EncryptionStrategy => {
     },
     aes128(key: string): Cipheriv {
       const hashedKey = scryptSync(key, '', 32);
-      const initVector: BinaryLike | null = hashedKey.slice(16);
-      const securityKey: CipherKey = hashedKey.slice(0, 16);
+      const initVector: BinaryLike | null = hashedKey.subarray(16);
+      const securityKey: CipherKey = hashedKey.subarray(0, 16);
       return createCipheriv(algorithm, securityKey, initVector);
     },
     aes192(key: string): Cipheriv {
       const hashedKey = scryptSync(key, '', 40);
-      const initVector: BinaryLike | null = hashedKey.slice(24);
-      const securityKey: CipherKey = hashedKey.slice(0, 24);
+      const initVector: BinaryLike | null = hashedKey.subarray(24);
+      const securityKey: CipherKey = hashedKey.subarray(0, 24);
       return createCipheriv(algorithm, securityKey, initVector);
     },
     aes256(key: string): Cipheriv {
       const hashedKey = scryptSync(key, '', 48);
-      const initVector: BinaryLike | null = hashedKey.slice(32);
-      const securityKey: CipherKey = hashedKey.slice(0, 32);
+      const initVector: BinaryLike | null = hashedKey.subarray(32);
+      const securityKey: CipherKey = hashedKey.subarray(0, 32);
       return createCipheriv(algorithm, securityKey, initVector);
     },
   };


### PR DESCRIPTION
### What does it do?

Replaces the deprecated `Buffer.slice()` method with `Buffer.subarray()` in the data-transfer encryption utilities. The changes affect both encryption and decryption cipher creation functions in:
- encrypt.ts
- decrypt.ts

### Why is it needed?

The `Buffer.slice()` method has been deprecated in Node.js in favor of `Buffer.subarray()`. While both methods currently work the same way, using the deprecated method:
- Triggers deprecation warnings in newer Node.js versions
- Goes against Node.js best practices and recommendations
- May be removed in future Node.js releases

Migrating to `subarray()` ensures the codebase remains compatible with current and future Node.js versions and eliminates deprecation warnings.

### How to test it?

- Run the existing unit tests for the data-transfer package:
   ```bash
   cd packages/core/data-transfer
   yarn test
   ```
- Test encryption/decryption functionality by running an import and export, attempt to import an exported file from a previous version

