### PR TITLE
chore: eslintignore coverage

### DIFF
--- a/packages/core/utils/.eslintignore
+++ b/packages/core/utils/.eslintignore
@@ -2,4 +2,5 @@ node_modules/
 .eslintrc.js
 jest.config.js
 dist/
+coverage/
 rollup.config.mjs


### PR DESCRIPTION
### What does it do?

ignores the test coverage dir

### Why is it needed?

otherwise linting fails if you've run a coverage report before

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
