### PR TITLE
fix(graphql): expose defaultResolve in resolver context

### DIFF
--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -6,6 +6,7 @@ import {
 } from '@apollo/server/plugin/landingPage/default';
 import { koaMiddleware } from '@as-integrations/koa';
 import depthLimit from 'graphql-depth-limit';
+import type { GraphQLResolveInfo } from 'graphql';
 import bodyParser from 'koa-bodyparser';
 import cors from '@koa/cors';
 
@@ -23,6 +24,14 @@ const merge = mergeWith((a, b) => {
 
 type StrapiGraphQLContext = BaseContext & {
   rootQueryArgs?: Record<string, unknown>;
+  graphql?: {
+    defaultResolve: (
+      parent?: unknown,
+      args?: unknown,
+      context?: unknown,
+      info?: GraphQLResolveInfo
+    ) => unknown;
+  };
 };
 
 export const determineLandingPage = (

--- a/packages/plugins/graphql/server/src/index.ts
+++ b/packages/plugins/graphql/server/src/index.ts
@@ -2,6 +2,9 @@ import { config } from './config';
 import { bootstrap } from './bootstrap';
 import { services } from './services';
 
+// Export types for users
+export type { StrapiGraphQLResolverContext } from './services/types';
+
 export default {
   config,
   bootstrap,

--- a/packages/plugins/graphql/server/src/services/types.ts
+++ b/packages/plugins/graphql/server/src/services/types.ts
@@ -1,7 +1,42 @@
+import type { GraphQLResolveInfo } from 'graphql';
 import type { Core } from '@strapi/types';
 import type { TypeRegistry } from './type-registry';
 
 export type Context = {
   strapi: Core.Strapi;
   registry: TypeRegistry;
+};
+
+/**
+ * GraphQL resolver context type for custom resolvers.
+ *
+ * This context is passed to all GraphQL resolvers and includes:
+ * - `state`: Koa state (auth info, route info)
+ * - `koaContext`: Reference to the Koa context for HTTP access
+ * - `rootQueryArgs`: Arguments from the root query (for nested resolvers)
+ * - `graphql.defaultResolve`: Function to call the default resolver (useful for data loader patterns)
+ */
+export type StrapiGraphQLResolverContext = {
+  state: any;
+  koaContext: any;
+  rootQueryArgs?: Record<string, unknown>;
+  graphql?: {
+    /**
+     * Call the default resolver for this field.
+     * Useful for data loader patterns where you want to fall back to the default behavior.
+     *
+     * @example
+     * ```typescript
+     * const cachedResult = await myDataLoader.load(args);
+     * if (cachedResult) return cachedResult;
+     * return context.graphql.defaultResolve(parent, args, context, info);
+     * ```
+     */
+    defaultResolve: (
+      parent?: unknown,
+      args?: unknown,
+      context?: unknown,
+      info?: GraphQLResolveInfo
+    ) => unknown;
+  };
 };


### PR DESCRIPTION
Add `context.graphql.defaultResolve` to allow custom resolvers to fall back to the default field resolver. This enables data loader optimization patterns where cached results can be returned early, with fallback to standard resolution.

Fixes #24294

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
