### PR TITLE
fix: handle relation cleanup in entity-manager deleteMany

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -475,16 +475,34 @@ export const createEntityManager = (db: Database): EntityManager => {
       return entity;
     },
 
-    // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params = {}) {
       const states = await db.lifecycles.run('beforeDeleteMany', uid, { params });
 
       const { where } = params;
 
+      // Fetch IDs before deletion so we can clean up their relations
+      const entitiesToDelete = await this.createQueryBuilder(uid)
+        .init({ select: ['id'], where })
+        .execute<{ id: ID }[]>();
+
       const deletedRows = await this.createQueryBuilder(uid)
         .where(where)
         .delete()
         .execute<number>({ mapResults: false });
+
+      // Clean up relations for each deleted entity
+      if (entitiesToDelete.length > 0) {
+        const trx = await strapi.db.transaction();
+        try {
+          for (const entity of entitiesToDelete) {
+            await this.deleteRelations(uid, entity.id, { transaction: trx.get() });
+          }
+          await trx.commit();
+        } catch (e) {
+          await trx.rollback();
+          throw e;
+        }
+      }
 
       const result = { count: deletedRows };
 


### PR DESCRIPTION
## Summary

Fixes #25640

The `deleteMany` method in `entity-manager` was deleting entity rows without cleaning up associated relations, leaving orphaned records in join/morph tables.

The existing `delete()` method correctly handles this by calling `deleteRelations()` after removing the entity row. This PR applies the same pattern to `deleteMany()`:

1. **Fetch entity IDs** matching the `where` clause before deletion
2. **Delete the entity rows** (unchanged behavior)
3. **Clean up relations** for each deleted entity within a transaction

This follows the established pattern from the single `delete()` method (lines 439-476) and addresses the existing TODO comment: *"where do we handle relation processing for many queries?"*

## Changes

- `packages/core/database/src/entity-manager/index.ts`: Added relation cleanup to `deleteMany()` using the same transaction pattern as `delete()`

## How to test

1. Create a content type with relations (e.g., `Article` with a relation to `Category`)
2. Create multiple articles linked to categories
3. Use `deleteMany` to bulk-delete articles
4. Verify that relation records in join tables are properly cleaned up (no orphaned rows)

## Related

- The `document-manager.deleteMany()` delegates to individual `delete()` calls, so it already handles relations correctly at the document level
- This fix addresses the database-level `entity-manager.deleteMany()` which is used by lower-level operations

/claim #25640