### PR TITLE
fix(database): process deleteMany relation filters via query init

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -482,7 +482,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       const { where } = params;
 
       const deletedRows = await this.createQueryBuilder(uid)
-        .where(where)
+        .init({ where })
         .delete()
         .execute<number>({ mapResults: false });
 


### PR DESCRIPTION
## Summary
- fix `deleteMany` to initialize the query builder with `{ where }` via `.init(...)`
- ensures nested relation filters are processed consistently before delete execution

## Context
Issue: #11998 (`deleteMany` not working when filtering by nested entity)

Previously `deleteMany` used `.where(where)` directly. Switching to `.init({ where })` aligns it with the pattern used in other query paths and ensures where params are fully initialized before delete.