### PR TITLE
fix(types): add missing typing for proxy.koa config

### DIFF
--- a/packages/core/types/src/core/config/server.ts
+++ b/packages/core/types/src/core/config/server.ts
@@ -41,6 +41,7 @@ export interface Proxy {
   http?: string;
   https?: string;
   fetch?: string;
+  koa?: boolean;
 }
 
 export interface Webhooks {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Types for server config were added in https://github.com/strapi/strapi/pull/24905 but the type of `proxy.koa` was missing. This PR adds it.

([See documentation on `proxy.koa`](https://github.com/strapi/documentation/blob/f2ad4ff9dde8d2087b224685e24309eb58426c7c/docusaurus/docs/cms/configurations/server.md#L47))

### Why is it needed?

It helps with type safety of `.ts` config files.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/24905