### PR TITLE
fix(content-type-builder): ai chat message width and submit behavior

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AIChat/Chat.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/Chat.tsx
@@ -340,6 +340,7 @@ const ChatInput = (props: React.FormHTMLAttributes<HTMLFormElement>) => {
                 <IconButton
                   label={t('chat.tooltips.send-message', 'Send')}
                   variant="default"
+                  type="submit"
                   // allow sending an empty message if there are attachments
                   disabled={input.trim().length === 0 && attachments.length === 0}
                 >

--- a/packages/core/content-type-builder/admin/src/components/AIChat/components/Messages/Message.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/components/Messages/Message.tsx
@@ -19,6 +19,8 @@ import { Marker } from './Marker';
 const MarkdownStyles = styled(Typography)`
   max-width: 65ch;
   margin: 0 auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 
   h1,
   h2,
@@ -75,6 +77,11 @@ const MarkdownStyles = styled(Typography)`
       text-decoration: underline;
     }
   }
+`;
+
+const UserMessageTypography = styled(Typography)`
+  overflow-wrap: anywhere;
+  word-break: break-word;
 `;
 
 // ---------------------------
@@ -195,7 +202,7 @@ const UserMessage = ({ message }: { message: UserMessageType }) => {
         <Box background="neutral150" borderStyle="none" padding={['10px', '16px']} hasRadius>
           {message.parts.map((content, index) => {
             if (content.type !== 'text') return null;
-            return <Typography key={index}>{content.text}</Typography>;
+            return <UserMessageTypography key={index}>{content.text}</UserMessageTypography>;
           })}
         </Box>
       ) : null}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

## Fix message width when long content (with no breakable characters)

### What does it do?

Adds `overflow-wrap: anywhere` and `word-break: break-word` CSS properties to both assistant messages and user messages to ensure long strings wrap within the chat message containers instead of overflowing.

### Why is it needed?

Very long strings (e.g., URLs, concatenated text without spaces) were overflowing the message bubble containers, breaking the chat UI layout and making content unreadable.
<img width="488" height="142" alt="Screenshot 2025-11-24 at 11 48 40" src="https://github.com/user-attachments/assets/cc7c804d-8600-44c6-9645-319999b7274b" />

### How to test it?

1. Open the Content-Type Builder AI chat
2. Send a message containing a very long string without spaces (e.g., "ItwouldbegreatifIcouldgrouparticlesintoseriesorcollectionslikeamulti")
3. Or trigger an AI response that contains such a long string
4. Verify that the text wraps within the message bubble boundaries instead of overflowing horizontally

## Fix submit message button

### What does it do?

Adds `type="submit"` attribute to the send message `IconButton` in the Content-Type Builder AI chat input component. This enables the button to properly trigger form submission when clicked, allowing users to submit messages via the button in addition to the Enter key.

### Why is it needed?

Previously, clicking the submit button in the AI chat did nothing - only pressing Enter would submit messages. This was because the `IconButton` component inside the form lacked the `type="submit"` attribute, so it didn't trigger the form's `onSubmit` handler. The Enter key worked because it was handled manually via a `onKeyDown` event in the `ResizableTextArea` component.

### How to test it?

1. Navigate to the Content-Type Builder in the Strapi admin panel
2. Open the AI chat (click the sparkle icon in the bottom-right corner)
3. Type a message in the chat input
4. Click the submit button (arrow up icon) - the message should be sent
5. Verify that pressing Enter still works as before
6. Verify that the button is disabled when the input is empty and there are no attachments

## Related issue(s)/PR(s)

—
