### PR TITLE
fix: vite and webpack config when linking ds locally

### DIFF
--- a/packages/core/strapi/src/node/core/linked-packages.ts
+++ b/packages/core/strapi/src/node/core/linked-packages.ts
@@ -1,25 +1,32 @@
 import path from 'node:path';
-import { createRequire } from 'node:module';
-import readPkgUp from 'read-pkg-up';
+import { getModulePath } from './resolve-module';
+
+const DESIGN_SYSTEM_MODULE = '@strapi/design-system';
+
+/**
+ * Detect if a package is locally linked (portal:, file:, yarn link) rather than installed in node_modules.
+ * When linked, the resolved path is outside node_modules.
+ *
+ * @internal
+ */
+export const isPackageLinked = (mod: string): boolean => {
+  const pkgRoot = getModulePath(mod);
+  const pathSegments = pkgRoot.split(path.sep);
+  return !pathSegments.includes('node_modules');
+};
 
 /**
  * Detects if @strapi/design-system is linked (portal:, file:, or yarn link).
  * Returns the package root path when linked, null otherwise.
+ * Uses the heuristic: linked packages resolve outside node_modules.
  */
-export const getLinkedDesignSystemPath = (cwd: string): string | null => {
+export const getLinkedDesignSystemPath = (): string | null => {
   try {
-    const require = createRequire(import.meta.url);
-    const resolvedPath = require.resolve('@strapi/design-system');
-    const pkg = readPkgUp.sync({ cwd: path.dirname(resolvedPath) });
-    if (!pkg) return null;
-    const pkgRoot = path.dirname(pkg.path);
-    const relativePath = path.relative(cwd, pkgRoot);
-    const isLinked = relativePath.startsWith('..') || path.isAbsolute(relativePath);
-    return isLinked ? pkgRoot : null;
+    const pkgRoot = getModulePath(DESIGN_SYSTEM_MODULE);
+    return isPackageLinked(DESIGN_SYSTEM_MODULE) ? pkgRoot : null;
   } catch {
     return null;
   }
 };
 
-export const isDesignSystemLinked = (cwd: string): boolean =>
-  getLinkedDesignSystemPath(cwd) !== null;
+export const isDesignSystemLinked = (): boolean => getLinkedDesignSystemPath() !== null;

--- a/packages/core/strapi/src/node/core/resolve-module.ts
+++ b/packages/core/strapi/src/node/core/resolve-module.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import readPkgUp from 'read-pkg-up';
+
+/**
+ * Resolve module to package root for use in aliases.
+ * Ensures pnpm's strict node_modules structure can resolve packages when bundling plugin chunks.
+ *
+ * @internal
+ */
+export const getModulePath = (mod: string): string => {
+  const modulePath = require.resolve(mod);
+  const pkg = readPkgUp.sync({ cwd: path.dirname(modulePath) });
+  return pkg ? path.dirname(pkg.path) : modulePath;
+};

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -1,30 +1,19 @@
-import path from 'node:path';
-import readPkgUp from 'read-pkg-up';
 import type { InlineConfig, UserConfig } from 'vite';
 import browserslistToEsbuild from 'browserslist-to-esbuild';
 import react from '@vitejs/plugin-react-swc';
 
 import { getUserConfig } from '../core/config';
+import { getModulePath } from '../core/resolve-module';
 import { isDesignSystemLinked } from '../core/linked-packages';
 import { loadStrapiMonorepo } from '../core/monorepo';
 import { getMonorepoAliases } from '../core/aliases';
 import type { BuildContext } from '../create-build-context';
 import { buildFilesPlugin } from './plugins';
 
-/**
- * Resolve module to package root for use in aliases. Ensures pnpm's strict
- * node_modules structure can resolve packages when bundling plugin chunks.
- */
-const getModulePath = (mod: string) => {
-  const modulePath = require.resolve(mod);
-  const pkg = readPkgUp.sync({ cwd: path.dirname(modulePath) });
-  return pkg ? path.dirname(pkg.path) : modulePath;
-};
-
 const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
   const target = browserslistToEsbuild(ctx.target);
   const isMonorepoExampleApp = (ctx.strapi as any).internal_config?.uuid === 'getstarted';
-  const designSystemLinked = isDesignSystemLinked(ctx.cwd);
+  const designSystemLinked = isDesignSystemLinked();
 
   return {
     root: ctx.cwd,

--- a/packages/core/strapi/src/node/webpack/config.ts
+++ b/packages/core/strapi/src/node/webpack/config.ts
@@ -6,7 +6,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import crypto from 'node:crypto';
 import path from 'node:path';
-import readPkgUp from 'read-pkg-up';
 import {
   Configuration,
   DefinePlugin,
@@ -20,6 +19,7 @@ import type { BuildContext } from '../create-build-context';
 import { getUserConfig } from '../core/config';
 import { getLinkedDesignSystemPath } from '../core/linked-packages';
 import { getMonorepoAliases } from '../core/aliases';
+import { getModulePath } from '../core/resolve-module';
 
 const resolveBaseConfig = async (ctx: BuildContext) => {
   const target = browserslistToEsbuild(ctx.target);
@@ -128,7 +128,7 @@ const resolveBaseConfig = async (ctx: BuildContext) => {
 const resolveDevelopmentConfig = async (ctx: BuildContext): Promise<Configuration> => {
   const baseConfig = await resolveBaseConfig(ctx);
   const monorepo = await loadStrapiMonorepo(ctx.cwd);
-  const linkedDesignSystemPath = getLinkedDesignSystemPath(ctx.cwd);
+  const linkedDesignSystemPath = getLinkedDesignSystemPath();
 
   return {
     ...baseConfig,
@@ -246,16 +246,6 @@ const mergeConfigWithUserConfig = async (config: Configuration, ctx: BuildContex
   }
 
   return config;
-};
-
-/**
- * @internal This function is used to resolve the path of a module.
- * It mimics what vite does internally already.
- */
-const getModulePath = (mod: string) => {
-  const modulePath = require.resolve(mod);
-  const pkg = readPkgUp.sync({ cwd: path.dirname(modulePath) });
-  return pkg ? path.dirname(pkg.path) : modulePath;
 };
 
 export { mergeConfigWithUserConfig, resolveDevelopmentConfig, resolveProductionConfig };


### PR DESCRIPTION
### What does it do?

In [this PR](https://github.com/strapi/strapi/pull/25435) we added the design-system that was missing from the webpack / vite configuration to get rid of issues encountered by plugins developers.
Unfortunately it was making the local linking of the design system to this repo not working anymore.

This PR checks if the design system is locally linked and skip the addition to the config in that case.

---

Recently, this issue was raised: https://github.com/strapi/strapi/issues/25567

I pushed the second commit to fix the build issue and it should work now. If you want to test, you can create a Strapi app with the following experimental: `0.0.0-experimental.0ea3a439e5cc345c331bdebae48b482841104581` and now the `pnpm build` should pass without errors.

### Why is it needed?

Fixing the local linking of the design system package and this repo + the build command.

### How to test it?

_You need both the design system and this repo on your computer_

- Open the terminal
- Go to the Design system folder
- Run the following command `cd packages/design-system`
- `yarn watch`
- Open a new terminal
- Go to the CMS repository
- Run the following command `yarn link {FULLPATH_TO_DESIGN_SYSTEM_FOLDER}/packages/design-system`
- Run strapi (`yarn develop --watch-admin` in getstarted example project)
- Edit anything on the design system
-> The page should refresh with the applied changes to the DS

### Related issue(s)/PR(s)

Introduced by https://github.com/strapi/strapi/pull/25435
Resolves https://github.com/strapi/strapi/issues/25567

🚀