### PR TITLE
fix(admin): prevent trailing ? in URL when params is empty object

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -340,7 +340,9 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
          * It's considered a breaking change because it impacts any API request, including the user's custom code
          */
         const serializedParams = qs.stringify(params, { encode: false });
-        return `${url}?${serializedParams}`;
+        if (serializedParams) {
+          return `${url}?${serializedParams}`;
+        }
       }
       return url;
     };

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -91,6 +91,40 @@ describe('getFetchClient', () => {
     );
   });
 
+  it('should not append trailing ? when params is an empty object', async () => {
+    (window.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ data: 'success response' }),
+      })
+    );
+    const fetchClient = getFetchClient();
+    await fetchClient.get('/content-manager/actions/publish', {
+      params: {},
+    });
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://localhost:1337/content-manager/actions/publish',
+      expect.anything()
+    );
+  });
+
+  it('should not append trailing ? when params is undefined', async () => {
+    (window.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ data: 'success response' }),
+      })
+    );
+    const fetchClient = getFetchClient();
+    await fetchClient.get('/content-manager/actions/publish');
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://localhost:1337/content-manager/actions/publish',
+      expect.anything()
+    );
+  });
+
   describe('token refresh on 401', () => {
     it('should refresh token and retry on 401 error', async () => {
       // First call returns 401


### PR DESCRIPTION
## What does this PR do?

Fixes the `paramsSerializer` in `getFetchClient` to skip appending `?` when `qs.stringify` produces an empty string from an empty params object (`{}`).

**Root cause:** When `params` is `{}` (e.g., from `buildValidParams({})`), the truthiness check `if (params)` passes since `{}` is truthy. Then `qs.stringify({})` returns `""`, and the URL gets a trailing `?` appended (e.g., `/actions/publish?`).

**Impact:** This breaks the history version deduplication guard in `lifecycles.ts`, which uses `endsWith('/actions/publish')` — the trailing `?` causes the check to fail, resulting in duplicate history versions on every publish action.

**Fix:** After calling `qs.stringify`, check that the serialized string is non-empty before appending the query separator.

## Why is this change needed?

Every time a document is published from the Content Manager, two identical history versions are created at the same timestamp instead of one. This happens because the deduplication guard that should suppress the internal `update` during a publish request fails to match the URL due to the trailing `?`.

Issue: #25724

## How was this tested?

- Added unit tests verifying that empty params `{}` and `undefined` params do not append a trailing `?` to the URL
- Verified all existing `getFetchClient` tests continue to pass (11/11)
- Verified the modified files have no lint errors

## Checklist
- [x] My branch is based on `develop`
- [x] Tests added/updated
- [x] All tests pass
- [x] Linked to relevant issue