### PR TITLE
fix: change commit-lint to make body length a warning

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -21,6 +21,11 @@ const config: UserConfig = {
         'future',
       ],
     ],
+    'body-max-line-length': [
+      RuleConfigSeverity.Warning,
+      'always',
+      150,
+    ],
   },
   ignores: [
     (commitMessage) => {


### PR DESCRIPTION
### What does it do?

Changes the commit lint body max length rule to be a warning not an error and increase the maximum from 100 to 150

### Why is it needed?

Annoying when you need to put links or references in your commit messages

### How to test it?

Make a commit with a body longer than 100

### Related issue(s)/PR(s)

N/A
