### PR TITLE
feat(admin): lazy load AuthPage and add vendor code splitting

### DIFF
--- a/packages/core/admin/admin/src/router.tsx
+++ b/packages/core/admin/admin/src/router.tsx
@@ -5,7 +5,6 @@ import { RouteObject } from 'react-router-dom';
 import { getEERoutes as getBaseEERoutes } from '../../ee/admin/src/constants';
 import { getEERoutes as getSettingsEERoutes } from '../../ee/admin/src/pages/SettingsPage/constants';
 
-import { AuthPage } from './pages/Auth/AuthPage';
 import { ROUTES_CE } from './pages/Settings/constants';
 
 /**
@@ -26,7 +25,13 @@ const getImmutableRoutes = (): RouteObject[] => [
   ...getBaseEERoutes(),
   {
     path: 'auth/:authType',
-    element: <AuthPage />,
+    lazy: async () => {
+      const { AuthPage } = await import('./pages/Auth/AuthPage');
+
+      return {
+        Component: AuthPage,
+      };
+    },
   },
 ];
 

--- a/packages/core/content-manager/admin/src/pages/CollectionTypePages.tsx
+++ b/packages/core/content-manager/admin/src/pages/CollectionTypePages.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable check-file/filename-naming-convention */
+import * as React from 'react';
+
+import { Navigate, useParams } from 'react-router-dom';
+
+import { COLLECTION_TYPES, SINGLE_TYPES } from '../constants/collections';
+
+const ProtectedEditViewPage = React.lazy(() =>
+  import('./EditView/EditViewPage').then((mod) => ({ default: mod.ProtectedEditViewPage }))
+);
+const ProtectedListViewPage = React.lazy(() =>
+  import('./ListView/ListViewPage').then((mod) => ({ default: mod.ProtectedListViewPage }))
+);
+
+const CollectionTypePages = () => {
+  const { collectionType } = useParams<{ collectionType: string }>();
+
+  /**
+   * We only support two types of collections.
+   */
+  if (collectionType !== COLLECTION_TYPES && collectionType !== SINGLE_TYPES) {
+    return <Navigate to="/404" />;
+  }
+
+  return collectionType === COLLECTION_TYPES ? (
+    <ProtectedListViewPage />
+  ) : (
+    <ProtectedEditViewPage />
+  );
+};
+
+export { CollectionTypePages };

--- a/packages/core/content-manager/admin/src/pages/tests/CollectionTypePages.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/tests/CollectionTypePages.test.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from 'react';
+
+import { render, screen } from '@tests/utils';
+import { Route, Routes } from 'react-router-dom';
+
+import { CollectionTypePages } from '../CollectionTypePages';
+
+const renderWithRouter = (initialEntries = ['/']) => {
+  return render(
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/content-manager/:collectionType/:slug" element={<CollectionTypePages />} />
+        <Route path="/404" element={<div>404 Not Found</div>} />
+      </Routes>
+    </Suspense>,
+    {
+      initialEntries,
+    }
+  );
+};
+
+describe('CollectionTypePages', () => {
+  it('should render list view page for collection-types', async () => {
+    renderWithRouter(['/content-manager/collection-types/api::address.address']);
+
+    // The component should try to load the lazy component
+    // We just verify it doesn't redirect to 404
+    await screen.findByText('Loading...');
+  });
+
+  it('should render edit view page for single-types', async () => {
+    renderWithRouter(['/content-manager/single-types/api::address.address']);
+
+    // The component should try to load the lazy component
+    await screen.findByText('Loading...');
+  });
+
+  it('should navigate to 404 for invalid collection type', async () => {
+    renderWithRouter(['/content-manager/invalid-type/api::address.address']);
+
+    await screen.findByText('404 Not Found');
+  });
+});

--- a/packages/core/content-manager/admin/src/router.tsx
+++ b/packages/core/content-manager/admin/src/router.tsx
@@ -1,17 +1,13 @@
 /* eslint-disable check-file/filename-naming-convention */
 import { lazy } from 'react';
 
