### PR TITLE
fix: layout page broken

### DIFF
--- a/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
@@ -124,6 +124,7 @@ const AdminLayout = () => {
               />
               <Flex
                 direction="column"
+                alignItems="stretch"
                 flex={1}
                 overflow="auto"
                 width="100%"


### PR DESCRIPTION
### What does it do?

The layout of the page was broken by a recent change we made on the AuthenticatedLayout (sorry about that...)
Pages are not displayed full width as before.
(e.g. Profile page or in the Media Library)

<img width="1573" height="905" alt="Screenshot 2026-02-19 at 15 27 43" src="https://github.com/user-attachments/assets/5d2913a1-19a2-4ab1-9629-f31badc7bb6f" />

<img width="1516" height="900" alt="Screenshot 2026-02-19 at 15 27 50" src="https://github.com/user-attachments/assets/7b489e60-3ce0-4d5e-8b34-87509833978d" />


### Why is it needed?

Well, we like our pages well displayed if possible 😬

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Bug introduced by yours truly in https://github.com/strapi/strapi/pull/25450 ✨

🚀