### PR TITLE
feat(*): introduce mcp core API

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,4 +7,5 @@ preferInteractive: true
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
 catalog:
+  "@modelcontextprotocol/sdk": ^1.27.1
   vitest: ^4.0.18

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
+    "@modelcontextprotocol/sdk": "catalog:",
     "@paralleldrive/cuid2": "2.2.2",
     "@strapi/admin": "5.38.0",
     "@strapi/database": "5.38.0",

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -237,6 +237,39 @@ class Strapi extends Container implements Core.Strapi {
     return this.get('validators');
   }
 
+  /**
+   * Model Context Protocol (MCP) service for AI assistant integration.
+   *
+   * The MCP service enables AI assistants to interact with Strapi through tools, prompts, and resources.
+   * It provides a standardized interface for AI applications to query and manipulate Strapi data and operations.
+   *
+   * **Availability**: Only available in development mode when:
+   * - `server.mcp.enabled` is set to `true` in configuration
+   * - running in development mode (`strapi.config.get('autoReload') === true`)
+   *
+   * @example
+   * ```typescript
+   * // Check if MCP is enabled
+   * strapi.mcp.registerTool({
+   *   name: 'my-custom-tool',
+   *   title: 'My Custom Tool',
+   *   description: 'Performs a custom operation',
+   *   inputSchema: z.object({ input: z.string() }),
+   *   outputSchema: z.object({ result: z.string() }),
+   *   devModeOnly: true,
+   *   createHandler: (strapi) => async ({ input }) => {
+   *     // Tool implementation
+   *     return { result: input };
+   *   },
+   * });
+   * ```
+   *
+   * @see {@link Modules.MCP.McpService} for the complete service interface and available methods.
+   */
+  get mcp(): Modules.MCP.McpService {
+    return this.get('mcp');
+  }
+
   async start() {
     try {
       if (!this.isLoaded) {

--- a/packages/core/core/src/providers/index.ts
+++ b/packages/core/core/src/providers/index.ts
@@ -1,6 +1,7 @@
 import admin from './admin';
 import coreStore from './coreStore';
 import cron from './cron';
+import mcp from './mcp';
 import registries from './registries';
 import sessionManager from './session-manager';
 import telemetry from './telemetry';
@@ -16,4 +17,5 @@ export const providers: Provider[] = [
   webhooks,
   telemetry,
   cron,
+  mcp,
 ];

--- a/packages/core/core/src/providers/mcp.ts
+++ b/packages/core/core/src/providers/mcp.ts
@@ -1,0 +1,30 @@
+import { defineProvider } from './provider';
+import { createMcpService } from '../services/mcp';
+
+export default defineProvider({
+  init(strapi) {
+    strapi.add('mcp', () => createMcpService(strapi));
+  },
+  async bootstrap(strapi) {
+    if (strapi.get('mcp').isEnabled()) {
+      try {
+        strapi.log.info('[MCP] Starting MCP server...');
+        await strapi.get('mcp').start();
+      } catch (error) {
+        strapi.log.error('[MCP] Failed to start MCP server', { error });
+      }
+    } else {
+      strapi.log.debug('[MCP] MCP server is disabled in configuration');
+    }
+  },
+  async destroy(strapi) {
+    if (strapi.get('mcp').isRunning()) {
+      try {
+        strapi.log.info('[MCP] Stopping MCP server...');
+        await strapi.get('mcp').stop();
+      } catch (error) {
+        strapi.log.error('[MCP] Failed to stop MCP server', { error });
+      }
+    }
+  },
+});

--- a/packages/core/core/src/services/mcp.ts
+++ b/packages/core/core/src/services/mcp.ts
@@ -1,0 +1,1 @@
+export { createMcpService } from './mcp/index';

--- a/packages/core/core/src/services/mcp/__tests__/routes.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/routes.test.ts
@@ -1,0 +1,187 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from '../internal/McpConfiguration';
+
+import { type McpRouteHandlers, createMcpRoutes } from '../routes';
+
+describe('MCP Routes', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockHandlers: McpRouteHandlers;
+
+  beforeEach(() => {
+    mockStrapi = {
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    mockHandlers = {
+      handlePost: jest.fn(),
+      handleGet: jest.fn(),
+      handleDelete: jest.fn(),
+    };
+  });
+
+  describe('createMcpRoutes', () => {
+    test('should create routes with correct structure', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes).toHaveLength(11);
+      expect(routes).toStrictEqual([
+        {
+          method: 'POST',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'GET',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'DELETE',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PUT',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PATCH',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'GET',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'POST',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PUT',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'DELETE',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PATCH',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'POST',
+          path: '/register',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+      ]);
+    });
+
+    test('should use path from config', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].path).toBe('/mcp');
+      expect(routes[1].path).toBe('/mcp');
+      expect(routes[2].path).toBe('/mcp');
+    });
+
+    test('should disable auth for all routes', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      routes.forEach((route) => {
+        expect(route.config?.auth).toBe(false);
+      });
+    });
+
+    test('should have correct HTTP methods', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].method).toBe('POST');
+      expect(routes[1].method).toBe('GET');
+      expect(routes[2].method).toBe('DELETE');
+    });
+
+    test('should assign correct handlers', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].handler).toBe(mockHandlers.handlePost);
+      expect(routes[1].handler).toBe(mockHandlers.handleGet);
+      expect(routes[2].handler).toBe(mockHandlers.handleDelete);
+    });
+  });
+
+  describe('route configuration', () => {
+    test('should use default path when config does not override', () => {
+      const defaultStrapi = {
+        config: {
+          get: jest.fn((key, defaultValue) => defaultValue),
+        } as any,
+      };
+      const defaultConfig = new McpConfiguration(defaultStrapi as Core.Strapi);
+      const routes = createMcpRoutes(defaultConfig, mockHandlers);
+
+      expect(routes[0].path).toBe('/mcp');
+    });
+  });
+
+  describe('handler assignment', () => {
+    test('should not mutate handlers object', () => {
+      const originalHandlers = { ...mockHandlers };
+
+      createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(mockHandlers).toEqual(originalHandlers);
+    });
+
+    test('should create independent route objects', () => {
+      const routes1 = createMcpRoutes(mockConfig, mockHandlers);
+      const routes2 = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes1).not.toBe(routes2);
+      expect(routes1[0]).not.toBe(routes2[0]);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -1,0 +1,241 @@
+import type { Core } from '@strapi/types';
+import { createMcpService } from '../index';
+
+jest.mock('../utils/createManagedInterval', () => ({
+  createManagedInterval: () => ({
+    start: jest.fn(),
+    clear: jest.fn(),
+  }),
+}));
+
+describe('MCP Service Integration', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockServerRoutes: jest.Mock;
+  let logDebugSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logDebugSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    logErrorSpy = jest.fn();
+    mockServerRoutes = jest.fn();
+
+    mockStrapi = {
+      log: {
+        debug: logDebugSpy,
+        info: logInfoSpy,
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => {
+          if (key === 'server.mcp.enabled') {
+            return true;
+          }
+          if (key === 'autoReload') {
+            return true; // Required for isEnabled() to return true
+          }
+          if (key === 'server.url') {
+            return 'http://localhost:1337';
+          }
+          return defaultValue;
+        }),
+      } as any,
+      server: {
+        routes: mockServerRoutes,
+      } as any,
+    };
+  });
+
+  describe('route registration on start', () => {
+    test('should register all routes when service starts', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(mockServerRoutes).toHaveBeenCalledTimes(1);
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      expect(registeredRoutes).toHaveLength(11);
+    });
+
+    test('should register POST route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const postRoute = registeredRoutes.find((r: any) => r.method === 'POST');
+
+      expect(postRoute).toBeDefined();
+      expect(postRoute.path).toBe('/mcp');
+      expect(postRoute.config.auth).toBe(false);
+      expect(typeof postRoute.handler).toBe('function');
+    });
+
+    test('should register GET route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const getRoute = registeredRoutes.find((r: any) => r.method === 'GET');
+
+      expect(getRoute).toBeDefined();
+      expect(getRoute.path).toBe('/mcp');
+      expect(getRoute.config.auth).toBe(false);
+      expect(typeof getRoute.handler).toBe('function');
+    });
+
+    test('should register DELETE route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const deleteRoute = registeredRoutes.find((r: any) => r.method === 'DELETE');
+
+      expect(deleteRoute).toBeDefined();
+      expect(deleteRoute.path).toBe('/mcp');
+      expect(deleteRoute.config.auth).toBe(false);
+      expect(typeof deleteRoute.handler).toBe('function');
+    });
+
+    test('should use hardcoded /mcp path', async () => {
+      // Path is currently hardcoded in McpConfiguration
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      const expectedMCPRoutesCount = registeredRoutes.filter((r: any) =>
+        r.path.includes('/mcp')
+      ).length;
+      expect(expectedMCPRoutesCount).toBe(5);
+    });
+
+    test('should not register routes when service is disabled', async () => {
+      const disabledStrapi = {
+        ...mockStrapi,
+        config: {
+          get: jest.fn((key: string, defaultValue?: any) => {
+            if (key === 'server.mcp.enabled') {
+              return false;
+            }
+            if (key === 'autoReload') {
+              return false; // Disabled will also require autoReload to be false
+            }
+            return defaultValue;
+          }),
+        } as any,
+      };
+
+      const service = createMcpService(disabledStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(mockServerRoutes).not.toHaveBeenCalled();
+      expect(logDebugSpy).toHaveBeenCalledWith('[MCP] Server is disabled');
+    });
+
+    test('should log correct endpoint URL after starting', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[MCP] Server available at http://localhost:1337/mcp'
+      );
+    });
+  });
+
+  describe('route authentication', () => {
+    test('should disable authentication for all routes', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      registeredRoutes.forEach((route: any) => {
+        expect(route.config).toBeDefined();
+        expect(route.config.auth).toBe(false);
+      });
+    });
+  });
+
+  describe('service state management', () => {
+    test('should update status to running after registering routes', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      expect(service.isRunning()).toBe(false);
+
+      await service.start();
+
+      expect(service.isRunning()).toBe(true);
+    });
+
+    test('should prevent registration before routes are registered', () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      // Tools can be registered before start
+      expect(() => {
+        service.registerTool({
+          name: 'test-tool',
+          title: 'Test Tool',
+          description: 'Test tool',
+          outputSchema: {} as any,
+          devModeOnly: false,
+          createHandler: jest.fn(),
+        });
+      }).not.toThrow();
+    });
+
+    test('should throw error when registering tools after start', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(() => {
+        service.registerTool({
+          name: 'test-tool',
+          title: 'Test Tool',
+          description: 'Test tool',
+          outputSchema: {} as any,
+          devModeOnly: false,
+          createHandler: jest.fn(),
+        });
+      }).toThrow('[MCP] Tools must be registered before MCP server starts');
+    });
+  });
+
+  describe('error state handling', () => {
+    test('should handle start/stop lifecycle correctly', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      // Start service
+      await service.start();
+      expect(mockServerRoutes).toHaveBeenCalledTimes(1);
+      expect(service.isRunning()).toBe(true);
+
+      // Stop service successfully
+      await service.stop();
+      expect(service.isRunning()).toBe(false);
+
+      // Should be able to start again after clean stop
+      await service.start();
+      expect(mockServerRoutes).toHaveBeenCalledTimes(2);
+      expect(service.isRunning()).toBe(true);
+    });
+
+    test('should prevent starting twice in a row', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      // Try to start again without stopping
+      await expect(service.start()).rejects.toThrow('[MCP] Server already started or starting');
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
@@ -1,0 +1,199 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { createDeleteHandler } from '../handleDelete';
+import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../utils/withTimeout', () => ({
+  withTimeout: jest.fn((promise) => promise),
+}));
+
+describe('handleDelete', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  test('should return error when session ID is missing', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {},
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Session ID required'));
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid session'));
+  });
+
+  test('should handle delete request when session is valid', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const res = {
+      headersSent: false,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
+  });
+
+  test('should handle errors during delete request', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const error = new Error('Delete failed');
+    const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      '[MCP] Error handling DELETE request',
+      expect.objectContaining({
+        error: 'Delete failed',
+      })
+    );
+    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
@@ -1,0 +1,203 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { createGetHandler } from '../handleGet';
+import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../utils/withTimeout', () => ({
+  withTimeout: jest.fn((promise) => promise),
+}));
+
+describe('handleGet', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  test('should return error when session ID is missing', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {},
+    } as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Session ID required'));
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid session'));
+  });
+
+  test('should handle request when session is valid', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const updateActivitySpy = jest.fn();
+    const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      updateActivity: updateActivitySpy,
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const res = {
+      headersSent: false,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(updateActivitySpy).toHaveBeenCalled();
+    expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
+  });
+
+  test('should handle errors during request processing', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const error = new Error('Request failed');
+    const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      updateActivity: jest.fn(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      '[MCP] Error handling GET request',
+      expect.objectContaining({
+        error: 'Request failed',
+      })
+    );
+    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -1,0 +1,364 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { createPostHandler } from '../handlePost';
+import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../utils/withTimeout', () => ({
+  withTimeout: jest.fn((promise) => promise),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: jest.fn(),
+}));
+
+describe('handlePost', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+        info: logInfoSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  describe('existing session', () => {
+    test('should handle request with existing session', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const updateActivitySpy = jest.fn();
+      const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: updateActivitySpy,
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const requestBody = { method: 'test' };
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const res = {
+        headersSent: false,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {
+          body: requestBody,
+        },
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(updateActivitySpy).toHaveBeenCalled();
+      expect(handleRequestSpy).toHaveBeenCalledWith(req, res, requestBody);
+    });
+
+    test('should return error when session is invalid', async () => {
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid session'));
+    });
+  });
+
+  describe('new session', () => {
+    test('should create new session when no session ID provided', async () => {
+      const mockMcpServer = {
+        connect: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const mockTransport = {
+        handleRequest: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const mockRegistries = {
+        toolRegistry: {},
+        promptRegistry: {},
+        resourceRegistry: {},
+      };
+
+      const createServerWithRegistries = jest.fn().mockReturnValue({
+        mcpServer: mockMcpServer,
+        registries: mockRegistries,
+      });
+
+      // Mock the StreamableHTTPServerTransport constructor
+      const { StreamableHTTPServerTransport } = jest.requireMock(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      StreamableHTTPServerTransport.mockImplementation((options: any) => {
+        // Immediately initialize session for testing
+        setTimeout(() => {
+          if (options.onsessioninitialized) {
+            options.onsessioninitialized('new-session-id');
+          }
+        }, 0);
+        return mockTransport;
+      });
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries,
+        capabilityDefinitions: {
+          tools: {} as any,
+          prompts: {} as any,
+          resources: {} as any,
+        },
+      };
+
+      const handler = createPostHandler(deps);
+
+      const requestBody = { method: 'initialize' };
+      const req = {
+        headers: {},
+      } as unknown as IncomingMessage;
+
+      const res = {
+        headersSent: false,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {
+          body: requestBody,
+        },
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(createServerWithRegistries).toHaveBeenCalledWith({
+        strapi: mockStrapi,
+        definitions: deps.capabilityDefinitions,
+        isDevMode: mockConfig.isDevMode(),
+      });
+      expect(mockMcpServer.connect).toHaveBeenCalledWith(mockTransport);
+      expect(mockTransport.handleRequest).toHaveBeenCalledWith(req, res, requestBody);
+    });
+
+    test('should return error when max sessions reached', async () => {
+      // Fill up session manager to max
+      const maxSessions = mockConfig.maxSessions;
+      for (let i = 0; i < maxSessions; i += 1) {
+        mockSessionManager.set(`session-${i}`, {
+          lastActivity: Date.now(),
+        } as any as McpSession);
+      }
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {},
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(503, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Maximum number of sessions reached')
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    test('should handle errors during request processing', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const error = new Error('Request failed');
+      const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: jest.fn(),
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        '[MCP] Error handling POST request',
+        expect.objectContaining({
+          error: 'Request failed',
+        })
+      );
+      expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    });
+
+    test('should handle non-Error exceptions', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const handleRequestSpy = jest.fn().mockRejectedValue('String error');
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: jest.fn(),
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        '[MCP] Error handling POST request',
+        expect.objectContaining({
+          error: 'Unknown error',
+        })
+      );
+      expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/handleDelete.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleDelete.ts
@@ -1,0 +1,41 @@
+import type { Core } from '@strapi/types';
+import { extractSessionId } from '../internal/extractSessionId';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import { withTimeout } from '../utils/withTimeout';
+import type { McpHandlerDependencies } from './types';
+
+export const createDeleteHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager, config } = deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    if (sessionId === undefined) {
+      sendJsonRpcError(res, 400, -32000, 'Session ID required');
+      return;
+    }
+
+    const session = sessionManager.get(sessionId);
+    if (session === undefined) {
+      sendJsonRpcError(res, 400, -32000, 'Invalid session');
+      return;
+    }
+
+    try {
+      await withTimeout(
+        session.transport.handleRequest(req, res, null),
+        config.requestTimeoutMs,
+        'transport.handleRequest'
+      );
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling DELETE request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 500, -32603, 'Internal error');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/handleGet.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleGet.ts
@@ -1,0 +1,46 @@
+import type { Core } from '@strapi/types';
+import { extractSessionId } from '../internal/extractSessionId';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import { withTimeout } from '../utils/withTimeout';
+import type { McpHandlerDependencies } from './types';
+
+export const createGetHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager, config } = deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    if (sessionId === undefined) {
+      sendJsonRpcError(res, 400, -32000, 'Session ID required');
+      return;
+    }
+
+    const session = sessionManager.get(sessionId);
+    if (session === undefined) {
+      sendJsonRpcError(res, 400, -32000, 'Invalid session');
+      return;
+    }
+
+    // Update activity to prevent timeout during active SSE/long-polling connections.
+    // GET requests in MCP context represent active client engagement waiting for
+    // server messages, not idempotent data retrieval.
+    session.updateActivity();
+
+    try {
+      await withTimeout(
+        session.transport.handleRequest(req, res, null),
+        config.requestTimeoutMs,
+        'transport.handleRequest'
+      );
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling GET request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 500, -32603, 'Internal error');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/handlePost.ts
+++ b/packages/core/core/src/services/mcp/handlers/handlePost.ts
@@ -1,0 +1,96 @@
+// eslint-disable-next-line import/extensions
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Core } from '@strapi/types';
+import { randomUUID } from 'node:crypto';
+import { extractSessionId } from '../internal/extractSessionId';
+import { McpSession } from '../session';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import { withTimeout } from '../utils/withTimeout';
+import type { McpHandlerDependencies } from './types';
+
+export const createPostHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager, config, createServerWithRegistries, capabilityDefinitions } =
+    deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    try {
+      let transport: StreamableHTTPServerTransport;
+
+      // Existing session handling
+      if (sessionId !== undefined) {
+        const existingSession = sessionManager.get(sessionId);
+        if (existingSession === undefined) {
+          sendJsonRpcError(res, 400, -32000, 'Invalid session');
+          return;
+        }
+        existingSession.updateActivity();
+        transport = existingSession.transport;
+
+        // Handle request with existing session
+        const requestBody = ctx.request.body ?? null;
+        await withTimeout(
+          transport.handleRequest(req, res, requestBody),
+          config.requestTimeoutMs,
+          'transport.handleRequest'
+        );
+      } else {
+        if (sessionManager.hasReachedMaxSessions() === true) {
+          sendJsonRpcError(res, 503, -32001, 'Maximum number of sessions reached');
+          return;
+        }
+
+        // New session initialization
+        const requestBody = ctx.request.body ?? null;
+
+        const { mcpServer, registries } = createServerWithRegistries({
+          strapi,
+          definitions: capabilityDefinitions,
+          isDevMode: config.isDevMode(),
+        });
+
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized(id) {
+            sessionManager.set(
+              id,
+              new McpSession({
+                server: mcpServer,
+                transport,
+                toolRegistry: registries.toolRegistry,
+                promptRegistry: registries.promptRegistry,
+                resourceRegistry: registries.resourceRegistry,
+              })
+            );
+            strapi.log.info('[MCP] Session initialized', { sessionId: id });
+          },
+          onsessionclosed(id) {
+            sessionManager.delete(id);
+            strapi.log.info('[MCP] Session closed', { sessionId: id });
+          },
+        });
+
+        await withTimeout(
+          mcpServer.connect(transport),
+          config.requestTimeoutMs,
+          'mcpServer.connect'
+        );
+        await withTimeout(
+          transport.handleRequest(req, res, requestBody),
+          config.requestTimeoutMs,
+          'transport.handleRequest'
+        );
+      }
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling POST request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 500, -32603, 'Internal error');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/types.ts
+++ b/packages/core/core/src/services/mcp/handlers/types.ts
@@ -1,0 +1,15 @@
+import type { Core } from '@strapi/types';
+import type { McpConfiguration } from '../internal/McpConfiguration';
+import type {
+  McpCapabilityDefinitions,
+  createMcpServerWithRegistries,
+} from '../internal/McpServerFactory';
+import type { McpSessionManager } from '../internal/McpSessionManager';
+
+export type McpHandlerDependencies = {
+  strapi: Core.Strapi;
+  sessionManager: McpSessionManager;
+  config: McpConfiguration;
+  createServerWithRegistries: typeof createMcpServerWithRegistries;
+  capabilityDefinitions: McpCapabilityDefinitions;
+};

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -1,0 +1,169 @@
+import type { Core, Modules } from '@strapi/types';
+import { createDeleteHandler } from './handlers/handleDelete';
+import { createGetHandler } from './handlers/handleGet';
+import { createPostHandler } from './handlers/handlePost';
+import type { McpHandlerDependencies } from './handlers/types';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import { McpConfiguration } from './internal/McpConfiguration';
+import { createMcpServerWithRegistries } from './internal/McpServerFactory';
+import { McpSessionManager } from './internal/McpSessionManager';
+import { createMcpRoutes } from './routes';
+import { logToolDefinition } from './tools/log';
+import { createManagedInterval } from './utils/createManagedInterval';
+
+/**
+ * Creates an MCP service instance for Strapi Core
+ */
+export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService => {
+  // Initialize configuration
+  const config = new McpConfiguration(strapi);
+
+  // Initialize session manager
+  const sessionManager = new McpSessionManager(config, strapi);
+
+  // Status tracking
+  let serverStatus: Modules.MCP.McpServiceStatus = 'idle';
+
+  // Cleanup interval management
+  const cleanupSessionsInterval = createManagedInterval();
+
+  // Definition registries
+  const toolDefinitions = new McpCapabilityDefinitionRegistry<
+    'tool',
+    Modules.MCP.McpToolDefinition
+  >('tool');
+
+  const promptDefinitions = new McpCapabilityDefinitionRegistry<
+    'prompt',
+    Modules.MCP.McpPromptDefinition
+  >('prompt');
+
+  const resourceDefinitions = new McpCapabilityDefinitionRegistry<
+    'resource',
+    Modules.MCP.McpResourceDefinition
+  >('resource');
+
+  // Prepare handler dependencies
+  const handlerDependencies: McpHandlerDependencies = {
+    strapi,
+    sessionManager,
+    config,
+    createServerWithRegistries: createMcpServerWithRegistries,
+    capabilityDefinitions: {
+      tools: toolDefinitions,
+      prompts: promptDefinitions,
+      resources: resourceDefinitions,
+    },
+  };
+
+  // Create HTTP handlers
+  const handlePost = createPostHandler(handlerDependencies);
+  const handleGet = createGetHandler(handlerDependencies);
+  const handleDelete = createDeleteHandler(handlerDependencies);
+
+  const service: Modules.MCP.McpService = {
+    isEnabled() {
+      return config.isEnabled();
+    },
+
+    isRunning() {
+      return serverStatus === 'running';
+    },
+
+    registerTool(tool) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Tools must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      const { inputSchema, ...rest } = tool;
+      toolDefinitions.define({
+        ...rest,
+        inputSchema,
+      });
+    },
+
+    registerPrompt(prompt) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Prompts must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      const { argsSchema, ...rest } = prompt;
+      promptDefinitions.define({
+        ...rest,
+        argsSchema,
+      });
+    },
+
+    registerResource(resource) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Resources must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      resourceDefinitions.define(resource);
+    },
+
+    async start() {
+      if (service.isEnabled() === false) {
+        strapi.log.debug('[MCP] Server is disabled');
+        return;
+      }
+      if (serverStatus === 'error') {
+        throw new Error('[MCP] Cannot start server: previous error state');
+      }
+      if (serverStatus !== 'idle') {
+        throw new Error(`[MCP] Server already started or starting (status: ${serverStatus})`);
+      }
+      serverStatus = 'starting';
+
+      const routes = createMcpRoutes(config, { handlePost, handleGet, handleDelete });
+      strapi.server.routes(routes);
+
+      // Set status to 'running' after routes are registered
+      serverStatus = 'running';
+
+      // Start periodic cleanup of idle sessions
+      cleanupSessionsInterval.start(() => {
+        sessionManager.cleanupIdleSessions();
+      }, config.cleanupIntervalMs);
+
+      const baseUrl = strapi.config.get('server.url', 'http://localhost:1337');
+      strapi.log.info(`[MCP] Server available at ${baseUrl}${config.path}`);
+    },
+
+    async stop() {
+      serverStatus = 'stopping';
+
+      try {
+        const { erroredSessionMessages, hasErrors } = await sessionManager.closeAllSessions();
+
+        // Log any errors encountered during session closures
+        if (hasErrors === true) {
+          strapi.log.error(
+            `[MCP] Errors occurred while stopping sessions:\n${erroredSessionMessages.join('\n')}`
+          );
+          serverStatus = 'error';
+        } else {
+          serverStatus = 'idle';
+        }
+      } catch (error) {
+        strapi.log.error('[MCP] Error stopping service', {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+        serverStatus = 'error';
+      } finally {
+        // Clear cleanup interval
+        cleanupSessionsInterval.clear();
+
+        strapi.log.info('[MCP] Service stopped');
+      }
+    },
+  };
+
+  service.registerTool(logToolDefinition);
+
+  return service;
+};

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
@@ -1,0 +1,40 @@
+import type { Modules } from '@strapi/types';
+
+export class McpCapabilityDefinitionRegistry<
+  CapabilityName extends 'tool' | 'prompt' | 'resource',
+  Definition extends Modules.MCP.McpCapabilityDefinition,
+> {
+  capability: CapabilityName;
+
+  #definitions = new Map<string, Definition>();
+
+  constructor(capability: CapabilityName) {
+    this.capability = capability;
+  }
+
+  define(definition: Definition) {
+    const existing = this.#definitions.get(definition.name);
+    if (existing !== undefined) {
+      throw new Error(
+        `[MCP] ${this.capability} with name "${definition.name}" is already registered. Names must be unique.`
+      );
+    }
+    this.#definitions.set(definition.name, definition);
+  }
+
+  get(name: string): Definition | undefined {
+    return this.#definitions.get(name);
+  }
+
+  delete(name: string): boolean {
+    return this.#definitions.delete(name);
+  }
+
+  get values(): Definition[] {
+    return Array.from(this.#definitions.values());
+  }
+
+  get size(): number {
+    return this.#definitions.size;
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
@@ -1,0 +1,133 @@
+import type { Modules } from '@strapi/types';
+// eslint-disable-next-line import/extensions
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpCapabilityDefinitionRegistry } from './McpCapabilityDefinitionRegistry';
+
+export interface McpCapabilityRegistry {
+  bind: (mcpServer: McpServer) => void;
+}
+
+export type RegisteredCapability = {
+  enabled: boolean;
+  enable(): void;
+  disable(): void;
+  remove(): void;
+};
+
+export class McpCapabilityRegistryBase<
+  CapabilityName extends 'tool' | 'prompt' | 'resource',
+  Definition extends Modules.MCP.McpCapabilityDefinition,
+  Registered extends RegisteredCapability,
+> {
+  #definitions: McpCapabilityDefinitionRegistry<CapabilityName, Definition>;
+
+  #registered = new Map<string, Registered>();
+
+  constructor(definitions: McpCapabilityDefinitionRegistry<CapabilityName, Definition>) {
+    this.#definitions = definitions;
+  }
+
+  protected register<LocallyRegistered extends Registered>(
+    registerFn: (definition: Definition) => LocallyRegistered
+  ) {
+    for (const definition of this.#definitions.values) {
+      const existing = this.#registered.get(definition.name);
+      if (existing !== undefined) {
+        throw new Error(
+          `[MCP] ${this.#definitions.capability} with name "${definition.name}" is already registered. Names must be unique.`
+        );
+      }
+
+      const registered = registerFn(definition);
+
+      // Disable the capability until explicitly enabled depending on devModeOnly and authorization
+      registered.disable();
+
+      this.#registered.set(definition.name, registered);
+    }
+  }
+
+  list(ctx?: {
+    filter?: {
+      status?: ('enabled' | 'disabled' | 'defined' | 'undefined')[];
+    };
+  }) {
+    const { filter } = ctx ?? {};
+    return this.#definitions.values.reduce<
+      {
+        name: string;
+        status: 'enabled' | 'disabled' | 'defined' | 'undefined';
+        devModeOnly: boolean;
+      }[]
+    >((acc, curr) => {
+      const status = this.status(curr.name);
+      if (filter?.status !== undefined && !filter.status.includes(status)) {
+        return acc;
+      }
+      acc.push({ name: curr.name, status, devModeOnly: curr.devModeOnly });
+      return acc;
+    }, []);
+  }
+
+  status(name: string): 'enabled' | 'disabled' | 'defined' | 'undefined' {
+    const registered = this.#registered.get(name);
+    if (registered !== undefined) {
+      return registered.enabled === true ? 'enabled' : 'disabled';
+    }
+    const definition = this.#definitions.get(name);
+    if (definition !== undefined) {
+      return 'defined';
+    }
+    return 'undefined';
+  }
+
+  enable(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.enable();
+  }
+
+  enableAll() {
+    for (const registered of this.#registered.values()) {
+      registered.enable();
+    }
+  }
+
+  disable(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.disable();
+  }
+
+  disableAll() {
+    for (const registered of this.#registered.values()) {
+      registered.disable();
+    }
+  }
+
+  remove(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.remove();
+    this.#registered.delete(name);
+  }
+
+  removeAll() {
+    for (const registered of this.#registered.values()) {
+      registered.remove();
+    }
+    this.#registered.clear();
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
+++ b/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
@@ -1,0 +1,39 @@
+import type { Core } from '@strapi/types';
+
+export class McpConfiguration {
+  readonly path: string;
+
+  readonly sessionIdleTimeoutMs: number;
+
+  readonly maxSessions: number;
+
+  readonly cleanupIntervalMs: number;
+
+  readonly requestTimeoutMs: number;
+
+  #strapi: Core.Strapi;
+
+  constructor(strapi: Core.Strapi) {
+    this.#strapi = strapi;
+    this.path = '/mcp';
+    this.sessionIdleTimeoutMs = strapi.config.get(
+      'server.mcp.sessionIdleTimeoutMs',
+      30 * 60 * 1000
+    ); // 30 minutes
+    this.maxSessions = strapi.config.get('server.mcp.maxSessions', 100);
+    this.cleanupIntervalMs = strapi.config.get('server.mcp.cleanupIntervalMs', 5 * 60 * 1000); // 5 minutes
+    this.requestTimeoutMs = strapi.config.get('server.mcp.requestTimeoutMs', 30 * 1000); // 30 seconds
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.#strapi.config.get('server.mcp.enabled', false) &&
+      // Only enabled in development mode until Auth is implemented
+      this.#strapi.config.get('autoReload') === true
+    );
+  }
+
+  isDevMode(): boolean {
+    return this.#strapi.config.get('autoReload', false);
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
+++ b/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
@@ -1,0 +1,113 @@
+// eslint-disable-next-line import/extensions
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { McpPromptRegistry } from '../prompt-registry';
+import { McpResourceRegistry } from '../resource-registry';
+import { McpToolRegistry } from '../tool-registry';
+import { McpCapabilityDefinitionRegistry } from './McpCapabilityDefinitionRegistry';
+
+export type McpCapabilityDefinitions = {
+  tools: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  prompts: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  resources: McpCapabilityDefinitionRegistry<'resource', Modules.MCP.McpResourceDefinition>;
+};
+
+export type McpRegistries = {
+  toolRegistry: McpToolRegistry;
+  promptRegistry: McpPromptRegistry;
+  resourceRegistry: McpResourceRegistry;
+};
+
+export type McpServerWithRegistries = {
+  mcpServer: McpServer;
+  registries: McpRegistries;
+};
+
+export type CreateMcpServerWithRegistriesParams = {
+  strapi: Core.Strapi;
+  definitions: McpCapabilityDefinitions;
+  isDevMode: boolean;
+};
+
+export const createMcpServerWithRegistries = ({
+  strapi,
+  definitions,
+  isDevMode,
+}: CreateMcpServerWithRegistriesParams): McpServerWithRegistries => {
+  const capabilities: {
+    logging?: Record<string, unknown>;
+    tools?: Record<string, unknown>;
+    prompts?: Record<string, unknown>;
+    resources?: Record<string, unknown>;
+  } = {
+    logging: {},
+  };
+  if (definitions.tools.size > 0) {
+    capabilities.tools = {};
+  }
+  if (definitions.prompts.size > 0) {
+    capabilities.prompts = {};
+  }
+  if (definitions.resources.size > 0) {
+    capabilities.resources = {};
+  }
+
+  const mcpServer = new McpServer(
+    {
+      name: 'strapi-mcp-server',
+      version: '1.0.0',
+    },
+    {
+      capabilities,
+    }
+  );
+
+  // Bootstrap registries with current definitions
+  const toolRegistry = new McpToolRegistry({
+    strapi,
+    definitions: definitions.tools,
+  });
+  const promptRegistry = new McpPromptRegistry({
+    strapi,
+    definitions: definitions.prompts,
+  });
+  const resourceRegistry = new McpResourceRegistry({
+    strapi,
+    definitions: definitions.resources,
+  });
+
+  // Register capabilities (disabled by default)
+  toolRegistry.bind(mcpServer);
+  promptRegistry.bind(mcpServer);
+  resourceRegistry.bind(mcpServer);
+
+  // TODO @Nico: Manage Permissions from Auth
+
+  // Enable devModeOnly capabilities when running in dev mode
+  if (isDevMode === true) {
+    toolRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        toolRegistry.enable(cap.name);
+      }
+    });
+    promptRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        promptRegistry.enable(cap.name);
+      }
+    });
+    resourceRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        resourceRegistry.enable(cap.name);
+      }
+    });
+  }
+
+  return {
+    mcpServer,
+    registries: {
+      toolRegistry,
+      promptRegistry,
+      resourceRegistry,
+    },
+  };
+};

