### PR TITLE
feat(configure-view): redirect insert field to Content-Type Builder when no fields remain

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -19,11 +19,12 @@ import { Cog, Cross, Drag, Pencil, Plus } from '@strapi/icons';
 import { generateNKeysBetween as generateNKeysBetweenImpl } from 'fractional-indexing';
 import { produce } from 'immer';
 import { useIntl } from 'react-intl';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { getTranslation } from '../../utils/translations';
 import { ComponentIcon } from '../ComponentIcon';
+import { useDoc } from '../../hooks/useDocument';
 
 import { EditFieldForm, EditFieldFormProps } from './EditFieldForm';
 
@@ -112,6 +113,8 @@ const createDragAndDropContainersFromLayout = (layout: ConfigurationFormData['la
 
 const Fields = ({ attributes, fieldSizes, components, metadatas = {} }: FieldsProps) => {
   const { formatMessage } = useIntl();
+  const { model } = useDoc();
+  const navigate = useNavigate();
 
   const layout = useForm<ConfigurationFormData['layout']>(
     'Fields',
@@ -523,22 +526,28 @@ const Fields = ({ attributes, fieldSizes, components, metadatas = {} }: FieldsPr
               <Menu.Trigger
                 startIcon={<Plus />}
                 endIcon={null}
-                disabled={remainingFields.length === 0}
                 fullWidth
                 variant="secondary"
+                onClick={() => {
+                  if (remainingFields.length === 0 && model) {
+                    navigate(`/plugins/content-type-builder/content-types/${model}`);
+                  }
+                }}
               >
                 {formatMessage({
                   id: getTranslation('containers.SettingPage.add.field'),
                   defaultMessage: 'Insert another field',
                 })}
               </Menu.Trigger>
-              <Menu.Content>
-                {remainingFields.map((field) => (
-                  <Menu.Item key={field.name} onSelect={handleAddField(field)}>
-                    {field.label}
-                  </Menu.Item>
-                ))}
-              </Menu.Content>
+              {remainingFields.length > 0 && (
+                <Menu.Content>
+                  {remainingFields.map((field) => (
+                    <Menu.Item key={field.name} onSelect={handleAddField(field)}>
+                      {field.label}
+                    </Menu.Item>
+                  ))}
+                </Menu.Content>
+              )}
             </Menu.Root>
           </Flex>
         </Box>


### PR DESCRIPTION
# What does it do?

This PR improves the UX of the **Content Manager → Configure the view** screen (Edit View layout configuration) for collection types.

It updates the behavior of the **“Insert another field”** button in:

`packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx`

Technical changes:

- Uses `useDoc()` to retrieve the current `modelUid`.
- Uses `useNavigate()` from `react-router-dom` for navigation.
- Updates the “Insert another field” button logic:
  - If `remainingFields.length > 0` → behavior remains unchanged (dropdown menu opens).
  - If `remainingFields.length === 0` → redirects to:
    `/admin/plugins/content-type-builder/content-types/<modelUid>`

The button is no longer effectively useless when all fields are already added to the layout.

---

### Why is it needed?

Currently, when all visible fields are already present in the edit view layout:

- The “Insert another field” button cannot insert anything.
- The UI provides no clear guidance on the next step.

In this scenario, the natural next action for the user is to add new fields to the content type in the **Content-Type Builder**.

This PR:

- Removes a dead-end UX state.
- Makes the button context-aware.
- Improves discoverability by redirecting users directly to the correct Content-Type Builder page.
- Aligns with the existing "Edit the model" navigation pattern in the Edit View header.

---

### How to test it?

#### Environment

- Node.js and Yarn installed.
- Strapi repository cloned and set up:

```bash
yarn install
yarn setup
````

Start the example app:

```bash
cd examples/getstarted
yarn develop --watch-admin
```

---

#### Case 1 – Remaining fields exist

1. Go to **Content Manager**.
2. Select a collection type (e.g. `Category`).
3. Open **Configure the view** for the Edit View.
4. Ensure not all fields are in the layout.
5. Click **“Insert another field”**.
6. A dropdown should open listing the remaining fields.
7. Selecting one should add it to the layout (no behavior change).

---

#### Case 2 – No remaining fields

1. Add all visible fields to the layout.
2. Click **“Insert another field”**.
3. You should be redirected to:

```
/admin/plugins/content-type-builder/content-types/<modelUid>
```

Example:

```
/admin/plugins/content-type-builder/content-types/api::category.category
```

---

#### Regression checks

Run:

```bash
yarn lint
yarn test:unit
yarn test:front
yarn test:e2e --setup --concurrency=1
```

Ensure all tests pass and no existing functionality is broken.
