### PR TITLE
fix: missing status filter in content manager list view ; chore: improve type safety for filter type checking

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
@@ -1,0 +1,180 @@
+import { render as renderRTL, screen, server } from '@tests/utils';
+import { rest } from 'msw';
+import { Route, Routes } from 'react-router-dom';
+
+import { Filters } from '../Filters';
+
+import type { Schema } from '../../../../hooks/useDocument';
+
+const baseMockSchema: Schema = {
+  uid: 'api::article.article',
+  apiID: 'article',
+  kind: 'collectionType',
+  info: {
+    singularName: 'article',
+    pluralName: 'articles',
+    displayName: 'Article',
+    description: '',
+  },
+  options: {},
+  attributes: {
+    id: { type: 'string' },
+    documentId: { type: 'string' },
+    title: { type: 'string' },
+    createdAt: { type: 'datetime' },
+    updatedAt: { type: 'datetime' },
+  },
+  isDisplayed: true,
+  pluginOptions: {},
+};
+
+const mockSchemaWithDraftAndPublish: Schema = {
+  ...baseMockSchema,
+  options: { draftAndPublish: true },
+};
+
+const mockSchemaWithoutDraftAndPublish: Schema = {
+  ...baseMockSchema,
+  options: { draftAndPublish: false },
+};
+
+const mockContentTypeConfiguration = {
+  contentType: {
+    uid: 'api::article.article',
+    settings: {
+      bulkable: true,
+      filterable: true,
+      searchable: true,
+      pageSize: 10,
+      mainField: 'title',
+      defaultSortBy: 'title',
+      defaultSortOrder: 'ASC',
+    },
+    metadatas: {
+      id: {
+        edit: {},
+        list: { label: 'id', searchable: true, sortable: true },
+      },
+      documentId: {
+        edit: {},
+        list: { label: 'documentId', searchable: true, sortable: true },
+      },
+      title: {
+        edit: { label: 'title', description: '', placeholder: '', visible: true, editable: true },
+        list: { label: 'title', searchable: true, sortable: true },
+      },
+      createdAt: {
+        edit: {},
+        list: { label: 'createdAt', searchable: true, sortable: true },
+      },
+      updatedAt: {
+        edit: {},
+        list: { label: 'updatedAt', searchable: true, sortable: true },
+      },
+    },
+    layouts: {
+      list: ['id', 'title'],
+      edit: [],
+    },
+  },
+  components: {},
+};
+
+const render = (schema: Schema) =>
+  renderRTL(<Filters schema={schema} />, {
+    renderOptions: {
+      wrapper({ children }) {
+        return (
+          <Routes>
+            <Route path="/content-manager/:collectionType/:slug" element={children} />
+          </Routes>
+        );
+      },
+    },
+    initialEntries: ['/content-manager/collection-types/api::article.article'],
+  });
+
+describe('Filters', () => {
+  beforeEach(() => {
+    server.use(
+      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
+        return res(ctx.json({ data: mockContentTypeConfiguration }));
+      }),
+      rest.get('/content-manager/init', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: {
+              components: [],
+              contentTypes: [baseMockSchema],
+            },
+          })
+        );
+      })
+    );
+  });
+
+  describe('Status filter', () => {
+    it('should display the status filter when draftAndPublish is enabled', async () => {
+      const { user } = render(mockSchemaWithDraftAndPublish);
+
+      // Open the filters popover
+      const filterButton = await screen.findByRole('button', { name: 'Filters' });
+      await user.click(filterButton);
+
+      // Find the field select and check for Status option
+      const fieldSelect = await screen.findByRole('combobox', { name: 'Select field' });
+      await user.click(fieldSelect);
+
+      // Status should be in the list of filter options
+      expect(await screen.findByRole('option', { name: 'Status' })).toBeInTheDocument();
+
+      // Close popover
+      await user.click(document.body);
+    });
+
+    it('should NOT display the status filter when draftAndPublish is disabled', async () => {
+      const { user } = render(mockSchemaWithoutDraftAndPublish);
+
+      // Open the filters popover
+      const filterButton = await screen.findByRole('button', { name: 'Filters' });
+      await user.click(filterButton);
+
+      // Find the field select
+      const fieldSelect = await screen.findByRole('combobox', { name: 'Select field' });
+      await user.click(fieldSelect);
+
+      // Status should NOT be in the list of filter options
+      expect(screen.queryByRole('option', { name: 'Status' })).not.toBeInTheDocument();
+
+      // Close popover
+      await user.click(document.body);
+    });
+
+    it('should show Draft and Published as status filter operators', async () => {
+      const { user } = render(mockSchemaWithDraftAndPublish);
+
+      // Open the filters popover
+      const filterButton = await screen.findByRole('button', { name: 'Filters' });
+      await user.click(filterButton);
+
+      // Select the Status field
+      const fieldSelect = await screen.findByRole('combobox', { name: 'Select field' });
+      await user.click(fieldSelect);
+
+      const statusOption = await screen.findByRole('option', { name: 'Status' });
+      await user.click(statusOption);
+
+      // Open the filter/operator select
+      const filterSelect = await screen.findByRole('combobox', { name: 'Select filter' });
+      await user.click(filterSelect);
+
+      // Should have Draft and Published options
+      expect(await screen.findByRole('option', { name: 'Draft' })).toBeInTheDocument();
+      expect(await screen.findByRole('option', { name: 'Published' })).toBeInTheDocument();
+
+      // Close popover
+      await user.click(document.body);
+    });
+  });
+});
+


### PR DESCRIPTION

### What does it do?

Adds a status filter to the Content Manager list view for content types with Draft & Publish enabled, and improves type safety in the Filters component.

**Changes:**
- Add status filter option when `schema.options.draftAndPublish` is `true`
- Filter uses `publishedAt` field with `$null` (Draft) and `$notNull` (Published) operators
- Improve type safety by using `as const satisfies` and a type guard function
- Remove `@ts-expect-error` comment in favor of proper type assertion
- Add unit tests for the new status filter functionality

### Why is it needed?

After migrating from Strapi 4 to Strapi 5, users lost the ability to filter content by draft/published status in the admin panel. While the list view displays a status column for content types with Draft & Publish enabled, there was no corresponding filter option available in the Filters dropdown.

This is critical when managing hundreds of content entries, as users cannot easily find all draft entries that need to be published or all published entries that might need updates.

### How to test it?

1. Create a content type with Draft & Publish enabled
2. Create entries with different statuses (published and drafts)
3. Go to Content Manager → select the content type
4. Click "Filters" → Select "Status" field
5. Choose "Draft" or "Published" to filter entries accordingly
6. Verify the filter works correctly

**Additional verification:**
- For content types WITHOUT Draft & Publish enabled, the "Status" filter should NOT appear
- The filter tag should display correctly (e.g., "Status Draft" or "Status Published")

### Related issue(s)/PR(s)

Fixes #24960

---

**Commits in this PR:**
- `fix: missing status filter in content manager list view`
- `chore: improve type safety for filter type checking`