### PR TITLE
fix(content-type-builder): default draftAndPublish to true in AI CTB

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/tests/toCTB.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/tests/toCTB.test.ts
@@ -1,0 +1,48 @@
+import { transformChatToCTB } from '../toCTB';
+
+import type { ContentType } from '../../../../../../types';
+import type { Schema } from '../../../types/schema';
+
+const makeSchema = (overrides: Partial<Schema> = {}): Schema => ({
+  action: 'create',
+  kind: 'collectionType',
+  uid: 'api::product.product',
+  modelType: 'contentType',
+  name: 'Product',
+  attributes: {
+    title: { type: 'string' },
+  },
+  ...overrides,
+});
+
+describe('transformChatToCTB', () => {
+  describe('draftAndPublish default', () => {
+    it('should default draftAndPublish to true when AI does not set it', () => {
+      const schema = makeSchema({ options: undefined });
+      const result = transformChatToCTB(schema) as ContentType;
+
+      expect(result.options.draftAndPublish).toBe(true);
+    });
+
+    it('should default draftAndPublish to true when options object is empty', () => {
+      const schema = makeSchema({ options: {} });
+      const result = transformChatToCTB(schema) as ContentType;
+
+      expect(result.options.draftAndPublish).toBe(true);
+    });
+
+    it('should respect explicit draftAndPublish: false from AI', () => {
+      const schema = makeSchema({ options: { draftAndPublish: false } });
+      const result = transformChatToCTB(schema) as ContentType;
+
+      expect(result.options.draftAndPublish).toBe(false);
+    });
+
+    it('should respect explicit draftAndPublish: true from AI', () => {
+      const schema = makeSchema({ options: { draftAndPublish: true } });
+      const result = transformChatToCTB(schema) as ContentType;
+
+      expect(result.options.draftAndPublish).toBe(true);
+    });
+  });
+});

--- a/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
+++ b/packages/core/content-type-builder/admin/src/components/AIChat/lib/transforms/schemas/toCTB.ts
@@ -172,7 +172,7 @@ export const transformChatToCTB = (
     collectionName: pluralName,
     attributes: transformAttributesFromChatToCTB(schema, oldSchema),
     options: {
-      draftAndPublish: schema.options?.draftAndPublish ?? false,
+      draftAndPublish: schema.options?.draftAndPublish ?? true,
     },
     pluginOptions: {
       i18n: {


### PR DESCRIPTION
## What does it do?

Changes the default value of `draftAndPublish` from `false` to `true` when the AI Content-Type Builder creates a content type without explicitly setting the option. This aligns AI-created content types with the normal CTB behavior (`FormModal.tsx:214`).

## Why is it needed?

The AI CTB never enables Draft & Publish on content types it creates (reported in CMS-369). The external AI service doesn't set `options.draftAndPublish` in its schema output, and the transform layer (`toCTB.ts`) defaulted to `false`. The normal CTB defaults to `true`, so this was an inconsistency.

## How to test it?

1. Open the Content-Type Builder with AI chat enabled (EE, non-production)
2. Ask the AI to generate a content type (e.g. "Generate a product schema")
3. Verify the created content type has Draft & Publish enabled by default
4. Verify that if the AI explicitly sets `draftAndPublish: false`, it is still respected

## Related issue(s)/PR(s)

fix CMS-369