### PR TITLE
feat: add shai-hulud 2.0 security scanning

### DIFF
--- a/.github/workflows/shai-hulud-check.yml
+++ b/.github/workflows/shai-hulud-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [develop]
 
+permissions:
+  contents: read
+
 jobs:
   security-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does it do?
Adds the Shai-Hulud 2.0 Detector github workflow

### Why is it needed?
We want to stop Shai-Hulud 2.0 being injected into Strapi

### How to test it?
View scan results in the Actions tab of your repository.
