### PR TITLE
fix(core): increase qs arrayLimit from 100 to 200

### DIFF
--- a/packages/core/core/src/middlewares/query.ts
+++ b/packages/core/core/src/middlewares/query.ts
@@ -6,7 +6,7 @@ type Config = Parameters<typeof qs.parse>[1];
 
 const defaults: Config = {
   strictNullHandling: true,
-  arrayLimit: 100,
+  arrayLimit: 200,
   depth: 20,
 };
 


### PR DESCRIPTION
## What does this PR do?

Increases the `qs` parser `arrayLimit` from `100` to `200` in the query middleware.

## Why is this change needed?

When a `populate` query parameter has more than 100 entries (e.g., `?populate[0]=field1&...&populate[101]=field101`), the `qs` parser — configured with `arrayLimit: 100` — produces a plain object with numeric string keys instead of an array:

```js
// Expected (arrayLimit >= entries):
['field1', 'field2', ...]

// Actual (arrayLimit < entries):
{ '0': 'field1', '1': 'field2', ... }
```

The populate traversal then treats this as a regular object, visiting each numeric key. Keys `"0"` and `"1"` accidentally pass a boolean-like check, but `"2"` and above fail — throwing `ValidationError: Invalid key 2`.

Content types with many relations (100+ populatable fields) hit this limit in real-world use.

Issue: #25632

## How was this tested?

- Verified the `qs` library behavior: `qs.parse` with `arrayLimit: 200` correctly parses arrays with up to 200 entries
- The middleware config is straightforward — it passes the value directly to `qs.parse`
- This value can also be overridden per-project via middleware configuration

## Checklist
- [x] My branch is based on `develop`
- [x] Linked to relevant issue