### PR TITLE
chore: update package metadata

### DIFF
--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/cli/cloud"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/cli/create-strapi-app"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/cli/create-strapi/package.json
+++ b/packages/cli/create-strapi/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/cli/create-strapi"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/admin",
   "version": "5.37.1",
   "description": "Strapi Admin",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/admin"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/content-manager",
   "version": "5.37.1",
   "description": "A powerful UI to easily manage your data.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/content-manager"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/content-releases",
   "version": "5.37.1",
   "description": "Strapi plugin for organizing and releasing content",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/content-releases"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/content-type-builder",
   "version": "5.37.1",
   "description": "Create and manage content types",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/content-type-builder"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/core"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -11,6 +11,15 @@
     "backup",
     "restore"
   ],
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/data-transfer"
+  },
   "license": "SEE LICENSE IN LICENSE",
   "author": {
     "name": "Strapi Solutions SAS",

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/database"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/email",
   "version": "5.37.1",
   "description": "Easily configure your Strapi application to send emails.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/email"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/openapi"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/permissions",
   "version": "5.37.1",
   "description": "Strapi's permission layer.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/permissions"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/review-workflows",
   "version": "5.37.1",
   "description": "Review workflows for your content",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/review-workflows"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -48,7 +48,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/strapi"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/types"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -2,6 +2,15 @@
   "name": "@strapi/upload",
   "version": "5.37.1",
   "description": "Makes it easy to upload images and files to your Strapi Application.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/upload"
+  },
   "license": "SEE LICENSE IN LICENSE",
   "author": {
     "name": "Strapi Solutions SAS",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/core/utils"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/generators/generators"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -2,6 +2,15 @@
   "name": "@strapi/plugin-cloud",
   "version": "5.37.1",
   "description": "Instructions to deploy your local project to Strapi Cloud",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/plugins/cloud"
+  },
   "license": "MIT",
   "author": {
     "name": "Strapi Solutions SAS",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -2,9 +2,13 @@
   "name": "@strapi/plugin-color-picker",
   "version": "5.37.1",
   "description": "Strapi maintained Custom Fields",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/plugins/color-picker"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -2,9 +2,13 @@
   "name": "@strapi/plugin-documentation",
   "version": "5.37.1",
   "description": "Create an OpenAPI Document and visualize your API with SWAGGER UI.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/plugins/documentation"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -2,9 +2,13 @@
   "name": "@strapi/plugin-graphql",
   "version": "5.37.1",
   "description": "Adds GraphQL endpoint with default API methods.",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/plugins/graphql"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -2,9 +2,13 @@
   "name": "@strapi/i18n",
   "version": "5.37.1",
   "description": "Create read and update content in different languages, both from the Admin Panel and from the API",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/plugins/i18n"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -2,9 +2,13 @@
   "name": "@strapi/plugin-sentry",
   "version": "5.37.1",
   "description": "Send Strapi error events to Sentry",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/plugins/sentry"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -2,9 +2,14 @@
   "name": "@strapi/plugin-users-permissions",
   "version": "5.37.1",
   "description": "Protect your API with a full-authentication process based on JWT",
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/plugins/users-permissions"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/email-amazon-ses"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/email-mailgun"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/email-nodemailer"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/email-sendgrid"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/email-sendmail"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/upload-aws-s3"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/upload-cloudinary"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/providers/upload-local"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/strapi/strapi.git",
+    "directory": "packages/utils/logger"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -6,6 +6,10 @@
     "strapi",
     "generators"
   ],
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/strapi/strapi.git",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -10,9 +10,13 @@
     "migrate",
     "version"
   ],
+  "homepage": "https://strapi.io",
+  "bugs": {
+    "url": "https://github.com/strapi/strapi/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/strapi.git",
+    "url": "git://github.com/strapi/strapi.git",
     "directory": "packages/utils/upgrade"
   },
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds homepage, bugs and repository information to every public package.

### Why is it needed?

1. Better developer experience when browsing npmjs.org (having direct links to the repo, issue tracker and homepage)
2. some automated tools like renovate (for notifying about dependency updates) use this information to group PRs so all strapi packages are bumped together https://docs.renovatebot.com/presets-monorepo/#monorepostrapi

### How to test it?

n.a.  as this does not touch any code/logic

### Related issue(s)/PR(s)

I didn't find any applicable ones and didn't see the benefit of opening an issue to discuss such a minor change.
