### PR TITLE
fix(admin): export useContentTypes hook to prevent null access errors

### DIFF
--- a/docs/docs/docs/01-core/content-manager/hooks/use-content-types.mdx
+++ b/docs/docs/docs/01-core/content-manager/hooks/use-content-types.mdx
@@ -1,25 +1,56 @@
 ---
 title: useContentTypes
-description: API reference for the useContentTypes hook in Strapi's Content Manager
+description: API reference for the useContentTypes hook in Strapi's Admin
 tags:
-  - content-manager
+  - admin
   - hooks
   - fetch
   - content-types
-  - components
 ---
 
-An abstraction around `react-query` to fetch content-types and components. It returns the raw API response
-for components. `collectionTypes` and `singleTypes` are filtered by `isDisplayed=true`.
+An abstraction around `react-query` to fetch content-types. Returns `collectionTypes` and `singleTypes` 
+filtered by `isDisplayed=true`. This hook handles null/undefined data gracefully and is the recommended 
+way to access content types in plugins and admin components.
 
 ## Usage
 
 ```jsx
-import { useContentTypes } from 'path/to/hooks';
+import { useContentTypes } from '@strapi/admin/strapi-admin';
 
 const MyComponent = () => {
-  const { isLoading, collectionTypes, singleTypes, components } = useContentTypes();
+  const { isLoading, collectionTypes, singleTypes } = useContentTypes();
 
-  return (/* ... */);
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  return (
+    <div>
+      <h2>Collection Types ({collectionTypes.length})</h2>
+      {collectionTypes.map((contentType) => (
+        <div key={contentType.uid}>{contentType.info.displayName}</div>
+      ))}
+      
+      <h2>Single Types ({singleTypes.length})</h2>
+      {singleTypes.map((contentType) => (
+        <div key={contentType.uid}>{contentType.info.displayName}</div>
+      ))}
+    </div>
+  );
 };
 ```
+
+## Return Value
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `isLoading` | `boolean` | Indicates whether the content types are being fetched |
+| `collectionTypes` | `ContentType[]` | Array of collection type content types (defaults to empty array if not loaded) |
+| `singleTypes` | `ContentType[]` | Array of single type content types (defaults to empty array if not loaded) |
+
+## Notes
+
+- The hook automatically handles error notifications
+- Returns empty arrays for `collectionTypes` and `singleTypes` during loading or if data is unavailable
+- Only returns content types where `isDisplayed` is `true`
+- For plugins, this is the recommended way to access content types instead of directly using `useGetContentTypesQuery`

--- a/packages/core/admin/admin/src/hooks/useContentTypes.ts
+++ b/packages/core/admin/admin/src/hooks/useContentTypes.ts
@@ -6,6 +6,36 @@ import { useGetContentTypesQuery } from '../services/contentManager';
 
 import type { ContentType } from '../../../shared/contracts/content-types';
 
+/**
+ * Hook to fetch and return content types (collection types and single types).
+ * This hook handles loading states and errors automatically, making it the
+ * recommended way to access content types in plugins and admin components.
+ *
+ * @returns An object containing:
+ * - `isLoading`: boolean indicating if content types are being fetched
+ * - `collectionTypes`: array of collection type content types (defaults to empty array)
+ * - `singleTypes`: array of single type content types (defaults to empty array)
+ *
+ * @example
+ * ```tsx
+ * import { useContentTypes } from '@strapi/admin/strapi-admin';
+ *
+ * function MyComponent() {
+ *   const { isLoading, collectionTypes, singleTypes } = useContentTypes();
+ *
+ *   if (isLoading) {
+ *     return <LoadingIndicator />;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <h2>Collection Types</h2>
+ *       {collectionTypes.map(ct => <div key={ct.uid}>{ct.info.displayName}</div>)}
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
 export function useContentTypes(): {
   isLoading: boolean;
   collectionTypes: ContentType[];

--- a/packages/core/admin/admin/src/index.ts
+++ b/packages/core/admin/admin/src/index.ts
@@ -63,6 +63,7 @@ export { useElementOnScreen } from './hooks/useElementOnScreen';
 export { useDebounce } from './hooks/useDebounce';
 export { useMediaQuery, useIsDesktop, useIsTablet, useIsMobile } from './hooks/useMediaQuery';
 export { useDeviceType } from './hooks/useDeviceType';
+export { useContentTypes } from './hooks/useContentTypes';
 export { useAdminUsers } from './services/users';
 export { useGetCountDocumentsQuery } from './services/homepage';
 
@@ -81,6 +82,7 @@ export type {
   Entity,
   FieldContentSourceMap,
 } from '../../shared/contracts/shared';
+export type { ContentType } from '../../shared/contracts/content-types';
 export type { RBACContext, RBACMiddleware } from './core/apis/rbac';
 export type { WidgetWithUID as WidgetType, WidgetArgs } from './core/apis/Widgets';
 


### PR DESCRIPTION
Fixes #24922

Export useContentTypes hook and ContentType type from @strapi/admin to provide a safe API for plugins to access content types. The hook handles null/undefined data gracefully by returning empty arrays, preventing "can't access property 'collectionTypes', contentTypes is null" errors.

Changes:
- Export useContentTypes hook from admin/src/index.ts
- Export ContentType type for proper TypeScript support
- Add comprehensive JSDoc documentation with usage examples
- Update documentation with correct import path and examples

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Exports the `useContentTypes` hook and `ContentType` type from `@strapi/admin/strapi-admin` to provide a safe, officially supported API for external plugins to access content types. The hook wraps `useGetContentTypesQuery` and ensures that:

- `collectionTypes` and `singleTypes` always return arrays (defaults to empty arrays when data is loading or unavailable)
- Error notifications are automatically handled
- Loading states are properly managed

Additionally, comprehensive JSDoc documentation and usage examples have been added to guide plugin developers.

### Why is it needed?

External plugins (like @strapi-community/plugin-seo) were experiencing null reference errors when trying to access content types because:

1. The `useContentTypes` hook was not exported, forcing plugins to use the raw `useGetContentTypesQuery`
2. The raw query can return `undefined` data during loading states
3. Plugins were trying to access properties on null/undefined objects, causing the error: "can't access property 'collectionTypes', contentTypes is null"

This fix provides a defensive, plugin-friendly API that prevents these errors.

### How to test it?

**Environment:**
- Node.js 20+ 
- Strapi 5.x

**Testing steps:**

1. Install the changes in a Strapi project
2. Import and use the hook in a plugin:
```tsx
   import { useContentTypes, type ContentType } from '@strapi/admin/strapi-admin';
   
   function MyComponent() {
     const { isLoading, collectionTypes, singleTypes } = useContentTypes();
     
     // These will never be null/undefined, always arrays
     console.log(collectionTypes, singleTypes);
     
     return <div>Found {collectionTypes.length} collection types</div>;
   }
```
3. Verify that `collectionTypes` and `singleTypes` are always defined arrays
4. Test with the SEO plugin or similar community plugins that need content type access

### Related issue(s)/PR(s)

Fixes #24922