### PR TITLE
Update revalidateChangedContentTypes to check for null value for oldContentTypes variable.

### DIFF
--- a/packages/core/content-releases/server/src/migrations/index.ts
+++ b/packages/core/content-releases/server/src/migrations/index.ts
@@ -125,7 +125,7 @@ export async function migrateIsValidAndStatusReleases() {
 }
 
 export async function revalidateChangedContentTypes({ oldContentTypes, contentTypes }: Input) {
-  if (oldContentTypes !== undefined && contentTypes !== undefined) {
+  if (oldContentTypes !== undefined && oldContentTypes!==null && contentTypes !== undefined) {
     const contentTypesWithDraftAndPublish = Object.keys(oldContentTypes).filter(
       (uid) => oldContentTypes[uid]?.options?.draftAndPublish
     );


### PR DESCRIPTION

After making a transfer of content (npx strapi transfer), in some cases, Strapi crashes and is unable to restart, As per my investigation, I found out that in that particular case the variable oldContentTypes is set to null which caused an exception at line 129.  therefore, I added the check for null value at line 128.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->
### What does it do?

Added a check on oldContentTypes variable to validate that it is not null (on top of the existing validation that it is not undefined)
### Why is it needed?

After running npx strapi transfer (--only content), sometimes, when Strapi restarts for the first time after the transfer, it raises an exception because the oldContentTypes variable is null.

### How to test it?

Run transfer of the content and the target Strapi should not start. although, this behavior does not always happens and I could not determine the exact conditions to reproduce it.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request