### PR TITLE
fix(graphql): expose status and hasPublishedVersion on non–D&P root queries for nested relations

### DIFF
--- a/packages/plugins/graphql/server/src/services/builders/utils.ts
+++ b/packages/plugins/graphql/server/src/services/builders/utils.ts
@@ -36,8 +36,19 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
       const { kind } = contentType;
 
-      // `status` / `hasPublishedVersion` on every root collection & single-type query.
-      // Document service ignores or applies them by content type (D&P vs not).
+      // On non–D&P roots (e.g. User) these args do not version the parent document, but they
+      // are required: association resolvers inherit them into nested D&P relations (see
+      // builders/resolvers/association.ts + rootQueryArgs). Omitting them broke draft/published
+      // control for populated relations (e.g. github.com/strapi/strapi/issues/25746).
+      //
+      // Future direction: add `status` / `hasPublishedVersion` to GraphQL args on nested
+      // to-many (and to-one) relation fields when the *target* content type has D&P, instead
+      // of relying on root-level “context” that is easy to misread (args on User affecting
+      // Articles). That would allow different publication settings per relation branch, match
+      // how developers think about the graph, and let non-DP roots drop these args if desired.
+      // Would require extending getContentTypeArgs(..., { isNested: true }) for D&P targets
+      // and teaching association.ts to honor args.hasPublishedVersion on nested fields, not
+      // only root inheritance.
       const publicationArgs = {
         status: args.PublicationStatusArg,
         hasPublishedVersion: args.HasPublishedVersionArg,


### PR DESCRIPTION
### What does it do?

Restores `status` and `hasPublishedVersion` on GraphQL root queries for **all** collection and single-type content types (including non–draft & publish types such as Users & Permissions `User`).
Previously (#25292) these arguments were only added when the content type had `draftAndPublish: true`, which removed them from non–D&P roots and broke clients that relied on them.

### Why is it needed?

On non–D&P parents, these arguments do not select draft/published **versions of the parent**, but they are still **valid and necessary**: the content API association resolver inherits them from the root query (`rootQueryArgs`) to apply draft vs published (and `hasPublishedVersion`) filters when loading **nested relations** whose **target** is draft & publish (e.g. User → related Articles). Without root-level `status` / `hasPublishedVersion`, nested D&P relations could not be queried as draft from a non–D&P entry ([#25746](https://github.com/strapi/strapi/issues/25746)).
A code comment documents a possible future direction (per-relation args on D&P targets instead of root inheritance).

### How to test it?

1. Enable the GraphQL plugin and open the GraphQL playground (or any GraphQL client).
2. Use a **non–D&P** root query (e.g. `usersPermissionsUsers` or another collection without D&P) and confirm the schema exposes `status` and `hasPublishedVersion` on that field.
3. Add a relation from that type to a **D&P** collection; run a query that loads that relation with `status: draft` vs `status: published` on the **root** field and assert nested results match (draft rows only when `draft`, published when `published`).
4. Optionally repeat with `hasPublishedVersion` if your setup uses it on nested D&P data.
5. Smoke-test a **D&P** root query (e.g. articles): behavior should remain unchanged.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/25746