### PR TITLE
fix(admin): prevent portal race conditions, add errorBoundary

### DIFF
--- a/packages/core/admin/admin/src/App.tsx
+++ b/packages/core/admin/admin/src/App.tsx
@@ -9,6 +9,7 @@ import { Outlet } from 'react-router-dom';
 
 import { GlobalNotifications } from '../../ee/admin/src/components/GlobalNotifications';
 
+import { AdminErrorBoundary } from './components/AdminErrorBoundary';
 import { Page } from './components/PageHelpers';
 import { Providers } from './components/Providers';
 import { LANGUAGE_LOCAL_STORAGE_KEY } from './reducer';
@@ -43,12 +44,14 @@ const App = ({ strapi, store }: AppProps) => {
 
   return (
     <Providers strapi={strapi} store={store}>
-      <Suspense fallback={<Page.Loading />}>
-        <GlobalNotifications />
-        {window.strapi.future.isEnabled('unstableMediaLibrary') &&
-          globalComponents.map(({ name, Component }) => <Component key={name} />)}
-        <Outlet />
-      </Suspense>
+      <AdminErrorBoundary>
+        <Suspense fallback={<Page.Loading />}>
+          <GlobalNotifications />
+          {window.strapi.future.isEnabled('unstableMediaLibrary') &&
+            globalComponents.map(({ name, Component }) => <Component key={name} />)}
+          <Outlet />
+        </Suspense>
+      </AdminErrorBoundary>
     </Providers>
   );
 };

