### PR TITLE
chore(*): register vitest dependency in Yarn catalog

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,6 @@ nodeLinker: node-modules
 preferInteractive: true
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+catalog:
+  vitest: ^4.0.18

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "tar": "7.5.9",
     "ts-jest": "29.1.0",
     "typescript": "5.4.4",
-    "vitest": "4.0.18",
+    "vitest": "catalog:",
     "yalc": "1.0.0-pre.53",
     "yargs": "17.7.2"
   },

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -136,7 +136,7 @@
     "eslint-config-custom": "5.37.1",
     "supertest": "6.3.3",
     "tsconfig": "5.37.1",
-    "vitest": "4.0.18",
+    "vitest": "catalog:",
     "vitest-config": "5.37.1"
   },
   "engines": {

--- a/packages/utils/vitest-config/package.json
+++ b/packages/utils/vitest-config/package.json
@@ -13,7 +13,7 @@
     "vitest": "^4.0.0"
   },
   "devDependencies": {
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,13 +1038,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.973.1, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.973.1":
+"@aws-sdk/types@npm:3.973.1, @aws-sdk/types@npm:^3.973.1":
   version: 3.973.1
   resolution: "@aws-sdk/types@npm:3.973.1"
   dependencies:
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/8a4a183cc39b4d6f4d065ece884b50d397a54b17add32b649f49adbe676174e7bee2c3c94394fc5227a4fccb96c34482291a1eb2702158e1dbb12c441af32863
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
+  version: 3.598.0
+  resolution: "@aws-sdk/types@npm:3.598.0"
+  dependencies:
+    "@smithy/types": "npm:^3.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/83abd25e07ffc071e24f36b4fb4dae6e552d662ab55f832f9918ccff251ae80155e30a86d2bd0b98bb8b94adaa2a13f05e1bb071edf491e4f36755084ac63d4f
   languageName: node
   linkType: hard
 
@@ -9294,6 +9304,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/types@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "@smithy/types@npm:3.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6b82a9177ae85d9c08247675831ffeed87a671c51ab35ecf64641ea0afb6036a97b3a00a83e717529a74b416b19df0c0fc2b2930a9b55bb0d34bea2390f835ad
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^4.12.0":
   version: 4.12.0
   resolution: "@smithy/types@npm:4.12.0"
@@ -9927,7 +9946,7 @@ __metadata:
     tsconfig: "npm:5.37.1"
     typescript: "npm:5.4.4"
     undici: "npm:6.23.0"
-    vitest: "npm:4.0.18"
+    vitest: "catalog:"
     vitest-config: "npm:5.37.1"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
@@ -17847,7 +17866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.4, elliptic@npm:^6.5.7":
+"elliptic@npm:^6.5.4":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -17859,6 +17878,21 @@ __metadata:
     minimalistic-assert: "npm:^1.0.1"
     minimalistic-crypto-utils: "npm:^1.0.1"
   checksum: 10c0/8b24ef782eec8b472053793ea1e91ae6bee41afffdfcb78a81c0a53b191e715cbe1292aa07165958a9bbe675bd0955142560b1a007ffce7d6c765bcaf951a867
+  languageName: node
+  linkType: hard
+
+"elliptic@npm:^6.5.7":
+  version: 6.5.7
+  resolution: "elliptic@npm:6.5.7"
+  dependencies:
+    bn.js: "npm:^4.11.9"
+    brorand: "npm:^1.1.0"
+    hash.js: "npm:^1.0.0"
+    hmac-drbg: "npm:^1.0.1"
+    inherits: "npm:^2.0.4"
+    minimalistic-assert: "npm:^1.0.1"
+    minimalistic-crypto-utils: "npm:^1.0.1"
+  checksum: 10c0/799959b6c54ea3564e8961f35abdf8c77e37617f3051614b05ab1fb6a04ddb65bd1caa75ed1bae375b15dda312a0f79fed26ebe76ecf05c5a7af244152a601b8
   languageName: node
   linkType: hard
 
@@ -32097,7 +32131,7 @@ __metadata:
     tar: "npm:7.5.9"
     ts-jest: "npm:29.1.0"
     typescript: "npm:5.4.4"
-    vitest: "npm:4.0.18"
+    vitest: "catalog:"
     yalc: "npm:1.0.0-pre.53"
     yargs: "npm:17.7.2"
   languageName: unknown
@@ -34538,13 +34572,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vitest-config@workspace:packages/utils/vitest-config"
   dependencies:
-    vitest: "npm:^4.0.18"
+    vitest: "catalog:"
   peerDependencies:
     vitest: ^4.0.0
   languageName: unknown
   linkType: soft
 
-"vitest@npm:4.0.18, vitest@npm:^4.0.18":
+"vitest@npm:^4.0.18":
   version: 4.0.18
   resolution: "vitest@npm:4.0.18"
   dependencies:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Adds a Yarn catalog entry for `vitest` in `.yarnrc.yml` with version `^4.0.18`.
- Replaces per-package vitest declarations with catalog references (`catalog:`) in:
  - Root `package.json` (devDependencies)
  - `packages/core/core/package.json` (devDependencies)
  - `packages/utils/vitest-config/package.json` (devDependencies; peerDependencies remain `^4.0.0`)
- Updates `yarn.lock` accordingly.

### Why is it needed?

Centralizes the vitest version in the Yarn catalog so it can be updated in one place across the monorepo, avoids version drift between packages, and aligns with Strapi’s dependency management approach.

### How to test it?

1. From repo root: `yarn install` (lockfile should apply without errors).
2. Run vitest: `yarn test:unit:vitest` — all 19 tests in 3 files under `packages/core/core` should pass.
3. Optionally run from `packages/core/core`: `yarn test:unit:vitest` and `yarn test:unit:vitest:watch`.

**⚠️ Warning**
We must validate that the catalog feature does not collide with the release system.

### Related issue(s)/PR(s)

Follow-up to PR #25286 
