### PR TITLE
enhancement: deduplicate pkg.ts validation logic between cloud-cli and strapi

### DIFF
--- a/packages/cli/cloud/src/utils/pkg.ts
+++ b/packages/cli/cloud/src/utils/pkg.ts
@@ -1,60 +1,12 @@
 import * as fse from 'fs-extra';
 import os from 'os';
 import pkgUp from 'pkg-up';
-import * as yup from 'yup';
-import chalk from 'chalk';
+import { validatePkg, PackageJson } from '@strapi/utils';
 import { Logger } from '../services/logger';
-
-interface Export {
-  types?: string;
-  source: string;
-  module?: string;
-  import?: string;
-  require?: string;
-  default: string;
-}
-
-const packageJsonSchema = yup.object({
-  name: yup.string().required(),
-  exports: yup.lazy((value) =>
-    yup
-      .object(
-        typeof value === 'object'
-          ? Object.entries(value).reduce(
-              (acc, [key, value]) => {
-                if (typeof value === 'object') {
-                  acc[key] = yup
-                    .object({
-                      types: yup.string().optional(),
-                      source: yup.string().required(),
-                      module: yup.string().optional(),
-                      import: yup.string().required(),
-                      require: yup.string().required(),
-                      default: yup.string().required(),
-                    })
-                    .noUnknown(true);
-                } else {
-                  acc[key] = yup
-                    .string()
-                    .matches(/^\.\/.*\.json$/)
-                    .required();
-                }
-
-                return acc;
-              },
-              {} as Record<string, yup.SchemaOf<string> | yup.SchemaOf<Export>>
-            )
-          : undefined
-      )
-      .optional()
-  ),
-});
-
-type PackageJson = yup.Asserts<typeof packageJsonSchema>;
 
 /**
  * @description being a task to load the package.json starting from the current working directory
- * using a shallow find for the package.json  and `fs` to read the file. If no package.json is found,
+ * using a shallow find for the package.json and `fs` to read the file. If no package.json is found,
  * the process will throw with an appropriate error message.
  */
 const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promise<PackageJson> => {
@@ -65,7 +17,6 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
   }
 
   const buffer = await fse.readFile(pkgPath);
-
   const pkg = JSON.parse(buffer.toString());
 
   logger.debug('Loaded package.json:', os.EOL, pkg);
@@ -73,56 +24,5 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
   return pkg;
 };
 
-/**
- * @description validate the package.json against a standardised schema using `yup`.
- * If the validation fails, the process will throw with an appropriate error message.
- */
-const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
-  try {
-    return await packageJsonSchema.validate(pkg, {
-      strict: true,
-    });
-  } catch (err) {
-    if (err instanceof yup.ValidationError) {
-      switch (err.type) {
-        case 'required':
-          if (err.path) {
-            throw new Error(
-              `'${err.path}' in 'package.json' is required as type '${chalk.magenta(
-                yup.reach(packageJsonSchema, err.path).type
-              )}'`
-            );
-          }
-          break;
-        /**
-         * This will only be thrown if there are keys in the export map
-         * that we don't expect so we can therefore make some assumptions
-         */
-        case 'noUnknown':
-          if (err.path && err.params && 'unknown' in err.params) {
-            throw new Error(
-              `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
-                err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
-                "['types', 'source', 'import', 'require', 'default']"
-              )}`
-            );
-          }
-          break;
-        default:
-          if (err.path && err.params && 'type' in err.params && 'value' in err.params) {
-            throw new Error(
-              `'${err.path}' in 'package.json' must be of type '${chalk.magenta(
-                err.params.type
-              )}' (received '${chalk.magenta(typeof err.params.value)}')`
-            );
-          }
-      }
-    }
-
-    throw err;
-  }
-};
-
-export type { PackageJson, Export };
+export type { PackageJson };
 export { loadPkg, validatePkg };

