### PR TITLE
feat(content-api): allow skipping validation/sanitization + precomputed total

### DIFF
--- a/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
@@ -15,18 +15,18 @@ export default ({ strapi }: Context) => ({
     const contentType = strapi.getModel(resourceUID);
     let total: number;
 
-    // If total is provided externally, skip compute
+    // If total is provided externally, skip compute.
     if (typeof precomputedTotal === "number") {
       total = precomputedTotal;
     } else {
-      // Run validation unless explicitly skipped
+      // Run validation unless explicitly skipped.
       if (skipValidation !== true) {
         await strapi.contentAPI.validate.query(args, contentType, {
           auth: ctx?.state?.auth,
         });
       }
 
-      // Sanitize query unless explicitly skipped
+      // Sanitize query unless explicitly skipped.
       const sanitizedQuery = skipSanitize
         ? args
         : await strapi.contentAPI.sanitize.query(args, contentType, {

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/pagination.ts
@@ -1,21 +1,40 @@
-import type { Context } from '../../types';
+import type { Context } from "../../types";
 
 export default ({ strapi }: Context) => ({
   async resolvePagination(parent: any, _: any, ctx: any) {
-    const { args, resourceUID } = parent.info;
+    const {
+      args,
+      resourceUID,
+      total: precomputedTotal,
+      skipValidation = false,
+      skipSanitize = false,
+    } = parent.info;
+
     const { start, limit } = args;
     const safeLimit = Math.max(limit, 1);
     const contentType = strapi.getModel(resourceUID);
+    let total: number;
 
-    await strapi.contentAPI.validate.query(args, contentType, {
-      auth: ctx?.state?.auth,
-    });
+    // If total is provided externally, skip compute
+    if (typeof precomputedTotal === "number") {
+      total = precomputedTotal;
+    } else {
+      // Run validation unless explicitly skipped
+      if (skipValidation !== true) {
+        await strapi.contentAPI.validate.query(args, contentType, {
+          auth: ctx?.state?.auth,
+        });
+      }
 
-    const sanitizedQuery = await strapi.contentAPI.sanitize.query(args, contentType, {
-      auth: ctx?.state?.auth,
-    });
+      // Sanitize query unless explicitly skipped
+      const sanitizedQuery = skipSanitize
+        ? args
+        : await strapi.contentAPI.sanitize.query(args, contentType, {
+            auth: ctx?.state?.auth,
+          });
 
-    const total = await strapi.documents!(resourceUID).count(sanitizedQuery);
+      total = await strapi.documents!(resourceUID).count(sanitizedQuery);
+    }
 
     const pageSize = limit === -1 ? total - start : safeLimit;
     const pageCount = limit === -1 ? safeLimit : Math.ceil(total / safeLimit);


### PR DESCRIPTION

## Summary

This PR enhances the `resolvePagination` resolver in the Strapi Content API by introducing optional parameters that improve performance and flexibility:

* **`total`** — allow passing a precomputed total to skip counting in the database
* **`skipValidation`** — optionally skip query validation if already done
* **`skipSanitize`** — optionally skip query sanitization if already done

These improvements are **fully backward-compatible**. Existing behavior remains unchanged when these options are not provided.

---

## Motivation

In complex GraphQL or custom controller scenarios, queries often:

1. Validate the query
2. Sanitize the query
3. Count documents
4. Call `resolvePagination`

This can lead to **duplicate work** and performance overhead.

Additionally, in some cases the total number of documents is already known from upstream logic, so recomputing it is unnecessary.

This PR provides optional escape hatches to improve performance while keeping the default behavior intact.

---

## Implementation

The resolver now checks:

1. If `total` is provided → skip validation, sanitization, and counting
2. If `skipValidation` is `true` → skip validation
3. If `skipSanitize` is `true` → skip sanitization
