### PR TITLE
Add Render deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@
 
 Strapi Community Edition is a free and open-source headless CMS enabling you to manage any content, anywhere.
 
-- **Self-hosted or Cloud**: You can host and scale Strapi projects the way you want. You can save time by deploying to [Strapi Cloud](https://cloud.strapi.io/signups?source=github1) or deploy to the hosting platform you want\*\*: AWS, Azure, Google Cloud, DigitalOcean.
+- **Self-hosted or Cloud**: You can host and scale Strapi projects the way you want. You can save time by deploying to [Strapi Cloud](https://cloud.strapi.io/signups?source=github1) or deploy to the hosting platform you want: AWS, Azure, Google Cloud, DigitalOcean, Render.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://dashboard.render.com/blueprint/new?repo=https://github.com/strapi/strapi&branch=develop&rootDir=templates/website)
 - **Modern Admin Panel**: Elegant, entirely customizable and a fully extensible admin panel.
 - **Multi-database support**: You can choose the database you prefer: PostgreSQL, MySQL, MariaDB, and SQLite.
 - **Customizable**: You can quickly build your logic by fully customizing APIs, routes, or plugins to fit your needs perfectly.

--- a/templates/website/README.md
+++ b/templates/website/README.md
@@ -36,6 +36,18 @@ yarn build
 
 Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
 
+### Deploy to Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://dashboard.render.com/blueprint/new?repo=https://github.com/strapi/strapi&branch=develop&rootDir=templates/website)
+
+This template includes a `render.yaml` Blueprint that provisions:
+- A Node.js web service running Strapi (Starter plan)
+- A PostgreSQL database (Free plan)
+
+All required secrets (`APP_KEYS`, `JWT_SECRET`, etc.) are auto-generated during deployment.
+
+### Deploy to Strapi Cloud
+
 ```
 yarn strapi deploy
 ```

--- a/templates/website/render.yaml
+++ b/templates/website/render.yaml
@@ -1,0 +1,34 @@
+services:
+  - type: web
+    name: strapi
+    runtime: node
+    plan: starter
+    buildCommand: yarn install && yarn build
+    startCommand: yarn start
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: HOST
+        value: 0.0.0.0
+      - key: DATABASE_CLIENT
+        value: postgres
+      - key: DATABASE_URL
+        fromDatabase:
+          name: strapi-db
+          property: connectionString
+      - key: APP_KEYS
+        generateValue: true
+      - key: API_TOKEN_SALT
+        generateValue: true
+      - key: ADMIN_JWT_SECRET
+        generateValue: true
+      - key: TRANSFER_TOKEN_SALT
+        generateValue: true
+      - key: JWT_SECRET
+        generateValue: true
+
+databases:
+  - name: strapi-db
+    databaseName: strapi
+    plan: free


### PR DESCRIPTION
- Add render.yaml Blueprint to templates/website for one-click deployment
- Add Deploy to Render button in main README
- Update templates/website README with Render deployment instructions

The Blueprint provisions a Node.js web service (Starter plan) and PostgreSQL database (Free plan) with auto-generated secrets for APP_KEYS, JWT_SECRET, API_TOKEN_SALT, ADMIN_JWT_SECRET, and TRANSFER_TOKEN_SALT.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
