### PR TITLE
fix(content-manager): prevent crash when switching b/w content-types with same component/field names.

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -153,7 +153,7 @@ const ListViewPage = () => {
    */
   const tableHeaders = React.useMemo(() => {
     const headers = runHookWaterfall(INJECT_COLUMN_IN_TABLE, {
-      displayedHeaders,
+      displayedHeaders: list.layout,
       layout: list,
     });
 
@@ -195,14 +195,7 @@ const ListViewPage = () => {
     }
 
     return formattedHeaders;
-  }, [
-    displayedHeaders,
-    formatMessage,
-    list,
-    runHookWaterfall,
-    schema?.options?.draftAndPublish,
-    model,
-  ]);
+  }, [formatMessage, list, runHookWaterfall, schema?.options?.draftAndPublish, model]);
 
   if (isFetching) {
     return <Page.Loading />;


### PR DESCRIPTION
### Description
This PR fixes a frontend crash (TypeError: content.map is not a function) that occurs in the Content Manager's List View.

The issue was caused by a state logic mismatch in ListViewPage.tsx. When a user navigates between two content types that share an component/field name but have different data structures—specifically switching from a Repeatable Component (array) to a String—the dashboard incorrectly attempts to render the string using the repeatable component's logic.

### Root Cause
In the ListViewPage, when list.layout changes, we pass updated 'content' value but stale attribute.type value. And since component/field names are same, it finds that name key in the 'content' and tries to render repeatable component(array) for updated content-type(String), causing the error.

### Changes

Modified 'headers' inside useMemo hook to use updated list.layout value instead of using displayedHeaders which is stale on the first re-render.

### Related Issue
Fixes #25230

### How to test it
Create Content Type A with a repeatable component named testField.

Create Content Type B with a short text field named testField.

Add data to both.

Navigate to the List View of A.

Click directly on Content Type B in the sidebar.

Result: The page now renders correctly instead of throwing a white-screen TypeError.

Checklist
1. My code follows the contribution guidelines.

2. I have performed a self-review of my own code.

3. I have linked the relevant issue.

4. I have verified the fix locally.

