### PR TITLE
fix: some fields not updating or interactable in live preview

### DIFF
--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -68,11 +68,7 @@ const NestedValue = ({
 
   // Use the email type to test clickable preview elements
   if (fieldName === 'email') {
-    return (
-      <Button variant="tertiary" onClick={() => window.alert('Sending email!')}>
-        {value}
-      </Button>
-    );
+    return <Typography>{value}</Typography>;
   }
 
   if (isMedia(value)) {

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -6,10 +6,6 @@ import { Page, Layouts } from '@strapi/admin/strapi-admin';
 import { Grid, Flex, Typography, JSONInput, Box, Button } from '@strapi/design-system';
 import { ChevronDown, ChevronRight } from '@strapi/icons';
 
-const isMedia = (value) => {
-  return typeof value === 'object' && value !== null && 'url' in value;
-};
-
 const filterAttributes = (item) => {
   const excludedKeys = ['documentId', 'id', 'createdAt', 'updatedAt', 'publishedAt'];
   return Object.entries(item).filter(([key]) => !excludedKeys.includes(key));
@@ -49,6 +45,10 @@ const ToggleableContainer = ({ headerText, children, isEmpty = false }) => {
   );
 };
 
+const isMedia = (value) => {
+  return typeof value === 'object' && value !== null && 'url' in value;
+};
+
 const NestedValue = ({
   value,
   level = 0,
@@ -60,14 +60,7 @@ const NestedValue = ({
 }) => {
   if (fieldName === 'blocks') {
     return (
-      <Flex
-        direction="column"
-        alignItems="flex-start"
-        fontSize="1.4rem"
-        gap={2}
-        data-strapi-source={`path=${path}&type=blocks&model=${model}&documentId=${documentId}`}
-        width="100%"
-      >
+      <Flex direction="column" alignItems="flex-start" fontSize="1.4rem" gap={2}>
         {value ? <BlocksRenderer content={value} /> : 'null'}
       </Flex>
     );
@@ -76,55 +69,40 @@ const NestedValue = ({
   // Use the email type to test clickable preview elements
   if (fieldName === 'email') {
     return (
-      <Button
-        variant="tertiary"
-        onClick={() => window.alert('Sending email!')}
-        data-strapi-source={`path=${path}&type=email&model=${model}&documentId=${documentId}`}
-      >
+      <Button variant="tertiary" onClick={() => window.alert('Sending email!')}>
         {value}
       </Button>
     );
   }
 
-  if (typeof value === 'boolean') {
-    return (
-      <Box
-        data-strapi-source={`path=${path}&type=boolean&model=${model}&documentId=${documentId}`}
-        padding={1}
-        background={value ? 'success100' : 'danger100'}
-        borderColor={value ? 'success200' : 'danger200'}
-        borderWidth="1px"
-        hasRadius
-      >
-        <Typography variant="sigma" textColor={value ? 'success600' : 'danger600'}>
-          {String(value).toUpperCase()}
-        </Typography>
-      </Box>
-    );
-  }
-
   if (isMedia(value)) {
-    // Check for video mime type if available, otherwise assume image for preview if url exists
-    const isVideo = value.mime?.startsWith('video/');
-    const sourceString = `path=${path}&type=media&model=${model}&documentId=${documentId}`;
+    const url = value.url;
+    const mime = value.mime;
+    const isVideo = mime?.startsWith('video/');
+    const isImage = mime?.startsWith('image/') || (!mime && !!url);
+    const fileName = value.name || 'file';
 
     return (
       <Box style={{ maxWidth: '300px' }}>
-        {isVideo ? (
-          <video
-            src={value.url}
-            controls
-            style={{ maxWidth: '100%' }}
-            data-strapi-source={sourceString}
-          />
-        ) : (
-          <img
-            src={value.url}
-            alt={value.alternativeText || ''}
-            style={{ maxWidth: '100%' }}
-            data-strapi-source={sourceString}
-          />
+        {isImage && (
+          <>
+            <img
+              src={isImage ? url : undefined}
+              alt={value.alternativeText || ''}
+              style={{ maxWidth: '100%', display: isImage ? 'block' : 'none' }}
+            />
+          </>
         )}
+        {isVideo && (
+          <>
+            <video
+              src={isVideo ? url : undefined}
+              controls
+              style={{ maxWidth: '100%', display: isVideo ? 'block' : 'none' }}
+            />
+          </>
+        )}
+        {!isImage && !isVideo && <Typography>{fileName}</Typography>}
       </Box>
     );
   }
@@ -202,11 +180,7 @@ const NestedValue = ({
 
   return (
     <Box>
-      <Typography
-        data-strapi-source={`path=${path}&type=text&model=${model}&documentId=${documentId}`}
-      >
-        {value === null || value === undefined || String(value) === '' ? '\u00A0' : String(value)}
-      </Typography>
+      <Typography>{String(value)}</Typography>
     </Box>
   );
 };
@@ -272,7 +246,16 @@ const PreviewComponent = () => {
   }, []);
 
   return (
-    <Box height="100vh" background="neutral100" overflow="auto">
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={100}
+      background="neutral100"
+      overflow="auto"
+    >
       <Layouts.Root>
         <Page.Main>
           <Page.Title>{`Previewing ${apiName}`}</Page.Title>

--- a/examples/getstarted/src/admin/preview/dummy-preview.jsx
+++ b/examples/getstarted/src/admin/preview/dummy-preview.jsx
@@ -3,18 +3,12 @@ import { useParams, useLoaderData, useRevalidator } from 'react-router-dom';
 import { BlocksRenderer } from '@strapi/blocks-react-renderer';
 
 import { Page, Layouts } from '@strapi/admin/strapi-admin';
-import {
-  Grid,
-  Flex,
-  Typography,
-  JSONInput,
-  Box,
-  IconButton,
-  Link,
-  LinkButton,
-  Button,
-} from '@strapi/design-system';
+import { Grid, Flex, Typography, JSONInput, Box, Button } from '@strapi/design-system';
 import { ChevronDown, ChevronRight } from '@strapi/icons';
+
+const isMedia = (value) => {
+  return typeof value === 'object' && value !== null && 'url' in value;
+};
 
 const filterAttributes = (item) => {
   const excludedKeys = ['documentId', 'id', 'createdAt', 'updatedAt', 'publishedAt'];
@@ -55,10 +49,25 @@ const ToggleableContainer = ({ headerText, children, isEmpty = false }) => {
   );
 };
 
-const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = undefined }) => {
+const NestedValue = ({
+  value,
+  level = 0,
+  arrayIndex = undefined,
+  fieldName = undefined,
+  path,
+  model,
+  documentId,
+}) => {
   if (fieldName === 'blocks') {
     return (
-      <Flex direction="column" alignItems="flex-start" fontSize="1.4rem" gap={2}>
+      <Flex
+        direction="column"
+        alignItems="flex-start"
+        fontSize="1.4rem"
+        gap={2}
+        data-strapi-source={`path=${path}&type=blocks&model=${model}&documentId=${documentId}`}
+        width="100%"
+      >
         {value ? <BlocksRenderer content={value} /> : 'null'}
       </Flex>
     );
@@ -67,9 +76,56 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
   // Use the email type to test clickable preview elements
   if (fieldName === 'email') {
     return (
-      <Button variant="tertiary" onClick={() => window.alert('Sending email!')}>
+      <Button
+        variant="tertiary"
+        onClick={() => window.alert('Sending email!')}
+        data-strapi-source={`path=${path}&type=email&model=${model}&documentId=${documentId}`}
+      >
         {value}
       </Button>
+    );
+  }
+
+  if (typeof value === 'boolean') {
+    return (
+      <Box
+        data-strapi-source={`path=${path}&type=boolean&model=${model}&documentId=${documentId}`}
+        padding={1}
+        background={value ? 'success100' : 'danger100'}
+        borderColor={value ? 'success200' : 'danger200'}
+        borderWidth="1px"
+        hasRadius
+      >
+        <Typography variant="sigma" textColor={value ? 'success600' : 'danger600'}>
+          {String(value).toUpperCase()}
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isMedia(value)) {
+    // Check for video mime type if available, otherwise assume image for preview if url exists
+    const isVideo = value.mime?.startsWith('video/');
+    const sourceString = `path=${path}&type=media&model=${model}&documentId=${documentId}`;
+
+    return (
+      <Box style={{ maxWidth: '300px' }}>
+        {isVideo ? (
+          <video
+            src={value.url}
+            controls
+            style={{ maxWidth: '100%' }}
+            data-strapi-source={sourceString}
+          />
+        ) : (
+          <img
+            src={value.url}
+            alt={value.alternativeText || ''}
+            style={{ maxWidth: '100%' }}
+            data-strapi-source={sourceString}
+          />
+        )}
+      </Box>
     );
   }
 
@@ -88,6 +144,9 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
                   level={level + 1}
                   arrayIndex={index}
                   fieldName={fieldName}
+                  path={`${path}.${index}`}
+                  model={model}
+                  documentId={documentId}
                 />
               ) : (
                 <Flex direction="column" gap={1}>
@@ -99,6 +158,9 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
                     level={level + 1}
                     arrayIndex={index}
                     fieldName={fieldName}
+                    path={`${path}.${index}`}
+                    model={model}
+                    documentId={documentId}
                   />
                 </Flex>
               )}
@@ -123,7 +185,14 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
               <Typography variant="sigma" textColor="neutral600">
                 {key}
               </Typography>
-              <NestedValue value={val} level={level + 1} fieldName={key} />
+              <NestedValue
+                value={val}
+                level={level + 1}
+                fieldName={key}
+                path={`${path}.${key}`}
+                model={model}
+                documentId={documentId}
+              />
             </Flex>
           ))}
         </Flex>
@@ -133,12 +202,16 @@ const NestedValue = ({ value, level = 0, arrayIndex = undefined, fieldName = und
 
   return (
     <Box>
-      <Typography>{String(value)}</Typography>
+      <Typography
+        data-strapi-source={`path=${path}&type=text&model=${model}&documentId=${documentId}`}
+      >
+        {value === null || value === undefined || String(value) === '' ? '\u00A0' : String(value)}
+      </Typography>
     </Box>
   );
 };
 
-const Entry = ({ data }) => {
+const Entry = ({ data, model, documentId }) => {
   return (
     <Grid.Root gap={5} tag="dl">
       {filterAttributes(data).map(([key, value]) => (
@@ -147,7 +220,13 @@ const Entry = ({ data }) => {
             {key}
           </Typography>
           <Flex gap={3} direction="column" alignItems="start" tag="dd">
-            <NestedValue value={value} fieldName={key} />
+            <NestedValue
+              value={value}
+              fieldName={key}
+              path={key}
+              model={model}
+              documentId={documentId}
+            />
           </Flex>
         </Grid.Item>
       ))}
@@ -193,16 +272,7 @@ const PreviewComponent = () => {
   }, []);
 
   return (
-    <Box
-      position="fixed"
-      top={0}
-      left={0}
-      right={0}
-      bottom={0}
-      zIndex={100}
-      background="neutral100"
-      overflow="auto"
-    >
+    <Box height="100vh" background="neutral100" overflow="auto">
       <Layouts.Root>
         <Page.Main>
           <Page.Title>{`Previewing ${apiName}`}</Page.Title>
@@ -264,7 +334,7 @@ const PreviewComponent = () => {
               {revalidator.state === 'loading' && <Typography>Refreshing data...</Typography>}
               {main ? (
                 <>
-                  <Entry data={main} />
+                  <Entry data={main} model={apiName} documentId={documentId} />
                   <JSONInput value={JSON.stringify(main, null, 2)} disabled />
                 </>
               ) : (
@@ -275,7 +345,7 @@ const PreviewComponent = () => {
                   <Typography variant="delta" tag="h3">
                     Unrelated API data
                   </Typography>
-                  <Entry data={unrelated} />
+                  <Entry data={unrelated} model={apiName} documentId={documentId} />
                 </>
               )}
             </Flex>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -372,9 +372,18 @@ const dragNoop = () => true;
 interface BlocksContentProps {
   placeholder?: string;
   ariaLabelId: string;
+  autoFocus?: boolean;
+  onFocus?: React.FocusEventHandler<HTMLElement>;
+  onBlur?: React.FocusEventHandler<HTMLElement>;
 }
 
-const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
+const BlocksContent = ({
+  placeholder,
+  ariaLabelId,
+  autoFocus,
+  onFocus,
+  onBlur,
+}: BlocksContentProps) => {
   const { editor, disabled, blocks, modifiers, setLiveText, isExpandedMode } =
     useBlocksEditorContext('BlocksContent');
   const isMobile = useIsMobile();
@@ -624,6 +633,9 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
         // As we have our own handler to drag and drop the elements returing true will skip slate's own event handler
         onDrop={dragNoop}
         onDragStart={dragNoop}
+        autoFocus={autoFocus}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
       {modalElement}
     </Box>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksInput.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksInput.tsx
@@ -10,6 +10,7 @@ import type { Schema } from '@strapi/types';
 interface BlocksInputProps extends Omit<InputProps, 'type'> {
   labelAction?: React.ReactNode;
   type: Schema.Attribute.Blocks['type'];
+  autoFocus?: boolean;
 }
 
 const BlocksInput = React.forwardRef<{ focus: () => void }, BlocksInputProps>(

--- a/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/InputRenderer.tsx
@@ -174,6 +174,7 @@ const BaseInputRenderer = ({
           hint={hint}
           type={props.type}
           disabled={fieldIsDisabled}
+          autoFocus={isInPreviewPopover}
         />
       );
     case 'component':

--- a/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
+++ b/packages/core/content-manager/admin/src/preview/components/InputPopover.tsx
@@ -77,7 +77,9 @@ const InputPopover = ({ documentResponse }: { documentResponse: ReturnType<UseDo
          * current document. This doesn't do anything about fields that may come from relations to
          * the current document however.
          */
-        if (fieldMetaData.documentId !== document.documentId) {
+        const isUploadAssetSource = fieldMetaData.model === 'plugin::upload.file';
+
+        if (!isUploadAssetSource && fieldMetaData.documentId !== document.documentId) {
           const { type, message } = PREVIEW_ERROR_MESSAGES.DIFFERENT_DOCUMENT;
           toggleNotification({ type, message: formatMessage(message) });
           return;

--- a/packages/core/content-manager/admin/src/preview/hooks/tests/usePreviewInputManager.test.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/tests/usePreviewInputManager.test.ts
@@ -1,0 +1,200 @@
+import { useField } from '@strapi/admin/strapi-admin';
+import { renderHook, act, waitFor } from '@tests/utils';
+
+import { useHasInputPopoverParent } from '../../components/InputPopover';
+import { usePreviewContext } from '../../pages/Preview';
+import { INTERNAL_EVENTS } from '../../utils/constants';
+import { usePreviewInputManager } from '../usePreviewInputManager';
+
+// Mocks
+jest.mock('@strapi/admin/strapi-admin', () => ({
+  useField: jest.fn(),
+}));
+
+jest.mock('../../pages/Preview', () => ({
+  usePreviewContext: jest.fn(),
+}));
+
+jest.mock('../../components/InputPopover', () => ({
+  useHasInputPopoverParent: jest.fn(),
+}));
+
+describe('usePreviewInputManager', () => {
+  const mockIframeRef = {
+    current: {
+      src: 'http://localhost:3000',
+      contentWindow: {
+        postMessage: jest.fn(),
+      },
+    },
+  };
+
+  const mockSetPopoverField = jest.fn();
+  let mockFieldValue = 'test-value';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFieldValue = 'test-value';
+
+    (usePreviewContext as jest.Mock).mockImplementation((consumerName, selector) => {
+      // The hook is called as: usePreviewContext(consumerName, selector, checkContext)
+      // We only care about the selector here
+      if (typeof selector === 'function') {
+        const state = {
+          iframeRef: mockIframeRef,
+          setPopoverField: mockSetPopoverField,
+        };
+        return selector(state);
+      }
+      return null;
+    });
+
+    (useField as jest.Mock).mockImplementation(() => ({ value: mockFieldValue }));
+    (useHasInputPopoverParent as jest.Mock).mockReturnValue(false);
+  });
+
+  const defaultProps = {
+    name: 'test-field',
+    attribute: { type: 'text' } as any,
+  };
+
+  test('sends focus event on focus', () => {
+    const { result } = renderHook(() =>
+      usePreviewInputManager(defaultProps.name, defaultProps.attribute)
+    );
+
+    // Clear the initial mount change event
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onFocus({} as any);
+    });
+
+    expect(mockIframeRef.current.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: INTERNAL_EVENTS.STRAPI_FIELD_FOCUS,
+        payload: { field: 'test-field' },
+      },
+      'http://localhost:3000'
+    );
+  });
+
+  test('sends blur event on blur', () => {
+    const { result } = renderHook(() =>
+      usePreviewInputManager(defaultProps.name, defaultProps.attribute)
+    );
+
+    // Clear the initial mount change event
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onBlur({} as any);
+    });
+
+    expect(mockSetPopoverField).toHaveBeenCalledWith(null);
+
+    expect(mockIframeRef.current.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: INTERNAL_EVENTS.STRAPI_FIELD_BLUR,
+        payload: { field: 'test-field' },
+      },
+      'http://localhost:3000'
+    );
+  });
+
+  test('does not send focus/blur events if inside popover parent', () => {
+    (useHasInputPopoverParent as jest.Mock).mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      usePreviewInputManager(defaultProps.name, defaultProps.attribute)
+    );
+
+    // Clear the initial mount change event
+    jest.clearAllMocks();
+
+    act(() => {
+      result.current.onFocus({} as any);
+    });
+    expect(mockIframeRef.current.contentWindow.postMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.onBlur({} as any);
+    });
+    expect(mockIframeRef.current.contentWindow.postMessage).not.toHaveBeenCalled();
+  });
+
+  test('sends change event when value changes for allowed types', async () => {
+    const { rerender } = renderHook(
+      (props: any) => usePreviewInputManager(props.name, props.attribute),
+      {
+        initialProps: defaultProps,
+      }
+    );
+
+    // Check initial effect call
+    expect(mockIframeRef.current.contentWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: INTERNAL_EVENTS.STRAPI_FIELD_CHANGE,
+        payload: { field: 'test-field', value: 'test-value' },
+      },
+      'http://localhost:3000'
+    );
+
+    // Update value
+    mockFieldValue = 'new-value';
+
+    // Force re-render with slightly different props to ensure hook runs
+    rerender({ ...defaultProps, attribute: { ...defaultProps.attribute, minLength: 1 } });
+
+    await waitFor(() => {
+      expect(mockIframeRef.current.contentWindow.postMessage).toHaveBeenCalledWith(
+        {
+          type: INTERNAL_EVENTS.STRAPI_FIELD_CHANGE,
+          payload: { field: 'test-field', value: 'new-value' },
+        },
+        'http://localhost:3000'
+      );
+    });
+  });
+
+  test('does not send change event for excluded field types', () => {
+    const excludedTypes = ['component', 'dynamiczone', 'json', 'relation'];
+
+    excludedTypes.forEach((type) => {
+      jest.clearAllMocks();
+
+      // We need to set the mock value back to default or anything to avoid confusion
+      (useField as jest.Mock).mockReturnValue({ value: 'test-value' });
+
+      const props = {
+        name: 'excluded-field',
+        attribute: { type } as any,
+      };
+
+      renderHook(() => usePreviewInputManager(props.name, props.attribute));
+
+      const calls = mockIframeRef.current.contentWindow.postMessage.mock.calls.filter(
+        (call) => call[0].type === INTERNAL_EVENTS.STRAPI_FIELD_CHANGE
+      );
+
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  test('sends change event for complex types removed from exclusion list (media)', () => {
+    const props = {
+      name: 'media-field',
+      attribute: { type: 'media' } as any,
+    };
+
+    renderHook(() => usePreviewInputManager(props.name, props.attribute));
+
+    expect(mockIframeRef.current.contentWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: INTERNAL_EVENTS.STRAPI_FIELD_CHANGE,
+        payload: expect.objectContaining({ field: 'media-field' }),
+      }),
+      expect.any(String)
+    );
+  });
+});

--- a/packages/core/content-manager/admin/src/preview/hooks/tests/usePreviewInputManager.test.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/tests/usePreviewInputManager.test.ts
@@ -158,7 +158,7 @@ describe('usePreviewInputManager', () => {
   });
 
   test('does not send change event for excluded field types', () => {
-    const excludedTypes = ['component', 'dynamiczone', 'json', 'relation'];
+    const excludedTypes = ['component', 'dynamiczone'];
 
     excludedTypes.forEach((type) => {
       jest.clearAllMocks();

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -36,7 +36,7 @@ export function usePreviewInputManager(
      * Only send message if the field is not a data structure (component, dynamic zone)
      * because we already send events for their fields
      */
-    if (!['component', 'dynamiczone'].includes(type)) {
+    if (!['component', 'dynamiczone', 'json', 'relation'].includes(type)) {
       const sendMessage = getSendMessage(iframe);
       sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_CHANGE, { field: name, value });
     }

--- a/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
+++ b/packages/core/content-manager/admin/src/preview/hooks/usePreviewInputManager.ts
@@ -34,9 +34,9 @@ export function usePreviewInputManager(
 
     /**
      * Only send message if the field is not a data structure (component, dynamic zone)
-     * because we already send events for their fields
+     * because we already send events for their fields.
      */
-    if (!['component', 'dynamiczone', 'json', 'relation'].includes(type)) {
+    if (!['component', 'dynamiczone'].includes(type)) {
       const sendMessage = getSendMessage(iframe);
       sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_CHANGE, { field: name, value });
     }

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -69,7 +69,106 @@ const previewScript = (config: PreviewScriptConfig) => {
   };
 
   const getElementsByPath = (path: string) => {
-    return document.querySelectorAll(`[${SOURCE_ATTRIBUTE}*="path=${path}"]`);
+    const nodes = document.querySelectorAll(`[${SOURCE_ATTRIBUTE}*="path=${path}"]`);
+    return Array.from(nodes).filter((node) => {
+      const attr = node.getAttribute(SOURCE_ATTRIBUTE);
+      const params = new URLSearchParams(attr ?? '');
+      return params.get('path') === path;
+    });
+  };
+
+  const isMediaElement = (element: Element): boolean => {
+    return element.tagName === 'IMG' || element.tagName === 'VIDEO';
+  };
+
+  /**
+   * Get the field path to use for focusing a media field.
+   * - For IMG/VIDEO elements: the path was already normalized (stripped of .url) during stega decoding
+   * - For non-media elements with model=plugin::upload.file (e.g., caption text): strip the last
+   *   segment to focus the parent media field (e.g., "hero.caption" -> "hero")
+   */
+  const getFieldPathForMedia = (sourceAttr: string, element: Element): string => {
+    // IMG/VIDEO elements already have the correct path from stega decoding
+    if (isMediaElement(element)) {
+      return sourceAttr;
+    }
+
+    // For non-media elements, check if it's a media asset field
+    const params = new URLSearchParams(sourceAttr);
+    if (params.get('model') === 'plugin::upload.file') {
+      const elementPath = params.get('path');
+      if (elementPath) {
+        // Strip the last segment (e.g., "hero.caption" -> "hero")
+        const parentPath = elementPath.split('.').slice(0, -1).join('.');
+        params.set('path', parentPath);
+        return params.toString();
+      }
+    }
+
+    return sourceAttr;
+  };
+
+  const renderBlocks = (blocks: any[]): string => {
+    if (!Array.isArray(blocks)) {
+      return '';
+    }
+
+    const renderChildren = (children: any[]): string => {
+      if (!Array.isArray(children)) return '';
+
+      return children
+        .map((child) => {
+          if (!child) return '';
+          let text = child.text || '';
+
+          if (child.bold) text = `<strong>${text}</strong>`;
+          if (child.italic) text = `<em>${text}</em>`;
+          if (child.underline) text = `<u>${text}</u>`;
+          if (child.strikethrough) text = `<del>${text}</del>`;
+          if (child.code) text = `<code>${text}</code>`;
+
+          if (child.type === 'link') {
+            return `<a href="${child.url}">${renderChildren(child.children)}</a>`;
+          }
+
+          return text;
+        })
+        .join('');
+    };
+
+    return blocks
+      .map((block) => {
+        if (!block) return '';
+
+        switch (block.type) {
+          case 'paragraph':
+            return `<p>${renderChildren(block.children)}</p>`;
+          case 'heading':
+            return `<h${block.level}>${renderChildren(block.children)}</h${block.level}>`;
+          case 'list':
+            const tag = block.format === 'ordered' ? 'ol' : 'ul';
+            const listItems = Array.isArray(block.children)
+              ? block.children
+                  .map((item: any) => `<li>${renderChildren(item.children)}</li>`)
+                  .join('')
+              : '';
+            return `<${tag}>${listItems}</${tag}>`;
+          case 'quote':
+            return `<blockquote>${renderChildren(block.children)}</blockquote>`;
+          case 'code':
+            return `<pre><code>${renderChildren(block.children)}</code></pre>`;
+          case 'image':
+            if (block.image && block.image.url) {
+              return `<img src="${block.image.url}" alt="${block.image.alternativeText || ''}" />`;
+            }
+            return '';
+          case 'link':
+            return `<a href="${block.url}">${renderChildren(block.children)}</a>`;
+          default:
+            return '';
+        }
+      })
+      .join('');
   };
 
   /* -----------------------------------------------------------------------------------------------
@@ -88,6 +187,34 @@ const previewScript = (config: PreviewScriptConfig) => {
     );
 
     const applyStegaToElement = (element: Element) => {
+      // Handle img and video tags - check src attribute for stega encoding
+      if (isMediaElement(element)) {
+        const src = element.getAttribute('src');
+        if (src) {
+          try {
+            const result = stegaDecode(src);
+            if (result && 'strapiSource' in result) {
+              // Parse the source and remove .url suffix to point to the media field
+              const sourceValue = result.strapiSource as string;
+              const pathMatch = sourceValue.match(/path=([^&]+)/);
+              if (pathMatch) {
+                const originalPath = pathMatch[1];
+                // Remove .url to get the media field path
+                const mediaPath = originalPath.replace(/\.url$/, '');
+                const newSource = sourceValue.replace(`path=${originalPath}`, `path=${mediaPath}`);
+                element.setAttribute(SOURCE_ATTRIBUTE, newSource);
+              }
+            }
+            // Clean the src attribute so the resource can load
+            const cleanedSrc = stegaClean(src);
+            if (cleanedSrc !== src) {
+              element.setAttribute('src', cleanedSrc);
+            }
+          } catch (error) {}
+        }
+        return;
+      }
+
       const directTextNodes = Array.from(element.childNodes).filter(
         (node) => node.nodeType === Node.TEXT_NODE
       );
@@ -140,6 +267,13 @@ const previewScript = (config: PreviewScriptConfig) => {
         if (mutation.type === 'characterData' && mutation.target.parentElement) {
           applyStegaToElement(mutation.target.parentElement);
         }
+        // Handle src attribute changes for img/video elements
+        if (mutation.type === 'attributes' && mutation.attributeName === 'src') {
+          const target = mutation.target as Element;
+          if (isMediaElement(target)) {
+            applyStegaToElement(target);
+          }
+        }
       });
     });
 
@@ -147,6 +281,8 @@ const previewScript = (config: PreviewScriptConfig) => {
       childList: true,
       subtree: true,
       characterData: true,
+      attributes: true,
+      attributeFilter: ['src'],
     });
 
     return observer;
@@ -304,9 +440,10 @@ const previewScript = (config: PreviewScriptConfig) => {
 
         const sourceAttribute = element.getAttribute(SOURCE_ATTRIBUTE);
         if (sourceAttribute) {
+          const path = getFieldPathForMedia(sourceAttribute, element);
           const rect = element.getBoundingClientRect();
           sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_FOCUS_INTENT, {
-            path: sourceAttribute,
+            path,
             position: {
               top: rect.top,
               left: rect.left,
@@ -540,11 +677,103 @@ const previewScript = (config: PreviewScriptConfig) => {
 
         getElementsByPath(field).forEach((element) => {
           if (element instanceof HTMLElement) {
-            element.textContent = value || '';
+            // For img/video elements, update the src attribute instead of text content
+            if (isMediaElement(element)) {
+              // Value can be a media object with url property, or a string URL
+              const url = typeof value === 'object' && value !== null ? value.url : value;
+              const mime = typeof value === 'object' && value !== null ? value.mime : undefined;
+
+              if (url) {
+                // Check if the media type matches the element type
+                const isImage = element.tagName === 'IMG';
+                const isVideo = element.tagName === 'VIDEO';
+                const isImageMime = mime?.startsWith('image/');
+                const isVideoMime = mime?.startsWith('video/');
+
+                // Check if we need to replace the element due to media type mismatch
+                const needsReplacement =
+                  mime && ((isImage && isVideoMime) || (isVideo && isImageMime));
+
+                if (needsReplacement) {
+                  // Create a new element of the correct type
+                  const newTagName = isImageMime ? 'IMG' : 'VIDEO';
+                  const newElement = document.createElement(newTagName);
+
+                  // Copy all attributes from the old element
+                  Array.from(element.attributes).forEach((attr) => {
+                    newElement.setAttribute(attr.name, attr.value);
+                  });
+
+                  // Set the new src
+                  newElement.setAttribute('src', url);
+
+                  // Copy inline styles
+                  newElement.style.cssText = element.style.cssText;
+                  newElement.style.display = '';
+
+                  // For video elements, add common attributes
+                  if (newTagName === 'VIDEO') {
+                    newElement.setAttribute('controls', '');
+                  }
+
+                  // Replace the old element with the new one
+                  element.parentNode?.replaceChild(newElement, element);
+                } else {
+                  // Same media type, just update the src
+                  const shouldShow = !mime || (isImage && isImageMime) || (isVideo && isVideoMime);
+
+                  if (shouldShow) {
+                    element.setAttribute('src', url);
+                    element.style.display = '';
+                  } else {
+                    element.style.display = 'none';
+                    element.removeAttribute('src');
+                  }
+                }
+              } else {
+                // Hide element when media is deleted/empty
+                element.style.display = 'none';
+                element.removeAttribute('src');
+              }
+            } else if (
+              Array.isArray(value) &&
+              value.length > 0 &&
+              typeof value[0] === 'object' &&
+              'type' in value[0]
+            ) {
+              element.innerHTML = renderBlocks(value);
+            } else {
+              const text = value !== null && value !== undefined ? String(value) : '';
+              element.textContent = text === '' ? '\u00A0' : text;
+            }
           }
         });
 
-        // Update highlight dimensions since the new text content may affect them
+        // Handle nested media asset fields (caption, alt, etc.)
+        if (typeof value === 'object' && value !== null) {
+          const allSourceElements = document.querySelectorAll(`[${SOURCE_ATTRIBUTE}]`);
+
+          allSourceElements.forEach((element) => {
+            const sourceAttr = element.getAttribute(SOURCE_ATTRIBUTE);
+            if (!sourceAttr) return;
+
+            const params = new URLSearchParams(sourceAttr);
+            const model = params.get('model');
+            const elementPath = params.get('path');
+
+            if (model !== 'plugin::upload.file' || !elementPath) return;
+
+            if (elementPath.startsWith(`${field}.`)) {
+              const propertyName = elementPath.slice(field.length + 1);
+              const propertyValue = value[propertyName];
+              if (element instanceof HTMLElement && propertyValue !== undefined) {
+                element.textContent = propertyValue || '';
+              }
+            }
+          });
+        }
+
+        // Update highlight dimensions since the new content may affect them
         highlightManager.updateAllHighlights();
         return;
       }
@@ -564,7 +793,15 @@ const previewScript = (config: PreviewScriptConfig) => {
         highlightManager.setFocusedField(field);
         getElementsByPath(field).forEach((element, index) => {
           if (index === 0) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // Check if scrollIntoViewIfNeeded is available (e.g. Chrome)
+            if (
+              'scrollIntoViewIfNeeded' in element &&
+              typeof (element as any).scrollIntoViewIfNeeded === 'function'
+            ) {
+              (element as any).scrollIntoViewIfNeeded({ behavior: 'smooth', block: 'center' });
+            } else {
+              element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
           }
           const highlight =
             highlightManager.highlights[Array.from(highlightManager.elements).indexOf(element)];

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -68,12 +68,31 @@ const previewScript = (config: PreviewScriptConfig) => {
     window.parent.postMessage({ type, payload }, '*');
   };
 
-  const getElementsByPath = (path: string) => {
-    const nodes = document.querySelectorAll(`[${SOURCE_ATTRIBUTE}*="path=${path}"]`);
+  const getElementsByPath = (
+    path: string,
+    options: {
+      includeDescendants?: boolean;
+      includeFieldPath?: boolean;
+    } = {}
+  ) => {
+    const { includeDescendants = false, includeFieldPath = false } = options;
+    const nodes = document.querySelectorAll(`[${SOURCE_ATTRIBUTE}]`);
+
     return Array.from(nodes).filter((node) => {
       const attr = node.getAttribute(SOURCE_ATTRIBUTE);
       const params = new URLSearchParams(attr ?? '');
-      return params.get('path') === path;
+      const sourcePath = params.get('path');
+      const fieldPath = params.get('fieldPath');
+
+      if (sourcePath === path) {
+        return true;
+      }
+
+      if (includeFieldPath && fieldPath === path) {
+        return true;
+      }
+
+      return includeDescendants && !!sourcePath && sourcePath.startsWith(`${path}.`);
     });
   };
 
@@ -81,94 +100,255 @@ const previewScript = (config: PreviewScriptConfig) => {
     return element.tagName === 'IMG' || element.tagName === 'VIDEO';
   };
 
-  /**
-   * Get the field path to use for focusing a media field.
-   * - For IMG/VIDEO elements: the path was already normalized (stripped of .url) during stega decoding
-   * - For non-media elements with model=plugin::upload.file (e.g., caption text): strip the last
-   *   segment to focus the parent media field (e.g., "hero.caption" -> "hero")
-   */
-  const getFieldPathForMedia = (sourceAttr: string, element: Element): string => {
-    // IMG/VIDEO elements already have the correct path from stega decoding
-    if (isMediaElement(element)) {
-      return sourceAttr;
+  const normalizeMediaFieldPath = (
+    sourcePath: string,
+    options: { stripLeafProperty?: boolean } = {}
+  ) => {
+    const { stripLeafProperty = false } = options;
+    const pathSegments = sourcePath.split('.').filter(Boolean);
+
+    if (pathSegments.length === 0) {
+      return sourcePath;
     }
 
-    // For non-media elements, check if it's a media asset field
+    // For non-media text nodes from upload files (e.g. alt/caption), drop the property segment first.
+    if (stripLeafProperty) {
+      pathSegments.pop();
+    }
+
+    // Stega on media URLs may still point to "...url". Always normalize to the media field path.
+    if (pathSegments[pathSegments.length - 1] === 'url') {
+      pathSegments.pop();
+    }
+
+    // Repeatable media fields resolve to "<field>.<index>": normalize to "<field>" for InputRenderer.
+    const lastSegment = pathSegments[pathSegments.length - 1];
+    if (lastSegment && /^\d+$/.test(lastSegment)) {
+      pathSegments.pop();
+    }
+
+    return pathSegments.join('.');
+  };
+
+  /**
+   * Get the field path to use for focusing a field from a stega source.
+   * - Prefer explicit fieldPath when available (e.g. blocks nested text nodes)
+   * - For blocks without fieldPath, derive the root blocks field from "X.<index>.children..."
+   * - For media-derived upload fields (url, caption, alt), normalize to the parent media field path.
+   */
+  const getFieldPathForMedia = (sourceAttr: string, element: Element): string => {
     const params = new URLSearchParams(sourceAttr);
-    if (params.get('model') === 'plugin::upload.file') {
-      const elementPath = params.get('path');
-      if (elementPath) {
-        // Strip the last segment (e.g., "hero.caption" -> "hero")
-        const parentPath = elementPath.split('.').slice(0, -1).join('.');
-        params.set('path', parentPath);
+    const fieldPath = params.get('fieldPath');
+
+    // For nested stega paths (e.g. blocks text nodes), focus the parent field.
+    if (fieldPath) {
+      params.set('path', fieldPath);
+      params.delete('fieldPath');
+      return params.toString();
+    }
+
+    const type = params.get('type');
+    const sourcePath = params.get('path');
+
+    if (type === 'blocks' && sourcePath) {
+      const blocksPathMatch = sourcePath.match(/^(.*?)\.\d+\.children\./);
+      if (blocksPathMatch?.[1]) {
+        params.set('path', blocksPathMatch[1]);
         return params.toString();
       }
+    }
+
+    if (params.get('model') === 'plugin::upload.file' && sourcePath) {
+      const normalizedPath = normalizeMediaFieldPath(sourcePath, {
+        stripLeafProperty: !isMediaElement(element),
+      });
+
+      if (normalizedPath) {
+        params.set('path', normalizedPath);
+      }
+
+      return params.toString();
     }
 
     return sourceAttr;
   };
 
-  const renderBlocks = (blocks: any[]): string => {
-    if (!Array.isArray(blocks)) {
-      return '';
+  const getInteractiveClickTarget = (element: HTMLElement): HTMLElement => {
+    if (!isMediaElement(element)) {
+      return element;
     }
 
-    const renderChildren = (children: any[]): string => {
-      if (!Array.isArray(children)) return '';
+    let parent = element.parentElement;
+    while (parent) {
+      if (
+        parent.tagName === 'A' ||
+        parent.tagName === 'BUTTON' ||
+        parent.hasAttribute('onclick') ||
+        parent.getAttribute('role') === 'button' ||
+        parent.getAttribute('role') === 'link'
+      ) {
+        return parent;
+      }
 
-      return children
-        .map((child) => {
-          if (!child) return '';
-          let text = child.text || '';
+      parent = parent.parentElement;
+    }
 
-          if (child.bold) text = `<strong>${text}</strong>`;
-          if (child.italic) text = `<em>${text}</em>`;
-          if (child.underline) text = `<u>${text}</u>`;
-          if (child.strikethrough) text = `<del>${text}</del>`;
-          if (child.code) text = `<code>${text}</code>`;
+    return element;
+  };
 
-          if (child.type === 'link') {
-            return `<a href="${child.url}">${renderChildren(child.children)}</a>`;
-          }
+  const getRenderableTextValue = (value: unknown): string | null => {
+    if (value === null || value === undefined) {
+      return 'null';
+    }
 
-          return text;
-        })
-        .join('');
+    if (typeof value === 'string') {
+      return value === '' ? 'null' : value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+      return String(value);
+    }
+
+    // Complex values should be rendered by the frontend app itself.
+    return null;
+  };
+
+  const isBlocksValue = (value: unknown): boolean => {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+
+    return value.every(
+      (item) =>
+        item !== null &&
+        typeof item === 'object' &&
+        'type' in item &&
+        'children' in item &&
+        Array.isArray((item as { children?: unknown[] }).children)
+    );
+  };
+
+  const getBlocksTextUpdates = (
+    blocks: unknown,
+    rootPath: string
+  ): Array<{ path: string; text: string }> => {
+    const updates: Array<{ path: string; text: string }> = [];
+
+    const visitNode = (node: unknown, currentPath: string) => {
+      if (Array.isArray(node)) {
+        node.forEach((child, index) => {
+          visitNode(child, `${currentPath}.${index}`);
+        });
+        return;
+      }
+
+      if (!node || typeof node !== 'object') {
+        return;
+      }
+
+      if ('text' in node && typeof node.text === 'string') {
+        updates.push({ path: `${currentPath}.text`, text: node.text });
+      }
+
+      if ('children' in node && Array.isArray(node.children)) {
+        node.children.forEach((child, index) => {
+          visitNode(child, `${currentPath}.children.${index}`);
+        });
+      }
     };
 
-    return blocks
-      .map((block) => {
-        if (!block) return '';
+    visitNode(blocks, rootPath);
+    return updates;
+  };
 
-        switch (block.type) {
-          case 'paragraph':
-            return `<p>${renderChildren(block.children)}</p>`;
-          case 'heading':
-            return `<h${block.level}>${renderChildren(block.children)}</h${block.level}>`;
-          case 'list':
-            const tag = block.format === 'ordered' ? 'ol' : 'ul';
-            const listItems = Array.isArray(block.children)
-              ? block.children
-                  .map((item: any) => `<li>${renderChildren(item.children)}</li>`)
-                  .join('')
-              : '';
-            return `<${tag}>${listItems}</${tag}>`;
-          case 'quote':
-            return `<blockquote>${renderChildren(block.children)}</blockquote>`;
-          case 'code':
-            return `<pre><code>${renderChildren(block.children)}</code></pre>`;
-          case 'image':
-            if (block.image && block.image.url) {
-              return `<img src="${block.image.url}" alt="${block.image.alternativeText || ''}" />`;
-            }
-            return '';
-          case 'link':
-            return `<a href="${block.url}">${renderChildren(block.children)}</a>`;
-          default:
-            return '';
-        }
-      })
-      .join('');
+  const isMediaLikeValue = (value: unknown): value is { url?: unknown; mime?: unknown } => {
+    return value !== null && typeof value === 'object' && 'url' in value;
+  };
+
+  const getSourcePathFromElement = (element: Element): string | null => {
+    const sourceAttr = element.getAttribute(SOURCE_ATTRIBUTE);
+    if (!sourceAttr) {
+      return null;
+    }
+
+    return new URLSearchParams(sourceAttr).get('path');
+  };
+
+  const getMediaValueForSourcePath = (
+    field: string,
+    value: unknown,
+    sourcePath: string | null
+  ): unknown => {
+    if (!sourcePath) {
+      return null;
+    }
+
+    if (Array.isArray(value)) {
+      if (!sourcePath.startsWith(`${field}.`)) {
+        return null;
+      }
+
+      const relativePath = sourcePath.slice(field.length + 1);
+      const mediaIndex = Number(relativePath.split('.')[0]);
+      if (Number.isNaN(mediaIndex)) {
+        return null;
+      }
+
+      return value[mediaIndex] ?? null;
+    }
+
+    if (isMediaLikeValue(value) && sourcePath === field) {
+      return value;
+    }
+
+    return null;
+  };
+
+  const updateMediaElement = (
+    element: HTMLElement,
+    value: unknown,
+    siblingElements: HTMLElement[]
+  ) => {
+    const url = typeof value === 'string' ? value : isMediaLikeValue(value) ? value.url : undefined;
+    const mime = isMediaLikeValue(value) ? value.mime : undefined;
+    const normalizedUrl = typeof url === 'string' ? url : '';
+    const normalizedMime = typeof mime === 'string' ? mime : undefined;
+
+    if (!normalizedUrl) {
+      element.style.display = 'none';
+      element.removeAttribute('src');
+      return;
+    }
+
+    const isImageElement = element.tagName === 'IMG';
+    const isVideoElement = element.tagName === 'VIDEO';
+    const isImageMime = normalizedMime?.startsWith('image/');
+    const isVideoMime = normalizedMime?.startsWith('video/');
+    const isCompatible =
+      !normalizedMime ||
+      (isImageElement && !!isImageMime) ||
+      (isVideoElement && !!isVideoMime) ||
+      (!isImageMime && !isVideoMime);
+
+    const hasCompatibleSibling =
+      (isImageMime &&
+        siblingElements.some((sibling) => sibling !== element && sibling.tagName === 'IMG')) ||
+      (isVideoMime &&
+        siblingElements.some((sibling) => sibling !== element && sibling.tagName === 'VIDEO'));
+
+    if (!isCompatible && hasCompatibleSibling) {
+      element.style.display = 'none';
+      element.removeAttribute('src');
+      return;
+    }
+
+    // Avoid replacing nodes in-place (React-managed trees may crash on save after external replaceChild).
+    element.setAttribute('src', normalizedUrl);
+    element.style.display = '';
+
+    if (isVideoElement) {
+      element.setAttribute('controls', '');
+    }
   };
 
   /* -----------------------------------------------------------------------------------------------
@@ -180,7 +360,11 @@ const previewScript = (config: PreviewScriptConfig) => {
       return;
     }
 
-    const { vercelStegaDecode: stegaDecode, vercelStegaClean: stegaClean } = await import(
+    const {
+      vercelStegaDecode: stegaDecode,
+      vercelStegaDecodeAll: stegaDecodeAll,
+      vercelStegaClean: stegaClean,
+    } = await import(
       // @ts-expect-error it's not a local dependency
       // eslint-disable-next-line import/no-unresolved
       'https://cdn.jsdelivr.net/npm/@vercel/stega@0.1.2/+esm'
@@ -216,30 +400,58 @@ const previewScript = (config: PreviewScriptConfig) => {
       }
 
       const directTextNodes = Array.from(element.childNodes).filter(
-        (node) => node.nodeType === Node.TEXT_NODE
+        (node): node is Text => node.nodeType === Node.TEXT_NODE
       );
 
-      const directTextContent = directTextNodes.map((node) => node.textContent || '').join('');
+      if (directTextNodes.length === 0) {
+        return;
+      }
 
-      if (directTextContent) {
+      let decodedSource: string | null = null;
+
+      // Decode each direct text node independently so split rich text leaves are handled.
+      directTextNodes.forEach((node) => {
+        if (!node.textContent) {
+          return;
+        }
+
         try {
-          // TODO: check if we can call split instead of decode+clean
-          const result = stegaDecode(directTextContent);
-          if (result && 'strapiSource' in result) {
-            element.setAttribute(SOURCE_ATTRIBUTE, result.strapiSource);
+          const decodedSources = stegaDecodeAll(node.textContent) as Array<{
+            strapiSource?: string;
+          }>;
+          const firstSource = decodedSources.find((decoded) => decoded?.strapiSource)?.strapiSource;
+          if (!decodedSource && firstSource) {
+            decodedSource = firstSource;
+          }
 
-            // Remove encoded part from DOM text content (to avoid breaking links for example)
-            directTextNodes.forEach((node) => {
-              if (node.textContent) {
-                const cleanedText = stegaClean(node.textContent);
-                if (cleanedText !== node.textContent) {
-                  node.textContent = cleanedText;
-                }
-              }
-            });
+          const cleanedText = stegaClean(node.textContent);
+          if (cleanedText !== node.textContent) {
+            node.textContent = cleanedText;
           }
         } catch (error) {}
+      });
+
+      if (decodedSource) {
+        element.setAttribute(SOURCE_ATTRIBUTE, decodedSource);
+        return;
       }
+
+      // Fallback to merged direct text content for edge cases where encoded chars are split across nodes.
+      const directTextContent = directTextNodes.map((node) => node.textContent || '').join('');
+
+      if (!directTextContent) {
+        return;
+      }
+
+      try {
+        const decodedSources = stegaDecodeAll(directTextContent) as Array<{
+          strapiSource?: string;
+        }>;
+        const firstSource = decodedSources.find((decoded) => decoded?.strapiSource)?.strapiSource;
+        if (firstSource) {
+          element.setAttribute(SOURCE_ATTRIBUTE, firstSource);
+        }
+      } catch (error) {}
     };
 
     // Process all existing elements
@@ -403,6 +615,8 @@ const previewScript = (config: PreviewScriptConfig) => {
           // Send single-click hint notification
           sendMessage(INTERNAL_EVENTS.STRAPI_FIELD_SINGLE_CLICK_HINT, null);
 
+          const targetElement = getInteractiveClickTarget(element);
+
           // Re-trigger the click on the underlying element after the double-click timeout
           // Create a new event to dispatch with a marker to prevent re-handling
           const newEvent = new MouseEvent('click', {
@@ -420,7 +634,7 @@ const previewScript = (config: PreviewScriptConfig) => {
             metaKey: event.metaKey,
           });
           (newEvent as any).__strapi_redispatched = true;
-          element.dispatchEvent(newEvent);
+          targetElement.dispatchEvent(newEvent);
         }, DOUBLE_CLICK_TIMEOUT);
 
         pendingClicks.set(element, timeout);
@@ -675,78 +889,106 @@ const previewScript = (config: PreviewScriptConfig) => {
         const { field, value } = event.data.payload;
         if (!field) return;
 
+        if (isBlocksValue(value)) {
+          getBlocksTextUpdates(value, field).forEach(({ path, text }) => {
+            const elements = getElementsByPath(path);
+
+            if (elements.length > 0) {
+              elements.forEach((element) => {
+                if (element instanceof HTMLElement && !isMediaElement(element)) {
+                  element.innerText = text;
+                }
+              });
+              return;
+            }
+
+            // If the element doesn't exist (e.g. new block added), try to find a preceding sibling to clone
+            // We assume paths like "field.0.children.0.text" and try to find "field.0.children.-1.text" (conceptually)
+            // We look for all numeric segments in the path and try decrementing them from right to left.
+            const segments = path.split('.');
+            const numericIndices = segments
+              .map((s, i) => (/^\d+$/.test(s) ? i : -1))
+              .filter((i) => i !== -1);
+
+            // Iterate from right to left (deepest to shallowest)
+            for (let i = numericIndices.length - 1; i >= 0; i--) {
+              const segmentIndex = numericIndices[i];
+              const currentIndex = parseInt(segments[segmentIndex], 10);
+
+              if (currentIndex > 0) {
+                const previousIndex = currentIndex - 1;
+                const candidateSegments = [...segments];
+                candidateSegments[segmentIndex] = previousIndex.toString();
+                const candidatePath = candidateSegments.join('.');
+
+                const previousElements = getElementsByPath(candidatePath);
+
+                if (previousElements.length > 0) {
+                  previousElements.forEach((prevEl) => {
+                    if (prevEl instanceof HTMLElement && prevEl.parentElement) {
+                      // Clone strategy
+                      const clone = prevEl.cloneNode(true) as HTMLElement;
+
+                      // Update source attribute
+                      const oldSource = prevEl.getAttribute(SOURCE_ATTRIBUTE);
+                      if (oldSource) {
+                        const newSource = oldSource.replace(
+                          `path=${candidatePath}`,
+                          `path=${path}`
+                        );
+                        clone.setAttribute(SOURCE_ATTRIBUTE, newSource);
+                      }
+
+                      clone.innerText = text;
+                      prevEl.parentElement.insertBefore(clone, prevEl.nextSibling);
+                    }
+                  });
+                  // If we found a match at this level, we stop searching.
+                  return;
+                }
+              }
+            }
+          });
+
+          highlightManager.updateAllHighlights();
+          return;
+        }
+
         getElementsByPath(field).forEach((element) => {
           if (element instanceof HTMLElement) {
-            // For img/video elements, update the src attribute instead of text content
-            if (isMediaElement(element)) {
-              // Value can be a media object with url property, or a string URL
-              const url = typeof value === 'object' && value !== null ? value.url : value;
-              const mime = typeof value === 'object' && value !== null ? value.mime : undefined;
-
-              if (url) {
-                // Check if the media type matches the element type
-                const isImage = element.tagName === 'IMG';
-                const isVideo = element.tagName === 'VIDEO';
-                const isImageMime = mime?.startsWith('image/');
-                const isVideoMime = mime?.startsWith('video/');
-
-                // Check if we need to replace the element due to media type mismatch
-                const needsReplacement =
-                  mime && ((isImage && isVideoMime) || (isVideo && isImageMime));
-
-                if (needsReplacement) {
-                  // Create a new element of the correct type
-                  const newTagName = isImageMime ? 'IMG' : 'VIDEO';
-                  const newElement = document.createElement(newTagName);
-
-                  // Copy all attributes from the old element
-                  Array.from(element.attributes).forEach((attr) => {
-                    newElement.setAttribute(attr.name, attr.value);
-                  });
-
-                  // Set the new src
-                  newElement.setAttribute('src', url);
-
-                  // Copy inline styles
-                  newElement.style.cssText = element.style.cssText;
-                  newElement.style.display = '';
-
-                  // For video elements, add common attributes
-                  if (newTagName === 'VIDEO') {
-                    newElement.setAttribute('controls', '');
-                  }
-
-                  // Replace the old element with the new one
-                  element.parentNode?.replaceChild(newElement, element);
-                } else {
-                  // Same media type, just update the src
-                  const shouldShow = !mime || (isImage && isImageMime) || (isVideo && isVideoMime);
-
-                  if (shouldShow) {
-                    element.setAttribute('src', url);
-                    element.style.display = '';
-                  } else {
-                    element.style.display = 'none';
-                    element.removeAttribute('src');
-                  }
-                }
-              } else {
-                // Hide element when media is deleted/empty
-                element.style.display = 'none';
-                element.removeAttribute('src');
+            if (!isMediaElement(element)) {
+              const nextText = getRenderableTextValue(value);
+              if (nextText !== null) {
+                element.textContent = nextText;
               }
-            } else if (
-              Array.isArray(value) &&
-              value.length > 0 &&
-              typeof value[0] === 'object' &&
-              'type' in value[0]
-            ) {
-              element.innerHTML = renderBlocks(value);
-            } else {
-              const text = value !== null && value !== undefined ? String(value) : '';
-              element.textContent = text === '' ? '\u00A0' : text;
             }
           }
+        });
+
+        const mediaElements = getElementsByPath(field, { includeDescendants: true }).filter(
+          (element): element is HTMLElement =>
+            element instanceof HTMLElement && isMediaElement(element)
+        );
+
+        const mediaElementsByPath = new Map<string, HTMLElement[]>();
+        mediaElements.forEach((element) => {
+          const sourcePath = getSourcePathFromElement(element);
+          if (!sourcePath) {
+            return;
+          }
+
+          const currentElements = mediaElementsByPath.get(sourcePath) ?? [];
+          currentElements.push(element);
+          mediaElementsByPath.set(sourcePath, currentElements);
+        });
+
+        mediaElements.forEach((element) => {
+          const sourcePath = getSourcePathFromElement(element);
+          const mediaValue = getMediaValueForSourcePath(field, value, sourcePath);
+          const siblingElements = sourcePath
+            ? (mediaElementsByPath.get(sourcePath) ?? [element])
+            : [element];
+          updateMediaElement(element, mediaValue, siblingElements);
         });
 
         // Handle nested media asset fields (caption, alt, etc.)
@@ -761,13 +1003,39 @@ const previewScript = (config: PreviewScriptConfig) => {
             const model = params.get('model');
             const elementPath = params.get('path');
 
-            if (model !== 'plugin::upload.file' || !elementPath) return;
+            if (
+              model !== 'plugin::upload.file' ||
+              !elementPath ||
+              !(element instanceof HTMLElement)
+            ) {
+              return;
+            }
+
+            if (Array.isArray(value)) {
+              if (!elementPath.startsWith(`${field}.`) || isMediaElement(element)) return;
+
+              const relativePath = elementPath.slice(field.length + 1);
+              const [indexPart, ...propertyPath] = relativePath.split('.');
+              const mediaIndex = Number(indexPart);
+
+              if (Number.isNaN(mediaIndex) || propertyPath.length === 0) return;
+
+              const mediaItem = value[mediaIndex];
+              if (!mediaItem || typeof mediaItem !== 'object') return;
+
+              const propertyName = propertyPath.join('.');
+              const propertyValue = (mediaItem as Record<string, unknown>)[propertyName];
+              if (propertyValue !== undefined) {
+                element.textContent = propertyValue ? String(propertyValue) : '';
+              }
+              return;
+            }
 
             if (elementPath.startsWith(`${field}.`)) {
               const propertyName = elementPath.slice(field.length + 1);
-              const propertyValue = value[propertyName];
-              if (element instanceof HTMLElement && propertyValue !== undefined) {
-                element.textContent = propertyValue || '';
+              const propertyValue = (value as Record<string, unknown>)[propertyName];
+              if (!isMediaElement(element) && propertyValue !== undefined) {
+                element.textContent = propertyValue ? String(propertyValue) : '';
               }
             }
           });
@@ -791,13 +1059,21 @@ const previewScript = (config: PreviewScriptConfig) => {
 
         // Set new focused field and highlight matching elements
         highlightManager.setFocusedField(field);
-        getElementsByPath(field).forEach((element, index) => {
+        const exactMatches = getElementsByPath(field);
+        const matchingElements =
+          exactMatches.length > 0
+            ? exactMatches
+            : getElementsByPath(field, { includeDescendants: true, includeFieldPath: true });
+
+        matchingElements.forEach((element, index) => {
           if (index === 0) {
             // Check if scrollIntoViewIfNeeded is available (e.g. Chrome)
             if (
               'scrollIntoViewIfNeeded' in element &&
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               typeof (element as any).scrollIntoViewIfNeeded === 'function'
             ) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (element as any).scrollIntoViewIfNeeded({ behavior: 'smooth', block: 'center' });
             } else {
               element.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -65,6 +65,10 @@ const previewScript = (config: PreviewScriptConfig) => {
     type: (typeof INTERNAL_EVENTS)[keyof typeof INTERNAL_EVENTS],
     payload: unknown
   ) => {
+    /**
+     * We intentionally use "*" here because the preview iframe (user site) and Strapi admin (parent)
+     * are frequently on different origins. Target origin validation should happen on the receiver side.
+     */
     window.parent.postMessage({ type, payload }, '*');
   };
 
@@ -315,8 +319,21 @@ const previewScript = (config: PreviewScriptConfig) => {
     const normalizedMime = typeof mime === 'string' ? mime : undefined;
 
     if (!normalizedUrl) {
-      element.style.display = 'none';
-      element.removeAttribute('src');
+      if (normalizedMime === 'application/x-strapi-empty-media') {
+        // Render a 1x1 transparent GIF as placeholder so it remains selectable
+        element.setAttribute(
+          'src',
+          'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        );
+        element.style.display = '';
+        element.style.minWidth = '24px'; // Ensure it has some dimensions
+        element.style.minHeight = '24px';
+        element.style.backgroundColor = '#f0f0f0'; // Slight background to be visible
+        element.style.border = '1px dashed #ccc';
+      } else {
+        element.style.display = 'none';
+        element.removeAttribute('src');
+      }
       return;
     }
 
@@ -345,6 +362,12 @@ const previewScript = (config: PreviewScriptConfig) => {
     // Avoid replacing nodes in-place (React-managed trees may crash on save after external replaceChild).
     element.setAttribute('src', normalizedUrl);
     element.style.display = '';
+
+    // Reset placeholder styles if present
+    element.style.minWidth = '';
+    element.style.minHeight = '';
+    element.style.backgroundColor = '';
+    element.style.border = '';
 
     if (isVideoElement) {
       element.setAttribute('controls', '');
@@ -394,7 +417,9 @@ const previewScript = (config: PreviewScriptConfig) => {
             if (cleanedSrc !== src) {
               element.setAttribute('src', cleanedSrc);
             }
-          } catch (error) {}
+          } catch {
+            // noop – invalid stega payload / decode failure
+          }
         }
         return;
       }
@@ -428,7 +453,9 @@ const previewScript = (config: PreviewScriptConfig) => {
           if (cleanedText !== node.textContent) {
             node.textContent = cleanedText;
           }
-        } catch (error) {}
+        } catch {
+          // noop – invalid stega payload / decode failure
+        }
       });
 
       if (decodedSource) {
@@ -451,7 +478,9 @@ const previewScript = (config: PreviewScriptConfig) => {
         if (firstSource) {
           element.setAttribute(SOURCE_ATTRIBUTE, firstSource);
         }
-      } catch (error) {}
+      } catch {
+        // noop – invalid stega payload / decode failure
+      }
     };
 
     // Process all existing elements
@@ -557,7 +586,7 @@ const previewScript = (config: PreviewScriptConfig) => {
 
   type EventListenersList = Array<{
     element: HTMLElement | Window;
-    type: keyof HTMLElementEventMap | 'message';
+    type: keyof HTMLElementEventMap | keyof WindowEventMap | 'message';
     handler: EventListener;
   }>;
 
@@ -566,6 +595,7 @@ const previewScript = (config: PreviewScriptConfig) => {
     const eventListeners: EventListenersList = [];
     const focusedHighlights: HTMLElement[] = [];
     const pendingClicks = new Map<Element, number>(); // number is timeout id
+    const clonedElements: HTMLElement[] = []; // Track cloned elements to remove on cleanup
     let focusedField: string | null = null;
 
     const drawHighlight = (target: Element, highlight: HTMLElement) => {
@@ -593,6 +623,7 @@ const previewScript = (config: PreviewScriptConfig) => {
       highlight.className = 'strapi-highlight';
       const clickHandler = (event: MouseEvent) => {
         // Skip if this is a re-dispatched event from our delayed handler to avoid infinite loops
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((event as any).__strapi_redispatched) {
           return;
         }
@@ -633,6 +664,7 @@ const previewScript = (config: PreviewScriptConfig) => {
             shiftKey: event.shiftKey,
             metaKey: event.metaKey,
           });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (newEvent as any).__strapi_redispatched = true;
           targetElement.dispatchEvent(newEvent);
         }, DOUBLE_CLICK_TIMEOUT);
@@ -711,7 +743,8 @@ const previewScript = (config: PreviewScriptConfig) => {
       // Remove event listeners for this highlight
       const listenersToRemove = eventListeners.filter((listener) => listener.element === highlight);
       listenersToRemove.forEach(({ element, type, handler }) => {
-        element.removeEventListener(type, handler);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        element.removeEventListener(type as any, handler);
       });
 
       // Mutate eventListeners to remove listeners for this highlight
@@ -750,6 +783,10 @@ const previewScript = (config: PreviewScriptConfig) => {
         pendingClicks.forEach((timeout) => clearTimeout(timeout));
         pendingClicks.clear();
       },
+      registerClonedElement: (element: HTMLElement) => {
+        clonedElements.push(element);
+      },
+      clonedElements,
     };
   };
 
@@ -941,6 +978,9 @@ const previewScript = (config: PreviewScriptConfig) => {
 
                       clone.innerText = text;
                       prevEl.parentElement.insertBefore(clone, prevEl.nextSibling);
+
+                      // Track the cloned element for cleanup
+                      highlightManager.registerClonedElement(clone);
                     }
                   });
                   // If we found a match at this level, we stop searching.
@@ -1107,7 +1147,7 @@ const previewScript = (config: PreviewScriptConfig) => {
     // Add the message handler to the cleanup list
     const messageEventListener = {
       element: window,
-      type: 'message' as keyof HTMLElementEventMap,
+      type: 'message' as const,
       handler: handleMessage as EventListener,
     };
 
@@ -1134,7 +1174,13 @@ const previewScript = (config: PreviewScriptConfig) => {
 
       // Remove highlight event listeners
       eventHandlers.forEach(({ element, type, handler }) => {
-        element.removeEventListener(type, handler);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (element as any).removeEventListener(type, handler);
+      });
+
+      // Tracked cloned elements removal to prevent React reconciliation errors
+      highlightManager.clonedElements.forEach((element) => {
+        element.remove();
       });
 
       // Clean up CSS styles

--- a/packages/core/core/src/services/__tests__/content-source-maps.test.ts
+++ b/packages/core/core/src/services/__tests__/content-source-maps.test.ts
@@ -1,0 +1,144 @@
+import { vercelStegaDecode } from '@vercel/stega';
+
+import { createContentSourceMapsService } from '../content-source-maps';
+
+const decodeSourceParams = (value: string) => {
+  const decoded = vercelStegaDecode(value);
+
+  if (!decoded || !('strapiSource' in decoded)) {
+    return null;
+  }
+
+  return new URLSearchParams(decoded.strapiSource);
+};
+
+describe('Content source maps service', () => {
+  const articleSchema = {
+    uid: 'api::article.article',
+    kind: 'collectionType',
+    attributes: {
+      title: { type: 'string' },
+      body: { type: 'blocks' },
+    },
+  };
+
+  const uploadFileSchema = {
+    uid: 'plugin::upload.file',
+    kind: 'collectionType',
+    attributes: {
+      url: { type: 'string' },
+      mime: { type: 'string' },
+      alternativeText: { type: 'string' },
+    },
+  };
+
+  const articleWithMediaSchema = {
+    uid: 'api::article-with-media.article-with-media',
+    kind: 'collectionType',
+    attributes: {
+      title: { type: 'string' },
+      singleMedia: { type: 'media' },
+      multipleMedia: { type: 'media' },
+    },
+  };
+
+  const strapi = {
+    getModel: jest.fn((uid) => {
+      if (uid === articleSchema.uid) {
+        return articleSchema;
+      }
+      if (uid === articleWithMediaSchema.uid) {
+        return articleWithMediaSchema;
+      }
+      if (uid === uploadFileSchema.uid) {
+        return uploadFileSchema;
+      }
+
+      throw new Error(`Unknown model: ${uid}`);
+    }),
+    log: {
+      error: jest.fn(),
+    },
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('encodes blocks text nodes with stega metadata while preserving non-text fields', async () => {
+    const service = createContentSourceMapsService(strapi);
+    const data = {
+      documentId: 'doc-1',
+      locale: 'en',
+      title: 'Article title',
+      body: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', text: 'First line' },
+            {
+              type: 'link',
+              url: 'https://strapi.io',
+              rel: 'noopener noreferrer',
+              target: '_blank',
+              children: [{ type: 'text', text: 'Read more' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const encoded = await service.encodeSourceMaps({ data, schema: articleSchema as any });
+    const encodedTitle = decodeSourceParams(encoded.title);
+    const encodedFirstText = decodeSourceParams(encoded.body[0].children[0].text);
+    const encodedLinkText = decodeSourceParams(encoded.body[0].children[1].children[0].text);
+    const encodedLinkUrl = decodeSourceParams(encoded.body[0].children[1].url);
+
+    expect(encodedTitle?.get('path')).toBe('title');
+    expect(encodedTitle?.get('type')).toBe('string');
+    expect(encodedTitle?.get('fieldPath')).toBeNull();
+
+    expect(encoded.body[0].type).toBe('paragraph');
+    expect(encoded.body[0].children[1].type).toBe('link');
+    expect(encoded.body[0].children[1].url).toBe('https://strapi.io');
+    expect(encodedLinkUrl).toBeNull();
+
+    expect(encodedFirstText?.get('path')).toBe('body.0.children.0.text');
+    expect(encodedFirstText?.get('fieldPath')).toBe('body');
+    expect(encodedFirstText?.get('type')).toBe('blocks');
+    expect(encodedFirstText?.get('documentId')).toBe('doc-1');
+    expect(encodedFirstText?.get('locale')).toBe('en');
+    expect(encodedFirstText?.get('model')).toBe('api::article.article');
+
+    expect(encodedLinkText?.get('path')).toBe('body.0.children.1.children.0.text');
+    expect(encodedLinkText?.get('fieldPath')).toBe('body');
+    expect(encodedLinkText?.get('type')).toBe('blocks');
+  });
+
+  test('encodes blocks-like json arrays as blocks text nodes', async () => {
+    const service = createContentSourceMapsService(strapi);
+    const schemaWithJsonBlocks = {
+      ...articleSchema,
+      attributes: {
+        content: { type: 'json' },
+      },
+    };
+
+    const data = {
+      documentId: 'doc-2',
+      content: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', text: 'Fallback blocks value' }],
+        },
+      ],
+    };
+
+    const encoded = await service.encodeSourceMaps({ data, schema: schemaWithJsonBlocks as any });
+    const encodedText = decodeSourceParams(encoded.content[0].children[0].text);
+
+    expect(encodedText?.get('path')).toBe('content.0.children.0.text');
+    expect(encodedText?.get('fieldPath')).toBe('content');
+    expect(encodedText?.get('type')).toBe('blocks');
+  });
+});

--- a/packages/core/core/src/services/content-source-maps.ts
+++ b/packages/core/core/src/services/content-source-maps.ts
@@ -21,7 +21,6 @@ const ENCODABLE_TYPES = [
   /**
    * We cannot modify the response shape, so types that aren't based on string cannot be encoded:
    * - json: object
-   * - blocks: object, will require a custom implementation in a dedicated PR
    * - integer, float and decimal: number
    * - boolean: boolean (believe it or not)
    * - uid: can be stringified but would mess up URLs
@@ -46,15 +45,33 @@ interface EncodingInfo {
   schema: Struct.Schema;
 }
 
+type EncodableFieldContentSourceMap = FieldContentSourceMap & {
+  fieldPath?: string;
+};
+
 const isObject = (value: unknown): value is Record<string, any> => {
   return typeof value === 'object' && value !== null;
+};
+
+const isBlocksLikeValue = (value: unknown): boolean => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  return value.every((node) => {
+    if (!isObject(node)) {
+      return false;
+    }
+
+    return typeof node.type === 'string' && Array.isArray(node.children);
+  });
 };
 
 const createContentSourceMapsService = (strapi: Core.Strapi) => {
   return {
     encodeField(
       text: string,
-      { kind, model, documentId, type, path, locale }: FieldContentSourceMap
+      { kind, model, documentId, type, path, locale, fieldPath }: EncodableFieldContentSourceMap
     ) {
       /**
        * Combine all metadata into into a one string so we only have to deal with one data-atribute
@@ -75,8 +92,64 @@ const createContentSourceMapsService = (strapi: Core.Strapi) => {
       if (locale) {
         strapiSource.set('locale', locale);
       }
+      if (fieldPath) {
+        strapiSource.set('fieldPath', fieldPath);
+      }
 
-      return vercelStegaCombine(text, { strapiSource: strapiSource.toString() });
+      const encoded = vercelStegaCombine(
+        text,
+        {
+          strapiSource: strapiSource.toString(),
+        },
+        false
+      );
+
+      return encoded;
+    },
+
+    encodeBlocks(
+      blocks: unknown,
+      metadata: Omit<EncodableFieldContentSourceMap, 'path' | 'type'> & {
+        path: string;
+        fieldPath: string;
+      }
+    ): unknown {
+      const visitNode = (node: unknown, currentPath: string): unknown => {
+        if (Array.isArray(node)) {
+          return node.map((child, index) => visitNode(child, `${currentPath}.${index}`));
+        }
+
+        if (!isObject(node)) {
+          return node;
+        }
+
+        return Object.entries(node).reduce(
+          (acc, [nodeKey, nodeValue]) => {
+            if (nodeKey === 'text' && typeof nodeValue === 'string') {
+              acc[nodeKey] = this.encodeField(nodeValue, {
+                ...metadata,
+                path: `${currentPath}.text`,
+                type: 'blocks',
+                fieldPath: metadata.fieldPath,
+              });
+              return acc;
+            }
+
+            if (nodeKey === 'children' && Array.isArray(nodeValue)) {
+              acc[nodeKey] = nodeValue.map((child, index) =>
+                visitNode(child, `${currentPath}.children.${index}`)
+              );
+              return acc;
+            }
+
+            acc[nodeKey] = nodeValue;
+            return acc;
+          },
+          {} as Record<string, unknown>
+        );
+      };
+
+      return visitNode(blocks, metadata.path);
     },
 
     async encodeEntry({ data, schema }: EncodingInfo): Promise<any> {
@@ -90,11 +163,65 @@ const createContentSourceMapsService = (strapi: Core.Strapi) => {
             return;
           }
 
+          const fieldPath = path.rawWithIndices ?? key;
+
+          if (
+            (attribute.type === 'blocks' || attribute.type === 'json') &&
+            isBlocksLikeValue(value)
+          ) {
+            set(
+              key,
+              this.encodeBlocks(value, {
+                path: fieldPath,
+                fieldPath,
+                kind: schema.kind,
+                model: schema.uid as UID.Schema,
+                locale: data.locale,
+                documentId: data.documentId,
+              }) as any
+            );
+            return;
+          }
+
+          if (attribute.type === 'media' && isObject(value)) {
+            const encodeMediaItem = (item: any, index?: number) => {
+              if (!isObject(item) || typeof item.url !== 'string') {
+                return item;
+              }
+
+              let itemPath = fieldPath;
+              if (index !== undefined) {
+                itemPath = `${itemPath}.${index}`;
+              }
+
+              const encodedUrl = this.encodeField(item.url, {
+                path: `${itemPath}.url`,
+                type: attribute.type,
+                kind: schema.kind,
+                model: schema.uid as UID.Schema,
+                locale: data.locale,
+                documentId: data.documentId,
+              });
+
+              return {
+                ...item,
+                url: encodedUrl,
+              };
+            };
+
+            if (Array.isArray(value)) {
+              set(key, value.map((item, index) => encodeMediaItem(item, index)) as any);
+            } else {
+              set(key, encodeMediaItem(value));
+            }
+            return;
+          }
+
           if (ENCODABLE_TYPES.includes(attribute.type) && typeof value === 'string') {
             set(
               key,
               this.encodeField(value, {
-                path: path.rawWithIndices!,
+                path: fieldPath,
                 type: attribute.type,
                 kind: schema.kind,
                 model: schema.uid as UID.Schema,


### PR DESCRIPTION
### What does it do?

This PR improves the Live Preview integration for media and rich content fields by:

- `Enabling` `STRAPI_FIELD_CHANGE` **events for media fields** in the `usePreviewInputManager` hook so image and video updates are propagated immediately to the preview (optimistic updates).
- **Removing the exclusion of media field types** from change events while preserving exclusions for unsupported/internal field types.
- **Improving preview element targeting** by moving the `data-strapi-source` attribute directly onto rendered `<img>` and `<video>` elements, allowing the preview script to correctly identify, focus, and scroll to media elements.
- **Fixing Block Renderer handling** to ensure structured rich content updates properly trigger preview synchronization and element mapping.
- **Adding comprehensive unit tests** for `usePreviewInputManager`, covering:
    - Focus events
    - Blur events
    - Change events
    - Excluded field types
    - Media field change propagation

### Why is it needed?

Previously:

- Media fields (images and videos) did not trigger change events, meaning the Live Preview only updated after saving.
- Clicking an image or video in the preview did not correctly focus the corresponding field in the Content Manager.
- The preview script could not reliably locate media elements because `data-strapi-source` was not attached directly to `<img>` or `<video> `elements.
- Some structured fields (including Block Renderer content) did not consistently synchronize with the preview during optimistic updates.

This resulted in an inconsistent and delayed editing experience.

This PR ensures:

- Media fields update immediately in Live Preview.
- Clicking media in the preview correctly focuses/highlights the related field.
- Block renderer fields behave consistently.
- The overall preview experience is smoother and closer to true real-time editing.

### How to test it?

**Manual verification**

1. Open a content type (e.g., Kitchensink or any custom type with media fields).
2. Open Live Preview.
3. Change an image or video field. 
    - The media updates immediately in the preview (without saving).
4. Click the image or video inside the preview.
    - The corresponding field in the Content Manager is focused/highlighted.
5. Update content inside a Block Renderer field.
    - The preview updates correctly.
6. Verify focus behaviour works for nested/component fields.

### Related issue(s)/PR(s)

N/A
