### PR TITLE
fix: use strapi.fetch for remote uploads

### DIFF
--- a/packages/core/upload/server/src/services/file.ts
+++ b/packages/core/upload/server/src/services/file.ts
@@ -109,10 +109,11 @@ const fetchUrlToInputFile = async (
     throw new ApplicationError(`Could not resolve hostname: ${parsedUrl.hostname}`);
   }
 
-  // Fetch the URL with timeout
+  // use strapi.fetch so we can intercept requests and support proxy settings
+  const doFetch = typeof strapi?.fetch === 'function' ? strapi.fetch : fetch;
   let response: Response;
   try {
-    response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    response = await doFetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
   } catch (error) {
     if (error instanceof Error && error.name === 'TimeoutError') {
       throw new ApplicationError(`Request timed out while fetching URL: ${url}`);

--- a/packages/utils/api-tests/mock-fetch.js
+++ b/packages/utils/api-tests/mock-fetch.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * Test utilities for mocking global fetch in API and integration tests,
+ * so tests do not depend on remote servers (e.g. httpbin) and are reliable.
+ *
+ * Use withMockedFetch() to temporarily replace fetch; use createMockResponse()
+ * to build Response-like objects for the mock.
+ */
+
+/**
+ * Create a Response for use in fetch mocks.
+ * @param {object} options
+ * @param {number} [options.status=200]
+ * @param {Record<string, string>} [options.headers={}]
+ * @param {string|Buffer|ArrayBuffer|Uint8Array} [options.body]
+ * @returns {Response}
+ */
+function createMockResponse({ status = 200, headers = {}, body } = {}) {
+  const bodyBuffer = body == null ? new Uint8Array(0) : toUint8Array(body);
+  const responseHeaders = new Headers(headers);
+  if (bodyBuffer.length && !responseHeaders.has('Content-Length')) {
+    responseHeaders.set('Content-Length', String(bodyBuffer.length));
+  }
+  return new Response(bodyBuffer, { status, headers: responseHeaders });
+}
+
+function toUint8Array(value) {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (Buffer.isBuffer(value)) return new Uint8Array(value);
+  if (typeof value === 'string') return new TextEncoder().encode(value);
+  return new Uint8Array(0);
+}
+
+/**
+ * Run an async function with global fetch replaced by a custom implementation.
+ * Original fetch is restored when the function completes (or throws).
+ *
+ * @param {((url: string, init?: RequestInit) => Response | Promise<Response> | undefined)} mockFn
+ *   Called for each fetch(url, init). Return a Response to mock, or undefined to use real fetch.
+ * @param {() => Promise<void>} fn Async function to run while fetch is mocked.
+ * @returns {Promise<void>}
+ *
+ * @example
+ * const { withMockedFetch, createMockResponse } = require('api-tests/mock-fetch');
+ *
+ * await withMockedFetch(async (url) => {
+ *   if (url === 'https://example.com/bytes/1000') {
+ *     return createMockResponse({
+ *       status: 200,
+ *       headers: { 'Content-Length': '1000' },
+ *       body: Buffer.alloc(1000),
+ *     });
+ *   }
+ *   return undefined; // use real fetch
+ * }, async () => {
+ *   // make requests that trigger fetch
+ * });
+ */
+async function withMockedFetch(mockFn, fn) {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async (url, init) => {
+      const normalizedUrl = typeof url === 'string' ? url : (url?.url ?? String(url));
+      const response = await mockFn(normalizedUrl, init);
+      if (response !== undefined) {
+        return response;
+      }
+      return originalFetch.call(globalThis, url, init);
+    };
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+module.exports = {
+  createMockResponse,
+  withMockedFetch,
+};

--- a/tests/api/core/upload/admin/upload-stream.test.api.js
+++ b/tests/api/core/upload/admin/upload-stream.test.api.js
@@ -6,6 +6,7 @@ const http = require('http');
 
 const { createStrapiInstance } = require('api-tests/strapi');
 const { createAuthRequest } = require('api-tests/request');
+const { withMockedFetch, createMockResponse } = require('api-tests/mock-fetch');
 
 let strapi;
 let rq;
@@ -458,32 +459,35 @@ describe('Upload SSE Streaming', () => {
           return;
         }
 
-        // Use a URL that will likely fail but still trigger the event flow
-        const res = await makeRawRequest(strapi, {
-          method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: { urls: ['https://example.com/nonexistent-image.jpg'] },
-        });
+        const url = 'https://example.com/nonexistent-image.jpg';
+        await withMockedFetch(
+          (u) => (u === url ? createMockResponse({ status: 404, body: '' }) : undefined),
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls: [url] },
+            });
 
-        expect(res.statusCode).toBe(200);
-        expect(res.headers['content-type']).toBe('text/event-stream');
+            expect(res.statusCode).toBe(200);
+            expect(res.headers['content-type']).toBe('text/event-stream');
 
-        // Should have file:fetching event
-        const fetchingEvent = res.events.find((e) => e.event === 'file:fetching');
-        expect(fetchingEvent).toBeDefined();
-        expect(fetchingEvent.data).toMatchObject({
-          url: 'https://example.com/nonexistent-image.jpg',
-          index: 0,
-          total: 1,
-        });
+            const fetchingEvent = res.events.find((e) => e.event === 'file:fetching');
+            expect(fetchingEvent).toBeDefined();
+            expect(fetchingEvent.data).toMatchObject({
+              url,
+              index: 0,
+              total: 1,
+            });
 
-        // Should have stream:complete event
-        const completeEvent = res.events.find((e) => e.event === 'stream:complete');
-        expect(completeEvent).toBeDefined();
+            const completeEvent = res.events.find((e) => e.event === 'stream:complete');
+            expect(completeEvent).toBeDefined();
+          }
+        );
       });
 
       test('Streams file:error event for invalid URL protocol', async () => {
@@ -520,28 +524,31 @@ describe('Upload SSE Streaming', () => {
           'https://example.com/image3.jpg',
         ];
 
-        const res = await makeRawRequest(strapi, {
-          method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: { urls },
-        });
+        await withMockedFetch(
+          (u) => (urls.includes(u) ? createMockResponse({ status: 404, body: '' }) : undefined),
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls },
+            });
 
-        expect(res.statusCode).toBe(200);
+            expect(res.statusCode).toBe(200);
 
-        // Should have file:fetching events for each URL
-        const fetchingEvents = res.events.filter((e) => e.event === 'file:fetching');
-        expect(fetchingEvents.length).toBe(3);
+            const fetchingEvents = res.events.filter((e) => e.event === 'file:fetching');
+            expect(fetchingEvents.length).toBe(3);
 
-        // Verify indices and totals
-        for (let i = 0; i < 3; i++) {
-          expect(fetchingEvents[i].data.index).toBe(i);
-          expect(fetchingEvents[i].data.total).toBe(3);
-          expect(fetchingEvents[i].data.url).toBe(urls[i]);
-        }
+            for (let i = 0; i < 3; i++) {
+              expect(fetchingEvents[i].data.index).toBe(i);
+              expect(fetchingEvents[i].data.total).toBe(3);
+              expect(fetchingEvents[i].data.url).toBe(urls[i]);
+            }
+          }
+        );
       });
     });
 
