### PR TITLE
Issues project linking

### DIFF
--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -10,7 +10,6 @@ permissions:
   actions: read
   checks: read
   contents: read
-  repository-projects: read
   statuses: read
 
 jobs:
@@ -203,18 +202,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           lock-reason: 'off-topic'
-
-      - name: assign issues to DevExp squad project
-        uses: actions/add-to-project@v0.4.1
-        with:
-          project-url: https://github.com/orgs/strapi/projects/13
-          github-token: ${{ secrets.PROJECT_TRANSFER_TOKEN }}
-          labeled: 'source: cli, source: core:content-type-builder, source: core:core, source: core:data-transfer, source: core:database, source: core:strapi, source: core:utils, source: dependencies, source: marketplace, source: plugin:graphql, source: plugin:users-permissions, source: tooling, source: typescript, source: utils:upgrade, source: core:permissions, source: rbac, source: providers, source: core:openapi, source: strapi-ai'
-          label-operator: OR
-      - name: assign issues to Content squad project
-        uses: actions/add-to-project@v0.4.1
-        with:
-          project-url: https://github.com/orgs/strapi/projects/48
-          github-token: ${{ secrets.PROJECT_TRANSFER_TOKEN }}
-          labeled: 'source: core:admin, source: core:content-manager, source: core:content-releases, source: core:review-workflows, source: core:upload, source: plugin:color-picker, source: plugin:documentation, source: plugin:i18n, source: core:preview'
-          label-operator: OR


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What does it do?

Removes the `actions/add-to-project` steps from the `issues_handleLabel.yml` workflow. This also removes the `repository-projects: read` permission as it's no longer needed.

### Why is it needed?

To stop automatically adding issues to GitHub projects when labels are applied, as per the request.

### How to test it?

1.  Create a new issue in the repository.
2.  Apply a label that would previously trigger the `add-to-project` action (e.g., `type: bug`, `type: feature`).
3.  Verify that the issue is *not* automatically added to the DevExp squad project (projects/13) or Content squad project (projects/48).

### Related issue(s)/PR(s)

---
<p><a href="https://cursor.com/agents/bc-ac76fa6e-a1a6-4df5-9d86-58443011896c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac76fa6e-a1a6-4df5-9d86-58443011896c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->