### PR TITLE
fix: change several file field types from string to text

### DIFF
--- a/packages/core/upload/server/src/content-types/file.ts
+++ b/packages/core/upload/server/src/content-types/file.ts
@@ -22,16 +22,16 @@ export default {
     },
     attributes: {
       name: {
-        type: 'string',
+        type: 'text',
         configurable: false,
         required: true,
       },
       alternativeText: {
-        type: 'string',
+        type: 'text',
         configurable: false,
       },
       caption: {
-        type: 'string',
+        type: 'text',
         configurable: false,
       },
       width: {
@@ -66,12 +66,12 @@ export default {
         required: true,
       },
       url: {
-        type: 'string',
+        type: 'text',
         configurable: false,
         required: true,
       },
       previewUrl: {
-        type: 'string',
+        type: 'text',
         configurable: false,
       },
       provider: {


### PR DESCRIPTION
### What does it do?

Changes several of the text based fields in the file content-type from the upload package from string to text

### Why is it needed?

string based fields in most databases limit the total characters of the value to 255, text (which converts to the `longtext` in some databases) have practically no limit. This is useful especially for URLs where they can easily exceed this limit.

### How to test it?

Double check the database to ensure column type changes without data loss and that you can have file type URLs, file names, ect that exceed 255 characters

### Related issue(s)/PR(s)

fixes: https://github.com/strapi/strapi/issues/22385
Also fixes another issue but I couldn't find it, cc @christophecvb
