### PR TITLE
docs: fix typo 'recieve' -> 'receive' in layouts documentation

### DIFF
--- a/docs/docs/docs/01-core/content-manager/02-layouts.md
+++ b/docs/docs/docs/01-core/content-manager/02-layouts.md
@@ -73,7 +73,7 @@ type EditFieldLayout = {
 }[Attribute.Kind];
 ```
 
-The excluded `type` values are unique to the content-manager and as such aren't expected to be rendered as universal form inputs. This data-structure is passed to the `InputRenderer` component to render any form input (previously known as `GenericInputs` from the helper-plugin). Notice how these inputs don't recieve their `value`, `onChange` or `error` prop. These are extracted from the `Form` using `useField(name)`:
+The excluded `type` values are unique to the content-manager and as such aren't expected to be rendered as universal form inputs. This data-structure is passed to the `InputRenderer` component to render any form input (previously known as `GenericInputs` from the helper-plugin). Notice how these inputs don't receive their `value`, `onChange` or `error` prop. These are extracted from the `Form` using `useField(name)`:
 
 ```ts
 export const StringInput = forwardRef<HTMLInputElement, InputProps>(


### PR DESCRIPTION
## Summary
- Fixed typo in `docs/docs/01-core/content-manager/02-layouts.md` line 76
- Changed `recieve` to `receive`

## Test plan
- [x] Verified the change is a simple typo fix with no impact on functionality