### PR TITLE
enhancement(create-strapi-app): add --non-interactive mode for CI and scripts

### DIFF
--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -54,6 +54,9 @@ const command = new commander.Command('create-strapi-app')
   .option('--enable-ab-tests', 'Enable anonymous A/B testing')
   .option('--no-enable-ab-tests', 'Disable anonymous A/B testing')
 
+  // Automation
+  .option('--non-interactive', 'Skip all interactive prompts and use defaults')
+
   // Database options
   .option('--dbclient <dbclient>', 'Database client')
   .option('--dbhost <dbhost>', 'Database host')
@@ -116,6 +119,14 @@ async function run(args: string[]): Promise<void> {
     );
   }
 
+  if (options.nonInteractive && !directory) {
+    logger.fatal(
+      `Please specify the ${chalk.bold('<directory>')} of your project when using ${chalk.bold('--non-interactive')}`
+    );
+  }
+
+  const skipPrompts = options.quickstart || options.nonInteractive;
+
   checkNodeRequirements();
 
   const appDirectory = directory || (await prompts.directory());
@@ -123,7 +134,7 @@ async function run(args: string[]): Promise<void> {
   const rootPath = await checkInstallPath(appDirectory);
 
   let shouldCreateGrowthSsoTrial = false;
-  if (!options.skipCloud) {
+  if (!options.skipCloud && !options.nonInteractive) {
     shouldCreateGrowthSsoTrial = await handleCloudLogin();
   }
 
@@ -172,7 +183,7 @@ async function run(args: string[]): Promise<void> {
     scope.useExample = false;
   } else if (options.example === true) {
     scope.useExample = true;
-  } else if (options.example === false || options.quickstart === true) {
+  } else if (options.example === false || skipPrompts) {
     scope.useExample = false;
   } else {
     scope.useExample = await prompts.example();
@@ -180,13 +191,13 @@ async function run(args: string[]): Promise<void> {
 
   if (options.javascript === true) {
     scope.useTypescript = false;
-  } else if (options.typescript === true || options.quickstart) {
+  } else if (options.typescript === true || skipPrompts) {
     scope.useTypescript = true;
   } else if (!options.template) {
     scope.useTypescript = await prompts.typescript();
   }
 
-  scope.installDependencies = await resolveOption(options.install, options.quickstart, true, () =>
+  scope.installDependencies = await resolveOption(options.install, skipPrompts, true, () =>
     prompts.installDependencies(scope.packageManager)
   );
 
@@ -200,11 +211,11 @@ async function run(args: string[]): Promise<void> {
     };
   }
 
-  scope.gitInit = await resolveOption(options.gitInit, options.quickstart, true, prompts.gitInit);
+  scope.gitInit = await resolveOption(options.gitInit, skipPrompts, true, prompts.gitInit);
 
   scope.isABTestEnabled = await resolveOption(
     options.enableAbTests,
-    options.quickstart,
+    skipPrompts,
     false,
     prompts.enableABTests
   );
@@ -225,16 +236,16 @@ async function run(args: string[]): Promise<void> {
 }
 
 /**
- * Resolves a boolean CLI option: explicit flag wins, then quickstart default, then interactive prompt.
+ * Resolves a boolean CLI option: explicit flag wins, then non-interactive default, then interactive prompt.
  */
 async function resolveOption(
   explicitValue: boolean | undefined,
-  quickstart: boolean | undefined,
-  quickstartDefault: boolean,
+  skipPrompts: boolean | undefined,
+  defaultValue: boolean,
   promptFn: () => Promise<boolean>
 ): Promise<boolean> {
   if (explicitValue !== undefined) return explicitValue;
-  if (quickstart) return quickstartDefault;
+  if (skipPrompts) return defaultValue;
   return promptFn();
 }
 

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -21,6 +21,7 @@ export interface Options {
   example?: boolean;
   gitInit?: boolean;
   enableAbTests?: boolean;
+  nonInteractive?: boolean;
   templateBranch?: string;
   templatePath?: string;
 }

--- a/packages/cli/create-strapi-app/src/utils/database.ts
+++ b/packages/cli/create-strapi-app/src/utils/database.ts
@@ -74,7 +74,7 @@ export async function getDatabaseInfos(options: Options): Promise<DBConfig> {
   const hasDBOptions = DBOptions.some((key) => key in options);
 
   if (!hasDBOptions) {
-    if (options.quickstart) {
+    if (options.quickstart || options.nonInteractive) {
       return DEFAULT_CONFIG;
     }
 


### PR DESCRIPTION
## Summary

This PR builds on top of #25316 (which added `--enable-ab-tests` / `--no-enable-ab-tests` CLI flags) with two improvements:

- **Extracts `resolveOption()` helper** — replaces 3 repetitive if/else blocks (`install`, `gitInit`, `enableAbTests`) with a shared function that encodes the priority chain: explicit flag > non-interactive default > interactive prompt
- **Adds `--non-interactive` flag** — skips ALL interactive prompts (cloud login, database, example, typescript, install, git init, AB tests) and uses sensible defaults. Unlike `--quickstart`, it does **not** auto-run the app or set `isQuickstart`

### `--non-interactive` defaults

| Option | Default |
|--------|---------|
| Cloud login | skipped |
| Database | sqlite |
| Example | false |
| TypeScript | true |
| Install deps | true |
| Git init | true |
| AB tests | false |
| Auto-run app | **no** (unlike `--quickstart`) |

Explicit flags still override defaults:
```bash
# Non-interactive with JavaScript instead of TypeScript, no install
npx create-strapi-app my-project --non-interactive --js --no-install
```

### Individual flags still supported

Each option can also be controlled individually for fine-grained automation:
```bash
npx create-strapi-app my-project \
  --skip-cloud \
  --skip-db \
  --no-enable-ab-tests \
  --install \
  --git-init \
  --ts
```

## Context

PR #25316 was opened from the `strapi/strapi` repo directly, so we were unable to push to that branch. This PR includes the original commit from #25316 plus the refactoring and `--non-interactive` feature. The original PR author (@cache-your-dreams) could alternatively cherry-pick the new commits into their branch to consolidate into #25316.

## Test plan

- [x] `--non-interactive` creates a project with zero prompts using all defaults
- [x] `--non-interactive --no-install --js` respects explicit overrides
- [x] `--no-enable-ab-tests` skips the AB test prompt
- [x] `--enable-ab-tests` skips the prompt and enables AB tests
- [x] No flags triggers all interactive prompts (existing behavior preserved)
- [x] `--quickstart` still works as before (auto-runs app, sets isQuickstart)
- [x] Linting and commitlint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)