### PR TITLE
feat(): adding skip AB Testing CLI option

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -50,6 +50,10 @@ const command = new commander.Command('create-strapi-app')
   .option('--git-init', 'Initialize a git repository')
   .option('--no-git-init', 'Do no initialize a git repository')
 
+  // A/B testing options
+  .option('--enable-ab-tests', 'Enable anonymous A/B testing')
+  .option('--no-enable-ab-tests', 'Disable anonymous A/B testing')
+
   // Database options
   .option('--dbclient <dbclient>', 'Database client')
   .option('--dbhost <dbhost>', 'Database host')
@@ -208,7 +212,13 @@ async function run(args: string[]): Promise<void> {
     scope.gitInit = await prompts.gitInit();
   }
 
-  scope.isABTestEnabled = await prompts.enableABTests();
+  if (options.enableAbTests === true) {
+    scope.isABTestEnabled = true;
+  } else if (options.enableAbTests === false || options.quickstart) {
+    scope.isABTestEnabled = false;
+  } else {
+    scope.isABTestEnabled = await prompts.enableABTests();
+  }
 
   addDatabaseDependencies(scope);
 

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -20,6 +20,7 @@ export interface Options {
   install?: boolean;
   example?: boolean;
   gitInit?: boolean;
+  enableAbTests?: boolean;
   templateBranch?: string;
   templatePath?: string;
 }


### PR DESCRIPTION
### What does it do?

Adding skip AB Testing CLI option so that automation is possible

### Why is it needed?

Without this option, automatically creating a strapi app is not possible because a manual intervention is needed to AB Testing. This option makes it possible.

### How to test it?

With an experimental release, launch the following command:
npx create-strapi@experimental-number my-project \
  --skip-cloud \
  --skip-db \
  --example \
  --install \
  --git-init \
  --no-enable-ab-tests \
  --ts
