### PR TITLE
feat: add media field option for relation thumbnail

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
@@ -29,6 +29,7 @@ const FIELD_SCHEMA = yup.object().shape({
   description: yup.string().nullable(),
   placeholder: yup.string().nullable(),
   editable: yup.boolean(),
+  mediaField: yup.string().nullable(),
   size: yup.number().required(),
 });
 
@@ -71,6 +72,40 @@ const EditFieldForm = ({ attribute, name, onClose }: EditFieldFormProps) => {
                * we're editing.
                */
               if (!ATTRIBUTE_TYPES_THAT_CANNOT_BE_MAIN_FIELD.includes(attribute.type)) {
+                acc.push({
+                  label: key,
+                  value: key,
+                });
+              }
+
+              return acc;
+            }, []),
+          };
+        }
+      }
+
+      return { data: [] };
+    },
+    skip: attribute?.type !== 'relation',
+  });
+
+  const { data: mediaFieldOptions } = useGetInitialDataQuery(undefined, {
+    selectFromResult: (res) => {
+      if (attribute?.type !== 'relation' || !res.data) {
+        return { data: [] };
+      }
+
+      if ('targetModel' in attribute && typeof attribute.targetModel === 'string') {
+        const targetSchema = res.data.contentTypes.find(
+          (schema) => schema.uid === attribute.targetModel
+        );
+
+        if (targetSchema) {
+          return {
+            data: Object.entries(targetSchema.attributes).reduce<
+              Array<{ label: string; value: string }>
+            >((acc, [key, attribute]) => {
+              if (attribute.type === 'media') {
                 acc.push({
                   label: key,
                   value: key,
@@ -186,6 +221,29 @@ const EditFieldForm = ({ attribute, name, onClose }: EditFieldFormProps) => {
                 type: 'enumeration' as const,
               },
               {
+                name: 'mediaField',
+                label: formatMessage({
+                  id: getTranslation('containers.edit-settings.modal-form.mediaField'),
+                  defaultMessage: 'Entry thumbnail',
+                }),
+                hint: formatMessage({
+                  id: getTranslation('containers.edit-settings.modal-form.mediaField.hint'),
+                  defaultMessage: 'Set the media field used as thumbnail for relation items',
+                }),
+                size: 6,
+                options: [
+                  {
+                    label: formatMessage({
+                      id: 'global.none',
+                      defaultMessage: 'None',
+                    }),
+                    value: '',
+                  },
+                  ...mediaFieldOptions,
+                ],
+                type: 'enumeration' as const,
+              },
+              {
                 name: 'size',
                 label: formatMessage({
                   id: getTranslation('containers.ListSettingsView.modal-form.size'),
@@ -239,19 +297,26 @@ const filterFieldsBasedOnAttributeType = (type: Schema.Attribute.Kind) => (field
   switch (type) {
     case 'blocks':
     case 'richtext':
-      return field.name !== 'size' && field.name !== 'mainField';
+      return field.name !== 'size' && field.name !== 'mainField' && field.name !== 'mediaField';
     case 'boolean':
     case 'media':
-      return field.name !== 'placeholder' && field.name !== 'mainField';
+      return (
+        field.name !== 'placeholder' && field.name !== 'mainField' && field.name !== 'mediaField'
+      );
     case 'component':
       return field.name === 'label' || field.name === 'editable';
     case 'dynamiczone':
     case 'json':
-      return field.name !== 'placeholder' && field.name !== 'mainField' && field.name !== 'size';
+      return (
+        field.name !== 'placeholder' &&
+        field.name !== 'mainField' &&
+        field.name !== 'mediaField' &&
+        field.name !== 'size'
+      );
     case 'relation':
       return true;
     default:
-      return field.name !== 'mainField';
+      return field.name !== 'mainField' && field.name !== 'mediaField';
   }
 };
 

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Form.tsx
@@ -48,9 +48,11 @@ interface ConfigurationFormData extends Pick<EditLayout, 'settings'> {
   layout: Array<{
     __temp_key__: string;
     children: Array<
-      | (Pick<EditFieldLayout, 'label' | 'size' | 'name' | 'placeholder' | 'mainField'> & {
+      | (Pick<EditFieldLayout, 'label' | 'size' | 'name' | 'placeholder'> & {
           description: EditFieldLayout['hint'];
           editable: EditFieldLayout['disabled'];
+          mainField?: string;
+          mediaField?: string;
           __temp_key__: string;
         })
       | EditFieldSpacerLayout
@@ -233,6 +235,7 @@ const replaceMainFieldWithNameOnly = (layout: EditLayout['layout'][number]) =>
     row.map((field) => ({
       ...field,
       mainField: field.mainField?.name,
+      mediaField: field.mediaField?.name,
     }))
   );
 
@@ -244,11 +247,12 @@ const extractMetadata = (
   layout: EditLayout['layout'][number]
 ): Array<Exclude<ConfigurationFormData['layout'], { name: '_TEMP_' }>[number]['children']> => {
   return layout.map((row) =>
-    row.map(({ label, disabled, hint, placeholder, size, name, mainField }) => ({
+    row.map(({ label, disabled, hint, placeholder, size, name, mainField, mediaField }) => ({
       label,
       editable: !disabled,
       description: hint,
-      mainField,
+      mainField: mainField as string | undefined,
+      mediaField: mediaField as string | undefined,
       placeholder,
       size,
       name,

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -11,7 +11,7 @@ import {
 import { HOOKS } from '../constants/hooks';
 import { useGetContentTypeConfigurationQuery } from '../services/contentTypes';
 import { BaseQueryError } from '../utils/api';
-import { getMainField } from '../utils/attributes';
+import { getMainField, getMediaField, type MediaField } from '../utils/attributes';
 import { normalizeContentManagerLayout } from '../utils/layouts/normalizeContentManagerLayout';
 
 import { useContentTypeSchema } from './useContentTypeSchema';
@@ -59,6 +59,7 @@ interface EditFieldSharedProps
     Pick<Filters.Filter, 'mainField'> {
   hint?: string;
   label: string;
+  mediaField?: MediaField;
   size: number;
   unique?: boolean;
   visible?: boolean;
@@ -469,8 +470,11 @@ const convertEditLayoutToFieldLayouts = (
           hint: metadata.description,
           label: metadata.label ?? '',
           name: field.name,
-          // @ts-expect-error – mainField does exist on the metadata for a relation.
           mainField: getMainField(attribute, metadata.mainField || settings.mainField, {
+            schemas,
+            components: components?.schemas ?? {},
+          }),
+          mediaField: getMediaField(attribute, metadata.mediaField, {
             schemas,
             components: components?.schemas ?? {},
           }),

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -384,7 +384,8 @@ const formatEditLayout = (
           configuration.layouts.edit,
           componentSchema.attributes,
           configuration.metadatas,
-          { configurations: data.components, schemas: components }
+          { configurations: data.components, schemas: components },
+          schemas
         ),
         settings: {
           ...configuration.settings,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -10,6 +10,7 @@ import {
   useIsDesktop,
 } from '@strapi/admin/strapi-admin';
 import {
+  Avatar,
   Box,
   Combobox,
   ComboboxOption,
@@ -53,14 +54,43 @@ import {
 } from '../../../../../services/relations';
 import { type MainField } from '../../../../../utils/attributes';
 import { setIn } from '../../../../../utils/objects';
-import { getRelationLabel } from '../../../../../utils/relations';
+import { getRelationLabel, getRelationThumbnail } from '../../../../../utils/relations';
 import { getTranslation } from '../../../../../utils/translations';
+import { prefixFileUrlWithBackendUrl } from '../../../../../utils/urls';
 import { DocumentStatus } from '../../DocumentStatus';
 import { useComponent } from '../ComponentContext';
 import { RelationModalRenderer, getCollectionType } from '../Relations/RelationModal';
 
 import type { FindAvailable } from '../../../../../../../shared/contracts/relations';
 import type { Schema } from '@strapi/types';
+
+/* -------------------------------------------------------------------------------------------------
+ * RelationThumbnail
+ * -----------------------------------------------------------------------------------------------*/
+
+interface RelationThumbnailProps {
+  media: { url: string; alt: string } | undefined;
+  /**
+   * The human readable name of the relation, used as the avatar text when the image cannot be loaded.
+   */
+  label: string;
+  /**
+   * Rendered whenever there is no displayable image, so the caller can always show something.
+   */
+  fallback?: React.ReactNode;
+}
+
+const RelationThumbnail = ({ media, label, fallback = null }: RelationThumbnailProps) => {
+  const src = media?.url ? prefixFileUrlWithBackendUrl(media.url) : undefined;
+
+  if (!media || !src) {
+    return <>{fallback}</>;
+  }
+
+  const alt = media.alt || label;
+
+  return <Avatar.Item src={src} alt={alt} fallback={alt} preview />;
+};
 
 /**
  * Remove a relation, whether it's been already saved or not.
@@ -126,6 +156,7 @@ type RelationPosition =
 interface Relation extends Pick<RelationResult, 'documentId' | 'id' | 'locale' | 'status'> {
   href: string;
   label: string;
+  media?: { url: string; alt: string };
   position?: RelationPosition;
   __temp_key__: string;
   apiData?: {
@@ -274,6 +305,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         field: field.value,
         href: `../${COLLECTION_TYPES}/${targetModel}`,
         mainField: props.mainField,
+        mediaField: props.mediaField,
       };
 
       /**
@@ -306,7 +338,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         if (a.__temp_key__ > b.__temp_key__) return 1;
         return 0;
       });
-    }, [serverData, field.value, targetModel, props.mainField]);
+    }, [serverData, field.value, targetModel, props.mainField, props.mediaField]);
 
     const handleDisconnect = useHandleDisconnect(props.name, 'RelationsField');
 
@@ -329,6 +361,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
           // Fallback to `id` if there is no `mainField` value, which will overwrite the above `id` property with the exact same data.
           [props.mainField?.name ?? 'documentId']: relation[props.mainField?.name ?? 'documentId'],
           label: getRelationLabel(relation, props.mainField),
+          media: getRelationThumbnail(relation, props.mediaField),
           href: `../${COLLECTION_TYPES}/${targetModel}/${relation.documentId}?${relation.locale ? `plugins[i18n][locale]=${relation.locale}` : ''}`,
         };
 
@@ -348,6 +381,7 @@ const RelationsField = React.forwardRef<HTMLDivElement, RelationsFieldProps>(
         onChangeRelationField,
         props.attribute.relation,
         props.mainField,
+        props.mediaField,
         props.name,
         relations,
         targetModel,
@@ -420,7 +454,7 @@ const StyledFlex = styled<FlexComponent>(Flex)`
  * Relation Transformations
  * -----------------------------------------------------------------------------------------------*/
 
-interface TransformationContext extends Pick<RelationsFieldProps, 'mainField'> {
+interface TransformationContext extends Pick<RelationsFieldProps, 'mainField' | 'mediaField'> {
   field?: RelationsFormValue;
   href: string;
 }
@@ -456,7 +490,7 @@ const removeDisconnected =
  * a better UI where we can link to the relation and display a human-readable label.
  */
 const addLabelAndHref =
-  ({ mainField, href }: TransformationContext) =>
+  ({ mainField, mediaField, href }: TransformationContext) =>
   (relations: RelationResult[]): Relation[] =>
     relations.map((relation) => {
       return {
@@ -464,6 +498,7 @@ const addLabelAndHref =
         // Fallback to `id` if there is no `mainField` value, which will overwrite the above `documentId` property with the exact same data.
         [mainField?.name ?? 'documentId']: relation[mainField?.name ?? 'documentId'],
         label: getRelationLabel(relation, mainField),
+        media: getRelationThumbnail(relation, mediaField),
         href: `${href}/${relation.documentId}?${relation.locale ? `plugins[i18n][locale]=${relation.locale}` : ''}`,
       };
     });
@@ -688,6 +723,7 @@ const RelationModalWithContext = ({
   isLoadingPermissions,
   handleChange,
   mainField,
+  mediaField,
   setSearchParams,
   fieldValue,
   data,
@@ -785,12 +821,17 @@ const RelationModalWithContext = ({
         >
           {options?.map((opt) => {
             const textValue = getRelationLabel(opt, mainField);
+            const thumbnail = getRelationThumbnail(opt, mediaField);
 
             return (
               <ComboboxOption key={opt.id} value={opt.id.toString()} textValue={textValue}>
                 <Flex gap={2} justifyContent="space-between">
                   <Flex gap={2}>
-                    <LinkIcon fill="neutral500" />
+                    <RelationThumbnail
+                      media={thumbnail}
+                      label={textValue}
+                      fallback={<LinkIcon fill="neutral500" />}
+                    />
                     <Typography ellipsis>{textValue}</Typography>
                   </Flex>
                   {opt.status ? <DocumentStatus status={opt.status} /> : null}
@@ -1197,6 +1238,7 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
     id,
     label: originalLabel,
     status: originalStatus,
+    media,
     documentId,
     apiData,
     locale,
@@ -1304,9 +1346,12 @@ const ListItem = React.memo(({ data, index, style }: ListItemProps) => {
               </IconButton>
             ) : null}
             <Flex width="100%" minWidth={0} gap={4} justifyContent="space-between">
-              <Box flex={1} minWidth={0} paddingTop={1} paddingBottom={1}>
-                <RelationModalRenderer relation={documentMeta}>{label}</RelationModalRenderer>
-              </Box>
+              <Flex flex={1} minWidth={0} gap={2} alignItems="center">
+                <RelationThumbnail media={media} label={label} />
+                <Box flex={1} minWidth={0} paddingTop={1} paddingBottom={1}>
+                  <RelationModalRenderer relation={documentMeta}>{label}</RelationModalRenderer>
+                </Box>
+              </Flex>
               {status ? <DocumentStatus status={status} /> : null}
             </Flex>
           </FlexWrapper>

--- a/packages/core/content-manager/admin/src/pages/tests/formatComponentConfigurationEditLayout.test.ts
+++ b/packages/core/content-manager/admin/src/pages/tests/formatComponentConfigurationEditLayout.test.ts
@@ -131,7 +131,6 @@ describe('formatComponentConfigurationEditLayout', () => {
               placeholder: '',
               visible: true,
               editable: true,
-              // @ts-expect-error — mainField is used at runtime (see useDocumentLayout getMainField call).
               mainField: 'title',
             },
             list: { label: 'Cta' },

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -143,6 +143,8 @@
   "containers.edit-settings.modal-form.mainField": "Entry title",
   "containers.edit-settings.modal-form.mainField.hint": "Set the displayed field in both the edit and list views",
   "containers.edit-settings.modal-form.editable": "Editable field",
+  "containers.edit-settings.modal-form.mediaField": "Entry thumbnail",
+  "containers.edit-settings.modal-form.mediaField.hint": "Set the media field used as thumbnail for relation items",
   "containers.edit-settings.modal-form.size": "Size",
   "containers.SettingPage.add.field": "Insert another field",
   "containers.SettingPage.add.relational-field": "Insert another related field",

--- a/packages/core/content-manager/admin/src/utils/attributes.ts
+++ b/packages/core/content-manager/admin/src/utils/attributes.ts
@@ -62,5 +62,44 @@ const getMainField = (
   };
 };
 
-export { checkIfAttributeIsDisplayable, getMainField };
-export type { MainField };
+interface MediaField {
+  name: string;
+}
+
+/**
+ * @internal
+ * @description given an attribute and a mediaField name, verify the target schema has a matching media attribute.
+ */
+const getMediaField = (
+  attribute: SchemaUtils.Attribute.AnyAttribute,
+  mediaFieldName: string | undefined,
+  { schemas, components }: { schemas: Schema[]; components: ComponentsDictionary }
+): MediaField | undefined => {
+  if (!mediaFieldName) {
+    return undefined;
+  }
+
+  let targetAttributes: Schema['attributes'] | undefined;
+
+  if (attribute.type === 'component') {
+    targetAttributes = components[attribute.component]?.attributes;
+  } else if (attribute.type === 'relation') {
+    const target =
+      'targetModel' in attribute
+        ? attribute.targetModel
+        : 'target' in attribute
+          ? attribute.target
+          : undefined;
+
+    targetAttributes = schemas.find((schema) => schema.uid === target)?.attributes;
+  }
+
+  if (targetAttributes?.[mediaFieldName]?.type !== 'media') {
+    return undefined;
+  }
+
+  return { name: mediaFieldName };
+};
+
+export { checkIfAttributeIsDisplayable, getMainField, getMediaField };
+export type { MainField, MediaField };

--- a/packages/core/content-manager/admin/src/utils/relations.ts
+++ b/packages/core/content-manager/admin/src/utils/relations.ts
@@ -1,4 +1,4 @@
-import type { MainField } from './attributes';
+import type { MainField, MediaField } from './attributes';
 import type { RelationResult } from '../../../shared/contracts/relations';
 
 /**
@@ -24,4 +24,51 @@ const getRelationLabel = (relation: RelationResult, mainField?: MainField): stri
   return relation.documentId;
 };
 
-export { getRelationLabel };
+interface RelationThumbnail {
+  url: string;
+  alt: string;
+}
+
+interface MediaValue {
+  url: string;
+  alternativeText?: string | null;
+  mime?: string;
+  formats?: Record<string, { url: string } | undefined> | null;
+}
+
+const isMediaValue = (value: unknown): value is MediaValue => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return typeof (value as { url?: unknown }).url === 'string';
+};
+
+/**
+ * @internal
+ * @description Extract a thumbnail URL from a relation's media field.
+ * Only returns a thumbnail for image files; non-images return undefined.
+ */
+const getRelationThumbnail = (
+  relation: RelationResult,
+  mediaField?: MediaField
+): RelationThumbnail | undefined => {
+  if (!mediaField) {
+    return undefined;
+  }
+
+  const mediaValue: unknown = relation[mediaField.name];
+  const media = Array.isArray(mediaValue) ? mediaValue[0] : mediaValue;
+
+  if (!isMediaValue(media) || !media.mime?.startsWith('image')) {
+    return undefined;
+  }
+
+  return {
+    url: media.formats?.thumbnail?.url ?? media.url,
+    alt: media.alternativeText ?? '',
+  };
+};
+
+export { getRelationLabel, getRelationThumbnail };
+export type { RelationThumbnail };

--- a/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
@@ -1,12 +1,109 @@
-import { checkIfAttributeIsDisplayable, getMainField } from '../attributes';
+import { checkIfAttributeIsDisplayable, getMainField, getMediaField } from '../attributes';
 
+import type { ComponentsDictionary, Schema as ContentTypeSchema } from '../../hooks/useDocument';
 import type { Schema } from '@strapi/types';
 
 type RelationAttributeWithTargetModel = Schema.Attribute.Relation & {
   targetModel: string;
 };
 
+type RelationTarget = Schema.Attribute.OneToOne['target'];
+
 describe('attributes', () => {
+  describe('getMediaField', () => {
+    const schemas = [
+      {
+        uid: 'api::product.product',
+        attributes: {
+          name: { type: 'string' },
+          coverImage: { type: 'media' },
+          description: { type: 'text' },
+        },
+      },
+    ] as unknown as ContentTypeSchema[];
+
+    const components: ComponentsDictionary = {};
+
+    const relationTo = (targetModel: RelationTarget) =>
+      ({
+        type: 'relation',
+        relation: 'oneToOne',
+        target: targetModel,
+        targetModel,
+      }) satisfies RelationAttributeWithTargetModel;
+
+    it('should return undefined when mediaFieldName is undefined', () => {
+      const attribute = relationTo('api::product.product');
+      expect(getMediaField(attribute, undefined, { schemas, components })).toBeUndefined();
+    });
+
+    it('should return MediaField object for valid media attribute', () => {
+      const attribute = relationTo('api::product.product');
+      const result = getMediaField(attribute, 'coverImage', { schemas, components });
+      expect(result).toEqual({ name: 'coverImage' });
+    });
+
+    it('should return undefined for non-media attribute', () => {
+      const attribute = relationTo('api::product.product');
+      expect(getMediaField(attribute, 'name', { schemas, components })).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent attribute', () => {
+      const attribute = relationTo('api::product.product');
+      expect(getMediaField(attribute, 'nonExistent', { schemas, components })).toBeUndefined();
+    });
+
+    it('should return undefined when target schema is not found', () => {
+      const attribute = relationTo('api::unknown.unknown');
+      expect(getMediaField(attribute, 'coverImage', { schemas, components })).toBeUndefined();
+    });
+
+    it('should resolve the target schema from `target` when `targetModel` is absent', () => {
+      const attribute = {
+        type: 'relation',
+        relation: 'oneToOne',
+        target: 'api::product.product',
+      } as Schema.Attribute.AnyAttribute;
+
+      expect(getMediaField(attribute, 'coverImage', { schemas, components })).toEqual({
+        name: 'coverImage',
+      });
+    });
+
+    it('should resolve the media field from the component attributes', () => {
+      const componentsWithMedia = {
+        'basic.card': {
+          uid: 'basic.card',
+          attributes: {
+            title: { type: 'string' },
+            picture: { type: 'media' },
+          },
+        },
+      } as unknown as ComponentsDictionary;
+
+      const attribute = {
+        type: 'component',
+        component: 'basic.card',
+        repeatable: false,
+      } satisfies Schema.Attribute.Component;
+
+      expect(
+        getMediaField(attribute, 'picture', { schemas, components: componentsWithMedia })
+      ).toEqual({ name: 'picture' });
+
+      expect(
+        getMediaField(attribute, 'title', { schemas, components: componentsWithMedia })
+      ).toBeUndefined();
+
+      expect(getMediaField(attribute, 'picture', { schemas, components })).toBeUndefined();
+    });
+
+    it('should return undefined for an attribute that is neither a relation nor a component', () => {
+      const attribute = { type: 'string' } satisfies Schema.Attribute.String;
+
+      expect(getMediaField(attribute, 'coverImage', { schemas, components })).toBeUndefined();
+    });
+  });
   describe('checkIfAttributeIsDisplayable', () => {
     it('should return false if the relation is morph', () => {
       const attribute = {

--- a/packages/core/content-manager/admin/src/utils/tests/relations.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/relations.test.ts
@@ -1,5 +1,6 @@
-import { getRelationLabel } from '../relations';
+import { getRelationLabel, getRelationThumbnail } from '../relations';
 
+import type { RelationResult } from '../../../../shared/contracts/relations';
 import type { MainField } from '../attributes';
 
 const mainField = (name: string, type: MainField['type'] = 'string'): MainField => ({
@@ -49,5 +50,142 @@ describe('getRelationLabel', () => {
         mainField('pub_number', 'integer')
       )
     ).toBe('doc-1');
+  });
+});
+
+describe('getRelationThumbnail', () => {
+  it('should return undefined when mediaField is undefined', () => {
+    const relation = { documentId: 'abc', id: 1 } as RelationResult;
+    expect(getRelationThumbnail(relation, undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when relation has no media value', () => {
+    const relation = { documentId: 'abc', id: 1 } as RelationResult;
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toBeUndefined();
+  });
+
+  it('should return thumbnail for image media', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: {
+        url: '/uploads/image.jpg',
+        alternativeText: 'A product',
+        mime: 'image/jpeg',
+        formats: {
+          thumbnail: { url: '/uploads/thumbnail_image.jpg' },
+        },
+      },
+    } as RelationResult;
+
+    const result = getRelationThumbnail(relation, { name: 'coverImage' });
+    expect(result).toEqual({
+      url: '/uploads/thumbnail_image.jpg',
+      alt: 'A product',
+    });
+  });
+
+  it('should fall back to main url when no thumbnail format', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: {
+        url: '/uploads/image.jpg',
+        alternativeText: '',
+        mime: 'image/png',
+        formats: {},
+      },
+    } as RelationResult;
+
+    const result = getRelationThumbnail(relation, { name: 'coverImage' });
+    expect(result).toEqual({
+      url: '/uploads/image.jpg',
+      alt: '',
+    });
+  });
+
+  it('should return undefined for non-image media (PDF)', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: {
+        url: '/uploads/doc.pdf',
+        alternativeText: 'A document',
+        mime: 'application/pdf',
+        formats: {},
+      },
+    } as RelationResult;
+
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toBeUndefined();
+  });
+
+  it('should use first item for array media (multiple=true)', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: [
+        {
+          url: '/uploads/first.jpg',
+          alternativeText: 'First',
+          mime: 'image/jpeg',
+          formats: {},
+        },
+        {
+          url: '/uploads/second.jpg',
+          alternativeText: 'Second',
+          mime: 'image/jpeg',
+          formats: {},
+        },
+      ],
+    } as RelationResult;
+
+    const result = getRelationThumbnail(relation, { name: 'coverImage' });
+    expect(result).toEqual({
+      url: '/uploads/first.jpg',
+      alt: 'First',
+    });
+  });
+
+  it('should return undefined when media value is not an object', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: 'not-an-object',
+    } as RelationResult;
+
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toBeUndefined();
+  });
+
+  it('should return undefined for empty array media', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: [],
+    } as RelationResult;
+
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toBeUndefined();
+  });
+
+  it('should return undefined when the media object has no url', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: { mime: 'image/jpeg', alternativeText: 'no url' },
+    } as RelationResult;
+
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toBeUndefined();
+  });
+
+  it('should treat a null alternativeText as an empty alt', () => {
+    const relation = {
+      documentId: 'abc',
+      id: 1,
+      coverImage: { url: '/uploads/a.jpg', alternativeText: null, mime: 'image/jpeg' },
+    } as RelationResult;
+
+    expect(getRelationThumbnail(relation, { name: 'coverImage' })).toEqual({
+      url: '/uploads/a.jpg',
+      alt: '',
+    });
   });
 });

--- a/packages/core/content-manager/server/src/controllers/__tests__/relations-media-field.test.ts
+++ b/packages/core/content-manager/server/src/controllers/__tests__/relations-media-field.test.ts
@@ -1,0 +1,298 @@
+import { queryParams } from '@strapi/utils';
+
+// @ts-expect-error - types are not generated for this file
+// eslint-disable-next-line import/no-relative-packages
+import createContext from '../../../../../../../tests/helpers/create-context';
+import relations from '../relations';
+
+/**
+ * Coverage for the `mediaField` populate added to the relation endpoints.
+ *
+ * The upstream `relations.test.ts` suite is `describe.skip`-ed, so these tests live in
+ * their own file and build their own mocks rather than reviving that suite.
+ */
+
+const MEDIA_FIELDS = ['url', 'alternativeText', 'formats', 'width', 'height', 'mime', 'name'];
+
+// What the query-params transform is expected to produce out of MEDIA_FIELDS
+const EXPECTED_MEDIA_SELECT = ['id', 'documentId', ...MEDIA_FIELDS];
+
+const contentTypes: Record<string, any> = {
+  main: {
+    uid: 'main',
+    modelType: 'contentType',
+    kind: 'collectionType',
+    options: {},
+    attributes: {
+      products: {
+        type: 'relation',
+        relation: 'oneToMany',
+        target: 'target',
+        targetModel: 'target',
+      },
+    },
+  },
+  target: {
+    uid: 'target',
+    modelType: 'contentType',
+    kind: 'collectionType',
+    options: {},
+    attributes: {
+      myField: { type: 'string' },
+      coverImage: { type: 'media', multiple: false },
+      category: { type: 'relation', relation: 'manyToOne', target: 'main', targetModel: 'main' },
+    },
+  },
+  'plugin::upload.file': {
+    uid: 'plugin::upload.file',
+    modelType: 'contentType',
+    kind: 'collectionType',
+    options: {},
+    attributes: {
+      name: { type: 'string' },
+      url: { type: 'string' },
+      alternativeText: { type: 'string' },
+      formats: { type: 'json' },
+      width: { type: 'integer' },
+      height: { type: 'integer' },
+      mime: { type: 'string' },
+      // Fields that must never leak into the relation payload
+      provider: { type: 'string' },
+      provider_metadata: { type: 'json' },
+      folderPath: { type: 'string' },
+    },
+  },
+};
+
+const { transformQueryParams } = queryParams.createTransformer({
+  getModel: (uid: string) => contentTypes[uid],
+});
+
+type Options = {
+  mediaField?: string | null;
+  canReadMediaField?: boolean;
+  permissionQueryPopulate?: Record<string, unknown>;
+};
+
+const loadPages = jest.fn(() => ({ results: [{ id: 1 }, { id: 2 }], pagination: {} }));
+const findPage = jest.fn(() => ({ results: [] }));
+const findOne = jest.fn(() => ({ id: 1 }));
+const findMany = jest.fn(() => [
+  { id: 1, coverImage: { id: 10, url: '/uploads/a.jpg', mime: 'image/jpeg' } },
+  { id: 2, coverImage: null },
+]);
+
+const setupStrapi = ({
+  mediaField = 'coverImage',
+  canReadMediaField = true,
+  permissionQueryPopulate,
+}: Options = {}) => {
+  const services: Record<string, any> = {
+    'permission-checker': {
+      create: jest.fn(() => ({
+        can: {
+          read: jest.fn((_entity: unknown, field?: string) =>
+            field === 'coverImage' ? canReadMediaField : true
+          ),
+        },
+        cannot: { read: jest.fn(() => false) },
+        sanitizedQuery: {
+          read: jest.fn((params: Record<string, unknown>) => ({
+            ...params,
+            ...(permissionQueryPopulate ? { populate: permissionQueryPopulate } : {}),
+          })),
+        },
+      })),
+    },
+    'populate-builder': () => ({
+      populateFromQuery: jest.fn().mockReturnThis(),
+      build: jest.fn(() => ({})),
+    }),
+    'content-types': {
+      findConfiguration: jest.fn(() => ({
+        metadatas: {
+          products: {
+            edit: { mainField: 'myField', ...(mediaField ? { mediaField } : {}) },
+          },
+        },
+      })),
+    },
+  };
+
+  // NOTE: `tests/setup/unit.setup.js` derives `strapi.plugin()` from `strapi.plugins`
+  global.strapi = {
+    getModel: jest.fn((uid: string) => contentTypes[uid]),
+    get: jest.fn((name: string) => {
+      if (name === 'query-params') {
+        return { transform: transformQueryParams };
+      }
+
+      throw new Error(`Unexpected strapi.get('${name}')`);
+    }),
+    plugins: {
+      'content-manager': { services },
+      i18n: {
+        services: { 'content-types': { isLocalizedContentType: () => false } },
+      },
+    },
+    db: {
+      query: jest.fn(() => ({ loadPages, load: jest.fn(), findOne, findPage, findMany })),
+    },
+  } as any;
+};
+
+const createFindExistingContext = () =>
+  createContext(
+    { params: { model: 'main', targetField: 'products', id: 'doc-1' }, query: {} },
+    { state: { userAbility: {} } }
+  );
+
+describe('Relations controller | mediaField populate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findExisting', () => {
+    test('never populates the media on the permission-free query', async () => {
+      setupStrapi();
+
+      await relations.findExisting(createFindExistingContext());
+
+      expect(loadPages).toHaveBeenCalledTimes(2);
+
+      // First query bypasses the permission query: it must expose ids/dates only
+      const [, , unsanitizedOptions] = loadPages.mock.calls[0] as unknown as any[];
+
+      expect(unsanitizedOptions).not.toHaveProperty('populate');
+      expect(unsanitizedOptions.select).toEqual([
+        'id',
+        'documentId',
+        'locale',
+        'publishedAt',
+        'updatedAt',
+      ]);
+    });
+
+    /**
+     * REGRESSION GUARD — `loadPages` forwards the very same options to its `count: true`
+     * companion. Any populate here leaks the selected columns into an aggregate, which
+     * PostgreSQL rejects with `column "t0.id" must appear in the GROUP BY clause`.
+     * SQLite and MySQL tolerate it, so this can only be caught structurally.
+     */
+    test('never passes a media populate to loadPages, on either query', async () => {
+      setupStrapi();
+
+      await relations.findExisting(createFindExistingContext());
+
+      const [, , unsanitizedOptions] = loadPages.mock.calls[0] as unknown as any[];
+      const [, , sanitizedOptions] = loadPages.mock.calls[1] as unknown as any[];
+
+      expect(unsanitizedOptions?.populate?.coverImage).toBeUndefined();
+      expect(sanitizedOptions?.populate?.coverImage).toBeUndefined();
+    });
+
+    test('loads the media in a dedicated query, restricted to the permission-checked ids', async () => {
+      setupStrapi();
+
+      await relations.findExisting(createFindExistingContext());
+
+      expect(findMany).toHaveBeenCalledTimes(1);
+
+      const [query] = findMany.mock.calls[0] as unknown as any[];
+
+      // Only the ids returned by the sanitized query may have their media loaded
+      expect(query.where).toEqual({ id: { $in: [1, 2] } });
+      // `fields` is dropped by the db layer's pickPopulateParams, `select` is not
+      expect(query.populate.coverImage).not.toHaveProperty('fields');
+      expect(query.populate.coverImage.select).toEqual(EXPECTED_MEDIA_SELECT);
+      expect(query.populate.coverImage.select).not.toContain('provider');
+      expect(query.populate.coverImage.select).not.toContain('provider_metadata');
+    });
+
+    test('attaches the loaded media to the returned relations', async () => {
+      setupStrapi();
+
+      const ctx = createFindExistingContext();
+      await relations.findExisting(ctx);
+
+      const results = (ctx.body as any).results;
+
+      expect(results.find((r: any) => r.id === 1).coverImage).toEqual({
+        id: 10,
+        url: '/uploads/a.jpg',
+        mime: 'image/jpeg',
+      });
+      expect(results.find((r: any) => r.id === 2).coverImage).toBeNull();
+    });
+
+    test('leaves the populate coming from the permission query untouched', async () => {
+      setupStrapi({ permissionQueryPopulate: { category: true } });
+
+      await relations.findExisting(createFindExistingContext());
+
+      const [, , sanitizedOptions] = loadPages.mock.calls[1] as unknown as any[];
+
+      expect(sanitizedOptions.populate).toMatchObject({ category: true });
+      expect(sanitizedOptions.populate).not.toHaveProperty('coverImage');
+    });
+
+    test('does not query the media when no mediaField is configured', async () => {
+      setupStrapi({ mediaField: null });
+
+      await relations.findExisting(createFindExistingContext());
+
+      const [, , unsanitizedOptions] = loadPages.mock.calls[0] as unknown as any[];
+
+      expect(unsanitizedOptions).not.toHaveProperty('populate');
+      expect(findMany).not.toHaveBeenCalled();
+    });
+
+    test('does not query the media when the user cannot read the media field', async () => {
+      setupStrapi({ canReadMediaField: false });
+
+      await relations.findExisting(createFindExistingContext());
+
+      expect(findMany).not.toHaveBeenCalled();
+    });
+
+    test('does not query the media when the configured field is not a media attribute', async () => {
+      setupStrapi({ mediaField: 'myField' });
+
+      await relations.findExisting(createFindExistingContext());
+
+      expect(findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findAvailable', () => {
+    const createFindAvailableContext = () =>
+      createContext(
+        { params: { model: 'main', targetField: 'products' }, query: {} },
+        { state: { userAbility: {} } }
+      );
+
+    test('populates the media using db params and keeps the permission query populate', async () => {
+      setupStrapi({ permissionQueryPopulate: { category: true } });
+
+      await relations.findAvailable(createFindAvailableContext());
+
+      const [dbQuery] = findPage.mock.calls[0] as unknown as any[];
+
+      expect(dbQuery.populate).toMatchObject({
+        category: true,
+        coverImage: { select: EXPECTED_MEDIA_SELECT },
+      });
+      expect(dbQuery.populate.coverImage).not.toHaveProperty('fields');
+    });
+
+    test('does not populate anything when no mediaField is configured', async () => {
+      setupStrapi({ mediaField: null });
+
+      await relations.findAvailable(createFindAvailableContext());
+
+      const [dbQuery] = findPage.mock.calls[0] as unknown as any[];
+
+      expect(dbQuery).not.toHaveProperty('populate');
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/controllers/relations.ts
+++ b/packages/core/content-manager/server/src/controllers/relations.ts
@@ -1,7 +1,7 @@
 import { prop, uniq, uniqBy, concat, flow, isEmpty } from 'lodash/fp';
 
 import { isOperatorOfType, contentTypes, relations, errors } from '@strapi/utils';
-import type { Data, Modules, UID } from '@strapi/types';
+import type { Data, Modules, Struct, UID } from '@strapi/types';
 
 import { getService } from '../utils';
 import { validateFindAvailable, validateFindExisting } from './validation/relations';
@@ -48,6 +48,72 @@ const sanitizeMainField = (model: any, mainField: any, userAbility: any) => {
   }
 
   return mainField;
+};
+
+const sanitizeMediaField = (
+  model: Struct.Schema,
+  mediaField: string,
+  userAbility: unknown
+): string | null => {
+  const attr = model.attributes?.[mediaField];
+  if (!attr || attr.type !== 'media') return null;
+
+  const permissionChecker = getService('permission-checker').create({
+    userAbility,
+    model: model.uid,
+  });
+
+  if (!permissionChecker.can.read(null, mediaField)) return null;
+
+  return mediaField;
+};
+
+/**
+ * Loads the media of the given relations through a dedicated query and returns a new
+ * list with it attached.
+ *
+ * The media is deliberately NOT populated through `loadPages`: that helper forwards the
+ * very same query to its `count: true` companion, so a populate there leaks the selected
+ * columns into an aggregate. Strict engines reject it — PostgreSQL raises
+ * `column "t0.id" must appear in the GROUP BY clause` — while SQLite and MySQL let it pass.
+ *
+ * `permittedIds` must only ever contain ids returned by the permission-checked query, so
+ * the media of relations the user is not allowed to read is never loaded.
+ */
+const loadRelationsMedia = async ({
+  targetUid,
+  mediaField,
+  populateForMedia,
+  relations,
+  permittedIds,
+}: {
+  targetUid: string;
+  mediaField: string;
+  populateForMedia: Record<string, unknown>;
+  relations: Array<Record<string, unknown>>;
+  permittedIds: unknown[];
+}): Promise<Array<Record<string, unknown>>> => {
+  if (permittedIds.length === 0) {
+    return relations;
+  }
+
+  const { populate } = strapi
+    .get('query-params')
+    .transform(targetUid, { populate: populateForMedia });
+
+  const rows: Array<Record<string, unknown>> = await strapi.db.query(targetUid).findMany({
+    select: ['id'],
+    where: { id: { $in: permittedIds } },
+    populate,
+  });
+
+  const mediaById = new Map(rows.map((row) => [row.id, row[mediaField]]));
+
+  return relations.map((relation) =>
+    mediaById.has(relation.id)
+      ? { ...relation, [mediaField]: mediaById.get(relation.id) }
+      : relation
+  );
 };
 
 /**
@@ -244,6 +310,20 @@ export default {
       (mainField) => sanitizeMainField(targetSchema, mainField, userAbility)
     )(modelConfig);
 
+    const mediaField = flow(
+      prop(`metadatas.${targetField}.edit.mediaField`),
+      (field: string | undefined) =>
+        field ? sanitizeMediaField(targetSchema, field, userAbility) : null
+    )(modelConfig);
+
+    const populateForMedia = mediaField
+      ? {
+          [mediaField]: {
+            fields: ['url', 'alternativeText', 'formats', 'width', 'height', 'mime', 'name'],
+          },
+        }
+      : undefined;
+
     const fieldsToSelect = uniq([
       mainField,
       PUBLISHED_AT_ATTRIBUTE,
@@ -262,6 +342,8 @@ export default {
       attribute,
       fieldsToSelect,
       mainField,
+      mediaField,
+      populateForMedia,
       source: { schema: sourceSchema, isLocalized: isSourceLocalized },
       target: { schema: targetSchema, isLocalized: isTargetLocalized },
       sourceSchema,
@@ -286,6 +368,7 @@ export default {
       targetField,
       fieldsToSelect,
       mainField,
+      populateForMedia,
       source: {
         schema: { uid: sourceUid, modelType: sourceModelType },
         isLocalized: isSourceLocalized,
@@ -315,6 +398,9 @@ export default {
       // cannot select other fields as the user may not have the permissions
       fields: fieldsToSelect,
       ...permissionQuery,
+      ...(populateForMedia
+        ? { populate: { ...permissionQuery.populate, ...populateForMedia } }
+        : {}),
     };
 
     // If no status is requested, we find all the draft relations and later update them
@@ -429,6 +515,8 @@ export default {
       targetField,
       fieldsToSelect,
       status,
+      mediaField,
+      populateForMedia,
       source: { schema: sourceSchema },
       target: { schema: targetSchema },
     } = await this.extractAndValidateRequestInfo(ctx, id);
@@ -481,6 +569,10 @@ export default {
      * - Second one also loads the main field, and excludes forbidden relations.
      *
      * The response contains the union of the two queries.
+     *
+     * NOTE: the media thumbnail is deliberately NOT populated here. This query
+     * bypasses the permission query, so populating it would expose the media of
+     * relations the user is not allowed to read.
      */
     const res = await loadRelations({ id: entryId }, targetField, {
       select: ['id', 'documentId', 'locale', 'publishedAt', 'updatedAt'],
@@ -511,6 +603,17 @@ export default {
     // NOTE: the order is very important to make sure sanitized relations are kept in priority
     const relationsUnion = uniqBy('id', concat(sanitizedRes.results, res.results));
 
+    const relationsWithMedia =
+      mediaField && populateForMedia
+        ? await loadRelationsMedia({
+            targetUid,
+            mediaField,
+            populateForMedia,
+            relations: relationsUnion,
+            permittedIds: sanitizedRes.results.map((relation: { id: unknown }) => relation.id),
+          })
+        : relationsUnion;
+
     ctx.body = {
       pagination: res.pagination || {
         page: 1,
@@ -518,7 +621,7 @@ export default {
         pageSize: 10,
         total: relationsUnion.length,
       },
-      results: await addStatusToRelations(targetUid, relationsUnion),
+      results: await addStatusToRelations(targetUid, relationsWithMedia),
     };
   },
 };

--- a/packages/core/content-manager/server/src/controllers/validation/__tests__/model-configuration.test.ts
+++ b/packages/core/content-manager/server/src/controllers/validation/__tests__/model-configuration.test.ts
@@ -3,6 +3,7 @@ import modelConfigurationValidation from '../model-configuration';
 describe('model-configuration validation', () => {
   // Mock strapi service
   const mockGetService = jest.fn();
+  const mockFindContentType = jest.fn();
 
   beforeAll(() => {
     global.strapi = {
@@ -14,6 +15,15 @@ describe('model-configuration validation', () => {
           description: { type: 'text' },
         },
       }),
+      plugins: {
+        'content-manager': {
+          services: {
+            'content-types': {
+              findContentType: mockFindContentType,
+            },
+          },
+        },
+      },
     } as any;
   });
 
@@ -452,6 +462,124 @@ describe('model-configuration validation', () => {
       const schema = modelConfigurationValidation(mockSchema);
       // This should fail because label is required and shouldn't be null
       await expect(schema.validate(config)).rejects.toThrow();
+    });
+  });
+
+  describe('mediaField validation', () => {
+    const schemaWithRelation = {
+      attributes: {
+        title: { type: 'string' },
+        product: {
+          type: 'relation',
+          relation: 'manyToOne',
+          target: 'api::product.product',
+          targetModel: 'api::product.product',
+        },
+      },
+    };
+
+    const setupMediaMock = () => {
+      mockFindContentType.mockReturnValue({
+        attributes: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          coverImage: { type: 'media' },
+          document: { type: 'media' },
+        },
+      });
+    };
+
+    it('should accept valid mediaField for relation attributes', async () => {
+      setupMediaMock();
+      const config = {
+        metadatas: {
+          product: {
+            edit: {
+              label: 'Product',
+              mainField: 'name',
+              mediaField: 'coverImage',
+            },
+          },
+        },
+      };
+
+      const schema = modelConfigurationValidation(schemaWithRelation);
+      const result = await schema.validate(config);
+      expect(result.metadatas.product.edit.mediaField).toBe('coverImage');
+    });
+
+    it('should reject mediaField pointing to non-media attribute', async () => {
+      setupMediaMock();
+      const config = {
+        metadatas: {
+          product: {
+            edit: {
+              label: 'Product',
+              mainField: 'name',
+              mediaField: 'name',
+            },
+          },
+        },
+      };
+
+      const schema = modelConfigurationValidation(schemaWithRelation);
+      await expect(schema.validate(config)).rejects.toThrow();
+    });
+
+    it('should accept null mediaField', async () => {
+      setupMediaMock();
+      const config = {
+        metadatas: {
+          product: {
+            edit: {
+              label: 'Product',
+              mainField: 'name',
+              mediaField: null,
+            },
+          },
+        },
+      };
+
+      const schema = modelConfigurationValidation(schemaWithRelation);
+      const result = await schema.validate(config);
+      expect(result.metadatas.product.edit.mediaField).toBeNull();
+    });
+
+    it('should accept undefined mediaField', async () => {
+      setupMediaMock();
+      const config = {
+        metadatas: {
+          product: {
+            edit: {
+              label: 'Product',
+              mainField: 'name',
+            },
+          },
+        },
+      };
+
+      const schema = modelConfigurationValidation(schemaWithRelation);
+      const result = await schema.validate(config);
+      expect(result.metadatas.product.edit.mediaField).toBeUndefined();
+    });
+
+    it('should accept another valid media attribute', async () => {
+      setupMediaMock();
+      const config = {
+        metadatas: {
+          product: {
+            edit: {
+              label: 'Product',
+              mainField: 'name',
+              mediaField: 'document',
+            },
+          },
+        },
+      };
+
+      const schema = modelConfigurationValidation(schemaWithRelation);
+      const result = await schema.validate(config);
+      expect(result.metadatas.product.edit.mediaField).toBe('document');
     });
   });
 

--- a/packages/core/content-manager/server/src/controllers/validation/model-configuration.ts
+++ b/packages/core/content-manager/server/src/controllers/validation/model-configuration.ts
@@ -76,6 +76,25 @@ const createMetadasSchema = (schema: any) => {
 
                 return yup.string().oneOf(validAttributes.concat('id')).default('id');
               }),
+              mediaField: yup.lazy((value) => {
+                if (!value) {
+                  return yup.string().nullable();
+                }
+
+                const targetSchema = getService('content-types').findContentType(
+                  schema.attributes[key].targetModel
+                );
+
+                if (!targetSchema) {
+                  return yup.string().nullable();
+                }
+
+                const validMediaAttributes = Object.keys(targetSchema.attributes).filter(
+                  (attrKey) => targetSchema.attributes[attrKey].type === 'media'
+                );
+
+                return yup.string().oneOf(validMediaAttributes).nullable();
+              }),
             })
             .noUnknown()
             .required(),

--- a/packages/core/content-manager/server/src/services/utils/configuration/__tests__/metadatas.test.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/__tests__/metadatas.test.ts
@@ -1,0 +1,106 @@
+import { syncMetadatas } from '../metadatas';
+
+const target = {
+  uid: 'api::target.target',
+  modelType: 'contentType',
+  attributes: {
+    id: { type: 'integer' },
+    documentId: { type: 'string' },
+    name: { type: 'string' },
+    coverImage: { type: 'media', multiple: false },
+  },
+};
+
+const targetWithoutMedia = {
+  ...target,
+  attributes: {
+    id: { type: 'integer' },
+    documentId: { type: 'string' },
+    name: { type: 'string' },
+  },
+};
+
+const schema = {
+  uid: 'api::main.main',
+  modelType: 'contentType',
+  attributes: {
+    id: { type: 'integer' },
+    documentId: { type: 'string' },
+    products: {
+      type: 'relation',
+      relationType: 'oneToMany',
+      targetModel: 'api::target.target',
+    },
+  },
+};
+
+const setup = (targetSchema: unknown) => {
+  global.strapi = {
+    plugins: {
+      'content-manager': {
+        services: {
+          'content-types': { findContentType: jest.fn(() => targetSchema) },
+        },
+      },
+    },
+  } as any;
+};
+
+const configurationWith = (edit: Record<string, unknown>) => ({
+  metadatas: {
+    products: {
+      edit,
+      list: { label: 'products', searchable: false, sortable: false },
+    },
+  },
+});
+
+describe('syncMetadatas | mediaField', () => {
+  test('keeps the mediaField when it still points to a media attribute of the target', async () => {
+    setup(target);
+
+    const metadatas: any = await syncMetadatas(
+      configurationWith({ mainField: 'name', mediaField: 'coverImage' }),
+      schema
+    );
+
+    expect(metadatas.products.edit.mediaField).toBe('coverImage');
+  });
+
+  test('removes the mediaField when the media attribute no longer exists on the target', async () => {
+    setup(targetWithoutMedia);
+
+    const metadatas: any = await syncMetadatas(
+      configurationWith({ mainField: 'name', mediaField: 'coverImage' }),
+      schema
+    );
+
+    expect(metadatas.products.edit).not.toHaveProperty('mediaField');
+  });
+
+  /**
+   * `mainField` defaults to 'id' whenever the target has no listable string field, so the
+   * cleanup must not sit behind the mainField early-returns.
+   */
+  test("removes a stale mediaField even when the mainField is 'id'", async () => {
+    setup(targetWithoutMedia);
+
+    const metadatas: any = await syncMetadatas(
+      configurationWith({ mainField: 'id', mediaField: 'coverImage' }),
+      schema
+    );
+
+    expect(metadatas.products.edit).not.toHaveProperty('mediaField');
+  });
+
+  test('removes the mediaField when the attribute is not a relation anymore', async () => {
+    setup(target);
+
+    const metadatas: any = await syncMetadatas(configurationWith({ mediaField: 'coverImage' }), {
+      ...schema,
+      attributes: { ...schema.attributes, products: { type: 'string' } },
+    });
+
+    expect(metadatas.products.edit).not.toHaveProperty('mediaField');
+  });
+});

--- a/packages/core/content-manager/server/src/services/utils/configuration/metadatas.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/metadatas.ts
@@ -63,6 +63,7 @@ function createDefaultMetadata(schema: any, name: any) {
       'visible',
       'editable',
       'mainField',
+      'mediaField',
     ])
   );
 
@@ -115,27 +116,34 @@ async function syncMetadatas(configuration: any, schema: any) {
       _.set(acc, [key], updatedMeta);
     }
 
-    if (!_.has(edit, 'mainField')) return acc;
-
-    // remove mainField if the attribute is not a relation anymore
+    // remove mainField and mediaField if the attribute is not a relation anymore
     if (!isRelation(attr)) {
-      _.set(updatedMeta, 'edit', _.omit(edit, ['mainField']));
-      _.set(acc, [key], updatedMeta);
+      if (_.has(edit, 'mainField') || _.has(edit, 'mediaField')) {
+        _.set(updatedMeta, 'edit', _.omit(edit, ['mainField', 'mediaField']));
+        _.set(acc, [key], updatedMeta);
+      }
       return acc;
     }
+
+    const targetSchema = getTargetSchema(attr.targetModel);
+
+    if (!targetSchema) return acc;
+
+    // remove the mediaField if it does not point to a media attribute of the targetModel anymore
+    if (edit.mediaField && targetSchema.attributes?.[edit.mediaField]?.type !== 'media') {
+      _.set(updatedMeta, 'edit', _.omit(edit, ['mediaField']));
+      _.set(acc, [key], updatedMeta);
+    }
+
+    if (!_.has(edit, 'mainField')) return acc;
 
     // if the mainField is id you can keep it
     if (edit.mainField === 'id') return acc;
 
     // check the mainField in the targetModel
-    const targetSchema = getTargetSchema(attr.targetModel);
-
-    if (!targetSchema) return acc;
-
     if (!isSortable(targetSchema, edit.mainField) && !isListable(targetSchema, edit.mainField)) {
       _.set(updatedMeta, ['edit', 'mainField'], getDefaultMainField(targetSchema));
       _.set(acc, [key], updatedMeta);
-      return acc;
     }
 
     return acc;

--- a/packages/core/content-manager/shared/contracts/content-types.ts
+++ b/packages/core/content-manager/shared/contracts/content-types.ts
@@ -23,6 +23,8 @@ export type Metadatas = {
       placeholder?: string;
       visible?: boolean;
       editable?: boolean;
+      mainField?: string;
+      mediaField?: string;
     };
     list: {
       label?: string;


### PR DESCRIPTION

![relation-media-field](https://github.com/user-attachments/assets/17d935dd-7542-4a3d-aa22-70f82aebc511)


## What does it do?

Adds an optional `mediaField` configuration to relation fields, allowing a thumbnail to be displayed alongside the text label in the edit view relation picker.

Changes across all layers:
  - Shared types: Added mediaField to Metadatas edit and list blocks
  - Server validation: Added yup schema for mediaField (validates against media-type attributes in target schema)
  - Server metadata sync: Handles mediaField in defaults and sync (removes if attribute is no longer a relation, validates target still has media
  attribute)
  - Server content-types controller: Propagates mediaField from edit to list metadata (mirrors assocMainField pattern)
  - Server relations controller: Extracts, sanitizes and populates media data when fetching relations
  - Admin utilities: Added getMediaField and getRelationThumbnail helpers
  - Admin layout hook: Threads mediaField through EditFieldSharedProps and convertEditLayoutToFieldLayouts
  - Admin configuration UI: Added "Entry thumbnail" dropdown in the edit field modal for relation fields
  - Admin Relations UI: Added RelationThumbnail component using Avatar.Item, displayed in combobox dropdown and connected relations list
  - Tests: Server validation tests (5), getMediaField tests (5), getRelationThumbnail tests (10)

## Why is it needed?

When editing a relation field, entries are identified only by a text label (mainField). When multiple entries share similar names, products with generic titles, users with common names, it's hard to tell them apart. Editors have to open each entry to verify which one is correct, which slows down the editorial workflow.

This feature lets administrators configure a media field as thumbnail, so editors can visually identify relation entries at a glance.

## How to test it?

  1. Start Strapi with cd examples/getstarted && yarn develop
  2. Create a content-type "Product" with fields: name (string), coverImage (media)
  3. Create a content-type "Order" with a relation to "Product"
  4. Go to Content Manager → Configure the view for "Order"
  5. Click the relation field → Edit modal should show "Entry thumbnail" dropdown
  6. Select "coverImage" → Save
  7. Create some Products with images
  8. Go to Order edit view → Add relation → Combobox dropdown should show thumbnails
  9. Connected relations in the list should also show thumbnails

Edge cases:
  - Entry with no image → shows default LinkIcon
  - Entry with PDF media → shows default LinkIcon (non-image)
  - Entry with multiple=true media → shows first image
  - No mediaField configured → behavior identical to before (no regression)
  - Select "None" in config → thumbnails disappear