### PR TITLE
fix: generated provider url wrongly formatted causing CORS/CSP err in…

### DIFF
--- a/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/is-url-from-bucket.test.ts
@@ -43,14 +43,26 @@ describe('Test for URLs', () => {
 
   describe('S3 Compatible', () => {
     describe('DO Spaces', () => {
-      test('is from same bucket', async () => {
+      test('virtual-hosted-style: is from same bucket', async () => {
         const url = 'https://bucket-name.nyc3.digitaloceanspaces.com/folder/img.png';
         const isFromBucket = isUrlFromBucket(url, 'bucket-name');
         expect(isFromBucket).toEqual(true);
       });
-      test('is not from same bucket', async () => {
+      test('virtual-hosted-style: is not from same bucket', async () => {
         const url = 'https://bucket-name.nyc3.digitaloceanspaces.com/folder/img.png';
         const isFromBucket = isUrlFromBucket(url, 'bucket');
+        expect(isFromBucket).toEqual(false);
+      });
+      test('CDN path-style (forcePathStyle:true): bucket in path, is from same bucket', async () => {
+        // URL generated when endpoint is set to the CDN and forcePathStyle:true
+        // e.g. https://fra1.cdn.digitaloceanspaces.com/pcstrapi/thumbnail_IMG_1351.jpg
+        const url = 'https://fra1.cdn.digitaloceanspaces.com/pcstrapi/thumbnail_IMG_1351.jpg';
+        const isFromBucket = isUrlFromBucket(url, 'pcstrapi');
+        expect(isFromBucket).toEqual(true);
+      });
+      test('CDN path-style (forcePathStyle:true): bucket in path, is not from same bucket', async () => {
+        const url = 'https://fra1.cdn.digitaloceanspaces.com/pcstrapi/thumbnail_IMG_1351.jpg';
+        const isFromBucket = isUrlFromBucket(url, 'other-bucket');
         expect(isFromBucket).toEqual(false);
       });
     });

--- a/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
+++ b/packages/providers/upload-aws-s3/src/__tests__/upload-aws-s3.test.ts
@@ -1158,10 +1158,34 @@ describe('AWS-S3 provider', () => {
   });
 
   describe('S3-compatible provider URL construction', () => {
-    test('should construct URL from endpoint for IONOS', async () => {
+    test('should construct path-style URL from endpoint for IONOS when forcePathStyle is true', async () => {
       uploadMock.done.mockImplementationOnce(() =>
         Promise.resolve({
           // IONOS returns incorrect Location format for multipart uploads
+          Location: 'my-bucket/tmp/test.json',
+          ETag: '"abc"',
+        })
+      );
+
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          endpoint: 'https://s3-eu-central-2.ionoscloud.com',
+          forcePathStyle: true,
+          params: {
+            Bucket: 'my-bucket',
+          },
+        },
+      });
+
+      const file = createTestFile();
+      await providerInstance.upload(file);
+
+      expect(file.url).toBe('https://s3-eu-central-2.ionoscloud.com/my-bucket/tmp/test.json');
+    });
+
+    test('should construct virtual-hosted-style URL from endpoint for IONOS when forcePathStyle is false (default)', async () => {
+      uploadMock.done.mockImplementationOnce(() =>
+        Promise.resolve({
           Location: 'my-bucket/tmp/test.json',
           ETag: '"abc"',
         })
@@ -1179,10 +1203,10 @@ describe('AWS-S3 provider', () => {
       const file = createTestFile();
       await providerInstance.upload(file);
 
-      expect(file.url).toBe('https://s3-eu-central-2.ionoscloud.com/my-bucket/tmp/test.json');
+      expect(file.url).toBe('https://my-bucket.s3-eu-central-2.ionoscloud.com/tmp/test.json');
     });
 
-    test('should construct URL from endpoint for MinIO', async () => {
+    test('should construct path-style URL from endpoint for MinIO when forcePathStyle is true', async () => {
       uploadMock.done.mockImplementationOnce(() =>
         Promise.resolve({
           Location: 'test-bucket/tmp/test.json',
@@ -1193,6 +1217,7 @@ describe('AWS-S3 provider', () => {
       const providerInstance = awsProvider.init({
         s3Options: {
           endpoint: 'http://minio.local:9000',
+          forcePathStyle: true,
           params: {
             Bucket: 'test-bucket',
           },
@@ -1203,6 +1228,56 @@ describe('AWS-S3 provider', () => {
       await providerInstance.upload(file);
 
       expect(file.url).toBe('http://minio.local:9000/test-bucket/tmp/test.json');
+    });
+
+    test('should construct virtual-hosted-style URL for DigitalOcean Spaces (default, forcePathStyle not set)', async () => {
+      uploadMock.done.mockImplementationOnce(() =>
+        Promise.resolve({
+          // DO Spaces may return a path-style Location from the SDK when forcePathStyle is not set
+          Location: 'fra1.digitaloceanspaces.com/pcstrapi/tmp/test.json',
+          ETag: '"abc"',
+        })
+      );
+
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          endpoint: 'https://fra1.digitaloceanspaces.com',
+          params: {
+            Bucket: 'pcstrapi',
+          },
+        },
+      });
+
+      const file = createTestFile();
+      await providerInstance.upload(file);
+
+      // Virtual-hosted-style: bucket is part of the hostname, not the path
+      expect(file.url).toBe('https://pcstrapi.fra1.digitaloceanspaces.com/tmp/test.json');
+    });
+
+    test('should construct path-style URL for DigitalOcean Spaces CDN when forcePathStyle is true', async () => {
+      uploadMock.done.mockImplementationOnce(() =>
+        Promise.resolve({
+          Location: 'fra1.cdn.digitaloceanspaces.com/pcstrapi/tmp/test.json',
+          ETag: '"abc"',
+        })
+      );
+
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          endpoint: 'https://fra1.cdn.digitaloceanspaces.com',
+          forcePathStyle: true,
+          params: {
+            Bucket: 'pcstrapi',
+          },
+        },
+      });
+
+      const file = createTestFile();
+      await providerInstance.upload(file);
+
+      // Path-style: bucket appears in path (CDN-style for DO)
+      expect(file.url).toBe('https://fra1.cdn.digitaloceanspaces.com/pcstrapi/tmp/test.json');
     });
 
     test('should prefer baseUrl over endpoint', async () => {
@@ -1229,7 +1304,7 @@ describe('AWS-S3 provider', () => {
       expect(file.url).toBe('https://cdn.example.com/tmp/test.json');
     });
 
-    test('should handle endpoint without protocol', async () => {
+    test('should handle endpoint without protocol using virtual-hosted-style by default', async () => {
       uploadMock.done.mockImplementationOnce(() =>
         Promise.resolve({
           Location: 'bucket/tmp/test.json',
@@ -1240,6 +1315,31 @@ describe('AWS-S3 provider', () => {
       const providerInstance = awsProvider.init({
         s3Options: {
           endpoint: 's3.wasabisys.com',
+          params: {
+            Bucket: 'my-bucket',
+          },
+        },
+      });
+
+      const file = createTestFile();
+      await providerInstance.upload(file);
+
+      // Default (no forcePathStyle) → virtual-hosted-style
+      expect(file.url).toBe('https://my-bucket.s3.wasabisys.com/tmp/test.json');
+    });
+
+    test('should handle endpoint without protocol using path-style when forcePathStyle is true', async () => {
+      uploadMock.done.mockImplementationOnce(() =>
+        Promise.resolve({
+          Location: 'bucket/tmp/test.json',
+          ETag: '"abc"',
+        })
+      );
+
+      const providerInstance = awsProvider.init({
+        s3Options: {
+          endpoint: 's3.wasabisys.com',
+          forcePathStyle: true,
           params: {
             Bucket: 'my-bucket',
           },

--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -410,6 +410,13 @@ export default {
     /**
      * Constructs the correct file URL.
      * Handles S3-compatible providers that return incorrect Location formats.
+     *
+     * When a custom endpoint is configured, the URL style depends on `forcePathStyle`:
+     * - `forcePathStyle: true`  → path-style:          `{endpoint}/{bucket}/{key}`
+     * - `forcePathStyle: false` → virtual-hosted-style: `{bucket}.{endpoint-host}/{key}` (default)
+     *
+     * This mirrors how the AWS SDK itself routes requests, preventing mismatches between
+     * the stored URL and the actual object location (e.g. DigitalOcean Spaces CDN URLs).
      */
     const constructFileUrl = (fileKey: string, uploadLocation: string): string => {
       // Priority 1: Use baseUrl if configured (CDN or custom domain)
@@ -418,14 +425,24 @@ export default {
         return `${cleanBase}/${fileKey}`;
       }
 
-      // Priority 2: Construct URL from endpoint if configured
-      // This fixes issues with S3-compatible providers (IONOS, MinIO, etc.)
-      // that return Location in incorrect format for multipart uploads
+      // Priority 2: Construct URL from endpoint if configured.
+      // Respect forcePathStyle to match the AWS SDK's actual request routing.
       const endpoint = config.endpoint?.toString();
       if (endpoint) {
         const endpointUrl = endpoint.startsWith('http') ? endpoint : `https://${endpoint}`;
-        const cleanEndpoint = endpointUrl.replace(/\/+$/, '');
-        return `${cleanEndpoint}/${config.params.Bucket}/${fileKey}`;
+
+        if (config.forcePathStyle) {
+          // Path-style: https://{endpoint}/{bucket}/{key}
+          // Required for providers like MinIO and IONOS that do not support virtual-hosted-style.
+          const cleanEndpoint = endpointUrl.replace(/\/+$/, '');
+          return `${cleanEndpoint}/${config.params.Bucket}/${fileKey}`;
+        }
+
+        // Virtual-hosted-style: https://{bucket}.{endpoint-host}/{key}
+        // This is the default (forcePathStyle defaults to false in the AWS SDK) and is
+        // required for providers like DigitalOcean Spaces.
+        const endpointUrlObj = new URL(endpointUrl);
+        return `${endpointUrlObj.protocol}//${config.params.Bucket}.${endpointUrlObj.host}/${fileKey}`;
       }
 
       // Priority 3: Use the Location from S3 response


### PR DESCRIPTION
### What does it do?

Modifies `constructFileUrl` in `packages/providers/upload-aws-s3/src/index.ts` to respect the forcePathStyle option from the S3 client config when building the stored file URL:

```
forcePathStyle: true → path-style URL: https://{endpoint}/{bucket}/{key}
forcePathStyle: false (default) → virtual-hosted-style URL: https://{bucket}.{endpoint-host}/{key}
```

Previously, the function always produced path-style URLs for any provider with a custom endpoint, regardless of forcePathStyle.

Also adds test coverage for both URL styles for DigitalOcean Spaces and expands  `isUrlFromBucket` tests to cover CDN path-style DO URLs.


### Why is it needed?

When using `@strapi/provider-upload-aws-s3` with DigitalOcean Spaces (or any S3-compatible provider that supports virtual-hosted-style URLs), setting a custom endpoint caused Strapi to store path-style URLs (https://fra1.digitaloceanspaces.com/pcstrapi/image.jpg) even though the AWS SDK.  With its default of forcePathStyle: false actually serves the object at the virtual-hosted URL (https://pcstrapi.fra1.digitaloceanspaces.com/image.jpg). This mismatch broke image display in the Media Library due to CORS/CSP mismatches.

### How to test it?

Automated test:
```
node_modules/.bin/jest packages/providers/upload-aws-s3 --no-coverage
# Expected: 83 tests pass
```

Manual (DigitalOcean Spaces):

Configure the plugin with a DO Spaces endpoint and no forcePathStyle:

```
// config/plugins.js
upload: {
  config: {
    provider: 'aws-s3',
    providerOptions: {
      s3Options: {
        endpoint: 'https://fra1.digitaloceanspaces.com',
        // forcePathStyle not set (defaults to false)
        params: { Bucket: 'my-bucket' },
      },
    },
  },
},

```

Upload an image, verify the stored URL is `https://my-bucket.fra1.digitaloceanspaces.com/...` and the image loads in the Media Library.

NOTE: Users currently relying on path-style URLs with a custom endpoint (MinIO, IONOS, Wasabi, etc.) must add forcePathStyle: true to their s3Options to preserve the previous behavior.

### Related issue(s)/PR(s)

#25592 
