### PR TITLE
fix(content-type-builder): show configure the view outside development

### DIFF
--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -116,36 +116,39 @@ const ListView = () => {
 
   const isDeleted = type.status === 'REMOVED';
 
-  const primaryAction = isInDevelopmentMode && (
+  const primaryAction = (
     <Flex gap={2}>
       <LinkToCMSettingsView
         key="link-to-cm-settings-view"
         type={type}
         disabled={type.status === 'NEW' || isDeleted}
       />
-      <Button
-        startIcon={<Pencil />}
-        variant="tertiary"
-        onClick={onEdit}
-        disabled={!canEdit || isDeleted}
-      >
-        {formatMessage({
-          id: 'app.utils.edit',
-          defaultMessage: 'Edit',
-        })}
-      </Button>
-
-      <Button
-        startIcon={<Plus />}
-        variant="secondary"
-        minWidth="max-content"
-        onClick={() => {
-          onOpenModalAddField({ forTarget, targetUid: type.uid });
-        }}
-        disabled={isDeleted}
-      >
-        {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
-      </Button>
+      {isInDevelopmentMode && (
+        <>
+          <Button
+            startIcon={<Pencil />}
+            variant="tertiary"
+            onClick={onEdit}
+            disabled={!canEdit || isDeleted}
+          >
+            {formatMessage({
+              id: 'app.utils.edit',
+              defaultMessage: 'Edit',
+            })}
+          </Button>
+          <Button
+            startIcon={<Plus />}
+            variant="secondary"
+            minWidth="max-content"
+            onClick={() => {
+              onOpenModalAddField({ forTarget, targetUid: type.uid });
+            }}
+            disabled={isDeleted}
+          >
+            {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
+          </Button>
+        </>
+      )}
     </Flex>
   );
 


### PR DESCRIPTION
### What does it do?

- Shows Configure the view outside development mode.
- Keeps Edit and Add another field development-only.

### Why is it needed?

- Configure the view is a settings shortcut, not a schema edit action.

### How to test it?

- Start with strapi start.
- Open /admin/plugins/content-type-builder/content-types/api::page.page.
- Check that Configure the view is visible, while Edit and Add another field are hidden.

### Related issue(s)/PR(s)

Fix #25783