### PR TITLE
docs(CONTRIBUTING): set link to latest version of `.commitlintrc.ts`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ The types are based on our GitHub label, here are a subset:
 - `doc` – When writing documentation.
 - `feat` – When working on a feature.
 
-You can see the complete list [here](https://github.com/strapi/strapi/blob/1cb6f95889ccaad897759cfa14d2804adeaeb7ee/.commitlintrc.ts#L11).
+You can see the complete list [here](https://github.com/strapi/strapi/blob/develop/.commitlintrc.ts#L11).
 
 #### Subject
 


### PR DESCRIPTION
### What does it do?

This PR sets link in `CONTRIBUTING.md`  to latest version of `.commitlintrc.ts` instead of outdated version.

### Why is it needed?

To link to the current version of a file.
