### PR TITLE
fix(core/upload): rollback file name to string

### DIFF
--- a/packages/core/upload/server/src/content-types/file.ts
+++ b/packages/core/upload/server/src/content-types/file.ts
@@ -22,7 +22,7 @@ export default {
     },
     attributes: {
       name: {
-        type: 'text',
+        type: 'string',
         configurable: false,
         required: true,
       },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Rollback `packages/core/upload/server/src/content-types/file.ts` > `name: { type: 'string' }`.

### Why is it needed?

Resolving regression caught in #25001 where `name: { type: 'text' }` produces an error on new databases.

### How to test it?

1. In monorepo, checkout `develop`, `yarn build`
2. Navigate to `examples/getstarted`, configure an new/empty MySQL database
3. Launch dev server `yarn develop`

### Related issue(s)/PR(s)

Resolves #25001 
Fixes #24931 by rolling back to previous behavior for `name` attribute.
