### PR TITLE
feat: update iso-locales.json with papiamento & regional variants

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -1796,6 +1796,22 @@
     "name": "Punjabi (Gurmukhi, India) (pa-Guru-IN)"
   },
   {
+    "code": "pap",
+    "name": "Papiamento (pap)"
+  },
+  {
+    "code": "pap-AW",
+    "name": "Papiamento (Aruba) (pap-AW)"
+  },
+  {
+    "code": "pap-CW",
+    "name": "Papiamentu (Curaçao) (pap-CW)"
+  },
+  {
+    "code": "pap-BQ",
+    "name": "Papiamentu (Bonaire) (pap-BQ)"
+  },
+  {
     "code": "ro",
     "name": "Romanian (ro)"
   },

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -1799,6 +1799,22 @@ exports[`ISO locales getIsoLocales 1`] = `
     "name": "Punjabi (Gurmukhi, India) (pa-Guru-IN)",
   },
   {
+    "code": "pap",
+    "name": "Papiamento (pap)",
+  },
+  {
+    "code": "pap-AW",
+    "name": "Papiamento (Aruba) (pap-AW)",
+  },
+  {
+    "code": "pap-CW",
+    "name": "Papiamentu (Curaçao) (pap-CW)",
+  },
+  {
+    "code": "pap-BQ",
+    "name": "Papiamentu (Bonaire) (pap-BQ)",
+  },
+  {
     "code": "ro",
     "name": "Romanian (ro)",
   },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It adds the Papiamentu/Papiamento locales & their regional variants to the list of ISO locales.

### Why is it needed?

We have clients who need to use this language on our website.
It looks like there is no way to handle this via a plugin option or by "extending" iso-locales.json file.

### How to test it?

Start the example application, go to Internationalization plugin settings, then add a new locale.
