### PR TITLE
fix(database): keyLength index attribute WIP

### DIFF
--- a/packages/core/database/src/schema/types.ts
+++ b/packages/core/database/src/schema/types.ts
@@ -26,6 +26,7 @@ export interface Index {
   columns: string[];
   name: string;
   type?: IndexType;
+  keyLength?: number | Record<string, number>;
 }
 
 export interface ForeignKey {

--- a/packages/core/upload/server/src/content-types/file.ts
+++ b/packages/core/upload/server/src/content-types/file.ts
@@ -124,6 +124,7 @@ export default {
         name: `upload_files_name_index`,
         columns: ['name'],
         type: null,
+        keyLength: 512,
       },
       {
         name: `upload_files_size_index`,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Detect and handle text based indexes. Apply an arbitrary `keyLength` to them.

### Why is it needed?

Preventing issue described in #25001 

### How to test it?

1. In monorepo, checkout `develop`, `yarn build`
2. Navigate to `examples/getstarted`, configure an new/empty MySQL database
3. Launch dev server `yarn develop` — server must start without error

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
