### PR TITLE
fix(utils): return 400 instead of 500 for invalid sort order query params

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,4 +1,5 @@
 import { createTransformer } from '../convert-query-params';
+import { ValidationError } from '../errors';
 import { Model } from '../types';
 
 const models = {
@@ -86,7 +87,41 @@ describe('convert-query-params', () => {
     test.todo('partial filtering works');
   });
 
-  test.todo('convertSortQueryParams');
+  describe('convertSortQueryParams', () => {
+    it('accepts valid sort orders', () => {
+      expect(transformer.private_convertSortQueryParams('title:asc')).toEqual([{ title: 'asc' }]);
+      expect(transformer.private_convertSortQueryParams('title:desc')).toEqual([{ title: 'desc' }]);
+      expect(transformer.private_convertSortQueryParams('title:ASC')).toEqual([{ title: 'ASC' }]);
+      expect(transformer.private_convertSortQueryParams('title:DESC')).toEqual([{ title: 'DESC' }]);
+    });
+
+    it('defaults to asc when no order is specified', () => {
+      expect(transformer.private_convertSortQueryParams('title')).toEqual([{ title: 'asc' }]);
+    });
+
+    it('handles multiple sort fields', () => {
+      expect(transformer.private_convertSortQueryParams('title:asc,createdAt:desc')).toEqual([
+        { title: 'asc' },
+        { createdAt: 'desc' },
+      ]);
+    });
+
+    it('throws a ValidationError for invalid sort order suffix', () => {
+      expect(() => transformer.private_convertSortQueryParams('title:asc$')).toThrow(
+        ValidationError
+      );
+      expect(() => transformer.private_convertSortQueryParams('title:invalid')).toThrow(
+        /Invalid order/
+      );
+      expect(() => transformer.private_convertSortQueryParams('title:123')).toThrow(
+        /Invalid order/
+      );
+    });
+
+    it('throws a ValidationError for invalid sort param type', () => {
+      expect(() => transformer.private_convertSortQueryParams(123 as any)).toThrow(ValidationError);
+    });
+  });
 
   describe('convertStartQueryParams', () => {
     it('accepts valid non-negative integers', () => {

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -23,7 +23,7 @@ import {
   isDynamicZoneAttribute,
   isMorphToRelationalAttribute,
 } from './content-types';
-import { PaginationError } from './errors';
+import { PaginationError, ValidationError } from './errors';
 import { isOperator } from './operators';
 
 import parseType from './parse-type';
@@ -118,18 +118,17 @@ export interface Query {
   pageSize?: number;
 }
 
-class InvalidOrderError extends Error {
+class InvalidOrderError extends ValidationError {
   constructor() {
-    super();
-    this.message = 'Invalid order. order can only be one of asc|desc|ASC|DESC';
+    super('Invalid order. order can only be one of asc|desc|ASC|DESC');
   }
 }
 
-class InvalidSortError extends Error {
+class InvalidSortError extends ValidationError {
   constructor() {
-    super();
-    this.message =
-      'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects';
+    super(
+      'Invalid sort parameter. Expected a string, an array of strings, a sort object or an array of sort objects'
+    );
   }
 }
 


### PR DESCRIPTION
### What does it do?

Changes `InvalidOrderError` and `InvalidSortError` in `convert-query-params.ts` to extend `ValidationError` (from `@strapi/utils/errors`) instead of the plain `Error` class.

This ensures Strapi's error middleware recognizes these as `ApplicationError` subclasses and returns a **400** status code with a descriptive error message, instead of a generic **500** internal server error.

### Why is it needed?

When an invalid sort order suffix is provided in a query parameter (e.g., `?sort=field:asc$`), Strapi throws an `InvalidOrderError` which extends plain `Error`. The error middleware only maps `ApplicationError` subclasses to 400-level responses — plain `Error` instances fall through to a 500 response.

This is inconsistent with how other invalid query parameters are handled (e.g., invalid pagination params already use `PaginationError` which extends `ApplicationError` and correctly returns 400).

### How to test it?

1. Create a content-type with some fields and add data
2. Make an API request with a valid sort: `GET /api/tests?sort=title:asc` → works correctly
3. Make an API request with an invalid sort order: `GET /api/tests?sort=title:asc$`
4. **Before fix**: Returns 500 Internal Server Error
5. **After fix**: Returns 400 with message `"Invalid order. order can only be one of asc|desc|ASC|DESC"`

### Related issue(s)/PR(s)

Fix #25560