### PR TITLE
chore(core): parallelize and cache dynamic zone populate

### DIFF
--- a/packages/core/core/src/services/document-service/utils/populate.ts
+++ b/packages/core/core/src/services/document-service/utils/populate.ts
@@ -10,12 +10,20 @@ interface Options {
 
 const { CREATED_BY_ATTRIBUTE, UPDATED_BY_ATTRIBUTE } = contentTypes.constants;
 
+const deepPopulateCache = new Map<string, any>();
+
 // We want to build a populate object based on the schema
 export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
+  const cacheKey = `${uid}::${JSON.stringify(opts)}`;
+  const cached = deepPopulateCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const model = strapi.getModel(uid);
   const attributes = Object.entries(model.attributes);
 
-  return attributes.reduce((acc: any, [attributeName, attribute]) => {
+  const result = attributes.reduce((acc: any, [attributeName, attribute]) => {
     switch (attribute.type) {
       case 'relation': {
         // TODO: Support polymorphic relations
@@ -67,4 +75,7 @@ export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
 
     return acc;
   }, {});
+
+  deepPopulateCache.set(cacheKey, result);
+  return result;
 };

--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -539,26 +539,28 @@ const morphToMany = async (input: Input<Relation.MorphToMany>, ctx: Context) => 
   const map: MorphIdMap = {};
   const { on, ...typePopulate } = populateValue;
 
-  for (const type of Object.keys(idsByType)) {
-    const ids = idsByType[type];
+  await Promise.all(
+    Object.keys(idsByType).map(async (type) => {
+      const ids = idsByType[type];
 
-    // type was removed but still in morph relation
-    if (!db.metadata.get(type)) {
-      map[type] = {};
+      // type was removed but still in morph relation
+      if (!db.metadata.get(type)) {
+        map[type] = {};
 
-      continue;
-    }
+        return;
+      }
 
-    const qb = db.entityManager.createQueryBuilder(type);
+      const qb = db.entityManager.createQueryBuilder(type);
 
-    const rows = await qb
-      .init(on?.[type] ?? typePopulate)
-      .addSelect(`${qb.alias}.${idColumn.referencedColumn}`)
-      .where({ [idColumn.referencedColumn]: ids })
-      .execute<Row[]>({ mapResults: false });
+      const rows = await qb
+        .init(on?.[type] ?? typePopulate)
+        .addSelect(`${qb.alias}.${idColumn.referencedColumn}`)
+        .where({ [idColumn.referencedColumn]: ids })
+        .execute<Row[]>({ mapResults: false });
 
-    map[type] = _.groupBy<Row>(idColumn.referencedColumn)(rows);
-  }
+      map[type] = _.groupBy<Row>(idColumn.referencedColumn)(rows);
+    })
+  );
 
   results.forEach((result) => {
     const joinResults = joinMap[result[joinColumn.referencedColumn] as string] || [];
@@ -701,7 +703,7 @@ const applyPopulate = async (results: Row[], populate: Record<string, any>, ctx:
     return results;
   }
 
-  for (const attributeName of Object.keys(populate)) {
+  const populateAttribute = async (attributeName: string) => {
     const attribute = meta.attributes[attributeName];
 
     if (attribute.type !== 'relation') {
@@ -753,7 +755,9 @@ const applyPopulate = async (results: Row[], populate: Record<string, any>, ctx:
         break;
       }
     }
-  }
+  };
+
+  await Promise.all(Object.keys(populate).map(populateAttribute));
 };
 
 export default applyPopulate;


### PR DESCRIPTION
## What does it do?

Parallelizes dynamic zone population queries in the database layer to improve performance when populating content types with many DZ component types.

**Two changes:**

1. **Parallelized `morphToMany` per-type queries** (`packages/core/database/src/query/helpers/populate/apply.ts`) — When populating a dynamic zone, Strapi queries each component type sequentially in a `for` loop. With 10 component types, that's 10 sequential DB round-trips. This change runs them concurrently via `Promise.all`.

2. **Parallelized `applyPopulate` relation handlers** (same file) — The top-level orchestrator that processes all populate attributes (relations, media, morphToMany) also ran sequentially. Now runs concurrently.

3. **Memoized `getDeepPopulate`** (`packages/core/core/src/services/document-service/utils/populate.ts`) — Caches the populate config object since schemas don't change at runtime.

## Why is it needed?

Users with many component types in dynamic zones report slow population performance. The current workaround is a double lookup — first `populate: "*"` to discover which component types are present, then a targeted populate with only those types. This fix reduces the need for that workaround by making the single-pass populate significantly faster.

## Benchmark results

Tested against Strapi Cloud (remote Postgres) with a complex page-builder schema: 50 entries, 10 DZ section types with 3 levels of nesting (nested components, relations, media).

| Scenario | Before (P50) | After (P50) | Improvement |
|---|---|---|---|
| Full deep populate (all 10 sections) | 158.40 ms | 125.69 ms | **-20.6%** |
| Wildcard populate (`*`) | 202.15 ms | 165.32 ms | **-18.2%** |
| No populate (baseline) | 74.22 ms | 69.88 ms | ~same |

## How to test

### Setup

Ping me on slack for the setup

1. Copy the `api/` and `components/` folders from the `dz-populate-reproduction` folder into your Strapi project's `src/` directory. This adds:
   - 3 simple content types: `author`, `category`, `tag`
   - 10 complex DZ section components with nested components, relations, and media (`sections.*`, `cards.*`, `shared.*`)
   - A `dz-benchmark` content type with a dynamic zone using all 10 section types
2. Copy the `benchmarks/` folder to your project root
3. Create a strapi cloud project and deploy: `yarn deploy`
4. Create a **full-access API token** in the admin panel (Settings → API Tokens)
5. Run the benchamark script

```bash
# First run seeds 50 entries automatically
STRAPI_URL=https://your-app.strapiapp.com API_TOKEN=<your-token> node benchmarks/dz-populate.js
```
6. Update the package.json to use this experimental: `0.0.0-experimental.5506031e822d7cf75a5fc7435ac7eeb9bc85ebcd` and repeat all the steps again
7. Now compare the numbers

The "Full deep populate" and "Wildcard populate" scenarios should show ~20% improvement. "No populate" should be unchanged (confirms the improvement is in the population layer).
