### PR TITLE
fix: handle mounted uploads directory when backing up assets during transfer

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/index.ts
@@ -25,6 +25,12 @@ import { assertValidStrapi } from '../../../utils/providers';
 export const VALID_CONFLICT_STRATEGIES = ['restore'];
 export const DEFAULT_CONFLICT_STRATEGY = 'restore';
 
+const isAssetsBackupMoveError = (error: unknown): boolean => {
+  const err = error as NodeJS.ErrnoException;
+
+  return ['EBUSY', 'EXDEV'].includes(err.code ?? '');
+};
+
 export interface ILocalStrapiDestinationProviderOptions {
   getStrapi(): Core.Strapi | Promise<Core.Strapi>; // return an initialized instance of Strapi
 
@@ -270,8 +276,24 @@ class LocalStrapiDestinationProvider implements IDestinationProvider {
         // eslint-disable-next-line no-bitwise
         await fse.access(path.join(assetsDirectory, '..'), fse.constants.W_OK | fse.constants.R_OK);
 
-        await fse.move(assetsDirectory, backupDirectory);
-        await fse.mkdir(assetsDirectory);
+        try {
+          await fse.move(assetsDirectory, backupDirectory);
+          await fse.mkdir(assetsDirectory);
+        } catch (error) {
+          if (!isAssetsBackupMoveError(error)) {
+            throw error;
+          }
+
+          // Mounted directories (e.g. Docker/Kubernetes volumes) cannot always be moved because the underlying rename can fail (e.g. EBUSY, EXDEV).
+          // In that case, back up the contents by copying and keep the uploads directory in place.
+          await fse.copy(assetsDirectory, backupDirectory, {
+            overwrite: false,
+            errorOnExist: true,
+          });
+
+          await fse.emptyDir(assetsDirectory);
+        }
+
         // Create a .gitkeep file to ensure the directory is not empty
         await fse.outputFile(path.join(assetsDirectory, '.gitkeep'), '');
         this.#reportInfo(`created assets backup directory ${backupDirectory}`);


### PR DESCRIPTION
### What does it do?

Adds a fallback when backing up `public/uploads` during `strapi transfer`.  
If `fs-extra.move()` fails (e.g. mounted uploads), it falls back to copying the directory contents and emptying the original directory. The fallback uses strict copy options (`overwrite: false`, `errorOnExist: true`).

### Why is it needed?

When `public/uploads` is mounted (Docker bind mount / Kubernetes volume), `fs-extra.move()` can fail with:

- `EBUSY` (device or resource busy)
- `EXDEV` (cross-device link)

This currently causes the transfer restore process to fail during the assets backup step with a misleading permissions error. The fallback ensures transfers work correctly with mounted uploads.

### How to test it?

1. Run two Strapi instances:
   - source instance
   - destination instance with `public/uploads` mounted as a volume  
     (e.g. `-v /host/uploads:/app/public/uploads`)
2. On the source instance:
   - create content
   - upload at least one file
   - create a transfer token
3. From the destination instance, run:  
   `strapi transfer --from <source-url> --from-token <token>`
4. Before this change:
   - transfer fails during the assets backup step
5. After this change:
   - transfer succeeds
   - uploads are transferred correctly

### Related issue(s)/PR(s)

Fixes #25821  
Depends on #23479