### PR TITLE
fix: add pagination support for /api/upload/files endpoint (#24624)

### DIFF
--- a/packages/core/upload/admin/src/hooks/tests/useAssets.test.ts
+++ b/packages/core/upload/admin/src/hooks/tests/useAssets.test.ts
@@ -8,7 +8,15 @@ jest.mock('@strapi/admin/strapi-admin', () => ({
   useFetchClient: jest.fn().mockReturnValue({
     get: jest.fn().mockResolvedValue({
       data: {
-        id: 1,
+        data: [],
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: 10,
+            pageCount: 1,
+            total: 0,
+          },
+        },
       },
     }),
   }),
@@ -165,7 +173,7 @@ describe('useAssets', () => {
 
     (get as jest.Mock).mockReturnValue({
       data: {
-        results: [
+        data: [
           {
             name: null,
             mime: 'image/jpeg',
@@ -177,6 +185,14 @@ describe('useAssets', () => {
             ext: 'jpg',
           },
         ],
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: 10,
+            pageCount: 1,
+            total: 2,
+          },
+        },
       },
     });
 
@@ -198,7 +214,7 @@ describe('useAssets', () => {
 
     (get as jest.Mock).mockReturnValue({
       data: {
-        results: [
+        data: [
           {
             name: 'test 1',
             mime: null,
@@ -220,11 +236,19 @@ describe('useAssets', () => {
             ext: 'jpg',
           },
         ],
+        meta: {
+          pagination: {
+            page: 1,
+            pageSize: 10,
+            pageCount: 1,
+            total: 4,
+          },
+        },
       },
     });
 
     const { result } = setup({});
 
-    await waitFor(() => expect(result.current.data?.results ?? []).toHaveLength(0));
+    await waitFor(() => expect(result.current.data?.results ?? []).toHaveLength(4));
   });
 });

--- a/packages/core/upload/admin/src/hooks/useAssets.ts
+++ b/packages/core/upload/admin/src/hooks/useAssets.ts
@@ -5,13 +5,19 @@ import { useNotifyAT } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
 
-import { Query, GetFiles } from '../../../shared/contracts/files';
+import { Query, GetFiles, File, Pagination } from '../../../shared/contracts/files';
 import { pluginId } from '../pluginId';
 
 interface UseAssetsOptions {
   skipWhen?: boolean;
   query?: Query;
 }
+
+// Type for the transformed response that maintains backward compatibility
+type TransformedAssetsResponse = {
+  results: (File & { mime: string; ext: string })[];
+  pagination: Pagination;
+};
 
 export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {}) => {
   const { formatMessage } = useIntl();
@@ -41,10 +47,15 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
     };
   }
 
-  const { data, error, isLoading } = useQuery<GetFiles.Response, GetFiles.Response['error']>(
+  const { data, error, isLoading } = useQuery<
+    GetFiles.Response,
+    GetFiles.Response['error'],
+    TransformedAssetsResponse,
+    any
+  >(
     [pluginId, 'assets', params],
     async () => {
-      const { data } = await get('/upload/files', { params });
+      const { data } = await get<GetFiles.Response>('/upload/files', { params });
 
       return data;
     },
@@ -52,10 +63,9 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
       enabled: !skipWhen,
       staleTime: 0,
       cacheTime: 0,
-      select(data) {
+      select(data: GetFiles.Response): TransformedAssetsResponse {
         if (data?.data && Array.isArray(data.data)) {
           return {
-            ...data,
             results: data.data
               /**
                * Filter out assets that don't have a name.
@@ -76,7 +86,16 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
           };
         }
 
-        return data;
+        // Fallback for empty/invalid data
+        return {
+          results: [],
+          pagination: {
+            page: 1,
+            pageSize: 10,
+            pageCount: 0,
+            total: 0,
+          },
+        };
       },
     }
   );

--- a/packages/core/upload/admin/src/hooks/useAssets.ts
+++ b/packages/core/upload/admin/src/hooks/useAssets.ts
@@ -41,10 +41,7 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
     };
   }
 
-  const { data, error, isLoading } = useQuery<
-    GetFiles.Response['data'],
-    GetFiles.Response['error']
-  >(
+  const { data, error, isLoading } = useQuery<GetFiles.Response, GetFiles.Response['error']>(
     [pluginId, 'assets', params],
     async () => {
       const { data } = await get('/upload/files', { params });
@@ -56,10 +53,10 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
       staleTime: 0,
       cacheTime: 0,
       select(data) {
-        if (data?.results && Array.isArray(data.results)) {
+        if (data?.data && Array.isArray(data.data)) {
           return {
             ...data,
-            results: data.results
+            results: data.data
               /**
                * Filter out assets that don't have a name.
                * So we don't try to render them as assets
@@ -75,6 +72,7 @@ export const useAssets = ({ skipWhen = false, query = {} }: UseAssetsOptions = {
                 mime: asset.mime ?? '',
                 ext: asset.ext ?? '',
               })),
+            pagination: data.meta.pagination,
           };
         }
 

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -38,9 +38,14 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       await validateQuery(ctx.query, ctx);
       const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
 
-      const files = await getService('upload').findMany(sanitizedQuery);
+      const { results, pagination } = await getService('upload').findPage(sanitizedQuery);
 
-      ctx.body = await sanitizeOutput(files, ctx);
+      const sanitizedResults = await sanitizeOutput(results, ctx);
+
+      ctx.body = {
+        data: sanitizedResults,
+        meta: { pagination },
+      };
     },
 
     async findOne(ctx: Context) {

--- a/packages/core/upload/server/src/routes/content-api.ts
+++ b/packages/core/upload/server/src/routes/content-api.ts
@@ -30,7 +30,7 @@ const createRoutes = createContentApiRoutesFactory((): Core.RouterInput['routes'
           filters: validator.filters.optional(),
         },
       },
-      response: validator.files,
+      response: validator.paginatedFiles,
     },
     {
       method: 'GET',

--- a/packages/core/upload/server/src/routes/validation/upload.ts
+++ b/packages/core/upload/server/src/routes/validation/upload.ts
@@ -50,10 +50,27 @@ export class UploadRouteValidator extends AbstractRouteValidator {
   }
 
   /**
-   * Array of files schema
+   * Array of files schema (for backwards compatibility, non-paginated responses)
    */
   get files() {
     return z.array(this.file);
+  }
+
+  /**
+   * Paginated files response schema
+   */
+  get paginatedFiles() {
+    return z.object({
+      data: z.array(this.file),
+      meta: z.object({
+        pagination: z.object({
+          page: z.number().int().positive(),
+          pageSize: z.number().int().positive(),
+          pageCount: z.number().int().nonnegative(),
+          total: z.number().int().nonnegative(),
+        }),
+      }),
+    });
   }
 
   /**

--- a/packages/core/upload/shared/contracts/files.ts
+++ b/packages/core/upload/shared/contracts/files.ts
@@ -126,8 +126,8 @@ export declare namespace GetFiles {
   }
 
   export interface Response {
-    data: {
-      results: File[];
+    data: File[];
+    meta: {
       pagination: Pagination;
     };
     error?: errors.ApplicationError | errors.NotFoundError;


### PR DESCRIPTION

### What does it do?

This PR fixes an issue where **pagination was not properly applied in the Upload plugin’s file list**.  
The backend was ignoring pagination params (`page`, `pageSize`, `start`, `limit`) for `/upload/files`, causing incorrect results when navigating pages.

The fix ensures:
- Pagination params are correctly validated
- Correct query parameters are passed to the entity service
- File list responses now match expected pagination behavior

### Why is it needed?

Without this fix:
- The Upload library UI shows incorrect page results
- API consumers receive full lists instead of paginated results
- Large media libraries cause slow responses or timeouts

This update restores correct pagination functionality and improves performance in large projects.

### How to test it?

1. Go to **Media Library → List View**
2. Ensure you have more than 20 files
3. Navigate through pages  
   You should now see:
   - Correct number of items on each page  
   - Accurate total/page metadata  
   - No duplication/missing items  
4. API test:  
   Call  
```

GET /api/upload/files?page=2&pageSize=10

```
You should receive the correct paginated result.

### Related issue(s)/PR(s)

Fixes: **#24624**  
(Upload plugin pagination not working)

