### PR TITLE
fix(database): prevent migration failure from long index names and transaction abort

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
@@ -2,27 +2,39 @@ import type { Knex } from 'knex';
 
 import type { Migration } from '../common';
 
+/**
+ * PostgreSQL silently truncates identifiers longer than 63 characters.
+ * When the migration later checks for the full-length name, it does not
+ * find the truncated version, and the CREATE INDEX fails with 42P07.
+ */
+const PG_IDENTIFIER_MAX_LENGTH = 63;
+
 // Add an index if it does not already exist
 const createIndex = async (knex: Knex, tableName: string, columns: string[], indexName: string) => {
+  // Truncate to PostgreSQL's identifier limit to avoid silent name mismatch
+  const safeName =
+    indexName.length > PG_IDENTIFIER_MAX_LENGTH
+      ? indexName.substring(0, PG_IDENTIFIER_MAX_LENGTH)
+      : indexName;
+
   try {
-    // If the database can check for indexes, avoid duplicates
-    const hasIndex = (
-      knex.schema as unknown as {
-        hasIndex?: (tableName: string, indexName: string) => Promise<boolean>;
-      }
-    ).hasIndex;
-    if (hasIndex) {
-      const exists = await hasIndex.call(knex.schema, tableName, indexName);
-      if (exists) {
-        return;
-      }
-    }
+    // Use a savepoint so that a duplicate-index error in PostgreSQL does not
+    // abort the surrounding transaction and block all subsequent statements.
+    await knex.raw('SAVEPOINT create_idx');
 
     await knex.schema.alterTable(tableName, (table) => {
-      table.index(columns, indexName);
+      table.index(columns, safeName);
     });
-  } catch (error) {
-    // If the index exists (or cannot be created), move on
+
+    await knex.raw('RELEASE SAVEPOINT create_idx');
+  } catch {
+    // Index already exists or cannot be created — roll back to the savepoint
+    // so the transaction remains usable for subsequent operations.
+    try {
+      await knex.raw('ROLLBACK TO SAVEPOINT create_idx');
+    } catch {
+      // Savepoints may not be supported (e.g. some SQLite modes); ignore.
+    }
   }
 };
 

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-06-add-document-id-indexes.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-06-add-document-id-indexes.test.ts
@@ -2,26 +2,34 @@ import type { Knex } from 'knex';
 
 import { addDocumentIdIndexes } from '../5.0.0-06-add-document-id-indexes';
 
