### PR TITLE
chore: add --no-build-admin option to 'strapi develop' command

### DIFF
--- a/packages/core/strapi/src/cli/commands/develop.ts
+++ b/packages/core/strapi/src/cli/commands/develop.ts
@@ -34,6 +34,8 @@ const command: StrapiCommand = ({ ctx }) => {
     .option('--polling', 'Watch for file changes in network directories', false)
     .option('--watch-admin', 'Watch the admin panel for hot changes', true)
     .option('--no-watch-admin', 'Do not watch the admin panel for hot changes')
+    .option('--build-admin', 'Build the admin panel', true)
+    .option('--no-build-admin', 'Do not build the admin panel in case watch is disabled')
     .option('--open', 'Open the admin in your browser', true)
     .description('Start your Strapi application in development mode')
     .action(async (options: DevelopCLIOptions) => {

--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -25,6 +25,7 @@ interface DevelopOptions extends CLIContext {
   polling?: boolean;
   open?: boolean;
   watchAdmin?: boolean;
+  buildAdmin?: boolean;
 }
 
 // This method removes all non-admin build files from the dist directory
@@ -75,6 +76,7 @@ const develop = async ({
   logger,
   tsconfig,
   watchAdmin,
+  buildAdmin,
   ...options
 }: DevelopOptions) => {
   const timer = getTimer();
@@ -100,7 +102,7 @@ const develop = async ({
      * sure that at least the admin is built for users & they can interact
      * with the application.
      */
-    if (!watchAdmin) {
+    if (!watchAdmin && buildAdmin) {
       timer.start('createBuildContext');
       const contextSpinner = logger.spinner(`Building build context`).start();
       console.log('');


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This is to allow to prebuild the admin panel before starting the development server.

Running `strapi develop --no-watch-admin --no-build-admin` will be much faster.

I wonder if just passing `strapi develop --no-build-admin` should automatically disable admin watch?

### Why is it needed?

Describe the issue you are solving.

### How to test it?

In an example project:

- prebuild the admin `yarn strapi build`
- run the develop command `yarn strapi develop --no-watch-admin --no-build-admin`

The admin should not be rebuilt

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
