### PR TITLE
chore: add file path to the error message for transfer command

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -72,9 +72,10 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   /**
    * Handles errors that occur in read streams.
    */
-  #handleStreamError(streamType: string, err: Error) {
-    const { message, stack } = err;
-    const errorMessage = `[Data transfer] Error in ${streamType} read stream: ${message}`;
+  #handleStreamError(streamType: string, err: Error & { filepath?: string }) {
+    const { message, stack, filepath } = err;
+    const filepathInfo = filepath ? ` (file: ${filepath})` : '';
+    const errorMessage = `[Data transfer] Error in ${streamType} read stream${filepathInfo}: ${message}`;
     const formattedError = {
       message: errorMessage,
       stack,

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -140,7 +140,6 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
 
     // Init the asset map
     const assets: {
-      // TODO: could we include filename in this for improved logging?
       [assetID: string]: IAsset & {
         stream: PassThrough;
         queue: Array<QueueableAction>;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add file path to the error message for asset transfer command

### Why is it needed?
When a file is deleted in AWS bucket or we are no longer able to access to the container, the error message is not enough to locate which file is missing.

Before: [Data transfer] Error in assets read stream: ENOENT: no such file or directory
<img width="777" height="287" alt="Screenshot 2026-01-20 at 2 55 31 PM" src="https://github.com/user-attachments/assets/056644a7-db0e-462d-a491-17f2641ff091" />

After: [Data transfer] Error in assets read stream (file: /path/to/file.jpg): ENOENT: no such file or directory
<img width="1570" height="824" alt="SCR-20260120-meb" src="https://github.com/user-attachments/assets/6c84c3b2-3731-4101-80cc-94a9ce6d9662" />

### How to test it?

Delete a file in the container(AWS / Azure), then run transfer

### Related issue(s)/PR(s)
#24268 
