### PR TITLE
fix(upgrade): fallback to yarn classic registry

### DIFF
--- a/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
+++ b/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
@@ -5,11 +5,15 @@ import * as constants from '../constants';
 import { Logger } from '../../logger';
 
 jest.mock('execa');
-jest.mock('@strapi/utils', () => ({
-  packageManager: {
-    getPreferred: jest.fn(),
-  },
-}));
+jest.mock(
+  '@strapi/utils',
+  () => ({
+    packageManager: {
+      getPreferred: jest.fn(),
+    },
+  }),
+  { virtual: true }
+);
 
 const mockNpmPackage = {
   _id: '@test/test',
@@ -228,6 +232,52 @@ describe('Package registry URL determination', () => {
     });
     expect(global.fetch).toHaveBeenCalledWith(
       'https://yarn-registry.example.com/@test/package',
+      expect.anything()
+    );
+  });
+
+  it('should fallback to the Yarn Classic registry when the Berry registry key is undefined', async () => {
+    mockGetPreferred.mockResolvedValue('yarn');
+    mockExeca
+      .mockResolvedValueOnce({ stdout: 'undefined\n' } as ExecaReturnValue)
+      .mockResolvedValueOnce({
+        stdout: 'https://classic-yarn-registry.example.com/',
+      } as ExecaReturnValue);
+
+    const pkg = new Package('@test/package', mockCwd, mockLogger);
+    await pkg.refresh();
+
+    expect(mockExeca).toHaveBeenNthCalledWith(1, 'yarn', ['config', 'get', 'npmRegistryServer'], {
+      timeout: 10_000,
+    });
+    expect(mockExeca).toHaveBeenNthCalledWith(2, 'yarn', ['config', 'get', 'registry'], {
+      timeout: 10_000,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://classic-yarn-registry.example.com/@test/package',
+      expect.anything()
+    );
+  });
+
+  it('should fallback to the Yarn Classic registry when the Berry registry lookup fails', async () => {
+    mockGetPreferred.mockResolvedValue('yarn');
+    mockExeca
+      .mockRejectedValueOnce(new Error('Unknown configuration setting'))
+      .mockResolvedValueOnce({
+        stdout: 'https://classic-yarn-registry.example.com/',
+      } as ExecaReturnValue);
+
+    const pkg = new Package('@test/package', mockCwd, mockLogger);
+    await pkg.refresh();
+
+    expect(mockExeca).toHaveBeenNthCalledWith(1, 'yarn', ['config', 'get', 'npmRegistryServer'], {
+      timeout: 10_000,
+    });
+    expect(mockExeca).toHaveBeenNthCalledWith(2, 'yarn', ['config', 'get', 'registry'], {
+      timeout: 10_000,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://classic-yarn-registry.example.com/@test/package',
       expect.anything()
     );
   });

--- a/packages/utils/upgrade/src/modules/npm/package.ts
+++ b/packages/utils/upgrade/src/modules/npm/package.ts
@@ -50,6 +50,16 @@ export class Package implements PackageInterface {
     return Object.values(this.npmPackage.versions);
   }
 
+  private normalizeRegistry(registry: string): string | undefined {
+    const normalizedRegistry = registry.trim();
+
+    if (!normalizedRegistry || normalizedRegistry === 'undefined') {
+      return undefined;
+    }
+
+    return normalizedRegistry;
+  }
+
   findVersionsInRange(range: Version.Range) {
     const versions = this.getVersionsAsList();
 
@@ -70,18 +80,39 @@ export class Package implements PackageInterface {
       if (!packageManagerName) return undefined;
 
       const registryCommands = {
-        yarn: ['config', 'get', 'npmRegistryServer'],
-        npm: ['config', 'get', 'registry'],
+        yarn: [
+          ['config', 'get', 'npmRegistryServer'],
+          ['config', 'get', 'registry'],
+        ],
+        npm: [['config', 'get', 'registry']],
       } as const;
 
-      const command = registryCommands[packageManagerName as keyof typeof registryCommands];
-      if (!command) {
+      const commands = registryCommands[packageManagerName as keyof typeof registryCommands];
+      if (!commands) {
         this.logger.warn(`Unsupported package manager: ${packageManagerName}`);
         return undefined;
       }
 
-      const { stdout } = await execa(packageManagerName, command, { timeout: 10_000 });
-      return stdout.trim() || undefined;
+      let lastError: unknown;
+
+      for (const command of commands) {
+        try {
+          const { stdout } = await execa(packageManagerName, command, { timeout: 10_000 });
+          const registry = this.normalizeRegistry(stdout);
+
+          if (registry) {
+            return registry;
+          }
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      if (lastError) {
+        this.logger.warn('Failed to determine registry URL from package manager');
+      }
+
+      return undefined;
     } catch (error) {
       this.logger.warn('Failed to determine registry URL from package manager');
       return undefined;


### PR DESCRIPTION
Fixes #25830.

## Summary
- treat Yarn Berry's `npmRegistryServer` result of `undefined` as unusable and fall back to Yarn Classic's `yarn config get registry`
- keep tolerating a Berry lookup error so Classic projects still proceed through the fallback path
- add regressions for both `undefined` output and a thrown Berry lookup

## Validation
- `corepack yarn install --immutable`
- `corepack yarn test:unit --selectProjects Upgrade --runTestsByPath packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts`
- `corepack yarn prettier --check packages/utils/upgrade/src/modules/npm/package.ts packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts`

## Notes
- `corepack yarn workspace @strapi/upgrade test:ts` still fails in this checkout with pre-existing workspace resolution errors for `@strapi/utils` and `@strapi/types`