### PR TITLE
fix(i18n): show locale key in disabled select when editing locale

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
+++ b/packages/plugins/i18n/admin/src/components/CreateLocale.tsx
@@ -397,6 +397,9 @@ const EnumerationInput = ({
     }
   };
 
+  // Find the label for the current value to display in the combobox
+  const selectedOption = options.find((option) => option.value === value);
+
   return (
     <Field.Root error={error} hint={hint} name={name} required={required}>
       <Field.Label>{label}</Field.Label>
@@ -406,6 +409,7 @@ const EnumerationInput = ({
         onClear={() => handleChange('')}
         placeholder={placeholder}
         value={value}
+        textValue={selectedOption?.label}
         autocomplete={{ type: 'list', filter: 'contains' }}
       >
         {options.map((option) => (


### PR DESCRIPTION
### What does it do?

Adds `textValue` prop to the Combobox component in `EnumerationInput` to display the selected locale's label when the field is disabled in edit mode.

Changes in `packages/plugins/i18n/admin/src/components/CreateLocale.tsx`:
- Find the matching option based on current value
- Pass the option's label as `textValue` to the Combobox

### Why is it needed?

When editing a locale, the disabled select box for the locale key was showing "Select" (the placeholder text) instead of the actual locale name (e.g., "English"). This made it unclear which locale was being edited.

### How to test it?

1. Go to Settings → Internationalization
2. Create a new locale (e.g., French) and save
3. Click edit on the newly created locale
4. Verify the left-side "Locales" dropdown (disabled) shows the locale name (e.g., "French") instead of "Select"

Also verify creating a new locale still works:
1. Click "Add new locale"
2. Verify the dropdown shows "Select" initially
3. Select a locale and verify it displays correctly

### Related issue(s)/PR(s)

Fix #25120

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234