### PR TITLE
chore: update pinned axios, glob, form-data, and sha.js

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14106,7 +14106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.12.2":
+"axios@npm:1.12.2, axios@npm:^1.6.0, axios@npm:^1.6.8, axios@npm:^1.7.4":
   version: 1.12.2
   resolution: "axios@npm:1.12.2"
   dependencies:
@@ -14114,28 +14114,6 @@ __metadata:
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
   checksum: 10c0/80b063e318cf05cd33a4d991cea0162f3573481946f9129efb7766f38fde4c061c34f41a93a9f9521f02b7c9565ccbc197c099b0186543ac84a24580017adfed
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.6.0, axios@npm:^1.6.8":
-  version: 1.7.7
-  resolution: "axios@npm:1.7.7"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/4499efc89e86b0b49ffddc018798de05fab26e3bf57913818266be73279a6418c3ce8f9e934c7d2d707ab8c095e837fc6c90608fb7715b94d357720b5f568af7
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.7.4":
-  version: 1.7.8
-  resolution: "axios@npm:1.7.8"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.0"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/23ae2d0105aea9170c34ac9b6f30d9b2ab2fa8b1370205d2f7ce98b9f9510ab420148c13359ee837ea5a4bf2fb028ff225bd2fc92052fb0c478c6b4a836e2d5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**_NOTE: Hotfix for release branch_**

### What does it do?

Updates pinned versions of axios, glob, sha.js, and form-data

### Why is it needed?

GHSA-95m3-7q98-8xr5
GHSA-jr5f-v2jv-69x6
GHSA-5j98-mcp5-4vw2
GHSA-4hjh-wcwx-xvwj
GHSA-fjxv-7rqg-78g4

### How to test it?

Everything should work as before

Note: I manually checked the newly added packages for signs of shai-hulud, but be vigilant :)

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
