### PR TITLE
fix(documentation): align with Data.ID: number | string

### DIFF
--- a/packages/plugins/documentation/server/src/services/__tests__/build-component-schema.test.ts
+++ b/packages/plugins/documentation/server/src/services/__tests__/build-component-schema.test.ts
@@ -73,7 +73,7 @@ describe('Documentation plugin | Build component schema', () => {
         type: 'object',
         properties: {
           id: {
-            type: 'number',
+            oneOf: [{ type: 'string' }, { type: 'number' }],
           },
           documentId: {
             type: 'string',
@@ -96,7 +96,7 @@ describe('Documentation plugin | Build component schema', () => {
         type: 'object',
         properties: {
           id: {
-            type: 'number',
+            oneOf: [{ type: 'string' }, { type: 'number' }],
           },
           documentId: {
             type: 'string',
@@ -150,7 +150,7 @@ describe('Documentation plugin | Build component schema', () => {
         type: 'object',
         properties: {
           id: {
-            type: 'number',
+            oneOf: [{ type: 'string' }, { type: 'number' }],
           },
           documentId: {
             type: 'string',
@@ -254,7 +254,7 @@ describe('Documentation plugin | Build component schema', () => {
         type: 'object',
         properties: {
           id: {
-            type: 'number',
+            oneOf: [{ type: 'string' }, { type: 'number' }],
           },
           documentId: {
             type: 'string',

--- a/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/build-component-schema.ts
@@ -132,7 +132,7 @@ const getAllSchemasForContentType = ({ routeInfo, attributes, uniqueName }: ApiI
       type: 'object',
       ...(requiredAttributes.length && { required: requiredAttributes }),
       properties: {
-        id: { type: 'number' },
+        id: { oneOf: [{ type: 'string' }, { type: 'number' }] },
         documentId: { type: 'string' },
         ...cleanSchemaAttributes(attributes, { didAddStrapiComponentsToSchemas }),
       },

--- a/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
@@ -108,7 +108,7 @@ const cleanSchemaAttributes = (
         const rawComponentSchema: OpenAPIV3.SchemaObject = {
           type: 'object',
           properties: {
-            ...(isRequest ? {} : { id: { type: 'number' } }),
+            ...(isRequest ? {} : { id: { oneOf: [{ type: 'string' }, { type: 'number' }] } }),
             ...cleanSchemaAttributes(componentAttributes, {
               typeMap,
               isRequest,
@@ -143,7 +143,7 @@ const cleanSchemaAttributes = (
           const rawComponentSchema: OpenAPIV3.SchemaObject = {
             type: 'object',
             properties: {
-              ...(isRequest ? {} : { id: { type: 'number' } }),
+              ...(isRequest ? {} : { id: { oneOf: [{ type: 'string' }, { type: 'number' }] } }),
               __component: { type: 'string', enum: [component] },
               ...cleanSchemaAttributes(componentAttributes, {
                 typeMap,

--- a/packages/plugins/documentation/server/src/services/helpers/utils/get-schema-data.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/get-schema-data.ts
@@ -18,7 +18,7 @@ export default (
       items: {
         type: 'object',
         properties: {
-          id: { type: 'number' },
+          id: { oneOf: [{ type: 'string' }, { type: 'number' }] },
           documentId: { type: 'string' },
           ...attributes,
         },
@@ -29,7 +29,7 @@ export default (
   return {
     type: 'object',
     properties: {
-      id: { type: 'number' },
+      id: { oneOf: [{ type: 'string' }, { type: 'number' }] },
       documentId: { type: 'string' },
       ...attributes,
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update the documentation plugin to reflect the type described for [`Data.ID: number | string`](https://github.com/strapi/strapi/blob/develop/packages/core/types/src/data/constants.ts#L4)

### Why is it needed?

Strapi defines IDs as `number | string` in the rest of its definition.
In the future, we want to move from increments to string-based IDs.

> [!WARNING]
> This change is a breaking change to the openAPI generation. We would push it forward since the feature is still beta and not supposed to be widely adopted.

### How to test it?

- `strapi openapi generate` must generate updated schema definitions including:
```ts
id: {
  oneOf: [{ type: 'string' }, { type: 'number' }],
}
```

### Related issue(s)/PR(s)

Side effect of #24953
