### PR TITLE
fix(document-service): re-insert cascade-deleted bidirectional relations

### DIFF
--- a/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
+++ b/packages/core/core/src/services/document-service/utils/bidirectional-relations.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-continue */
 import { keyBy, omit } from 'lodash/fp';
-import { async } from '@strapi/utils';
 import type { UID, Schema } from '@strapi/types';
 import type { JoinTable } from '@strapi/database';
 
@@ -171,46 +170,63 @@ const sync = async (
         continue;
       }
 
-      // Update order values for each relation
-      // TODO: Find a way to batch it more efficiently
-      await async.map(relations, async (relation: Record<string, unknown>) => {
-        const oldSourceId = relation[sourceColumn] as string;
-        const targetId = relation[targetColumn] as string;
-        const originalOrder = relation[orderColumn];
+      const mappedRelations = relations
+        .map((relation) => ({
+          relation,
+          oldSourceId: relation[sourceColumn] as string,
+          targetId: relation[targetColumn] as string,
+          originalOrder: relation[orderColumn],
+          newSourceId: entryIdMapping[relation[sourceColumn] as string],
+        }))
+        .filter((r): r is typeof r & { newSourceId: string } => Boolean(r.newSourceId));
 
-        const newSourceId = entryIdMapping[oldSourceId];
+      if (!mappedRelations.length) continue;
 
-        // If no mapping exists for this old entry, skip it
-        if (!newSourceId) {
-          return;
-        }
+      const newSourceIds = mappedRelations.map((r) => r.newSourceId);
 
-        // Check whether the join entry already exists for the new entity ID.
-        // We cannot rely on UPDATE's affected-row count to detect missing rows
-        // because MySQL/MariaDB returns 0 for no-op updates (value unchanged),
-        // which would cause a spurious INSERT and a duplicate join row.
-        const existingRow = await trx(joinTable.name)
-          .where(sourceColumn, newSourceId)
-          .where(targetColumn, targetId)
-          .first();
+      // Batch UPDATE: set each row's order in a single statement using CASE
+      const caseFragments = mappedRelations.map(() => `WHEN ?? = ? AND ?? = ? THEN ?`);
+      const caseBindings = mappedRelations.flatMap(({ newSourceId, targetId, originalOrder }) => [
+        sourceColumn,
+        newSourceId,
+        targetColumn,
+        targetId,
+        originalOrder,
+      ]);
 
-        if (existingRow) {
-          // Row exists — update the order column only.
-          await trx(joinTable.name)
-            .where(sourceColumn, newSourceId)
-            .where(targetColumn, targetId)
-            .update({ [orderColumn]: originalOrder });
-        } else if (!isRepublishedEntry(newSourceId)) {
-          // Missing row was cascade-deleted (we republished the target) — re-insert.
-          // If we republished the source, the row was never created (user removed the relation).
-          const newRelation = {
-            ...omit(strapi.db.metadata.identifiers.ID_COLUMN, relation),
-            [sourceColumn]: newSourceId,
-            [orderColumn]: originalOrder,
-          };
-          await trx(joinTable.name).insert(newRelation);
-        }
-      });
+      await trx(joinTable.name)
+        .whereIn(sourceColumn, newSourceIds)
+        .update({
+          [orderColumn]: trx.raw(`CASE ${caseFragments.join(' ')} ELSE ?? END`, [
+            ...caseBindings,
+            orderColumn,
+          ]),
+        });
+
+      // Batch SELECT: find which rows exist so we know what to insert
+      const existingRows = await trx(joinTable.name)
+        .whereIn(sourceColumn, newSourceIds)
+        .select(sourceColumn, targetColumn);
+
+      const existingSet = new Set(
+        existingRows.map((r: Record<string, unknown>) => `${r[sourceColumn]}:${r[targetColumn]}`)
+      );
+
+      // Batch INSERT: insert cascade-deleted rows that aren't from republished sources
+      const toInsert = mappedRelations
+        .filter(
+          ({ newSourceId, targetId }) =>
+            !existingSet.has(`${newSourceId}:${targetId}`) && !isRepublishedEntry(newSourceId)
+        )
+        .map(({ relation, newSourceId, originalOrder }) => ({
+          ...omit(strapi.db.metadata.identifiers.ID_COLUMN, relation),
+          [sourceColumn]: newSourceId,
+          [orderColumn]: originalOrder,
+        }));
+
+      if (toInsert.length) {
+        await trx.batchInsert(joinTable.name, toInsert, 1000);
+      }
     }
   });
 };

--- a/tests/api/core/strapi/document-service/relations/bidirectional-relations.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/bidirectional-relations.test.api.ts
@@ -201,12 +201,12 @@ describe('Document Service bidirectional relations', () => {
         status: 'published',
       });
 
-      // All 3 tags should still be present after republishing tagB
-      expect(publishedProduct?.tags).toHaveLength(3);
-      const tagNames = publishedProduct?.tags.map((t) => t.name);
-      expect(tagNames).toContain('OrderTagA');
-      expect(tagNames).toContain('OrderTagB Updated');
-      expect(tagNames).toContain('OrderTagC');
+      // All 3 tags should still be present in the original order after republishing tagB
+      expect(publishedProduct?.tags.map((t) => t.name)).toEqual([
+        'OrderTagA',
+        'OrderTagB Updated',
+        'OrderTagC',
+      ]);
     }
   );
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->
## What does it do?
Fixes bidirectionalRelations.sync() in the document service to re-insert join table entries that were removed by FK cascade delete during publish/discard-draft operations.

The fix uses an explicit existence check (SELECT … FIRST) before deciding to UPDATE (row exists, fix order) or INSERT (row was cascade-deleted, restore it). A plain UPDATE affected-row count was avoided because MySQL/MariaDB returns 0 for no-op updates (value unchanged), which would have caused spurious duplicate row inserts.

## Why is it needed?

When editors republish a related entry that another content type or component references via a bidirectional relation, the API response for the referencing entry returns stale or missing data until the Page is manually unpublished and republished.


## How to test it?

Run the new regression tests

`yarn test:api --testPathPattern="bidirectional-relations"`

Verify no regression in existing relation tests

`yarn test:api --testPathPattern="(bidirectional|unidirectional)-relations"`

## Manual Test

- Create a Tag content type (D&P) and a Product content type (D&P) with a bidirectional manyToMany to Tag
- Create and publish a Tag, create and publish a Product referencing that Tag
- Update the Tag's name and republish it
- `GET /api/products/:id?populate=tags&status=published`

Before fix: tags is empty or shows old data. 
After fix: tags contains the Tag with the updated name

## Related issue(s)/PR(s)

Fixes CMS-237
#23618 