### PR TITLE
fix: content-manager ui is very slow because of over population by localization field (#24504)

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -137,6 +137,7 @@ export default {
       .populateFromQuery(permissionQuery)
       .populateDeep(1)
       .countRelations({ toOne: false, toMany: true })
+      .limitLocalizationsPopulate()
       .build();
 
     const { locale, status } = await getDocumentLocaleAndStatus(query, model);
@@ -189,6 +190,7 @@ export default {
       .populateFromQuery(permissionQuery)
       .populateDeep(Infinity)
       .countRelations()
+      .limitLocalizationsPopulate()
       .build();
 
     const { locale, status } = await getDocumentLocaleAndStatus(ctx.query, model);

--- a/packages/core/content-manager/server/src/services/__tests__/populate-builder.test.ts
+++ b/packages/core/content-manager/server/src/services/__tests__/populate-builder.test.ts
@@ -1,0 +1,64 @@
+import populateBuilder from '../populate-builder';
+
+const mockModel = {
+  kind: 'collectionType',
+  collectionName: 'mocks',
+  apiName: 'mock',
+  globalId: 'Mock',
+  uid: 'api::mock.mock',
+  modelType: 'contentType',
+  modelName: 'mock',
+  pluginOptions: { i18n: { localized: true } },
+  attributes: {
+    localizations: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::restaurant.restaurant',
+      writable: false,
+      private: false,
+      configurable: false,
+      visible: false,
+      unstable_virtual: true,
+      joinColumn: [Object],
+    },
+  },
+};
+
+describe('populate-builder', () => {
+  describe('limitLocalizationsPopulate', () => {
+    const uid = 'api::mock.mock';
+
+    test('returns limited populate', async () => {
+      global.strapi = {
+        ...global.strapi,
+        getModel: jest.fn(() => mockModel) as unknown as typeof global.strapi.getModel,
+      };
+      const populate: any = await populateBuilder()(uid)
+        .populateDeep()
+        .limitLocalizationsPopulate()
+        .build();
+
+      expect(
+        ['documentId', 'id', 'locale', 'createdAt', 'updatedAt', 'publishedAt'].every((field) =>
+          populate?.localizations?.fields?.includes(field)
+        )
+      ).toBeTruthy();
+    });
+
+    test('returns no limited populate if model is not localized', async () => {
+      global.strapi = {
+        ...global.strapi,
+        getModel: jest.fn(() => ({
+          ...mockModel,
+          pluginOptions: { i18n: { localized: false } },
+        })) as unknown as typeof global.strapi.getModel,
+      };
+      const populate: any = await populateBuilder()(uid)
+        .populateDeep()
+        .limitLocalizationsPopulate()
+        .build();
+
+      expect(populate?.localizations?.fields).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -150,7 +150,7 @@ function getPopulateFor(
 const getDeepPopulate = (
   uid: UID.Schema,
   {
-    initialPopulate = {} as any,
+    initialPopulate = {},
     countMany = false,
     countOne = false,
     maxLevel = Infinity,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a new method, `limitLocalizationsPopulate`, to the `populate-builder` service.
This method is now used in the `find` and `findOne` controllers for the content-manager admin routes.

In the future we would also need to cleanup the `meta` data. But to keep changes simple in this PR I've skipped that part.

### Why is it needed?

Strapi projects with large amounts of data and **multiple locales** often experience **very slow loading times** in collection views. This update ensures that only the **necessary fields** of the localizations attribute are loaded, which significantly improves page load performance.

### How to test it?

https://github.com/user-attachments/assets/40bcf1b8-2b52-48d6-80ee-11420029dcb9

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/24504
- https://github.com/strapi/strapi/issues/24982
- https://github.com/strapi/strapi/pull/25279
