### PR TITLE
ci(prerelease): use github trusted publisher instead of token

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -8,21 +8,37 @@ on:
         default: 'experimental'
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  id-token: write # Required for npm trusted publishing via GitHub OIDC
+  contents: read # Allows the workflow to check out the repository
 
 jobs:
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
+
+    # Safety check to ensure this workflow only runs on the main Strapi repository
     if: github.repository == 'strapi/strapi'
+
     steps:
+      # Fetch the repository contents
       - uses: actions/checkout@v4
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
+      # Install Node.js and configure npm to use the public npm registry
+      # This also wires npm to GitHub OIDC for trusted publishing
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      # Ensure a recent npm version that supports OIDC trusted publishing
+      - name: Install compatible npm version
+        run: npm install -g npm@11.5.1
+
+      # Install project dependencies
       - run: yarn
+
+      # Run the prerelease publish script
+      # IMPORTANT: this script must call `npm publish` (not `yarn publish`)
       - run: ./scripts/pre-publish.sh
         env:
           VERSION: '0.0.0-experimental.${{ github.sha }}'


### PR DESCRIPTION
### What does it do?

stop using NPM_TOKEN now that we've configured github as a trusted publisher on npm

### Why is it needed?

to do experimental releases

### How to test it?

run the "prerelease" action (after merging this) and ensure it works now


### Related issue(s)/PR(s)


