### PR TITLE
docs: fix typos in content-releases frontend intro

### DIFF
--- a/docs/docs/docs/01-core/content-releases/02-frontend/00-intro.md
+++ b/docs/docs/docs/01-core/content-releases/02-frontend/00-intro.md
@@ -7,14 +7,14 @@ tags:
 
 ## Summary
 
-There are two pages, ReleasesPage and ReleaseDetailsPage. To access these pages a user will need a valid Strapi license with the feature enabled and at lease `plugin::content-releases.read` permissions.
+There are two pages, ReleasesPage and ReleaseDetailsPage. To access these pages a user will need a valid Strapi license with the feature enabled and at least `plugin::content-releases.read` permissions.
 
 Redux toolkit is used to manage content releases data (data retrieval, release creation and editing, and fetching release actions). `Formik` is used to create/edit a release and all input components are controlled components.
 
 ### License limits
 
 Most licenses have feature-based usage limits configured through Chargebee. These limits are exposed to the frontend through [`useLicenseLimits`](/docs/core/admin/ee/hooks/use-license-limits).
-If the license doesn't specify the number of maximum pending releases an hard-coded is used: max. 3 pending releases.
+If the license doesn't specify the number of maximum pending releases a hard-coded default is used: max. 3 pending releases.
 
 ### Endpoints
 


### PR DESCRIPTION
## Summary
- Fix "at lease" → "at least"
- Fix "an hard-coded is used" → "a hard-coded default is used" (wrong article + missing noun)

## Test plan
- [x] Verified the markdown renders correctly
- [x] Changes are documentation-only, no functional impact