### PR TITLE
fix: add maxwidth to documentactions menu

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -409,7 +409,7 @@ const DocumentActionsMenu = ({
         icon={<More />}
         variant={variant}
       />
-      <Menu.Content maxHeight={undefined} popoverPlacement="bottom-end">
+      <Menu.Content maxHeight={undefined} popoverPlacement="bottom-end" maxWidth="25rem">
         {actions.map((action) => {
           return (
             <Menu.Item

--- a/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/Header.tsx
@@ -408,7 +408,12 @@ const Information = ({ activeTab }: InformationProps) => {
           <Typography tag="dt" variant="pi" fontWeight="bold">
             {info.label}
           </Typography>
-          <Typography tag="dd" variant="pi" textColor="neutral600">
+          <Typography
+            tag="dd"
+            variant="pi"
+            textColor="neutral600"
+            style={{ wordBreak: 'break-word' }}
+          >
             {info.value}
           </Typography>
         </Flex>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Adding a max-width to the DocumentActions' Menu.

### Why is it needed?
Without it, that larger elements inside (name, locale's name) would make the menu very large (especially on mobile).
**BEFORE**
<img width="518" height="423" alt="Capture d’écran 2026-03-06 à 14 56 07" src="https://github.com/user-attachments/assets/86880330-25ec-4c3b-8f22-631f1cc54f47" />

**AFTER**
<img width="408" height="455" alt="Capture d’écran 2026-03-06 à 14 55 53" src="https://github.com/user-attachments/assets/55d7f8e5-4582-49a1-99ef-ef3e67b60567" />

### How to test it?
* Go to the Edit view of a content type.
* Click on the "More" actions button on the top right corner.
* Check with a locale with a long name.
* Go to your personal settings and update your name to be longer.
* Go back to the Edit view and check with that longer name.

Fixes CMS-285
