### PR TITLE
fix(vite): deduplicate @strapi/* packages to prevent bundle bloat from local plugins

### DIFF
--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -102,7 +102,20 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     },
     resolve: {
       // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
-      dedupe: ['react', 'react-dom', 'react-router-dom', 'styled-components'],
+      // Also deduplicate @strapi/* packages so local plugins that list them as
+      // direct dependencies don't pull in a second copy during the build.
+      // See: https://github.com/strapi/strapi/issues/22946
+      dedupe: [
+        'react',
+        'react-dom',
+        'react-router-dom',
+        'styled-components',
+        '@strapi/strapi',
+        '@strapi/admin',
+        '@strapi/design-system',
+        '@strapi/icons',
+        '@strapi/utils',
+      ],
     },
     plugins: [react(), buildFilesPlugin(ctx)],
   };


### PR DESCRIPTION
## Summary

Relates to #22946

Local plugins that include `@strapi/*` packages as direct dependencies (rather than peer dependencies) can cause Vite to resolve and bundle multiple copies of those packages — one from the root `node_modules` and one from the plugin's own `node_modules`. This increases build size and memory usage.

Vite already deduplicates React and related packages via `resolve.dedupe` to prevent the [duplicate React hook problem](https://react.dev/warnings/invalid-hook-call-warning#duplicate-react). This PR extends the same mechanism to cover the core `@strapi/*` packages so that Vite always resolves a single copy from the root `node_modules` regardless of what a local plugin lists in its own dependencies.

**Packages added to `dedupe`:**
- `@strapi/strapi`
- `@strapi/admin`
- `@strapi/design-system`
- `@strapi/icons`
- `@strapi/utils`

> **Note:** `resolve.dedupe` addresses bundling (the Vite build step). For the underlying disk-space issue caused by npm/yarn installing `@strapi/*` as direct dependencies inside a plugin's `node_modules`, the recommended solution is to declare those packages as `peerDependencies` only in local plugins, which is already the pattern in the `todo-example` plugin.

## Changes

- `packages/core/strapi/src/node/vite/config.ts`: extend `resolve.dedupe` with `@strapi/*` core packages

## Test plan

- [ ] Create a local plugin with `@strapi/strapi` as a direct `dependency` (not peer dep)
- [ ] Run `strapi build` — verify no duplicate `@strapi/*` module warnings from Vite
- [ ] Confirm the admin panel build still works correctly