+const createKnexMock = (columns: string[] = ['document_id', 'locale', 'published_at']) => {
+  const indexCalls: Array<{ columns: string[]; name: string }> = [];
+  const rawCalls: string[] = [];
+
+  const knex = {
+    schema: {
+      hasTable: jest.fn().mockResolvedValue(true),
+      hasColumn: jest.fn().mockImplementation((_table: string, column: string) => {
+        return columns.includes(column);
+      }),
+      alterTable: jest.fn(async (_table: string, tableBuilder: (table: any) => void) => {
+        const table = {
+          index(cols: string[], name: string) {
+            indexCalls.push({ columns: cols, name });
+          },
+        };
+        tableBuilder(table);
+      }),
+    },
+    raw: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Knex.Transaction;
+
+  return { knex, indexCalls, rawCalls };
+};
+
 describe('addDocumentIdIndexes migration', () => {
   it('adds document_id and composite indexes when columns exist', async () => {
-    const indexCalls: Array<{ columns: string[]; name: string }> = [];
-
-    const knex = {
-      schema: {
-        hasTable: jest.fn().mockResolvedValue(true),
-        hasColumn: jest.fn().mockImplementation((_table: string, column: string) => {
-          return ['document_id', 'locale', 'published_at'].includes(column);
-        }),
-        alterTable: jest.fn(async (_table: string, tableBuilder: (table: any) => void) => {
-          const table = {
-            index(columns: string[], name: string) {
-              indexCalls.push({ columns, name });
-            },
-          };
-          tableBuilder(table);
-        }),
-      },
-    } as unknown as Knex.Transaction;
+    const { knex, indexCalls } = createKnexMock();
 
     const db = {
       metadata: {
@@ -40,5 +48,65 @@ describe('addDocumentIdIndexes migration', () => {
         },
       ])
     );
+  });
+
+  it('truncates index names exceeding 63 characters', async () => {
+    const { knex, indexCalls } = createKnexMock();
+
+    // A long table name that will produce index names > 63 chars
+    const longTableName = 'strapi_transfer_token_permissions';
+
+    const db = {
+      metadata: {
+        values: () => [{ tableName: longTableName, attributes: {} }],
+      },
+    } as any;
+
+    await addDocumentIdIndexes.up(knex, db);
+
+    // The composite index name would be 69 chars without truncation:
+    // "strapi_transfer_token_permissions_document_id_locale_published_at_idx"
+    for (const call of indexCalls) {
+      expect(call.name.length).toBeLessThanOrEqual(63);
+    }
+  });
+
+  it('uses savepoints around index creation', async () => {
+    const { knex } = createKnexMock();
+
+    const db = {
+      metadata: {
+        values: () => [{ tableName: 'articles', attributes: {} }],
+      },
+    } as any;
+
+    await addDocumentIdIndexes.up(knex, db);
+
+    const rawCalls = (knex.raw as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(rawCalls).toContain('SAVEPOINT create_idx');
+    expect(rawCalls).toContain('RELEASE SAVEPOINT create_idx');
+  });
+
+  it('rolls back savepoint when index creation fails', async () => {
+    const knex = {
+      schema: {
+        hasTable: jest.fn().mockResolvedValue(true),
+        hasColumn: jest.fn().mockResolvedValue(true),
+        alterTable: jest.fn().mockRejectedValue(new Error('relation already exists')),
+      },
+      raw: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Knex.Transaction;
+
+    const db = {
+      metadata: {
+        values: () => [{ tableName: 'articles', attributes: {} }],
+      },
+    } as any;
+
+    // Should not throw
+    await addDocumentIdIndexes.up(knex, db);
+
+    const rawCalls = (knex.raw as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(rawCalls).toContain('ROLLBACK TO SAVEPOINT create_idx');
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the `5.0.0-06-add-document-id-indexes` migration to handle two PostgreSQL-specific failure modes that prevent Strapi from starting.

## Why is this change needed?

The migration fails in PostgreSQL under these conditions:

### 1. Index name exceeds 63-character identifier limit

For tables with long names (e.g., `strapi_transfer_token_permissions`), the generated composite index name exceeds PostgreSQL's 63-character limit:

```
strapi_transfer_token_permissions_document_id_locale_published_at_idx
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                            69 characters
```

PostgreSQL silently truncates to 63 chars on first creation. On subsequent runs, `hasIndex()` checks for the full 69-char name, doesn't find it, and tries to create it again — failing with `42P07 relation already exists`.

### 2. Transaction abort cascades to all subsequent operations

When a `CREATE INDEX` fails inside a PostgreSQL transaction, the transaction enters an aborted state. Every subsequent SQL statement fails with:

```
current transaction is aborted, commands ignored until end of transaction block
```

This means a single duplicate-index error cascades and breaks all remaining table migrations.

## Changes

- **Truncate index names** to PostgreSQL's 63-character identifier limit before creation
- **Wrap each index creation in a SAVEPOINT** so that a failure can be rolled back without poisoning the surrounding transaction
- **Remove the unreliable `hasIndex()` check** — the SAVEPOINT + catch approach handles duplicates reliably across all databases

## How was this tested?

- All 4 tests pass (1 existing + 3 new):
  - Index creation with all columns present
  - Index name truncation for long table names
  - SAVEPOINT usage verification
  - ROLLBACK TO SAVEPOINT on duplicate index error

Issue: #25697

## Checklist
- [x] My branch is based on `develop`
- [x] Tests added/updated
- [x] All tests pass
- [x] Linked to relevant issue