### PR TITLE
fix(admin): prevent stale field values from overwriting form state

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -313,6 +313,13 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
 
     const handleChange: FormContextValue['onChange'] = useCallbackRef((eventOrPath, v) => {
       if (typeof eventOrPath === 'string') {
+        const currentValue = getIn(state.values, eventOrPath);
+
+        // Only dispatch if the specific field value is actually different
+        if (isEqual(currentValue, v)) {
+          return;
+        }
+
         dispatch({
           type: 'SET_FIELD_VALUE',
           payload: {


### PR DESCRIPTION
## Summary
This PR resolves an issue where draft content incorrectly persisted in the "Published" view of the Content Manager (specifically within Rich Text/MarkDown fields). The root cause was a race condition in the `Form` component's state management during tab transitions.

## Related Issue
Fixes #25143

## The Problem
When a user switches between the **Draft** and **Published** tabs in the Content Manager:
1. The `Form` component's `useEffect` correctly triggers `SET_INITIAL_VALUES` with the fresh data from the selected tab.
2. Simultaneously, custom field components (like the Rich Text editor) may re-mount or re-render, firing a `change` event with their last-known "stale" value.
3. The `handleChange` function in `Form.tsx` would immediately dispatch `SET_FIELD_VALUE`, overwriting the correct state values with the stale data.
4. This results in the UI showing draft content in the published view and triggering unnecessary "Unsaved changes" warnings.

## Proposed Changes
- Modified the `handleChange` function within `packages/core/admin/admin/src/components/Form.tsx`.
- Added an **idempotency check** using `isEqual` and `getIn` to verify if the incoming value actually differs from the current state.
- The `SET_FIELD_VALUE` action is now only dispatched if the new value is different, effectively ignoring stale no-op events during lifecycle transitions.
- I have also verified that the issue only occurs in the case of RichText/MarkDown field. It doesn't occurs with other fields.

## How to Test
1. Create a Content Type with a **Rich Text** (MarkDown) field..
2. Create an entry, add content, and **Publish** it.
3. Modify the content in the **Draft** version and **Save** (do not publish).
4. Toggle between the **Draft** and **Published** tabs.
5. **Verification:**
    - The "Published" tab should consistently show the original published content.
    - Switching from "Published" to "Draft" should no longer trigger a "Changes will be lost" warning since no manual edits were made. 
     
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings