### PR TITLE
docs(task1): add README for Strapi local setup

### DIFF
--- a/README_TASK1.md
+++ b/README_TASK1.md
@@ -1,0 +1,71 @@
+\# TASK-1: Strapi Local Setup
+
+\## Overview
+
+This task demonstrates cloning the Strapi repository, running Strapi locally,
+
+starting the admin panel, creating sample content, and documenting the process.
+
+\## Prerequisites
+
+\- Node.js v20.x
+
+\- Yarn
+
+\- Git
+
+\## Steps Performed
+
+\### 1. Clone the Repository
+
+```bash
+
+git clone https://github.com/strapi/strapi.git
+
+
+
+2\. Install Dependencies
+
+yarn install
+
+
+
+3.Build Strapi
+
+yarn build
+
+
+
+4.Run Strapi Locally
+
+yarn develop
+
+
+
+5.Access Admin Panel
+
+URL: http://localhost:1337/admin
+
+Admin user created successfully
+
+
+
+6\. Content Creation
+
+Edited and published Homepage (Single Type)
+
+Created a sample Collection Type (Article)
+
+Published a sample Article entry
+
+
+
+Result
+
+Strapi successfully running locally with admin panel and published content.
+
+
+
+
+
+```


### PR DESCRIPTION
TASK-1 submission.

- Cloned the Strapi repository
- Ran Strapi locally
- Started the Admin Panel
- Created and published sample content
- Added README_TASK1.md documenting the setup
