### PR TITLE
feat(core/core): content-type `id` attribute schema is `number | string`

### DIFF
--- a/packages/core/core/src/core-api/routes/validation/content-type.ts
+++ b/packages/core/core/src/core-api/routes/validation/content-type.ts
@@ -78,7 +78,7 @@ export class CoreContentTypeRouteValidator extends AbstractCoreRouteValidator<UI
     return z
       .object({
         documentId: this.documentID,
-        id: z.number(),
+        id: z.union([z.string(), z.number()]),
       })
       .extend(attributesSchema.shape);
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update content-type `id` attribute schema to be union of `number | string`

### Why is it needed?

Aligning implementation with current [`Data.ID`](https://github.com/strapi/strapi/blob/develop/packages/core/types/src/data/constants.ts#L4) definition.
Strapi aims to move to string-based IDs in the future.

### How to test it?

This change must not create any change in behavior.

### Related issue(s)/PR(s)

Related to #24953
