### PR TITLE
fix(types): added support for required fields in entity's

### DIFF
--- a/packages/core/types/src/data/component.ts
+++ b/packages/core/types/src/data/component.ts
@@ -1,8 +1,10 @@
 import type { ID } from './constants';
 
 import type { Intersect } from '../utils';
-import type { AttributeNames, AttributeValueByName } from '../schema';
+import type { AttributeNames, AttributeValueByName, RequiredAttributeNames } from '../schema';
 import type * as UID from '../uid';
+
+// AttributeNames<TComponentUID>
 
 /**
  * Represents a component entry.
@@ -13,14 +15,25 @@ import type * as UID from '../uid';
 export type Component<
   TComponentUID extends UID.Component = UID.Component,
   TComponentKeys extends AttributeNames<TComponentUID> = AttributeNames<TComponentUID>,
-> = Intersect<[{ id: ID }, Pick<AttributeValues<TComponentUID>, TComponentKeys>]>;
+> = Intersect<
+  [
+    { id: ID },
+    Pick<
+      AttributeValues<TComponentUID>,
+      Extract<TComponentKeys, keyof AttributeValues<TComponentUID>>
+    >,
+  ]
+>;
 
 /**
  * @internal
  */
 type AttributeValues<TComponentUID extends UID.Component = UID.Component> = {
-  [TAttributeName in AttributeNames<TComponentUID>]?: AttributeValueByName<
-    TComponentUID,
-    TAttributeName
-  > | null;
+  [TAttributeName in Exclude<
+    AttributeNames<TComponentUID>,
+    RequiredAttributeNames<TComponentUID>
+  >]?: AttributeValueByName<TComponentUID, TAttributeName> | null;
+} & {
+  [TAttributeName in AttributeNames<TComponentUID> &
+    RequiredAttributeNames<TComponentUID>]: AttributeValueByName<TComponentUID, TAttributeName>;
 };

--- a/packages/core/types/src/data/content-type.ts
+++ b/packages/core/types/src/data/content-type.ts
@@ -2,7 +2,7 @@ import type { ID } from './constants';
 
 import type { Intersect } from '../utils';
 import type * as UID from '../uid';
-import type { AttributeNames, AttributeValueByName } from '../schema';
+import type { AttributeNames, AttributeValueByName, RequiredAttributeNames } from '../schema';
 
 /**
  * A type used as the identifier for a document.
@@ -19,12 +19,24 @@ export type ContentType<
   TContentTypeUID extends UID.ContentType = UID.ContentType,
   TContentTypeKeys extends AttributeNames<TContentTypeUID> = AttributeNames<TContentTypeUID>,
 > = Intersect<
-  [{ id: ID; documentId: DocumentID }, Pick<AttributeValues<TContentTypeUID>, TContentTypeKeys>]
+  [
+    { id: ID; documentId: DocumentID },
+    Pick<
+      AttributeValues<TContentTypeUID>,
+      Extract<TContentTypeKeys, keyof AttributeValues<TContentTypeUID>>
+    >,
+  ]
 >;
 
+/**
+ * @internal
+ */
 type AttributeValues<TContentTypeUID extends UID.ContentType = UID.ContentType> = {
-  [TAttributeName in AttributeNames<TContentTypeUID>]?: AttributeValueByName<
-    TContentTypeUID,
-    TAttributeName
-  > | null;
+  [TAttributeName in Exclude<
+    AttributeNames<TContentTypeUID>,
+    RequiredAttributeNames<TContentTypeUID>
+  >]?: AttributeValueByName<TContentTypeUID, TAttributeName> | null;
+} & {
+  [TAttributeName in AttributeNames<TContentTypeUID> &
+    RequiredAttributeNames<TContentTypeUID>]: AttributeValueByName<TContentTypeUID, TAttributeName>;
 };


### PR DESCRIPTION
### What does it do?

Introduce support for required fields in the entity types.

### Why is it needed?

See #23789

### How to test it?

- Create a content type with required fields.
- Use the content Type: `let test: Data.ContentType<'api::test.test'> = null;` and check typing.

### Related issue(s)/PR(s)

may fix: #23789
