### PR TITLE
fix: relation field not displaying numbered titles

### DIFF
--- a/packages/core/content-manager/admin/src/utils/relations.ts
+++ b/packages/core/content-manager/admin/src/utils/relations.ts
@@ -10,10 +10,13 @@ import type { RelationResult } from '../../../shared/contracts/relations';
  * We fallback to the documentId.
  */
 const getRelationLabel = (relation: RelationResult, mainField?: MainField): string => {
-  const label = mainField && relation[mainField.name] ? relation[mainField.name] : null;
+  const label = mainField && relation[mainField.name] != null ? relation[mainField.name] : null;
 
-  if (typeof label === 'string') {
+  if (typeof label === 'string' && label !== '') {
     return label;
+  }
+  if (typeof label === 'number') {
+    return String(label);
   }
 
   return relation.documentId;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows for relations to a collection type with the entry type being numeric field to be displayed. I also needed to amend the null check to ensure that 0 is allowed to be displayed.

### Why is it needed?

Minor QOL improvement to allow a recognisable numeric ID / custom field to be displayed, rather than the document ID.

### How to test it?

1. Create 2 collection types, with the first one having a numeric field added (integer)
2. Create a relation to the first collection type and alter the view so that the entry title for the relation is the numeric field
3. Ensure the newly created relation field on the second collection type has the entry field set to the numeric field on the field itself, which is set within the view.
4. Create a entry for the second collection type and when selecting the relation, ensure that the entry titles show correctly, including numbers
5. Test changing the entry title to different field types to ensure they display correctly. All strings or numbers should load and if not, fall back to document ID.

### Related issue(s)/PR(s)

Fix #25111 
