### PR TITLE
chore: use https instead of git url in package.repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "https://github.com/strapi/strapi.git"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/cli/cloud"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/cli/create-strapi-app"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/cli/create-strapi/package.json
+++ b/packages/cli/create-strapi/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/cli/create-strapi"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/admin"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/content-manager"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/content-releases"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/content-type-builder"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/core"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/data-transfer"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/database"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/email"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/openapi"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/permissions"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/review-workflows"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/strapi"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/types"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/upload"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/core/utils"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/generators/generators"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/cloud"
   },
   "license": "MIT",

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/color-picker"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/documentation"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/graphql"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/i18n"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/sentry"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/plugins/users-permissions"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/email-amazon-ses"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/email-mailgun"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/email-nodemailer"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/email-sendgrid"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/email-sendmail"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/upload-aws-s3"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/upload-cloudinary"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/providers/upload-local"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/utils/logger"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/utils/typescript"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git",
+    "url": "https://github.com/strapi/strapi.git",
     "directory": "packages/utils/upgrade"
   },
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

followup to #25599 migrating the package url to `https://` instead of the deprecated `git://`

### Why is it needed?

Requested as a followup https://github.com/strapi/strapi/pull/25599#pullrequestreview-3914698658

### How to test it?

n.a.

### Related issue(s)/PR(s)

#25599
