### PR TITLE
fix(content-manager): relation dropdown should list more than 10 options

### DIFF
--- a/packages/core/utils/src/pagination.ts
+++ b/packages/core/utils/src/pagination.ts
@@ -33,7 +33,7 @@ const STRAPI_DEFAULTS = {
   },
   page: {
     page: 1,
-    pageSize: 10,
+    pageSize: 100,
   },
 };
 
@@ -167,7 +167,7 @@ const transformPagedPaginationInfo = (
   return {
     ...paginationInfo,
     page: 1,
-    pageSize: 10,
+    pageSize: 100,
     pageCount: 1,
     total,
   };


### PR DESCRIPTION
Fixes #25280

Relation select inputs were limited to 10 results due to default pagination.
This increases the initial page size so all options appear without requiring search.
