### PR TITLE
chore: fix typos in comments and docs

### DIFF
--- a/docs/docs/docs/01-core/content-manager/00-intro.md
+++ b/docs/docs/docs/01-core/content-manager/00-intro.md
@@ -8,7 +8,7 @@ tags:
 
 ## What is the Content Manager?
 
-The content-manager is a plugin that allows users to write / update & delete their content, it's currently held within the `@strapi/admin` package, but from V5 will be removed back to to its own plugin. At its very basic form, the CM is just a table & a few forms. There are a few public APIs to manipulate these forms & tables as well as some universal hooks exported for user's to additionally interact with within their own plugins outside of the CM plugin & within.
+The content-manager is a plugin that allows users to write / update & delete their content, it's currently held within the `@strapi/admin` package, but from V5 will be removed back to its own plugin. At its very basic form, the CM is just a table & a few forms. There are a few public APIs to manipulate these forms & tables as well as some universal hooks exported for user's to additionally interact with within their own plugins outside of the CM plugin & within.
 
 ## Sections
 

--- a/packages/core/admin/admin/src/pages/Settings/pages/Roles/utils/forms.ts
+++ b/packages/core/admin/admin/src/pages/Settings/pages/Roles/utils/forms.ts
@@ -140,7 +140,7 @@ const createDefaultPropertiesForm = (
 };
 
 /**
- * Creates the default for for a content type
+ * Creates the default for a content type
  */
 const createDefaultCTForm = (
   { subjects, actions = [] }: ContentPermission,

--- a/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts
@@ -65,7 +65,7 @@ const getRetentionDays = (strapi: Core.Strapi) => {
 
 /**
  * @description
- * Manages the the lifecycle of audit logs. Accessible via strapi.get('audit-logs-lifecycles')
+ * Manages the lifecycle of audit logs. Accessible via strapi.get('audit-logs-lifecycles')
  */
 const createAuditLogsLifecycleService = (strapi: Core.Strapi) => {
   // Manage internal service state privately

--- a/packages/core/admin/ee/server/src/index.ts
+++ b/packages/core/admin/ee/server/src/index.ts
@@ -49,7 +49,7 @@ const getAdminEE = () => {
       ...(isAIEnabled ? { ai: aiRoutes } : {}),
     },
     async register({ strapi }: { strapi: Core.Strapi }) {
-      // Run the the default registration
+      // Run the default registration
       await eeAdmin.register({ strapi });
 
       // Register internal ai service

--- a/packages/core/core/src/services/document-service/transform/__tests__/id-transform-no-dp.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/id-transform-no-dp.test.ts
@@ -83,7 +83,7 @@ describe('Transform relational data', () => {
       });
     });
 
-    it('Connect to to both draft and publish by default', async () => {
+    it('Connect to both draft and publish by default', async () => {
       // Should connect to the default locale if not provided in the relation
       const { data } = await transformParamsDocumentId(SHOP_UID, {
         data: {

--- a/packages/core/database/src/utils/identifiers/index.ts
+++ b/packages/core/database/src/utils/identifiers/index.ts
@@ -400,7 +400,7 @@ export class Identifiers {
           return this.getShortenedName(token.name, token.allocatedLength);
         }
 
-        // if is is only compressible as a fixed value, use that
+        // if it is only compressible as a fixed value, use that
         if (token.compressible === false && token.shortName) {
           return token.shortName;
         }


### PR DESCRIPTION
## Summary

Fix minor typos in comments and documentation:

- `docs/docs/docs/01-core/content-manager/00-intro.md`: `to to` → `to`
- `packages/core/database/src/utils/identifiers/index.ts`: `is is` → `it is`
- `packages/core/core/src/services/document-service/transform/__tests__/id-transform-no-dp.test.ts`: `to to` → `to`
- `packages/core/admin/ee/server/src/audit-logs/services/lifecycles.ts`: `the the` → `the`
- `packages/core/admin/ee/server/src/index.ts`: `the the` → `the`
- `packages/core/admin/admin/src/pages/Settings/pages/Roles/utils/forms.ts`: `for for` → `for`