### PR TITLE
fix: made changes to resolve Firefox timepicker issue (#25129)

### DIFF
--- a/packages/core/admin/admin/src/components/FormInputs/Time.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/Time.tsx
@@ -8,6 +8,12 @@ import { useField } from '../Form';
 
 import { InputProps } from './types';
 
+const formatTimeForTimePicker = (value: string | null | undefined): string => {
+  if (!value) return '';
+  const [hours, minutes] = value.split(':');
+  return hours && minutes ? `${hours}:${minutes}` : value;
+};
+
 const TimeInput = forwardRef<HTMLInputElement, InputProps>(
   ({ name, required, label, hint, labelAction, ...props }, ref) => {
     const { formatMessage } = useIntl();
@@ -26,7 +32,7 @@ const TimeInput = forwardRef<HTMLInputElement, InputProps>(
             field.onChange(name, `${time}:00.000`);
           }}
           onClear={() => field.onChange(name, null)}
-          value={field.value ?? ''}
+          value={formatTimeForTimePicker(field.value)}
           {...props}
         />
         <Field.Hint />

--- a/packages/core/admin/admin/src/components/FormInputs/tests/Time.test.tsx
+++ b/packages/core/admin/admin/src/components/FormInputs/tests/Time.test.tsx
@@ -33,12 +33,12 @@ describe('TimeInput Component', () => {
     expect(screen.getByText('Test Time')).toBeInTheDocument();
   });
 
-  it('should display initial time value correctly', () => {
+  it('should strip seconds and milliseconds from display value', () => {
     setupTest('14:30:00.000');
     render(<TimeInput type="time" name="testTime" label="Test Time" />);
 
     const input = screen.getByRole('combobox');
-    expect(input).toHaveValue('14:30:00.000');
+    expect(input).toHaveValue('14:30');
   });
 
   it('should handle time selection and add seconds/milliseconds suffix', () => {
@@ -138,7 +138,6 @@ describe('TimeInput Component', () => {
     render(<TimeInput type="time" name="testTime" label="Test Time" />);
 
     const input = screen.getByRole('combobox');
-    // TimePicker displays full format
-    expect(input).toHaveValue('08:15:00.000');
+    expect(input).toHaveValue('08:15');
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added a helper that strips seconds and milliseconds off the time value before passing it on to the TimePicker. 

### Why is it needed?

The TimePicker field alternates between different formats of showing time while focusing in Firefox browser. This happens as the browser provides the time in format containing seconds and milliseconds, but the TimeInput component was passing the raw backend value directly to TimePicker without stripping them. The fix normalizes the value to HH:mm format before displaying it.

### How to test it?
yarn version: v4.12.0
node version: v22.22.0
Strapi version: v5.35.0
The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #25129 