@@ -565,21 +572,27 @@ describe('Upload SSE Streaming', () => {
           return;
         }
 
-        const res = await makeRawRequest(strapi, {
-          method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: { urls: ['https://example.com/definitely-does-not-exist-12345.jpg'] },
-        });
+        const url = 'https://example.com/definitely-does-not-exist-12345.jpg';
+        await withMockedFetch(
+          (u) => (u === url ? createMockResponse({ status: 404, body: '' }) : undefined),
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls: [url] },
+            });
 
-        expect(res.statusCode).toBe(200);
+            expect(res.statusCode).toBe(200);
 
-        const completeEvent = res.events.find((e) => e.event === 'stream:complete');
-        expect(completeEvent).toBeDefined();
-        expect(completeEvent.data.errors.length).toBeGreaterThan(0);
+            const completeEvent = res.events.find((e) => e.event === 'stream:complete');
+            expect(completeEvent).toBeDefined();
+            expect(completeEvent.data.errors.length).toBeGreaterThan(0);
+          }
+        );
       });
 
       test('Continues processing remaining URLs after one fails', async () => {
@@ -592,21 +605,25 @@ describe('Upload SSE Streaming', () => {
           'https://example.com/another-image.jpg', // Will be attempted
         ];
 
-        const res = await makeRawRequest(strapi, {
-          method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
-          },
-          body: { urls },
-        });
+        await withMockedFetch(
+          (u) => (u === urls[1] ? createMockResponse({ status: 404, body: '' }) : undefined),
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls },
+            });
 