--- a/packages/core/admin/admin/src/components/AdminErrorBoundary.tsx
+++ b/packages/core/admin/admin/src/components/AdminErrorBoundary.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+
+import {
+  Alert,
+  Button,
+  Flex,
+  Main,
+  Typography,
+  Link,
+  TypographyComponent,
+} from '@strapi/design-system';
+import { Duplicate, WarningCircle } from '@strapi/icons';
+import { styled } from 'styled-components';
+
+import { RESPONSIVE_DEFAULT_SPACING } from '../constants/theme';
+
+interface AdminErrorBoundaryState {
+  error: Error | null;
+  componentStack: string | null;
+}
+
+interface AdminErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+class AdminErrorBoundary extends React.Component<AdminErrorBoundaryProps, AdminErrorBoundaryState> {
+  constructor(props: AdminErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null, componentStack: null };
+  }
+
+  static getDerivedStateFromError(error: Error): AdminErrorBoundaryState {
+    return { error, componentStack: null };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('[AdminErrorBoundary]', {
+      message: error.message,
+      stack: error.stack,
+      componentStack: info.componentStack,
+      pathname: window.location.pathname,
+    });
+    this.setState({ componentStack: info.componentStack ?? null });
+  }
+
+  render() {
+    if (this.state.error !== null) {
+      return <ErrorFallback error={this.state.error} componentStack={this.state.componentStack} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+interface ErrorFallbackProps {
+  error: Error;
+  componentStack: string | null;
+}
+
+const ErrorFallback = ({ error, componentStack }: ErrorFallbackProps) => {
+  const handleCopy = async () => {
+    const text = [
+      '```',
+      error.stack ?? error.message,
+      '```',
+      componentStack !== null ? `\nComponent stack:\n${componentStack}` : '',
+    ]
+      .join('\n')
+      .trim();
+
+    await navigator.clipboard.writeText(text);
+  };
+
+  const trimmedStack =
+    componentStack !== null ? componentStack.trim().split('\n').slice(0, 8).join('\n') : null;
+
+  return (
+    <Main height="100%">
+      <Flex
+        alignItems="center"
+        height="100%"
+        justifyContent="center"
+        paddingLeft={RESPONSIVE_DEFAULT_SPACING}
+        paddingRight={RESPONSIVE_DEFAULT_SPACING}
+      >
+        <Flex
+          gap={7}
+          padding={{
+            initial: 6,
+            small: 7,
+            medium: 8,
+          }}
+          direction="column"
+          width="100%"
+          maxWidth="512px"
+          shadow="tableShadow"
+          borderColor="neutral150"
+          background="neutral0"
+          hasRadius
+        >
+          <Flex direction="column" gap={2}>
+            <WarningCircle width="32px" height="32px" fill="danger600" />
+            <Typography fontSize={4} fontWeight="bold" textAlign="center">
+              Something went wrong
+            </Typography>
+            <Typography variant="omega" textAlign="center">
+              {`It seems like there is a bug in your instance, but we've got you covered. Please notify your technical team so they can investigate the source of the problem and report the issue to us by opening a bug report on `}
+              <Link
+                isExternal
+                endIcon
+                href="https://github.com/strapi/strapi/issues/new?assignees=&labels=&projects=&template=BUG_REPORT.md"
+              >{`Strapi's GitHub`}</Link>
+              .
+            </Typography>
+          </Flex>
+          <Flex gap={4} direction="column" width="100%">
+            <StyledAlert onClose={() => {}} width="100%" closeLabel="" variant="danger">
+              <ErrorType>{error.message}</ErrorType>
+            </StyledAlert>
+            {trimmedStack !== null && (
+              <StyledAlert onClose={() => {}} width="100%" closeLabel="" variant="default">
+                <StackType>{trimmedStack}</StackType>
+              </StyledAlert>
+            )}
+            <Flex gap={2}>
+              <Button onClick={handleCopy} variant="tertiary" startIcon={<Duplicate />}>
+                Copy to clipboard
+              </Button>
+              <Button onClick={() => window.location.reload()} variant="secondary">
+                Reload page
+              </Button>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Main>
+  );
+};
+
+const StyledAlert = styled(Alert)`
+  & > div:first-child {
+    display: none;
+  }
+
+  & > button {
+    display: none;
+  }
+`;
+
+const ErrorType = styled<TypographyComponent>(Typography)`
+  word-break: break-all;
+  color: ${({ theme }) => theme.colors.danger600};
+`;
+
+const StackType = styled<TypographyComponent>(Typography)`
+  word-break: break-all;
+  white-space: pre-wrap;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.neutral600};
+`;
+
+export { AdminErrorBoundary };

--- a/packages/core/admin/admin/src/components/MainNav/NavBurgerMenu.tsx
+++ b/packages/core/admin/admin/src/components/MainNav/NavBurgerMenu.tsx
@@ -41,12 +41,11 @@ export const NavBurgerMenu = ({
   listLinks,
 }: NavBurgerMenuProps) => {
   return (
-    <Portal>
-      <AnimatePresence>
-        {isShown && (
+    <AnimatePresence>
+      {isShown === true && (
+        <Portal key="burger">
           <FocusTrap onEscape={onClose}>
             <MotionLayer
-              key="burger"
               role="dialog"
               aria-modal="true"
               initial={{ y: '-100%' }}
@@ -83,8 +82,8 @@ export const NavBurgerMenu = ({
               </Surface>
             </MotionLayer>
           </FocusTrap>
-        )}
-      </AnimatePresence>
-    </Portal>
+        </Portal>
+      )}
+    </AnimatePresence>
   );
 };

--- a/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
+++ b/packages/core/content-type-builder/admin/src/components/AutoReloadOverlayBlocker.tsx
@@ -130,42 +130,52 @@ interface BlockerProps {
 
 const Blocker = ({ displayedIcon, description, title, isOpen }: BlockerProps) => {
   const { formatMessage } = useIntl();
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
 
-  // eslint-disable-next-line no-undef
-  return isOpen && globalThis?.document?.body
-    ? createPortal(
-        <Overlay id="autoReloadOverlayBlocker" direction="column" alignItems="center" gap={6}>
-          <Flex direction="column" alignItems="center" gap={2}>
-            <Typography tag="h1" variant="alpha">
-              {formatMessage(title)}
-            </Typography>
-            <Typography tag="h2" textColor="neutral600" fontSize={4} fontWeight="regular">
-              {formatMessage(description)}
-            </Typography>
-          </Flex>
-          {displayedIcon === 'reload' && (
-            <IconBox padding={6} background="primary100" borderColor="primary200">
-              <LoaderReload width="4rem" height="4rem" />
-            </IconBox>
-          )}
-          {displayedIcon === 'time' && (
-            <IconBox padding={6} background="primary100" borderColor="primary200">
-              <Clock width="4rem" height="4rem" />
-            </IconBox>
-          )}
-          <Box marginTop={2}>
-            <Link href="https://docs.strapi.io" isExternal>
-              {formatMessage({
-                id: 'global.documentation',
-                defaultMessage: 'Read the documentation',
-              })}
-            </Link>
-          </Box>
-        </Overlay>,
-        // eslint-disable-next-line no-undef
-        globalThis.document.body
-      )
-    : null;
+  React.useEffect(() => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    containerRef.current = container;
+
+    return () => {
+      document.body.removeChild(container);
+      containerRef.current = null;
+    };
+  }, []);
+
+  if (isOpen === false || containerRef.current === null) return null;
+
+  return createPortal(
+    <Overlay id="autoReloadOverlayBlocker" direction="column" alignItems="center" gap={6}>
+      <Flex direction="column" alignItems="center" gap={2}>
+        <Typography tag="h1" variant="alpha">
+          {formatMessage(title)}
+        </Typography>
+        <Typography tag="h2" textColor="neutral600" fontSize={4} fontWeight="regular">
+          {formatMessage(description)}
+        </Typography>
+      </Flex>
+      {displayedIcon === 'reload' && (
+        <IconBox padding={6} background="primary100" borderColor="primary200">
+          <LoaderReload width="4rem" height="4rem" />
+        </IconBox>
+      )}
+      {displayedIcon === 'time' && (
+        <IconBox padding={6} background="primary100" borderColor="primary200">
+          <Clock width="4rem" height="4rem" />
+        </IconBox>
+      )}
+      <Box marginTop={2}>
+        <Link href="https://docs.strapi.io" isExternal>
+          {formatMessage({
+            id: 'global.documentation',
+            defaultMessage: 'Read the documentation',
+          })}
+        </Link>
+      </Box>
+    </Overlay>,
+    containerRef.current
+  );
 };
 
 const rotation = keyframes`


### PR DESCRIPTION
### What does it do?

**Fix `removeChild` crash in admin portal lifecycle + add `AdminErrorBoundary`**

Three targeted changes:

1. **`NavBurgerMenu.tsx`** — Inverted the `Portal` / `AnimatePresence` nesting. `AnimatePresence` now wraps `Portal`, so the portal container is only mounted when the menu is open (`isShown === true`). After the 200 ms exit animation completes, React cleanly unmounts the `Portal` and removes its container div from `document.body`. The previous structure kept the portal container alive permanently, creating a race between React's commit-phase deletion and `motion/react`'s async exit cleanup.

2. **`AutoReloadOverlayBlocker.tsx`** — Replaced `createPortal(…, document.body)` with a dedicated stable container element created and destroyed via `useEffect`. The container's lifecycle is tied to the `Blocker` component, giving React an exclusive, clean reference and eliminating the double-removal race that occurred when the CTB parent tree unmounted while `isOpen` was `true`.

3. **`AdminErrorBoundary.tsx`** (new) + **`App.tsx`** — Added a `React.Component` class boundary with `getDerivedStateFromError` and `componentDidCatch`. It logs `error.message`, `error.stack`, `info.componentStack`, and `window.location.pathname`. The fallback UI mirrors the existing `ErrorElement` style and adds a trimmed component stack section and a "Reload page" button. Placed inside `<Providers>` in `App.tsx` so the fallback has access to Theme and i18n.

---

### Why is it needed?

A `NotFoundError: Failed to execute 'removeChild' on 'Node'` crash has been reported in [47+ GitHub issues](https://github.com/strapi/strapi/issues?q=is%3Aissue%20removeChild) spanning Oct 2024 → Mar 2026, all on Strapi v5.x. The error is thrown by React's reconciler during the commit/deletion phase when it calls `container.removeChild(node)` but `node` is no longer a child of `container`.

Two root causes were identified:

- **H1 — `NavBurgerMenu`**: The `<Portal>` container was always mounted in `document.body`. `AnimatePresence` + `motion/react` intercept the unmount of `MotionLayer` to play a 200 ms CSS exit animation. If the parent layout unmounts during that window, React's commit-phase deletion of the portal container races with `motion/react`'s animation cleanup → `portalDiv.removeChild(motionLayerNode)` throws.

- **H3 — `AutoReloadOverlayBlocker`**: `createPortal(child, document.body)` with a conditional `isOpen` render. When the CTB parent tree unmounts while `isOpen=true` (server restart mid-navigation), React processes deletion of the portal fiber from `document.body`. In concurrent mode, the parent teardown and the portal cleanup can interleave, causing a double-removal.

Additionally, the admin had no `componentDidCatch` class boundary. The existing `ErrorElement` uses React Router's `useRouteError()`, which only catches render-phase errors routed through React Router's own internal boundary — not commit-phase errors like `removeChild`. This meant the crash caused a full tree unmount with zero debugging context and no recovery path.

---

### How to test it?

**Environment**: Strapi v5.x, any browser, with `STRAPI_ENFORCE_SOURCEMAPS=true` for readable stack traces.

**H1 — NavBurgerMenu race (mobile viewport)**

1. Open the admin at a viewport width below the large breakpoint (< ~1280 px) so the burger menu button is visible.
2. Open the burger menu.
3. Immediately navigate to a different section (e.g., click Content Manager in the nav or use the browser back button) while the menu close animation is in progress.
4. Before: `removeChild` error in the console + full page crash. After: clean navigation, no error.

**H3 — AutoReloadOverlayBlocker race**

1. Open the Content-Type Builder.
2. Create or modify a content type and save — this triggers the auto-reload overlay (`lockAppWithAutoreload`).
3. While the overlay is visible, navigate away (click a nav link or use the browser back button).
4. Before: potential `removeChild` error. After: clean unmount, no error.

**AdminErrorBoundary**

1. Temporarily throw an error inside a child component of `<Outlet>` (e.g., add `throw new Error('test boundary')` at the top of a page component).
2. Navigate to that page.
3. Before: full white screen or React Router's generic error page with no component stack. After: styled error card with the error message, trimmed component stack, "Copy to clipboard" and "Reload page" buttons.

---

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/strapi/issues/25544

Related reports (same root cause):

- https://github.com/strapi/strapi/issues/23999
- https://github.com/strapi/strapi/issues/23627
- https://github.com/strapi/strapi/issues/24559
- https://github.com/strapi/strapi/issues/24777
- https://github.com/strapi/strapi/issues/22446
- https://github.com/strapi/strapi/issues/25593

---

## Analysis & Plan

> Full analysis: [`removeChild-bug-analysis.md`](./removeChild-bug-analysis.md)

### Root cause summary

The error is thrown by React's reconciler in the commit/deletion phase — not Strapi application logic. Two distinct call paths exist:

| Path  | Entry point                | Meaning                                                                                    |
| ----- | -------------------------- | ------------------------------------------------------------------------------------------ |
| **A** | `removeChildFromContainer` | React unmounting a **portal** — removing a child from a portal container (`document.body`) |
| **B** | `removeChild`              | React unmounting a **regular DOM child**                                                   |

Path A accounts for the vast majority of the 47 reported issues.

### Portal inventory (risk-ranked)

| File                                        | Portal type                      | Always mounted?         | Risk        |
| ------------------------------------------- | -------------------------------- | ----------------------- | ----------- |
| `MainNav/NavBurgerMenu.tsx`                 | `<Portal>` (design-system)       | **Yes — always**        | **Highest** |
| `AutoReloadOverlayBlocker.tsx`              | `createPortal(…, document.body)` | Conditional on `isOpen` | High        |
| `content-type-builder/FullScreenImage.tsx`  | `createPortal(…, document.body)` | Conditional on `isOpen` | Medium      |
| `GuidedTour/Tours.tsx`                      | `<Portal>` + Radix `Popover`     | Conditional             | Medium      |
| Radix UI (Dialog, Modal, Popover, Tooltip…) | Implicit portals                 | Conditional             | Medium      |
| `NpsSurvey.tsx`                             | `<Portal>`                       | Conditional             | Low         |

### Fix approach

**H1 — `NavBurgerMenu.tsx`**

`<Portal>` was always mounted (a container div lives in `document.body` forever). `AnimatePresence` and `motion/react` sit _inside_ the Portal and play an async 200 ms exit animation. If the parent layout unmounts during that window, React's commit-phase deletion of the Portal container races with `motion/react`'s animation cleanup → `portalDiv.removeChild(motionLayerNode)` throws.

```tsx
// Before (broken)
<Portal>
  <AnimatePresence>
    {isShown && <MotionLayer exit={{ y: '-100%' }}>...</MotionLayer>}
  </AnimatePresence>
</Portal>

// After: Portal inside the AnimatePresence condition
<AnimatePresence>
  {isShown === true && (
    <Portal key="burger">
      <FocusTrap onEscape={onClose}>
        <MotionLayer ...>...</MotionLayer>
      </FocusTrap>
    </Portal>
  )}
</AnimatePresence>
```

`AnimatePresence` keeps the whole `Portal` subtree alive during the exit animation (React context propagates through portals, so `motion/react` still receives the `AnimatePresence` context). After the animation completes, React cleanly unmounts the Portal and removes its container div from `document.body` — no race.

**H3 — `AutoReloadOverlayBlocker.tsx`**

`createPortal(child, globalThis.document.body)` with a conditional `isOpen` render. When the CTB parent tree unmounts while `isOpen=true`, React processes deletion of the portal fiber from `document.body`. If any other code mutated `document.body` in between, the removal fails.

Fix: use a **dedicated stable container element** instead of portaling directly to `document.body`. The container's lifecycle is tied to the component, so React always has a clean, exclusive reference.

```tsx
const containerRef = React.useRef<HTMLDivElement | null>(null);

React.useEffect(() => {
  const container = document.createElement('div');
  document.body.appendChild(container);
  containerRef.current = container;

  return () => {
    document.body.removeChild(container);
    containerRef.current = null;
  };
}, []);

if (isOpen === false || containerRef.current === null) return null;
return createPortal(<Overlay />, containerRef.current);
```

**Track 2 — `AdminErrorBoundary.tsx`**

No `componentDidCatch` class boundary existed in the admin. The existing `ErrorElement` uses React Router's `useRouteError()` — that only catches render-phase errors routed through React Router's own internal boundary. A proper `componentDidCatch` boundary placed closer to the content tree catches earlier, provides `info.componentStack`, and enables graceful recovery.

Placed in `App.tsx` inside `<Providers>` so the fallback has access to Theme and i18n:

```tsx
<Providers strapi={strapi} store={store}>
  <AdminErrorBoundary>
    <Suspense fallback={<Page.Loading />}>
      <GlobalNotifications />
      <Outlet />
    </Suspense>
  </AdminErrorBoundary>
</Providers>
```
