### PR TITLE
fix(admin): guidedTourMeta can be undefined and error

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Overview.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Overview.tsx
@@ -172,7 +172,7 @@ export const GuidedTourHomepageOverview = () => {
   };
 
   if (
-    !guidedTourMeta?.data.isFirstSuperAdminUser ||
+    !guidedTourMeta?.data?.isFirstSuperAdminUser ||
     !enabled ||
     hidden ||
     process.env.NODE_ENV !== 'development'


### PR DESCRIPTION
### What does it do?

Ensure guidedTourMeta.data is not undefined to avoid erroring when guidedTourMeta is [] (which is the case if you've already dismissed them)

### Why is it needed?
Without this in some cases you can get when you go to /admin
<img width="1077" height="834" alt="image" src="https://github.com/user-attachments/assets/106afc9e-d0c9-4483-947f-e54b9c9e1aa3" />


### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

#24567 
