### PR TITLE
docs: fix typos in documentation plugin README

### DIFF
--- a/packages/plugins/documentation/README.md
+++ b/packages/plugins/documentation/README.md
@@ -16,7 +16,7 @@ This plugin automates your API documentation creation. It basically generates a 
 
 ### Config
 
-Create a `settings.json` file located in `src/extensions/documentation/config` folder where you can specify all your environment variables, licenses, external documentation and so one...
+Create a `settings.json` file located in `src/extensions/documentation/config` folder where you can specify all your environment variables, licenses, external documentation and so on...
 You can add all the entries listed in the [specification](https://swagger.io/specification/).
 
 _NOTE_ if you need to add a custom key you can do it by prefixing your key by `x-{something}`
@@ -88,7 +88,7 @@ You can modify the `tags`, `paths`, and `components` keys on the generated docum
 
 #### How does it generate the others plugins documentation ?
 
-In other to reference a plugin's route into the documentation you need to add a `description` key in the `config` object.
+In order to reference a plugin's route into the documentation you need to add a `description` key in the `config` object.
 
 For example this is the plugin email routes.json file
 


### PR DESCRIPTION
## Summary
- Fix "so one" → "so on" (line 19)
- Fix "In other to" → "In order to" (line 91)

## Test plan
- [x] Verified the markdown renders correctly
- [x] Changes are documentation-only, no functional impact