### PR TITLE
fix: use admin basename for 401 redirect path

### DIFF
--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -9,8 +9,8 @@ import {
 } from '@reduxjs/toolkit';
 
 import { reducer as appReducer, AppState, logout } from '../../reducer';
-import { getBasename } from '../utils/basename';
 import { adminApi } from '../../services/api';
+import { getBasename } from '../utils/basename';
 
 /**
  * @description Static reducers are ones we know, they live in the admin package.

--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -9,6 +9,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import { reducer as appReducer, AppState, logout } from '../../reducer';
+import { getBasename } from '../utils/basename';
 import { adminApi } from '../../services/api';
 
 /**
@@ -92,7 +93,8 @@ const rtkQueryUnauthorizedMiddleware: Middleware =
     // isRejectedWithValue Or isRejected
     if (isRejected(action) && action.payload?.status === 401) {
       dispatch(logout());
-      window.location.href = '/admin/auth/login';
+      const basename = getBasename();
+      window.location.href = `${basename}/auth/login`;
       return;
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the logout/session expiry redirect when Strapi is deployed with a custom admin URL prefix.

**The problem**: `rtkQueryUnauthorizedMiddleware` hardcodes `window.location.href = '/admin/auth/login'` when it receives a 401 response. If the admin panel is served under a custom path like `/application/cms`, the redirect goes to `/admin/auth/login` instead of `/application/cms/auth/login`, resulting in a 404.

**The fix**: Use `getBasename()` (the same utility that provides the React Router basename in `StrapiApp`) to dynamically construct the redirect path. This means the middleware respects whatever admin path prefix is configured via `ADMIN_PATH`.

In the default case (`ADMIN_PATH = /admin`), the behavior is unchanged — it still redirects to `/admin/auth/login`. For custom setups, it now correctly redirects to `{custom-prefix}/auth/login`.

Fixes #24665
Fixes #23920
Fixes #24475
Fixes #25386

Related #23921

## How to test

1. Deploy Strapi with a custom admin URL (e.g. set `admin.path` to `/application/cms` in config)
2. Log in to the admin panel
3. Wait for the session token to expire, or manually trigger a 401
4. Verify the redirect goes to `/application/cms/auth/login` instead of `/admin/auth/login`