### PR TITLE
fix: bulk publish validation on required components in dz

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -59,7 +59,7 @@ type DocumentActionPosition = 'panel' | 'header' | 'table-row' | 'preview' | 're
 
 interface DocumentActionDescription {
   label: string;
-  type?: string;
+  type?: 'publish' | 'update' | 'unpublish' | 'discard';
   onClick?: (event: React.SyntheticEvent) => Promise<boolean | void> | boolean | void;
   icon?: React.ReactNode;
   /**
@@ -210,7 +210,7 @@ const DocumentActions = ({ actions }: DocumentActionsProps) => {
           <DocumentActionButton
             {...primaryAction}
             variant={primaryAction.variant || 'default'}
-            {...(primaryAction.type === 'publish' ? {} : { buttonType: 'submit' })}
+            buttonType={primaryAction.type === 'publish' ? undefined : 'submit'}
           />
         )}
       </Flex>
@@ -258,15 +258,16 @@ const DocumentActions = ({ actions }: DocumentActionsProps) => {
  * DocumentActionButton
  * -----------------------------------------------------------------------------------------------*/
 
-interface DocumentActionButtonProps extends Action {
+interface DocumentActionButtonProps extends Omit<Action, 'type'> {
   buttonType?: 'button' | 'submit' | 'reset';
+  type?: string;
 }
 
 const DocumentActionButton = ({ buttonType = 'button', ...action }: DocumentActionButtonProps) => {
   const [dialogId, setDialogId] = React.useState<string | null>(null);
   const { toggleNotification } = useNotification();
 
-  const handleClick = (action: Action) => async (e: React.MouseEvent) => {
+  const handleClick = (action: DocumentActionButtonProps) => async (e: React.MouseEvent) => {
     const { onClick = () => false, dialog, id } = action;
 
     const muteDialog = await onClick(e);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -260,7 +260,7 @@ const DocumentActions = ({ actions }: DocumentActionsProps) => {
 
 interface DocumentActionButtonProps extends Omit<Action, 'type'> {
   buttonType?: 'button' | 'submit' | 'reset';
-  type?: string;
+  type?: DocumentActionDescription['type'];
 }
 
 const DocumentActionButton = ({ buttonType = 'button', ...action }: DocumentActionButtonProps) => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -59,6 +59,7 @@ type DocumentActionPosition = 'panel' | 'header' | 'table-row' | 'preview' | 're
 
 interface DocumentActionDescription {
   label: string;
+  type?: string;
   onClick?: (event: React.SyntheticEvent) => Promise<boolean | void> | boolean | void;
   icon?: React.ReactNode;
   /**
@@ -204,22 +205,14 @@ const DocumentActions = ({ actions }: DocumentActionsProps) => {
   const primaryActionContent = (
     <>
       <Flex flex={1} alignItems="stretch" direction="column">
-        {primaryAction.label === 'Publish'
-          ? addHintTooltip(
-              primaryAction,
-              <DocumentActionButton
-                {...primaryAction}
-                variant={primaryAction.variant || 'default'}
-              />
-            )
-          : addHintTooltip(
-              primaryAction,
-              <DocumentActionButton
-                {...primaryAction}
-                variant={primaryAction.variant || 'default'}
-                buttonType="submit"
-              />
-            )}
+        {addHintTooltip(
+          primaryAction,
+          <DocumentActionButton
+            {...primaryAction}
+            variant={primaryAction.variant || 'default'}
+            {...(primaryAction.type === 'publish' ? {} : { buttonType: 'submit' })}
+          />
+        )}
       </Flex>
 
       {restActions.length > 0 ? (
@@ -241,7 +234,7 @@ const DocumentActions = ({ actions }: DocumentActionsProps) => {
       </tours.contentManager.Publish>
       {secondaryAction ? (
         <Flex flex={1} order={{ initial: -1, large: 0 }} alignItems="stretch" direction="column">
-          {secondaryAction.label === 'Publish' ? (
+          {secondaryAction.type === 'publish' ? (
             <tours.contentManager.Publish>
               <DocumentActionButton
                 {...secondaryAction}
@@ -622,7 +615,6 @@ const PublishAction: DocumentActionComponent = ({
   const validate = useForm('PublishAction', (state) => state.validate);
   const setErrors = useForm('PublishAction', (state) => state.setErrors);
   const formValues = useForm('PublishAction', ({ values }) => values);
-  const initialValues = useForm('PublishAction', ({ initialValues }) => initialValues);
   const resetForm = useForm('PublishAction', ({ resetForm }) => resetForm);
   const {
     currentDocument: { components },
@@ -953,6 +945,7 @@ const PublishAction: DocumentActionComponent = ({
   }
 
   return {
+    type: 'publish',
     loading: isLoading,
     position: ['panel', 'preview', 'relation-modal'],
     /**

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/Actions.tsx
@@ -67,7 +67,7 @@ const BulkActionsRenderer = () => {
         ).getBulkActions()}
       >
         {(actions) =>
-          actions.map((action) => {
+          actions.map(({ type: _bulkType, ...action }) => {
             return list.settings.bulkable && <DocumentActionButton key={action.id} {...action} />;
           })
         }

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -34,13 +34,14 @@ import { useDocumentActions } from '../../../../hooks/useDocumentActions';
 import { useDocLayout } from '../../../../hooks/useDocumentLayout';
 import { contentManagerApi } from '../../../../services/api';
 import {
-  useGetAllDocumentsQuery,
+  useGetDocumentsForValidationQuery,
   usePublishManyDocumentsMutation,
 } from '../../../../services/documents';
 import { buildValidParams } from '../../../../utils/api';
 import { getTranslation } from '../../../../utils/translations';
 import { createYupSchema } from '../../../../utils/validation';
 import { DocumentStatus } from '../../../EditView/components/DocumentStatus';
+import { transformDocument } from '../../../EditView/utils/data';
 
 import { ConfirmDialogPublishAll, ConfirmDialogPublishAllProps } from './ConfirmBulkActionDialog';
 
@@ -413,60 +414,46 @@ const SelectedEntriesModalContent = ({
   const [{ query }] = useQueryParams<{ sort?: string; plugins?: Record<string, any> }>();
   const params = React.useMemo(() => buildValidParams(query), [query]);
 
-  // Fetch the documents based on the selected entries and update the modal table
-  const { data, isLoading, isFetching, refetch } = useGetAllDocumentsQuery(
+  // Fetch via findOne (same as edit view) so we get the exact same data structure.
+  // The list API returns a different structure that causes false validation errors.
+  const {
+    data: documents = [],
+    isLoading,
+    isFetching,
+    refetch,
+  } = useGetDocumentsForValidationQuery(
     {
+      collectionType: 'collection-types',
       model,
-      params: {
-        page: '1',
-        pageSize: documentIds.length.toString(),
-        sort: query.sort,
-        filters: {
-          documentId: {
-            $in: documentIds,
-          },
-        },
-        locale: query.plugins?.i18n?.locale,
-      },
+      documentIds,
+      params: { locale: query.plugins?.i18n?.locale },
     },
-    {
-      selectFromResult: ({ data, ...restRes }) => ({ data: data?.results ?? [], ...restRes }),
-    }
+    { skip: documentIds.length === 0 }
   );
 
-  // Validate the entries based on the schema to show errors if any
+  // Transform and validate like the edit view - transformDocument prepares data
+  // for validation (relations, temp keys, etc.)
   const { rows, validationErrors } = React.useMemo(() => {
-    if (data.length > 0 && schema) {
-      const validate = createYupSchema(
-        schema.attributes,
-        components,
-        // Since this is the "Publish" action, the validation
-        // schema must enforce the rules for published entities
-        { status: 'published' }
-      );
+    if (documents.length > 0 && schema) {
+      const validate = createYupSchema(schema.attributes, components, { status: 'published' });
+      const transform = transformDocument(schema, components);
       const validationErrors: Record<TableRow['documentId'], FormErrors> = {};
-      const rows = data.map((entry: Document) => {
+      const rows = documents.map((entry: Document) => {
+        const transformed = transform(entry);
         try {
-          validate.validateSync(entry, { abortEarly: false });
-
+          validate.validateSync(transformed, { abortEarly: false });
           return entry;
         } catch (e) {
           if (e instanceof ValidationError) {
             validationErrors[entry.documentId] = getYupValidationErrors(e);
           }
-
           return entry;
         }
       });
-
       return { rows, validationErrors };
     }
-
-    return {
-      rows: [],
-      validationErrors: {},
-    };
-  }, [components, data, schema]);
+    return { rows: [], validationErrors: {} };
+  }, [components, documents, schema]);
 
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -426,6 +426,7 @@ const SelectedEntriesModalContent = ({
       model,
       documentIds,
       locale: query.plugins?.i18n?.locale,
+      sort: query.sort,
     },
     { skip: documentIds.length === 0 }
   );
@@ -437,7 +438,20 @@ const SelectedEntriesModalContent = ({
       const validate = createYupSchema(schema.attributes, components, { status: 'published' });
       const transform = transformDocument(schema, components);
       const validationErrors: Record<TableRow['documentId'], FormErrors> = {};
-      const rows = documents.map((entry: Document) => {
+      // Re-order documents to match the list view selection order, and restore the
+      // correct status (draft fetch returns 'draft' even for 'modified' documents)
+      const documentsMap = new Map(documents.map((doc: Document) => [doc.documentId, doc]));
+      const listViewStatusMap = new Map(
+        listViewSelectedEntries.map(({ documentId, status }) => [documentId, status])
+      );
+      const orderedDocuments = documentIds
+        .map((id) => {
+          const doc = documentsMap.get(id);
+          if (!doc) return undefined;
+          return { ...doc, status: listViewStatusMap.get(id) ?? doc.status };
+        })
+        .filter((doc): doc is Document => doc !== undefined);
+      const rows = orderedDocuments.map((entry: Document) => {
         const transformed = transform(entry);
         try {
           validate.validateSync(transformed, { abortEarly: false });
@@ -452,7 +466,7 @@ const SelectedEntriesModalContent = ({
       return { rows, validationErrors };
     }
     return { rows: [], validationErrors: {} };
-  }, [components, documents, schema]);
+  }, [components, documents, documentIds, listViewSelectedEntries, schema]);
 
   const [isDialogOpen, setIsDialogOpen] = React.useState(false);
 

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -423,10 +423,9 @@ const SelectedEntriesModalContent = ({
     refetch,
   } = useGetDocumentsForValidationQuery(
     {
-      collectionType: 'collection-types',
       model,
       documentIds,
-      params: { locale: query.plugins?.i18n?.locale },
+      locale: query.plugins?.i18n?.locale,
     },
     { skip: documentIds.length === 0 }
   );

--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -448,7 +448,7 @@ const SelectedEntriesModalContent = ({
         .map((id) => {
           const doc = documentsMap.get(id);
           if (!doc) return undefined;
-          return { ...doc, status: listViewStatusMap.get(id) ?? doc.status };
+          return { ...doc, status: listViewStatusMap.get(id) ?? doc.status } as Document;
         })
         .filter((doc): doc is Document => doc !== undefined);
       const rows = orderedDocuments.map((entry: Document) => {

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -265,12 +265,13 @@ const documentApi = contentManagerApi.injectEndpoints({
         model: string;
         documentIds: string[];
         locale?: string;
+        sort?: string;
       }
     >({
-      query: ({ model, documentIds, locale }) => ({
+      query: ({ model, documentIds, locale, sort }) => ({
         url: `/content-manager/collection-types/${model}/actions/bulkFindForValidation`,
         method: 'POST',
-        data: { documentIds, locale },
+        data: { documentIds, locale, sort },
       }),
       transformResponse: (response: { results: Find.Response['results'] }) =>
         response?.results ?? [],

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -257,38 +257,23 @@ const documentApi = contentManagerApi.injectEndpoints({
       }),
     }),
     /**
-     * Fetches documents via the existing findOne endpoint (same as edit view).
-     * Reuses the edit view's data structure for validation.
+     * Fetches multiple documents with deep populate in a single request for bulk publish validation.
      */
     getDocumentsForValidation: builder.query<
       Find.Response['results'],
       {
-        collectionType: string;
         model: string;
         documentIds: string[];
-        params?: FindOne.Request['query'];
+        locale?: string;
       }
     >({
-      queryFn: async (
-        { collectionType, model, documentIds, params },
-        _api,
-        _extraOpts,
-        baseQuery
-      ) => {
-        const results = await Promise.all(
-          documentIds.map(async (documentId) => {
-            const res = await baseQuery({
-              url: `/content-manager/${collectionType}/${model}/${documentId}`,
-              method: 'GET',
-              config: { params },
-            });
-            if (res.error) return null;
-            return (res.data as FindOne.Response)?.data ?? null;
-          })
-        );
-        const documents = results.filter((doc): doc is FindOne.Response['data'] => doc != null);
-        return { data: documents };
-      },
+      query: ({ model, documentIds, locale }) => ({
+        url: `/content-manager/collection-types/${model}/actions/bulkFindForValidation`,
+        method: 'POST',
+        data: { documentIds, locale },
+      }),
+      transformResponse: (response: { results: Find.Response['results'] }) =>
+        response?.results ?? [],
       providesTags: (result, _error, { model }) =>
         result
           ? [

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -261,7 +261,7 @@ const documentApi = contentManagerApi.injectEndpoints({
      * Reuses the edit view's data structure for validation.
      */
     getDocumentsForValidation: builder.query<
-      FindOne.Response['data'][],
+      Find.Response['results'],
       {
         collectionType: string;
         model: string;

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -256,6 +256,50 @@ const documentApi = contentManagerApi.injectEndpoints({
         },
       }),
     }),
+    /**
+     * Fetches documents via the existing findOne endpoint (same as edit view).
+     * Reuses the edit view's data structure for validation.
+     */
+    getDocumentsForValidation: builder.query<
+      FindOne.Response['data'][],
+      {
+        collectionType: string;
+        model: string;
+        documentIds: string[];
+        params?: FindOne.Request['query'];
+      }
+    >({
+      queryFn: async (
+        { collectionType, model, documentIds, params },
+        _api,
+        _extraOpts,
+        baseQuery
+      ) => {
+        const results = await Promise.all(
+          documentIds.map(async (documentId) => {
+            const res = await baseQuery({
+              url: `/content-manager/${collectionType}/${model}/${documentId}`,
+              method: 'GET',
+              config: { params },
+            });
+            if (res.error) return null;
+            return (res.data as FindOne.Response)?.data ?? null;
+          })
+        );
+        const documents = results.filter((doc): doc is FindOne.Response['data'] => doc != null);
+        return { data: documents };
+      },
+      providesTags: (result, _error, { model }) =>
+        result
+          ? [
+              ...result.map((doc) => ({
+                type: 'Document' as const,
+                id: `${model}_${doc.documentId}`,
+              })),
+              { type: 'Document', id: `${model}_LIST` },
+            ]
+          : [],
+    }),
     getDocument: builder.query<
       FindOne.Response,
       Pick<FindOne.Params, 'model'> &
@@ -515,6 +559,7 @@ const {
   useDeleteManyDocumentsMutation,
   useDiscardDocumentMutation,
   useGetAllDocumentsQuery,
+  useGetDocumentsForValidationQuery,
   useLazyGetDocumentQuery,
   useGetDocumentQuery,
   useLazyGetDraftRelationCountQuery,
@@ -534,6 +579,7 @@ export {
   useDeleteManyDocumentsMutation,
   useDiscardDocumentMutation,
   useGetAllDocumentsQuery,
+  useGetDocumentsForValidationQuery,
   useLazyGetDocumentQuery,
   useGetDocumentQuery,
   useLazyGetDraftRelationCountQuery as useGetDraftRelationCountQuery,

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -632,7 +632,7 @@ export default {
   async bulkFindForValidation(ctx: any) {
     const { userAbility } = ctx.state;
     const { model } = ctx.params;
-    const { documentIds, locale } = ctx.request.body;
+    const { documentIds, locale, sort } = ctx.request.body;
 
     await validateBulkActionInput(ctx.request.body);
 
@@ -652,6 +652,7 @@ export default {
       populate,
       filters: { documentId: { $in: documentIds } } as any,
       locale,
+      sort,
       status: 'draft',
     });
 

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -642,10 +642,6 @@ export default {
       return ctx.forbidden();
     }
 
-    if (documentIds.length > 100) {
-      return ctx.badRequest('documentIds must not exceed 100 items');
-    }
-
     const populate = await buildDeepPopulate(model as UID.CollectionType);
 
     const documents = await strapi.documents(model as UID.CollectionType).findMany({

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -9,7 +9,7 @@ import { getProhibitedCloningFields, excludeNotCreatableFields } from './utils/c
 import { getDocumentLocaleAndStatus } from './validation/dimensions';
 import { formatDocumentWithMetadata } from './utils/metadata';
 import { indexByDocumentId } from './utils/document-status';
-import { getPopulateForLocalizations } from '../services/utils/populate';
+import { getPopulateForLocalizations, buildDeepPopulate } from '../services/utils/populate';
 
 /**
  * Returns documentIds for (documentId, locale) that have both draft and published,
@@ -627,6 +627,37 @@ export default {
 
     const sanitizedDocument = await permissionChecker.sanitizeOutput(publishedDocument);
     ctx.body = await formatDocumentWithMetadata(permissionChecker, model, sanitizedDocument);
+  },
+
+  async bulkFindForValidation(ctx: any) {
+    const { userAbility } = ctx.state;
+    const { model } = ctx.params;
+    const { documentIds, locale } = ctx.request.body;
+
+    await validateBulkActionInput(ctx.request.body);
+
+    const permissionChecker = getService('permission-checker').create({ userAbility, model });
+
+    if (permissionChecker.cannot.read()) {
+      return ctx.forbidden();
+    }
+
+    if (documentIds.length > 100) {
+      return ctx.badRequest('documentIds must not exceed 100 items');
+    }
+
+    const populate = await buildDeepPopulate(model as UID.CollectionType);
+
+    const documents = await strapi.documents(model as UID.CollectionType).findMany({
+      populate,
+      filters: { documentId: { $in: documentIds } } as any,
+      locale,
+      status: 'draft',
+    });
+
+    const results = await Promise.all(documents.map(permissionChecker.sanitizeOutput));
+
+    ctx.body = { results };
   },
 
   async bulkPublish(ctx: any) {

--- a/packages/core/content-manager/server/src/routes/admin.ts
+++ b/packages/core/content-manager/server/src/routes/admin.ts
@@ -394,6 +394,21 @@ export default {
     },
     {
       method: 'POST',
+      path: '/collection-types/:model/actions/bulkFindForValidation',
+      handler: 'collection-types.bulkFindForValidation',
+      config: {
+        middlewares: [routing],
+        policies: [
+          'admin::isAuthenticatedAdmin',
+          {
+            name: 'plugin::content-manager.hasPermissions',
+            config: { actions: ['plugin::content-manager.explorer.read'] },
+          },
+        ],
+      },
+    },
+    {
+      method: 'POST',
       path: '/collection-types/:model/actions/bulkPublish',
       handler: 'collection-types.bulkPublish',
       config: {

--- a/tests/api/core/strapi/document-service/document-id-uniqueness.test.api.ts
+++ b/tests/api/core/strapi/document-service/document-id-uniqueness.test.api.ts
@@ -1,9 +1,41 @@
 import type { Core } from '@strapi/types';
 import { errors } from '@strapi/utils';
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
-import resources from './resources/index';
 
 const ARTICLE_UID = 'api::article.article';
+
+// Minimal schema — only what this test needs (title + i18n + draftAndPublish).
+// Avoids the heavyweight shared resources (4 content types, 5 components, fixtures)
+// which cause slow setup/teardown due to multiple Strapi restarts per schema deletion.
+const resources = {
+  schemas: {
+    'content-types': {
+      [ARTICLE_UID]: {
+        kind: 'collectionType',
+        collectionName: 'articles',
+        singularName: 'article',
+        pluralName: 'articles',
+        displayName: 'Article',
+        draftAndPublish: true,
+        pluginOptions: { i18n: { localized: true } },
+        attributes: {
+          title: {
+            type: 'string',
+            pluginOptions: { i18n: { localized: true } },
+          },
+        },
+      },
+    },
+    components: {},
+  },
+  fixtures: {
+    'content-types': {
+      [ARTICLE_UID]: [],
+    },
+  },
+  locales: [{ name: 'French', code: 'fr' }],
+};
+
 describe('Document Service - Document ID Uniqueness', () => {
   let testUtils;
   let strapi: Core.Strapi;

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -202,6 +202,7 @@ exports[`routes:list should output list of routes 1`] = `
 │ POST               │ /content-manager/collection-types/:model/:id/actions/unpublish                  │
 │ POST               │ /content-manager/collection-types/:model/:id/actions/discard                    │
 │ POST               │ /content-manager/collection-types/:model/actions/bulkDelete                     │
+│ POST               │ /content-manager/collection-types/:model/actions/bulkFindForValidation          │
 │ POST               │ /content-manager/collection-types/:model/actions/bulkPublish                    │
 │ POST               │ /content-manager/collection-types/:model/actions/bulkUnpublish                  │
 │ HEAD|GET           │ /content-manager/collection-types/:model/:id/actions/countDraftRelations        │


### PR DESCRIPTION
### What does it do?

1. Fixes a validation issue making the bulk publish impossible on documents that have required components in dynamic zones.
If the component is required but was correctly provided, the publish action should be possible (and indeed, publishing directly from the edit view page is working) but when selecting the item for a bulk publish, a validation error says that the field is required (as if it was empty even if it's not the case).

Issue:

https://github.com/user-attachments/assets/2af42ae1-6bac-4911-9c12-07ed540c12fe


After fix:

https://github.com/user-attachments/assets/0d995f15-bd9a-4f25-9f0c-cbe0061e4cd7


2. Also fixes an issue targetting the publish button in the document actions based on its label but if using another locale on the platform, this check isn't working.

Issue:

https://github.com/user-attachments/assets/9c789205-be03-42c2-a6c0-ded522865e08


_ℹ️ There's another issue wrongly displaying the errors related to dynamic zones and components but it's part of this community PR: https://github.com/strapi/strapi/pull/24196_

### Why is it needed?

To unblock the bulk publish on documents that can really be published.

### How to test it?

1. Bulk publish issue
- Create or use a collection type with a dynamic zone that contains a required component (repeatable or not)
- Create a draft an fill all the required information
- Click Save
- Go back to the list view page and select the newly created document
- Select Publish action to open bulk publish modal
-> You shouldn't have any error displayed and should be able to publish the document

2. Publish type button
- Go to the profile settings
- Change the language of the interface to anything else than English
- Go to any collection or single type that has draft and publish
- Open any document
- Inspect the "Publish" button translated to show the console
-> The type of the button tag should be button and not submit (Save button should be the default submit of the form)

### Related issue(s)/PR(s)

Fixes #23606 
Fixes #18810
Fixes #24576

🚀