### PR TITLE
enhancement(core): remove beta on Document API, enforce deprecation on EntityService API

### DIFF
--- a/packages/core/types/src/core/strapi.ts
+++ b/packages/core/types/src/core/strapi.ts
@@ -19,13 +19,19 @@ export interface Strapi extends Container {
   cron: Modules.Cron.CronService;
   store: Modules.CoreStore.CoreStore;
   /**
-   * @deprecated will be removed in the next major
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   entityValidator: Modules.EntityValidator.EntityValidator;
+  /**
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
+   * @see {@link https://docs.strapi.io/dev-docs/api/document-service} Document Service API
+   */
   entityService: Modules.EntityService.EntityService;
   /**
-   * @description interact with documents within Strapi, this API is currently in beta and is subject to change in the future
-   * @beta
+   * The Document Service is the primary API to interact with content in Strapi v5+.
+   * It replaces the deprecated `entityService` and provides full support for Draft & Publish and internationalization.
+   *
+   * @see {@link https://docs.strapi.io/dev-docs/api/document-service} Document Service API
    */
   documents: Modules.Documents.Service;
   telemetry: Modules.Metrics.TelemetryService;

--- a/packages/core/types/src/modules/entity-service/index.ts
+++ b/packages/core/types/src/modules/entity-service/index.ts
@@ -16,9 +16,13 @@ export * from './plugin';
 type WrapAction = Omit<keyof EntityService, 'wrapParams' | 'wrapResult' | 'emitEvent'>;
 
 /**
- * @deprecated will be removed in the next major version
+ * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
+ * @see {@link https://docs.strapi.io/dev-docs/api/document-service} Document Service API
  */
 export interface EntityService {
+  /**
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
+   */
   wrapParams<
     TResult extends object = object,
     TContentTypeUID extends UID.ContentType = UID.ContentType,
@@ -29,13 +33,16 @@ export interface EntityService {
   ): Promise<TResult> | TResult;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   wrapResult<TResult = any, TContentTypeUID extends UID.ContentType = UID.ContentType>(
     result: unknown,
     options?: { uid: TContentTypeUID; action: WrapAction; [key: string]: unknown }
   ): Promise<TResult> | TResult;
 
+  /**
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
+   */
   findMany<
     TContentTypeUID extends UID.ContentType,
     TParams extends Params.Pick<
@@ -56,7 +63,7 @@ export interface EntityService {
   >;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   findOne<
     TContentTypeUID extends UID.ContentType,
@@ -68,7 +75,7 @@ export interface EntityService {
   ): Promise<Result<TContentTypeUID, TParams> | null>;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   delete<
     TContentTypeUID extends UID.ContentType,
@@ -80,7 +87,7 @@ export interface EntityService {
   ): Promise<Result<TContentTypeUID, TParams> | null>;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   create<
     TContentTypeUID extends UID.ContentType,
@@ -91,7 +98,7 @@ export interface EntityService {
   ): Promise<Result<TContentTypeUID, TParams>>;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   update<
     TContentTypeUID extends UID.ContentType,
@@ -103,7 +110,7 @@ export interface EntityService {
   ): Promise<Result<TContentTypeUID, TParams> | null>;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   findPage<
     TContentTypeUID extends UID.ContentType,
@@ -117,7 +124,7 @@ export interface EntityService {
   ): Promise<PaginatedResult<TContentTypeUID, TParams>>;
 
   /**
-   * @deprecated will be removed in the next major version
+   * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
    */
   count<TContentTypeUID extends UID.ContentType>(
     uid: TContentTypeUID,
@@ -125,7 +132,7 @@ export interface EntityService {
   ): Promise<number>;
 
   /**
-   * @deprecated
+   * @deprecated Will be removed in the next major version.
    * @internal
    */
   load<
@@ -139,7 +146,7 @@ export interface EntityService {
   ): Promise<any>;
 
   /**
-   * @deprecated
+   * @deprecated Will be removed in the next major version.
    * @internal
    */
   loadPages<

--- a/packages/core/types/src/modules/entity-validator.ts
+++ b/packages/core/types/src/modules/entity-validator.ts
@@ -10,6 +10,9 @@ export type Entity = {
 
 type Options = { isDraft?: boolean; locale?: string };
 
+/**
+ * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
+ */
 export interface EntityValidator {
   validateEntityCreation: <TUID extends UID.ContentType>(
     model: ContentTypes[TUID],

--- a/packages/core/types/src/public/shared.ts
+++ b/packages/core/types/src/public/shared.ts
@@ -48,7 +48,7 @@ export interface DocumentServicePluginParams {}
  *
  * @remark This type needs to be reviewed since it's not augmented anywhere yet
  *
- * @deprecated The entity service is deprecated and will be removed in v6. Use the document service instead.
+ * @deprecated Use the Document Service (`strapi.documents`) instead. Will be removed in the next major version.
  */
 export interface EntityServicePluginParams {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR updates type definitions to:
- Remove the `@beta` flag from the Document API (`strapi.documents`) and enhance its JSDoc description.
- Add `@deprecated` flags to the Entity API (`strapi.entityService`, `strapi.entityValidator`, `EntityService` interface, `wrapParams`, `findMany`, `EntityValidator` interface, `EntityServicePluginParams`).
- Standardize all deprecation messages to explicitly guide users towards the Document Service.

### Why is it needed?

This is needed to clearly communicate the deprecation of the Entity API and the promotion of the Document API as the primary API for Strapi v5+ in the type definitions, ensuring developers are properly informed.

### How to test it?

This PR primarily affects type definitions and JSDoc comments.
- Review the changes in `packages/core/types/src/core/strapi.ts`, `packages/core/types/src/modules/entity-service/index.ts`, `packages/core/types/src/modules/entity-validator.ts`, and `packages/core/types/src/public/shared.ts`.
- Verify that `@beta` is removed from `strapi.documents` and `@deprecated` is correctly applied and consistently messaged across all Entity API related types.

### Related issue(s)/PR(s)

Addresses the observations and requirements outlined in the initial prompt regarding API deprecation and promotion.

<div><a href="https://cursor.com/agents/bc-75ced5d1-88b9-4b3a-9296-033c12da0a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ced5d1-88b9-4b3a-9296-033c12da0a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->