### PR TITLE
fix(users-permissions): implement session revocation on password changes

### DIFF
--- a/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
+++ b/docs/docs/docs/01-core/authentication/00-sessions-and-jwt.md
@@ -119,6 +119,16 @@ Key files:
 - Routes: `packages/plugins/users-permissions/server/routes/content-api/auth.js`
 - JWT service: `packages/plugins/users-permissions/server/services/jwt.js`
 
+## Session Revocation on Credential Changes
+
+For security, **password changes and resets automatically invalidate all active refresh/session tokens** across all devices:
+
+- **Admin**: When an admin user changes their password via `PUT /admin/users/me` (with `currentPassword` and `password`), all admin sessions are revoked, including the current session. The user must re-authenticate.
+- **Admin**: When an admin resets their password via `POST /admin/reset-password`, all existing admin sessions are revoked before issuing a new session.
+- **Content API (refresh mode)**: When a user changes their password via `POST /api/auth/change-password` or resets it via `POST /api/auth/reset-password`, all users-permissions sessions are revoked. A new refresh token is issued for the current request.
+
+This behavior ensures that compromised refresh tokens cannot be used after a password change, mitigating persistent session hijacking attacks.
+
 ## Notes
 
 - Access tokens are always used in the `Authorization` header as `Bearer <token>`.

--- a/packages/core/admin/server/src/controllers/authenticated-user.ts
+++ b/packages/core/admin/server/src/controllers/authenticated-user.ts
@@ -4,6 +4,7 @@ import type { AdminUser } from '../../../shared/contracts/shared';
 import { getService } from '../utils';
 import { validateProfileUpdateInput } from '../validation/user';
 import { GetMe, GetOwnPermissions, UpdateMe } from '../../../shared/contracts/users';
