### PR TITLE
fix: excessive rerenders on edit view

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { useForm, createRulesEngine } from '@strapi/admin/strapi-admin';
 import { Box, BoxProps, Flex, Grid } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -52,8 +51,6 @@ interface FormLayoutProps extends Pick<EditLayout, 'layout'> {
 const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps) => {
   const { formatMessage } = useIntl();
   const modelUid = document.schema?.uid;
-  const fieldValues = useForm('Fields', (state) => state.values);
-  const rulesEngine = createRulesEngine();
 
   const getLabel = (name: string, label: string) => {
     return formatMessage({
@@ -75,15 +72,6 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
         if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
           const [row] = panel;
           const [field] = row;
-          const attribute = document.schema?.attributes[field.name];
-          const condition = attribute?.conditions?.visible;
-
-          if (condition) {
-            const isVisible = rulesEngine.evaluate(condition, fieldValues);
-            if (!isVisible) {
-              return null; // Skip rendering the dynamic zone if the condition is not met
-            }
-          }
 
           return (
             <Grid.Root key={field.name} gap={4}>
@@ -109,24 +97,9 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
               }}
             >
               {panel.map((row, gridRowIndex) => {
-                const visibleFields = row.filter(({ name }) => {
-                  const attribute = document.schema?.attributes[name];
-                  const condition = attribute?.conditions?.visible;
-
-                  if (condition) {
-                    return rulesEngine.evaluate(condition, fieldValues);
-                  }
-
-                  return true;
-                });
-
-                if (visibleFields.length === 0) {
-                  return null; // Skip rendering the entire grid row
-                }
-
                 return (
                   <ResponsiveGridRoot key={gridRowIndex} gap={4}>
-                    {visibleFields.map(({ size, ...field }) => {
+                    {row.map(({ size, ...field }) => {
                       return (
                         <ResponsiveGridItem
                           col={size}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -5,6 +5,8 @@ import {
   useForm,
   InputRenderer as FormInputRenderer,
   useField,
+  createRulesEngine,
+  type JsonLogicCondition,
 } from '@strapi/admin/strapi-admin';
 import { useIntl } from 'react-intl';
 
@@ -41,7 +43,7 @@ type InputRendererProps = DistributiveOmit<EditFieldLayout, 'size'> & {
  * the complete EditFieldLayout and will handle RBAC conditions and rendering CM specific
  * components such as Blocks / Relations.
  */
-const InputRenderer = ({
+const BaseInputRenderer = ({
   visible,
   hint: providedHint,
   document,
@@ -183,7 +185,7 @@ const InputRenderer = ({
           disabled={fieldIsDisabled}
         >
           {(componentInputProps) => (
-            <InputRenderer
+            <BaseInputRenderer
               key={`input-${componentInputProps.name}-${localeKey}`}
               {...componentInputProps}
             />
@@ -263,6 +265,26 @@ const InputRenderer = ({
   }
 };
 
+const rulesEngine = createRulesEngine();
+
+/**
+ * A wrapper around BaseInputRenderer that conditionally renders it depending on the attribute's condition.
+ */
+const ConditionAwareInputRenderer = ({
+  condition,
+  ...props
+}: InputRendererProps & { condition: JsonLogicCondition }) => {
+  // Note: this selector causes a re-render every time any form value on the page changes
+  const fieldValues = useForm('ConditionalInputRenderer', (state) => state.values);
+  const isVisible = rulesEngine.evaluate(condition, fieldValues);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return <BaseInputRenderer {...props} />;
+};
+
 const attributeHasCustomFieldProperty = (
   attribute: Schema.Attribute.AnyAttribute
 ): attribute is Schema.Attribute.AnyAttribute & Schema.Attribute.CustomField<string> =>
@@ -329,7 +351,22 @@ const getMinMax = (attribute: Schema.Attribute.AnyAttribute) => {
   }
 };
 
-const MemoizedInputRenderer = React.memo(InputRenderer);
+/**
+ * Conditionally routes the exported InputRender component towards ConditionalInputRenderer
+ * (when there's a JSON logic condition on the attribute, or BaseInputRenderer otherwise.
+ * We do this because rendering a conditional field requires access to the values of
+ * other form fields, which causes many re-renders and performance issues on complex content
+ * types. By splitting the component into two, we isolate the performance issue to
+ * conditional fields only, not all edit view fields.
+ */
+const MemoizedInputRenderer = React.memo((props: InputRendererProps) => {
+  const condition = props.attribute.conditions?.visible;
+  if (condition) {
+    return <ConditionAwareInputRenderer {...props} condition={condition} />;
+  }
+
+  return <BaseInputRenderer {...props} />;
+});
 
 export type { InputRendererProps };
 export { MemoizedInputRenderer as InputRenderer, useFieldHint };


### PR DESCRIPTION
### What does it do?

Prevents excessive re-renders on the CM edit view.

The problem came from the conditional fields feature. In order to check if an input should be rendered, it needs to subscribe to all other fields on the page, which is very expensive. My proposed fix is to only do that when an attribute does have a condition set up, so that we avoid the performance issue for the vast majority of fields that aren't conditionally rendered.

### Why is it needed?

Performance, input lag.
### How to test it?

**Excessive rerenders**
I recommend using react-scan to identify the issue, either via the browser extension or the npx command. It highlights all the components that get rerendered. You'll see that this is what happens on develop:

https://github.com/user-attachments/assets/df2ebb54-e426-45fa-9ad2-992e81b73af1

Compared to this branch:

https://github.com/user-attachments/assets/1e3f4b7f-2098-4547-99f8-38a91737438e



**Conditional rendering**

Also gotta make sure we haven't broken the conditional field feature. Use the 'Condition' content type on getstarted for that, you should see a field appear and disappear based on the boolean field.
### Related issue(s)/PR(s)

fix #24462