### PR TITLE
fix(homepage): render widgets progressively and batch permission checks

### DIFF
--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -244,3 +244,23 @@ These commands will:
 - `yarn build` - Build for production
 - `yarn start` - Start production server
 - `yarn strapi` - Run Strapi CLI commands
+
+## V5 Seeding (Large Dataset)
+
+Use the v5 seeder in this project to generate a large dataset for homepage perf testing:
+
+```bash
+yarn seed:v5
+```
+
+You can scale the volume with a multiplier:
+
+```bash
+yarn seed:v5 -- --multiplier 20
+```
+
+Or:
+
+```bash
+SEED_MULTIPLIER=20 yarn seed:v5
+```

--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -23,6 +23,7 @@
     "db:check:mysql": "node scripts/db-mysql.js check",
     "start": "strapi start",
     "setup:v4": "node scripts/setup-v4-project.js",
+    "seed:v5": "node scripts/seed-v5.js",
     "test:migration": "node scripts/validate-migration.js"
   },
   "dependencies": {

--- a/examples/complex/scripts/seed-v5.js
+++ b/examples/complex/scripts/seed-v5.js
@@ -1,0 +1,530 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createStrapi, compileStrapi } = require('@strapi/strapi');
+
+let strapi;
+
+const BASE_COUNTS = {
+  basic: 5,
+  basicDp: { published: 3, drafts: 2 },
+  basicDpI18n: { published: 3, drafts: 2 },
+  relation: 5,
+  relationDp: { published: 5, drafts: 3 },
+  relationDpI18n: { published: 5, drafts: 3 },
+  mediaFiles: 10,
+};
+
+const LOCALES = ['en', 'fr'];
+
+function parseCliArgs(argv) {
+  const opts = { multiplier: 1 };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--multiplier' && argv[i + 1] != null) {
+      opts.multiplier = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (arg && arg.startsWith('--multiplier=')) {
+      opts.multiplier = Number(arg.split('=')[1]);
+      continue;
+    }
+
+    if (!Number.isNaN(Number(arg))) {
+      opts.multiplier = Number(arg);
+    }
+  }
+
+  const envMultiplier = process.env.SEED_MULTIPLIER;
+  if (!Number.isNaN(Number(envMultiplier))) {
+    opts.multiplier = Number(envMultiplier);
+  }
+
+  if (!Number.isFinite(opts.multiplier) || opts.multiplier <= 0) {
+    opts.multiplier = 1;
+  }
+
+  return opts;
+}
+
+function applyMultiplierToCounts(base, multiplier) {
+  const m = Number(multiplier) || 1;
+
+  return {
+    basic: base.basic * m,
+    basicDp: {
+      published: base.basicDp.published * m,
+      drafts: base.basicDp.drafts * m,
+    },
+    basicDpI18n: {
+      published: base.basicDpI18n.published * m,
+      drafts: base.basicDpI18n.drafts * m,
+    },
+    relation: base.relation * m,
+    relationDp: {
+      published: base.relationDp.published * m,
+      drafts: base.relationDp.drafts * m,
+    },
+    relationDpI18n: {
+      published: base.relationDpI18n.published * m,
+      drafts: base.relationDpI18n.drafts * m,
+    },
+    mediaFiles: base.mediaFiles * m,
+  };
+}
+
+const { multiplier } = parseCliArgs(process.argv.slice(2));
+const COUNTS = applyMultiplierToCounts(BASE_COUNTS, multiplier);
+
+const random = {
+  string: (len = 8) =>
+    Math.random()
+      .toString(36)
+      .substring(2, len + 2),
+  number: (min = 0, max = 100) => Math.floor(Math.random() * (max - min + 1)) + min,
+  boolean: () => Math.random() > 0.5,
+  date: () => new Date(2020 + Math.random() * 5, random.number(0, 11), random.number(1, 28)),
+  pick: (arr) => arr[random.number(0, arr.length - 1)],
+};
+
+const fields = {
+  basic: () => ({
+    stringField: `String ${random.string()}`,
+    textField: `Text ${random.string(20)}`,
+    richText: `<p>Rich ${random.string(15)}</p>`,
+    integerField: random.number(1, 1000),
+    bigintegerField: random.number(1000000, 9999999),
+    decimalField: parseFloat((Math.random() * 100).toFixed(2)),
+    floatField: parseFloat((Math.random() * 100).toFixed(2)),
+    booleanField: random.boolean(),
+    dateField: random.date().toISOString().split('T')[0],
+    datetimeField: random.date().toISOString(),
+    timeField: `${String(random.number(0, 23)).padStart(2, '0')}:${String(random.number(0, 59)).padStart(2, '0')}:00`,
+    emailField: `seed${random.string()}@example.com`,
+    passwordField: 'TestPassword123!',
+    jsonField: { key: random.string(), value: random.number() },
+    enumerationField: random.pick(['one', 'two', 'three']),
+  }),
+};
+
+const components = {
+  textBlock: () => ({
+    heading: `Heading ${random.string()}`,
+    body: `<p>Body ${random.string(20)}</p>`,
+    author: `Author ${random.string(5)}`,
+    publishedDate: random.date().toISOString().split('T')[0],
+  }),
+  mediaBlock: () => ({
+    title: `Media ${random.string()}`,
+    mediaUrl: `https://example.com/media/${random.string()}.${random.pick(['jpg', 'mp4', 'mp3'])}`,
+    mediaType: random.pick(['image', 'video', 'audio']),
+    description: `Description ${random.string(12)}`,
+  }),
+  simpleInfo: () => ({
+    title: `Info ${random.string()}`,
+    description: `Description ${random.string(10)}`,
+    count: random.number(1, 100),
+    active: random.boolean(),
+  }),
+  imageBlock: () => ({
+    alt: `Image ${random.string()}`,
+    url: `https://example.com/images/${random.string()}.jpg`,
+    caption: `Caption ${random.string()}`,
+    width: random.number(100, 2000),
+    height: random.number(100, 2000),
+  }),
+  logo: (mediaId) => ({
+    name: `Logo ${random.string()}`,
+    logo: mediaId || null,
+  }),
+  header: (mediaId) => ({
+    title: `Header ${random.string()}`,
+    headerlogo: components.logo(mediaId),
+  }),
+  referenceList: () => ({
+    title: `Reference List ${random.string()}`,
+    references: [{ label: `Ref ${random.string()}` }, { label: `Ref ${random.string()}` }],
+  }),
+  dz: (type, data) => ({ __component: `shared.${type}`, ...data }),
+};
+
+const PNG_BUFFER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+]);
+
+async function createMediaFile(index) {
+  const name = `v5-seed-${index}.png`;
+  const tempPath = path.join(os.tmpdir(), name);
+
+  try {
+    fs.writeFileSync(tempPath, PNG_BUFFER);
+
+    const result = await strapi
+      .plugin('upload')
+      .service('upload')
+      .upload({
+        files: {
+          filepath: tempPath,
+          path: tempPath,
+          originalFilename: name,
+          name,
+          size: PNG_BUFFER.length,
+          mimetype: 'image/png',
+          type: 'image/png',
+        },
+        data: {
+          fileInfo: {
+            alternativeText: `Seed ${name}`,
+            caption: name,
+            name: name.replace('.png', ''),
+          },
+        },
+      });
+
+    return result[0] || null;
+  } finally {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // no-op
+    }
+  }
+}
+
+async function createMediaFiles() {
+  console.log(`Creating ${COUNTS.mediaFiles} media files...`);
+  const files = [];
+
+  for (let i = 0; i < COUNTS.mediaFiles; i += 1) {
+    const file = await createMediaFile(i + 1);
+    if (file) files.push(file);
+    if ((i + 1) % 50 === 0 || i + 1 === COUNTS.mediaFiles) {
+      console.log(`  media: ${i + 1}/${COUNTS.mediaFiles}`);
+    }
+  }
+
+  return files;
+}
+
+async function createDocument(uid, data, options = {}) {
+  const { status, locale } = options;
+  const payload = { data };
+  if (status) payload.status = status;
+  if (locale) payload.locale = locale;
+
+  return strapi.documents(uid).create(payload);
+}
+
+async function seedBasic() {
+  const items = [];
+  console.log(`Seeding basic: ${COUNTS.basic}`);
+
+  for (let i = 0; i < COUNTS.basic; i += 1) {
+    const entry = await createDocument('api::basic.basic', {
+      ...fields.basic(),
+      textBlocks: [components.textBlock(), components.textBlock()],
+      mediaBlock: components.mediaBlock(),
+      sections: [
+        components.dz('text-block', components.textBlock()),
+        components.dz('media-block', components.mediaBlock()),
+      ],
+    });
+    items.push(entry);
+  }
+
+  return items;
+}
+
+async function seedBasicDp(mediaFiles) {
+  const published = [];
+  const drafts = [];
+  console.log(
+    `Seeding basic-dp: ${COUNTS.basicDp.published} published / ${COUNTS.basicDp.drafts} drafts`
+  );
+
+  for (let i = 0; i < COUNTS.basicDp.published; i += 1) {
+    const mediaId = mediaFiles[i % mediaFiles.length]?.id;
+    const entry = await createDocument(
+      'api::basic-dp.basic-dp',
+      {
+        ...fields.basic(),
+        textBlocks: [components.textBlock(), components.textBlock()],
+        mediaBlock: components.mediaBlock(),
+        header: components.header(mediaId),
+        sections: [
+          components.dz('text-block', components.textBlock()),
+          components.dz('media-block', components.mediaBlock()),
+          components.dz('header', components.header(mediaId)),
+        ],
+      },
+      { status: 'published' }
+    );
+    published.push(entry);
+  }
+
+  for (let i = 0; i < COUNTS.basicDp.drafts; i += 1) {
+    const mediaId = mediaFiles[(i + 7) % mediaFiles.length]?.id;
+    const entry = await createDocument('api::basic-dp.basic-dp', {
+      ...fields.basic(),
+      textBlocks: [components.textBlock(), components.textBlock()],
+      mediaBlock: components.mediaBlock(),
+      header: components.header(mediaId),
+      sections: [
+        components.dz('text-block', components.textBlock()),
+        components.dz('media-block', components.mediaBlock()),
+        components.dz('header', components.header(mediaId)),
+      ],
+    });
+    drafts.push(entry);
+  }
+
+  return { published, drafts, all: [...published, ...drafts] };
+}
+
+async function seedBasicDpI18n() {
+  const published = [];
+  const drafts = [];
+  console.log(
+    `Seeding basic-dp-i18n: ${COUNTS.basicDpI18n.published} published / ${COUNTS.basicDpI18n.drafts} drafts per locale`
+  );
+
+  for (const locale of LOCALES) {
+    for (let i = 0; i < COUNTS.basicDpI18n.published; i += 1) {
+      const entry = await createDocument(
+        'api::basic-dp-i18n.basic-dp-i18n',
+        {
+          ...fields.basic(),
+          textBlocks: [components.textBlock(), components.textBlock()],
+          mediaBlock: components.mediaBlock(),
+          sections: [
+            components.dz('text-block', components.textBlock()),
+            components.dz('media-block', components.mediaBlock()),
+          ],
+        },
+        { status: 'published', locale }
+      );
+      published.push(entry);
+    }
+
+    for (let i = 0; i < COUNTS.basicDpI18n.drafts; i += 1) {
+      const entry = await createDocument(
+        'api::basic-dp-i18n.basic-dp-i18n',
+        {
+          ...fields.basic(),
+          textBlocks: [components.textBlock(), components.textBlock()],
+          mediaBlock: components.mediaBlock(),
+          sections: [
+            components.dz('text-block', components.textBlock()),
+            components.dz('media-block', components.mediaBlock()),
+          ],
+        },
+        { locale }
+      );
+      drafts.push(entry);
+    }
+  }
+
+  return { published, drafts, all: [...published, ...drafts] };
+}
+
+async function seedRelation() {
+  const items = [];
+  console.log(`Seeding relation: ${COUNTS.relation}`);
+
+  for (let i = 0; i < COUNTS.relation; i += 1) {
+    const entry = await createDocument('api::relation.relation', {
+      name: `Relation ${random.string()}`,
+      simpleInfo: components.simpleInfo(),
+      content: [
+        components.dz('simple-info', components.simpleInfo()),
+        components.dz('image-block', components.imageBlock()),
+      ],
+      textBlocks: [components.textBlock(), components.textBlock()],
+      mediaBlock: components.mediaBlock(),
+      sections: [
+        components.dz('text-block', components.textBlock()),
+        components.dz('media-block', components.mediaBlock()),
+      ],
+    });
+    items.push(entry);
+  }
+
+  return items;
+}
+
+async function seedRelationDp(mediaFiles) {
+  const published = [];
+  const drafts = [];
+  console.log(
+    `Seeding relation-dp: ${COUNTS.relationDp.published} published / ${COUNTS.relationDp.drafts} drafts`
+  );
+
+  for (let i = 0; i < COUNTS.relationDp.published; i += 1) {
+    const mediaId = mediaFiles[i % mediaFiles.length]?.id;
+    const entry = await createDocument(
+      'api::relation-dp.relation-dp',
+      {
+        name: `Relation DP Published ${i + 1}`,
+        cover: mediaId || null,
+        simpleInfo: components.simpleInfo(),
+        content: [
+          components.dz('simple-info', components.simpleInfo()),
+          components.dz('image-block', components.imageBlock()),
+        ],
+        textBlocks: [components.textBlock(), components.textBlock()],
+        mediaBlock: components.mediaBlock(),
+        header: components.header(mediaId),
+        sections: [
+          components.dz('text-block', components.textBlock()),
+          components.dz('media-block', components.mediaBlock()),
+          components.dz('header', components.header(mediaId)),
+          components.dz('reference-list', components.referenceList()),
+        ],
+      },
+      { status: 'published' }
+    );
+    published.push(entry);
+  }
+
+  for (let i = 0; i < COUNTS.relationDp.drafts; i += 1) {
+    const mediaId = mediaFiles[(i + 11) % mediaFiles.length]?.id;
+    const entry = await createDocument('api::relation-dp.relation-dp', {
+      name: `Relation DP Draft ${i + 1}`,
+      cover: mediaId || null,
+      simpleInfo: components.simpleInfo(),
+      content: [
+        components.dz('simple-info', components.simpleInfo()),
+        components.dz('image-block', components.imageBlock()),
+      ],
+      textBlocks: [components.textBlock(), components.textBlock()],
+      mediaBlock: components.mediaBlock(),
+      header: components.header(mediaId),
+      sections: [
+        components.dz('text-block', components.textBlock()),
+        components.dz('media-block', components.mediaBlock()),
+        components.dz('header', components.header(mediaId)),
+        components.dz('reference-list', components.referenceList()),
+      ],
+    });
+    drafts.push(entry);
+  }
+
+  return { published, drafts, all: [...published, ...drafts] };
+}
+
+async function seedRelationDpI18n() {
+  const published = [];
+  const drafts = [];
+  console.log(
+    `Seeding relation-dp-i18n: ${COUNTS.relationDpI18n.published} published / ${COUNTS.relationDpI18n.drafts} drafts per locale`
+  );
+
+  for (const locale of LOCALES) {
+    for (let i = 0; i < COUNTS.relationDpI18n.published; i += 1) {
+      const entry = await createDocument(
+        'api::relation-dp-i18n.relation-dp-i18n',
+        {
+          name: `Relation DP i18n Published ${locale}-${i + 1}`,
+          simpleInfo: components.simpleInfo(),
+          content: [
+            components.dz('simple-info', components.simpleInfo()),
+            components.dz('image-block', components.imageBlock()),
+          ],
+          textBlocks: [components.textBlock(), components.textBlock()],
+          mediaBlock: components.mediaBlock(),
+          sections: [
+            components.dz('text-block', components.textBlock()),
+            components.dz('media-block', components.mediaBlock()),
+          ],
+        },
+        { status: 'published', locale }
+      );
+      published.push(entry);
+    }
+
+    for (let i = 0; i < COUNTS.relationDpI18n.drafts; i += 1) {
+      const entry = await createDocument(
+        'api::relation-dp-i18n.relation-dp-i18n',
+        {
+          name: `Relation DP i18n Draft ${locale}-${i + 1}`,
+          simpleInfo: components.simpleInfo(),
+          content: [
+            components.dz('simple-info', components.simpleInfo()),
+            components.dz('image-block', components.imageBlock()),
+          ],
+          textBlocks: [components.textBlock(), components.textBlock()],
+          mediaBlock: components.mediaBlock(),
+          sections: [
+            components.dz('text-block', components.textBlock()),
+            components.dz('media-block', components.mediaBlock()),
+          ],
+        },
+        { locale }
+      );
+      drafts.push(entry);
+    }
+  }
+
+  return { published, drafts, all: [...published, ...drafts] };
+}
+
+async function seed() {
+  console.log('🌱 Starting v5 seed...');
+  console.log(`Multiplier: ${multiplier}`);
+  console.log(`Counts: ${JSON.stringify(COUNTS)}\n`);
+
+  try {
+    const appContext = await compileStrapi();
+    strapi = await createStrapi(appContext).load();
+    strapi.log.level = 'error';
+
+    const mediaFiles = await createMediaFiles();
+    const basic = await seedBasic();
+    const basicDp = await seedBasicDp(mediaFiles);
+    const basicDpI18n = await seedBasicDpI18n();
+    const relation = await seedRelation();
+    const relationDp = await seedRelationDp(mediaFiles);
+    const relationDpI18n = await seedRelationDpI18n();
+
+    console.log('\n✅ v5 seed completed successfully');
+    console.log(`  - basic: ${basic.length}`);
+    console.log(`  - basic-dp: ${basicDp.all.length}`);
+    console.log(`  - basic-dp-i18n: ${basicDpI18n.all.length}`);
+    console.log(`  - relation: ${relation.length}`);
+    console.log(`  - relation-dp: ${relationDp.all.length}`);
+    console.log(`  - relation-dp-i18n: ${relationDpI18n.all.length}`);
+    console.log(`  - upload files: ${mediaFiles.length}`);
+  } catch (error) {
+    console.error('\n❌ v5 seed failed:', error.message);
+    if (error.details?.errors) {
+      error.details.errors.forEach((e, index) => {
+        console.error(`  ${index + 1}. ${e.path || 'unknown'}: ${e.message}`);
+      });
+    }
+    throw error;
+  } finally {
+    // We intentionally do not call strapi.destroy() here.
+    // In this script we rely on process exit, which avoids intermittent pool abort errors.
+  }
+}
+
+if (require.main === module) {
+  seed()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+module.exports = seed;

--- a/packages/core/admin/admin/src/pages/Home/HomePage.tsx
+++ b/packages/core/admin/admin/src/pages/Home/HomePage.tsx
@@ -17,7 +17,11 @@ import { useEnterprise } from '../../ee';
 import { useAuth } from '../../features/Auth';
 import { useStrapiApp } from '../../features/StrapiApp';
 import { useWidgets } from '../../features/Widgets';
-import { useGetHomepageLayoutQuery } from '../../services/homepage';
+import {
+  useGetCountDocumentsQuery,
+  useGetHomepageLayoutQuery,
+  useGetKeyStatisticsQuery,
+} from '../../services/homepage';
 import {
   getWidgetElement,
   WIDGET_DATA_ATTRIBUTES,
@@ -33,6 +37,22 @@ import { FreeTrialEndedModal } from './components/FreeTrialEndedModal';
 import { FreeTrialWelcomeModal } from './components/FreeTrialWelcomeModal';
 
 import type { WidgetWithUID } from '../../core/apis/Widgets';
+
+type WidgetPermissionStatus = 'allowed' | 'denied' | 'loading';
+
+const getWidgetPermissionsCacheKey = (permissions: NonNullable<WidgetWithUID['permissions']>) => {
+  return permissions
+    .map((permission) =>
+      JSON.stringify({
+        action: permission.action,
+        subject: permission.subject,
+        conditions: permission.conditions ?? [],
+        properties: permission.properties ?? {},
+      })
+    )
+    .sort()
+    .join('|');
+};
 
 // Styled wrapper for the drag preview
 const DragPreviewWrapper = styled.div<{ $maxWidth: string }>`
@@ -87,11 +107,22 @@ const HomePageCE = () => {
   const user = useAuth('HomePageCE', (state) => state.user);
   const displayName = user?.firstname ?? user?.username ?? user?.email;
   const getAllWidgets = useStrapiApp('UnstableHomepageCe', (state) => state.widgets.getAll);
+  const allWidgets = React.useMemo(() => getAllWidgets(), [getAllWidgets]);
   const checkUserHasPermissions = useAuth('WidgetRoot', (state) => state.checkUserHasPermissions);
   const { data: homepageLayout, isLoading: _isLoadingLayout } = useGetHomepageLayoutQuery();
+  // Prefetch expensive widget data as soon as the homepage route is active.
+  useGetCountDocumentsQuery();
+  useGetKeyStatisticsQuery();
   const [filteredWidgets, setFilteredWidgets] = React.useState<WidgetWithUID[]>([]);
-  const [allAvailableWidgets, setAllAvailableWidgets] = React.useState<WidgetWithUID[]>([]);
-  const [loading, setLoading] = React.useState(true);
+  const [widgetPermissionStatus, setWidgetPermissionStatus] = React.useState<
+    Record<string, WidgetPermissionStatus>
+  >(() =>
+    allWidgets.reduce<Record<string, WidgetPermissionStatus>>((acc, widget) => {
+      acc[widget.uid] =
+        !widget.permissions || widget.permissions.length === 0 ? 'allowed' : 'loading';
+      return acc;
+    }, {})
+  );
   const [isAddWidgetModalOpen, setIsAddWidgetModalOpen] = React.useState(false);
 
   // Use custom hook for widget management
@@ -114,31 +145,102 @@ const HomePageCE = () => {
   });
 
   React.useEffect(() => {
-    const checkWidgetsPermissions = async () => {
-      const allWidgets = getAllWidgets();
-      const authorizedWidgets = await Promise.all(
-        allWidgets.map(async (widget) => {
-          if (!widget.permissions || widget.permissions.length === 0) return true;
-          const matchingPermissions = await checkUserHasPermissions(widget.permissions);
-          return matchingPermissions.length >= widget.permissions.length;
-        })
-      );
-      const authorizedWidgetsList = allWidgets.filter((_, i) => authorizedWidgets[i]);
+    const initialPermissionStatus = allWidgets.reduce<Record<string, WidgetPermissionStatus>>(
+      (acc, widget) => {
+        acc[widget.uid] =
+          !widget.permissions || widget.permissions.length === 0 ? 'allowed' : 'loading';
+        return acc;
+      },
+      {}
+    );
 
-      setAllAvailableWidgets(authorizedWidgetsList);
-      setLoading(false);
+    setWidgetPermissionStatus(initialPermissionStatus);
+
+    const widgetsWithPermissions = allWidgets.filter(
+      (widget) => widget.permissions && widget.permissions.length > 0
+    );
+
+    if (widgetsWithPermissions.length === 0) {
+      return;
+    }
+
+    const groupedPermissions = widgetsWithPermissions.reduce<
+      Map<string, { permissions: NonNullable<WidgetWithUID['permissions']>; uids: string[] }>
+    >((acc, widget) => {
+      const permissions = widget.permissions ?? [];
+      const key = getWidgetPermissionsCacheKey(permissions);
+      const existingGroup = acc.get(key);
+
+      if (existingGroup) {
+        existingGroup.uids.push(widget.uid);
+      } else {
+        acc.set(key, { permissions, uids: [widget.uid] });
+      }
+
+      return acc;
+    }, new Map());
+
+    let isMounted = true;
+
+    const checkWidgetsPermissions = async () => {
+      try {
+        const permissionResults = await Promise.all(
+          Array.from(groupedPermissions.values()).map(async ({ permissions, uids }) => {
+            const matchingPermissions = await checkUserHasPermissions(permissions);
+            const status: WidgetPermissionStatus =
+              matchingPermissions.length >= permissions.length ? 'allowed' : 'denied';
+
+            return { uids, status };
+          })
+        );
+
+        if (!isMounted) return;
+
+        setWidgetPermissionStatus((prev) => {
+          const next = { ...prev };
+
+          permissionResults.forEach(({ uids, status }) => {
+            uids.forEach((uid) => {
+              next[uid] = status;
+            });
+          });
+
+          return next;
+        });
+      } catch {
+        if (!isMounted) return;
+
+        // Keep the UI responsive even when permission checks fail.
+        setWidgetPermissionStatus((prev) => {
+          const next = { ...prev };
+          widgetsWithPermissions.forEach((widget) => {
+            next[widget.uid] = 'denied';
+          });
+          return next;
+        });
+      }
     };
 
     checkWidgetsPermissions();
-  }, [checkUserHasPermissions, getAllWidgets]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [allWidgets, checkUserHasPermissions]);
+
+  const allAvailableWidgets = React.useMemo(() => {
+    return allWidgets.filter((widget) => widgetPermissionStatus[widget.uid] === 'allowed');
+  }, [allWidgets, widgetPermissionStatus]);
+
+  const renderableWidgets = React.useMemo(() => {
+    return allWidgets.filter((widget) => widgetPermissionStatus[widget.uid] !== 'denied');
+  }, [allWidgets, widgetPermissionStatus]);
 
   React.useEffect(() => {
-    if (allAvailableWidgets.length === 0) return;
-
     // If user has customized the homepage layout, apply it
     if (homepageLayout && homepageLayout.widgets) {
       const { filteredWidgets, widths: homepageWidths } = applyHomepageLayout(
-        allAvailableWidgets,
+        renderableWidgets,
         homepageLayout
       );
 
@@ -146,10 +248,10 @@ const HomePageCE = () => {
       setColumnWidths(homepageWidths);
     } else {
       // Set default layout when no custom layout exists
-      setFilteredWidgets(allAvailableWidgets);
-      setColumnWidths(createDefaultWidgetWidths(allAvailableWidgets));
+      setFilteredWidgets(renderableWidgets);
+      setColumnWidths(createDefaultWidgetWidths(renderableWidgets));
     }
-  }, [homepageLayout, allAvailableWidgets, setColumnWidths]);
+  }, [homepageLayout, renderableWidgets, setColumnWidths]);
 
   const widgetLayout = React.useMemo(() => {
     return filteredWidgets.map((widget, index) => {
@@ -213,75 +315,73 @@ const HomePageCE = () => {
         <Layouts.Content>
           <Flex direction="column" alignItems="stretch" gap={8} paddingBottom={10}>
             <GuidedTourHomepageOverview />
-            {loading ? (
-              <Box position="absolute" top={0} left={0} right={0} bottom={0}>
-                <Page.Loading />
-              </Box>
-            ) : (
-              <Box position="relative" {...{ [WIDGET_DATA_ATTRIBUTES.GRID_CONTAINER]: true }}>
-                <Grid.Root gap={5}>
-                  {widgetLayout.map(
-                    ({
-                      widget,
-                      isLastInRow,
-                      rightWidgetId,
-                      widgetWidth,
-                      rightWidgetWidth,
-                      canResize,
-                    }) => (
-                      <React.Fragment key={widget.uid}>
-                        <Grid.Item col={widgetWidth} xs={12}>
-                          <WidgetRoot
-                            uid={widget.uid}
-                            title={widget.title}
-                            icon={widget.icon}
-                            link={widget.link}
-                            findWidget={findWidget}
-                            deleteWidget={deleteWidget}
-                            onDragStart={handleDragStart}
-                            onDragEnd={handleDragEnd}
-                            component={widget.component}
-                          >
+            <Box position="relative" {...{ [WIDGET_DATA_ATTRIBUTES.GRID_CONTAINER]: true }}>
+              <Grid.Root gap={5}>
+                {widgetLayout.map(
+                  ({
+                    widget,
+                    isLastInRow,
+                    rightWidgetId,
+                    widgetWidth,
+                    rightWidgetWidth,
+                    canResize,
+                  }) => (
+                    <React.Fragment key={widget.uid}>
+                      <Grid.Item col={widgetWidth} xs={12}>
+                        <WidgetRoot
+                          uid={widget.uid}
+                          title={widget.title}
+                          icon={widget.icon}
+                          link={widget.link}
+                          findWidget={findWidget}
+                          deleteWidget={deleteWidget}
+                          onDragStart={handleDragStart}
+                          onDragEnd={handleDragEnd}
+                          component={widget.component}
+                        >
+                          {widgetPermissionStatus[widget.uid] === 'loading' ? (
+                            <Widget.Loading />
+                          ) : (
                             <WidgetComponent
                               component={widget.component}
                               columnWidth={widgetWidth}
                             />
-                          </WidgetRoot>
-                        </Grid.Item>
+                          )}
+                        </WidgetRoot>
+                      </Grid.Item>
 
-                        {!isLastInRow && canResize && rightWidgetId && (
-                          <WidgetResizeHandle
-                            key={`resize-${widget.uid}`}
-                            leftWidgetId={widget.uid}
-                            rightWidgetId={rightWidgetId}
-                            leftWidgetWidth={widgetWidth}
-                            rightWidgetWidth={rightWidgetWidth}
-                            onResize={handleWidgetResize}
-                            saveLayout={saveLayout}
-                            filteredWidgets={filteredWidgets}
-                          />
-                        )}
-                      </React.Fragment>
-                    )
-                  )}
-                </Grid.Root>
-
-                {isDraggingWidget && (
-                  <GapDropZoneManager
-                    filteredWidgets={filteredWidgets}
-                    columnWidths={columnWidths}
-                    draggedWidgetId={draggedWidgetId}
-                    moveWidget={moveWidget}
-                  />
+                      {!isLastInRow && canResize && rightWidgetId && (
+                        <WidgetResizeHandle
+                          key={`resize-${widget.uid}`}
+                          leftWidgetId={widget.uid}
+                          rightWidgetId={rightWidgetId}
+                          leftWidgetWidth={widgetWidth}
+                          rightWidgetWidth={rightWidgetWidth}
+                          onResize={handleWidgetResize}
+                          saveLayout={saveLayout}
+                          filteredWidgets={filteredWidgets}
+                        />
+                      )}
+                    </React.Fragment>
+                  )
                 )}
-              </Box>
-            )}
+              </Grid.Root>
+
+              {isDraggingWidget && (
+                <GapDropZoneManager
+                  filteredWidgets={filteredWidgets}
+                  columnWidths={columnWidths}
+                  draggedWidgetId={draggedWidgetId}
+                  moveWidget={moveWidget}
+                />
+              )}
+            </Box>
           </Flex>
         </Layouts.Content>
 
         {/* Add the DragLayer to handle custom drag previews */}
         <DragLayer
-          renderItem={({ type, item }) => {
+          renderItem={({ type: _type, item }) => {
             if (!isWidgetDragItem(item)) {
               return null;
             }


### PR DESCRIPTION
### What does it do?

- Refactors homepage widget loading to remove page-wide blocking during permission resolution.
- Adds per-widget permission state (`loading` / `allowed` / `denied`) so the homepage grid renders immediately and each widget resolves independently.
- Starts expensive homepage data queries (`count-documents`, `key-statistics`) as soon as the homepage route mounts, in parallel with layout and permission resolution.
- Adds a new v5 large-data seed script for `examples/complex` (`seed:v5`) with configurable volume (`--multiplier` / `SEED_MULTIPLIER`) to support perf validation.

### Why is it needed?

- On large datasets, homepage performance degrades because widget content (notably document counts) is heavy.
- Previously, the homepage stayed in a global loading state until all widget permission checks completed, delaying first meaningful render.
- Users had to remove widgets to improve perceived performance; this change improves responsiveness without requiring layout changes

### How to test it?

- Environment:
  - Run from `examples/complex`
  - Use PostgreSQL or MySQL local DB via existing scripts (`develop:postgres` / `develop:mysql`)
- Seed large data:
  - `yarn seed:v5 -- --multiplier 100`
- Verify homepage behavior (admin app):
  - Open `/admin` homepage
  - Confirm grid renders immediately (no full-page blocking spinner while permissions resolve)
  - Confirm widgets show their own loading states and appear progressively
  - Confirm no permission regression (denied widgets remain hidden/unavailable)
