### PR TITLE
fix:Negative number attributes were not correctly compared with "mini…

### DIFF
--- a/packages/core/utils/src/__tests__/validation-utilities.test.ts
+++ b/packages/core/utils/src/__tests__/validation-utilities.test.ts
@@ -1,0 +1,37 @@
+import * as z from 'zod/v4';
+import { maybeWithMinMax } from '../validation/utilities';
+
+describe('maybeWithMinMax', () => {
+  it('should apply min and max when both are provided', () => {
+    const schema = maybeWithMinMax(0, 10)(z.number());
+
+    expect(schema.safeParse(-1).success).toBe(false);
+    expect(schema.safeParse(11).success).toBe(false);
+    expect(schema.safeParse(5).success).toBe(true);
+  });
+
+  it('should apply min and max when min is negative', () => {
+    const schema = maybeWithMinMax(-1, 10)(z.number());
+
+    // This is the user's case: min -1, max 10. Value -15.
+    // Should fail.
+    expect(schema.safeParse(-15).success).toBe(false);
+    expect(schema.safeParse(-2).success).toBe(false);
+    expect(schema.safeParse(-1).success).toBe(true);
+    expect(schema.safeParse(0).success).toBe(true);
+    expect(schema.safeParse(10).success).toBe(true);
+    expect(schema.safeParse(11).success).toBe(false);
+  });
+
+  it('should apply min if max is undefined', () => {
+    const schema = maybeWithMinMax(0, undefined)(z.number());
+    expect(schema.safeParse(-1).success).toBe(false);
+    expect(schema.safeParse(1).success).toBe(true);
+  });
+
+  it('should apply max if min is undefined', () => {
+    const schema = maybeWithMinMax(undefined, 10)(z.number());
+    expect(schema.safeParse(11).success).toBe(false);
+    expect(schema.safeParse(5).success).toBe(true);
+  });
+});

--- a/packages/core/utils/src/validation/__tests__/MaybeWithMinMax.test.ts
+++ b/packages/core/utils/src/validation/__tests__/MaybeWithMinMax.test.ts
@@ -1,0 +1,37 @@
+import * as z from 'zod/v4';
+import { maybeWithMinMax } from '../utilities';
+
+describe('maybeWithMinMax', () => {
+  it('should apply min and max when both are provided', () => {
+    const schema = maybeWithMinMax(0, 10)(z.number());
+
+    expect(schema.safeParse(-1).success).toBe(false);
+    expect(schema.safeParse(11).success).toBe(false);
+    expect(schema.safeParse(5).success).toBe(true);
+  });
+
+  it('should apply min and max when min is negative', () => {
+    const schema = maybeWithMinMax(-1, 10)(z.number());
+
+    // This is the user's case: min -1, max 10. Value -15.
+    // Should fail.
+    expect(schema.safeParse(-15).success).toBe(false);
+    expect(schema.safeParse(-2).success).toBe(false);
+    expect(schema.safeParse(-1).success).toBe(true);
+    expect(schema.safeParse(0).success).toBe(true);
+    expect(schema.safeParse(10).success).toBe(true);
+    expect(schema.safeParse(11).success).toBe(false);
+  });
+
+  it('should apply min if max is undefined', () => {
+    const schema = maybeWithMinMax(0, undefined)(z.number());
+    expect(schema.safeParse(-1).success).toBe(false);
+    expect(schema.safeParse(1).success).toBe(true);
+  });
+
+  it('should apply max if min is undefined', () => {
+    const schema = maybeWithMinMax(undefined, 10)(z.number());
+    expect(schema.safeParse(11).success).toBe(false);
+    expect(schema.safeParse(5).success).toBe(true);
+  });
+});

--- a/packages/core/utils/src/validation/utilities.ts
+++ b/packages/core/utils/src/validation/utilities.ts
@@ -109,7 +109,17 @@ export const maybeWithDefault = (defaultValue?: unknown) => {
  */
 export const maybeWithMinMax = (min?: number, max?: number) => {
   return <R extends z.ZodString | z.ZodEmail | z.ZodNumber | z.ZodArray<z.ZodAny>>(schema: R) => {
-    return min !== undefined && max !== undefined ? schema.min(min).max(max) : schema;
+    let result = schema;
+
+    if (min !== undefined) {
+      result = result.min(min) as R;
+    }
+
+    if (max !== undefined) {
+      result = result.max(max) as R;
+    }
+
+    return result;
   };
 };
 


### PR DESCRIPTION
Issue where Negative number attributes were not correctly compared with "minimum" requirement

Fix #24861

What does it do?
I updated the maybeWithMinMax utility function in packages/core/utils/src/validation/utilities.ts to apply min and max constraints independently. Previously, it only applied them if both were defined. I also added a unit test file packages/core/utils/src/tests/validation-utilities.test.ts to verify this behavior.

Why is it needed?
This fixes a bug where decimal number attributes (and others using this utility) were not being validated against their minimum requirement if a maximum wasn't also set (and vice versa). Specifically, negative numbers were being accepted even when they were below the configured minimum.

How to test it?
You can run the newly added unit test to verify the fix:

Navigate to packages/core/utils
Run yarn test:unit src/tests/validation-utilities.test.ts
The test confirms that both. min and max constraints are correctly applied even when used individually.