### PR TITLE
fix(content-manager): apply i18n translations to dynamic zone component names

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -53,7 +53,7 @@ const ComponentCategory = ({
                 <ComponentIcon color="currentColor" background="primary200" icon={icon} />
 
                 <Typography variant="pi" fontWeight="bold">
-                  {displayName}
+                  {formatMessage({ id: uid, defaultMessage: displayName })}
                 </Typography>
               </Flex>
             </ComponentBox>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -53,7 +53,7 @@ const ComponentCategory = ({
                 <ComponentIcon color="currentColor" background="primary200" icon={icon} />
 
                 <Typography variant="pi" fontWeight="bold">
-                  {formatMessage({ id: uid, defaultMessage: displayName })}
+                  {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
                 </Typography>
               </Flex>
             </ComponentBox>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -74,10 +74,19 @@ const DynamicComponent = ({
   const displayedValue = mainField === 'id' || !mainFieldValue ? '' : String(mainFieldValue).trim();
   const displayTitle = displayedValue.length > 0 ? `- ${displayedValue}` : displayedValue;
 
-  const [category] = componentUid.split('.');
-  const { icon, displayName } = (dynamicComponentsByCategory[category] ?? []).find(
-    (component) => component.uid === componentUid
-  ) ?? { icon: null, displayName: null };
+  const { icon, displayName } = React.useMemo(() => {
+    const [category] = componentUid.split('.');
+    const { icon, displayName } = (dynamicComponentsByCategory[category] ?? []).find(
+      (component) => component.uid === componentUid
+    ) ?? { icon: null, displayName: null };
+    const mainValue = displayedValue.length > 0 ? `- ${displayedValue}` : displayedValue;
+
+    return {
+      mainValue,
+      icon,
+      displayName: formatMessage({ id: componentUid, defaultMessage: displayName ?? '' }),
+    };
+  }, [componentUid, dynamicComponentsByCategory, formatMessage]);
 
   const [{ handlerId, isDragging, handleKeyDown }, boxRef, dropRef, dragRef, dragPreviewRef] =
     useDragAndDrop(!disabled, {
@@ -223,10 +232,12 @@ const DynamicComponent = ({
             <Menu.SubContent>
               {Object.entries(dynamicComponentsByCategory).map(([category, components]) => (
                 <React.Fragment key={category}>
-                  <Menu.Label>{category}</Menu.Label>
+                  <Menu.Label>
+                    {formatMessage({ id: category, defaultMessage: category })}
+                  </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index)}>
-                      {displayName}
+                      {formatMessage({ id: uid, defaultMessage: displayName })}
                     </Menu.Item>
                   ))}
                 </React.Fragment>
@@ -243,10 +254,12 @@ const DynamicComponent = ({
             <Menu.SubContent>
               {Object.entries(dynamicComponentsByCategory).map(([category, components]) => (
                 <React.Fragment key={category}>
-                  <Menu.Label>{category}</Menu.Label>
+                  <Menu.Label>
+                    {formatMessage({ id: category, defaultMessage: category })}
+                  </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index + 1)}>
-                      {displayName}
+                      {formatMessage({ id: uid, defaultMessage: displayName })}
                     </Menu.Item>
                   ))}
                 </React.Fragment>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -79,12 +79,13 @@ const DynamicComponent = ({
     const { icon, displayName } = (dynamicComponentsByCategory[category] ?? []).find(
       (component) => component.uid === componentUid
     ) ?? { icon: null, displayName: null };
-    const mainValue = displayedValue.length > 0 ? `- ${displayedValue}` : displayedValue;
 
     return {
-      mainValue,
       icon,
-      displayName: formatMessage({ id: componentUid, defaultMessage: displayName ?? '' }),
+      displayName: formatMessage({
+        id: componentUid,
+        defaultMessage: displayName || componentUid,
+      }),
     };
   }, [componentUid, dynamicComponentsByCategory, formatMessage]);
 
@@ -237,7 +238,7 @@ const DynamicComponent = ({
                   </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index)}>
-                      {formatMessage({ id: uid, defaultMessage: displayName })}
+                      {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
                     </Menu.Item>
                   ))}
                 </React.Fragment>
@@ -259,7 +260,7 @@ const DynamicComponent = ({
                   </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index + 1)}>
-                      {formatMessage({ id: uid, defaultMessage: displayName })}
+                      {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
                     </Menu.Item>
                   ))}
                 </React.Fragment>


### PR DESCRIPTION
## Problem

Closes #24078

Custom translations set for component display names (via `src/admin/app.ts` translations config) render correctly in the Content-Type Builder sidebar but are shown as raw English display names in the Dynamic Zone. This affects:

- The Dynamic Zone component picker grid
- The component category accordion headers in the picker
- The accordion row header for each dynamic zone entry
- The "Add component above/below" context menus
- The drag preview label

The Content-Type Builder nav already handles this correctly by wrapping component names with `formatMessage({ id: subLink.name, defaultMessage: subLink.title })`, but the Dynamic Zone components render `displayName` raw without going through `formatMessage`.

## Fix

Wrapped all raw `displayName` renders in the Dynamic Zone components with `formatMessage` using the component UID as the message id, matching the existing pattern in the Content-Type Builder nav.

**ComponentCategory.tsx**: wrapped the display name in the component picker grid with `formatMessage({ id: uid, defaultMessage: displayName })`.

**DynamicComponent.tsx**: 
- Translated `displayName` inside the `useMemo` that resolves it, so the accordion header and drag preview label both use the translated value
- Wrapped category labels in the "add above/below" context menus with `formatMessage({ id: category, defaultMessage: category })`
- Wrapped component display names in the "add above/below" menu items with `formatMessage({ id: uid, defaultMessage: displayName })`

When no custom translation is registered for a component UID, `formatMessage` falls back to the `defaultMessage` (the original English display name), so this is fully backward compatible.