### PR TITLE
feat(database): export lifecycle event type

### DIFF
--- a/docs/docs/docs/01-core/database/04-lifecycles.md
+++ b/docs/docs/docs/01-core/database/04-lifecycles.md
@@ -9,7 +9,7 @@ tags:
 
 Content-type lifecycle hooks (`src/api/<api>/content-types/<content-type>/lifecycles.ts`) receive a database lifecycle `Event` object.
 
-For TypeScript projects, import the type from `@strapi/database` or `@strapi/strapi`:
+For TypeScript projects, import the type from `@strapi/database`:
 
 ```ts
 import type { Event } from '@strapi/database';
@@ -20,12 +20,6 @@ export default {
     // ...
   },
 };
-```
-
-`@strapi/strapi` re-exports the same type for apps that only depend on the main package:
-
-```ts
-import type { Event } from '@strapi/strapi';
 ```
 
 The `Event` type includes `action`, `model`, `params`, `state`, and optional `result`. It is defined in `@strapi/database` alongside the lifecycle subscriber implementation.

--- a/docs/docs/docs/01-core/database/04-lifecycles.md
+++ b/docs/docs/docs/01-core/database/04-lifecycles.md
@@ -1,0 +1,31 @@
+---
+title: Lifecycles
+description: TypeScript types for content-type lifecycle hooks
+tags:
+  - database
+  - lifecycles
+  - typescript
+---
+
+Content-type lifecycle hooks (`src/api/<api>/content-types/<content-type>/lifecycles.ts`) receive a database lifecycle `Event` object.
+
+For TypeScript projects, import the type from `@strapi/database` or `@strapi/strapi`:
+
+```ts
+import type { Event } from '@strapi/database';
+
+export default {
+  async beforeCreate(event: Event) {
+    const { data } = event.params;
+    // ...
+  },
+};
+```
+
+`@strapi/strapi` re-exports the same type for apps that only depend on the main package:
+
+```ts
+import type { Event } from '@strapi/strapi';
+```
+
+The `Event` type includes `action`, `model`, `params`, `state`, and optional `result`. It is defined in `@strapi/database` alongside the lifecycle subscriber implementation.

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -16,6 +16,8 @@ import type { Model, JoinTable } from './types';
 import type { Identifiers } from './utils/identifiers';
 import { createRepairManager, type RepairManager } from './repairs';
 
+export type { Event } from './lifecycles';
+
 export { isKnexQuery } from './utils/knex';
 
 interface Settings {

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -8,6 +8,7 @@ import { createMetadata, Metadata } from './metadata';
 import { createEntityManager, EntityManager } from './entity-manager';
 import { createMigrationsProvider, MigrationProvider, type Migration } from './migrations';
 import { createLifecyclesProvider, LifecycleProvider } from './lifecycles';
+import type { Event } from './lifecycles';
 import { createConnection } from './connection';
 import * as errors from './errors';
 import { Callback, transactionCtx, TransactionObject } from './transaction-context';
@@ -15,8 +16,6 @@ import { validateDatabase } from './validations';
 import type { Model, JoinTable } from './types';
 import type { Identifiers } from './utils/identifiers';
 import { createRepairManager, type RepairManager } from './repairs';
-
-export type { Event } from './lifecycles';
 
 export { isKnexQuery } from './utils/knex';
 
@@ -266,4 +265,4 @@ class Database {
 }
 
 export { Database, errors };
-export type { Model, JoinTable, Identifiers, Migration };
+export type { Model, JoinTable, Identifiers, Migration, Event };

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -1,7 +1,5 @@
 import { Strapi } from './core';
 
-export type { Event } from '@strapi/database';
-
 export type * as Core from './core';
 export type * as Data from './data';
 export type * as Internal from './internal';

--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -1,5 +1,7 @@
 import { Strapi } from './core';
 
+export type { Event } from '@strapi/database';
+
 export type * as Core from './core';
 export type * as Data from './data';
 export type * as Internal from './internal';


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Export the life cycle `Event` type for type safety in custom lifecycle files.

### Why is it needed?

When writing a custom `src/api/<content type>content-types/<content type>/lifecycles.ts` file, it is currently difficult to add type safety to lifecycle functions. We can see people trying to grab the `Event` type directly from `@strapi/database/dist/lifecycles`: [example 1](https://github.com/incubateur-ademe/nosgestesclimat-cms/blob/41291c525f469214c7d124d14accc17694839075/src/api/faq/content-types/faq/lifecycles.ts#L1), [example 2](https://github.com/wizbii/strapi-plugin-strapi-algolia/blob/6f6f5d6394adb7593ec4e370b9a6b17a66a1884b/utils/event.d.ts#L1).

It might be nicer for the lifecycle `Event` type to be exported from the package index.

### How to test it?

The built `@strapi/database` should have the `Event` type exported.

### Related issue(s)/PR(s)

N/A
