### PR TITLE
fix(content-manager): ListViewPage uses native link instead of onClick for row navigation

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -31,7 +31,7 @@ import { Plus } from '@strapi/icons';
 import { EmptyDocuments } from '@strapi/icons/symbols';
 import { stringify } from 'qs';
 import { useIntl } from 'react-intl';
-import { useNavigate, Link as ReactRouterLink, useParams } from 'react-router-dom';
+import { NavLink, Link as ReactRouterLink, useNavigate, useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { InjectionZone } from '../../components/InjectionZone';
@@ -57,8 +57,6 @@ import { listViewFilters as Filters } from './components/Filters';
 import { TableActions } from './components/TableActions';
 import { CellContent } from './components/TableCells/CellContent';
 import { ViewSettingsMenu } from './components/ViewSettingsMenu';
-
-import type { Modules } from '@strapi/types';
 
 const { INJECT_COLUMN_IN_TABLE } = HOOKS;
 
@@ -264,14 +262,6 @@ const ListViewPage = () => {
         defaultMessage: 'Untitled',
       });
 
-  const handleRowClick = (id: Modules.Documents.ID) => () => {
-    trackUsage('willEditEntryFromList');
-    navigate({
-      pathname: id.toString(),
-      search: stringify({ plugins: query.plugins }),
-    });
-  };
-
   const isEmptyState = !isFetching && results.length === 0;
 
   const endActions = (
@@ -393,18 +383,31 @@ const ListViewPage = () => {
                   <Table.Body>
                     {results.map((row) => {
                       return (
-                        <Table.Row
-                          cursor="pointer"
-                          key={row.id}
-                          onClick={handleRowClick(row.documentId)}
-                        >
-                          <Table.CheckboxCell id={row.id} />
-                          {tableHeaders.map(({ cellFormatter, ...header }) => {
+                        <Table.Row position="relative" key={row.id}>
+                          <Table.CheckboxCell id={row.id} position="relative" zIndex={1} />
+                          {tableHeaders.map(({ cellFormatter, ...header }, index) => {
+                            const blockLink =
+                              index === 0 ? (
+                                <RowLink
+                                  to={{
+                                    pathname: row.documentId.toString(),
+                                    search: stringify({ plugins: query.plugins }),
+                                  }}
+                                  onClick={() => trackUsage('willEditEntryFromList')}
+                                  tabIndex={-1}
+                                  aria-label={formatMessage({
+                                    id: 'app.utils.edit',
+                                    defaultMessage: 'Edit',
+                                  })}
+                                />
+                              ) : null;
+
                             if (header.name === 'status') {
                               const { status } = row;
 
                               return (
                                 <Table.Cell key={header.name}>
+                                  {blockLink}
                                   <DocumentStatus status={status} maxWidth={'min-content'} />
                                 </Table.Cell>
                               );
@@ -415,6 +418,7 @@ const ListViewPage = () => {
                               // In this case, we display a dash
                               return (
                                 <Table.Cell key={header.name}>
+                                  {blockLink}
                                   <Typography textColor="neutral800">
                                     {row[header.name.split('.')[0]]
                                       ? getDisplayName(row[header.name.split('.')[0]])
@@ -426,6 +430,7 @@ const ListViewPage = () => {
                             if (typeof cellFormatter === 'function') {
                               return (
                                 <Table.Cell key={header.name}>
+                                  {blockLink}
                                   {/* @ts-expect-error – TODO: fix this TS error */}
                                   {cellFormatter(row, header, { collectionType, model })}
                                 </Table.Cell>
@@ -433,6 +438,7 @@ const ListViewPage = () => {
                             }
                             return (
                               <Table.Cell key={header.name}>
+                                {blockLink}
                                 <CellContent
                                   content={row[header.name.split('.')[0]]}
                                   rowId={row.documentId}
@@ -441,8 +447,7 @@ const ListViewPage = () => {
                               </Table.Cell>
                             );
                           })}
-                          {/* we stop propagation here to allow the menu to trigger it's events without triggering the row redirect */}
-                          <ActionsCell onClick={(e) => e.stopPropagation()}>
+                          <ActionsCell>
                             <TableActions document={row} />
                           </ActionsCell>
                         </Table.Row>
@@ -469,6 +474,15 @@ const ListViewPage = () => {
 const ActionsCell = styled(Table.Cell)`
   display: flex;
   justify-content: flex-end;
+  position: relative;
+  z-index: 1;
+`;
+
+const RowLink = styled(NavLink)`
+  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
 `;
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does it do?

Replaces the JS-only `onClick` row navigation in the ListView table with a **block link pattern** using a `NavLink` (`position: absolute; inset: 0`) inside the first data cell, with `<tr position: relative>` as the CSS containing block.

- Adds `RowLink` styled component (`NavLink`, `position: absolute; inset: 0; z-index: 0`) injected as first child of the first `<td>` in each row
- `Table.Row`: removes `onClick` / `cursor="pointer"`, adds `position="relative"`
- `Table.CheckboxCell`: adds `position="relative" zIndex={1}` to stay above the link
- `ActionsCell`: adds `position: relative; z-index: 1` so action buttons remain clickable
- Removes the now-unused `handleRowClick` function

### Why is it needed?

The previous implementation used a JS `onClick` handler on `<tr>` to navigate to the edit view. This meant right-click → "Open in new tab" and middle-click did nothing, breaking a basic browser navigation expectation for users browsing a list of entries.

### How to test it?

1. Open any collection type in the Content Manager → List View
2. **Left-click** a row → should navigate to the edit view as before
3. **Right-click** a row → context menu should offer "Open in new tab"
4. **Middle-click** a row → should open the edit view in a new tab
5. **Checkbox** → should still toggle row selection (not navigate)
6. **Action menu** (⋯ button) → should still open the actions menu (not navigate)

### Related issue(s)/PR(s)

Fixes #25619