### PR TITLE
fix(upload): allow upload of files with empty MIME type

### DIFF
--- a/packages/core/upload/admin/src/utils/getAllowedFiles.ts
+++ b/packages/core/upload/admin/src/utils/getAllowedFiles.ts
@@ -26,7 +26,7 @@ export const getAllowedFiles = (pluralTypes: string[] | null, files: AllowedFile
     const fileType = file?.mime?.split('/')[0];
 
     if (!fileType) {
-      return false;
+      return singularTypes.includes('file');
     }
 
     if (singularTypes.includes('file') && !['video', 'image', 'audio'].includes(fileType)) {

--- a/packages/core/upload/admin/src/utils/tests/getAllowedFiles.test.ts
+++ b/packages/core/upload/admin/src/utils/tests/getAllowedFiles.test.ts
@@ -86,6 +86,14 @@ const FILE_9 = {
   ...COMMON_PROPERTIES,
 };
 
+const FILE_10 = {
+  id: 10,
+  mime: '',
+  name: 'animation.lottie',
+  url: '/uploads/animation.lottie',
+  ...COMMON_PROPERTIES,
+};
+
 const files = [FILE_1, FILE_2, FILE_3, FILE_4, FILE_5, FILE_6, FILE_7, FILE_8, FILE_9];
 
 describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', () => {
@@ -129,5 +137,23 @@ describe('UPLOAD | components | MediaLibraryInput | utils | getAllowedFiles', ()
     const results = getAllowedFiles(['videos', 'images', 'files', 'audios'], files);
 
     expect(results).toEqual(files);
+  });
+
+  it('allows files with empty MIME type when "files" is an allowed type', () => {
+    const results = getAllowedFiles(['files'], [FILE_10]);
+
+    expect(results).toEqual([FILE_10]);
+  });
+
+  it('rejects files with empty MIME type when "files" is not an allowed type', () => {
+    const results = getAllowedFiles(['images', 'videos', 'audios'], [FILE_10]);
+
+    expect(results).toEqual([]);
+  });
+
+  it('allows files with empty MIME type alongside other types when "files" is included', () => {
+    const results = getAllowedFiles(['videos', 'images', 'files', 'audios'], [...files, FILE_10]);
+
+    expect(results).toEqual([...files, FILE_10]);
   });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Changed the client-side `getAllowedFiles` filter in the upload plugin to allow files with an empty/unknown browser MIME type.



[fix-25834.webm](https://github.com/user-attachments/assets/fa095b89-113f-4641-b0f1-41cf1d98a90d)

### Why is it needed?

Browser did not know the MIME type file, this resulted in empty mime value, causing outright rejection previously even though the media field was configured to accept all file types. This resulted in inconsistency wherein the file which was allowed through media library route was rejected via content types media field.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #25834 
