### PR TITLE
fix(preview-config): allow and await for async handler

### DIFF
--- a/packages/core/content-manager/server/src/preview/services/preview.ts
+++ b/packages/core/content-manager/server/src/preview/services/preview.ts
@@ -22,7 +22,7 @@ const createPreviewService = ({ strapi }: { strapi: Core.Strapi }) => {
 
       try {
         // Try to get the preview URL from the user-defined handler
-        return handler(uid, params);
+        return await handler(uid, params);
       } catch (error) {
         // Log the error and throw a generic error
         strapi.log.error(`Failed to get preview URL: ${error}`);

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -99,7 +99,10 @@ export interface PreviewHandlerParams {
 
 export interface PreviewConfig {
   allowedOrigins?: string[];
-  handler: (uid: string, params: PreviewHandlerParams) => string | null | undefined;
+  handler: (
+    uid: string,
+    params: PreviewHandlerParams
+  ) => string | null | undefined | Promise<string | null | undefined>;
 }
 
 export interface Preview {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the type for admin preview config handler and awaits for it

### Why is it needed?

Without this, users can't define an async handler.

### How to test it?

Create an async handler for preview config (the tests already cover this case)

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/24905#discussion_r2782268513
