### PR TITLE
fix: embed design-system for plugins

### DIFF
--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -37,6 +37,11 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
         'react-dom/client',
         'styled-components',
         'react-router-dom',
+        // Pre-bundle design-system so plugin custom field chunks (dynamic imports) resolve
+        // to the same instance as the main app. Otherwise TooltipProvider/DesignSystemProvider
+        // context from the root is not seen by components in plugin chunks.
+        '@strapi/design-system',
+        '@radix-ui/react-tooltip',
         /**
          * Pre-bundle other dependencies that would otherwise cause a page reload when imported.
          * See "performance" section: https://vite.dev/guide/dep-pre-bundling.html#the-why
@@ -102,7 +107,15 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     },
     resolve: {
       // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
-      dedupe: ['react', 'react-dom', 'react-router-dom', 'styled-components'],
+      // Include design-system so plugin chunks use the same instance and inherit root context
+      dedupe: [
+        'react',
+        'react-dom',
+        'react-router-dom',
+        'styled-components',
+        '@strapi/design-system',
+        '@radix-ui/react-tooltip',
+      ],
     },
     plugins: [react(), buildFilesPlugin(ctx)],
   };

--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -36,6 +36,9 @@ const resolveBaseConfig = async (ctx: BuildContext) => {
         'react-dom': getModulePath('react-dom'),
         'styled-components': getModulePath('styled-components'),
         'react-router-dom': getModulePath('react-router-dom'),
+        // Force single instance so plugin custom field chunks inherit root DesignSystemProvider context
+        '@strapi/design-system': getModulePath('@strapi/design-system'),
+        '@radix-ui/react-tooltip': getModulePath('@radix-ui/react-tooltip'),
       },
       extensions: ['.js', '.jsx', '.react.js', '.ts', '.tsx'],
     },


### PR DESCRIPTION
### What does it do?

Fixes the need of wrapping components in a DesignSystemProvider in a plugin.
When importing any component from the design system that uses Tooltip, there was an error thrown saying `Error: Tooltip must be used within TooltipProvider` (e.g. IconButton, Combobox since 2.0.0-rc.19 or just Tooltip).

The workaround found by the community was to wrap their component in their own DesignSystemProvider. But since it's already wrapping the whole CMS, they shouldn't have to do that. Also, doing that breaks the global styles of the whole page if the component gets unmounted.

⚠️ It was happening only on a Strapi project. Working on a plugin inside this repository is fine and there is no error.

### Why is it needed?

Helping the plugins developer to get rid of the error and be able to use all the components from the design system without any error and without the need to wrap them in a DesignSystemProvider.

### How to test it?

_I created a Strapi project for the use case, it's simpler than configuring everything on your own_

- Clone the following repository: https://github.com/Adzouz/strapi-ds-provider/tree/main (`git clone git@github.com:Adzouz/strapi-ds-provider.git`)
- `cd strapi-ds-provider`
- `npm install`
- `cd src/plugins/strapi-plugin-generic-custom-fields/`
- `pnpm install` (if you don't already have pnpm, install it first)
- `pnpm build`
- `cd ../../../`
- `npm run develop`

-> It should start the Strapi project. Create a user and login

#### Testing the bug:
- Go to the Content Manager > Article
- Create a new entry
- Click on the toggle visible to display the combobox
- Click on the combobox and select a value

<img width="1147" height="737" alt="Screenshot 2026-02-12 at 10 26 40" src="https://github.com/user-attachments/assets/8dc25a64-730b-4ead-aede-a7f66038206d" />

-> You should have the following error:

<img width="551" height="425" alt="Screenshot 2026-02-12 at 10 28 15" src="https://github.com/user-attachments/assets/672cc415-ae45-444d-87c9-bb3ae459519e" />

#### Fixing the bug:
- Kill the develop command
- Edit the package.json at the root folder of the project and update the following dependencies: `@strapi/plugin-cloud`, `@strapi/plugin-users-permissions` and `@strapi/strapi` to change their version from `5.36.0` to `0.0.0-experimental.d2a63b7d070930ac7f3580b6fcb9c2b61b18cec9`
- Run `rm -rf node_modules`
- Run `rm package-lock.json`
- Run `npm install --legacy-peer-deps`
- Run `npm run develop`

-> Once the Strapi project is started, do the same steps as before and this time, you shouldn't see the error

Full video of the test:

https://www.loom.com/share/cd716b0e80ef47688eb04a41bf4e7c00

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/21823
Fixes https://github.com/strapi/design-system/issues/1998

🚀