-        expect(res.statusCode).toBe(200);
+            expect(res.statusCode).toBe(200);
 
-        // Should have processed both URLs
-        const fetchingEvents = res.events.filter((e) => e.event === 'file:fetching');
-        expect(fetchingEvents.length).toBe(2);
+            const fetchingEvents = res.events.filter((e) => e.event === 'file:fetching');
+            expect(fetchingEvents.length).toBe(2);
+          }
+        );
       });
     });
 
@@ -638,23 +655,39 @@ describe('Upload SSE Streaming', () => {
         // Set a very small size limit (100 bytes)
         strapi.config.set('plugin::upload.sizeLimit', 100);
 
-        // Use httpbin which returns proper Content-Length headers
-        const res = await makeRawRequest(strapi, {
-          method: 'POST',
-          path: '/upload/unstable/stream-from-urls',
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-            'Content-Type': 'application/json',
+        // Use a URL that resolves to a public IP (example.com) so SSRF check passes.
+        // Mock fetch so we don't rely on remote servers; mock returns 200 + Content-Length: 1000
+        // so the upload service rejects based on size limit.
+        const sizeLimitTestUrl = 'https://example.com/bytes/1000';
+        await withMockedFetch(
+          (url) => {
+            if (url === sizeLimitTestUrl) {
+              return createMockResponse({
+                status: 200,
+                headers: { 'Content-Length': '1000' },
+                body: Buffer.alloc(1000),
+              });
+            }
+            return undefined;
           },
-          body: { urls: ['https://httpbin.org/bytes/1000'] }, // 1000 bytes > 100 byte limit
-        });
+          async () => {
+            const res = await makeRawRequest(strapi, {
+              method: 'POST',
+              path: '/upload/unstable/stream-from-urls',
+              headers: {
+                Authorization: `Bearer ${authToken}`,
+                'Content-Type': 'application/json',
+              },
+              body: { urls: [sizeLimitTestUrl] }, // 1000 bytes > 100 byte limit
+            });
 
-        expect(res.statusCode).toBe(200);
+            expect(res.statusCode).toBe(200);
 
-        // Should have file:error event for size limit
-        const errorEvent = res.events.find((e) => e.event === 'file:error');
-        expect(errorEvent).toBeDefined();
-        expect(errorEvent.data.message).toMatch(/too large|size/i);
+            const errorEvent = res.events.find((e) => e.event === 'file:error');
+            expect(errorEvent).toBeDefined();
+            expect(errorEvent.data.message).toMatch(/too large|size/i);
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
### What does it do?

- use strapi.fetch for remote file uploads/downloads
- remove reliance on a remote server from our API tests

### Why is it needed?

- tests are flaky because the remote server sometimes doesn't respond
- we should use strapi.fetch whenever possible over native fetch, since it does additional configuration like proxy settings and logging

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
