### PR TITLE
fix(content-type-builder): show Configure the view link outside dev mode

### DIFF
--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -116,36 +116,40 @@ const ListView = () => {
 
   const isDeleted = type.status === 'REMOVED';
 
-  const primaryAction = isInDevelopmentMode && (
+  const primaryAction = (
     <Flex gap={2}>
       <LinkToCMSettingsView
         key="link-to-cm-settings-view"
         type={type}
         disabled={type.status === 'NEW' || isDeleted}
       />
-      <Button
-        startIcon={<Pencil />}
-        variant="tertiary"
-        onClick={onEdit}
-        disabled={!canEdit || isDeleted}
-      >
-        {formatMessage({
-          id: 'app.utils.edit',
-          defaultMessage: 'Edit',
-        })}
-      </Button>
+      {isInDevelopmentMode && (
+        <>
+          <Button
+            startIcon={<Pencil />}
+            variant="tertiary"
+            onClick={onEdit}
+            disabled={!canEdit || isDeleted}
+          >
+            {formatMessage({
+              id: 'app.utils.edit',
+              defaultMessage: 'Edit',
+            })}
+          </Button>
 
-      <Button
-        startIcon={<Plus />}
-        variant="secondary"
-        minWidth="max-content"
-        onClick={() => {
-          onOpenModalAddField({ forTarget, targetUid: type.uid });
-        }}
-        disabled={isDeleted}
-      >
-        {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
-      </Button>
+          <Button
+            startIcon={<Plus />}
+            variant="secondary"
+            minWidth="max-content"
+            onClick={() => {
+              onOpenModalAddField({ forTarget, targetUid: type.uid });
+            }}
+            disabled={isDeleted}
+          >
+            {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
+          </Button>
+        </>
+      )}
     </Flex>
   );
 


### PR DESCRIPTION
## Summary

- Fixes the "Configure the view" shortcut being hidden in the Content-Type Builder when Strapi runs outside development mode (`strapi start`)
- The `LinkToCMSettingsView` component was wrapped inside an `isInDevelopmentMode` conditional along with schema-editing buttons (Edit, Add field). This PR moves it outside that gate so it remains visible in all modes
- The component already has its own RBAC permission check via `useRBAC`, so access control is preserved

Fixes #25783

## Changes

**`packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx`**

Before: the entire `primaryAction` block (including `LinkToCMSettingsView`) was gated behind `isInDevelopmentMode`:
```tsx
const primaryAction = isInDevelopmentMode && (
  <Flex gap={2}>
    <LinkToCMSettingsView ... />
    <Button>Edit</Button>
    <Button>Add another field</Button>
  </Flex>
);
```

After: `LinkToCMSettingsView` is always rendered, while only schema-editing actions remain gated:
```tsx
const primaryAction = (
  <Flex gap={2}>
    <LinkToCMSettingsView ... />
    {isInDevelopmentMode && (
      <>
        <Button>Edit</Button>
        <Button>Add another field</Button>
      </>
    )}
  </Flex>
);
```

## Test plan

- [ ] Start Strapi in development mode (`yarn develop`) — verify "Configure the view", "Edit", and "Add another field" buttons all appear
- [ ] Start Strapi in non-development mode (`yarn start`) — verify "Configure the view" still appears, while "Edit" and "Add another field" are hidden
- [ ] Click "Configure the view" in non-dev mode — verify it navigates to the Content Manager configuration page
- [ ] Verify RBAC: a user without `configure-view` permission should still not see the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)