### PR TITLE
fix(core): populate with more than 100 fields breaks validation

### DIFF
--- a/packages/core/core/src/middlewares/query.ts
+++ b/packages/core/core/src/middlewares/query.ts
@@ -6,7 +6,7 @@ type Config = Parameters<typeof qs.parse>[1];
 
 const defaults: Config = {
   strictNullHandling: true,
-  arrayLimit: 100,
+  arrayLimit: 1000,
   depth: 20,
 };
 

--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -286,6 +286,31 @@ describe('convert-query-params', () => {
         expect(newPopulate).toStrictEqual({ [key]: { count: true } });
       });
     });
+
+    describe('Numeric-key object fallback (qs arrayLimit overflow)', () => {
+      test('converts an object with numeric keys back to an array', () => {
+        // Simulates what qs returns when populate has more entries than arrayLimit
+        const populate = { '0': 'title', '1': 'one_to_one', '2': 'cpa' } as any;
+
+        const result = transformer.private_convertPopulateQueryParams(
+          populate,
+          models['api::dog.dog']
+        );
+
+        expect(result).toStrictEqual(['title', 'one_to_one', 'cpa']);
+      });
+
+      test('does not treat regular attribute-key objects as arrays', () => {
+        const populate = { cpa: true, cpb: true };
+
+        const result = transformer.private_convertPopulateQueryParams(
+          populate,
+          models['api::dog.dog']
+        );
+
+        expect(result).toStrictEqual({ cpa: true, cpb: true });
+      });
+    });
   });
 
   test.todo('convertFieldsQueryParams');

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -332,6 +332,17 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (_.isPlainObject(populate)) {
+      // When qs parses arrays that exceed its arrayLimit, it returns an object
+      // with numeric string keys (e.g. { '0': 'field1', '1': 'field2' }).
+      // Convert these back to arrays so populate works correctly.
+      const keys = Object.keys(populate);
+      if (keys.length > 0 && keys.every((k) => /^\d+$/.test(k))) {
+        const arr = keys
+          .sort((a, b) => Number(a) - Number(b))
+          .map((k) => (populate as Record<string, unknown>)[k]);
+        return convertPopulateQueryParams(arr as PopulateParams, schema, depth);
+      }
+
       return convertPopulateObject(populate, schema);
     }
 


### PR DESCRIPTION
### What does it do?

Two changes:

1. **Increased `arrayLimit`** from `100` to `1000` in the `qs` parser configuration (`packages/core/core/src/middlewares/query.ts`)
2. **Added a safeguard** in `convertPopulateQueryParams` (`packages/core/utils/src/convert-query-params.ts`) to detect when `qs` returns an object with numeric string keys (instead of an array) and convert it back to an array before processing

### Why is it needed?

When a `populate` query parameter has more than 100 entries (e.g. `?populate[0]=title&populate[1]=slug&...&populate[101]=meta`), the `qs` parser — configured with `arrayLimit: 100` — returns a plain object with numeric string keys (`{ '0': 'title', '1': 'slug', ... }`) instead of an array.

The `convertPopulateQueryParams` function then treats this object as an attribute-keyed populate object and passes it to `convertPopulateObject`, which expects real attribute names — not `'0'`, `'1'`, `'2'`. This causes a `ValidationError: Invalid key 2`.

The `arrayLimit` was last bumped to 100 in PR #7430 (2020). Modern usage with many fields requires a higher limit. The safeguard ensures that even if the limit is exceeded again in the future, numeric-key objects are correctly converted back to arrays.

### How to test it?

1. Create a content-type with several fields
2. Make an API request with more than 100 populate entries:
   ```
   GET /api/pages?populate[0]=field1&populate[1]=field2&...&populate[101]=field102
   ```
3. **Before fix**: Returns `ValidationError: Invalid key 2`
4. **After fix**: Returns the populated response correctly

### Related issue(s)/PR(s)

Fix #25632