### PR TITLE
feat(upload): allow file upload into user selected folder

### DIFF
--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -149,10 +149,10 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         data.fileInfo = data.fileInfo || [];
         data.fileInfo = validFiles.map((_f, i) => ({
           ...data.fileInfo[i],
-          folder: apiUploadFolder.id,
+          folder: data.fileInfo[i]?.folder ?? apiUploadFolder.id,
         }));
       } else {
-        data.fileInfo = { ...data.fileInfo, folder: apiUploadFolder.id };
+        data.fileInfo = { ...data.fileInfo, folder: data.fileInfo?.folder ?? apiUploadFolder.id };
       }
 
       const uploadedFiles = await getService('upload').upload({

--- a/packages/core/upload/server/src/controllers/validation/content-api/upload.ts
+++ b/packages/core/upload/server/src/controllers/validation/content-api/upload.ts
@@ -14,6 +14,7 @@ const fileInfoSchema = yup
     alternativeText: yup.string().nullable(),
     caption: yup.string().nullable(),
     focalPoint: focalPointSchema,
+    folder: yup.number().nullable(),
   })
   .noUnknown();
 


### PR DESCRIPTION
### What does it do?

Enable file uploading to a user selected folder.

### Why is it needed?

There was a request in discord.

### How to test it?

- Create a upload folder in strapi admin.
- Get the folder id from the folder url.
- upload a file to a folder using the regular upload using the fileInfo:

  ```
  {
    ...
    folder: <your-folder-id>,
  }
  ```

### Related issue(s)/PR(s)

unknown
