### PR TITLE
test(api): remove the expiresin warnings (again)

### DIFF
--- a/packages/utils/api-tests/strapi.js
+++ b/packages/utils/api-tests/strapi.js
@@ -73,10 +73,8 @@ const createStrapiInstance = async ({
   if (bootstrap) {
     const modules = instance.get('modules');
     const originalBootstrap = modules.bootstrap;
-    // decorate modules bootstrap
     modules.bootstrap = async () => {
       await bootstrap({ strapi: instance });
-
       await originalBootstrap();
     };
   }


### PR DESCRIPTION
### What does it do?

uses the new jwt config settings

### Why is it needed?

when we run `yarn test:api` we get warnings about expiresIn being deprecated

### How to test it?

run `yarn test:api` and see that we not longer get warnings in every test about expiresIn being deprecated

### Related issue(s)/PR(s)

first attempt that somehow broke in between the first commit and merging it: https://github.com/strapi/strapi/pull/25303/changes