--- a/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
+++ b/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
@@ -1,0 +1,120 @@
+import type { Core } from '@strapi/types';
+import { McpSession } from '../session';
+import { McpConfiguration } from './McpConfiguration';
+
+export class McpSessionManager {
+  #sessions = new Map<string, McpSession>();
+
+  #config: McpConfiguration;
+
+  #strapi: Core.Strapi;
+
+  constructor(config: McpConfiguration, strapi: Core.Strapi) {
+    this.#config = config;
+    this.#strapi = strapi;
+  }
+
+  get(id: string): McpSession | undefined {
+    return this.#sessions.get(id);
+  }
+
+  set(id: string, session: McpSession): void {
+    this.#sessions.set(id, session);
+  }
+
+  async delete(id: string): Promise<void> {
+    const session = this.#sessions.get(id);
+    if (session === undefined) {
+      return;
+    }
+    try {
+      await session.server.close();
+    } catch (err) {
+      this.#strapi.log.error('[MCP] Error closing server for session', {
+        sessionId: id,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    } finally {
+      this.#sessions.delete(id);
+    }
+  }
+
+  hasReachedMaxSessions(): boolean {
+    return this.#sessions.size >= this.#config.maxSessions;
+  }
+
+  get size(): number {
+    return this.#sessions.size;
+  }
+
+  cleanupIdleSessions(): string[] {
+    const now = Date.now();
+    const expiredSessions: string[] = [];
+
+    for (const [sessionId, session] of this.#sessions.entries()) {
+      const idleTime = now - session.lastActivity;
+      if (idleTime >= this.#config.sessionIdleTimeoutMs) {
+        expiredSessions.push(sessionId);
+      }
+    }
+
+    for (const sessionId of expiredSessions) {
+      const session = this.#sessions.get(sessionId);
+      if (session !== undefined) {
+        session.server.close().catch((err) => {
+          this.#strapi.log.error('[MCP] Error closing expired session', {
+            sessionId,
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+        });
+        this.#sessions.delete(sessionId);
+        this.#strapi.log.info('[MCP] Expired session cleaned up', { sessionId });
+      }
+    }
+
+    return expiredSessions;
+  }
+
+  async closeAllSessions(): Promise<{
+    erroredSessionMessages: string[];
+    hasErrors: boolean;
+  }> {
+    const closeSessionPromises = Array.from(this.#sessions.entries()).map(
+      async ([sessionId, { server, transport }]) =>
+        Promise.allSettled([transport.close(), server.close()]).then(
+          ([transportResult, serverResult]) => ({
+            sessionId,
+            transportResult,
+            serverResult,
+          })
+        )
+    );
+
+    const closedSessions = await Promise.all(closeSessionPromises);
+
+    const erroredSessionMessages = closedSessions
+      .filter(
+        ({ transportResult, serverResult }) =>
+          transportResult.status === 'rejected' || serverResult.status === 'rejected'
+      )
+      .map(
+        ({ sessionId, transportResult, serverResult }) =>
+          `session ${sessionId}: ${
+            transportResult.status === 'rejected'
+              ? `Transport error: ${transportResult.reason instanceof Error ? transportResult.reason.message : String(transportResult.reason)}.`
+              : ''
+          } ${
+            serverResult.status === 'rejected'
+              ? `Server error: ${serverResult.reason instanceof Error ? serverResult.reason.message : String(serverResult.reason)}.`
+              : ''
+          }`
+      );
+
+    this.#sessions.clear();
+
+    return {
+      erroredSessionMessages,
+      hasErrors: erroredSessionMessages.length > 0,
+    };
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
@@ -1,0 +1,89 @@
+import type { Modules } from '@strapi/types';
+
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+
+describe('McpCapabilityDefinitionRegistry', () => {
+  test('stores capability type', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    expect(registry.capability).toBe('tool');
+  });
+
+  test('define() registers a definition and get() returns it', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    const definition: Modules.MCP.McpCapabilityDefinition = {
+      name: 'my-capability',
+      devModeOnly: false,
+    };
+
+    registry.define(definition);
+
+    expect(registry.get('my-capability')).toBe(definition);
+    expect(registry.get('unknown')).toBeUndefined();
+    expect(registry.size).toBe(1);
+    expect(registry.values).toEqual([definition]);
+  });
+
+  test('define() throws when name is already registered', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'prompt',
+      Modules.MCP.McpCapabilityDefinition
+    >('prompt');
+
+    const definitionA: Modules.MCP.McpCapabilityDefinition = {
+      name: 'duplicate',
+      devModeOnly: true,
+    };
+    const definitionB: Modules.MCP.McpCapabilityDefinition = {
+      name: 'duplicate',
+      devModeOnly: false,
+    };
+
+    registry.define(definitionA);
+
+    expect(() => registry.define(definitionB)).toThrow(
+      '[MCP] prompt with name "duplicate" is already registered. Names must be unique.'
+    );
+
+    expect(registry.get('duplicate')).toBe(definitionA);
+    expect(registry.size).toBe(1);
+  });
+
+  test('delete() removes definitions and reports success', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'resource',
+      Modules.MCP.McpCapabilityDefinition
+    >('resource');
+
+    const definitionA: Modules.MCP.McpCapabilityDefinition = {
+      name: 'a',
+      devModeOnly: false,
+    };
+    const definitionB: Modules.MCP.McpCapabilityDefinition = {
+      name: 'b',
+      devModeOnly: true,
+    };
+
+    registry.define(definitionA);
+    registry.define(definitionB);
+
+    expect(registry.size).toBe(2);
+    expect(registry.values).toEqual([definitionA, definitionB]);
+
+    expect(registry.delete('a')).toBe(true);
+    expect(registry.get('a')).toBeUndefined();
+    expect(registry.size).toBe(1);
+    expect(registry.values).toEqual([definitionB]);
+
+    expect(registry.delete('a')).toBe(false);
+    expect(registry.delete('unknown')).toBe(false);
+    expect(registry.size).toBe(1);
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
@@ -1,0 +1,562 @@
+import type { Modules } from '@strapi/types';
+import { McpCapabilityRegistryBase, RegisteredCapability } from '../McpCapabilityRegistry';
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+
+// Mock definition type for testing
+type MockDefinition = Modules.MCP.McpCapabilityDefinition<string> & {
+  title: string;
+  description: string;
+};
+
+// Mock registered capability for testing
+class MockRegisteredCapability implements RegisteredCapability {
+  enabled: boolean = false;
+
+  enable = jest.fn(() => {
+    this.enabled = true;
+  });
+
+  disable = jest.fn(() => {
+    this.enabled = false;
+  });
+
+  remove = jest.fn();
+}
+
+// Concrete implementation for testing
+class TestCapabilityRegistry extends McpCapabilityRegistryBase<
+  'tool',
+  MockDefinition,
+  MockRegisteredCapability
+> {
+  registerDefinitions() {
+    this.register(() => new MockRegisteredCapability());
+  }
+}
+
+describe('McpCapabilityRegistryBase', () => {
+  let definitionRegistry: McpCapabilityDefinitionRegistry<'tool', MockDefinition>;
+  let registry: TestCapabilityRegistry;
+
+  beforeEach(() => {
+    definitionRegistry = new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool');
+    registry = new TestCapabilityRegistry(definitionRegistry);
+  });
+
+  describe('register', () => {
+    test('should register all definitions from the definition registry', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+
+      registry.registerDefinitions();
+
+      const list = registry.list();
+      expect(list).toHaveLength(2);
+      expect(list[0].name).toBe('tool-1');
+      expect(list[1].name).toBe('tool-2');
+    });
+
+    test('should disable capabilities by default after registration', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+
+      registry.registerDefinitions();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should throw error when registering a capability with duplicate name', () => {
+      definitionRegistry.define({
+        name: 'duplicate-tool',
+        title: 'Tool',
+        description: 'Tool',
+        devModeOnly: false,
+      });
+
+      registry.registerDefinitions();
+
+      // Try to register again
+      expect(() => {
+        registry.registerDefinitions();
+      }).toThrow(
+        '[MCP] tool with name "duplicate-tool" is already registered. Names must be unique.'
+      );
+    });
+  });
+
+  describe('list', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      definitionRegistry.define({
+        name: 'tool-3',
+        title: 'Tool 3',
+        description: 'Third tool',
+        devModeOnly: false,
+      });
+    });
+
+    test('should list all capabilities with status', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list();
+
+      expect(list).toHaveLength(3);
+      expect(list).toEqual([
+        { name: 'tool-1', status: 'disabled', devModeOnly: false },
+        { name: 'tool-2', status: 'disabled', devModeOnly: true },
+        { name: 'tool-3', status: 'disabled', devModeOnly: false },
+      ]);
+    });
+
+    test('should list capabilities filtered by enabled status', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['enabled'] },
+      });
+
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual({ name: 'tool-1', status: 'enabled', devModeOnly: false });
+    });
+
+    test('should list capabilities filtered by disabled status', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['disabled'] },
+      });
+
+      expect(list).toHaveLength(2);
+      expect(list[0].name).toBe('tool-2');
+      expect(list[1].name).toBe('tool-3');
+    });
+
+    test('should list capabilities filtered by defined status', () => {
+      // Don't register, only define
+      const list = registry.list({
+        filter: { status: ['defined'] },
+      });
+
+      expect(list).toHaveLength(3);
+      expect(list[0]).toEqual({ name: 'tool-1', status: 'defined', devModeOnly: false });
+      expect(list[1]).toEqual({ name: 'tool-2', status: 'defined', devModeOnly: true });
+      expect(list[2]).toEqual({ name: 'tool-3', status: 'defined', devModeOnly: false });
+    });
+
+    test('should list capabilities filtered by multiple statuses', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['enabled', 'disabled'] },
+      });
+
+      expect(list).toHaveLength(3);
+    });
+
+    test('should return empty array when no capabilities match filter', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list({
+        filter: { status: ['enabled'] },
+      });
+
+      expect(list).toHaveLength(0);
+    });
+
+    test('should include devModeOnly flag in list results', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list();
+
+      expect(list[0].devModeOnly).toBe(false);
+      expect(list[1].devModeOnly).toBe(true);
+      expect(list[2].devModeOnly).toBe(false);
+    });
+  });
+
+  describe('status', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+    });
+
+    test('should return "disabled" for registered but disabled capability', () => {
+      registry.registerDefinitions();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should return "enabled" for registered and enabled capability', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should return "defined" for defined but not registered capability', () => {
+      // Don't call registerDefinitions
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should return "undefined" for unknown capability', () => {
+      expect(registry.status('unknown-tool')).toBe('undefined');
+    });
+  });
+
+  describe('enable', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should enable a disabled capability', () => {
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should call enable method on registered capability', () => {
+      registry.enable('tool-1');
+
+      // The enable method should have been called through the internal registered capability
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should throw error when enabling unregistered capability', () => {
+      expect(() => {
+        registry.enable('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+  });
+
+  describe('enableAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should enable all registered capabilities', () => {
+      registry.enableAll();
+
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('enabled');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.enableAll();
+      }).not.toThrow();
+    });
+  });
+
+  describe('disable', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should disable an enabled capability', () => {
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+
+      registry.disable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should call disable method on registered capability', () => {
+      registry.enable('tool-1');
+
+      registry.disable('tool-1');
+
+      // The disable method should have been called through the internal registered capability
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should throw error when disabling unregistered capability', () => {
+      expect(() => {
+        registry.disable('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+  });
+
+  describe('disableAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should disable all registered capabilities', () => {
+      registry.enableAll();
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('enabled');
+
+      registry.disableAll();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.disableAll();
+      }).not.toThrow();
+    });
+  });
+
+  describe('remove', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should remove a registered capability', () => {
+      expect(registry.status('tool-1')).toBe('disabled');
+
+      registry.remove('tool-1');
+
+      // Should now be "defined" since it's only in definition registry
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should call remove method on registered capability', () => {
+      registry.remove('tool-1');
+
+      // Verify it was removed by checking it's no longer in the list of registered
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should throw error when removing unregistered capability', () => {
+      expect(() => {
+        registry.remove('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+
+    test('should allow removing and re-registering a capability', () => {
+      registry.remove('tool-1');
+      expect(registry.status('tool-1')).toBe('defined');
+
+      registry.registerDefinitions();
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+  });
+
+  describe('removeAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should remove all registered capabilities', () => {
+      expect(registry.status('tool-1')).toBe('disabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+
+      registry.removeAll();
+
+      // Should now be "defined" since they're only in definition registry
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('defined');
+    });
+
+    test('should call remove method on all registered capabilities', () => {
+      registry.removeAll();
+
+      // Verify they were removed by checking status
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('defined');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.removeAll();
+      }).not.toThrow();
+    });
+
+    test('should clear the registered capabilities map', () => {
+      registry.removeAll();
+
+      const list = registry.list({ filter: { status: ['disabled', 'enabled'] } });
+      expect(list).toHaveLength(0);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    test('should handle enable-disable-enable cycle', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+
+      registry.disable('tool-1');
+      expect(registry.status('tool-1')).toBe('disabled');
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should handle enableAll-disableAll cycle', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enableAll();
+      expect(registry.list({ filter: { status: ['enabled'] } })).toHaveLength(2);
+
+      registry.disableAll();
+      expect(registry.list({ filter: { status: ['enabled'] } })).toHaveLength(0);
+    });
+
+    test('should handle partial enable and selective removal', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+
+      registry.remove('tool-1');
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+
+    test('should maintain separate state for each capability', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
@@ -1,0 +1,121 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from '../McpConfiguration';
+
+describe('McpConfiguration', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let configGetSpy: jest.Mock;
+
+  beforeEach(() => {
+    configGetSpy = jest.fn();
+    mockStrapi = {
+      config: {
+        get: configGetSpy,
+      } as any,
+    };
+  });
+
+  test('should initialize with default values when config is not set', () => {
+    configGetSpy.mockImplementation((key, defaultValue) => defaultValue);
+
+    const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    expect(config.path).toBe('/mcp');
+    expect(config.sessionIdleTimeoutMs).toBe(30 * 60 * 1000);
+    expect(config.maxSessions).toBe(100);
+    expect(config.cleanupIntervalMs).toBe(5 * 60 * 1000);
+    expect(config.requestTimeoutMs).toBe(30 * 1000);
+  });
+
+  test('should use custom config values when provided', () => {
+    configGetSpy.mockImplementation((key, defaultValue) => {
+      const customConfig: Record<string, any> = {
+        'server.mcp.sessionIdleTimeoutMs': 10 * 60 * 1000,
+        'server.mcp.maxSessions': 50,
+        'server.mcp.cleanupIntervalMs': 2 * 60 * 1000,
+        'server.mcp.requestTimeoutMs': 60 * 1000,
+      };
+      return customConfig[key] ?? defaultValue;
+    });
+
+    const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    expect(config.sessionIdleTimeoutMs).toBe(10 * 60 * 1000);
+    expect(config.maxSessions).toBe(50);
+    expect(config.cleanupIntervalMs).toBe(2 * 60 * 1000);
+    expect(config.requestTimeoutMs).toBe(60 * 1000);
+  });
+
+  describe('isEnabled', () => {
+    test('should return true when both mcp.enabled and autoReload are true', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return true;
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(true);
+    });
+
+    test('should return false when mcp.enabled is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return false;
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+
+    test('should return false when autoReload is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return true;
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+
+    test('should return false when both are false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return false;
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('isDevMode', () => {
+    test('should return true when autoReload is true', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isDevMode()).toBe(true);
+    });
+
+    test('should return false when autoReload is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isDevMode()).toBe(false);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
@@ -1,0 +1,149 @@
+import type { Core, Modules } from '@strapi/types';
+import * as z from 'zod';
+import type { RegisteredCapability } from '../McpCapabilityRegistry';
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+import { createMcpServerWithRegistries } from '../McpServerFactory';
+
+// Mock registered capability for testing
+class MockRegisteredCapability implements RegisteredCapability {
+  enabled: boolean = false;
+
+  enable = jest.fn(() => {
+    this.enabled = true;
+  });
+
+  disable = jest.fn(() => {
+    this.enabled = false;
+  });
+
+  remove = jest.fn();
+}
+
+// Mock the MCP SDK
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    registerTool() {
+      return new MockRegisteredCapability();
+    },
+    registerPrompt() {
+      return new MockRegisteredCapability();
+    },
+    registerResource() {
+      return new MockRegisteredCapability();
+    },
+  })),
+}));
+
+describe('createMcpServerWithRegistries', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let toolDefinitions: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  let promptDefinitions: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  let resourceDefinitions: McpCapabilityDefinitionRegistry<
+    'resource',
+    Modules.MCP.McpResourceDefinition
+  >;
+
+  beforeEach(() => {
+    mockStrapi = {} as Core.Strapi;
+    toolDefinitions = new McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>(
+      'tool'
+    );
+    promptDefinitions = new McpCapabilityDefinitionRegistry<
+      'prompt',
+      Modules.MCP.McpPromptDefinition
+    >('prompt');
+    resourceDefinitions = new McpCapabilityDefinitionRegistry<
+      'resource',
+      Modules.MCP.McpResourceDefinition
+    >('resource');
+  });
+
+  test('should create MCP server with registries', () => {
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    expect(result.mcpServer).toBeDefined();
+    expect(result.registries.toolRegistry).toBeDefined();
+    expect(result.registries.promptRegistry).toBeDefined();
+    expect(result.registries.resourceRegistry).toBeDefined();
+  });
+
+  test('should enable devModeOnly capabilities when in dev mode', () => {
+    // Add a devModeOnly tool
+    toolDefinitions.define({
+      name: 'dev-tool',
+      title: 'Dev Tool',
+      description: 'A dev-only tool',
+      devModeOnly: true,
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: true,
+    });
+
+    // The tool should be enabled
+    const enabledTools = result.registries.toolRegistry.list({ filter: { status: ['enabled'] } });
+    expect(enabledTools.some((t) => t.name === 'dev-tool')).toBe(true);
+  });
+
+  test('should not enable devModeOnly capabilities when not in dev mode', () => {
+    // Add a devModeOnly tool
+    toolDefinitions.define({
+      name: 'dev-tool',
+      title: 'Dev Tool',
+      description: 'A dev-only tool',
+      devModeOnly: true,
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    // The tool should remain disabled
+    const disabledTools = result.registries.toolRegistry.list({
+      filter: { status: ['disabled'] },
+    });
+    expect(disabledTools.some((t) => t.name === 'dev-tool')).toBe(true);
+  });
+
+  test('should handle empty definitions', () => {
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    expect(result.registries.toolRegistry.list().length).toBe(0);
+    expect(result.registries.promptRegistry.list().length).toBe(0);
+    expect(result.registries.resourceRegistry.list().length).toBe(0);
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
@@ -1,0 +1,206 @@
+import type { Core } from '@strapi/types';
+import { McpSession } from '../../session';
+import { McpConfiguration } from '../McpConfiguration';
+import { McpSessionManager } from '../McpSessionManager';
+
+describe('McpSessionManager', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let sessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+        info: logInfoSpy,
+      } as any,
+      config: {
+        get: jest.fn((_, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    sessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  describe('get and set', () => {
+    test('should store and retrieve sessions', () => {
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: jest.fn() },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      expect(sessionManager.get('session-1')).toBe(mockSession);
+    });
+
+    test('should return undefined for non-existent session', () => {
+      expect(sessionManager.get('non-existent')).toBeUndefined();
+    });
+  });
+
+  describe('delete', () => {
+    test('should delete session and close server', async () => {
+      const closeSpy = jest.fn().mockResolvedValue(undefined);
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: closeSpy },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      await sessionManager.delete('session-1');
+
+      expect(closeSpy).toHaveBeenCalled();
+      expect(sessionManager.get('session-1')).toBeUndefined();
+    });
+
+    test('should handle errors when closing server', async () => {
+      const error = new Error('Close failed');
+      const closeSpy = jest.fn().mockRejectedValue(error);
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: closeSpy },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      await sessionManager.delete('session-1');
+
+      expect(logErrorSpy).toHaveBeenCalledWith('[MCP] Error closing server for session', {
+        sessionId: 'session-1',
+        error: 'Close failed',
+      });
+      expect(sessionManager.get('session-1')).toBeUndefined();
+    });
+
+    test('should do nothing if session does not exist', async () => {
+      await sessionManager.delete('non-existent');
+
+      expect(logErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasReachedMaxSessions', () => {
+    test('should return false when below max sessions', () => {
+      expect(sessionManager.hasReachedMaxSessions()).toBe(false);
+    });
+
+    test('should return true when at max sessions', () => {
+      const maxSessions = mockConfig.maxSessions;
+      for (
+        let i = 0;
+        i < maxSessions;
+        // eslint-disable-next-line no-plusplus
+        i++
+      ) {
+        sessionManager.set(`session-${i}`, {
+          lastActivity: Date.now(),
+        } as any as McpSession);
+      }
+
+      expect(sessionManager.hasReachedMaxSessions()).toBe(true);
+    });
+  });
+
+  describe('size', () => {
+    test('should return the number of active sessions', () => {
+      expect(sessionManager.size).toBe(0);
+
+      sessionManager.set('session-1', { lastActivity: Date.now() } as any as McpSession);
+      expect(sessionManager.size).toBe(1);
+
+      sessionManager.set('session-2', { lastActivity: Date.now() } as any as McpSession);
+      expect(sessionManager.size).toBe(2);
+    });
+  });
+
+  describe('cleanupIdleSessions', () => {
+    test('should remove idle sessions', () => {
+      const now = Date.now();
+      const idleTime = mockConfig.sessionIdleTimeoutMs + 1000;
+
+      const activeSession = {
+        lastActivity: now,
+        server: { close: jest.fn() },
+      } as any as McpSession;
+
+      const idleSession = {
+        lastActivity: now - idleTime,
+        server: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession;
+
+      sessionManager.set('active', activeSession);
+      sessionManager.set('idle', idleSession);
+
+      const expired = sessionManager.cleanupIdleSessions();
+
+      expect(expired).toEqual(['idle']);
+      expect(sessionManager.get('active')).toBe(activeSession);
+      expect(sessionManager.get('idle')).toBeUndefined();
+    });
+
+    test('should handle errors when closing idle sessions', () => {
+      const now = Date.now();
+      const idleTime = mockConfig.sessionIdleTimeoutMs + 1000;
+
+      const idleSession = {
+        lastActivity: now - idleTime,
+        server: { close: jest.fn().mockRejectedValue(new Error('Close failed')) },
+      } as any as McpSession;
+
+      sessionManager.set('idle', idleSession);
+
+      const expired = sessionManager.cleanupIdleSessions();
+
+      expect(expired).toEqual(['idle']);
+      expect(sessionManager.get('idle')).toBeUndefined();
+    });
+  });
+
+  describe('closeAllSessions', () => {
+    test('should close all sessions successfully', async () => {
+      const closeSpy1 = jest.fn().mockResolvedValue(undefined);
+      const closeSpy2 = jest.fn().mockResolvedValue(undefined);
+
+      sessionManager.set('session-1', {
+        server: { close: closeSpy1 },
+        transport: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession);
+
+      sessionManager.set('session-2', {
+        server: { close: closeSpy2 },
+        transport: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession);
+
+      const result = await sessionManager.closeAllSessions();
+
+      expect(result.hasErrors).toBe(false);
+      expect(result.erroredSessionMessages).toEqual([]);
+      expect(sessionManager.size).toBe(0);
+    });
+
+    test('should handle errors when closing sessions', async () => {
+      const serverError = new Error('Server close failed');
+      const transportError = new Error('Transport close failed');
+
+      sessionManager.set('session-1', {
+        server: { close: jest.fn().mockRejectedValue(serverError) },
+        transport: { close: jest.fn().mockRejectedValue(transportError) },
+      } as any as McpSession);
+
+      const result = await sessionManager.closeAllSessions();
+
+      expect(result.hasErrors).toBe(true);
+      expect(result.erroredSessionMessages.length).toBe(1);
+      expect(result.erroredSessionMessages[0]).toContain('session-1');
+      expect(result.erroredSessionMessages[0]).toContain('Transport error');
+      expect(result.erroredSessionMessages[0]).toContain('Server error');
+      expect(sessionManager.size).toBe(0);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/extractSessionId.ts
+++ b/packages/core/core/src/services/mcp/internal/extractSessionId.ts
@@ -1,0 +1,19 @@
+import type { IncomingMessage } from 'node:http';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_LENGTH = 36;
+
+function isValidUUID(str: string): boolean {
+  return str.length === UUID_LENGTH && UUID_REGEX.test(str);
+}
+
+export const extractSessionId = (req: IncomingMessage): string | undefined => {
+  const maybeSessionId = req.headers['mcp-session-id'];
+  if (typeof maybeSessionId === 'string' && maybeSessionId.length !== 0) {
+    if (isValidUUID(maybeSessionId) === true) {
+      return maybeSessionId;
+    }
+    return undefined;
+  }
+  return undefined;
+};

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -1,0 +1,91 @@
+// eslint-disable-next-line import/extensions
+import type { McpServer, RegisteredPrompt } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import * as z from 'zod';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpPromptDefinition = <
+  Name extends string,
+  Title extends string,
+  Description extends string,
+  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+>(prompt: {
+  name: Name;
+  title: Title;
+  description: Description;
+  argsSchema?: ArgsSchema;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpPromptCallback<ArgsSchema>;
+}): Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description> =>
+  prompt as Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description>;
+
+export class McpPromptRegistry
+  extends McpCapabilityRegistryBase<'prompt', Modules.MCP.McpPromptDefinition, RegisteredPrompt>
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, title, description, argsSchema, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Prompt',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async () => ({
+            messages: [
+              {
+                role: 'user' as const,
+                content: {
+                  type: 'text' as const,
+                  text: `Prompt "${name}" failed to initialize: ${errorMessage}`,
+                },
+              },
+            ],
+          });
+        },
+        createErrorResult(error) {
+          return {
+            messages: [
+              {
+                role: 'user' as const,
+                content: {
+                  type: 'text' as const,
+                  text: `Prompt "${name}" execution failed: ${error.message}`,
+                },
+              },
+            ],
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerPrompt(
+            name,
+            {
+              title,
+              description,
+              // @ts-expect-error - Internal handler type mismatch due to optional argsSchema
+              argsSchema,
+            },
+            safeHandler
+          );
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -1,0 +1,78 @@
+import type {
+  McpServer,
+  RegisteredResource,
+  ResourceMetadata,
+  // eslint-disable-next-line import/extensions
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpResourceDefinition = <Name extends string>(resource: {
+  name: Name;
+  uri: string;
+  metadata: ResourceMetadata;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpResourceCallback;
+}): Modules.MCP.McpResourceDefinition<Name> => resource as Modules.MCP.McpResourceDefinition<Name>;
+
+export class McpResourceRegistry
+  extends McpCapabilityRegistryBase<
+    'resource',
+    Modules.MCP.McpResourceDefinition,
+    RegisteredResource
+  >
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'resource', Modules.MCP.McpResourceDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, uri, metadata, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Resource',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async (resourceUri) => ({
+            contents: [
+              {
+                uri: resourceUri.href,
+                text: `Resource "${name}" failed to initialize: ${errorMessage}`,
+                mimeType: 'text/plain',
+              },
+            ],
+          });
+        },
+        createErrorResult(error, args) {
+          return {
+            contents: [
+              {
+                uri: args[0] instanceof URL ? args[0].href : uri,
+                text: `Resource "${name}" execution failed: ${error.message}`,
+                mimeType: 'text/plain',
+              },
+            ],
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerResource(name, uri, metadata, safeHandler);
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/routes.ts
+++ b/packages/core/core/src/services/mcp/routes.ts
@@ -1,0 +1,90 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from './internal/McpConfiguration';
+
+/**
+ * Handler for unsupported HTTP methods on /mcp endpoint.
+ * Returns JSON-RPC error instead of plain text so MCP clients can parse it.
+ */
+const handleMethodNotAllowed: Core.MiddlewareHandler = async (ctx) => {
+  ctx.status = 405;
+  ctx.set('Allow', 'GET, POST, DELETE');
+  ctx.set('Content-Type', 'application/json');
+  ctx.body = {
+    jsonrpc: '2.0',
+    error: { code: -32000, message: 'Method not allowed' },
+    id: null,
+  };
+};
+/**
+ * Handler for OAuth discovery endpoints.
+ * Returns JSON 404 so MCP clients skip OAuth and use Bearer token auth.
+ */
+const handleOAuthNotSupported: Core.MiddlewareHandler = async (ctx) => {
+  ctx.status = 404;
+  ctx.set('Content-Type', 'application/json');
+  ctx.body = { error: 'not_found', error_description: 'OAuth not supported' };
+};
+
+export type McpRouteHandlers = {
+  handlePost: Core.MiddlewareHandler;
+  handleGet: Core.MiddlewareHandler;
+  handleDelete: Core.MiddlewareHandler;
+};
+
+/**
+ * Creates MCP route definitions for registration with Strapi server.
+ * @internal
+ */
+export const createMcpRoutes = (
+  config: McpConfiguration,
+  handlers: McpRouteHandlers
+): Omit<Core.Route, 'info'>[] => {
+  const noAuth = { auth: false } as const;
+
+  return [
+    // Core MCP endpoints
+    { method: 'POST', path: config.path, handler: handlers.handlePost, config: noAuth },
+    { method: 'GET', path: config.path, handler: handlers.handleGet, config: noAuth },
+    { method: 'DELETE', path: config.path, handler: handlers.handleDelete, config: noAuth },
+    // Unsupported methods on /mcp - return JSON error for MCP client compatibility
+    { method: 'PUT', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
+    { method: 'PATCH', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
+    // OAuth discovery endpoints - return 404 JSON so clients fall back to Bearer auth
+    {
+      method: 'GET',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'POST',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'PUT',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'DELETE',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'PATCH',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    /**
+     * OAuth Dynamic Client Registration endpoint (RFC 7591).
+     * Claude Code's MCP client probes this endpoint; without a JSON response,
+     * Strapi returns plain text "Method Not Allowed" which breaks the client.
+     */
+    { method: 'POST', path: '/register', handler: handleOAuthNotSupported, config: noAuth },
+  ];
+};

--- a/packages/core/core/src/services/mcp/session.ts
+++ b/packages/core/core/src/services/mcp/session.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/extensions
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+// eslint-disable-next-line import/extensions
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpPromptRegistry } from './prompt-registry';
+import { McpResourceRegistry } from './resource-registry';
+import { McpToolRegistry } from './tool-registry';
+
+export class McpSession {
+  server: McpServer;
+
+  transport: StreamableHTTPServerTransport;
+
+  toolRegistry: McpToolRegistry;
+
+  promptRegistry: McpPromptRegistry;
+
+  resourceRegistry: McpResourceRegistry;
+
+  lastActivity: number;
+
+  constructor(params: {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+    toolRegistry: McpToolRegistry;
+    promptRegistry: McpPromptRegistry;
+    resourceRegistry: McpResourceRegistry;
+  }) {
+    this.server = params.server;
+    this.transport = params.transport;
+    this.toolRegistry = params.toolRegistry;
+    this.promptRegistry = params.promptRegistry;
+    this.resourceRegistry = params.resourceRegistry;
+    this.lastActivity = Date.now();
+  }
+
+  updateActivity(): void {
+    this.lastActivity = Date.now();
+  }
+}

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -1,0 +1,89 @@
+// eslint-disable-next-line import/extensions
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import * as z from 'zod';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpToolDefinition = <
+  Name extends string,
+  Title extends string,
+  Description extends string,
+  OutputSchema extends z.ZodObject<z.ZodRawShape>,
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+>(tool: {
+  name: Name;
+  title: Title;
+  description: Description;
+  inputSchema?: InputSchema;
+  outputSchema: OutputSchema;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpToolCallback<InputSchema, OutputSchema>;
+}): Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description> =>
+  tool as Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description>;
+
+export class McpToolRegistry
+  extends McpCapabilityRegistryBase<'tool', Modules.MCP.McpToolDefinition, RegisteredTool>
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, title, description, inputSchema, outputSchema, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Tool',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async () => ({
+            content: [
+              {
+                type: 'text' as const,
+                text: `Tool "${name}" failed to initialize: ${errorMessage}`,
+              },
+            ],
+            structuredContent: {
+              dope: true,
+            },
+            isError: true,
+          });
+        },
+        createErrorResult(error) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Tool "${name}" execution failed: ${error.message}`,
+              },
+            ],
+            structuredContent: {},
+            isError: true,
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerTool(
+            name,
+            { title, description, inputSchema, outputSchema },
+            // @ts-expect-error - Internal handler type mismatch due to optional inputSchema
+            safeHandler
+          );
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/tools/log.ts
+++ b/packages/core/core/src/services/mcp/tools/log.ts
@@ -1,0 +1,85 @@
+import * as z from 'zod';
+
+import { makeMcpToolDefinition } from '../tool-registry';
+
+export const logToolDefinition = makeMcpToolDefinition({
+  name: 'log',
+  title: 'Strapi Log',
+  description: 'Logs a message to the Strapi logger with specified level',
+  inputSchema: z.object({
+    message: z.string().describe('Message to log'),
+    level: z
+      .enum(['info', 'http', 'warn', 'error', 'log'])
+      .optional()
+      .describe('Log level (default: info)'),
+  }),
+  outputSchema: z.object({
+    status: z.string(),
+    message: z.string(),
+    level: z.string(),
+    timestamp: z.string(),
+  }),
+  devModeOnly: true,
+  createHandler: (strapi) => async (params) => {
+    const { message, level = 'info' } = params;
+
+    // Security: Sanitize message to prevent log injection
+    // 1. Limit length to prevent log spam (10KB max)
+    const MAX_MESSAGE_LENGTH = 10 * 1024;
+    let sanitizedMessage =
+      message.length > MAX_MESSAGE_LENGTH
+        ? `${message.substring(0, MAX_MESSAGE_LENGTH)}...[truncated]`
+        : message;
+
+    // 2. Remove control characters (including ANSI escape codes)
+    // This regex matches: \x00-\x1F (C0 controls), \x7F (DEL), \x80-\x9F (C1 controls)
+    // and ANSI escape sequences (\x1B[ followed by parameters and command)
+    sanitizedMessage = sanitizedMessage
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1B\[[0-9;]*[A-Za-z]/g, '') // Remove ANSI escape sequences
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1F\x7F-\x9F]/g, ''); // Remove control characters
+
+    // 3. Replace newlines with spaces to prevent fake log entry injection
+    sanitizedMessage = sanitizedMessage.replace(/[\r\n]+/g, ' ');
+
+    // 4. Trim whitespace
+    sanitizedMessage = sanitizedMessage.trim();
+
+    // Map level to appropriate logger method
+    switch (level) {
+      case 'http':
+        strapi.log.http(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'warn':
+        strapi.log.warn(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'error':
+        strapi.log.error(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'log':
+        strapi.log.info(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'info':
+      default:
+        strapi.log.info(`[MCP] ${sanitizedMessage}`);
+        break;
+    }
+
+    const result = {
+      status: 'logged',
+      message: sanitizedMessage,
+      level,
+      timestamp: new Date().toISOString(),
+    };
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      structuredContent: result,
+    };
+  },
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/createManagedInterval.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/createManagedInterval.test.ts
@@ -1,0 +1,107 @@
+import { createManagedInterval } from '../createManagedInterval';
+
+describe('createManagedInterval', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('starts interval and calls callback at specified interval', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  test('clears interval when clear is called', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    interval.clear();
+
+    jest.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(1); // Should not increase
+  });
+
+  test('clears existing interval when start is called again', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const interval = createManagedInterval();
+
+    // Start first interval
+    interval.start(callback1, 1000);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Start second interval - should clear first one
+    interval.start(callback2, 500);
+
+    // Advance by first interval time
+    jest.advanceTimersByTime(1000);
+    // First callback should not be called again
+    expect(callback1).toHaveBeenCalledTimes(1);
+    // Second callback should be called twice (500ms * 2 = 1000ms)
+    expect(callback2).toHaveBeenCalledTimes(2);
+  });
+
+  test('handles clear when no interval is active', () => {
+    const interval = createManagedInterval();
+
+    // Should not throw
+    expect(() => interval.clear()).not.toThrow();
+  });
+
+  test('handles multiple clear calls', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+    interval.clear();
+    interval.clear(); // Second clear
+
+    // Should not throw and callback should not be called
+    expect(() => interval.clear()).not.toThrow();
+    jest.advanceTimersByTime(2000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('can restart interval after clearing', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    interval.clear();
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1); // No additional calls
+
+    // Restart
+    interval.start(callback, 1000);
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(2); // Called again
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/createSafeCapabilityRegistration.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/createSafeCapabilityRegistration.test.ts
@@ -1,0 +1,229 @@
+import {
+  createSafeCapabilityRegistration,
+  FAILED_REGISTERED_CAPABILITY,
+} from '../createSafeCapabilityRegistration';
+
+const createMockStrapi = () =>
+  ({
+    log: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  }) as any;
+
+describe('createSafeCapabilityRegistration', () => {
+  describe('when all handlers succeed', () => {
+    test('creates handler, wraps it safely, and registers with SDK', () => {
+      const strapi = createMockStrapi();
+      const mockHandler = jest.fn().mockResolvedValue({ result: 'ok' });
+      const createHandler = jest.fn().mockReturnValue(mockHandler);
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'my-tool',
+        createHandler,
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(createHandler).toHaveBeenCalledWith(strapi);
+      expect(registerWithSdk).toHaveBeenCalled();
+      expect(result).toEqual({ registered: true });
+      expect(strapi.log.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Level 1: createHandler throws during factory invocation', () => {
+    test('catches error, logs it, and uses fallback handler', () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        throw new Error('factory explosion');
+      });
+      const fallbackHandler = jest.fn().mockResolvedValue({ fallback: true });
+      const createFallbackHandler = jest.fn().mockReturnValue(fallbackHandler);
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'my-prompt',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Prompt "my-prompt" handler factory threw during initialization: factory explosion'
+      );
+      expect(createFallbackHandler).toHaveBeenCalledWith('factory explosion');
+      expect(registerWithSdk).toHaveBeenCalled();
+      expect(result).toEqual({ registered: true });
+    });
+
+    test('handles non-Error throws', () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'string error';
+      });
+      const createFallbackHandler = jest.fn().mockReturnValue(jest.fn());
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Resource',
+        name: 'my-resource',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(createFallbackHandler).toHaveBeenCalledWith('string error');
+    });
+  });
+
+  describe('Level 2: handler throws during runtime execution', () => {
+    test('wraps handler and catches runtime errors', async () => {
+      const strapi = createMockStrapi();
+      const mockHandler = jest.fn().mockRejectedValue(new Error('runtime boom'));
+      const createHandler = jest.fn().mockReturnValue(mockHandler);
+      const createErrorResult = jest.fn().mockReturnValue({ error: 'handled' });
+      let capturedSafeHandler: (...args: any[]) => any;
+      const registerWithSdk = jest.fn().mockImplementation((handler) => {
+        capturedSafeHandler = handler;
+        return { registered: true };
+      });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'fail-tool',
+        createHandler,
+        createFallbackHandler: jest.fn(),
+        createErrorResult,
+        registerWithSdk,
+      });
+
+      // Execute the wrapped handler that was registered
+      const result = await capturedSafeHandler!('arg1', 'arg2');
+
+      expect(result).toEqual({ error: 'handled' });
+      expect(createErrorResult).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'runtime boom' }),
+        ['arg1', 'arg2']
+      );
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Tool "fail-tool" threw an error during execution',
+        expect.objectContaining({ error: 'runtime boom' })
+      );
+    });
+  });
+
+  describe('Level 3: SDK registration throws', () => {
+    test('catches SDK error, logs it, and returns FAILED_REGISTERED_CAPABILITY', () => {
+      const strapi = createMockStrapi();
+      const registerWithSdk = jest.fn().mockImplementation(() => {
+        throw new Error('SDK rejected registration');
+      });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'bad-prompt',
+        createHandler: jest.fn().mockReturnValue(jest.fn()),
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Failed to register prompt "bad-prompt" with MCP server: SDK rejected registration'
+      );
+      expect(result).toEqual({
+        enabled: false,
+        enable: expect.any(Function),
+        disable: expect.any(Function),
+        remove: expect.any(Function),
+      });
+    });
+
+    test('FAILED_REGISTERED_CAPABILITY methods are no-ops', () => {
+      const strapi = createMockStrapi();
+      const registerWithSdk = jest.fn().mockImplementation(() => {
+        throw new Error('rejection');
+      });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'rejected-tool',
+        createHandler: jest.fn().mockReturnValue(jest.fn()),
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      // These should not throw
+      expect(() => result.enable()).not.toThrow();
+      expect(() => result.disable()).not.toThrow();
+      expect(() => result.remove()).not.toThrow();
+      expect(result.enabled).toBe(false);
+    });
+  });
+
+  describe('integration: all three levels protect independently', () => {
+    test('Level 1 error does not prevent Level 2 wrapping', async () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        throw new Error('factory fail');
+      });
+      const fallbackHandler = jest.fn().mockRejectedValue(new Error('fallback fail'));
+      const createFallbackHandler = jest.fn().mockReturnValue(fallbackHandler);
+      const createErrorResult = jest.fn().mockReturnValue({ error: 'from level 2' });
+      let capturedSafeHandler: (...args: any[]) => any;
+      const registerWithSdk = jest.fn().mockImplementation((handler) => {
+        capturedSafeHandler = handler;
+        return { registered: true };
+      });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'cascade-tool',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult,
+        registerWithSdk,
+      });
+
+      // Even though the fallback handler fails, Level 2 should catch it
+      const result = await capturedSafeHandler!();
+
+      expect(result).toEqual({ error: 'from level 2' });
+      expect(strapi.log.error).toHaveBeenCalledTimes(2); // Once for Level 1, once for Level 2
+    });
+  });
+});
+
+describe('FAILED_REGISTERED_CAPABILITY', () => {
+  test('has enabled set to false', () => {
+    expect(FAILED_REGISTERED_CAPABILITY.enabled).toBe(false);
+  });
+
+  test('enable/disable/remove are no-ops that do not throw', () => {
+    expect(() => FAILED_REGISTERED_CAPABILITY.enable()).not.toThrow();
+    expect(() => FAILED_REGISTERED_CAPABILITY.disable()).not.toThrow();
+    expect(() => FAILED_REGISTERED_CAPABILITY.remove()).not.toThrow();
+  });
+
+  test('is frozen (immutable)', () => {
+    expect(Object.isFrozen(FAILED_REGISTERED_CAPABILITY)).toBe(true);
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/safeHandlerWrapper.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/safeHandlerWrapper.test.ts
@@ -1,0 +1,186 @@
+import { wrapSafeHandler } from '../safeHandlerWrapper';
+
+const createMockStrapi = () =>
+  ({
+    log: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  }) as any;
+
+describe('wrapSafeHandler', () => {
+  describe('when the handler succeeds', () => {
+    test('returns the handler result as-is', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockResolvedValue({ content: 'ok' });
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'my-tool',
+        createErrorResult: () => ({ content: 'error' }),
+      });
+
+      const result = await safe('arg1', 'arg2');
+
+      expect(result).toEqual({ content: 'ok' });
+      expect(handler).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(strapi.log.error).not.toHaveBeenCalled();
+    });
+
+    test('passes through all arguments to the original handler', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockResolvedValue('result');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'my-prompt',
+        createErrorResult: () => 'error',
+      });
+
+      await safe('a', 'b', 'c');
+
+      expect(handler).toHaveBeenCalledWith('a', 'b', 'c');
+    });
+  });
+
+  describe('when the handler throws an Error', () => {
+    test('catches the error and returns the error result', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(new Error('something broke'));
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'bad-tool',
+        createErrorResult: (error) => ({ errorMessage: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ errorMessage: 'something broke' });
+    });
+
+    test('logs the error with full detail via strapi logger', async () => {
+      const strapi = createMockStrapi();
+      const error = new Error('db connection lost');
+      const handler = jest.fn().mockRejectedValue(error);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Resource',
+        name: 'my-resource',
+        createErrorResult: () => 'fallback',
+      });
+
+      await safe();
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Resource "my-resource" threw an error during execution',
+        {
+          error: 'db connection lost',
+          stack: error.stack,
+        }
+      );
+    });
+  });
+
+  describe('when the handler throws a non-Error value', () => {
+    test('normalizes a string throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue('raw string error');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'string-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'raw string error' });
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Tool "string-throw" threw an error during execution',
+        expect.objectContaining({ error: 'raw string error' })
+      );
+    });
+
+    test('normalizes a number throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(42);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'number-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: '42' });
+    });
+
+    test('normalizes undefined throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(undefined);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'undefined-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'undefined' });
+    });
+  });
+
+  describe('when the handler throws synchronously', () => {
+    test('catches synchronous errors', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockImplementation(() => {
+        throw new Error('sync explosion');
+      });
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'sync-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'sync explosion' });
+      expect(strapi.log.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('createErrorResult receives args', () => {
+    test('passes the original call args to createErrorResult', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(new Error('fail'));
+
+      const createErrorResult = jest.fn().mockReturnValue('error');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Resource',
+        name: 'res',
+        createErrorResult,
+      });
+
+      const fakeUri = new URL('https://example.com/resource');
+      await safe(fakeUri, { extra: true });
+
+      expect(createErrorResult).toHaveBeenCalledWith(expect.any(Error), [fakeUri, { extra: true }]);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
@@ -1,0 +1,65 @@
+import { ServerResponse } from 'node:http';
+import { sendJsonRpcError } from '../sendJsonRpcError';
+
+describe('sendJsonRpcError', () => {
+  let mockResponse: Partial<ServerResponse>;
+  let writeHeadSpy: jest.Mock;
+  let endSpy: jest.Mock;
+
+  beforeEach(() => {
+    writeHeadSpy = jest.fn();
+    endSpy = jest.fn();
+    mockResponse = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    };
+  });
+
+  test('should send JSON-RPC error response with correct format', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 400, -32000, 'Invalid request');
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Invalid request' },
+        id: null,
+      })
+    );
+  });
+
+  test('should not send response if headers already sent', () => {
+    mockResponse.headersSent = true;
+
+    sendJsonRpcError(mockResponse as ServerResponse, 500, -32603, 'Internal error');
+
+    expect(writeHeadSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  test('should handle different HTTP status codes', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 503, -32001, 'Service unavailable');
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(503, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Service unavailable' },
+        id: null,
+      })
+    );
+  });
+
+  test('should handle different error codes', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 400, -32700, 'Parse error');
+
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: -32700, message: 'Parse error' },
+        id: null,
+      })
+    );
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/withTimeout.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/withTimeout.test.ts
@@ -1,0 +1,114 @@
+import { withTimeout } from '../withTimeout';
+
+describe('withTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('resolves when promise resolves before timeout', async () => {
+    const promise = Promise.resolve('success');
+    const result = withTimeout(promise, 1000, 'test-operation');
+
+    await expect(result).resolves.toBe('success');
+  });
+
+  test('rejects when timeout is reached before promise resolves', async () => {
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('success'), 2000);
+    });
+    const result = withTimeout(promise, 1000, 'test-operation');
+
+    jest.advanceTimersByTime(1000);
+
+    await expect(result).rejects.toThrow("Operation 'test-operation' timed out after 1000ms");
+  });
+
+  test('error message includes operation name and timeout duration', async () => {
+    const promise = new Promise<string>(() => {
+      // Never resolves
+    });
+    const result = withTimeout(promise, 500, 'my-custom-operation');
+
+    jest.advanceTimersByTime(500);
+
+    await expect(result).rejects.toThrow("Operation 'my-custom-operation' timed out after 500ms");
+  });
+
+  test('rejects with original error when promise rejects before timeout', async () => {
+    const originalError = new Error('Original error message');
+    const promise = Promise.reject(originalError);
+    const result = withTimeout(promise, 1000, 'reject-op');
+
+    await expect(result).rejects.toThrow('Original error message');
+  });
+
+  test('handles promise rejection after timeout', async () => {
+    let rejectPromise: (error: Error) => void;
+    const promise = new Promise<string>((_, reject) => {
+      rejectPromise = reject;
+    });
+    const result = withTimeout(promise, 1000, 'delayed-reject');
+
+    jest.advanceTimersByTime(1000);
+
+    // Timeout should win the race
+    await expect(result).rejects.toThrow("Operation 'delayed-reject' timed out after 1000ms");
+
+    // Rejecting after timeout should not affect the result
+    rejectPromise!(new Error('Too late'));
+  });
+
+  test('handles promise that resolves after timeout', async () => {
+    let resolvePromise: (value: string) => void;
+    const promise = new Promise<string>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const result = withTimeout(promise, 1000, 'delayed-resolve');
+
+    jest.advanceTimersByTime(1000);
+
+    // Timeout should win the race
+    await expect(result).rejects.toThrow("Operation 'delayed-resolve' timed out after 1000ms");
+
+    // Resolving after timeout should not affect the result
+    resolvePromise!('Too late');
+  });
+
+  test('handles zero timeout before promise resolves', async () => {
+    const promise = new Promise(() => {
+      // Never resolves
+    });
+    const result = withTimeout(promise, 0, 'zero-timeout');
+
+    jest.advanceTimersByTime(0);
+
+    await expect(result).rejects.toThrow("Operation 'zero-timeout' timed out after 0ms");
+  });
+
+  test('handles zero timeout after promise resolves', async () => {
+    const promise = new Promise<string>((resolve) => {
+      resolve('success');
+    });
+    const result = withTimeout(promise, 0, 'zero-timeout');
+
+    jest.advanceTimersByTime(0);
+
+    await expect(result).resolves.toBe('success');
+  });
+
+  test('preserves promise value when resolved quickly', async () => {
+    const promise = new Promise<number>((resolve) => {
+      setTimeout(() => resolve(123), 100);
+    });
+    const result = withTimeout(promise, 1000, 'quick-resolve');
+
+    jest.advanceTimersByTime(100);
+
+    await expect(result).resolves.toBe(123);
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/createManagedInterval.ts
+++ b/packages/core/core/src/services/mcp/utils/createManagedInterval.ts
@@ -1,0 +1,33 @@
+export type ManagedInterval = {
+  start: (callback: () => void, intervalMs: number) => void;
+  clear: () => void;
+};
+
+/**
+ * Creates a managed interval that automatically clears any existing interval before starting a new one
+ */
+export const createManagedInterval = (): ManagedInterval => {
+  let intervalId: NodeJS.Timeout | undefined;
+
+  return {
+    /**
+     * Starts the interval, clearing any existing interval first
+     */
+    start(callback, intervalMs) {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+      }
+      intervalId = setInterval(callback, intervalMs);
+    },
+
+    /**
+     * Clears the current interval if one exists
+     */
+    clear() {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+        intervalId = undefined;
+      }
+    },
+  };
+};

--- a/packages/core/core/src/services/mcp/utils/createSafeCapabilityRegistration.ts
+++ b/packages/core/core/src/services/mcp/utils/createSafeCapabilityRegistration.ts
@@ -1,0 +1,90 @@
+import type { Core } from '@strapi/types';
+import type { RegisteredCapability } from '../internal/McpCapabilityRegistry';
+import { wrapSafeHandler } from './safeHandlerWrapper';
+
+/**
+ * A no-op registered capability used as fallback when SDK registration fails.
+ *
+ * This prevents one broken capability from aborting the entire registration loop.
+ * The capability will appear as "disabled" and cannot be enabled.
+ */
+export const FAILED_REGISTERED_CAPABILITY: RegisteredCapability = Object.freeze({
+  enabled: false,
+  enable() {},
+  disable() {},
+  remove() {},
+});
+
+/**
+ * Configuration for creating a safe capability registration
+ */
+export type SafeCapabilityRegistrationConfig<THandler, TErrorResult, TRegistered> = {
+  strapi: Core.Strapi;
+  capabilityType: string;
+  name: string;
+  createHandler: (strapi: Core.Strapi) => THandler;
+  createFallbackHandler: (errorMessage: string) => NoInfer<THandler>;
+  createErrorResult: (error: Error, args: unknown[]) => TErrorResult;
+  registerWithSdk: (safeHandler: THandler) => TRegistered;
+};
+
+/**
+ * Creates a safe capability registration that protects Strapi core from user callback errors
+ * at three levels:
+ *
+ * - Level 1: Catch factory invocation errors (createHandler throws)
+ * - Level 2: Catch runtime execution errors (handler throws during invocation)
+ * - Level 3: Catch MCP SDK registration errors (SDK rejects the registration)
+ *
+ * This prevents one broken capability from:
+ * - Aborting the entire registration loop
+ * - Crashing the MCP server
+ * - Leaking unhandled errors to the user
+ */
+export const createSafeCapabilityRegistration = <THandler, TErrorResult, TRegistered>(
+  config: SafeCapabilityRegistrationConfig<THandler, TErrorResult, TRegistered>
+): TRegistered => {
+  const {
+    strapi,
+    capabilityType,
+    name,
+    createHandler,
+    createFallbackHandler,
+    createErrorResult,
+    registerWithSdk,
+  } = config;
+
+  try {
+    // Level 1: Safe factory invocation — catch errors from user's createHandler
+    let rawHandler: THandler;
+
+    try {
+      rawHandler = createHandler(strapi);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      strapi.log.error(
+        `[MCP] ${capabilityType} "${name}" handler factory threw during initialization: ${message}`
+      );
+
+      // Substitute a fallback handler that always returns an error to the MCP client
+      rawHandler = createFallbackHandler(message);
+    }
+
+    // Level 2: Safe runtime wrapping — catch errors from user's handler during execution
+    const safeHandler = wrapSafeHandler(rawHandler as (...args: unknown[]) => Promise<unknown>, {
+      strapi,
+      capabilityType,
+      name,
+      createErrorResult,
+    });
+
+    return registerWithSdk(safeHandler as THandler);
+  } catch (error) {
+    // Level 3: Catch MCP SDK registration errors — prevent one broken capability from aborting all others
+    const message = error instanceof Error ? error.message : String(error);
+    strapi.log.error(
+      `[MCP] Failed to register ${capabilityType.toLowerCase()} "${name}" with MCP server: ${message}`
+    );
+    return FAILED_REGISTERED_CAPABILITY as unknown as TRegistered;
+  }
+};

--- a/packages/core/core/src/services/mcp/utils/safeHandlerWrapper.ts
+++ b/packages/core/core/src/services/mcp/utils/safeHandlerWrapper.ts
@@ -1,0 +1,38 @@
+import type { Core } from '@strapi/types';
+
+/**
+ * Wraps an MCP capability handler to catch and log errors from user-provided callbacks.
+ *
+ * This prevents externally-registered capabilities (from plugin developers)
+ * from crashing Strapi core when they throw during execution.
+ *
+ * Errors are:
+ * - Logged with full detail (message + stack) via Strapi's logger
+ * - Returned to the MCP client as a safe error response (no stack trace leak)
+ */
+export const wrapSafeHandler = <TArgs extends unknown[], TResult>(
+  handler: (...args: TArgs) => Promise<TResult>,
+  options: {
+    strapi: Core.Strapi;
+    capabilityType: string;
+    name: string;
+    createErrorResult: (error: Error, args: TArgs) => TResult;
+  }
+): ((...args: TArgs) => Promise<TResult>) => {
+  const { strapi, capabilityType, name, createErrorResult } = options;
+
+  return async (...args: TArgs): Promise<TResult> => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error(String(error));
+
+      strapi.log.error(`[MCP] ${capabilityType} "${name}" threw an error during execution`, {
+        error: normalized.message,
+        stack: normalized.stack,
+      });
+
+      return createErrorResult(normalized, args);
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/utils/sendJsonRpcError.ts
+++ b/packages/core/core/src/services/mcp/utils/sendJsonRpcError.ts
@@ -1,0 +1,19 @@
+import type { ServerResponse } from 'node:http';
+
+export const sendJsonRpcError = (
+  res: ServerResponse,
+  httpStatus: number,
+  code: number,
+  message: string
+): void => {
+  if (res.headersSent === false) {
+    res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code, message },
+        id: null,
+      })
+    );
+  }
+};

--- a/packages/core/core/src/services/mcp/utils/withTimeout.ts
+++ b/packages/core/core/src/services/mcp/utils/withTimeout.ts
@@ -1,0 +1,16 @@
+/**
+ * Wraps a promise with a timeout to prevent hanging operations
+ */
+export const withTimeout = <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string
+): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Operation '${operation}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }),
+  ]);

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -46,6 +46,7 @@
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
+    "@modelcontextprotocol/sdk": "catalog:",
     "@strapi/database": "5.38.0",
     "@strapi/logger": "5.38.0",
     "@strapi/permissions": "5.38.0",

--- a/packages/core/types/src/core/strapi.ts
+++ b/packages/core/types/src/core/strapi.ts
@@ -63,6 +63,7 @@ export interface Strapi extends Container {
   components: Schema.Components;
   reload: Reloader;
   config: ConfigProvider;
+  mcp: Modules.MCP.McpService;
   services: Record<string, Core.Service>;
   service(uid: UID.Service): Core.Service;
   controllers: Record<string, Core.Controller>;

--- a/packages/core/types/src/modules/index.ts
+++ b/packages/core/types/src/modules/index.ts
@@ -12,6 +12,7 @@ export type * as EntityValidator from './entity-validator';
 export type * as EventHub from './event-hub';
 export type * as Features from './features';
 export type * as Fetch from './fetch';
+export type * as MCP from './mcp';
 export type * as Metrics from './metrics';
 export type * as RequestContext from './request-context';
 export type * as SessionManager from './session-manager';

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -1,0 +1,190 @@
+// eslint-disable-next-line import/extensions
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type {
+  ServerNotification,
+  ServerRequest,
+  ContentBlock,
+  GetPromptResult,
+  ReadResourceResult,
+  // eslint-disable-next-line import/extensions
+} from '@modelcontextprotocol/sdk/types.js';
+// eslint-disable-next-line import/extensions
+import type { ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js';
+// eslint-disable-next-line import/extensions
+import * as z from 'zod';
+import type * as Core from '../core';
+
+/**
+ * Base definition for Strapi MCP capabilities
+ */
+export interface McpCapabilityDefinition<Name extends string = string> {
+  name: Name;
+  devModeOnly: boolean;
+}
+
+/**
+ * Callback function for Strapi MCP tools
+ */
+export type McpToolCallback<
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+  OutputSchema extends z.ZodObject<z.ZodRawShape>,
+> = InputSchema extends z.ZodTypeAny
+  ? (
+      args: z.infer<InputSchema>,
+      extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+    ) => Promise<{
+      content: ContentBlock[];
+      structuredContent: z.infer<OutputSchema>;
+      isError?: boolean;
+    }>
+  : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => Promise<{
+      content: ContentBlock[];
+      structuredContent: z.infer<OutputSchema>;
+      isError?: boolean;
+    }>;
+
+/**
+ * Definition for Strapi MCP tools
+ */
+export interface McpToolDefinition<
+  Name extends string = string,
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  OutputSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
+  Title extends string = string,
+  Description extends string = string,
+> extends McpCapabilityDefinition<Name> {
+  title: Title;
+  description: Description;
+  inputSchema: InputSchema;
+  outputSchema: OutputSchema;
+  createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
+}
+
+/**
+ * Callback function for Strapi MCP prompts
+ */
+export type McpPromptCallback<ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined> =
+  ArgsSchema extends z.ZodTypeAny
+    ? (
+        args: z.infer<ArgsSchema>,
+        extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+      ) => Promise<GetPromptResult>
+    : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => Promise<GetPromptResult>;
+
+/**
+ * Definition for Strapi MCP prompts
+ */
+export interface McpPromptDefinition<
+  Name extends string = string,
+  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  Title extends string = string,
+  Description extends string = string,
+> extends McpCapabilityDefinition<Name> {
+  title: Title;
+  description: Description;
+  argsSchema?: ArgsSchema;
+  createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+}
+
+/**
+ * Callback function for Strapi MCP resources
+ */
+export type McpResourceCallback = (
+  uri: URL,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+) => Promise<ReadResourceResult>;
+
+/**
+ * Definition for Strapi MCP resources
+ */
+export interface McpResourceDefinition<Name extends string = string>
+  extends McpCapabilityDefinition<Name> {
+  uri: string;
+  metadata: ResourceMetadata;
+  createHandler: (strapi: Core.Strapi) => McpResourceCallback;
+}
+
+export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
+
+/**
+ * Service providing Model Context Protocol (MCP) capabilities.
+ * Available on Strapi.mcp.
+ */
+export interface McpService {
+  /**
+   * Check if the MCP service is enabled in configuration
+   */
+  isEnabled(): boolean;
+
+  /**
+   * Check if the MCP server is currently running
+   */
+  isRunning(): boolean;
+
+  /**
+   * Register a single MCP tool.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerTool<
+    Name extends string,
+    OutputSchema extends z.ZodObject<z.ZodRawShape>,
+    Title extends string,
+    Description extends string,
+    InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+  >(tool: {
+    name: Name;
+    title: Title;
+    description: Description;
+    inputSchema?: InputSchema;
+    outputSchema: OutputSchema;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
+  }): void;
+
+  /**
+   * Register a single MCP prompt.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerPrompt<
+    Name extends string,
+    ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+    Title extends string,
+    Description extends string,
+  >(prompt: {
+    name: Name;
+    title: Title;
+    description: Description;
+    argsSchema?: ArgsSchema;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+  }): void;
+
+  /**
+   * Register a single MCP resource.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerResource<Name extends string>(resource: {
+    name: Name;
+    uri: string;
+    metadata: ResourceMetadata;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpResourceCallback;
+  }): void;
+
+  /**
+   * Start the MCP server
+   */
+  start(): Promise<void>;
+
+  /**
+   * Stop the MCP server
+   */
+  stop(): Promise<void>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,6 +4440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.9
+  resolution: "@hono/node-server@npm:1.19.9"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/de18c06b6b266dc45fe55fb82053bd1da8fe84939c49b6fbab4d2448b679d54ab5affbf8b15de9bead26f29b1755284d770aafb5ad14a8e4b3cfb4f79334554e
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.10":
   version: 0.11.11
   resolution: "@humanwhocodes/config-array@npm:0.11.11"
@@ -5316,6 +5325,39 @@ __metadata:
   version: 0.15.1
   resolution: "@microsoft/tsdoc@npm:0.15.1"
   checksum: 10c0/09948691fac56c45a0d1920de478d66a30371a325bd81addc92eea5654d95106ce173c440fea1a1bd5bb95b3a544b6d4def7bb0b5a846c05d043575d8369a20c
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.27.1":
+  version: 1.27.1
+  resolution: "@modelcontextprotocol/sdk@npm:1.27.1"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/1b8ad87093c9e43174c7d65864b3d826a8dd050d5c32248f5da49fd72c51b556ebd702e3e49a7f1cc7fa25717a3f7fcee22ed89edd5bd3d8f4e1f8ca499b365e
   languageName: node
   linkType: hard
 
@@ -9675,6 +9717,7 @@ __metadata:
   dependencies:
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
+    "@modelcontextprotocol/sdk": "catalog:"
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/admin": "npm:5.38.0"
     "@strapi/database": "npm:5.38.0"
@@ -10535,6 +10578,7 @@ __metadata:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
+    "@modelcontextprotocol/sdk": "catalog:"
     "@strapi/database": "npm:5.38.0"
     "@strapi/logger": "npm:5.38.0"
     "@strapi/permissions": "npm:5.38.0"
@@ -13594,6 +13638,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -13796,7 +13850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:~3.0.1":
+"ajv-formats@npm:^3.0.1, ajv-formats@npm:~3.0.1":
   version: 3.0.1
   resolution: "ajv-formats@npm:3.0.1"
   dependencies:
@@ -13854,7 +13908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.17.1, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -14806,6 +14860,23 @@ __metadata:
   version: 4.12.3
   resolution: "bn.js@npm:4.12.3"
   checksum: 10c0/53b6a4db8a583abd2522eacd480fece26fe6c4d8d35d03e5e11e15cb0873a3044eb4e3d1f9fef56f47eb008219e99ba5b620c26f57db49a687c6ab2cf848d50b
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "body-parser@npm:2.2.2"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.7.0"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.1"
+    raw-body: "npm:^3.0.1"
+    type-is: "npm:^2.0.1"
+  checksum: 10c0/95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
   languageName: node
   linkType: hard
 
@@ -16221,6 +16292,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "content-disposition@npm:1.0.1"
+  checksum: 10c0/bd7ff1fe8d2542d3a2b9a29428cc3591f6ac27bb5595bba2c69664408a68f9538b14cbd92479796ea835b317a09a527c8c7209c4200381dedb0c34d3b658849e
+  languageName: node
+  linkType: hard
+
 "content-type@npm:^1.0.4, content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
@@ -16386,7 +16464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:~0.7.1":
+"cookie@npm:^0.7.1, cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -16644,6 +16722,17 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.5":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
   languageName: node
   linkType: hard
 
@@ -16963,7 +17052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.4.0, debug@npm:^4.4.1":
+"debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -17730,7 +17819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encodeurl@npm:~2.0.0":
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
@@ -19147,7 +19236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
@@ -19175,6 +19264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1, eventsource-parser@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "eventsource-parser@npm:3.0.6"
+  checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
+  languageName: node
+  linkType: hard
+
 "eventsource-parser@npm:^3.0.5":
   version: 3.0.5
   resolution: "eventsource-parser@npm:3.0.5"
@@ -19182,17 +19278,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "eventsource-parser@npm:3.0.6"
-  checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
-  languageName: node
-  linkType: hard
-
 "eventsource@npm:2.0.2":
   version: 2.0.2
   resolution: "eventsource@npm:2.0.2"
   checksum: 10c0/0b8c70b35e45dd20f22ff64b001be9d530e33b92ca8bdbac9e004d0be00d957ab02ef33c917315f59bf2f20b178c56af85c52029bc8e6cc2d61c31d87d943573
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
   languageName: node
   linkType: hard
 
@@ -19335,6 +19433,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "express-rate-limit@npm:8.2.1"
+  dependencies:
+    ip-address: "npm:10.0.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/54185f211c25655382436b8ad1a2136df0d5dc88f4d9d4438ca7cbc87cef0cd34cb01b8fc62d290445326aa6581470d2ff44502c3f1a34a5ed2c2ce56809fa01
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.21.1":
   version: 4.22.1
   resolution: "express@npm:4.22.1"
@@ -19371,6 +19480,42 @@ __metadata:
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
   checksum: 10c0/ea57f512ab1e05e26b53a14fd432f65a10ec735ece342b37d0b63a7bcb8d337ffbb830ecb8ca15bcdfe423fbff88cea09786277baff200e8cde3ab40faa665cd
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10c0/45e8c841ad188a41402ddcd1294901e861ee0819f632fb494f2ed344ef9c43315d294d443fb48d594e6586a3b779785120f43321417adaef8567316a55072949
   languageName: node
   linkType: hard
 
@@ -19686,6 +19831,20 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/6bd664e21b7b2e79efcaace7d1a427169f61cce048fae68eb56290e6934e676b78e55d89f5998c5508871345bc59a61f47002dc505dc7288be68cceac1b701e2
   languageName: node
   linkType: hard
 
@@ -20074,6 +20233,13 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/716addd9fa85dd2c1475ab848e14c4e6d3246ced041de84afc19b1d6534c897256c8f2878864cf057039116e56f5ca1b87a4cbb943f0b1cf37199ef7174c3cf8
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
   languageName: node
   linkType: hard
 
@@ -21297,6 +21463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hono@npm:^4.11.4":
+  version: 4.11.9
+  resolution: "hono@npm:4.11.9"
+  checksum: 10c0/fe396a8e1a61755adb7afe8ce8e0935a6423a5680ec62f4fd3577c5c5a9236dec390dc28fef6b9742e067b5d9c53ddb3aa511b3359bf87dcc2105dae751f1242
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -21504,19 +21677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:~1.6.2":
-  version: 1.6.3
-  resolution: "http-errors@npm:1.6.3"
-  dependencies:
-    depd: "npm:~1.1.2"
-    inherits: "npm:2.0.3"
-    setprototypeof: "npm:1.1.0"
-    statuses: "npm:>= 1.4.0 < 2"
-  checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -21526,6 +21687,18 @@ __metadata:
     statuses: "npm:~2.0.2"
     toidentifier: "npm:~1.0.1"
   checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:~1.6.2":
+  version: 1.6.3
+  resolution: "http-errors@npm:1.6.3"
+  dependencies:
+    depd: "npm:~1.1.2"
+    inherits: "npm:2.0.3"
+    setprototypeof: "npm:1.1.0"
+    statuses: "npm:>= 1.4.0 < 2"
+  checksum: 10c0/17ec4046ee974477778bfdd525936c254b872054703ec2caa4d6f099566b8adade636ae6aeeacb39302c5cd6e28fb407ebd937f500f5010d0b6850750414ff78
   languageName: node
   linkType: hard
 
@@ -21667,6 +21840,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
+  version: 0.7.1
+  resolution: "iconv-lite@npm:0.7.1"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/f5c9e2bddd7101a71b07a381ace44ebdc65ca76a10be0e9e64d372b511132acc4ee41b830962f438840d492cd6f9e08c237289f760d6a7fed754e61cffcb6757
   languageName: node
   linkType: hard
 
@@ -22035,6 +22217,13 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.0.0"
   checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:10.0.1":
+  version: 10.0.1
+  resolution: "ip-address@npm:10.0.1"
+  checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843
   languageName: node
   linkType: hard
 
@@ -22469,6 +22658,13 @@ __metadata:
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
   languageName: node
   linkType: hard
 
@@ -23412,6 +23608,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "jose@npm:6.1.3"
+  checksum: 10c0/b9577b4a7a5e84131011c23823db9f5951eae3ba796771a6a2401ae5dd50daf71104febc8ded9c38146aa5ebe94a92ac09c725e699e613ef26949b9f5a8bc30f
+  languageName: node
+  linkType: hard
+
 "js-levenshtein@npm:^1.1.6":
   version: 1.1.6
   resolution: "js-levenshtein@npm:1.1.6"
@@ -23648,6 +23851,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -25375,6 +25585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "memfs@npm:4.6.0":
   version: 4.6.0
   resolution: "memfs@npm:4.6.0"
@@ -25447,6 +25664,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10c0/95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
   languageName: node
   linkType: hard
 
@@ -25731,12 +25955,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:^2.1.27, mime-types@npm:^2.1.28, mime-types@npm:^2.1.31, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -27214,7 +27454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.3.0, on-finished@npm:~2.4.1":
+"on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -27911,7 +28151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:^1.3.2, parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.2, parseurl@npm:^1.3.3, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
@@ -28097,6 +28337,13 @@ __metadata:
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
   checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^8.0.0":
+  version: 8.3.0
+  resolution: "path-to-regexp@npm:8.3.0"
+  checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
   languageName: node
   linkType: hard
 
@@ -28352,6 +28599,13 @@ __metadata:
     "@napi-rs/nice":
       optional: true
   checksum: 10c0/ab67830065ff41523cd901db41b11045cb00a0be43bf79323ff7b4ef2fbce5e3a56ad440d99d6c3944ce94451a0a69fd175500e3220b21efe54142e601322189
+  languageName: node
+  linkType: hard
+
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
   languageName: node
   linkType: hard
 
@@ -28894,7 +29148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7, proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -28985,7 +29239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:^6.5.2, qs@npm:^6.9.6":
+"qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:^6.14.0, qs@npm:^6.14.1, qs@npm:^6.5.2, qs@npm:^6.9.6":
   version: 6.14.1
   resolution: "qs@npm:6.14.1"
   dependencies:
@@ -29072,6 +29326,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -30490,6 +30756,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10c0/3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -30771,6 +31050,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10c0/fbbbbdc902a913d65605274be23f3d604065cfc3ee3d78bf9fc8af1dc9fc82667c50d3d657f5e601ac657bac9b396b50ee97bd29cd55436320cf1cddebdcec72
+  languageName: node
+  linkType: hard
+
 "send@npm:~0.19.0, send@npm:~0.19.1":
   version: 0.19.2
   resolution: "send@npm:0.19.2"
@@ -30835,6 +31133,18 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10c0/37986096e8572e2dfaad35a3925fa8da0c0969f8814fd7788e84d4d388bc068cf0c06d1658509788e55bed942a6b6d040a8a267fa92bb9ffb1179f8bacde5fd7
   languageName: node
   linkType: hard
 
@@ -31726,7 +32036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.1, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
@@ -33242,6 +33552,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/7f7ec0a060b16880bdad36824ab37c26019454b67d73e8a465ed5a3587440fbe158bc765f0da68344498235c877e7dbbb1600beccc94628ed05599d667951b99
+  languageName: node
+  linkType: hard
+
 "typed-array-buffer@npm:^1.0.0":
   version: 1.0.0
   resolution: "typed-array-buffer@npm:1.0.0"
@@ -33584,7 +33905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:6.23.0, undici@npm:^6.19.5":
+"undici@npm:6.23.0":
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
   checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
@@ -33597,6 +33918,13 @@ __metadata:
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
   checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.19.5":
+  version: 6.20.1
+  resolution: "undici@npm:6.20.1"
+  checksum: 10c0/b2c8d5adcd226c53d02f9270e4cac277256a7147cf310af319369ec6f87651ca46b2960366cb1339a6dac84d937e01e8cdbec5cb468f1f1ce5e9490e438d7222
   languageName: node
   linkType: hard
 
@@ -35238,6 +35566,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.1
+  resolution: "zod-to-json-schema@npm:3.25.1"
+  peerDependencies:
+    zod: ^3.25 || ^4
+  checksum: 10c0/711b30e34d1f1211f1afe64bf457f0d799234199dc005cca720b236ea808804c03164039c232f5df33c46f462023874015a8a0b3aab1585eca14124c324db7e2
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^2.1.0":
   version: 2.1.0
   resolution: "zod-validation-error@npm:2.1.0"
@@ -35258,6 +35595,13 @@ __metadata:
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 10c0/7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.3.5
+  resolution: "zod@npm:4.3.5"
+  checksum: 10c0/5a2db7e59177a3d7e202543f5136cb87b97b047b77c8a3d824098d3fa8b80d3aa40a0a5f296965c3b82dfdccdd05dbbfacce91347f16a39c675680fd7b1ab109
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?
                                                                                                                                                       
Introduces the MCP (Model Context Protocol) core API into Strapi's @strapi/core package. Specifically:

- Adds a new mcp service (createMcpService) exposed on the strapi object, with start(), stop(), isEnabled(), isRunning(), registerTool(),
registerPrompt(), and registerResource() methods
- Implements an SSE-based HTTP transport with 3 route handlers: POST, GET (SSE stream), and DELETE (session termination)
- Introduces internal classes: McpSessionManager (session lifecycle + idle cleanup), McpServerFactory (creates @modelcontextprotocol/sdk server
instances per session), McpCapabilityRegistry (runtime capability registration), McpCapabilityDefinitionRegistry (capability blueprint store),
McpConfiguration (reads config from strapi.config)
- Adds utility helpers: createManagedInterval, createSafeCapabilityRegistration, safeHandlerWrapper, sendJsonRpcError, withTimeout
- Ships a built-in log tool (dev-mode only) as first-class capability
- Adds full TypeScript types in @strapi/types under Modules.MCP
- Adds @modelcontextprotocol/sdk as a dependency

### Why is it needed?

Enables Strapi instances to expose an MCP server, allowing AI agents and LLM clients (e.g. Claude, Cursor, Windsurf) to interact with Strapi's data and
  functionality via the standardized Model Context Protocol. This is the foundational layer that plugins and users will build MCP
tools/prompts/resources on top of.

### How to test it?

1. Start a Strapi app with MCP enabled in config (e.g. mcp: { enabled: true, path: '/api/mcp' })
2. Connect an MCP client (e.g. Claude Desktop, or @modelcontextprotocol/inspector) pointing to http://localhost:1337/api/mcp
3. Verify the SSE connection opens (GET /api/mcp), a session ID is returned, and the log tool appears in the tool list
4. Call the log tool and verify a log message appears in Strapi's console
5. Send DELETE /api/mcp with the session ID to confirm clean session termination
6. Run unit tests: yarn test packages/core/core/src/services/mcp