### PR TITLE
fix(content-manager): document intentional catch in stega decoding

### DIFF
--- a/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/previewScript.ts
@@ -111,7 +111,11 @@ const previewScript = (config: PreviewScriptConfig) => {
               }
             });
           }
-        } catch (error) {}
+        } catch {
+          // Stega decoding is expected to fail for most text nodes since only
+          // a small subset contain encoded data. Silencing these errors avoids
+          // flooding the user's site console with noise.
+        }
       }
     };
 


### PR DESCRIPTION
## Summary

The empty `catch (error) {}` block in `applyStegaToElement` (preview script) silently swallowed all errors without documenting why. This looked like an oversight but is actually intentional — `stegaDecode` is called on every text node and is expected to fail for most of them (only a subset contain encoded data).

Changes:
- Add a comment explaining why the catch is intentionally empty
- Drop the unused `error` binding (`catch (error)` -> `catch`)

**File:** `packages/core/content-manager/admin/src/preview/utils/previewScript.ts`

## Test plan
- No functional change — this is a documentation-only improvement to an existing catch block