### PR TITLE
chore: remove unused imports in `getstarted` example app

### DIFF
--- a/examples/getstarted/src/admin/app.jsx
+++ b/examples/getstarted/src/admin/app.jsx
@@ -1,7 +1,3 @@
-import React from 'react';
-
-import { Button } from '@strapi/design-system';
-
 import { registerPreviewRoute } from './preview';
 
 const config = {


### PR DESCRIPTION
### What does it do?

This PR removes unused imports in `getstarted` example app.

### Why is it needed?

To reduce unused code and improve code style.