--- a/packages/core/strapi/src/cli/utils/pkg.ts
+++ b/packages/core/strapi/src/cli/utils/pkg.ts
@@ -1,58 +1,12 @@
 import fs from 'fs/promises';
 import os from 'os';
 import pkgUp from 'pkg-up';
-import * as yup from 'yup';
-import chalk from 'chalk';
+import { validatePkg, PackageJson } from '@strapi/utils';
 import { Logger } from './logger';
-
-interface Export {
-  types?: string;
-  source: string;
-  module?: string;
-  import?: string;
-  require?: string;
-  default: string;
-}
-
-const packageJsonSchema = yup.object({
-  name: yup.string().required(),
-  exports: yup.lazy((value) =>
-    yup
-      .object(
-        typeof value === 'object'
-          ? Object.entries(value).reduce(
-              (acc, [key, value]) => {
-                if (typeof value === 'object') {
-                  acc[key] = yup
-                    .object({
-                      types: yup.string().optional(),
-                      source: yup.string().required(),
-                      module: yup.string().optional(),
-                      import: yup.string().required(),
-                      require: yup.string().required(),
-                      default: yup.string().required(),
-                    })
-                    .noUnknown(true);
-                } else {
-                  acc[key] = yup
-                    .string()
-                    .matches(/^\.\/.*\.json$/)
-                    .required();
-                }
-
-                return acc;
-              },
-              {} as Record<string, yup.SchemaOf<string> | yup.SchemaOf<Export>>
-            )
-          : undefined
-      )
-      .optional()
-  ),
-});
 
 /**
  * @description being a task to load the package.json starting from the current working directory
- * using a shallow find for the package.json  and `fs` to read the file. If no package.json is found,
+ * using a shallow find for the package.json and `fs` to read the file. If no package.json is found,
  * the process will throw with an appropriate error message.
  */
 const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promise<object> => {
@@ -63,7 +17,6 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
   }
 
   const buffer = await fs.readFile(pkgPath);
-
   const pkg = JSON.parse(buffer.toString());
 
   logger.debug('Loaded package.json:', os.EOL, pkg);
@@ -71,60 +24,5 @@ const loadPkg = async ({ cwd, logger }: { cwd: string; logger: Logger }): Promis
   return pkg;
 };
 
-type PackageJson = yup.Asserts<typeof packageJsonSchema>;
-
-/**
- * @description validate the package.json against a standardised schema using `yup`.
- * If the validation fails, the process will throw with an appropriate error message.
- */
-const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
-  try {
-    const validatedPkg = await packageJsonSchema.validate(pkg, {
-      strict: true,
-    });
-
-    return validatedPkg;
-  } catch (err) {
-    if (err instanceof yup.ValidationError) {
-      switch (err.type) {
-        case 'required':
-          if (err.path) {
-            throw new Error(
-              `'${err.path}' in 'package.json' is required as type '${chalk.magenta(
-                yup.reach(packageJsonSchema, err.path).type
-              )}'`
-            );
-          }
-          break;
-        /**
-         * This will only be thrown if there are keys in the export map
-         * that we don't expect so we can therefore make some assumptions
-         */
-        case 'noUnknown':
-          if (err.path && err.params && 'unknown' in err.params) {
-            throw new Error(
-              `'${err.path}' in 'package.json' contains the unknown key ${chalk.magenta(
-                err.params.unknown
-              )}, for compatability only the following keys are allowed: ${chalk.magenta(
-                "['types', 'source', 'import', 'require', 'default']"
-              )}`
-            );
-          }
-          break;
-        default:
-          if (err.path && err.params && 'type' in err.params && 'value' in err.params) {
-            throw new Error(
-              `'${err.path}' in 'package.json' must be of type '${chalk.magenta(
-                err.params.type
-              )}' (received '${chalk.magenta(typeof err.params.value)}')`
-            );
-          }
-      }
-    }
-
-    throw err;
-  }
-};
-
-export type { PackageJson, Export };
+export type { PackageJson };
 export { loadPkg, validatePkg };

