### PR TITLE
fix(examples): correct dependency declarations in todo-example plugin

### DIFF
--- a/examples/plugins/todo-example/package.json
+++ b/examples/plugins/todo-example/package.json
@@ -24,20 +24,24 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "@strapi/strapi": "workspace:*"
-  },
-  "dependencies": {
-    "@strapi/design-system": "2.0.1",
-    "@strapi/icons": "2.0.1",
-    "eslint": "8.50.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "@strapi/strapi": "^5.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0",
     "styled-components": "^6.0.0"
   },
+  "dependencies": {
+    "@strapi/design-system": "2.0.1",
+    "@strapi/icons": "2.0.1"
+  },
   "devDependencies": {
     "@strapi/sdk-plugin": "^5.2.0",
-    "@strapi/strapi": "workspace:*"
+    "@strapi/strapi": "workspace:*",
+    "eslint": "8.50.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-router-dom": "6.22.3",
+    "styled-components": "6.1.8"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -102,7 +102,19 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     },
     resolve: {
       // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
-      dedupe: ['react', 'react-dom', 'react-router-dom', 'styled-components'],
+      // Extended dedupe list to prevent duplicate dependencies in local plugins
+      // See: https://github.com/strapi/strapi/issues/22946
+      dedupe: [
+        'react',
+        'react-dom',
+        'react-router-dom',
+        'styled-components',
+        '@strapi/design-system',
+        '@strapi/icons',
+        '@reduxjs/toolkit',
+        'react-intl',
+        'react-redux',
+      ],
     },
     plugins: [react(), buildFilesPlugin(ctx)],
   };


### PR DESCRIPTION
### What does it do?

  - Move `react`, `react-dom`, `react-router-dom`, `styled-components` from
  `dependencies` to `peerDependencies` in `todo-example` plugin
  - Move `eslint` from `dependencies` to `devDependencies`
  - Add these packages to `devDependencies` with pinned versions for
  monorepo development
  - Extend Vite's `dedupe` list to include `@strapi/design-system`,
  `@strapi/icons`, `@reduxjs/toolkit`, `react-intl`, `react-redux`

  ### Why is it needed?

  The current `todo-example` plugin declares shared packages (react,
  styled-components, etc.) in `dependencies` instead of `peerDependencies`.

  When users reference this example to create their own local plugins,
  npm/yarn treats these as separate dependencies and installs duplicate
  copies in the plugin's `node_modules`, causing significant size bloat
  (reported as 300MB -> 1.6GB per plugin in #22946).

  This fix aligns the example with npm best practices and matches the
  pattern used by official Strapi plugins like `@strapi/i18n` and
  `@strapi/plugin-graphql`.

  ### How to test it?

  1. Run `yarn install` - verify no new peer dependency warnings for
  `todo-example`
  2. Run `cd examples/plugins/todo-example && yarn build` - verify build
  succeeds
  3. Run `cd examples/getstarted && yarn build` - verify admin build
  succeeds

  ### Related issue(s)/PR(s)

  Related to #22946 (Strapi 5 local plugins: size has significantly
  increased)

  Note: This PR addresses prevention (fixing the example template) rather
  than a complete fix. Users with existing plugins will need to manually
  update their `package.json` following this pattern.