### PR TITLE
fix: added media to list of non localized fields

### DIFF
--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -211,6 +211,17 @@ const getComponentAttributes = (schema: Model) => {
   );
 };
 
+const getMediaAttributes = (schema: Model) => {
+  return _.reduce(
+    schema.attributes,
+    (acc, attr, attrName) => {
+      if (isMediaAttribute(attr)) acc.push(attrName);
+      return acc;
+    },
+    [] as string[]
+  );
+};
+
 const getScalarAttributes = (schema: Model) => {
   return _.reduce(
     schema.attributes,
@@ -270,6 +281,7 @@ export {
   constants,
   getNonWritableAttributes,
   getComponentAttributes,
+  getMediaAttributes,
   getScalarAttributes,
   getRelationalAttributes,
   getWritableAttributes,


### PR DESCRIPTION
### What does it do?

On issue ticket: https://github.com/strapi/strapi/issues/21850
I fixed all scalar fields to retain information in case of non localizable setting but it was missing the medias.
The original PR: [#24659](https://github.com/strapi/strapi/pull/24659)

https://github.com/user-attachments/assets/332a74e2-e8cb-4bf6-8433-d2edb9aa73be


### Why is it needed?

When you create a new locale version of an entry, you should have all non localizable fields prefilled correctly (except relations, dz and components) but the medias should be part of them.

### How to test it?

- You should have a collection type with Internationalization enabled and have a media field that is not localized
- Go to the Content Manager
- Create a new entry in the collection type
- Put a media (or more if multiple) and Publish
- Select another locale in the locale selector to create a new locale version
-> The media field should already be prefilled with the previous info provided

### Related issue(s)/PR(s)

Original PR: [#24659](https://github.com/strapi/strapi/pull/24659)
Related to https://github.com/strapi/strapi/issues/21850

🚀