### PR TITLE
fix: improve subnav on mobile so it works with banner

### DIFF
--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -23,17 +23,13 @@ import { tours } from './GuidedTour/Tours';
 
 const MainSubNav = styled(DSSubNav)`
   width: 100%;
-  height: calc(100dvh - ${HEIGHT_TOP_NAVIGATION} - 1px);
-  overflow: hidden;
+  height: auto;
   background-color: ${({ theme }) => theme.colors.neutral0};
   display: flex;
   flex-direction: column;
   border-right: 0;
   box-shadow: none;
-  position: fixed;
-  top: calc(${HEIGHT_TOP_NAVIGATION} + 1px);
-  left: 0;
-  z-index: 2;
+  position: relative;
 
   ${({ theme }) => theme.breakpoints.medium} {
     width: ${WIDTH_SIDE_NAVIGATION};

--- a/packages/core/admin/admin/src/components/SubNav.tsx
+++ b/packages/core/admin/admin/src/components/SubNav.tsx
@@ -32,6 +32,8 @@ const MainSubNav = styled(DSSubNav)`
   position: relative;
 
   ${({ theme }) => theme.breakpoints.medium} {
+    height: calc(100dvh - ${HEIGHT_TOP_NAVIGATION} - 1px);
+    overflow: hidden;
     width: ${WIDTH_SIDE_NAVIGATION};
     position: sticky;
     top: 0;

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -443,17 +443,13 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 
 .c1 {
   width: 100%;
-  height: calc(100dvh - 6.4rem - 1px);
-  overflow: hidden;
+  height: auto;
   background-color: #ffffff;
   display: flex;
   flex-direction: column;
   border-right: 0;
   box-shadow: none;
-  position: fixed;
-  top: calc(6.4rem + 1px);
-  left: 0;
-  z-index: 2;
+  position: relative;
 }
 
 .c42 {

--- a/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/core/content-type-builder/admin/src/components/ContentTypeBuilderNav/tests/__snapshots__/index.test.tsx.snap
@@ -637,6 +637,8 @@ exports[`<ContentTypeBuilderNav /> renders and matches the snapshot 1`] = `
 
 @media (min-width: 768px) {
   .c1 {
+    height: calc(100dvh - 6.4rem - 1px);
+    overflow: hidden;
     width: 23.2rem;
     position: sticky;
     top: 0;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Makes sure the banner is visible and clickable when navigating a subnav (Content Manager nav or Settings nav) on mobile.

### Why is it needed?
**BEFORE**
<img width="744" height="1102" alt="Capture d’écran 2026-01-22 à 17 39 22" src="https://github.com/user-attachments/assets/b1527bde-e36a-48ee-8e23-9cd54bd337fb" />

**AFTER** 
https://github.com/user-attachments/assets/89fdc6d9-e701-46e3-99e8-b132543fc8f1

### How to test it?
* Use your mobile device or go to the Inspecter's mobile version.
* Enable a free trial/Display the upsell banner through the UpsellBanner.tsx
* Click on the Content Manager icon in the navbar.
* Make sure the upsell banner is visible and clickable, and that the subnav is still navigable. 
* Go to the Settings page and check the same things. 