### PR TITLE
fix(openapi): add REST API prefix to content-api routes in generated spec

### DIFF
--- a/packages/core/openapi/__tests__/fixtures/routes.ts
+++ b/packages/core/openapi/__tests__/fixtures/routes.ts
@@ -1,13 +1,13 @@
 import { Core } from '@strapi/types';
 
 export const test = [
-  { info: { type: 'content-api' }, method: 'GET', path: '/api/test1', handler: '' },
+  { info: { type: 'content-api' }, method: 'GET', path: '/test1', handler: '' },
   { info: { type: 'admin' }, method: 'POST', path: '/test2', handler: '' },
-  { info: { type: 'content-api' }, method: 'DELETE', path: '/api/test3', handler: '' },
+  { info: { type: 'content-api' }, method: 'DELETE', path: '/test3', handler: '' },
 ] satisfies Core.Route[];
 
 export const foobar = [
-  { info: { type: 'content-api' }, method: 'PUT', path: '/api/foo', handler: '' },
+  { info: { type: 'content-api' }, method: 'PUT', path: '/foo', handler: '' },
   { info: { type: 'admin' }, method: 'PATCH', path: '/bar', handler: '' },
   { info: { type: 'admin' }, method: 'HEAD', path: '/baz', handler: '' },
 ] satisfies Core.Route[];

--- a/packages/core/openapi/__tests__/mocks/strapi.mock.ts
+++ b/packages/core/openapi/__tests__/mocks/strapi.mock.ts
@@ -31,4 +31,15 @@ export class StrapiMock {
       },
     };
   }
+
+  get config() {
+    return {
+      get: (key: string, defaultValue?: string) => {
+        const values: Record<string, string> = {
+          'api.rest.prefix': '/api',
+        };
+        return values[key] ?? defaultValue;
+      },
+    };
+  }
 }

--- a/packages/core/openapi/__tests__/routes/api-routes-provider.test.ts
+++ b/packages/core/openapi/__tests__/routes/api-routes-provider.test.ts
@@ -17,6 +17,59 @@ describe('ApiRoutesProvider', () => {
       // Assert
       expect(routes).toHaveLength(routesFixtures.test.length + routesFixtures.foobar.length);
     });
+
+    it('should prepend the REST API prefix to content-api routes', () => {
+      // Arrange
+      const strapiMock = new StrapiMock() as unknown as Core.Strapi;
+      const provider = new ApiRoutesProvider(strapiMock);
+
+      // Act
+      const { routes } = provider;
+
+      // Assert
+      const contentApiRoutes = routes.filter((r) => r.info.type === 'content-api');
+      const adminRoutes = routes.filter((r) => r.info.type === 'admin');
+
+      // Content-api routes should have the /api prefix
+      contentApiRoutes.forEach((route) => {
+        expect(route.path).toMatch(/^\/api\//);
+      });
+
+      // Admin routes should not have the /api prefix
+      adminRoutes.forEach((route) => {
+        expect(route.path).not.toMatch(/^\/api\//);
+      });
+    });
+
+    it('should use the configured REST API prefix', () => {
+      // Arrange
+      const strapiMock = {
+        apis: {
+          articles: {
+            routes: {
+              'content-api': {
+                routes: [
+                  { info: { type: 'content-api' }, method: 'GET', path: '/articles', handler: '' },
+                ],
+              },
+            },
+          },
+        },
+        config: {
+          get: (key: string, defaultValue?: string) => {
+            if (key === 'api.rest.prefix') return '/custom-api';
+            return defaultValue;
+          },
+        },
+      } as unknown as Core.Strapi;
+      const provider = new ApiRoutesProvider(strapiMock);
+
+      // Act
+      const { routes } = provider;
+
+      // Assert
+      expect(routes[0].path).toBe('/custom-api/articles');
+    });
   });
 
   describe('Symbol.Iterator', () =>

--- a/packages/core/openapi/src/routes/providers/api.ts
+++ b/packages/core/openapi/src/routes/providers/api.ts
@@ -24,12 +24,21 @@ export class ApiRoutesProvider extends AbstractRoutesProvider {
    */
   public get routes(): Core.Route[] {
     const { apis } = this._strapi;
+    const apiPrefix = this._strapi.config.get('api.rest.prefix', '/api');
 
     const routes = Object.values(apis)
       // Extract and flatten each router from every API
       .flatMap((api) => Object.values(api.routes))
       // Extract and flatten the routes from each router
-      .flatMap((router) => router.routes);
+      .flatMap((router) => router.routes)
+      // Apply the REST API prefix to content-api routes
+      .map((route) => {
+        if (route.info?.type === 'content-api') {
+          return { ...route, path: `${apiPrefix}${route.path}` };
+        }
+
+        return route;
+      });
 
     debug('found %o routes in Strapi APIs', routes.length);
 


### PR DESCRIPTION
## What does this PR do?

Adds the configured REST API prefix (`api.rest.prefix`, default `/api`) to content-api routes in the OpenAPI spec generator's `ApiRoutesProvider`.

## Why is this change needed?

When running `strapi openapi generate`, the generated spec produces paths like `/articles` instead of `/api/articles`. Since the REST API prefix is applied at the Koa Router level, routes stored in `strapi.apis` do not include it. The OpenAPI generator reads these routes directly, so the generated paths are missing the prefix and don't match the actual API endpoints.

This follows the same pattern used by the core content-api service when registering routes:

```ts
const apiPrefix = strapi.config.get('api.rest.prefix');
routes.map((route) => ({ ...route, path: `${apiPrefix}${route.path}` }));
```

Issue: #25493

## Changes

- **`ApiRoutesProvider`**: Apply `api.rest.prefix` to content-api routes (admin routes are left unchanged)
- **Test fixtures**: Updated to reflect that routes in `strapi.apis` don't include the prefix
- **`StrapiMock`**: Added `config.get` method
- **Tests**: Added 2 new tests for prefix application and custom prefix support

## How was this tested?

- All 22 existing + new OpenAPI tests pass
- Verified the prefix is only applied to `content-api` type routes
- Verified custom prefix support via config

## Checklist
- [x] My branch is based on `develop`
- [x] Tests added/updated
- [x] All tests pass
- [x] Linked to relevant issue