### PR TITLE
chore(BUG_REPORT): ask for in use package manager

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -10,12 +10,27 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: packageManager
+    attributes:
+      label: Package Manager
+      description: Which package manager are you using?
+      multiple: false
+      options:
+        - npm
+        - yarn
+        - pnpm
+        - bun
+        - Other
+    validations:
+      required: true
+
   - type: input
     id: pmVersion
     attributes:
-      label: NPM/Yarn/PNPM Version
-      description: The package manager and version you are using.
-      placeholder: NPM 10.0.0
+      label: Package Manager Version
+      description: The version of the package manager you selected above.
+      placeholder: 10.0.0
     validations:
       required: true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
- Adds a new dropdown field for selecting the package manager (npm, yarn, pnpm, bun, Other) in the bug report template.
- Separates the package manager selection from the package manager version input field.
- Reorders the fields to ensure the package manager is asked before its version.

### Why is it needed?
- To improve the clarity and accuracy of bug reports by explicitly asking for the package manager used before its version, ensuring precise environment information. Especially useful to distinguish `npm` and `pnpm`.

### How to test it?
1. Navigate to the Strapi GitHub repository.
2. Click on "Issues" -> "New issue".
3. Select the "Bug report" template.
4. Verify that the "Package Manager" dropdown appears before the "Package Manager Version" input field.
5. Check that the available options in the dropdown are correct.

### Related issue(s)/PR(s)
N/A

---
<p><a href="https://cursor.com/agents/bc-28a24228-698c-4a70-81d0-a6ae02659ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28a24228-698c-4a70-81d0-a6ae02659ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->