### PR TITLE
fix: date picker sends date-only format to avoid deprecation warning

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -48,7 +48,10 @@ const DateInput = React.forwardRef<HTMLInputElement, InputProps>(
           onBlur={() => {
             // When the input is blurred, revert to the last valid date if the current value is invalid
             if (field.value && !value) {
-              field.onChange(name, lastValidDate ? lastValidDate.toISOString().split('T')[0] : null);
+              field.onChange(
+                name,
+                lastValidDate ? lastValidDate.toISOString().split('T')[0] : null
+              );
             }
           }}
           value={value}

--- a/packages/core/admin/admin/src/components/FormInputs/Date.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Date.tsx
@@ -28,7 +28,7 @@ const DateInput = React.forwardRef<HTMLInputElement, InputProps>(
       // Convert to UTC midnight
       const utcDate = toUTCMidnight(date);
       // Save as ISO string in UTC format
-      field.onChange(name, utcDate.toISOString());
+      field.onChange(name, utcDate.toISOString().split('T')[0]);
       setLastValidDate(utcDate);
     };
 
@@ -48,7 +48,7 @@ const DateInput = React.forwardRef<HTMLInputElement, InputProps>(
           onBlur={() => {
             // When the input is blurred, revert to the last valid date if the current value is invalid
             if (field.value && !value) {
-              field.onChange(name, lastValidDate?.toISOString() ?? null);
+              field.onChange(name, lastValidDate ? lastValidDate.toISOString().split('T')[0] : null);
             }
           }}
           value={value}

--- a/packages/core/admin/admin/src/components/FormInputs/tests/HandleDateChange.test.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/tests/HandleDateChange.test.tsx
@@ -33,7 +33,7 @@ describe('DateInput Component', () => {
     fireEvent.change(input, { target: { value: '12/07/2024' } });
     fireEvent.blur(input);
 
-    expect(mockField.onChange).toHaveBeenCalledWith('testDate', '2024-12-07T00:00:00.000Z');
+    expect(mockField.onChange).toHaveBeenCalledWith('testDate', '2024-12-07');
   });
 
   it('should handle clearing the date', () => {
@@ -62,7 +62,7 @@ describe('DateInput Component', () => {
 
     // Check final value
     const lastCall = mockField.onChange.mock.lastCall;
-    expect(lastCall).toEqual(['testDate', '2024-12-08T00:00:00.000Z']);
+    expect(lastCall).toEqual(['testDate', '2024-12-08']);
   });
 
   it('should revert to last valid date on blur if current value is invalid', () => {
@@ -73,6 +73,6 @@ describe('DateInput Component', () => {
     const input = screen.getByRole('combobox');
     fireEvent.change(input, { target: { value: 'invalid-date' } });
     fireEvent.blur(input);
-    expect(mockField.onChange).toHaveBeenCalledWith('testDate', '2024-12-07T00:00:00.000Z');
+    expect(mockField.onChange).toHaveBeenCalledWith('testDate', '2024-12-07');
   });
 });


### PR DESCRIPTION
### What does it do?
Updates the `Date` form input component in the Admin to format dates as `YYYY-MM-DD` instead of an ISO string (which includes time) before saving. This aligns the client-side output with strict backend validation.

### Why is it needed?
Fixes #25261. The backend emits a deprecation warning (`[deprecated] Using a date format other than YYYY-MM-DD...`) when it receives a full ISO date string. This change ensures the correct format is sent, eliminating the warning.

### How to test it?
1. Create a Content Type with a `date` field.
2. Create or edit an entry.
3. Select a date using the date picker.
4. Save the entry.
5. Check server logs; the deprecation warning should no longer appear.
6. Verify the date is saved correctly in the database.

### Related issue(s)/PR(s)
Fixes #25261