### PR TITLE
chore(.cursor): add worktrees support

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,3 @@
+{
+  "setup-worktree": ["yarn install", "yarn build"]
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds initialization instruction for [Cursor Git Worktrees](https://cursor.com/docs/configuration/worktrees) feature.

### Why is it needed?

This allow any contributor to launch Cursor local background agents.

### How to test it?

1. Open Cursor editor
2. Open a new chat
3. Prompt `Let's launch the @getstarted example`, select: "Worktree" (≠Local), submit
4. Cursor must create a worktree with dependencies installed and strapi built, allowing to launch the example app right away.

### Related issue(s)/PR(s)

