### PR TITLE
fix(upload): cropping fails for cross-origin assets due to tainted canvas

### DIFF
--- a/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/PreviewBox/AssetPreview.tsx
@@ -38,7 +38,13 @@ export const AssetPreview = React.forwardRef<
 
   if (assetType === AssetType.Image) {
     return (
-      <img ref={ref as React.ForwardedRef<HTMLImageElement>} src={url} alt={name} {...props} />
+      <img
+        ref={ref as React.ForwardedRef<HTMLImageElement>}
+        src={url}
+        alt={name}
+        crossOrigin="anonymous"
+        {...props}
+      />
     );
   }
 

--- a/packages/core/upload/admin/src/hooks/useCropImg.ts
+++ b/packages/core/upload/admin/src/hooks/useCropImg.ts
@@ -45,7 +45,7 @@ export const useCropImg = () => {
         zoomable: false,
         cropBoxResizable: true,
         background: false,
-        checkCrossOrigin: false,
+        checkCrossOrigin: true,
         crop: handleResize,
       });
 


### PR DESCRIPTION
### What does it do?

- Adds `crossOrigin="anonymous"` to the image element in `AssetPreview`
- Sets `checkCrossOrigin: true` in the CropperJS configuration inside `useCropImg`

This ensures proper cross-origin handling when cropping images hosted on external storage providers.

### Why is it needed?

When assets are served from external storage providers (e.g. Azure Blob Storage) with a different origin than the admin panel, cropping fails with:

SecurityError: Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported.

The issue occurs because:
- The `<img>` element did not include `crossOrigin="anonymous"`
- CropperJS was initialized with `checkCrossOrigin: false`

This caused the canvas to become tainted, preventing export via `toBlob()`.

### How to test it?

Environment:
- Node 20+
- Strapi 5
- External storage provider (e.g. Azure Blob Storage) configured with proper CORS

Steps:
1. Configure Strapi to use an external upload provider (e.g. Azure Blob Storage).
2. Ensure the storage allows CORS for the admin origin.
3. Upload an image via Media Library.
4. Open the asset and click "Crop".
5. Adjust the crop area.
6. Click "Crop the original asset" or "Duplicate & crop".

Before this fix:
- Cropping fails with a tainted canvas error.

After this fix:
- Cropping succeeds without errors.

### Related issue(s)/PR(s)

Fixes #25573