### PR TITLE
fix: reorder components and dz on mobile

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -17,7 +17,7 @@ import {
   useComposedRefs,
   BoxComponent,
 } from '@strapi/design-system';
-import { Plus, Drag, Trash } from '@strapi/icons';
+import { Plus, Drag, Trash, ArrowUp, ArrowDown } from '@strapi/icons';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
 import { useLocation } from 'react-router-dom';
@@ -280,6 +280,7 @@ const RepeatableComponent = ({
                 onDropItem={handleDropItem}
                 onGrabItem={handleGrabItem}
                 __temp_key__={key}
+                totalLength={value.length}
               >
                 {layout.map((row, index) => {
                   const visibleFields = row.filter(({ ...field }) => {
@@ -393,6 +394,7 @@ interface ComponentProps
   toggleCollapses: () => void;
   children: React.ReactNode;
   __temp_key__: string;
+  totalLength: number;
 }
 
 const Component = ({
@@ -407,6 +409,8 @@ const Component = ({
   onDeleteComponent,
   toggleCollapses,
   __temp_key__,
+  totalLength,
+  onMoveItem,
   ...dragProps
 }: ComponentProps) => {
   const { formatMessage } = useIntl();
@@ -438,6 +442,7 @@ const Component = ({
         // Close all collapses
         toggleCollapses();
       },
+      onMoveItem,
       ...dragProps,
     });
 
@@ -450,6 +455,29 @@ const Component = ({
     boxRef as React.RefObject<HTMLDivElement>,
     dropRef
   );
+
+  const handleMoveUp = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (index > 0 && onMoveItem) {
+        onMoveItem(index - 1, index);
+      }
+    },
+    [index, onMoveItem]
+  );
+
+  const handleMoveDown = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (index < totalLength - 1 && onMoveItem) {
+        onMoveItem(index + 1, index);
+      }
+    },
+    [index, totalLength, onMoveItem]
+  );
+
+  const canMoveUp = index > 0;
+  const canMoveDown = index < totalLength - 1;
 
   return (
     <>
@@ -486,6 +514,36 @@ const Component = ({
                 >
                   <Drag />
                 </IconButton>
+              )}
+              {!isDesktop && (
+                <>
+                  {canMoveUp && (
+                    <IconButton
+                      disabled={disabled || !canMoveUp}
+                      variant="ghost"
+                      onClick={handleMoveUp}
+                      label={formatMessage({
+                        id: getTranslation('components.DynamicZone.move-up'),
+                        defaultMessage: 'Move up',
+                      })}
+                    >
+                      <ArrowUp />
+                    </IconButton>
+                  )}
+                  {canMoveDown && (
+                    <IconButton
+                      disabled={disabled || !canMoveDown}
+                      variant="ghost"
+                      onClick={handleMoveDown}
+                      label={formatMessage({
+                        id: getTranslation('components.DynamicZone.move-down'),
+                        defaultMessage: 'Move down',
+                      })}
+                    >
+                      <ArrowDown />
+                    </IconButton>
+                  )}
+                </>
               )}
             </Accordion.Actions>
           </Accordion.Header>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -11,7 +11,7 @@ import {
   Menu,
   BoxComponent,
 } from '@strapi/design-system';
-import { Drag, More, Trash } from '@strapi/icons';
+import { Drag, More, Trash, ArrowUp, ArrowDown } from '@strapi/icons';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -38,6 +38,7 @@ interface DynamicComponentProps
   onAddComponent: (componentUid: string, index: number) => void;
   onRemoveComponentClick: () => void;
   onMoveComponent: (dragIndex: number, hoverIndex: number) => void;
+  totalLength: number;
   children?: (props: InputRendererProps) => React.ReactNode;
 }
 
@@ -53,6 +54,7 @@ const DynamicComponent = ({
   onCancel,
   dynamicComponentsByCategory = {},
   onAddComponent,
+  totalLength,
   children,
 }: DynamicComponentProps) => {
   const { formatMessage } = useIntl();
@@ -124,6 +126,29 @@ const DynamicComponent = ({
 
   const composedBoxRefs = useComposedRefs(boxRef, dropRef);
 
+  const handleMoveUp = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (index > 0) {
+        onMoveComponent(index - 1, index);
+      }
+    },
+    [index, onMoveComponent]
+  );
+
+  const handleMoveDown = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (index < totalLength - 1) {
+        onMoveComponent(index + 1, index);
+      }
+    },
+    [index, totalLength, onMoveComponent]
+  );
+
+  const canMoveUp = index > 0;
+  const canMoveDown = index < totalLength - 1;
+
   const accordionActions = disabled ? null : (
     <>
       <IconButton
@@ -153,6 +178,36 @@ const DynamicComponent = ({
         >
           <Drag />
         </IconButton>
+      )}
+      {!isDesktop && (
+        <>
+          {canMoveUp && (
+            <IconButton
+              variant="ghost"
+              onClick={handleMoveUp}
+              disabled={!canMoveUp}
+              label={formatMessage({
+                id: getTranslation('components.DynamicZone.move-up'),
+                defaultMessage: 'Move up',
+              })}
+            >
+              <ArrowUp />
+            </IconButton>
+          )}
+          {canMoveDown && (
+            <IconButton
+              variant="ghost"
+              onClick={handleMoveDown}
+              disabled={!canMoveDown}
+              label={formatMessage({
+                id: getTranslation('components.DynamicZone.move-down'),
+                defaultMessage: 'Move down',
+              })}
+            >
+              <ArrowDown />
+            </IconButton>
+          )}
+        </>
       )}
       <Menu.Root>
         <Menu.Trigger size="S" endIcon={null} paddingLeft={0} paddingRight={0}>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/Field.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/Field.tsx
@@ -286,6 +286,7 @@ const DynamicZone = ({
                     onGrabItem={handleGrabItem}
                     onAddComponent={handleAddComponent}
                     dynamicComponentsByCategory={dynamicComponentsByCategory}
+                    totalLength={dynamicDisplayedComponentsLength}
                   >
                     {children}
                   </DynamicComponent>


### PR DESCRIPTION
### What does it do?

Improve reordering of components and dynamic zones on mobile with a different approach than the drag and drop.

https://github.com/user-attachments/assets/991613d0-5c15-468e-aaf4-1d7f34c3256a

### Why is it needed?

Help improving the experience on mobile and bring back the reordering feature of components in the content manager.

### How to test it?

- Go to the admin > Content Manager
- Select a content type that has repeatable components / dynamic zones
- Add multiple elements to a components field / a dynamic zone
- Fill some information to be able to differentiate them
-> Play with the arrows to switch the position of the components

🚀