### PR TITLE
fix(blocks-editor): support multi-block list conversion

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/List.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/List.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Typography } from '@strapi/design-system';
 import { BulletList, NumberList } from '@strapi/icons';
 import { Schema } from '@strapi/types';
-import { type Text, Editor, Node, Transforms, Path, Element } from 'slate';
+import { type Text, Editor, Node, Transforms, Path, Element, Range } from 'slate';
 import { type RenderElementProps, ReactEditor } from 'slate-react';
 import { styled, type CSSProperties, css } from 'styled-components';
 
@@ -277,6 +277,21 @@ const handleEnterKeyOnList = (editor: Editor) => {
  * Common handler for converting a node to a list
  */
 const handleConvertToList = (editor: Editor, format: Block<'list'>['format']) => {
+  if (!editor.selection) return;
+
+  // if multiple block
+  if (!Range.isCollapsed(editor.selection)) {
+    Transforms.setNodes(editor, { type: 'list-item' } as Partial<Node>, {
+      at: editor.selection,
+      match: (node) => Element.isElement(node) && node.type !== 'list' && node.type !== 'list-item',
+    });
+
+    Transforms.wrapNodes(editor, { type: 'list', format, children: [] }, { at: editor.selection });
+
+    return;
+  }
+
+  //if single block
   const convertedPath = baseHandleConvert<Block<'list-item'>>(editor, { type: 'list-item' });
 
   if (!convertedPath) return;

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/List.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/List.tsx
@@ -9,6 +9,7 @@ import { styled, type CSSProperties, css } from 'styled-components';
 
 import { type BlocksStore } from '../BlocksEditor';
 import { baseHandleConvert } from '../utils/conversions';
+import { getAttributesToClear } from '../utils/conversions';
 import { type Block } from '../utils/types';
 
 const listStyle = css`
@@ -274,19 +275,66 @@ const handleEnterKeyOnList = (editor: Editor) => {
 };
 
 /**
- * Common handler for converting a node to a list
+ * Converts the current selection into a list.
+ *
+ * - Supports both single-block and multi-block selections.
+ * - Ensures consistency with single-block behavior by clearing
+ *   block-specific attributes (e.g., heading level) when converting.
  */
 const handleConvertToList = (editor: Editor, format: Block<'list'>['format']) => {
-  if (!editor.selection) return;
+  /**
+   * Ensure there is a valid selection before applying transformations.
+   * If no selection exists:
+   * - For non-empty editors, move the cursor to the last block.
+   * - For empty editors, place the cursor at the start.
+   */
+  if (!editor.selection) {
+    const editorIsEmpty =
+      editor.children.length === 1 && Editor.isEmpty(editor, editor.children[0]);
 
-  // if multiple block
-  if (!Range.isCollapsed(editor.selection)) {
-    Transforms.setNodes(editor, { type: 'list-item' } as Partial<Node>, {
-      at: editor.selection,
-      match: (node) => Element.isElement(node) && node.type !== 'list' && node.type !== 'list-item',
-    });
+    if (!editorIsEmpty) {
+      const [_, lastPath] = Editor.last(editor, []);
+      Transforms.select(editor, Editor.start(editor, lastPath));
+    } else {
+      Transforms.select(editor, Editor.start(editor, [0, 0]));
+    }
+  }
 
-    Transforms.wrapNodes(editor, { type: 'list', format, children: [] }, { at: editor.selection });
+  const selection = editor.selection;
+  if (!selection) return;
+
+  // multi block selection
+  if (!Range.isCollapsed(selection)) {
+    const nodes = Array.from(
+      Editor.nodes(editor, {
+        at: selection,
+        match: (node) =>
+          Element.isElement(node) && node.type !== 'list' && node.type !== 'list-item',
+      })
+    );
+
+    // any block-specific attributes to match single-block behavior.
+    for (const [node, path] of nodes) {
+      const attrsToClear = getAttributesToClear(node as any);
+
+      Transforms.setNodes(
+        editor,
+        {
+          ...attrsToClear,
+          type: 'list-item',
+        },
+        { at: path }
+      );
+    }
+
+    Transforms.wrapNodes(
+      editor,
+      { type: 'list', format, children: [] },
+      {
+        at: selection,
+        match: (node) => Element.isElement(node) && node.type === 'list-item',
+      }
+    );
 
     return;
   }

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/List.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/List.test.tsx
@@ -1440,6 +1440,55 @@ describe('List', () => {
       },
     ];
 
+    //for multiple selected block
+    it('converts multiple selected blocks into a single list', () => {
+      const editor = createEditor();
+
+      editor.children = [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: 'Line one' }],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: 'Line two' }],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: 'Line three' }],
+        },
+      ];
+
+      // Select from first block to last block
+      Transforms.select(editor, {
+        anchor: { path: [0, 0], offset: 0 },
+        focus: { path: [2, 0], offset: 9 },
+      });
+
+      listBlocks['list-unordered'].handleConvert!(editor);
+
+      expect(editor.children).toEqual([
+        {
+          type: 'list',
+          format: 'unordered',
+          children: [
+            {
+              type: 'list-item',
+              children: [{ type: 'text', text: 'Line one' }],
+            },
+            {
+              type: 'list-item',
+              children: [{ type: 'text', text: 'Line two' }],
+            },
+            {
+              type: 'list-item',
+              children: [{ type: 'text', text: 'Line three' }],
+            },
+          ],
+        },
+      ]);
+    });
+
     // Set the cursor on the heading
     Transforms.select(baseEditor, {
       anchor: { path: [0, 0, 0], offset: 0 },

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/List.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/List.test.tsx
@@ -1440,55 +1440,6 @@ describe('List', () => {
       },
     ];
 
-    //for multiple selected block
-    it('converts multiple selected blocks into a single list', () => {
-      const editor = createEditor();
-
-      editor.children = [
-        {
-          type: 'paragraph',
-          children: [{ type: 'text', text: 'Line one' }],
-        },
-        {
-          type: 'paragraph',
-          children: [{ type: 'text', text: 'Line two' }],
-        },
-        {
-          type: 'paragraph',
-          children: [{ type: 'text', text: 'Line three' }],
-        },
-      ];
-
-      // Select from first block to last block
-      Transforms.select(editor, {
-        anchor: { path: [0, 0], offset: 0 },
-        focus: { path: [2, 0], offset: 9 },
-      });
-
-      listBlocks['list-unordered'].handleConvert!(editor);
-
-      expect(editor.children).toEqual([
-        {
-          type: 'list',
-          format: 'unordered',
-          children: [
-            {
-              type: 'list-item',
-              children: [{ type: 'text', text: 'Line one' }],
-            },
-            {
-              type: 'list-item',
-              children: [{ type: 'text', text: 'Line two' }],
-            },
-            {
-              type: 'list-item',
-              children: [{ type: 'text', text: 'Line three' }],
-            },
-          ],
-        },
-      ]);
-    });
-
     // Set the cursor on the heading
     Transforms.select(baseEditor, {
       anchor: { path: [0, 0, 0], offset: 0 },
@@ -1518,6 +1469,55 @@ describe('List', () => {
                 ],
               },
             ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  //for multiple selected blocks
+  it('converts multiple selected blocks into a single list', () => {
+    const editor = createEditor();
+
+    editor.children = [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Line one' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Line two' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Line three' }],
+      },
+    ];
+
+    // Select from first block to last block
+    Transforms.select(editor, {
+      anchor: { path: [0, 0], offset: 0 },
+      focus: { path: [2, 0], offset: 9 },
+    });
+
+    listBlocks['list-unordered'].handleConvert!(editor);
+
+    expect(editor.children).toEqual([
+      {
+        type: 'list',
+        format: 'unordered',
+        children: [
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'Line one' }],
+          },
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'Line two' }],
+          },
+          {
+            type: 'list-item',
+            children: [{ type: 'text', text: 'Line three' }],
           },
         ],
       },

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -401,8 +401,8 @@ const ListButton = ({ block, format, location = 'toolbar' }: ListButtonProps) =>
       return false;
     }
 
-    // Disabled if the anchor and focus are not in the same block
-    return anchorNodeEntry[0] !== focusNodeEntry[0];
+    // Allow multi-block selection for lists
+    return false;
   };
 
   const toggleList = (format: Block<'list'>['format']) => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksToolbar.tsx
@@ -372,39 +372,6 @@ const ListButton = ({ block, format, location = 'toolbar' }: ListButtonProps) =>
     return false;
   };
 
-  /**
-   * @TODO: Currently, applying list while multiple blocks are selected is not supported.
-   * We should implement this feature in the future.
-   */
-  const isListDisabled = () => {
-    // Always disabled when the whole editor is disabled
-    if (disabled) {
-      return true;
-    }
-
-    // Always enabled when there's no selection
-    if (!editor.selection) {
-      return false;
-    }
-
-    // Get the block node closest to the anchor and focus
-    const anchorNodeEntry = Editor.above(editor, {
-      at: editor.selection.anchor,
-      match: (node) => !Editor.isEditor(node) && node.type !== 'text',
-    });
-    const focusNodeEntry = Editor.above(editor, {
-      at: editor.selection.focus,
-      match: (node) => !Editor.isEditor(node) && node.type !== 'text',
-    });
-
-    if (!anchorNodeEntry || !focusNodeEntry) {
-      return false;
-    }
-
-    // Allow multi-block selection for lists
-    return false;
-  };
-
   const toggleList = (format: Block<'list'>['format']) => {
     let currentListEntry;
     if (editor.selection) {
@@ -448,7 +415,7 @@ const ListButton = ({ block, format, location = 'toolbar' }: ListButtonProps) =>
         startIcon={<Icon />}
         onSelect={() => toggleList(format)}
         isActive={isListActive()}
-        disabled={isListDisabled()}
+        disabled={disabled}
       >
         {formatMessage(block.label)}
       </StyledMenuItem>
@@ -461,7 +428,7 @@ const ListButton = ({ block, format, location = 'toolbar' }: ListButtonProps) =>
       name={format}
       label={block.label}
       isActive={isListActive()}
-      disabled={isListDisabled()}
+      disabled={disabled && !editor.selection}
       handleClick={() => toggleList(format)}
     />
   );


### PR DESCRIPTION
### What does it do?
This pr fixes the problem of the multiblock bullet/list format

### Why is it needed?
When you have multiple text lines in the blocks rich text editor, highlighting multiple blocks and attempting to format them to a bulleted or numbered list does not work(only works on a single block).


### How to test it?
1. Open the Content Manager.
2. Create or edit an entry with a Blocks editor field.
3. Add multiple paragraph or heading blocks.
4. Select multiple blocks (click and drag).
5. Click the Bulleted list or Numbered list toolbar button.
6. Verify that all selected blocks are converted into a single list with one list item per block.

### Before & After Video
 ## Before
 

https://github.com/user-attachments/assets/6717f459-8b70-4e14-871f-4e1793945d10

 ## After
 

https://github.com/user-attachments/assets/124149b3-8d7f-45b8-80e0-2d9c01acffdf



### Related issue
fixes #25189 
