### PR TITLE
enhancement: allow right-clicking on table row to show context menu

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -17,6 +17,7 @@ import {
   useTable,
   useIsMobile,
   useIsDesktop,
+  useMediaQuery,
   tours,
 } from '@strapi/admin/strapi-admin';
 import {
@@ -69,6 +70,15 @@ const LayoutsHeaderCustom = styled(Layouts.Header)`
   overflow-wrap: anywhere;
 `;
 
+const RowLink = styled(ReactRouterLink)`
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  z-index: 1;
+`;
+
 const ListViewPage = () => {
   const { trackUsage } = useTracking();
   const navigate = useNavigate();
@@ -77,6 +87,8 @@ const ListViewPage = () => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler(getTranslation);
   const isMobile = useIsMobile();
   const isDesktop = useIsDesktop();
+  // Only show the row link overlay (right-click context menu) on desktop with a mouse; tablet (even in landscape) and touch devices use row click
+  const showRowLinkOverlay = isDesktop && useMediaQuery('(pointer: fine)');
 
   usePersistentPartialQueryParams('STRAPI_LIST_VIEW_SETTINGS:', ['sort', 'filters', 'pageSize']);
   usePersistentPartialQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale'], false);
@@ -264,13 +276,24 @@ const ListViewPage = () => {
         defaultMessage: 'Untitled',
       });
 
+  const getRowLinkTo = (id: Modules.Documents.ID) => ({
+    pathname: id.toString(),
+    search: stringify({ plugins: query.plugins }),
+  });
+
   const handleRowClick = (id: Modules.Documents.ID) => () => {
     trackUsage('willEditEntryFromList');
-    navigate({
-      pathname: id.toString(),
-      search: stringify({ plugins: query.plugins }),
-    });
+    navigate(getRowLinkTo(id));
   };
+
+  const getRowLinkProps = (row: (typeof results)[number]) => ({
+    to: getRowLinkTo(row.documentId),
+    onClick: () => trackUsage('willEditEntryFromList'),
+    'aria-label': formatMessage({
+      id: getTranslation('components.Table.open-entry'),
+      defaultMessage: 'Open entry',
+    }),
+  });
 
   const isEmptyState = !isFetching && results.length === 0;
 
@@ -396,15 +419,27 @@ const ListViewPage = () => {
                         <Table.Row
                           cursor="pointer"
                           key={row.id}
-                          onClick={handleRowClick(row.documentId)}
+                          style={{ position: 'relative' }}
+                          {...(!showRowLinkOverlay && { onClick: handleRowClick(row.documentId) })}
                         >
-                          <Table.CheckboxCell id={row.id} />
-                          {tableHeaders.map(({ cellFormatter, ...header }) => {
+                          <Table.CheckboxCell
+                            id={row.id}
+                            style={{ position: 'relative', zIndex: 2 }}
+                            onClick={
+                              !showRowLinkOverlay
+                                ? (e: React.MouseEvent) => e.stopPropagation()
+                                : undefined
+                            }
+                          />
+                          {tableHeaders.map(({ cellFormatter, ...header }, cellIndex) => {
                             if (header.name === 'status') {
                               const { status } = row;
 
                               return (
                                 <Table.Cell key={header.name}>
+                                  {showRowLinkOverlay && cellIndex === 0 && (
+                                    <RowLink {...getRowLinkProps(row)} />
+                                  )}
                                   <DocumentStatus status={status} maxWidth={'min-content'} />
                                 </Table.Cell>
                               );
@@ -415,6 +450,9 @@ const ListViewPage = () => {
                               // In this case, we display a dash
                               return (
                                 <Table.Cell key={header.name}>
+                                  {showRowLinkOverlay && cellIndex === 0 && (
+                                    <RowLink {...getRowLinkProps(row)} />
+                                  )}
                                   <Typography textColor="neutral800">
                                     {row[header.name.split('.')[0]]
                                       ? getDisplayName(row[header.name.split('.')[0]])
@@ -426,6 +464,9 @@ const ListViewPage = () => {
                             if (typeof cellFormatter === 'function') {
                               return (
                                 <Table.Cell key={header.name}>
+                                  {showRowLinkOverlay && cellIndex === 0 && (
+                                    <RowLink {...getRowLinkProps(row)} />
+                                  )}
                                   {/* @ts-expect-error – TODO: fix this TS error */}
                                   {cellFormatter(row, header, { collectionType, model })}
                                 </Table.Cell>
@@ -433,6 +474,9 @@ const ListViewPage = () => {
                             }
                             return (
                               <Table.Cell key={header.name}>
+                                {showRowLinkOverlay && cellIndex === 0 && (
+                                  <RowLink {...getRowLinkProps(row)} />
+                                )}
                                 <CellContent
                                   content={row[header.name.split('.')[0]]}
                                   rowId={row.documentId}
@@ -469,6 +513,8 @@ const ListViewPage = () => {
 const ActionsCell = styled(Table.Cell)`
   display: flex;
   justify-content: flex-end;
+  position: relative;
+  z-index: 2;
 `;
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/Relations.tsx
@@ -70,7 +70,11 @@ const RelationMultiple = ({ mainField, content, rowId, name }: RelationMultipleP
 
   return (
     <Menu.Root onOpenChange={(isOpen) => setIsOpen(isOpen)}>
-      <Menu.Trigger onClick={(e) => e.stopPropagation()}>
+      <Menu.Trigger
+        onClick={(e) => e.stopPropagation()}
+        onContextMenu={(e) => e.stopPropagation()}
+        style={{ position: 'relative', zIndex: 2 }}
+      >
         <Typography style={{ cursor: 'pointer' }} textColor="neutral800" fontWeight="regular">
           {contentCount > 0
             ? formatMessage(

--- a/packages/plugins/i18n/admin/src/components/LocaleListCell.tsx
+++ b/packages/plugins/i18n/admin/src/components/LocaleListCell.tsx
@@ -82,7 +82,11 @@ const LocaleListCell = ({
 
   return (
     <Menu.Root>
-      <Menu.Trigger>
+      <Menu.Trigger
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        onContextMenu={(e: React.MouseEvent) => e.stopPropagation()}
+        style={{ position: 'relative', zIndex: 2 }}
+      >
         <Flex minWidth="100%" alignItems="center" justifyContent="center" fontWeight="regular">
           <Typography textColor="neutral800" ellipsis marginRight={2}>
             {getDisplayText()}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Support right-clicking on an entry table row to show the browser's context menu and open the entry in another tab for example.
https://github.com/user-attachments/assets/cffa7b79-61ec-43da-a6d7-f94600f19763

### Why is it needed?
Enhance user experience.

### How to test it?
* Create a content type with a field different types of fields, like a Relation and with localization set up. 
* Create an entry filling in those fields and creating at least in one another locale.
* Go to the list view and check you can right-click and open the entry in a new tab.
* Check that there are no regressions: checkbox can still be clicked, the Relation popover is still clickable and visible, the Locale dropdown is still clickable and visible (and clicking on a specific locale should redirect you to that specific locale's entry), the "..." menu is still clickable and usable. 
* If possible, check that there are no regressions on mobile/tablet too (right-clicking there is obviously not possible).

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/pull/23028
Resolves https://github.com/strapi/strapi/issues/25619
