### PR TITLE
fix(plugin-i18n): fetch published version for 'Fill in from another locale'

### DIFF
--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -556,7 +556,7 @@ const FillFromAnotherLocaleAction = ({
       collectionType,
       model,
       documentId,
-      params: { locale: localeSelected },
+      params: { locale: localeSelected, status: 'published' },
     });
     if (!response || !schema) {
       return;


### PR DESCRIPTION
## Overview

### Summary
This PR fixes issue #24873 where the "Fill in from another locale" feature was incorrectly fetching the **Draft** version of a source document instead of the **Published** version. 

### Context
In Strapi 5, `getDocument` defaults to fetching the latest version available (the Draft) if no status is specified. When a user syncs content from one locale to another, they generally expect the "Source of Truth" (the Published content) to be the source. Fetching the Draft leads to accidental syncing of unapproved or incomplete work-in-progress content.

### Solution
Modified the `getDocument` call within the `FillFromAnotherLocaleAction` component to explicitly include `status: 'published'` in the request parameters.

### How to verify
1. Enable **Internationalization** and **Draft & Publish** on a Collection Type.
2. Create an entry in a source locale (e.g., **English**) and **Publish** it with the text: *"Version 1 - Published"*.
3. Edit that same English entry, change the text to *"Version 2 - Draft"*, and click **Save** (do NOT publish).
4. Switch to a target locale (e.g., **French**).
5. Click the **"Fill in from another locale"** button and select **English**.
6. **Verify:** The French fields should now contain *"Version 1 - Published"*.

### Related Issues
Fixes: #24873