### PR TITLE
fix(guided-tour): no overlay in dark mode

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Popover, Portal } from '@strapi/design-system';
+import { Box, Popover, Portal, setOpacity } from '@strapi/design-system';
 import { styled } from 'styled-components';
 
 import { useGetGuidedTourMetaQuery } from '../../services/admin';
@@ -53,12 +53,6 @@ const GuidedTourTooltip = ({ children, ...props }: GuidedTourTooltipProps) => {
 
   return <GuidedTourTooltipImpl {...props}>{children}</GuidedTourTooltipImpl>;
 };
-
-// TODO: This should be exported from the design system
-const setOpacity = (hex: string, alpha: number) =>
-  `${hex}${Math.floor(alpha * 255)
-    .toString(16)
-    .padStart(2, '0')}`;
 
 const GuidedTourOverlay = styled(Box)`
   position: fixed;


### PR DESCRIPTION
### What does it do?

Uses the theme for the overlay so it works on both dark and light mode

### Why is it needed?

The tooltips are hard to spot on dark mode

### How to test it?

Reset the tour if neeeded
Be in dark mode
Start the tour 
You should see the dark mode overlay that strapi modals typically have
Test the same on light mode

<img width="1234" height="932" alt="Screenshot 2026-02-18 at 10 07 29" src="https://github.com/user-attachments/assets/ae9a544b-b9d0-4ef4-afdc-019e6f75b62a" />
<img width="1234" height="938" alt="Screenshot 2026-02-18 at 10 07 43" src="https://github.com/user-attachments/assets/d7255807-e901-41ec-bb2b-eba72e5d05b3" />

