### PR TITLE
fix: update cloud request limit

### DIFF
--- a/packages/plugins/cloud/admin/src/components/CloudFree.tsx
+++ b/packages/plugins/cloud/admin/src/components/CloudFree.tsx
@@ -8,7 +8,7 @@ const CloudFree = () => {
   const { formatMessage } = useIntl();
 
   const features = [
-    { id: 'api', message: '10K API requests' },
+    { id: 'api', message: '2.5K API requests' },
     { id: 'storage', message: '10 GB storage' },
     { id: 'bandwidth', message: '10 GB asset bandwidth' },
     { id: 'cdn', message: 'Global CDN' },

--- a/packages/plugins/cloud/admin/src/translations/en.json
+++ b/packages/plugins/cloud/admin/src/translations/en.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Package manager",
   "Homepage.deploy.cli.copy": "Copy",
   "Homepage.deploy.documentation": "Having trouble? Check our documentation",
-  "Homepage.freePlan.api": "10K API requests",
+  "Homepage.freePlan.api": "2.5K API requests",
   "Homepage.freePlan.storage": "10 GB storage",
   "Homepage.freePlan.bandwidth": "10 GB asset bandwidth",
   "Homepage.freePlan.cdn": "Global CDN",

--- a/packages/plugins/cloud/admin/src/translations/es.json
+++ b/packages/plugins/cloud/admin/src/translations/es.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Sistema de gestión de paquetes",
   "Homepage.deploy.cli.copy": "Copiar",
   "Homepage.deploy.documentation": "¿Tienes problemas? Consulta nuestra documentación",
-  "Homepage.freePlan.api": "10K peticiones API",
+  "Homepage.freePlan.api": "2.5K peticiones API",
   "Homepage.freePlan.storage": "10 GB de almacenamiento",
   "Homepage.freePlan.bandwidth": "10 GB de ancho de banda para assets",
   "Homepage.freePlan.cdn": "CDN global",

--- a/packages/plugins/cloud/admin/src/translations/fr.json
+++ b/packages/plugins/cloud/admin/src/translations/fr.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Gestionnaire de paquets",
   "Homepage.deploy.cli.copy": "Copier",
   "Homepage.deploy.documentation": "Des difficultés ? Consultez notre documentation",
-  "Homepage.freePlan.api": "10K appels API",
+  "Homepage.freePlan.api": "2.5K appels API",
   "Homepage.freePlan.storage": "10 Go de stockage",
   "Homepage.freePlan.bandwidth": "10 Go de bande passante pour les assets",
   "Homepage.freePlan.cdn": "CDN global",

--- a/packages/plugins/cloud/admin/src/translations/it.json
+++ b/packages/plugins/cloud/admin/src/translations/it.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Sistema di gestione dei pacchetti",
   "Homepage.deploy.cli.copy": "Copia",
   "Homepage.deploy.documentation": "Hai bisogno di aiuto? Consulta la nostra documentazione",
-  "Homepage.freePlan.api": "10K Richieste API",
+  "Homepage.freePlan.api": "2.5K Richieste API",
   "Homepage.freePlan.storage": "10 GB di spazio di archiviazione",
   "Homepage.freePlan.bandwidth": "10 GB di larghezza di banda per gli asset",
   "Homepage.freePlan.cdn": "CDN globale",

--- a/packages/plugins/cloud/admin/src/translations/ru.json
+++ b/packages/plugins/cloud/admin/src/translations/ru.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Система управления пакетами",
   "Homepage.deploy.cli.copy": "Копировать",
   "Homepage.deploy.documentation": "Возникли трудности? Ознакомьтесь с нашей документацией",
-  "Homepage.freePlan.api": "10 000 API-запросов",
+  "Homepage.freePlan.api": "2 500 API-запросов",
   "Homepage.freePlan.storage": "10 ГБ хранилища",
   "Homepage.freePlan.bandwidth": "10 ГБ трафика ресурсов",
   "Homepage.freePlan.cdn": "Глобальный CDN",

--- a/packages/plugins/cloud/admin/src/translations/uk.json
+++ b/packages/plugins/cloud/admin/src/translations/uk.json
@@ -13,7 +13,7 @@
   "Homepage.deploy.cli.ariaLabel": "Система керування пакунками",
   "Homepage.deploy.cli.copy": "Копіювати",
   "Homepage.deploy.documentation": "Маєте труднощі? Перевірте нашу документацію",
-  "Homepage.freePlan.api": "10 000 API-запитів",
+  "Homepage.freePlan.api": "2 500 API-запитів",
   "Homepage.freePlan.storage": "10 ГБ сховища",
   "Homepage.freePlan.bandwidth": "10 ГБ пропускної здатності для ресурсів",
   "Homepage.freePlan.cdn": "Глобальний CDN",


### PR DESCRIPTION
### What does it do?

Change the number of requests for Cloud.

<img width="1476" height="751" alt="Screenshot 2025-12-16 at 09 41 59" src="https://github.com/user-attachments/assets/3e0676df-c342-4d4c-879d-944e7aefa291" />


### Why is it needed?

To reflect changes made to the limitation.

### How to test it?

- Install `@strapi/plugin-cloud` to the package.json of your Strapi project (if not already installed)
- Go to the Cloud page in the CMS to display the Free plan message

🚀