+import { getSessionManager } from '../../../shared/utils/session-auth';
 
 export default {
   async getMe(ctx: Context) {
@@ -31,6 +32,12 @@ export default {
         return ctx.badRequest('ValidationError', {
           currentPassword: ['Invalid credentials'],
         });
+      }
+
+      // Invalidate all sessions when password changes for security
+      const sessionManager = getSessionManager();
+      if (sessionManager && sessionManager.hasOrigin('admin')) {
+        await sessionManager('admin').invalidateRefreshToken(String(ctx.state.user.id));
       }
     }
 

--- a/packages/plugins/users-permissions/server/controllers/auth.js
+++ b/packages/plugins/users-permissions/server/controllers/auth.js
@@ -235,12 +235,8 @@ module.exports = ({ strapi }) => ({
     if (mode === 'refresh') {
       const deviceId = extractDeviceId(ctx.request.body);
 
-      if (deviceId) {
-        // Invalidate sessions: specific device if deviceId provided
-        await strapi
-          .sessionManager('users-permissions')
-          .invalidateRefreshToken(String(user.id), deviceId);
-      }
+      // Invalidate all sessions when password changes for security
+      await strapi.sessionManager('users-permissions').invalidateRefreshToken(String(user.id));
 
       const newDeviceId = deviceId || crypto.randomUUID();
       const refresh = await strapi
@@ -296,12 +292,8 @@ module.exports = ({ strapi }) => ({
     if (mode === 'refresh') {
       const deviceId = extractDeviceId(ctx.request.body);
 
-      if (deviceId) {
-        // Invalidate sessions: specific device if deviceId provided
-        await strapi
-          .sessionManager('users-permissions')
-          .invalidateRefreshToken(String(user.id), deviceId);
-      }
+      // Invalidate all sessions when password is reset for security
+      await strapi.sessionManager('users-permissions').invalidateRefreshToken(String(user.id));
 
       const newDeviceId = deviceId || crypto.randomUUID();
       const refresh = await strapi

--- a/tests/api/core/admin/admin-password-change-revokes-sessions.test.api.ts
+++ b/tests/api/core/admin/admin-password-change-revokes-sessions.test.api.ts
@@ -1,0 +1,247 @@
+'use strict';
+
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createRequest } from 'api-tests/request';
+import { createUtils } from 'api-tests/utils';
+
+/**
+ * Tests for admin password change session revocation
+ * Focus: Verify that changing password via updateMe invalidates all refresh sessions
+ */
+describe('Admin Password Change Revokes Sessions', () => {
+  let strapi: any;
+  let rq: any;
+  let utils: any;
+
+  const cookieName = 'strapi_admin_refresh';
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance();
+    rq = createRequest({ strapi });
+    utils = createUtils(strapi);
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  const getCookie = (res: any, name: string): string | undefined => {
+    const setCookies: string[] = res.headers['set-cookie'] || [];
+    return setCookies.find((c) => c.startsWith(`${name}=`));
+  };
+
+  const extractRefreshToken = (cookie: string): string => {
+    return cookie.split(';')[0].split('=')[1];
+  };
+
+  test('Password change via updateMe invalidates all existing refresh sessions', async () => {
+    const initialPassword = 'Test1234!';
+    const newPassword = 'NewTest1234!';
+
+    // Create a test admin user
+    const testAdmin = await utils.createUser({
+      firstname: 'Test',
+      lastname: 'Admin',
+      email: 'test-pwd-change@strapi.io',
+      password: initialPassword,
+      isActive: true,
+    });
+
+    // Device 1: Login
+    const loginDevice1Res = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: initialPassword,
+        rememberMe: true,
+      },
+    });
+    expect(loginDevice1Res.statusCode).toBe(200);
+    const device1Cookie = getCookie(loginDevice1Res, cookieName);
+    expect(device1Cookie).toBeDefined();
+    const device1RefreshToken = extractRefreshToken(device1Cookie!);
+    const device1AccessToken = loginDevice1Res.body.data.token;
+
+    // Device 2: Login (simulate second device)
+    const loginDevice2Res = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: initialPassword,
+        rememberMe: true,
+      },
+    });
+    expect(loginDevice2Res.statusCode).toBe(200);
+    const device2Cookie = getCookie(loginDevice2Res, cookieName);
+    expect(device2Cookie).toBeDefined();
+    const device2RefreshToken = extractRefreshToken(device2Cookie!);
+
+    // Verify both refresh tokens work before password change
+    const refreshDevice1Before = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${device1RefreshToken}`,
+      },
+    });
+    expect(refreshDevice1Before.statusCode).toBe(200);
+    expect(refreshDevice1Before.body.data.token).toEqual(expect.any(String));
+
+    const refreshDevice2Before = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${device2RefreshToken}`,
+      },
+    });
+    expect(refreshDevice2Before.statusCode).toBe(200);
+    expect(refreshDevice2Before.body.data.token).toEqual(expect.any(String));
+
+    // Change password using device1's access token
+    const updateMeRes = await rq.put('/admin/users/me', {
+      headers: {
+        Authorization: `Bearer ${device1AccessToken}`,
+      },
+      body: {
+        currentPassword: initialPassword,
+        password: newPassword,
+      },
+    });
+    expect(updateMeRes.statusCode).toBe(200);
+
+    // Verify OLD refresh tokens from BOTH devices are now invalid
+    const refreshDevice1After = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${device1RefreshToken}`,
+      },
+    });
+    expect(refreshDevice1After.statusCode).toBe(401);
+
+    const refreshDevice2After = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${device2RefreshToken}`,
+      },
+    });
+    expect(refreshDevice2After.statusCode).toBe(401);
+
+    // Verify can login with new password
+    const reloginRes = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: newPassword,
+        rememberMe: true,
+      },
+    });
+    expect(reloginRes.statusCode).toBe(200);
+    expect(reloginRes.body.data.token).toEqual(expect.any(String));
+
+    // Verify the new login's refresh token works
+    const newCookie = getCookie(reloginRes, cookieName);
+    expect(newCookie).toBeDefined();
+    const newRefreshToken = extractRefreshToken(newCookie!);
+
+    const refreshNewToken = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${newRefreshToken}`,
+      },
+    });
+    expect(refreshNewToken.statusCode).toBe(200);
+    expect(refreshNewToken.body.data.token).toEqual(expect.any(String));
+  });
+
+  test('Cannot login with old password after password change', async () => {
+    const initialPassword = 'OldPass1234!';
+    const newPassword = 'NewPass1234!';
+
+    // Create a test admin user
+    const testAdmin = await utils.createUser({
+      firstname: 'Test2',
+      lastname: 'Admin',
+      email: 'test-pwd-change-2@strapi.io',
+      password: initialPassword,
+      isActive: true,
+    });
+
+    // Login
+    const loginRes = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: initialPassword,
+      },
+    });
+    expect(loginRes.statusCode).toBe(200);
+    const accessToken = loginRes.body.data.token;
+
+    // Change password
+    const updateMeRes = await rq.put('/admin/users/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: {
+        currentPassword: initialPassword,
+        password: newPassword,
+      },
+    });
+    expect(updateMeRes.statusCode).toBe(200);
+
+    // Verify cannot login with old password
+    const oldPasswordRes = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: initialPassword,
+      },
+    });
+    expect(oldPasswordRes.statusCode).toBe(400);
+
+    // Verify can login with new password
+    const newPasswordRes = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: newPassword,
+      },
+    });
+    expect(newPasswordRes.statusCode).toBe(200);
+  });
+
+  test('Profile update without password change does not invalidate sessions', async () => {
+    const initialPassword = 'InitialPass1234!';
+
+    // Create a test admin user
+    const testAdmin = await utils.createUser({
+      firstname: 'Test3',
+      lastname: 'Admin',
+      email: 'test-pwd-change-3@strapi.io',
+      password: initialPassword,
+      isActive: true,
+    });
+
+    // Login
+    const loginRes = await rq.post('/admin/login', {
+      body: {
+        email: testAdmin.email,
+        password: initialPassword,
+        rememberMe: true,
+      },
+    });
+
+    expect(loginRes.statusCode).toBe(200);
+    const cookie = getCookie(loginRes, cookieName);
+    expect(cookie).toBeDefined();
+    const refreshToken = extractRefreshToken(cookie!);
+    const accessToken = loginRes.body.data.token;
+
+    // Update profile without password change (e.g., just firstname)
+    const updateMeRes = await rq.put('/admin/users/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: {
+        firstname: 'UpdatedFirstname',
+      },
+    });
+    expect(updateMeRes.statusCode).toBe(200);
+
+    // Verify refresh token still works (no invalidation occurred)
+    const refreshAfter = await rq.post('/admin/access-token', {
+      headers: {
+        Cookie: `${cookieName}=${refreshToken}`,
+      },
+    });
+    expect(refreshAfter.statusCode).toBe(200);
+    expect(refreshAfter.body.data.token).toEqual(expect.any(String));
+  });
+});

--- a/tests/api/plugins/users-permissions/content-api/auth-password-update-revokes-sessions.test.api.ts
+++ b/tests/api/plugins/users-permissions/content-api/auth-password-update-revokes-sessions.test.api.ts
@@ -1,0 +1,190 @@
+'use strict';
+
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createRequest } from 'api-tests/request';
+import { createAuthenticatedUser } from '../utils';
+
+let strapi: any;
+
+const baseTestUser = {
+  password: 'Test1234!',
+  confirmed: true,
+  provider: 'local',
+};
+
+describe('Users & Permissions - Password updates revoke all refresh sessions', () => {
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      bypassAuth: false,
+      async bootstrap({ strapi: s }) {
+        s.config.set('plugin::users-permissions.jwtManagement', 'refresh');
+        s.config.set('plugin::users-permissions.sessions.httpOnly', false);
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.db.query('plugin::users-permissions.user').deleteMany();
+    await strapi.destroy();
+  });
+
+  // Helper to create a user with unique credentials
+  const createUser = async (prefix: string) => {
+    const userInfo = {
+      ...baseTestUser,
+      username: `${prefix}-${Date.now()}`,
+      email: `${prefix}-${Date.now()}@strapi.io`,
+    };
+    await createAuthenticatedUser({ strapi, userInfo });
+    return userInfo;
+  };
+
+  // Helper to login and get tokens
+  const loginUser = async (rqAuth: any, email: string, password: string) => {
+    const res = await rqAuth({
+      method: 'POST',
+      url: '/local',
+      body: { identifier: email, password },
+    });
+    expect(res.statusCode).toBe(200);
+    return {
+      jwt: res.body.jwt,
+      refreshToken: res.body.refreshToken,
+    };
+  };
+
+  // Helper to verify refresh token works
+  const verifyRefreshToken = async (rqAuth: any, refreshToken: string, shouldWork: boolean) => {
+    const res = await rqAuth({
+      method: 'POST',
+      url: '/refresh',
+      body: { refreshToken },
+    });
+    if (shouldWork) {
+      expect(res.statusCode).toBe(200);
+    } else {
+      expect(res.statusCode).toBe(401);
+      expect(res.body.error.message).toBe('Invalid refresh token');
+    }
+    return res;
+  };
+
+  describe.each([
+    {
+      name: 'password change',
+      performPasswordUpdate: async (
+        _rqAuth: any,
+        user: { email: string; password: string },
+        jwt: string,
+        newPassword: string
+      ) => {
+        const rqAuthed = createRequest({ strapi }).setURLPrefix('/api/auth').setToken(jwt);
+        const res = await rqAuthed({
+          method: 'POST',
+          url: '/change-password',
+          body: {
+            currentPassword: user.password,
+            password: newPassword,
+            passwordConfirmation: newPassword,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body.jwt).toEqual(expect.any(String));
+        expect(res.body.refreshToken).toEqual(expect.any(String));
+        return res.body.refreshToken;
+      },
+    },
+    {
+      name: 'password reset',
+      performPasswordUpdate: async (
+        rqAuth: any,
+        user: { email: string; password: string },
+        _jwt: string,
+        newPassword: string
+      ) => {
+        // Generate reset password token
+        const resetPasswordToken = `reset-token-${Date.now()}`;
+        const dbUser = await strapi.db
+          .query('plugin::users-permissions.user')
+          .findOne({ where: { email: user.email } });
+
+        await strapi.db.query('plugin::users-permissions.user').update({
+          where: { id: dbUser.id },
+          data: { resetPasswordToken },
+        });
+
+        // Reset password using the token
+        const res = await rqAuth({
+          method: 'POST',
+          url: '/reset-password',
+          body: {
+            code: resetPasswordToken,
+            password: newPassword,
+            passwordConfirmation: newPassword,
+          },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body.jwt).toEqual(expect.any(String));
+        expect(res.body.refreshToken).toEqual(expect.any(String));
+        return res.body.refreshToken;
+      },
+    },
+  ])('$name', ({ name, performPasswordUpdate }) => {
+    test(`${name} invalidates all existing refresh tokens (multi-session scenario)`, async () => {
+      const rqAuth = createRequest({ strapi }).setURLPrefix('/api/auth');
+      const user = await createUser(`test-${name.replace(' ', '-')}-revoke`);
+
+      // Create two sessions (simulating two devices)
+      const session1 = await loginUser(rqAuth, user.email, user.password);
+      const session2 = await loginUser(rqAuth, user.email, user.password);
+
+      // Verify tokens are different
+      expect(session1.refreshToken).not.toBe(session2.refreshToken);
+
+      // Verify both refresh tokens work before password update
+      await verifyRefreshToken(rqAuth, session1.refreshToken, true);
+      await verifyRefreshToken(rqAuth, session2.refreshToken, true);
+
+      // Perform password update
+      const newPassword = 'NewPassword1234!';
+      const newRefreshToken = await performPasswordUpdate(rqAuth, user, session1.jwt, newPassword);
+
+      // Verify the NEW refresh token from password update works
+      await verifyRefreshToken(rqAuth, newRefreshToken, true);
+
+      // Verify OLD refresh tokens from BOTH sessions are now invalid
+      await verifyRefreshToken(rqAuth, session1.refreshToken, false);
+      await verifyRefreshToken(rqAuth, session2.refreshToken, false);
+    });
+
+    test(`can login with new password after ${name}`, async () => {
+      const rqAuth = createRequest({ strapi }).setURLPrefix('/api/auth');
+      const user = await createUser(`test-${name.replace(' ', '-')}-login`);
+
+      // Login to get JWT (needed for password change)
+      const session = await loginUser(rqAuth, user.email, user.password);
+
+      // Perform password update
+      const newPassword = 'UpdatedPass1234!';
+      await performPasswordUpdate(rqAuth, user, session.jwt, newPassword);
+
+      // Verify can login with new password
+      const reloginRes = await rqAuth({
+        method: 'POST',
+        url: '/local',
+        body: { identifier: user.email, password: newPassword },
+      });
+      expect(reloginRes.statusCode).toBe(200);
+      expect(reloginRes.body.jwt).toEqual(expect.any(String));
+      expect(reloginRes.body.refreshToken).toEqual(expect.any(String));
+
+      // Verify cannot login with old password
+      const oldPasswordRes = await rqAuth({
+        method: 'POST',
+        url: '/local',
+        body: { identifier: user.email, password: user.password },
+      });
+      expect(oldPasswordRes.statusCode).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Implements session revocation when user passwords are changed or reset in the users-permissions plugin.

### How to test it?

Run added and modified tests

### Related issue(s)/PR(s)

CMS-82