### PR TITLE
security: update lodash to 4.17.23

### DIFF
--- a/examples/getstarted/package.json
+++ b/examples/getstarted/package.json
@@ -25,7 +25,7 @@
     "@strapi/provider-upload-cloudinary": "workspace:*",
     "@strapi/strapi": "workspace:*",
     "better-sqlite3": "12.4.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mysql2": "3.9.8",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -18,7 +18,7 @@
     "@strapi/provider-upload-cloudinary": "workspace:*",
     "@strapi/strapi": "workspace:*",
     "better-sqlite3": "12.4.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mysql2": "3.9.8",
     "passport-google-oauth2": "0.2.0",
     "pg": "8.11.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "jest-watch-typeahead": "2.2.2",
     "lerna": "8.2.0",
     "lint-staged": "15.2.10",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "npm-run-all": "4.1.5",
     "nx": "20.4.6",
     "plop": "4.0.1",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -59,7 +59,7 @@
     "inquirer": "8.2.5",
     "jsonwebtoken": "9.0.0",
     "jwks-rsa": "3.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "minimatch": "9.0.3",
     "open": "8.4.0",
     "ora": "5.4.1",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -57,7 +57,7 @@
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
     "inquirer": "8.2.5",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "node-machine-id": "^1.1.10",
     "ora": "^5.4.1",
     "rollup": "4.19.1",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -76,7 +76,7 @@
     "fs-extra": "11.2.0",
     "immer": "9.0.21",
     "jszip": "^3.10.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "micromatch": "^4.0.8",
     "pluralize": "8.0.0",
     "qs": "6.14.1",

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "11.2.0",
     "handlebars": "4.7.7",
     "jscodeshift": "17.3.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "plop": "4.0.1",
     "pluralize": "8.0.0"
   },

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -69,7 +69,7 @@
     "fs-extra": "11.2.0",
     "immer": "9.0.21",
     "koa-static": "^5.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "path-to-regexp": "8.2.0",
     "react-intl": "6.6.2",
     "swagger-ui-dist": "4.19.0",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -68,7 +68,7 @@
     "graphql-scalars": "1.22.2",
     "koa-bodyparser": "4.4.1",
     "koa-compose": "^4.1.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "nexus": "1.3.0",
     "pluralize": "8.0.0"
   },

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -60,7 +60,7 @@
     "@strapi/design-system": "2.1.2",
     "@strapi/icons": "2.1.2",
     "@strapi/utils": "5.33.4",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "qs": "6.14.1",
     "react-intl": "6.6.2",
     "react-redux": "8.1.3",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -59,7 +59,7 @@
     "jwk-to-pem": "2.0.5",
     "koa": "2.16.3",
     "koa2-ratelimit": "^1.1.3",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "prop-types": "^15.8.1",
     "purest": "4.0.2",
     "react-intl": "6.6.2",

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -57,7 +57,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "nodemailer": "6.10.1"
   },
   "devDependencies": {

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/lib-storage": "3.433.0",
     "@aws-sdk/s3-request-presigner": "3.433.0",
     "@aws-sdk/types": "3.433.0",
-    "lodash": "4.17.21"
+    "lodash": "4.17.23"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/packages/utils/api-tests/package.json
+++ b/packages/utils/api-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "dotenv": "16.4.5",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "qs": "6.14.1",
     "supertest": "6.3.3"
   }

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -40,7 +40,7 @@
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "winston": "3.10.0"
   },
   "devDependencies": {

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -38,7 +38,7 @@
     "chalk": "4.1.2",
     "cli-table3": "0.6.5",
     "fs-extra": "11.2.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "prettier": "3.3.3",
     "typescript": "5.4.4"
   },

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -70,7 +70,7 @@
     "fast-glob": "3.3.2",
     "fs-extra": "11.2.0",
     "jscodeshift": "17.1.2",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "memfs": "4.6.0",
     "ora": "5.4.1",
     "prompts": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9295,7 +9295,7 @@ __metadata:
     inquirer: "npm:8.2.5"
     jsonwebtoken: "npm:9.0.0"
     jwks-rsa: "npm:3.1.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     minimatch: "npm:9.0.3"
     open: "npm:8.4.0"
     ora: "npm:5.4.1"
@@ -9448,7 +9448,7 @@ __metadata:
     jszip: "npm:^3.10.1"
     koa: "npm:2.16.3"
     koa-body: "npm:6.0.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     micromatch: "npm:^4.0.8"
     pluralize: "npm:8.0.0"
     qs: "npm:6.14.1"
@@ -9738,7 +9738,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     handlebars: "npm:4.7.7"
     jscodeshift: "npm:17.3.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     outdent: "npm:^0.8.0"
     plop: "npm:4.0.1"
     pluralize: "npm:8.0.0"
