### PR TITLE
docs: add note about local plugins size in Strapi 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ This command generates a brand new project with the default features (authentica
 
 Enjoy 🎉
 
+## Local Plugins in Strapi 5
+
+When using local plugins in Strapi 5, each plugin may include its own `node_modules` directory, which can significantly increase the project size and cause deployment issues.
+
+### Recommendation:
+- Prefer using a monorepo or workspace setup to share dependencies.
+- Avoid committing plugin `node_modules` folders.
+- Consider linking plugins using package managers instead of copying dependencies.
+
+This helps keep builds smaller and deployments more reliable.
+
+
 ### 🖐 Requirements
 
 Complete installation requirements can be found in the documentation under <a href="https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html">Installation Requirements</a>.


### PR DESCRIPTION
Added recommendations for using local plugins in Strapi 5 to manage dependencies and reduce project size.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR adds documentation about local plugins behavior in Strapi 5, explaining the node_modules size increase issue and providing recommended best practices to avoid large build sizes.

### Why is it needed?

Local plugins in Strapi 5 may significantly increase project size due to duplicated dependencies, which can cause deployment and performance issues. Clear documentation helps developers avoid this problem.

### How to test it?

Open the README file and review the new "Local Plugins in Strapi 5" section. The information should be clear and easy to follow.

### Related issue(s)/PR(s)

Related to issue #22946
