### PR TITLE
docs(ci): improve tests workflow readability (no functional change)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Run lint
+        # To reproduce locally: yarn prettier:check
         run: yarn prettier:check
 
   lint:
@@ -121,6 +122,7 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
       - name: Run lint
+        # To reproduce locally: NX_BASE=origin/develop NX_HEAD=HEAD yarn nx affected --target=lint --parallel --nx-ignore-cycles
         run: yarn nx affected --target=lint --parallel --nx-ignore-cycles
 
   typescript:
@@ -144,6 +146,7 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
       - name: TSC for packages
+        # To reproduce locally: NX_BASE=origin/develop NX_HEAD=HEAD yarn nx affected --target=test:ts --nx-ignore-cycles
         run: yarn nx affected --target=test:ts --nx-ignore-cycles
       - name: TSC for back
         run: yarn nx affected --target=test:ts:back --nx-ignore-cycles


### PR DESCRIPTION
## Summary
- add inline comments in `.github/workflows/tests.yml` to map CI steps to local repro commands
- keep workflow behavior unchanged (`docs/readability only`)

## Why
The tests workflow is high-value but dense. Adding precise local repro hints lowers CI triage time for contributors.

## Evidence
- https://github.com/strapi/strapi/blob/develop/.github/workflows/tests.yml

## Local validation
- `git diff -- .github/workflows/tests.yml` (scope check)
- `npx --yes prettier --check .github/workflows/tests.yml`

## Risk
- low: comment-only changes
- no functional change
