### PR TITLE
fix(database): handle relations cleanup in deleteMany

### DIFF
--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -152,7 +152,6 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
       return {};
     },
 
-    // FIXME: handle relations
     async deleteMany(
       documentIds: Modules.Documents.ID[],
       uid: UID.CollectionType,

--- a/packages/core/database/src/entity-manager/__tests__/delete-many-relations.test.ts
+++ b/packages/core/database/src/entity-manager/__tests__/delete-many-relations.test.ts
@@ -1,0 +1,101 @@
+import { createEntityManager } from '..';
+
+describe('deleteMany', () => {
+  test('cleans up relations for each deleted entity', async () => {
+    const commitMock = jest.fn();
+    const rollbackMock = jest.fn();
+    const transactionMock = jest.fn().mockResolvedValue({
+      get: () => 'trx',
+      commit: commitMock,
+      rollback: rollbackMock,
+    });
+
+    const executeMock = jest.fn();
+    const initMock = jest.fn().mockReturnValue({ execute: executeMock });
+    const deleteMock = jest.fn().mockReturnValue({ execute: executeMock });
+    const whereMock = jest.fn().mockReturnValue({ delete: deleteMock });
+    const createQueryBuilderMock = jest.fn().mockReturnValue({
+      init: initMock,
+      where: whereMock,
+    });
+
+    const lifecycleRunMock = jest.fn().mockResolvedValue({});
+    const deleteRelationsMock = jest.fn().mockResolvedValue(undefined);
+
+    const db = {
+      metadata: { get: jest.fn().mockReturnValue({ attributes: {} }) },
+      lifecycles: { run: lifecycleRunMock },
+      transaction: transactionMock,
+    } as any;
+
+    const strapi = { db: { transaction: transactionMock } } as any;
+    (global as any).strapi = strapi;
+
+    const em = createEntityManager(db);
+
+    // Mock internal methods
+    em.createQueryBuilder = createQueryBuilderMock;
+    em.deleteRelations = deleteRelationsMock;
+
+    // First call (init select) returns entity IDs
+    executeMock
+      .mockResolvedValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }])
+      // Second call (delete) returns count
+      .mockResolvedValueOnce(3);
+
+    const result = await em.deleteMany('api::article.article', {
+      where: { publishedAt: null },
+    });
+
+    expect(result).toEqual({ count: 3 });
+
+    // Verify IDs were fetched before deletion
+    expect(initMock).toHaveBeenCalledWith({
+      select: ['id'],
+      where: { publishedAt: null },
+    });
+
+    // Verify relations were cleaned up for each entity
+    expect(deleteRelationsMock).toHaveBeenCalledTimes(3);
+    expect(deleteRelationsMock).toHaveBeenCalledWith('api::article.article', 1, {
+      transaction: 'trx',
+    });
+    expect(deleteRelationsMock).toHaveBeenCalledWith('api::article.article', 2, {
+      transaction: 'trx',
+    });
+    expect(deleteRelationsMock).toHaveBeenCalledWith('api::article.article', 3, {
+      transaction: 'trx',
+    });
+
+    expect(commitMock).toHaveBeenCalled();
+    expect(rollbackMock).not.toHaveBeenCalled();
+  });
+
+  test('skips relation cleanup when no entities match', async () => {
+    const transactionMock = jest.fn();
+    const executeMock = jest.fn();
+    const initMock = jest.fn().mockReturnValue({ execute: executeMock });
+    const deleteMock = jest.fn().mockReturnValue({ execute: executeMock });
+    const whereMock = jest.fn().mockReturnValue({ delete: deleteMock });
+
+    const db = {
+      metadata: { get: jest.fn().mockReturnValue({ attributes: {} }) },
+      lifecycles: { run: jest.fn().mockResolvedValue({}) },
+      transaction: transactionMock,
+    } as any;
+
+    const em = createEntityManager(db);
+    em.createQueryBuilder = jest.fn().mockReturnValue({ init: initMock, where: whereMock });
+    em.deleteRelations = jest.fn();
+
+    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce(0);
+
+    const result = await em.deleteMany('api::article.article', {
+      where: { id: 999 },
+    });
+
+    expect(result).toEqual({ count: 0 });
+    expect(transactionMock).not.toHaveBeenCalled();
+    expect(em.deleteRelations).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -475,16 +475,32 @@ export const createEntityManager = (db: Database): EntityManager => {
       return entity;
     },
 
-    // TODO: where do we handle relation processing for many queries ?
     async deleteMany(uid, params = {}) {
       const states = await db.lifecycles.run('beforeDeleteMany', uid, { params });
 
       const { where } = params;
 
+      const entitiesToDelete = await this.createQueryBuilder(uid)
+        .init({ select: ['id'], where })
+        .execute<{ id: ID }[]>();
+
       const deletedRows = await this.createQueryBuilder(uid)
         .where(where)
         .delete()
         .execute<number>({ mapResults: false });
+
+      if (entitiesToDelete.length > 0) {
+        const trx = await strapi.db.transaction();
+        try {
+          for (const entity of entitiesToDelete) {
+            await this.deleteRelations(uid, entity.id, { transaction: trx.get() });
+          }
+          await trx.commit();
+        } catch (e) {
+          await trx.rollback();
+          throw e;
+        }
+      }
 
       const result = { count: deletedRows };
 


### PR DESCRIPTION
### What does it do?

Adds relation cleanup to the entity manager's `deleteMany` method, following the same pattern used by the single `delete` method.

Before this change, `deleteMany` deleted rows via query builder but skipped `deleteRelations`, leaving orphaned entries in relation join tables. The single `delete` method at line 465 already calls `deleteRelations` in a transaction — this PR applies the same pattern to `deleteMany`.

Also removes the outdated `FIXME: handle relations` comment from the content-manager's `document-manager.ts`, since that method already delegates to individual `delete` calls which handle relations through the Document Service pipeline.

### Why is it needed?

The `deleteMany` method had a `TODO` comment acknowledging the missing relation processing. When bulk-deleting entities with relations (e.g., articles with categories, tags, or media), the relation join table entries were not cleaned up, leading to orphaned data.

### How to test it?

Unit tests added in `packages/core/database/src/entity-manager/__tests__/delete-many-relations.test.ts`:

- `cleans up relations for each deleted entity` — verifies `deleteRelations` is called for each entity ID, transaction is committed
- `skips relation cleanup when no entities match` — verifies no transaction is created when where clause matches nothing

```bash
yarn jest packages/core/database/src/entity-manager/__tests__/delete-many-relations.test.ts
```

### Related issue(s)/PR(s)

Fixes #25640

Note: the `TODO` comments for `createMany` (line 326) and `updateMany` (line 414) are separate concerns and not addressed in this PR to keep the scope focused.