### PR TITLE
fix(*): migrate IDs from int to bigint

### DIFF
--- a/examples/getstarted/compose.yml
+++ b/examples/getstarted/compose.yml
@@ -1,0 +1,27 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: strapi-empty-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: strapi
+      POSTGRES_PASSWORD: strapi
+      POSTGRES_DB: strapi
+    ports:
+      - '5100:5432'
+    volumes:
+      - ./.tmp/postgres:/var/lib/postgresql/data
+  mysql:
+    image: mysql:8.0
+    container_name: strapi-empty-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: strapi
+      MYSQL_DATABASE: strapi
+      MYSQL_USER: strapi
+      MYSQL_PASSWORD: strapi
+    ports:
+      - '5101:3306'
+    volumes:
+      - ./.tmp/mysql:/var/lib/mysql
+    command: --default-authentication-plugin=mysql_native_password

--- a/examples/getstarted/config/database.js
+++ b/examples/getstarted/config/database.js
@@ -1,51 +1,55 @@
-const sqlite = {
-  client: 'sqlite',
-  connection: {
-    filename: '.tmp/data.db',
-  },
-  useNullAsDefault: true,
-};
+module.exports = ({ env }) => {
+  const client = env('DATABASE_CLIENT', 'sqlite');
 
-const postgres = {
-  client: 'postgres',
-  connection: {
-    database: 'strapi',
-    user: 'strapi',
-    password: 'strapi',
-    port: 5432,
-    host: 'localhost',
-  },
-};
+  const sqlite = {
+    client: 'sqlite',
+    connection: {
+      filename: '.tmp/data.db',
+    },
+    useNullAsDefault: true,
+  };
 
-const mysql = {
-  client: 'mysql',
-  connection: {
-    database: 'strapi',
-    user: 'strapi',
-    password: 'strapi',
-    port: 3306,
-    host: 'localhost',
-  },
-};
+  const postgres = {
+    client: 'postgres',
+    connection: {
+      database: env('DATABASE_NAME', 'strapi'),
+      user: env('DATABASE_USERNAME', 'strapi'),
+      password: env('DATABASE_PASSWORD', 'strapi'),
+      port: env('DATABASE_PORT', 5432),
+      host: env('DATABASE_HOST', 'localhost'),
+    },
+  };
 
-const mariadb = {
-  client: 'mysql',
-  connection: {
-    database: 'strapi',
-    user: 'strapi',
-    password: 'strapi',
-    port: 3307,
-    host: 'localhost',
-  },
-};
+  const mysql = {
+    client: 'mysql',
+    connection: {
+      database: env('DATABASE_NAME', 'strapi'),
+      user: env('DATABASE_USERNAME', 'strapi'),
+      password: env('DATABASE_PASSWORD', 'strapi'),
+      port: env('DATABASE_PORT', 3306),
+      host: env('DATABASE_HOST', 'localhost'),
+    },
+  };
 
-const db = {
-  mysql,
-  sqlite,
-  postgres,
-  mariadb,
-};
+  const mariadb = {
+    client: 'mysql',
+    connection: {
+      database: env('DATABASE_NAME', 'strapi'),
+      user: env('DATABASE_USERNAME', 'strapi'),
+      password: env('DATABASE_PASSWORD', 'strapi'),
+      port: env('DATABASE_PORT', 3307),
+      host: env('DATABASE_HOST', 'localhost'),
+    },
+  };
 
-module.exports = {
-  connection: process.env.DB ? db[process.env.DB] || db.sqlite : db.sqlite,
+  const db = {
+    mysql,
+    sqlite,
+    postgres,
+    mariadb,
+  };
+
+  return {
+    connection: client ? db[client] || db.sqlite : db.sqlite,
+  };
 };

--- a/packages/core/content-manager/server/src/history/models/history-version.ts
+++ b/packages/core/content-manager/server/src/history/models/history-version.ts
@@ -7,7 +7,7 @@ const historyVersion: Model = {
   singularName: 'history-version',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
     },
     contentType: {
       type: 'string',

--- a/packages/core/content-manager/server/src/services/data-mapper.ts
+++ b/packages/core/content-manager/server/src/services/data-mapper.ts
@@ -24,7 +24,7 @@ export default () => ({
       isDisplayed: isVisible(contentType),
       attributes: {
         id: {
-          type: 'integer',
+          type: 'biginteger',
         },
         ...formatAttributes(contentType),
         documentId: {

--- a/packages/core/core/src/services/core-store.ts
+++ b/packages/core/core/src/services/core-store.ts
@@ -7,7 +7,7 @@ const coreStoreModel: Model = {
   tableName: 'strapi_core_store_settings',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
     },
     key: {
       type: 'string',

--- a/packages/core/core/src/services/webhook-store.ts
+++ b/packages/core/core/src/services/webhook-store.ts
@@ -14,7 +14,7 @@ const webhookModel: Model = {
   tableName: 'strapi_webhooks',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
     },
     name: {
       type: 'string',

--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
@@ -140,9 +140,11 @@ const expectedModels = [
     uid: 'countries_components',
     tableName: 'countries_components',
     attributes: {
-      id: { type: 'increments' },
-      entity_id: { type: 'integer', column: { unsigned: true } },
-      component_id: { type: 'integer', column: { unsigned: true } },
+      id: {
+        type: 'bigincrements',
+      },
+      entity_id: { type: 'biginteger', column: { unsigned: true } },
+      component_id: { type: 'biginteger', column: { unsigned: true } },
       component_type: { type: 'string' },
       field: { type: 'string' },
       order: { type: 'float', column: { unsigned: true, defaultTo: null } },
@@ -172,7 +174,9 @@ const expectedModels = [
     singularName: 'country',
     tableName: 'countries',
     attributes: {
-      id: { type: 'increments' },
+      id: {
+        type: 'bigincrements',
+      },
       documentId: { type: 'string' },
       name: { default: 'my name', type: 'string' },
       categories: { type: 'relation', relation: 'oneToMany', target: 'api::category.category' },
@@ -246,7 +250,9 @@ const expectedModels = [
     singularName: 'category',
     tableName: 'categories',
     attributes: {
-      id: { type: 'increments' },
+      id: {
+        type: 'bigincrements',
+      },
       documentId: { type: 'string' },
       name: { type: 'string' },
     },
@@ -262,7 +268,11 @@ const expectedModels = [
     uid: 'api::empty.empty',
     singularName: 'empty',
     tableName: 'empty',
-    attributes: { id: { type: 'increments' } },
+    attributes: {
+      id: {
+        type: 'bigincrements',
+      },
+    },
     lifecycles: {},
   },
 ];

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -210,16 +210,16 @@ const createCompoLinkModel = (
     tableName: name,
     attributes: {
       [identifiers.ID_COLUMN]: {
-        type: 'increments',
+        type: 'bigincrements',
       },
       [entityId]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
       },
       [componentId]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
@@ -311,7 +311,7 @@ export const transformContentTypesToModels = (
       tableName: contentType.collectionName, // This gets shortened in metadata.loadModels(), so we don't shorten here or it will happen twice
       attributes: {
         [identifiers.ID_COLUMN]: {
-          type: 'increments',
+          type: 'bigincrements',
         },
         ...documentIdAttribute,
         ...transformAttributes(contentType, identifiers),

--- a/packages/core/data-transfer/src/strapi/queries/__tests__/link.test.ts
+++ b/packages/core/data-transfer/src/strapi/queries/__tests__/link.test.ts
@@ -3,7 +3,7 @@ import { filterValidRelationalAttributes } from '../link';
 describe('link queries realtion fitlers', () => {
   test('filter out non relation attributes', () => {
     const attributes = {
-      id: { type: 'increments', columnName: 'id' },
+      id: { type: 'bigincrements', columnName: 'id' },
       name: { type: 'string', required: true, columnName: 'name' },
       test: { type: 'string', columnName: 'test' },
       categories: {
@@ -32,7 +32,7 @@ describe('link queries realtion fitlers', () => {
 
   test('filter out cmps tables from attributes', () => {
     const attributes = {
-      id: { type: 'increments', columnName: 'id' },
+      id: { type: 'bigincrements', columnName: 'id' },
       label: { type: 'string', default: 'toto', columnName: 'label' },
       start_date: { type: 'date', required: true, columnName: 'start_date' },
       end_date: { type: 'date', required: true, columnName: 'end_date' },

--- a/packages/core/database/src/dialects/sqlite/index.ts
+++ b/packages/core/database/src/dialects/sqlite/index.ts
@@ -61,6 +61,14 @@ export default class SqliteDialect extends Dialect {
       case 'timestamp': {
         return 'datetime';
       }
+      case 'bigIncrements': {
+        // SQLite requires INTEGER (not bigint) for AUTOINCREMENT
+        return 'increments';
+      }
+      case 'bigInteger': {
+        // SQLite doesn't have a separate bigint type, uses INTEGER
+        return 'integer';
+      }
       default: {
         return type;
       }

--- a/packages/core/database/src/dialects/sqlite/schema-inspector.ts
+++ b/packages/core/database/src/dialects/sqlite/schema-inspector.ts
@@ -61,7 +61,7 @@ const toStrapiType = (column: RawColumn) => {
   switch (rootType) {
     case 'integer': {
       if (column.pk) {
-        return { type: 'increments', args: [{ primary: true, primaryKey: true }] };
+        return { type: 'increments', args: [{ primaryKey: true }] };
       }
 
       return { type: 'integer' };
@@ -70,6 +70,10 @@ const toStrapiType = (column: RawColumn) => {
       return { type: 'float', args: [10, 2] };
     }
     case 'bigint': {
+      if (column.pk) {
+        return { type: 'bigIncrements', args: [{ primaryKey: true }] };
+      }
+
       return { type: 'bigInteger' };
     }
     case 'varchar': {

--- a/packages/core/database/src/fields/__tests__/biginteger-integration.test.ts
+++ b/packages/core/database/src/fields/__tests__/biginteger-integration.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Integration test for BigIntegerField to verify it works with the transform pipeline.
+ *
+ * Tests the distinction between:
+ * - Internal columns (IDs, FK columns) → cast to numbers
+ * - User-defined biginteger attributes → return as strings (backwards compatible)
+ */
+import { fromRow } from '../../query/helpers/transform';
+import type { Meta } from '../../metadata';
+
+describe('BigIntegerField Integration', () => {
+  describe('Internal columns (IDs and FKs)', () => {
+    // Mock metadata for a join table with internal biginteger columns
+    const mockJoinTableMeta: Meta = {
+      uid: 'articles_authors_lnk',
+      tableName: 'articles_authors_lnk',
+      attributes: {
+        id: {
+          type: 'bigincrements',
+          columnName: 'id',
+        },
+        article_id: {
+          type: 'biginteger',
+          columnName: 'article_id',
+          internalIntegerId: true, // FK column
+        },
+        author_id: {
+          type: 'biginteger',
+          columnName: 'author_id',
+          internalIntegerId: true, // FK column
+        },
+      },
+      columnToAttribute: {
+        id: 'id',
+        article_id: 'article_id',
+        author_id: 'author_id',
+      },
+    } as unknown as Meta;
+
+    it('should convert ID (bigincrements) to number', () => {
+      const dbRow = {
+        id: '123',
+        article_id: '1',
+        author_id: '2',
+      };
+
+      const result = fromRow(mockJoinTableMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 123,
+        article_id: 1,
+        author_id: 2,
+      });
+    });
+
+    it('should convert internal FK columns to numbers', () => {
+      const dbRow = {
+        id: '1',
+        article_id: '456',
+        author_id: '789',
+      };
+
+      const result = fromRow(mockJoinTableMeta, dbRow) as any;
+
+      expect(typeof result.article_id).toBe('number');
+      expect(typeof result.author_id).toBe('number');
+      expect(result.article_id).toBe(456);
+      expect(result.author_id).toBe(789);
+    });
+
+    it('should handle null FK values', () => {
+      const dbRow = {
+        id: '123',
+        article_id: null,
+        author_id: '1',
+      };
+
+      const result = fromRow(mockJoinTableMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 123,
+        article_id: null,
+        author_id: 1,
+      });
+    });
+
+    it('should handle large IDs within MAX_SAFE_INTEGER', () => {
+      const largeId = String(Number.MAX_SAFE_INTEGER - 1000);
+      const dbRow = {
+        id: largeId,
+        article_id: '1',
+        author_id: '1',
+      };
+
+      const result = fromRow(mockJoinTableMeta, dbRow) as any;
+
+      expect(result.id).toBe(Number(largeId));
+      expect(typeof result.id).toBe('number');
+    });
+
+    it('should throw error when ID exceeds MAX_SAFE_INTEGER', () => {
+      const overflowId = String(Number.MAX_SAFE_INTEGER + 1);
+      const dbRow = {
+        id: overflowId,
+        article_id: '1',
+        author_id: '1',
+      };
+
+      expect(() => fromRow(mockJoinTableMeta, dbRow)).toThrow(
+        /exceeds JavaScript's MAX_SAFE_INTEGER/
+      );
+    });
+
+    it('should handle arrays of join table rows', () => {
+      const dbRows = [
+        { id: '1', article_id: '10', author_id: '100' },
+        { id: '2', article_id: '20', author_id: '200' },
+        { id: '3', article_id: '30', author_id: '300' },
+      ];
+
+      const result = fromRow(mockJoinTableMeta, dbRows);
+
+      expect(result).toEqual([
+        { id: 1, article_id: 10, author_id: 100 },
+        { id: 2, article_id: 20, author_id: 200 },
+        { id: 3, article_id: 30, author_id: 300 },
+      ]);
+    });
+  });
+
+  describe('User-defined biginteger attributes', () => {
+    // Mock metadata for a content type with user-defined biginteger
+    const mockContentTypeMeta: Meta = {
+      uid: 'api::product.product',
+      tableName: 'products',
+      attributes: {
+        id: {
+          type: 'bigincrements',
+          columnName: 'id',
+        },
+        name: {
+          type: 'string',
+          columnName: 'name',
+        },
+        sku: {
+          type: 'biginteger', // User-defined, no __internal__
+          columnName: 'sku',
+        },
+        inventory_count: {
+          type: 'biginteger', // User-defined, no __internal__
+          columnName: 'inventory_count',
+        },
+      },
+      columnToAttribute: {
+        id: 'id',
+        name: 'name',
+        sku: 'sku',
+        inventory_count: 'inventory_count',
+      },
+    } as unknown as Meta;
+
+    it('should return user-defined biginteger as string (backwards compatible)', () => {
+      const dbRow = {
+        id: '1',
+        name: 'Widget',
+        sku: '123456789012345',
+        inventory_count: '1000',
+      };
+
+      const result = fromRow(mockContentTypeMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 1, // ID is still a number (type: bigincrements)
+        name: 'Widget',
+        sku: '123456789012345', // String
+        inventory_count: '1000', // String
+      });
+    });
+
+    it('should preserve large numbers as strings without overflow error', () => {
+      // User-defined biginteger can hold values beyond MAX_SAFE_INTEGER
+      const hugeBigInt = '9007199254740992'; // MAX_SAFE_INTEGER + 1
+      const veryLarge = '99999999999999999999';
+
+      const dbRow = {
+        id: '1',
+        name: 'Big Number Product',
+        sku: hugeBigInt,
+        inventory_count: veryLarge,
+      };
+
+      const result = fromRow(mockContentTypeMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 1,
+        name: 'Big Number Product',
+        sku: hugeBigInt, // Preserved as string
+        inventory_count: veryLarge, // Preserved as string
+      });
+    });
+
+    it('should handle null user-defined biginteger values', () => {
+      const dbRow = {
+        id: '1',
+        name: 'Widget',
+        sku: null,
+        inventory_count: '100',
+      };
+
+      const result = fromRow(mockContentTypeMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 1,
+        name: 'Widget',
+        sku: null,
+        inventory_count: '100',
+      });
+    });
+
+    it('should handle arrays of rows with user-defined biginteger', () => {
+      const dbRows = [
+        { id: '1', name: 'Product 1', sku: '111', inventory_count: '10' },
+        { id: '2', name: 'Product 2', sku: '222', inventory_count: '20' },
+      ];
+
+      const result = fromRow(mockContentTypeMeta, dbRows);
+
+      expect(result).toEqual([
+        { id: 1, name: 'Product 1', sku: '111', inventory_count: '10' },
+        { id: 2, name: 'Product 2', sku: '222', inventory_count: '20' },
+      ]);
+    });
+  });
+
+  describe('Mixed scenarios', () => {
+    // Content type with both internal FK and user-defined biginteger
+    const mockMixedMeta: Meta = {
+      uid: 'api::order.order',
+      tableName: 'orders',
+      attributes: {
+        id: {
+          type: 'bigincrements',
+          columnName: 'id',
+        },
+        order_number: {
+          type: 'biginteger', // User-defined
+          columnName: 'order_number',
+        },
+        customer_id: {
+          type: 'biginteger',
+          columnName: 'customer_id',
+          internalIntegerId: true, // FK column
+        },
+      },
+      columnToAttribute: {
+        id: 'id',
+        order_number: 'order_number',
+        customer_id: 'customer_id',
+      },
+    } as unknown as Meta;
+
+    it('should correctly distinguish internal vs user-defined biginteger', () => {
+      const dbRow = {
+        id: '1',
+        order_number: '9007199254740992', // User-defined, large number OK
+        customer_id: '42', // Internal FK, cast to number
+      };
+
+      const result = fromRow(mockMixedMeta, dbRow);
+
+      expect(result).toEqual({
+        id: 1,
+        order_number: '9007199254740992', // String preserved
+        customer_id: 42, // Number
+      });
+    });
+
+    it('should throw for internal FK overflow but not user-defined', () => {
+      const overflowValue = String(Number.MAX_SAFE_INTEGER + 1);
+
+      // User-defined can handle overflow
+      const dbRowUserDefined = {
+        id: '1',
+        order_number: overflowValue,
+        customer_id: '1',
+      };
+      expect(() => fromRow(mockMixedMeta, dbRowUserDefined)).not.toThrow();
+
+      // Internal FK throws on overflow
+      const dbRowInternalFK = {
+        id: '1',
+        order_number: '100',
+        customer_id: overflowValue,
+      };
+      expect(() => fromRow(mockMixedMeta, dbRowInternalFK)).toThrow(
+        /exceeds JavaScript's MAX_SAFE_INTEGER/
+      );
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    const mockMeta: Meta = {
+      uid: 'articles_links',
+      tableName: 'articles_links',
+      attributes: {
+        id: {
+          type: 'bigincrements',
+          columnName: 'id',
+        },
+        article_id: {
+          type: 'biginteger',
+          columnName: 'article_id',
+          internalIntegerId: true,
+        },
+      },
+      columnToAttribute: {
+        id: 'id',
+        article_id: 'article_id',
+      },
+    } as unknown as Meta;
+
+    it('should handle typical Strapi ID ranges (1 to millions)', () => {
+      const testCases = [
+        '1',
+        '100',
+        '1000',
+        '10000',
+        '100000',
+        '1000000',
+        '10000000',
+        '100000000',
+        '1000000000',
+      ];
+
+      testCases.forEach((idStr) => {
+        const dbRow = { id: idStr, article_id: '1' };
+        const result = fromRow(mockMeta, dbRow) as any;
+        expect(result.id).toBe(Number(idStr));
+        expect(typeof result.id).toBe('number');
+      });
+    });
+
+    it('should maintain backwards compatibility with existing numeric IDs', () => {
+      const dbRow = {
+        id: '42',
+        article_id: '100',
+      };
+
+      const result = fromRow(mockMeta, dbRow) as any;
+
+      // These should all work as before
+      expect(typeof result.id).toBe('number');
+      expect(result.id).toBe(42);
+      expect(result.id + 1).toBe(43);
+      expect(result.id > 40).toBe(true);
+      expect(result.id === 42).toBe(true);
+    });
+  });
+});

--- a/packages/core/database/src/fields/__tests__/biginteger.test.ts
+++ b/packages/core/database/src/fields/__tests__/biginteger.test.ts
@@ -1,0 +1,145 @@
+import BigIntegerField from '../biginteger';
+import type { Attribute } from '../../types';
+
+describe('BigIntegerField', () => {
+  describe('Internal columns (IDs and FK columns)', () => {
+    describe('type: increments (ID column)', () => {
+      let field: BigIntegerField;
+
+      beforeEach(() => {
+        field = new BigIntegerField({ type: 'increments' } as Attribute);
+      });
+
+      it('should convert string to number', () => {
+        expect(field.fromDB('123')).toBe(123);
+        expect(field.fromDB('0')).toBe(0);
+        expect(field.fromDB('1')).toBe(1);
+      });
+
+      it('should convert negative strings to numbers', () => {
+        expect(field.fromDB('-123')).toBe(-123);
+      });
+
+      it('should handle large numbers within MAX_SAFE_INTEGER', () => {
+        const maxSafeInteger = Number.MAX_SAFE_INTEGER;
+        expect(field.fromDB(String(maxSafeInteger))).toBe(maxSafeInteger);
+        expect(field.fromDB(String(maxSafeInteger - 1))).toBe(maxSafeInteger - 1);
+      });
+
+      it('should handle values that are already numbers', () => {
+        expect(field.fromDB(123)).toBe(123);
+        expect(field.fromDB(0)).toBe(0);
+        expect(field.fromDB(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+      });
+
+      it('should throw error when value exceeds MAX_SAFE_INTEGER (as string)', () => {
+        const overflowValue = String(Number.MAX_SAFE_INTEGER + 1);
+        expect(() => field.fromDB(overflowValue)).toThrow(/exceeds JavaScript's MAX_SAFE_INTEGER/);
+      });
+
+      it('should throw error when value exceeds MAX_SAFE_INTEGER (as number)', () => {
+        const overflowValue = Number.MAX_SAFE_INTEGER + 1;
+        expect(() => field.fromDB(overflowValue)).toThrow(/exceeds JavaScript's MAX_SAFE_INTEGER/);
+      });
+
+      it('should throw error for invalid string values', () => {
+        expect(() => field.fromDB('not-a-number')).toThrow(/Cannot convert value/);
+        expect(() => field.fromDB('abc')).toThrow(/Cannot convert value/);
+      });
+
+      it('should handle typical ID values', () => {
+        expect(field.fromDB('1')).toBe(1);
+        expect(field.fromDB('1000')).toBe(1000);
+        expect(field.fromDB('999999')).toBe(999999);
+        expect(field.fromDB('1000000000')).toBe(1000000000);
+      });
+    });
+
+    describe('type: bigincrements (ID column after migration)', () => {
+      let field: BigIntegerField;
+
+      beforeEach(() => {
+        field = new BigIntegerField({ type: 'bigincrements' } as Attribute);
+      });
+
+      it('should convert string to number', () => {
+        expect(field.fromDB('123')).toBe(123);
+        expect(field.fromDB('0')).toBe(0);
+        expect(field.fromDB('1')).toBe(1);
+      });
+
+      it('should throw error when value exceeds MAX_SAFE_INTEGER', () => {
+        const overflowValue = String(Number.MAX_SAFE_INTEGER + 1);
+        expect(() => field.fromDB(overflowValue)).toThrow(/exceeds JavaScript's MAX_SAFE_INTEGER/);
+      });
+    });
+
+    describe('type: biginteger with internalIntegerId: true (FK column)', () => {
+      let field: BigIntegerField;
+
+      beforeEach(() => {
+        field = new BigIntegerField({
+          type: 'biginteger',
+          internalIntegerId: true,
+        } as Attribute);
+      });
+
+      it('should convert string to number for internal FK columns', () => {
+        expect(field.fromDB('123')).toBe(123);
+        expect(field.fromDB('0')).toBe(0);
+        expect(field.fromDB('456')).toBe(456);
+      });
+
+      it('should throw error when FK value exceeds MAX_SAFE_INTEGER', () => {
+        const overflowValue = String(Number.MAX_SAFE_INTEGER + 1);
+        expect(() => field.fromDB(overflowValue)).toThrow(/exceeds JavaScript's MAX_SAFE_INTEGER/);
+      });
+    });
+  });
+
+  describe('User-defined biginteger attributes', () => {
+    let field: BigIntegerField;
+
+    beforeEach(() => {
+      // User-defined biginteger: no __internal__ flag
+      field = new BigIntegerField({ type: 'biginteger' } as Attribute);
+    });
+
+    it('should return string for user-defined biginteger (backwards compatible)', () => {
+      expect(field.fromDB('123')).toBe('123');
+      expect(field.fromDB('0')).toBe('0');
+      expect(field.fromDB('1')).toBe('1');
+    });
+
+    it('should preserve string representation of large numbers', () => {
+      // Values beyond MAX_SAFE_INTEGER should be preserved as strings
+      const hugeBigInt = '9007199254740992'; // MAX_SAFE_INTEGER + 1
+      expect(field.fromDB(hugeBigInt)).toBe(hugeBigInt);
+
+      const veryLarge = '99999999999999999999';
+      expect(field.fromDB(veryLarge)).toBe(veryLarge);
+    });
+
+    it('should convert number to string', () => {
+      expect(field.fromDB(123)).toBe('123');
+      expect(field.fromDB(0)).toBe('0');
+    });
+
+    it('should handle negative values', () => {
+      expect(field.fromDB('-123')).toBe('-123');
+      expect(field.fromDB(-456)).toBe('-456');
+    });
+  });
+
+  describe('toDB', () => {
+    it('should convert values to strings for both internal and user-defined', () => {
+      const internalField = new BigIntegerField({ type: 'increments' } as Attribute);
+      const userField = new BigIntegerField({ type: 'biginteger' } as Attribute);
+
+      expect(internalField.toDB(123)).toBe('123');
+      expect(internalField.toDB(0)).toBe('0');
+      expect(userField.toDB(123)).toBe('123');
+      expect(userField.toDB(0)).toBe('0');
+    });
+  });
+});

--- a/packages/core/database/src/fields/biginteger.ts
+++ b/packages/core/database/src/fields/biginteger.ts
@@ -1,3 +1,81 @@
-import StringField from './string';
+import { toString } from 'lodash/fp';
+import Field from './field';
 
-export default class BigIntegerField extends StringField {}
+/**
+ * BigIntegerField handles bigint columns from the database.
+ *
+ * For internal columns (IDs, relation FKs), we convert to numbers for backwards
+ * compatibility. We validate that values don't exceed JavaScript's
+ * MAX_SAFE_INTEGER (2^53 - 1) to ensure precision.
+ *
+ * For user-defined biginteger attributes, we keep the string representation
+ * to avoid breaking changes and precision loss for large numbers.
+ */
+export default class BigIntegerField extends Field {
+  toDB(value: unknown) {
+    return toString(value);
+  }
+
+  fromDB(value: unknown): number | string {
+    // Internal columns (IDs and FK columns) are cast to numbers
+    // - type 'increments' or 'bigincrements' is used for ID columns
+    // - internalIntegerId flag marks FK columns in join tables
+    const isInternalColumn =
+      this.attribute.type === 'increments' ||
+      this.attribute.type === 'bigincrements' ||
+      ('internalIntegerId' in this.attribute && this.attribute.internalIntegerId === true);
+
+    if (isInternalColumn) {
+      return this.toNumber(value);
+    }
+
+    // User-defined biginteger attributes return as string (backwards compatible)
+    return this.toString(value);
+  }
+
+  /**
+   * Converts a bigint value to a string representation.
+   * Used for user-defined biginteger attributes to preserve precision.
+   */
+  private toString(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    return toString(value);
+  }
+
+  /**
+   * Converts a bigint value to a number.
+   * Used for internal columns (IDs, FKs) where we expect values within safe integer range.
+   * Throws if the value exceeds MAX_SAFE_INTEGER.
+   */
+  private toNumber(value: unknown): number {
+    let numberValue: number;
+
+    // Optimize for the hot path: Knex returns bigint as strings
+    if (typeof value === 'string') {
+      numberValue = Number(value);
+    } else if (typeof value === 'number') {
+      numberValue = value;
+    } else {
+      // Fallback for unexpected types
+      numberValue = Number(String(value));
+    }
+
+    // Validate conversion succeeded
+    if (Number.isNaN(numberValue)) {
+      throw new Error(`Cannot convert value "${value}" to a valid number`);
+    }
+
+    // Check for overflow beyond MAX_SAFE_INTEGER
+    if (!Number.isSafeInteger(numberValue)) {
+      throw new Error(
+        `BigInt value ${value} exceeds JavaScript's MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}). ` +
+          `This may indicate data corruption or an ID overflow.`
+      );
+    }
+
+    return numberValue;
+  }
+}

--- a/packages/core/database/src/fields/field.ts
+++ b/packages/core/database/src/fields/field.ts
@@ -1,8 +1,10 @@
-export default class Field {
-  config: unknown;
+import type { Attribute } from '../types';
 
-  constructor(config: unknown) {
-    this.config = config;
+export default class Field {
+  attribute: Attribute;
+
+  constructor(attribute: Attribute) {
+    this.attribute = attribute;
   }
 
   toDB(value: unknown) {

--- a/packages/core/database/src/fields/index.ts
+++ b/packages/core/database/src/fields/index.ts
@@ -14,7 +14,8 @@ import BooleanField from './boolean';
 import type { Attribute } from '../types';
 
 const typeToFieldMap: Record<string, typeof Field> = {
-  increments: Field,
+  increments: BigIntegerField,
+  bigincrements: BigIntegerField,
   password: StringField,
   email: StringField,
   string: StringField,
@@ -39,7 +40,7 @@ export const createField = (attribute: Attribute): Field => {
   const { type } = attribute;
 
   if (_.has(type, typeToFieldMap)) {
-    return new typeToFieldMap[type]({});
+    return new typeToFieldMap[type](attribute);
   }
 
   throw new Error(`Undefined field for type ${type}`);

--- a/packages/core/database/src/metadata/__tests__/metadata.test.ts
+++ b/packages/core/database/src/metadata/__tests__/metadata.test.ts
@@ -90,7 +90,7 @@ describe('metadata', () => {
 
         // Test cases: Each entry is [attributeName, attributeDetails, expectedDetails]
         const testCases = [
-          ['id', { type: 'increments' }, { type: 'increments', columnName: 'id' }], // allows id
+          ['id', { type: 'bigincrements' }, { type: 'bigincrements', columnName: 'id' }], // allows id
           ['documentId', { type: 'string' }, { type: 'string', columnName: 'document_id' }], // allows documentId
           ['document_id', { type: 'string' }, { type: 'string', columnName: 'document_id' }], // allows documentId
           [

--- a/packages/core/database/src/metadata/__tests__/resources/expected-hashed-metadata.ts
+++ b/packages/core/database/src/metadata/__tests__/resources/expected-hashed-metadata.ts
@@ -9,7 +9,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -43,7 +43,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -89,18 +89,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes_comple5354f_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -156,7 +158,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -190,7 +192,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -264,18 +266,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes_comple3e8ce_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -344,7 +348,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -413,18 +417,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes_comple64178_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -480,7 +486,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -559,18 +565,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes_comple61dc1_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -654,7 +662,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'components_default_l807d8',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             longcomponentname: {
@@ -725,7 +733,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -775,18 +783,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'componen56bca_complex_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -840,18 +850,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'compon56bca_complexes_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -920,7 +932,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'components_default_l807d8',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             longcomponentname: {
@@ -991,7 +1003,7 @@ export const expectedMetadataHashedResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -1041,18 +1053,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'componen56bca_complex_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1106,18 +1120,20 @@ export const expectedMetadataHashedResults = {
           tableName: 'compon56bca_complexes_lnk',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1187,7 +1203,7 @@ export const expectedMetadataHashedResults = {
         tableName: 'components_default_l807d8',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           longcomponentname: {
@@ -1258,7 +1274,7 @@ export const expectedMetadataHashedResults = {
         tableName: 'complexes',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           documentId: {
@@ -1312,18 +1328,20 @@ export const expectedMetadataHashedResults = {
         tableName: 'componen56bca_complex_lnk',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           long_component_name_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
             columnName: 'long_component_name_id',
           },
           complex_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
@@ -1377,18 +1395,20 @@ export const expectedMetadataHashedResults = {
         tableName: 'compon56bca_complexes_lnk',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           long_component_name_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
             columnName: 'long_component_name_id',
           },
           complex_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },

--- a/packages/core/database/src/metadata/__tests__/resources/expected-metadata.ts
+++ b/packages/core/database/src/metadata/__tests__/resources/expected-metadata.ts
@@ -4,7 +4,7 @@ export const baseMetadata = {
   tableName: 'complexes',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
       columnName: 'id',
     },
     documentId: {
@@ -33,7 +33,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -67,7 +67,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -113,18 +113,20 @@ export const expectedMetadataResults = {
           tableName: 'complexes_complexhasonecomplex_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -180,7 +182,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -214,7 +216,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -288,18 +290,20 @@ export const expectedMetadataResults = {
           tableName: 'complexes_complexhasmanycomplexes_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -368,7 +372,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -437,18 +441,20 @@ export const expectedMetadataResults = {
           tableName: 'complexes_complexhasandbelongstoonecomplex_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -504,7 +510,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -583,18 +589,20 @@ export const expectedMetadataResults = {
           tableName: 'complexes_complexeshasandbelongstomanycomplexes_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'complex_id',
             },
             inv_complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -676,7 +684,7 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             longcomponentname: {
@@ -747,7 +755,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -796,18 +804,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complex_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -861,18 +871,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complexes_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -943,7 +955,7 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             longcomponentname: {
@@ -1014,7 +1026,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -1064,18 +1076,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complex_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1129,18 +1143,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complexes_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1209,7 +1225,7 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             longcomponentname: {
@@ -1280,7 +1296,7 @@ export const expectedMetadataResults = {
           tableName: 'complexes',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             documentId: {
@@ -1330,18 +1346,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complex_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1395,18 +1413,20 @@ export const expectedMetadataResults = {
           tableName: 'components_default_long_component_names_complexes_links',
           attributes: {
             id: {
-              type: 'increments',
+              type: 'bigincrements',
               columnName: 'id',
             },
             long_component_name_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
               columnName: 'long_component_name_id',
             },
             complex_id: {
-              type: 'integer',
+              type: 'biginteger',
+              internalIntegerId: true,
               column: {
                 unsigned: true,
               },
@@ -1476,7 +1496,7 @@ export const expectedMetadataResults = {
         tableName: 'components_default_long_component_names',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           longcomponentname: {
@@ -1547,7 +1567,7 @@ export const expectedMetadataResults = {
         tableName: 'complexes',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           documentId: {
@@ -1601,18 +1621,20 @@ export const expectedMetadataResults = {
         tableName: 'components_default_long_component_names_complex_links',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           long_component_name_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
             columnName: 'long_component_name_id',
           },
           complex_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
@@ -1666,18 +1688,20 @@ export const expectedMetadataResults = {
         tableName: 'components_default_long_component_names_complexes_links',
         attributes: {
           id: {
-            type: 'increments',
+            type: 'bigincrements',
             columnName: 'id',
           },
           long_component_name_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },
             columnName: 'long_component_name_id',
           },
           complex_id: {
-            type: 'integer',
+            type: 'biginteger',
+            internalIntegerId: true,
             column: {
               unsigned: true,
             },

--- a/packages/core/database/src/metadata/__tests__/resources/models.ts
+++ b/packages/core/database/src/metadata/__tests__/resources/models.ts
@@ -4,7 +4,7 @@ export const auxComponent = {
   tableName: 'components_default_long_component_names',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
     },
     longcomponentname: {
       type: 'string',
@@ -28,7 +28,7 @@ export const baseModel = {
   tableName: 'complexes',
   attributes: {
     id: {
-      type: 'increments',
+      type: 'bigincrements',
     },
     documentId: {
       type: 'string',

--- a/packages/core/database/src/metadata/relations.ts
+++ b/packages/core/database/src/metadata/relations.ts
@@ -255,21 +255,23 @@ const createMorphToMany = (
     tableName: joinTableName,
     attributes: {
       [ID]: {
-        type: 'increments',
+        type: 'bigincrements',
       },
       [joinColumnName]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
         // This must be set explicitly so that it is used instead of shortening the attribute name, which is already shortened
         columnName: joinColumnName,
+        internalIntegerId: true,
       },
       [idColumnName]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
+        internalIntegerId: true,
       },
       [typeColumnName]: {
         type: 'string',
@@ -469,23 +471,25 @@ const createJoinTable = (
     tableName: joinTableName,
     attributes: {
       [ID]: {
-        type: 'increments',
+        type: 'bigincrements',
       },
       [joinColumnName]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
         // This must be set explicitly so that it is used instead of shortening the attribute name, which is already shortened
         columnName: joinColumnName,
+        internalIntegerId: true,
       },
       [inverseJoinColumnName]: {
-        type: 'integer',
+        type: 'biginteger',
         column: {
           unsigned: true,
         },
         // This must be set explicitly so that it is used instead of shortening the attribute name, which is already shortened
         columnName: inverseJoinColumnName,
+        internalIntegerId: true,
       },
       // TODO: add extra pivot attributes -> user should use an intermediate entity
     },

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-06-migrate-ids-from-int-to-bigint.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-06-migrate-ids-from-int-to-bigint.ts
@@ -1,0 +1,467 @@
+/**
+ * Migration to convert all ID columns (primary keys and foreign keys) from INTEGER to BIGINT.
+ *
+ * This migration handles:
+ * - Primary key columns (id) in all content type tables
+ * - Foreign key columns in join tables and relation tables
+ * - Proper handling of foreign key constraints (drop before, recreate after)
+ * - Database-specific conversion logic for MySQL, PostgreSQL, and SQLite
+ *
+ * Note: This migration must run BEFORE schema sync to avoid conflicts.
+ */
+import type { Knex } from 'knex';
+
+import debug from 'debug';
+import type { Migration } from '../common';
+import type { Database } from '../../index';
+
+const migrationDebug = debug('strapi::database::migration::bigint');
+
+/**
+ * Get all foreign keys that reference a specific column in a table
+ */
+const getForeignKeysReferencingColumn = async (
+  knex: Knex,
+  db: Database,
+  tableName: string,
+  columnName: string
+): Promise<
+  Array<{
+    table: string;
+    column: string;
+    name: string;
+    onDelete?: string;
+    onUpdate?: string;
+  }>
+> => {
+  switch (db.dialect.client) {
+    case 'postgres': {
+      const schemaName = db.getSchemaName();
+
+      const query = `
+        SELECT 
+          tc.table_name as table,
+          kcu.column_name as column,
+          tc.constraint_name as name,
+          rc.delete_rule as "onDelete",
+          rc.update_rule as "onUpdate"
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu 
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON tc.constraint_name = ccu.constraint_name
+          AND tc.table_schema = ccu.table_schema
+        JOIN information_schema.referential_constraints rc
+          ON tc.constraint_name = rc.constraint_name
+          AND tc.table_schema = rc.constraint_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = ?
+          AND ccu.column_name = ?
+          ${schemaName ? 'AND tc.table_schema = ?' : ''}
+      `;
+
+      const result = await knex.raw(
+        query,
+        schemaName ? [tableName, columnName, schemaName] : [tableName, columnName]
+      );
+      return result.rows;
+    }
+
+    case 'mysql': {
+      const query = `
+        SELECT 
+          kcu.TABLE_NAME as \`table\`,
+          kcu.COLUMN_NAME as \`column\`,
+          kcu.CONSTRAINT_NAME as \`name\`,
+          rc.DELETE_RULE as \`onDelete\`,
+          rc.UPDATE_RULE as \`onUpdate\`
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+        JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+          ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+          AND kcu.TABLE_SCHEMA = rc.CONSTRAINT_SCHEMA
+        WHERE kcu.REFERENCED_TABLE_NAME = ?
+          AND kcu.REFERENCED_COLUMN_NAME = ?
+          AND kcu.TABLE_SCHEMA = database()
+          AND kcu.REFERENCED_TABLE_SCHEMA = database()
+      `;
+
+      const [result] = await knex.raw(query, [tableName, columnName]);
+      return result;
+    }
+
+    case 'sqlite': {
+      // SQLite: Query all tables and check their foreign keys
+      const tables = await knex.raw(`
+        SELECT name FROM sqlite_master 
+        WHERE type='table' AND name NOT LIKE 'sqlite_%'
+      `);
+
+      const foreignKeys: Array<{
+        table: string;
+        column: string;
+        name: string;
+        onDelete?: string;
+        onUpdate?: string;
+      }> = [];
+
+      for (const { name: table } of tables) {
+        const fkInfo = await knex.raw(`PRAGMA foreign_key_list(${table})`);
+
+        for (const fk of fkInfo) {
+          if (fk.table === tableName && fk.to === columnName) {
+            foreignKeys.push({
+              table,
+              column: fk.from,
+              name: `fk_${table}_${fk.from}`,
+              onDelete: fk.on_delete,
+              onUpdate: fk.on_update,
+            });
+          }
+        }
+      }
+
+      return foreignKeys;
+    }
+
+    default:
+      return [];
+  }
+};
+
+/**
+ * Check if a column is an integer type (and not already bigint)
+ */
+const isIntegerColumn = async (
+  knex: Knex,
+  db: Database,
+  tableName: string,
+  columnName: string
+): Promise<boolean> => {
+  const schemaName = db.getSchemaName();
+
+  switch (db.dialect.client) {
+    case 'postgres': {
+      const result = await knex.raw(
+        `
+        SELECT data_type 
+        FROM information_schema.columns 
+        WHERE table_name = ? 
+          AND column_name = ?
+          ${schemaName ? 'AND table_schema = ?' : ''}
+      `,
+        schemaName ? [tableName, columnName, schemaName] : [tableName, columnName]
+      );
+
+      const dataType = result.rows[0]?.data_type?.toLowerCase();
+      return dataType === 'integer' || dataType === 'int' || dataType === 'int4';
+    }
+
+    case 'mysql': {
+      const [result] = await knex.raw(
+        `
+        SELECT DATA_TYPE 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_NAME = ? 
+          AND COLUMN_NAME = ?
+          AND TABLE_SCHEMA = database()
+      `,
+        [tableName, columnName]
+      );
+
+      const dataType = result[0]?.DATA_TYPE?.toLowerCase();
+      return dataType === 'int' || dataType === 'integer';
+    }
+
+    case 'sqlite': {
+      const result = await knex.raw(`PRAGMA table_info(${tableName})`);
+      const column = result.find((col: any) => col.name === columnName);
+      const dataType = column?.type?.toLowerCase();
+      return dataType === 'integer' || dataType === 'int';
+    }
+
+    default:
+      return false;
+  }
+};
+
+/**
+ * Convert a column from INTEGER to BIGINT
+ */
+const convertColumnToBigInt = async (
+  knex: Knex,
+  db: Database,
+  tableName: string,
+  columnName: string,
+  isPrimaryKey: boolean = false
+): Promise<void> => {
+  migrationDebug(`Converting ${tableName}.${columnName} to BIGINT`);
+
+  switch (db.dialect.client) {
+    case 'postgres': {
+      // PostgreSQL: Use ALTER COLUMN with USING clause to convert data
+      if (isPrimaryKey) {
+        await knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? TYPE BIGINT USING ??::BIGINT`, [
+          tableName,
+          columnName,
+          columnName,
+        ]);
+      } else {
+        await knex.raw(`ALTER TABLE ?? ALTER COLUMN ?? TYPE BIGINT USING ??::BIGINT`, [
+          tableName,
+          columnName,
+          columnName,
+        ]);
+      }
+      break;
+    }
+
+    case 'mysql': {
+      // MySQL: Use MODIFY COLUMN
+      if (isPrimaryKey) {
+        await knex.raw(`ALTER TABLE ?? MODIFY COLUMN ?? BIGINT UNSIGNED NOT NULL AUTO_INCREMENT`, [
+          tableName,
+          columnName,
+        ]);
+      } else {
+        await knex.raw(`ALTER TABLE ?? MODIFY COLUMN ?? BIGINT UNSIGNED`, [tableName, columnName]);
+      }
+      break;
+    }
+
+    case 'sqlite': {
+      // SQLite: Requires table recreation due to limited ALTER TABLE support
+      // This is complex, so we'll handle it by recreating the table
+      await recreateTableWithBigInt(knex, tableName, columnName, isPrimaryKey);
+      break;
+    }
+
+    default:
+      migrationDebug(`Unsupported database dialect: ${db.dialect.client}`);
+      break;
+  }
+};
+
+/**
+ * SQLite-specific: Recreate table with BIGINT column
+ * SQLite doesn't support ALTER COLUMN, so we need to:
+ * 1. Create new table with updated schema
+ * 2. Copy data
+ * 3. Drop old table
+ * 4. Rename new table
+ */
+const recreateTableWithBigInt = async (
+  knex: Knex,
+  tableName: string,
+  columnName: string,
+  isPrimaryKey: boolean
+): Promise<void> => {
+  const tempTableName = `${tableName}_temp_bigint`;
+
+  // Get table info
+  const tableInfo = await knex.raw(`PRAGMA table_info(${tableName})`);
+
+  // Build CREATE TABLE statement for temp table
+  // Note: We need to quote column names to handle reserved keywords like "order"
+  const columnDefs = tableInfo
+    .map((col: any) => {
+      const quotedName = `"${col.name}"`;
+      if (col.name === columnName) {
+        // Convert to BIGINT
+        if (isPrimaryKey) {
+          return `${quotedName} INTEGER PRIMARY KEY`;
+        }
+        return `${quotedName} INTEGER${col.notnull ? ' NOT NULL' : ''}${col.dflt_value ? ` DEFAULT ${col.dflt_value}` : ''}`;
+      }
+      return `${quotedName} ${col.type}${col.notnull ? ' NOT NULL' : ''}${col.dflt_value ? ` DEFAULT ${col.dflt_value}` : ''}${col.pk && col.name !== columnName ? ' PRIMARY KEY' : ''}`;
+    })
+    .join(', ');
+
+  // Create temp table
+  await knex.raw(`CREATE TABLE "${tempTableName}" (${columnDefs})`);
+
+  // Copy data - quote all identifiers
+  const quotedColumnNames = tableInfo.map((col: any) => `"${col.name}"`).join(', ');
+  await knex.raw(
+    `INSERT INTO "${tempTableName}" (${quotedColumnNames}) SELECT ${quotedColumnNames} FROM "${tableName}"`
+  );
+
+  // Drop old table
+  await knex.raw(`DROP TABLE "${tableName}"`);
+
+  // Rename temp table
+  await knex.raw(`ALTER TABLE "${tempTableName}" RENAME TO "${tableName}"`);
+
+  // Note: Foreign keys and indexes need to be recreated by the calling code
+};
+
+/**
+ * Main migration logic
+ */
+export const migrateIdsFromIntToBigInt: Migration = {
+  name: '5.0.0-06-migrate-ids-from-int-to-bigint',
+
+  async up(knex, db) {
+    migrationDebug('Starting migration from INTEGER to BIGINT for all ID columns');
+
+    // Disable foreign key checks during migration (database-specific)
+    const disableForeignKeyChecks = async () => {
+      switch (db.dialect.client) {
+        case 'mysql':
+          await knex.raw('SET FOREIGN_KEY_CHECKS = 0');
+          break;
+        case 'sqlite':
+          await knex.raw('PRAGMA foreign_keys = OFF');
+          break;
+        case 'postgres':
+          break;
+        default:
+          throw new Error(`Unsupported database dialect: ${db.dialect.client}`);
+        // PostgreSQL: We'll drop and recreate FKs manually
+      }
+    };
+
+    const enableForeignKeyChecks = async () => {
+      switch (db.dialect.client) {
+        case 'mysql':
+          await knex.raw('SET FOREIGN_KEY_CHECKS = 1');
+          break;
+        case 'sqlite':
+          await knex.raw('PRAGMA foreign_keys = ON');
+          break;
+        case 'postgres':
+          break;
+        default:
+          throw new Error(`Unsupported database dialect: ${db.dialect.client}`);
+      }
+    };
+
+    try {
+      await disableForeignKeyChecks();
+
+      // Track foreign keys we need to recreate
+      const droppedForeignKeys: Array<{
+        table: string;
+        column: string;
+        name: string;
+        referencedTable: string;
+        referencedColumn: string;
+        onDelete?: string;
+        onUpdate?: string;
+      }> = [];
+
+      // Step 1: Convert all primary key columns
+      for (const meta of db.metadata.values()) {
+        const tableName = meta.tableName;
+        const hasTable = await knex.schema.hasTable(tableName);
+
+        if (!hasTable) {
+          continue;
+        }
+
+        // Check if ID column exists and is integer
+        const hasIdColumn = await knex.schema.hasColumn(tableName, 'id');
+        if (!hasIdColumn) {
+          continue;
+        }
+
+        const isInteger = await isIntegerColumn(knex, db, tableName, 'id');
+        if (!isInteger) {
+          migrationDebug(`Skipping ${tableName}.id - already BIGINT or not INTEGER`);
+          continue;
+        }
+
+        migrationDebug(`Processing table: ${tableName}`);
+
+        // Get all foreign keys referencing this table's ID
+        const referencingFKs = await getForeignKeysReferencingColumn(knex, db, tableName, 'id');
+
+        // Drop foreign keys referencing this column (for PostgreSQL and MySQL)
+        if (db.dialect.client === 'postgres' || db.dialect.client === 'mysql') {
+          for (const fk of referencingFKs) {
+            migrationDebug(`Dropping FK ${fk.name} from ${fk.table}.${fk.column}`);
+            try {
+              if (db.dialect.client === 'postgres') {
+                await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [fk.table, fk.name]);
+              } else if (db.dialect.client === 'mysql') {
+                await knex.raw(`ALTER TABLE ?? DROP FOREIGN KEY ??`, [fk.table, fk.name]);
+              }
+
+              droppedForeignKeys.push({
+                table: fk.table,
+                column: fk.column,
+                name: fk.name,
+                referencedTable: tableName,
+                referencedColumn: 'id',
+                onDelete: fk.onDelete,
+                onUpdate: fk.onUpdate,
+              });
+            } catch (error) {
+              migrationDebug(
+                `Error dropping FK ${fk.name}: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          }
+        }
+
+        // Convert primary key column
+        await convertColumnToBigInt(knex, db, tableName, 'id', true);
+
+        // Convert foreign key columns in other tables that reference this PK
+        for (const fk of referencingFKs) {
+          const fkTableExists = await knex.schema.hasTable(fk.table);
+          if (!fkTableExists) {
+            continue;
+          }
+
+          const fkColumnIsInteger = await isIntegerColumn(knex, db, fk.table, fk.column);
+          if (fkColumnIsInteger) {
+            await convertColumnToBigInt(knex, db, fk.table, fk.column, false);
+          }
+        }
+      }
+
+      // Step 2: Recreate foreign keys for PostgreSQL and MySQL
+      if (db.dialect.client === 'postgres' || db.dialect.client === 'mysql') {
+        for (const fk of droppedForeignKeys) {
+          migrationDebug(`Recreating FK ${fk.name} on ${fk.table}.${fk.column}`);
+          try {
+            let fkSQL = `ALTER TABLE ?? ADD CONSTRAINT ?? FOREIGN KEY (??) REFERENCES ?? (??)`;
+            const fkParams: any[] = [
+              fk.table,
+              fk.name,
+              fk.column,
+              fk.referencedTable,
+              fk.referencedColumn,
+            ];
+
+            // Add ON DELETE and ON UPDATE clauses if present
+            if (fk.onDelete) {
+              fkSQL += ` ON DELETE ${fk.onDelete.toUpperCase()}`;
+            }
+            if (fk.onUpdate) {
+              fkSQL += ` ON UPDATE ${fk.onUpdate.toUpperCase()}`;
+            }
+
+            await knex.raw(fkSQL, fkParams);
+          } catch (error) {
+            migrationDebug(
+              `Error recreating FK ${fk.name}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+      }
+
+      await enableForeignKeyChecks();
+
+      migrationDebug('Migration completed successfully');
+    } catch (error) {
+      await enableForeignKeyChecks();
+      throw error;
+    }
+  },
+
+  async down() {
+    throw new Error('Down migration from BIGINT to INTEGER is not supported');
+  },
+};

--- a/packages/core/database/src/migrations/internal-migrations/index.ts
+++ b/packages/core/database/src/migrations/internal-migrations/index.ts
@@ -5,6 +5,7 @@ import { createdLocale } from './5.0.0-03-locale';
 import { createdPublishedAt } from './5.0.0-04-published-at';
 import { dropSlugFieldsIndex } from './5.0.0-05-drop-slug-unique-index';
 import { addDocumentIdIndexes } from './5.0.0-06-add-document-id-indexes';
+import { migrateIdsFromIntToBigInt } from './5.0.0-06-migrate-ids-from-int-to-bigint';
 
 /**
  * List of all the internal migrations. The array order will be the order in which they are executed.
@@ -22,4 +23,5 @@ export const internalMigrations: Migration[] = [
   createdPublishedAt,
   dropSlugFieldsIndex,
   addDocumentIdIndexes,
+  migrateIdsFromIntToBigInt,
 ];

--- a/packages/core/database/src/migrations/storage.ts
+++ b/packages/core/database/src/migrations/storage.ts
@@ -12,7 +12,7 @@ export const createStorage = (opts: Options) => {
 
   const createMigrationTable = () => {
     return db.getSchemaConnection().createTable(tableName, (table) => {
-      table.increments('id');
+      table.bigIncrements('id');
       table.string('name');
       table.datetime('time', { useTz: false });
     });

--- a/packages/core/database/src/schema/__tests__/time-to-datetime-migration.test.ts
+++ b/packages/core/database/src/schema/__tests__/time-to-datetime-migration.test.ts
@@ -57,6 +57,7 @@ describe('PostgreSQL Date Time Type Conversions in Schema Builder', () => {
       dialect: {
         startSchemaUpdate: jest.fn(),
         endSchemaUpdate: jest.fn(),
+        getSqlType: jest.fn().mockImplementation((type) => type),
         schemaInspector: {
           getIndexes: jest.fn().mockResolvedValue([]),
           getForeignKeys: jest.fn().mockResolvedValue([]),

--- a/packages/core/database/src/schema/schema.ts
+++ b/packages/core/database/src/schema/schema.ts
@@ -55,7 +55,7 @@ const createTable = (meta: Meta): Table => {
 
         table.columns.push(
           createColumn(idColumnName, {
-            type: 'integer',
+            type: 'biginteger',
             column: {
               unsigned: true,
             },
@@ -75,7 +75,7 @@ const createTable = (meta: Meta): Table => {
           name: columnNameFull,
           referencedColumn,
           referencedTable,
-          columnType = 'integer',
+          columnType = 'biginteger',
         } = attribute.joinColumn;
 
         const columnName = identifiers.getName(columnNameFull);
@@ -142,7 +142,14 @@ const getColumnType = (attribute: Attribute) => {
     case 'increments': {
       return {
         type: 'increments',
-        args: [{ primary: true, primaryKey: true }],
+        args: [{ primaryKey: true }],
+        notNullable: true,
+      };
+    }
+    case 'bigincrements': {
+      return {
+        type: 'bigIncrements',
+        args: [{ primaryKey: true }],
         notNullable: true,
       };
     }

--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -10,7 +10,7 @@ export default (db: Database) => {
 
   const createSchemaTable = () => {
     return db.getSchemaConnection().createTable(TABLE_NAME, (t) => {
-      t.increments('id');
+      t.bigIncrements('id');
       t.json('schema');
       t.datetime('time', { useTz: false });
       t.string('hash');

--- a/packages/core/database/src/types/index.ts
+++ b/packages/core/database/src/types/index.ts
@@ -36,11 +36,19 @@ export interface BaseAttribute {
   };
   searchable?: boolean;
   enum?: string[];
+  /**
+   * Marks biginteger attributes created internally by Strapi (FK columns in join tables).
+   * Used to distinguish from user-defined biginteger attributes for type coercion.
+   * When true, biginteger values are cast to numbers; otherwise kept as strings.
+   * @internal
+   */
+  internalIntegerId?: boolean;
 }
 
 export interface ScalarAttribute extends BaseAttribute {
   type:
     | 'increments'
+    | 'bigincrements'
     | 'password'
     | 'email'
     | 'string'

--- a/packages/core/database/src/utils/identifiers/index.ts
+++ b/packages/core/database/src/utils/identifiers/index.ts
@@ -71,13 +71,15 @@ export class Identifiers {
     return undefined;
   };
 
-  // Generic name handler that must be used by all helper functions
+  // TODO: we should be requiring snake_case inputs for all names here, but we
+  // aren't and it will require some refactoring to make it work. Currently if
+  // we get names 'myModel' and 'my_model' they would be converted to the same
+  // final string my_model which generally works but is not entirely safe
   /**
-   * TODO: we should be requiring snake_case inputs for all names here, but we
-   * aren't and it will require some refactoring to make it work. Currently if
-   * we get names 'myModel' and 'my_model' they would be converted to the same
-   * final string my_model which generally works but is not entirely safe
-   * */
+   * Generic name handler that must be used by all helper functions
+   * @param names
+   * @param options
+   */
   getName = (names: NameInput, options?: NameOptions) => {
     const tokens: NameToken[] = _.castArray(names).map((name) => {
       return {

--- a/packages/core/database/src/utils/types.ts
+++ b/packages/core/database/src/utils/types.ts
@@ -2,6 +2,7 @@ import type { Attribute, ScalarAttribute, RelationalAttribute } from '../types';
 
 const SCALAR_TYPES = [
   'increments',
+  'bigincrements',
   'password',
   'email',
   'string',

--- a/packages/core/strapi/src/cli/index.ts
+++ b/packages/core/strapi/src/cli/index.ts
@@ -22,6 +22,15 @@ const createCLI = async (argv: string[], command = new Command()) => {
   const hasDebug = argv.includes('--debug');
   const hasSilent = argv.includes('--silent');
 
+  // Enable debug package when --debug flag is passed
+  if (hasDebug) {
+    // Enable migration debug logs and all database-related debug logs
+    const existingDebug = process.env.DEBUG;
+    const migrationDebug = 'strapi::database::migration::*,strapi::database::*';
+    process.env.DEBUG =
+      existingDebug !== undefined ? `${existingDebug},${migrationDebug}` : migrationDebug;
+  }
+
   const logger = createLogger({ debug: hasDebug, silent: hasSilent, timestamp: false });
 
   const tsconfig = loadTsConfig({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

## What does it do?

This PR migrates all ID columns (primary keys and foreign keys) from `INTEGER` to `BIGINT` across the database layer. This change ensures better support for large-scale applications and prevents integer overflow issues.
To account for backward compatibility, the `bigint` values are casted in Number up to 2^53, throw an exception if overflowing [MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).

> [!NOTE]
> This PR is currently meant only to trigger CI checks in order to help identify regressions.

## Changes


### Solution approach

#### Database migration

- **Automatic bigint migration**:
  - New internal migration (`5.0.0-06-migrate-ids-from-int-to-bigint`) upgrades:
    - **Primary keys** (`id` columns) in all content-type and internal tables.
    - **Foreign keys** in join/morph tables and relation tables.
  - Handles PostgreSQL, MySQL, and SQLite with dialect-specific logic:
    - Safely drops foreign key constraints before conversion, recreates them afterwards.
    - Uses table recreation where needed (e.g. SQLite’s limited `ALTER TABLE` support).
  - Skips columns that are already bigint-compatible, so it can safely run on existing projects.

#### Transparent bigint handling

- **Internal vs user-defined fields**:
  - Introduces an `internalIntegerId` flag on attributes to mark Strapi-created bigint FKs in join tables.
  - Distinguishes three cases:
    - **ID columns** (`type: 'increments'` or `type: 'bigincrements'`) → exposed as **numbers**.
    - **Internal FK columns** (`type: 'biginteger'` + `internalIntegerId: true`) → exposed as **numbers**.
    - **User-defined `biginteger` attributes** (no flag) → exposed as **strings**.
- **Safety and precision**:
  - Internal IDs/FKs are converted from DB strings to JS numbers and validated against `Number.MAX_SAFE_INTEGER`.
  - If an internal ID overflows the safe range or cannot be parsed, Strapi throws a clear error instead of silently corrupting data.
  - User-defined bigintegers are never clamped or validated against `MAX_SAFE_INTEGER` and keep their full string precision.

#### Schema & tooling updates

- **Schema builder & inspector**:
  - New content types and internal tables use `bigincrements` for IDs by default; join-table FKs use `biginteger`.
  - Dialects (MySQL, Postgres, SQLite) recognize bigint PK/FK columns and map them to the correct Strapi types.
- **Diffing & migrations**:
  - Schema diff treats `increments` and `bigincrements` as equivalent to avoid noisy, unnecessary migrations.
  - Internal migration and schema tools are aligned so that once IDs are bigint, subsequent syncs do not try to downgrade/flip types.

### What this changes

- **ID storage in the database**
  - All Strapi‑managed ID columns (PKs and FKs, including join/morph tables and internal tables) are now stored as `BIGINT` in supported databases.
  - A new internal migration walks all tables and:
    - Upgrades integer `id` PKs to bigint.
    - Upgrades integer FK columns that point to those IDs to bigint.
    - Handles FK constraints per dialect (Postgres/MySQL/SQLite) so the migration is consistent and safe.

- **How IDs are exposed in JavaScript**
  - **Internal IDs and FKs (Strapi‑created)**:
    - Still exposed as **numbers** in Node for typical ID ranges.
    - On read, values are validated to be within `Number.MAX_SAFE_INTEGER`; anything larger throws a clear error instead of silently losing precision.
  - **User‑defined `biginteger` attributes**:
    - Still exposed as **strings** (unchanged behavior), including very large values beyond JS safe integer range.
    - This preserves existing app logic that treats those values as strings.

- **Schema & metadata model**
  - Internal models (content types, join tables, history/core tables, migrations/schema tables) are updated to:
    - Use `bigincrements` for their `id` fields.
    - Use `biginteger` for internal FK columns.
  - The schema inspector and diffing logic are updated so:
    - PKs using `increments` vs `bigincrements` are treated as equivalent from a migration‑noise point of view.
    - Dialect‑specific quirks (e.g. SQLite’s lack of a real bigint type) are abstracted behind the dialect API.

### Scope in the codebase

- **Database layer**
  - Dialects (MySQL, Postgres, SQLite) schema inspectors and type mapping.
  - Schema builder, diffing, and internal migration storage/schema tables.
  - Field system, especially the bigint field and how it converts DB values to JS values.

- **Metadata and relation generation**
  - Metadata fixtures/expected outputs.
  - Relation/join table builders (including morph and many‑to‑many join tables).

- **Core / CM models and services**
  - Internal models that use Strapi‑managed IDs (history versions, core store, webhooks, etc.).
  - Utilities that transform content types into database models.

- **Tests**
  - New tests around bigint behavior and integration with the transform pipeline.
  - Existing schema/metadata tests updated to expect bigint IDs and FK columns.

### Backwards compatibility

- **Stable for existing apps**:
  - For “normal” ID ranges (i.e. well below \(2^{53}\)), behavior is unchanged: IDs are still numbers in JavaScript.
  - User‑defined `biginteger` fields remain strings and retain full precision; no breaking change there.
- **Stronger guarantees**:
  - If the underlying DB ever stores an internal ID beyond `Number.MAX_SAFE_INTEGER`, Strapi will now fail fast with an explicit error, instead of returning a silently corrupted number.

## How to test it?

- Start a Strapi instance on any prior version
- Create content types and content
- Stop the Strapi instance
- Checkout to this version (including the bigint migration)
- Start the Strapi instance
- All content should be migrated to the new bigint ids but the API still delivers number IDs

## Related issue(s)/PR(s)

resolves #24491
