### PR TITLE
chore: use design-system variables for preview

### DIFF
--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -21,7 +21,7 @@ import {
 import { ArrowLineLeft } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 import { useLocation, useParams } from 'react-router-dom';
-import { styled } from 'styled-components';
+import { styled, useTheme } from 'styled-components';
 
 import { GetPreviewUrl } from '../../../../shared/contracts/preview';
 import { COLLECTION_TYPES } from '../../constants/collections';
@@ -105,6 +105,7 @@ const AnimatedArrow = styled(ArrowLineLeft)<{ $isSideEditorOpen: boolean }>`
 const PreviewPage = () => {
   const location = useLocation();
   const { formatMessage } = useIntl();
+  const theme = useTheme();
 
   const iframeRef = React.useRef<HTMLIFrameElement>(null);
   const [isSideEditorOpen, setIsSideEditorOpen] = React.useState(true);
@@ -133,6 +134,11 @@ const PreviewPage = () => {
   );
   const device = DEVICES.find((d) => d.name === deviceName) ?? DEVICES[0];
 
+  const previewHighlightColors = {
+    highlightHoverColor: theme.colors.primary500,
+    highlightActiveColor: theme.colors.primary600,
+  };
+
   // Listen for ready message from iframe before injecting script
   React.useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -145,7 +151,10 @@ const PreviewPage = () => {
       }
 
       if (event.data?.type === PUBLIC_EVENTS.PREVIEW_READY) {
-        const script = `(${previewScript.toString()})()`;
+        const script = `(${previewScript.toString()})(${JSON.stringify({
+          shouldRun: true,
+          colors: previewHighlightColors,
+        })})`;
         const sendMessage = getSendMessage(iframeRef);
         sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
       }
@@ -156,7 +165,7 @@ const PreviewPage = () => {
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, [documentId, toggleNotification]);
+  }, [documentId, toggleNotification, theme]);
 
   if (!collectionType) {
     throw new Error('Could not find collectionType in url params');

--- a/packages/core/content-manager/admin/src/preview/utils/constants.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/constants.ts
@@ -3,7 +3,12 @@ import { MessageDescriptor } from 'react-intl';
 
 import { previewScript } from './previewScript';
 
-const scriptResponse = previewScript(false);
+export const PREVIEW_HIGHLIGHT_COLORS = {
+  highlightHoverColor: 'transparent',
+  highlightActiveColor: 'transparent',
+} as const;
+
+const scriptResponse = previewScript({ shouldRun: false, colors: PREVIEW_HIGHLIGHT_COLORS });
 
 /**
  * These events can be changed safely. They're used by the content manager admin on one side, and by

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -14,13 +14,26 @@ declare global {
  * It's why many functions are defined within previewScript, it's the only way to avoid going full spaghetti.
  * To get a better overview of everything previewScript does, go to the orchestration part at its end.
  */
-const previewScript = (shouldRun = true) => {
+type PreviewScriptColors = {
+  highlightHoverColor: string;
+  highlightActiveColor: string;
+};
+
+type PreviewScriptConfig = {
+  shouldRun?: boolean;
+  colors: PreviewScriptColors;
+};
+
+const previewScript = (config: PreviewScriptConfig) => {
+  const { shouldRun = true, colors } = config;
+
   /* -----------------------------------------------------------------------------------------------
    * Params
    * ---------------------------------------------------------------------------------------------*/
   const HIGHLIGHT_PADDING = 2; // in pixels
-  const HIGHLIGHT_HOVER_COLOR = window.STRAPI_HIGHLIGHT_HOVER_COLOR ?? '#4945ff'; // dark primary500
-  const HIGHLIGHT_ACTIVE_COLOR = window.STRAPI_HIGHLIGHT_ACTIVE_COLOR ?? '#7b79ff'; // dark primary600
+  const HIGHLIGHT_HOVER_COLOR = window.STRAPI_HIGHLIGHT_HOVER_COLOR ?? colors.highlightHoverColor;
+  const HIGHLIGHT_ACTIVE_COLOR =
+    window.STRAPI_HIGHLIGHT_ACTIVE_COLOR ?? colors.highlightActiveColor;
   const HIGHLIGHT_STYLES_ID = 'strapi-preview-highlight-styles';
   const DOUBLE_CLICK_TIMEOUT = 300; // milliseconds to wait for potential double-click
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Use the design system to set the colors used in Preview rather than hard-coded hex codes.

### Why is it needed?

Allows for easier maintainability of the code.

### How to test it?

* Set `PREVIEW_ENABLED=true` in your .env
* Go to any content type, click on an existing entry (or create a new entry, fill it out and click save)
* Click on the Preview button on the right side panel.
* Hover over a text field -> in Preview, that text field should be highlighted in a dark blue color.
