### PR TITLE
fix: typo 'compatability' -> 'compatibility' in error messages

### DIFF
--- a/packages/cli/cloud/src/utils/pkg.ts
+++ b/packages/cli/cloud/src/utils/pkg.ts
@@ -103,7 +103,7 @@ const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
             throw new Error(
               `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
                 err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
+              )}, for compatibility only the following keys are allowed: ${chalk.magenta(
                 "['types', 'source', 'import', 'require', 'default']"
               )}`
             );

--- a/packages/core/strapi/src/cli/utils/pkg.ts
+++ b/packages/core/strapi/src/cli/utils/pkg.ts
@@ -105,7 +105,7 @@ const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
             throw new Error(
               `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
                 err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
+              )}, for compatibility only the following keys are allowed: ${chalk.magenta(
                 "['types', 'source', 'import', 'require', 'default']"
               )}`
             );


### PR DESCRIPTION
## Summary

Fixes the misspelling `compatability` -> `compatibility` in CLI error messages shown when `package.json` contains unknown export keys.

**Files changed:**
- `packages/cli/cloud/src/utils/pkg.ts`
- `packages/core/strapi/src/cli/utils/pkg.ts`

## Test plan
- [x] Grep confirms no remaining instances of `compatability` in the codebase