### PR TITLE
feat: improve content manager left menu and default view

### DIFF
--- a/packages/core/content-manager/admin/src/components/LeftMenu.tsx
+++ b/packages/core/content-manager/admin/src/components/LeftMenu.tsx
@@ -148,10 +148,9 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
         <SubNav.Sections>
           {menu.map((section) => {
             return (
-              <SubNav.Section
+              <SubNav.SubSection
                 key={section.id}
-                label={section.title}
-                badgeLabel={section.links.length.toString()}
+                label={`${section.title} • ${section.links.length}`}
               >
                 {section.links.map((link) => {
                   return (
@@ -164,7 +163,7 @@ const LeftMenu = ({ isFullPage = false }: { isFullPage?: boolean }) => {
                     />
                   );
                 })}
-              </SubNav.Section>
+              </SubNav.SubSection>
             );
           })}
         </SubNav.Sections>

--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -23,9 +23,13 @@ const Layout = () => {
   const isMobile = useIsMobile();
 
   const { isLoading, collectionTypeLinks, models, singleTypeLinks } = useContentManagerInitData();
-  const authorisedModels = [...collectionTypeLinks, ...singleTypeLinks].sort((a, b) =>
+  const authorisedCollectionModels = [...collectionTypeLinks].sort((a, b) =>
     a.title.localeCompare(b.title)
   );
+  const authorisedSingleModels = [...singleTypeLinks].sort((a, b) =>
+    a.title.localeCompare(b.title)
+  );
+  const authorisedModels = [...authorisedCollectionModels, ...authorisedSingleModels];
 
   const { pathname } = useLocation();
   const { formatMessage } = useIntl();
@@ -63,13 +67,15 @@ const Layout = () => {
 
   // On /content-manager base route
   if (!contentTypeMatch && authorisedModels.length > 0) {
-    // On desktop: redirect to first collection type
+    // On desktop: redirect to first collection type when available, otherwise first model
     if (!isMobile) {
+      const targetModel = authorisedCollectionModels[0] ?? authorisedModels[0];
+
       return (
         <Navigate
           to={{
-            pathname: authorisedModels[0].to,
-            search: authorisedModels[0].search ?? '',
+            pathname: targetModel.to,
+            search: targetModel.search ?? '',
           }}
           replace
         />


### PR DESCRIPTION
##  Summary

This PR enhances the **Content Manager UX** in two ways:

1. Improves the **left navigation** by making the main sections collapsible and displaying the number of content types.
2. Adjusts the **default landing behavior** so that, on desktop, the Content Manager opens the **first collection type** when navigating to `/content-manager` (falling back to single types only if no collections exist).

These changes aim to make navigation clearer and more predictable, especially in projects with many content types.

---

## 🛠 What Changed

### 1. Left Menu UX (Collapsible Sections + Counts)

- Replaced `SubNav.Section` with the existing `SubNav.SubSection` component for:
  - **Collection Types**
  - **Single Types**
- Updated section labels to include item counts, e.g.:
  - `Collection Types • 12`
  - `Single Types • 3`
- Preserved existing functionality:
  - Search filtering logic
  - Localized sorting
  - Link rendering and navigation behavior

**File modified:**

```text
packages/core/content-manager/admin/src/components/LeftMenu.tsx
```

---

### 2. Default Content Type Selection (Prefer Collection Types)

- Adjusted the logic that decides which content type is opened when visiting `/content-manager` on desktop.
- Previously:
  - The app combined collection types and single types into a single `authorisedModels` array, sorted them by title, and redirected to `authorisedModels[0]`.
  - This could open a single type first if its title came first alphabetically.
- Now:
  - `authorisedCollectionModels` and `authorisedSingleModels` are sorted separately.
  - On desktop `/content-manager`, the app:
    - Redirects to the **first collection type** if there is at least one.
    - Falls back to the first model (single type) only when there are **no collection types**.
- Existing guard behavior is preserved:
  - Redirect to `/403` when there are models but none are authorized.
  - Redirect to `/no-content-types` when there are no content types at all.
  - Mobile behavior (showing the navigation page) is unchanged.

**File modified:**

```text
packages/core/content-manager/admin/src/layout.tsx
```

---

## 🎯 Why This Change Is Needed

### Left Menu

In projects with many collection types and single types, the left menu can become long and hard to scan:

- Sections are always expanded.
- Users cannot collapse unused groups.
- There is no quick overview of how many types exist per section.

This update:

- ✅ Enables collapsible sections using the existing `SubNav.SubSection` pattern  
- ✅ Improves scanability and focus  
- ✅ Displays item counts directly in the section header  
- ✅ Keeps behavior consistent with other collapsible patterns in the admin  

### Default Landing Content Type

From a user’s perspective, it’s more natural for the Content Manager to open a **collection type** first (e.g. “Articles”, “Products”) rather than a single type (e.g. “Homepage”), especially in content-heavy projects.

Previously, the first model was chosen purely by alphabetical order across both kinds, which could:

- Open a single type first by accident.
- Make the first experience feel inconsistent depending on naming.

This update:

- ✅ Ensures that, when both exist, **collection types are preferred** as the default landing view.  
- ✅ Keeps a sensible fallback to single types when there are no collections.  
- ✅ Preserves all existing edge-case handling (403, no content types, mobile navigation).

---

## 🧪 How to Test

### Environment

- Repository: `strapi/strapi` (monorepo)
- Node: `>= 20 <= 24`
- Package manager: Yarn

---

### Setup

```bash
yarn install
yarn setup
```

---

### Run Admin in Development Mode

```bash
# Terminal 1
cd packages/core/admin
yarn watch

# Terminal 2
cd examples/getstarted
yarn develop --watch-admin
```

---

### Verification Steps

#### 1. Left Menu Behavior

1. Open the admin panel (default: `http://localhost:1337/admin`).
2. Navigate to **Content Manager**.
3. Confirm:
   - “Collection Types” and “Single Types” render as **collapsible** sections.
   - Labels include counts, e.g. `Collection Types • N`, `Single Types • M`.
   - Chevron indicator is visible and rotates correctly when opening/closing.
4. Test search:
   - Only matching content types remain visible.
   - Section counts reflect the filtered list.
5. Click content type links:
   - Navigation still behaves as before.
   - Collapse/expand state works correctly.

#### 2. Default Landing Content Type (Desktop)

1. Ensure you have at least one collection type and one single type.
2. On desktop, go to `/content-manager` (e.g. via URL or menu).
3. Confirm:
   - You are redirected to the **first collection type** (by title), not a single type.
4. Remove or disable all collection types (if you want to test the fallback), leaving only single types.
5. Go to `/content-manager` again:
   - You should now be redirected to the **first single type**.
6. Verify that:
   - If there are content types but none are authorized → you are redirected to `/403`.
   - If there are no content types at all → you are redirected to `/no-content-types`.

---

## ✅ Tests & Quality Checks

Run from repository root:

```bash
yarn lint
yarn test:ts:front
```

All checks pass successfully after these changes.