-import { Navigate, PathRouteProps, useParams } from 'react-router-dom';
+import { PathRouteProps } from 'react-router-dom';
 
-import { COLLECTION_TYPES, SINGLE_TYPES } from './constants/collections';
 import { routes as historyRoutes } from './history/routes';
 import { routes as previewRoutes } from './preview/routes';
 
 const ProtectedEditViewPage = lazy(() =>
   import('./pages/EditView/EditViewPage').then((mod) => ({ default: mod.ProtectedEditViewPage }))
-);
-const ProtectedListViewPage = lazy(() =>
-  import('./pages/ListView/ListViewPage').then((mod) => ({ default: mod.ProtectedListViewPage }))
 );
 const ProtectedListConfiguration = lazy(() =>
   import('./pages/ListConfiguration/ListConfigurationPage').then((mod) => ({
@@ -35,23 +31,6 @@ const NoContentType = lazy(() =>
   import('./pages/NoContentTypePage').then((mod) => ({ default: mod.NoContentType }))
 );
 
-const CollectionTypePages = () => {
-  const { collectionType } = useParams<{ collectionType: string }>();
-
-  /**
-   * We only support two types of collections.
-   */
-  if (collectionType !== COLLECTION_TYPES && collectionType !== SINGLE_TYPES) {
-    return <Navigate to="/404" />;
-  }
-
-  return collectionType === COLLECTION_TYPES ? (
-    <ProtectedListViewPage />
-  ) : (
-    <ProtectedEditViewPage />
-  );
-};
-
 const CLONE_RELATIVE_PATH = ':collectionType/:slug/clone/:origin';
 const CLONE_PATH = `/content-manager/${CLONE_RELATIVE_PATH}`;
 const LIST_RELATIVE_PATH = ':collectionType/:slug';
@@ -60,7 +39,11 @@ const LIST_PATH = `/content-manager/collection-types/:slug`;
 const routes: PathRouteProps[] = [
   {
     path: LIST_RELATIVE_PATH,
-    element: <CollectionTypePages />,
+    lazy: async () => {
+      const { CollectionTypePages } = await import('./pages/CollectionTypePages');
+
+      return { Component: CollectionTypePages };
+    },
   },
   {
     path: ':collectionType/:slug/:id',

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -141,7 +141,24 @@ const resolveProductionConfig = async (ctx: BuildContext): Promise<InlineConfig>
         input: {
           strapi: ctx.entry,
         },
-      },
+        // Optimize chunk splitting for better lazy loading
+        // Split vendor code into separate chunks to reduce initial bundle size
+        output: {
+          manualChunks: {
+            // Core React ecosystem - loaded in initial bundle
+            'vendor-react': [
+              'react',
+              'react-dom',
+              'react-router-dom',
+              'react-router',
+            ],
+            // UI library - can be lazy loaded
+            'vendor-ui': [
+              '@strapi/design-system',
+              'styled-components',
+            ],
+          },
+        },
     },
   };
 };


### PR DESCRIPTION
## Summary

- Lazy load AuthPage to reduce initial bundle size
- Lazy load CollectionTypePages for content-manager routes  
- Add vendor chunk splitting for react, react-dom, react-router, and design-system

## Changes

- `packages/core/admin/admin/src/router.tsx`: Lazy load AuthPage
- `packages/core/content-manager/admin/src/pages/CollectionTypePages.tsx`: New file with lazy-loaded collection type pages
- `packages/core/content-manager/admin/src/router.tsx`: Use lazy loading for collection type routes
- `packages/core/strapi/src/node/vite/config.ts`: Add vendor chunk splitting for production builds
- `packages/core/content-manager/admin/src/pages/tests/CollectionTypePages.test.tsx`: Tests

## Benefits

- Reduces initial JavaScript bundle size by deferring AuthPage loading
- Splits vendor code into separate chunks for better caching
- Improves time-to-interactive for the admin panel

## Test plan

- [ ] Build the admin panel and verify chunks are generated
- [ ] Verify Auth page loads correctly when navigating to /admin/auth
- [ ] Verify content manager list/edit views work correctly