### PR TITLE
fix: support more than 100 populate entries

### DIFF
--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -1,4 +1,11 @@
 import { traverseQueryPopulate } from '../traverse';
+import {
+  validatePopulate,
+  POPULATE_TRAVERSALS,
+  FILTER_TRAVERSALS,
+  SORT_TRAVERSALS,
+  FIELDS_TRAVERSALS,
+} from '../validate/validators';
 
 describe('traverseQueryPopulate', () => {
   global.strapi = {
@@ -173,6 +180,89 @@ describe('traverseQueryPopulate', () => {
           name: 'test',
         },
       },
+    });
+  });
+
+  /**
+   * When qs parses a populate array with more entries than its arrayLimit (default 100 in Strapi),
+   * it produces a plain object with numeric string keys instead of an array:
+   *   { "0": "createdBy", "1": "updatedBy", "2": "createdBy" }
+   *
+   * The traverse should handle these array-like objects the same as actual arrays.
+   */
+  describe('array-like objects (qs arrayLimit exceeded)', () => {
+    const schema = {
+      kind: 'collectionType' as const,
+      attributes: {
+        title: { type: 'string' as const },
+        createdBy: {
+          type: 'relation' as const,
+          relation: 'oneToOne' as const,
+          target: 'admin::user',
+        },
+        updatedBy: {
+          type: 'relation' as const,
+          relation: 'oneToOne' as const,
+          target: 'admin::user',
+        },
+      },
+    };
+
+    const getModel = jest.fn((uid: string) => {
+      if (uid === 'admin::user') {
+        return {
+          uid: 'admin::user',
+          attributes: {
+            id: { type: 'integer' },
+            firstname: { type: 'string' },
+          },
+        };
+      }
+      return schema;
+    });
+
+    beforeEach(() => {
+      global.strapi = {
+        getModel,
+        db: {
+          metadata: {
+            get: jest.fn(() => ({
+              columnToAttribute: {},
+            })),
+          },
+        },
+      } as any;
+    });
+
+    test('traverseQueryPopulate should handle an object with numeric keys like an array', async () => {
+      // Simulate what qs produces when arrayLimit is exceeded
+      const populateAsObject = { '0': 'createdBy', '1': 'updatedBy', '2': 'createdBy' };
+
+      const visitor = jest.fn();
+      const result = await traverseQueryPopulate(visitor, {
+        schema,
+        getModel,
+      })(populateAsObject);
+
+      // Should not throw and should process all entries
+      expect(result).toBeDefined();
+    });
+
+    test('validatePopulate should not throw for an object with numeric string keys', async () => {
+      // This is what qs produces when populate has >100 entries
+      const populateAsObject: Record<string, string> = {};
+      for (const key of [0, 1, 2]) {
+        populateAsObject[String(key)] = 'createdBy';
+      }
+
+      await expect(
+        validatePopulate({ schema, getModel }, populateAsObject, {
+          filters: FILTER_TRAVERSALS,
+          sort: SORT_TRAVERSALS,
+          fields: FIELDS_TRAVERSALS,
+          populate: POPULATE_TRAVERSALS,
+        })
+      ).resolves.not.toThrow();
     });
   });
 });

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -33,6 +33,20 @@ const isPopulateString = (value: unknown): value is string => {
 const isStringArray = (value: unknown): value is string[] =>
   isArray(value) && value.every(isString);
 
+/**
+ * Detects objects with consecutive numeric string keys (e.g. { "0": "a", "1": "b", "2": "c" }).
+ * This happens when the `qs` query string parser exceeds its `arrayLimit` and produces
+ * a plain object instead of an array.
+ */
+const isArrayLikeObject = (value: unknown): value is Record<string, string> => {
+  if (!isObject(value) || isArray(value)) return false;
+
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) return false;
+
+  return keys.every((k) => /^\d+$/.test(k));
+};
+
 const isObj = (value: unknown): value is Record<string, unknown> => isObject(value);
 
 const populate = traverseFactory()
@@ -54,6 +68,11 @@ const populate = traverseFactory()
     );
 
     return paths.filter((item) => !isNil(item));
+  })
+  // qs produces objects with numeric keys when arrayLimit is exceeded; convert back to array
+  .intercept(isArrayLikeObject, async (visitor, options, populate, { recurse }) => {
+    const values = Object.values(populate);
+    return recurse(visitor, options, values);
   })
   // for wildcard, generate custom utilities to modify the values
   .parse(isWildcard, () => ({


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Applied a fix to `packages/core/utils/src/traverse/query-populate.ts`:
* Added `isArrayLikeObject`: detects objects where all keys are numeric strings (the `qs` `arrayLimit` artifact)
* Added an intercept that converts these array-like objects back to actual arrays via `Object.values()`, then recurses so the existing string-array handling takes over

dded related tests to `packages/core/utils/src/__tests__/query-populate.test.ts`:
* Added a `validatePopulate` test that passes an object with numeric keys `({ "0": "createdBy", "1": "updatedBy", "2": "createdBy" })` and asserts it doesn't throw.


### Why is it needed?

Current behaviour breaks when more than 100 entries are requested via `populate` query parameters.

### How to test it?

Fetch data from Strapi requesting more than 100 entries via `populate` query parameters.

### Related issue(s)/PR(s)

Fixes issue #25632 