@@ -9762,7 +9762,7 @@ __metadata:
     "@testing-library/react": "npm:16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
     koa: "npm:2.16.3"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     msw: "npm:1.3.0"
     qs: "npm:6.14.1"
     react: "npm:18.3.1"
@@ -9800,7 +9800,7 @@ __metadata:
   resolution: "@strapi/logger@workspace:packages/utils/logger"
   dependencies:
     eslint-config-custom: "npm:5.33.4"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     tsconfig: "npm:5.33.4"
     winston: "npm:3.10.0"
   languageName: unknown
@@ -9942,7 +9942,7 @@ __metadata:
     koa-body: "npm:6.0.1"
     koa-session: "npm:6.4.0"
     koa-static: "npm:^5.0.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     msw: "npm:1.3.0"
     openapi-types: "npm:12.1.3"
     path-to-regexp: "npm:8.2.0"
@@ -9989,7 +9989,7 @@ __metadata:
     koa: "npm:2.16.3"
     koa-bodyparser: "npm:4.4.1"
     koa-compose: "npm:^4.1.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     nexus: "npm:1.3.0"
     pluralize: "npm:8.0.0"
     react: "npm:18.3.1"
@@ -10047,7 +10047,7 @@ __metadata:
     jwk-to-pem: "npm:2.0.5"
     koa: "npm:2.16.3"
     koa2-ratelimit: "npm:^1.1.3"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     msw: "npm:1.3.0"
     prop-types: "npm:^15.8.1"
     purest: "npm:4.0.2"
@@ -10099,7 +10099,7 @@ __metadata:
   dependencies:
     "@types/nodemailer": "npm:6.4.7"
     eslint-config-custom: "npm:5.33.4"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     nodemailer: "npm:6.10.1"
     tsconfig: "npm:5.33.4"
   languageName: unknown
@@ -10138,7 +10138,7 @@ __metadata:
     "@aws-sdk/types": "npm:3.433.0"
     "@types/jest": "npm:29.5.2"
     eslint-config-custom: "npm:5.33.4"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     tsconfig: "npm:5.33.4"
   languageName: unknown
   linkType: soft
@@ -10372,7 +10372,7 @@ __metadata:
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     fs-extra: "npm:11.2.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     prettier: "npm:3.3.3"
     typescript: "npm:5.4.4"
   languageName: unknown
@@ -10427,7 +10427,7 @@ __metadata:
     fast-glob: "npm:3.3.2"
     fs-extra: "npm:11.2.0"
     jscodeshift: "npm:17.1.2"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     memfs: "npm:4.6.0"
     ora: "npm:5.4.1"
     prompts: "npm:2.4.2"
@@ -13739,7 +13739,7 @@ __metadata:
   resolution: "api-tests@workspace:packages/utils/api-tests"
   dependencies:
     dotenv: "npm:16.4.5"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     qs: "npm:6.14.1"
     supertest: "npm:6.3.3"
   languageName: unknown
@@ -16226,7 +16226,7 @@ __metadata:
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
     inquirer: "npm:8.2.5"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     node-machine-id: "npm:^1.1.10"
     ora: "npm:^5.4.1"
     rollup: "npm:4.19.1"
@@ -20090,7 +20090,7 @@ __metadata:
     "@strapi/provider-upload-cloudinary": "workspace:*"
     "@strapi/strapi": "workspace:*"
     better-sqlite3: "npm:12.4.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     mysql2: "npm:3.9.8"
     passport-google-oauth2: "npm:0.2.0"
     pg: "npm:8.11.1"
@@ -23468,7 +23468,7 @@ __metadata:
     "@strapi/provider-upload-cloudinary": "workspace:*"
     "@strapi/strapi": "workspace:*"
     better-sqlite3: "npm:12.4.1"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     mysql2: "npm:3.9.8"
     passport-google-oauth2: "npm:0.2.0"
     pg: "npm:8.11.1"
@@ -24262,6 +24262,13 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
+  languageName: node
+  linkType: hard
+
+"lodash@npm:4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
   languageName: node
   linkType: hard
 
@@ -31130,7 +31137,7 @@ __metadata:
     jest-watch-typeahead: "npm:2.2.2"
     lerna: "npm:8.2.0"
     lint-staged: "npm:15.2.10"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     npm-run-all: "npm:4.1.5"
     nx: "npm:20.4.6"
     plop: "npm:4.0.1"


### PR DESCRIPTION
### What does it do?

updates lodash from 4.17.21 to 4.17.23

### Why is it needed?

resolves security warnings -- unconfirmed if Strapi is vulnerable or not

### How to test it?

everything should work as before

### Related issue(s)/PR(s)

CMS-223
