### PR TITLE
fix(content-type-builder): disable display of invisible content types

### DIFF
--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -59,6 +59,12 @@ const ListView = () => {
     return <Navigate to="/plugins/content-type-builder/content-types/create-content-type" />;
   }
 
+  if (contentTypeUid && type.modelType === 'contentType' && type.visible === false) {
+    return (
+      <Navigate to="/plugins/content-type-builder/content-types/create-content-type" replace />
+    );
+  }
+
   const isFromPlugin = 'plugin' in type && type?.plugin !== undefined;
 
   const forTarget = contentTypeUid ? 'contentType' : 'component';

--- a/packages/core/content-type-builder/server/src/controllers/content-types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/content-types.ts
@@ -8,6 +8,7 @@ import {
   validateUpdateContentTypeInput,
   validateKind,
 } from './validation/content-type';
+import { isContentTypeVisible } from '../services/content-types';
 
 export default {
   async getContentTypes(ctx: Context) {
@@ -43,6 +44,10 @@ export default {
     const contentType = strapi.contentTypes[uid];
 
     if (!contentType) {
+      return ctx.send({ error: 'contentType.notFound' }, 404);
+    }
+
+    if (!isContentTypeVisible(contentType)) {
       return ctx.send({ error: 'contentType.notFound' }, 404);
     }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds visibility enforcement for content types in the content-type builder to prevent direct URL access to invisible content types.

**Backend changes:**
- Added visibility check in `getContentType` controller that returns 404 when accessing an invisible content type via the API endpoint (`GET /content-type-builder/content-types/:uid`)

**Frontend changes:**
- Added visibility check in `ListView` component that redirects users away from invisible content types when accessing them directly via URL in the admin panel

### Why is it needed?

Content types marked as invisible in the content-type builder were still accessible by directly navigating to their configuration page URL (e.g., `/admin/plugins/content-type-builder/content-types/admin::transfer-token`). This bypassed the visibility setting, allowing users to view and potentially modify content types that should be hidden from the UI.

### How to test it?

1. Start a Strapi instance with the content-type builder enabled
2. Verify that `admin::transfer-token` (or any other content type marked as invisible) is not visible in the content-type builder navigation menu
3. Attempt to visit the content type directly via URL:
   - Navigate to: `http://localhost:1337/admin/plugins/content-type-builder/content-types/admin::transfer-token`
   - **Expected behavior**: The page should redirect to `/admin/plugins/content-type-builder/content-types/create-content-type` instead of displaying the transfer-token configuration page
4. Verify the API endpoint also enforces visibility:
   - Make a request to: `GET http://localhost:1337/content-type-builder/content-types/admin::transfer-token`
   - **Expected behavior**: Should return 404 status code
5. Verify visible content types still work normally when accessed directly

### Related issue(s)/PR(s)

N/A