--- a/packages/core/strapi/tsconfig.json
+++ b/packages/core/strapi/tsconfig.json
@@ -6,6 +6,5 @@
     "module": "ESNext",
     "moduleResolution": "Bundler"
   },
-  "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -39,3 +39,4 @@ export * from './route-serialization';
 export * from './primitives';
 export * from './content-api-router';
 export * from './security';
+export * from './pkg-utils';

--- a/packages/core/utils/src/pkg-utils.ts
+++ b/packages/core/utils/src/pkg-utils.ts
@@ -1,0 +1,86 @@
+import * as yup from 'yup';
+
+interface Export {
+  types?: string;
+  source: string;
+  module?: string;
+  import?: string;
+  require?: string;
+  default: string;
+}
+
+const packageJsonSchema = yup.object({
+  name: yup.string().required(),
+  exports: yup.lazy((value) =>
+    yup
+      .object(
+        typeof value === 'object'
+          ? Object.entries(value).reduce(
+              (acc, [key, value]) => {
+                if (typeof value === 'object') {
+                  acc[key] = yup
+                    .object({
+                      types: yup.string().optional(),
+                      source: yup.string().required(),
+                      module: yup.string().optional(),
+                      import: yup.string().required(),
+                      require: yup.string().required(),
+                      default: yup.string().required(),
+                    })
+                    .noUnknown(true);
+                } else {
+                  acc[key] = yup
+                    .string()
+                    .matches(/^\.\/.*\.json$/)
+                    .required();
+                }
+
+                return acc;
+              },
+              {} as Record<string, yup.SchemaOf<string> | yup.SchemaOf<Export>>
+            )
+          : undefined
+      )
+      .optional()
+  ),
+});
+
+type PackageJson = yup.Asserts<typeof packageJsonSchema>;
+
+const validatePkg = async ({ pkg }: { pkg: object }): Promise<PackageJson> => {
+  try {
+    return await packageJsonSchema.validate(pkg, {
+      strict: true,
+    });
+  } catch (err) {
+    if (err instanceof yup.ValidationError) {
+      switch (err.type) {
+        case 'required':
+          if (err.path) {
+            throw new Error(`'${err.path}' in 'package.json' is required`);
+          }
+          break;
+
+        case 'noUnknown':
+          if (err.path && err.params && 'unknown' in err.params) {
+            throw new Error(
+              `'${err.path}' in 'package.json' contains the unknown key ${err.params.unknown}`
+            );
+          }
+          break;
+
+        default:
+          if (err.path && err.params && 'value' in err.params) {
+            throw new Error(
+              `'${err.path}' in 'package.json' is invalid (received '${typeof err.params.value}')`
+            );
+          }
+      }
+    }
+
+    throw err;
+  }
+};
+
+export type { PackageJson, Export };
+export { validatePkg };


### PR DESCRIPTION
## What does it do?

This PR removes duplicated `package.json` validation logic that existed in two different locations:

- `packages/cli/cloud/src/utils/pkg.ts`
- `packages/core/strapi/src/cli/utils/pkg.ts`

The shared validation logic (Yup schema + `validatePkg`) has been extracted into a new shared utility:
`packages/core/utils/src/pkg-utils.ts`


Both `cloud-cli` and `strapi` now import the validation logic from `@strapi/utils`, ensuring a single source of truth.

---

## Why is it needed?

Previously, the validation logic was duplicated across two files. This caused:

- Code duplication
- Risk of inconsistencies if one implementation changed
- Maintenance overhead

By extracting the shared logic into `@strapi/utils`, both packages now rely on a single implementation, improving maintainability and consistency.

---

## How to test it?

1. Build the repository:

```bash
yarn build
```
2.Ensure the following packages compile successfully:

`@strapi/cloud-cli`

`@strapi/strapi`

3.Verify that both `pkg.ts` files now import the shared validation logic from `@strapi/utils`.

### Related issue(s)/PR(s)

Fixes #25536