### PR TITLE
fix: don't translate enums with ai

### DIFF
--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -11,7 +11,12 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
   const aiServerUrl = process.env.STRAPI_AI_URL || 'https://strapi-ai.apps.strapi.io';
   const aiLocalizationJobsService = getService('ai-localization-jobs');
 
-  const UNSUPPORTED_ATTRIBUTE_TYPES: Schema.Attribute.Kind[] = ['media', 'relation', 'boolean'];
+  const UNSUPPORTED_ATTRIBUTE_TYPES: Schema.Attribute.Kind[] = [
+    'media',
+    'relation',
+    'boolean',
+    'enumeration',
+  ];
   const IGNORED_FIELDS = [
     'id',
     'documentId',


### PR DESCRIPTION
### What does it do?

prevents AI from attempting to translate enumeration fields

### Why is it needed?

Enum options are the same across all locales. Letting the AI try to translate it would fail when saving to the database.

### How to test it?

see #24963

### Related issue(s)/PR(s)

fixes #24963
