### PR TITLE
fix: content-manager ui is very slow because of over population by meta field (#24504)

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -212,7 +212,7 @@ export default {
         model,
         // @ts-expect-error TODO: fix
         { documentId: id, locale, publishedAt: null },
-        { availableLocales: true, availableStatus: false }
+        { availableLocales: false, availableStatus: false }
       );
 
       ctx.body = { data: {}, meta };
@@ -227,7 +227,10 @@ export default {
 
     // TODO: Count populated relations by permissions
     const sanitizedDocument = await permissionChecker.sanitizeOutput(version);
-    ctx.body = await formatDocumentWithMetadata(permissionChecker, model, sanitizedDocument);
+    ctx.body = await formatDocumentWithMetadata(permissionChecker, model, sanitizedDocument, {
+      availableLocales: false,
+      availableStatus: true,
+    });
   },
 
   async create(ctx: any) {

--- a/packages/core/content-manager/server/src/controllers/single-types.ts
+++ b/packages/core/content-manager/server/src/controllers/single-types.ts
@@ -124,7 +124,7 @@ export default {
         model,
         // @ts-expect-error - fix types
         { documentId: document.documentId, locale, publishedAt: null },
-        { availableLocales: true, availableStatus: false }
+        { availableLocales: false, availableStatus: false }
       );
       ctx.body = { data: {}, meta };
       return;
@@ -135,7 +135,10 @@ export default {
     }
 
     const sanitizedDocument = await permissionChecker.sanitizeOutput(version);
-    ctx.body = await formatDocumentWithMetadata(permissionChecker, model, sanitizedDocument);
+    ctx.body = await formatDocumentWithMetadata(permissionChecker, model, sanitizedDocument, {
+      availableLocales: false,
+      availableStatus: true,
+    });
   },
 
   async createOrUpdate(ctx: any) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Returns empty array for `availableLocales` on `meta` data for `find` and `findOne`.

### Why is it needed?

Strapi projects with large amounts of data and **multiple locales** often experience **very slow loading times** in collection views. This update ensures that only the necessary fields of the `meta` attribute are loaded, which significantly improves page load performance.

### How to test it?

Same as on https://github.com/strapi/strapi/pull/25277.

### Related issue(s)/PR(s)
- https://github.com/strapi/strapi/issues/24504
- https://github.com/strapi/strapi/issues/24982
- https://github.com/strapi/strapi/pull/25277
