### PR TITLE
fix: pin 30 unpinned action(s),extract 6 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
 
-      - uses: preactjs/compressed-size-action@v2
+      - uses: preactjs/compressed-size-action@8518045ed95e94e971b83333085e1cb99aa18aa8 # v2
         with:
           build-script: 'build:size'
           pattern: '**/build/**/*.{js,css,html,svg}'

--- a/.github/workflows/caniuse.yml
+++ b/.github/workflows/caniuse.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
       - name: Update Browserslist database and create PR if applies
-        uses: c2corg/browserslist-update-action@v2
+        uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: browserslist-update

--- a/.github/workflows/changeFreeze.yml
+++ b/.github/workflows/changeFreeze.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       isTeamMember: ${{ steps.get-user-teams-membership.outputs.isTeamMember }}
     steps:
-      - uses: tspascoal/get-user-teams-membership@v3
+      - uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3
         id: get-user-teams-membership
         with:
           GITHUB_TOKEN: ${{ secrets.CHECK_OWNERSHIP_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     needs: [check-ownership]
     if: ${{ needs.check-ownership.outputs.isTeamMember == 'false' && vars.CHANGE_FREEZE_ENABLED == 'true' }}
     steps:
-      - uses: thollander/actions-comment-pull-request@v2
+      - uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           message: |
             This repo is currently under a community change freeze. Please see any pinned issues for more information.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,9 +20,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${PR_HEAD_SHA} --verbose
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/contributor-doc.yml
+++ b/.github/workflows/contributor-doc.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build

--- a/.github/workflows/find_duplicate_issue.yml
+++ b/.github/workflows/find_duplicate_issue.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check for duplicate issues
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           prompt: |
             Analyze this issue and check if it's a duplicate of other issues in the repository.

--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check for inactive issues that can't be reproduced
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -19,7 +19,7 @@ jobs:
       # Unable to Reproduce Tasks
       - name: 'Comment: unable to reproduce'
         if: "${{ github.event.label.name == 'status: can not reproduce' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
       # v3 Legacy Issues
       - name: 'Comment: unsupported v3 issues'
         if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
             Thank You
       - name: 'Close: unsupported v3 issues'
         if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issue'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
       # v4 Legacy Issues
       - name: 'Comment: unsupported v4 issues'
         if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +99,7 @@ jobs:
             Thank You
       - name: 'Close: unsupported v4 issues'
         if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issue'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
       # Feature request redirections
       - name: 'Comment: redirect feature request to canny'
         if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
             Thank you for your insight and have a good day.
       - name: 'Close: redirect feature request to canny'
         if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issue'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
       # Invalid bug report template actions
       - name: 'Comment: invalid bug report template'
         if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -159,7 +159,7 @@ jobs:
             Thank you.
       - name: 'Close: invalid bug report template'
         if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issue'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -169,7 +169,7 @@ jobs:
       # Redirect questions to GitHub Discussions
       - name: 'Comment: redirect question to discussions'
         if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-comment'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
             Thank you!
       - name: 'Close: redirect question to discussions'
         if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issue'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
           close-reason: 'not_planned'
       - name: 'Lock: redirect question to discussions'
         if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'lock-issue'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label_stale_issues.yml
+++ b/.github/workflows/label_stale_issues.yml
@@ -22,7 +22,7 @@ jobs:
           # Get all issues last updated between the two dates
           # Exclude issues with 'status: confirmed', 'severity: high' or 'severity: critical' and 'issue: security' label and issues in milestones
           # NOTE: This will only process the first 100 issues due to pagination limitation
-          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/search/issues?q=repo:${{ github.repository }}+is:issue+is:open+updated:${DATE1}..${DATE2}+no:milestone+-label:%22severity:%20high%22+-label:%22status%20confirmed%22+-label:%22severity:%20critical%22+-label:%22issue:%20security%22&per_page=100" | \
             jq -r --arg label "$LABEL" ' 
@@ -35,7 +35,7 @@ jobs:
                 
                 # Add the label
                 curl -s -X POST \
-                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Authorization: token ${GITHUB_TOKEN}" \
                   -H "Accept: application/vnd.github.v3+json" \
                   "https://api.github.com/repos/${{ github.repository }}/issues/$issue_number/labels" \
                   -d "{\"labels\": [\"$LABEL\"]}"
@@ -45,3 +45,6 @@ jobs:
                 echo "No issue found."
               fi
             done
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: PR Review with Progress Tracking
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
         with:
           anthropic_api_key: ${{ secrets.PR_REVIEW_ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0 # Fetch full history
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/remove-dist-tag.yml
+++ b/.github/workflows/remove-dist-tag.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # need to check out previous 2 commits to see what has changed
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: .github/filters.yaml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Monorepo build
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Monorepo build
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Monorepo build
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Monorepo build
@@ -277,7 +277,7 @@ jobs:
         # Add the Trunk Analytics Uploader step
       - name: Upload results to trunk
         if: '!cancelled()'
-        uses: trunk-io/analytics-uploader@v1
+        uses: trunk-io/analytics-uploader@0e6c416c9d47c105654657984e5e4f0506dd84aa # v1
         with:
           junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi
@@ -328,7 +328,7 @@ jobs:
       # Add the Trunk Analytics Uploader step
       - name: Upload results to trunk
         if: '!cancelled()'
-        uses: trunk-io/analytics-uploader@v1
+        uses: trunk-io/analytics-uploader@0e6c416c9d47c105654657984e5e4f0506dd84aa # v1
         with:
           junit-paths: test-apps/junit-reports/*.xml
           org-slug: strapi
@@ -601,14 +601,14 @@ jobs:
         run: find . -name "lcov.info" -type f
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONARQUBE_HOST_URL }}
 
       - name: SonarQube Quality Gate check
         id: sonarqube-quality-gate-check
-        uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
+        uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
         timeout-minutes: 5
         continue-on-error: true
         env:


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/adminBundleSize.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/caniuse.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/changeFreeze.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/commitlint.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/commitlint.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/contributor-doc.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/find_duplicate_issue.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/issues_dailyCron.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/issues_handleLabel.yml` | Pinned 12 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/label_stale_issues.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/nightly.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/pr-reviewer.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/publish-prerelease.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/publish-release.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/remove-dist-tag.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/tests.yml` | Pinned 9 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-005 | medium | `.github/workflows/community-label.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.