### PR TITLE
enhancement: improve mobile design for content history forms

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Form, Layouts, useForm, createRulesEngine } from '@strapi/admin/strapi-admin';
+import { Form, Layouts, useForm, createRulesEngine, useIsMobile } from '@strapi/admin/strapi-admin';
 import { Box, Divider, Flex, Grid, Typography } from '@strapi/design-system';
 import pipe from 'lodash/fp/pipe';
 import { useIntl } from 'react-intl';
@@ -103,6 +103,7 @@ function getRemaingFieldsLayout({
  * -----------------------------------------------------------------------------------------------*/
 
 const FormPanel = ({ panel }: { panel: EditFieldLayout[][] }) => {
+  const isMobile = useIsMobile();
   const fieldValues = useForm('Fields', (state) => state.values);
   const rulesEngine = createRulesEngine();
   if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
@@ -128,14 +129,11 @@ const FormPanel = ({ panel }: { panel: EditFieldLayout[][] }) => {
 
   return (
     <Box
-      hasRadius
-      background="neutral0"
-      shadow="tableShadow"
-      paddingLeft={6}
-      paddingRight={6}
-      paddingTop={6}
-      paddingBottom={6}
-      borderColor="neutral150"
+      hasRadius={!isMobile}
+      background={{ initial: 'transparent', medium: 'neutral0' }}
+      shadow={{ initial: 'none', medium: 'tableShadow' }}
+      padding={{ initial: 0, medium: 6 }}
+      borderColor={{ initial: 'transparent', medium: 'neutral150' }}
     >
       <Flex direction="column" alignItems="stretch" gap={6}>
         {panel.map((row, gridRowIndex) => {
@@ -154,7 +152,7 @@ const FormPanel = ({ panel }: { panel: EditFieldLayout[][] }) => {
           }
 
           return (
-            <Grid.Root key={gridRowIndex} gap={4}>
+            <Grid.Root key={gridRowIndex} gap={{ initial: 6, medium: 4 }}>
               {visibleFields.map(({ size, ...field }) => {
                 return (
                   <Grid.Item


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Remove background and modify padding of the forms in the Content History view.

**BEFORE**
<img width="423" height="801" alt="Capture d’écran 2026-02-02 à 15 36 24" src="https://github.com/user-attachments/assets/5de888c1-b2f4-4067-b766-6853ce6f884f" />

**AFTER**
<img width="423" height="806" alt="Capture d’écran 2026-02-02 à 15 33 47" src="https://github.com/user-attachments/assets/9996d066-2d1a-462b-840d-6d0ca56146cf" />

### Why is it needed?
Improve the mobile experience of the Content History feature.

### How to test it?
* Be on a Growth or Entreprise license.
* Go to any content type. 
* Create an entry, save it, modify it and publish it (if you have draft&published enabled).
* Click on the "..." more button to click on "Content history".
* Select a previous version of your entry. (You may need to manually hide the aside with the list of versions available, as this will be moved to the new Drawer element in an upcoming PR).
=> The paddings and the background should be modified.
