### PR TITLE
Fix(admin): Prevent Dashboard crash on invalid 'Last Published' dates

### DIFF
--- a/packages/core/content-manager/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-manager/admin/src/components/RelativeTime.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
-import { Duration, intervalToDuration, isPast } from 'date-fns';
+import { Duration, intervalToDuration, isPast, isValid } from 'date-fns';
 import { useIntl } from 'react-intl';
+
+import { Typography } from '@strapi/design-system';
 
 const intervals: Array<keyof Duration> = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
 
@@ -33,6 +35,14 @@ interface RelativeTimeProps extends React.ComponentPropsWithoutRef<'time'> {
 const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
   ({ timestamp, customIntervals = [], ...restProps }, forwardedRef) => {
     const { formatRelativeTime, formatDate, formatTime } = useIntl();
+
+    if (!isValid(timestamp)) {
+      return (
+        <Typography variant="omega" textColor="neutral600" {...restProps} ref={forwardedRef}>
+          -
+        </Typography>
+      );
+    }
 
     /**
      * TODO: make this auto-update, like a clock.

--- a/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx
@@ -48,4 +48,11 @@ describe('RelativeTime', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent('now');
   });
+
+  it('returns a fallback for invalid dates', () => {
+    render(<RelativeTime timestamp={new Date('invalid')} />);
+
+    expect(screen.getByRole('time')).not.toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This fix adds a guard clause in the `RelativeTime` component to handle invalid dates safely by falling back to a default state, preventing the `RangeError: Start Date is invalid` crash that

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR prevents a critical crash in the Admin Dashboard by adding date validation to the [RelativeTime](cci:2://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/RelativeTime.tsx:15:0-18:1) component.

Technical changes:
- Added a guard clause in [RelativeTime.tsx](cci:7://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/RelativeTime.tsx:0:0-0:0) using `isValid` from `date-fns` to verify the `timestamp` before processing.
- Imported and utilized the `Typography` component from `@strapi/design-system` to render a safe fallback (`-`) for invalid dates.
- Prevented `intervalToDuration` from throwing a `RangeError: Start Date is invalid`.
- Added a new unit test case in [RelativeTime.test.tsx](cci:7://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/tests/RelativeTime.test.tsx:0:0-0:0) to ensure graceful handling of invalid date inputs.

### Why is it needed?

Currently, the [RelativeTime](cci:2://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/RelativeTime.tsx:15:0-18:1) component (used by widgets like [LastPublishedWidget](cci:1://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/Widgets.tsx:179:0-207:2) and [LastEditedWidget](cci:1://file:///C:/Users/eliz/.gemini/antigravity/scratch/strapi/packages/core/content-manager/admin/src/components/Widgets.tsx:147:0-173:2)) passes timestamps directly to `date-fns` without validation. If the database contains invalid date strings often due to legacy data imports, manual database edits, or corrupted fields. the entire Admin Dashboard crashes with a `RangeError`. This fix ensures the UI remains stable even when encountering malformed data.

### How to test it?

```bash
npm run test:unit -- admin/src/components/tests/RelativeTime.test.tsx
 ```
or Inject an invalid date string into an entry's updatedAt or publishedAt field in the database and navigate to the Admin Home page. The "Last Published" widget should show a - instead of crashing the page.

### Related issue(s)/PR(s)

N/A