### PR TITLE
fix: allow clearing placeholder and description in configure the view

### DIFF
--- a/packages/core/content-manager/server/src/services/utils/__tests__/store.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/__tests__/store.test.ts
@@ -1,0 +1,182 @@
+import storeUtils from '../store';
+
+const mockGet = jest.fn();
+const mockSet = jest.fn();
+
+describe('store utils', () => {
+  beforeEach(() => {
+    global.strapi = {
+      store: jest.fn(() => ({
+        get: mockGet,
+        set: mockSet,
+      })),
+    } as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('setModelConfiguration', () => {
+    test('persists normal non-null values', async () => {
+      mockGet.mockResolvedValue({
+        settings: { pageSize: 10 },
+        metadatas: {},
+        layouts: { list: [], edit: [] },
+      });
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: { pageSize: 25 },
+        metadatas: {
+          title: {
+            edit: { label: 'Title', description: 'Enter a title', placeholder: 'My title' },
+            list: { label: 'Title' },
+          },
+        },
+        layouts: { list: ['title'], edit: [] },
+      });
+
+      expect(mockSet).toHaveBeenCalledWith({
+        key: 'configuration_content_types::api::article.article',
+        value: expect.objectContaining({
+          settings: { pageSize: 25 },
+          metadatas: {
+            title: {
+              edit: { label: 'Title', description: 'Enter a title', placeholder: 'My title' },
+              list: { label: 'Title' },
+            },
+          },
+        }),
+      });
+    });
+
+    test('persists null values to allow clearing fields', async () => {
+      mockGet.mockResolvedValue({
+        settings: {},
+        metadatas: {
+          title: {
+            edit: { label: 'Title', description: 'Some description', placeholder: 'Some placeholder' },
+            list: { label: 'Title' },
+          },
+        },
+        layouts: { list: [], edit: [] },
+      });
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: {},
+        metadatas: {
+          title: {
+            edit: { label: 'Title', description: null, placeholder: null },
+            list: { label: 'Title' },
+          },
+        },
+        layouts: { list: [], edit: [] },
+      });
+
+      expect(mockSet).toHaveBeenCalledWith({
+        key: 'configuration_content_types::api::article.article',
+        value: expect.objectContaining({
+          metadatas: {
+            title: {
+              edit: { label: 'Title', description: null, placeholder: null },
+              list: { label: 'Title' },
+            },
+          },
+        }),
+      });
+    });
+
+    test('persists empty string values to allow clearing fields', async () => {
+      mockGet.mockResolvedValue({
+        settings: {},
+        metadatas: {
+          title: {
+            edit: { label: 'Title', description: 'Old description', placeholder: 'Old placeholder' },
+            list: { label: 'Title' },
+          },
+        },
+        layouts: { list: [], edit: [] },
+      });
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: {},
+        metadatas: {
+          title: {
+            edit: { label: 'Title', description: '', placeholder: '' },
+            list: { label: 'Title' },
+          },
+        },
+        layouts: { list: [], edit: [] },
+      });
+
+      expect(mockSet).toHaveBeenCalledWith({
+        key: 'configuration_content_types::api::article.article',
+        value: expect.objectContaining({
+          metadatas: {
+            title: {
+              edit: { label: 'Title', description: '', placeholder: '' },
+              list: { label: 'Title' },
+            },
+          },
+        }),
+      });
+    });
+
+    test('skips undefined values', async () => {
+      mockGet.mockResolvedValue({
+        settings: { pageSize: 10 },
+        metadatas: {},
+        layouts: { list: [], edit: [] },
+      });
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: { pageSize: 25 },
+        metadatas: {},
+        layouts: { list: [], edit: [] },
+        isComponent: undefined,
+      });
+
+      const savedValue = mockSet.mock.calls[0][0].value;
+      expect(savedValue).not.toHaveProperty('isComponent');
+    });
+
+    test('does not call set when config has not changed', async () => {
+      const existingConfig = {
+        settings: { pageSize: 10 },
+        metadatas: {},
+        layouts: { list: [], edit: [] },
+      };
+
+      mockGet.mockResolvedValue(existingConfig);
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: { pageSize: 10 },
+        metadatas: {},
+        layouts: { list: [], edit: [] },
+      });
+
+      expect(mockSet).not.toHaveBeenCalled();
+    });
+
+    test('persists top-level null values', async () => {
+      mockGet.mockResolvedValue({
+        settings: { pageSize: 10 },
+        metadatas: { title: { edit: {}, list: {} } },
+        layouts: { list: [], edit: [] },
+      });
+
+      await storeUtils.setModelConfiguration('content_types::api::article.article', {
+        settings: null,
+        metadatas: { title: { edit: {}, list: {} } },
+        layouts: { list: [], edit: [] },
+      });
+
+      expect(mockSet).toHaveBeenCalledWith({
+        key: 'configuration_content_types::api::article.article',
+        value: expect.objectContaining({
+          settings: null,
+        }),
+      });
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/services/utils/store.ts
+++ b/packages/core/content-manager/server/src/services/utils/store.ts
@@ -66,7 +66,7 @@ const setModelConfiguration = async (key: string, value: any) => {
   const currentConfig = { ...storedConfig };
 
   Object.keys(value).forEach((key) => {
-    if (value[key] !== null && value[key] !== undefined) {
+    if (value[key] !== undefined) {
       _.set(currentConfig, key, value[key]);
     }
   });


### PR DESCRIPTION
## Problem

Fixes #24161

`setModelConfiguration` in `packages/core/content-manager/server/src/services/utils/store.ts` skips writing values that are `null` or `undefined`. When a user clears the placeholder or description fields in the "Configure the View" modal, the cleared value (`null`) is never persisted to the store because the condition `value[key] !== null && value[key] !== undefined` filters it out. The old value stays in place.

## Fix

Changed the guard in `setModelConfiguration` to only skip `undefined` values, allowing `null` to pass through. `null` is the explicit "cleared" signal from the frontend validation schema (`yup.string().nullable()`), while `undefined` means "not provided" and should continue to be skipped (e.g., `isComponent` on non-component configurations).

The one-line change:
```diff
- if (value[key] !== null && value[key] !== undefined) {
+ if (value[key] !== undefined) {
```

## Testing

Added unit tests for `setModelConfiguration` covering:
- Normal non-null values persist correctly
- `null` values persist (clearing a field)
- Empty string values persist (clearing a field)
- `undefined` values are still skipped
- No write occurs when config hasn't changed
- Top-level `null` values persist