### PR TITLE
improves error messages in the Content Type Builder when validation errors occur while adding components to Dynamic Zones or modifying content types.

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
@@ -219,11 +219,45 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       await getDataRef.current();
       // Update the app's permissions
       await updatePermissions();
-    } catch (err) {
+    } catch (err: unknown) {
       console.error({ err });
+
+      // Extract error message from the response if available
+      let errorMessage = formatMessage({
+        id: 'notification.error',
+        defaultMessage: 'An error occurred',
+      });
+
+      const axiosError = err as {
+        response?: {
+          data?: {
+            error?: {
+              message?: string;
+              details?: { errors?: Array<{ path?: string[]; message?: string }> };
+            };
+          };
+        };
+      };
+      const responseError = axiosError?.response?.data?.error;
+
+      if (responseError) {
+        if (responseError.details?.errors && responseError.details.errors.length > 0) {
+          // Format validation errors with details
+          const errorDetails = responseError.details.errors
+            .map((e) => {
+              const path = e.path?.join('.') || 'unknown field';
+              return `${path}: ${e.message}`;
+            })
+            .join('; ');
+          errorMessage = `${responseError.message}: ${errorDetails}`;
+        } else if (responseError.message) {
+          errorMessage = responseError.message;
+        }
+      }
+
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
+        message: errorMessage,
       });
 
       trackUsage('didUpdateCTBSchema', {

--- a/packages/core/content-type-builder/server/src/controllers/content-types.ts
+++ b/packages/core/content-type-builder/server/src/controllers/content-types.ts
@@ -62,7 +62,18 @@ export default {
     try {
       await validateContentTypeInput(body);
     } catch (error) {
-      return ctx.send({ error }, 400);
+      // Return structured validation error with details
+      const validationError = error as Error & { details?: unknown };
+      return ctx.send(
+        {
+          error: {
+            name: validationError.name || 'ValidationError',
+            message: validationError.message || 'Validation failed',
+            details: validationError.details || {},
+          },
+        },
+        400
+      );
     }
 
     try {
@@ -95,7 +106,17 @@ export default {
       await strapi.telemetry.send('didNotCreateContentType', {
         eventProperties: { error: (err as Error).message || err },
       });
-      ctx.send({ error: (err as Error).message || 'Unknown error' }, 400);
+      const error = err as Error & { details?: unknown };
+      ctx.send(
+        {
+          error: {
+            name: error.name || 'ApplicationError',
+            message: error.message || 'Unknown error',
+            details: error.details || {},
+          },
+        },
+        400
+      );
     }
   },
 
@@ -110,7 +131,18 @@ export default {
     try {
       await validateUpdateContentTypeInput(body);
     } catch (error) {
-      return ctx.send({ error }, 400);
+      // Return structured validation error with details
+      const validationError = error as Error & { details?: unknown };
+      return ctx.send(
+        {
+          error: {
+            name: validationError.name || 'ValidationError',
+            message: validationError.message || 'Validation failed',
+            details: validationError.details || {},
+          },
+        },
+        400
+      );
     }
 
     try {
@@ -128,7 +160,17 @@ export default {
       ctx.send({ data: { uid: component.uid } }, 201);
     } catch (error) {
       strapi.log.error(error);
-      ctx.send({ error: (error as Error)?.message || 'Unknown error' }, 400);
+      const err = error as Error & { details?: unknown };
+      ctx.send(
+        {
+          error: {
+            name: err.name || 'ApplicationError',
+            message: err?.message || 'Unknown error',
+            details: err.details || {},
+          },
+        },
+        400
+      );
     }
   },
 

--- a/packages/core/content-type-builder/server/src/controllers/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/schema.ts
@@ -43,8 +43,24 @@ export default () => {
         ctx.body = {};
       } catch (error) {
         internals.isUpdating = false;
+
+        // Handle ValidationError with detailed error information
+        if (error instanceof Error && error.name === 'ValidationError') {
+          const validationError = error as Error & { details?: { errors?: unknown[] } };
+          return ctx.send(
+            {
+              error: {
+                name: 'ValidationError',
+                message: validationError.message,
+                details: validationError.details || {},
+              },
+            },
+            400
+          );
+        }
+
         const errorMessage = error instanceof Error ? error.message : String(error);
-        return ctx.send({ error: errorMessage }, 400);
+        return ctx.send({ error: { name: 'ApplicationError', message: errorMessage } }, 400);
       }
     },
 


### PR DESCRIPTION
…on failures

Previously, when validation errors occurred while adding components to Dynamic Zones or modifying content types, users would only see a generic 'An error occurred' message. This made it difficult to understand and fix configuration issues.

This commit improves error handling in both the backend and frontend:

Backend changes:
- schema.ts: Return structured error objects with name, message, and details
- content-types.ts: Same improvement for create/update content type operations

Frontend changes:
- DataManagerProvider.tsx: Extract and display detailed error messages including validation error paths and messages

Now users will see helpful messages like:
'Validation error: data.components.0.attributes.0.name: Attribute name is reserved' instead of just 'An error occurred'

Fixes issue with vague error messages when adding components to Dynamic Zones.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
