### PR TITLE
enhancement: add ESM syntax support for Vite .mts config file

### DIFF
--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -196,7 +196,7 @@ const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<InlineConfig
   };
 };
 
-const USER_CONFIGS = ['vite.config.js', 'vite.config.mjs', 'vite.config.ts'];
+const USER_CONFIGS = ['vite.config.js', 'vite.config.mjs', 'vite.config.ts', 'vite.config.mts'];
 
 type UserViteConfig = (config: UserConfig) => UserConfig;
 


### PR DESCRIPTION
### What does it do?

This PR adds ESM syntax support for Vite config file in TypeScrypt format.
Now it is possible to use `src/admin/vite.config.mts` file.

### Why is it needed?

Using ESM syntax for Vite config file is preferred because [Vite CJS Node API is deprecated](https://v6.vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated).

### Related issue(s)/PR(s)

Fix #21716
