### PR TITLE
fix: skip entity lifecycles (beforeDelete/afterDelete) on republish and discard-draft

### DIFF
--- a/packages/core/core/src/services/document-service/entries.ts
+++ b/packages/core/core/src/services/document-service/entries.ts
@@ -1,4 +1,5 @@
 import type { UID, Modules } from '@strapi/types';
+import type { DeleteReason } from '@strapi/database';
 import { async, errors } from '@strapi/utils';
 import { assoc, omit } from 'lodash/fp';
 
@@ -87,10 +88,10 @@ const createEntriesService = (
     return doc;
   }
 
-  async function deleteEntry(id: number) {
+  async function deleteEntry(id: number, deleteParams = {} as { deleteReason?: DeleteReason }) {
     const componentsToDelete = await components.getComponents(uid, { id });
 
-    const deletedEntry = await strapi.db.query(uid).delete({ where: { id } });
+    const deletedEntry = await strapi.db.query(uid).delete({ where: { id }, ...deleteParams });
 
     await components.deleteComponents(uid, componentsToDelete as any, { loadComponents: false });
 

--- a/packages/core/core/src/services/document-service/repository.ts
+++ b/packages/core/core/src/services/document-service/repository.ts
@@ -9,6 +9,7 @@ import {
 } from '@strapi/utils';
 
 import type { UID, Modules } from '@strapi/types';
+import { DeleteReason } from '@strapi/database';
 import { wrapInTransaction, type RepositoryFactoryMethod } from './common';
 import * as DP from './draft-and-publish';
 import * as i18n from './internationalization';
@@ -577,8 +578,10 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldPublishedVersions,
     });
 
-    // Delete old published versions
-    await async.map(oldPublishedVersions, (entry: any) => entries.delete(entry.id));
+    // Delete old published versions (skip entity lifecycles - republish, not explicit delete)
+    await async.map(oldPublishedVersions, (entry: any) =>
+      entries.delete(entry.id, { deleteReason: DeleteReason.Republish })
+    );
 
     // Add firstPublishedAt to draft if it doesn't exist
     const updatedDraft = await async.map(draftsToPublish, (draft: any) =>
@@ -673,8 +676,10 @@ export const createContentTypeRepository: RepositoryFactoryMethod = (
       oldVersions: oldDrafts,
     });
 
-    // Delete old drafts
-    await async.map(oldDrafts, (entry: any) => entries.delete(entry.id));
+    // Delete old drafts (skip entity lifecycles - discard-draft cycle, not explicit delete)
+    await async.map(oldDrafts, (entry: any) =>
+      entries.delete(entry.id, { deleteReason: DeleteReason.DiscardDraft })
+    );
 
     // Transform published entry data and create draft versions
     const draftEntries = await async.map(versionsToDraft, (entry: any) =>

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -47,7 +47,8 @@ import { relationsOrderer } from './relations-orderer';
 import type { Database } from '..';
 import type { Meta } from '../metadata';
 import type { ID } from '../types';
-import { EntityManager, Repository, Entity } from './types';
+import { EntityManager, Repository, Entity, DeleteReason } from './types';
+import type { States } from '../lifecycles';
 
 export * from './types';
 
@@ -437,9 +438,18 @@ export const createEntityManager = (db: Database): EntityManager => {
     },
 
     async delete(uid, params = {}) {
-      const states = await db.lifecycles.run('beforeDelete', uid, { params });
+      const { deleteReason, ...paramsWithoutReason } = params as typeof params & {
+        deleteReason?: DeleteReason;
+      };
+      const skipLifecycles =
+        deleteReason === DeleteReason.Republish || deleteReason === DeleteReason.DiscardDraft;
 
-      const { where, select, populate } = params;
+      let states!: States;
+      if (!skipLifecycles) {
+        states = await db.lifecycles.run('beforeDelete', uid, { params: paramsWithoutReason });
+      }
+
+      const { where, select, populate } = paramsWithoutReason;
 
       if (isEmpty(where)) {
         throw new Error('Delete requires a where parameter');
@@ -470,7 +480,14 @@ export const createEntityManager = (db: Database): EntityManager => {
         throw e;
       }
 
-      await db.lifecycles.run('afterDelete', uid, { params, result: entity }, states);
+      if (!skipLifecycles) {
+        await db.lifecycles.run(
+          'afterDelete',
+          uid,
+          { params: paramsWithoutReason, result: entity },
+          states
+        );
+      }
 
       return entity;
     },

--- a/packages/core/database/src/entity-manager/types.ts
+++ b/packages/core/database/src/entity-manager/types.ts
@@ -21,6 +21,11 @@ export type Params = {
 
 export type FindOneParams = Pick<Params, 'where' | 'select' | 'populate' | '_q' | 'orderBy'>;
 
+export enum DeleteReason {
+  Republish = 'republish',
+  DiscardDraft = 'discardDraft',
+}
+
 export interface Repository {
   findOne(params?: FindOneParams): Promise<any>;
   findMany(params?: Params): Promise<any[]>;

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -265,3 +265,4 @@ class Database {
 
 export { Database, errors };
 export type { Model, JoinTable, Identifiers, Migration };
+export { DeleteReason } from './entity-manager';


### PR DESCRIPTION
### What does it do?

- Adds an internal `deleteReason` when the document service deletes entries for **republish** (publish flow) or **discard-draft** (discardDraft flow).
- In the entity manager `delete()`, when `deleteReason` is `republish` or `discardDraft`, **beforeDelete** and **afterDelete** lifecycles are skipped; the row is still deleted and relations cleaned up.
- Introduces a `DeleteReason` enum (`Republish`, `DiscardDraft`) and uses it in the document service and entity manager so call sites don’t rely on string literals.

### Why is it needed?

Fixes #25578: with Draft & Publish enabled, **afterDelete** (and **beforeDelete**) were firing when editing a published document and clicking “Save” then “Publish”. That flow deletes the old published row and creates a new one; that internal delete was triggering entity lifecycles, so hooks couldn’t tell “republish” from a real delete/unpublish. Lifecycles should only run for explicit delete/unpublish, not for republish or discard-draft.

### How to test it?

1. Build: `yarn build` (or build `@strapi/database`, `@strapi/core`, `@strapi/strapi`).
2. Run the getstarted example: `cd examples/getstarted && yarn develop --watch-admin`.
3. Use a content type with **draftAndPublish: true** (e.g. Restaurant) and add a simple `afterDelete` log in its lifecycles.
4. **Republish:** Create → Publish → edit (e.g. name) → Save → Publish. **Expected:** no `afterDelete` log.
5. **Unpublish / Delete:** Unpublish or delete an entry. **Expected:** `afterDelete` runs and the log appears.

### Related issue(s)/PR(s)

Fixes #25578
