### PR TITLE
fix: adapt header height when title changes

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -138,9 +138,12 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
     threshold: 0,
   });
 
-  useResizeObserver([containerRef], () => {
-    if (containerRef.current) {
-      const newSize = containerRef.current.getBoundingClientRect();
+  useResizeObserver([containerRef, baseHeaderLayoutRef], () => {
+    const headerContainer = baseHeaderLayoutRef.current ?? containerRef.current;
+
+    if (headerContainer) {
+      const newSize = headerContainer.getBoundingClientRect();
+
       setHeaderSize((prevSize) => {
         // Only update if size actually changed
         if (!prevSize || prevSize.height !== newSize.height || prevSize.width !== newSize.width) {
@@ -152,8 +155,9 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
   });
 
   React.useEffect(() => {
-    if (containerRef.current) {
-      setHeaderSize(containerRef.current.getBoundingClientRect());
+    if (baseHeaderLayoutRef.current || containerRef.current) {
+      const headerContainer = baseHeaderLayoutRef.current ?? containerRef.current;
+      setHeaderSize(headerContainer?.getBoundingClientRect() ?? null);
     }
   }, [containerRef]);
 


### PR DESCRIPTION
### What does it do?

Dynamically update the height of the header when title changes.

Before:

https://github.com/user-attachments/assets/ffb7e033-5587-46a2-8946-025031bf1341

After:

https://github.com/user-attachments/assets/03d85705-fb76-46f5-a67a-6b6b247d9da0

### Why is it needed?

When updating the title for a longer title (two lines), the header is cut behind the content and the action button can be inaccessible.

### How to test it?

- Go to Profile
- Change the name for something very long
-> The header height should change based on the length of the content

🚀