### PR TITLE
chore(core): explicit Vite aliases for react, react-dom, react-router-dom, and styled-components

### DIFF
--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -130,6 +130,10 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
       // Explicit aliases ensure resolution under pnpm's strict dependency isolation,
       // where packages imported by plugins may not be resolvable from plugin chunks
       alias: {
+        react: getModulePath('react'),
+        'react-dom': getModulePath('react-dom'),
+        'react-router-dom': getModulePath('react-router-dom'),
+        'styled-components': getModulePath('styled-components'),
         '@strapi/design-system': getModulePath('@strapi/design-system'),
         '@radix-ui/react-tooltip': getModulePath('@radix-ui/react-tooltip'),
         lodash: getModulePath('lodash'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Adds explicit Vite aliases for `react`, `react-dom`, `react-router-dom`, and `styled-components` in `packages/core/strapi/src/node/vite/config.ts`. This aligns Vite's dependency resolution strategy with webpack's existing behavior.

### Why is it needed?
This change addresses an issue where the Admin UI crashes due to `styled-components` receiving `undefined` when creating a styled component (e.g., `styled(Popover.Arrow)`). The root cause is a singleton resolution gap in Vite, which allows multiple instances of `styled-components` (and other critical libraries) to be bundled, leading to runtime errors. This fix ensures these libraries resolve to a single physical install, preventing such conflicts.
Fixes #25571

### How to test it?
1.  Reproduce the issue described in #25571 (e.g., by having a plugin that might cause duplicate `styled-components` instances).
2.  Apply this PR.
3.  Build and run the Strapi admin panel.
4.  Verify that the Admin UI loads without crashing and the Guided Tour component functions correctly.

### Related issue(s)/PR(s)
Fixes #25571

---
<p><a href="https://cursor.com/agents/bc-cf3dc0d0-45e4-4305-a40d-2ba317159a89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf3dc0d0-45e4-4305-a40d-2ba317159a89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->