### PR TITLE
fix: homepage dashboard duplicates entries for users with multiple roles

### DIFF
--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -1,0 +1,124 @@
+import { createHomepageService } from '../homepage';
+
+jest.mock(
+  '@strapi/utils',
+  () => ({
+    contentTypes: {
+      hasDraftAndPublish: jest.fn(() => false),
+    },
+  }),
+  { virtual: true }
+);
+
+describe('homepage service', () => {
+  describe('queryLastDocuments', () => {
+    it('deduplicates permitted content types before querying recent documents', async () => {
+      const contentTypes = {
+        'api::article.article': {
+          uid: 'api::article.article',
+          info: { displayName: 'Article' },
+          kind: 'collectionType',
+          options: {},
+          attributes: {},
+        },
+        'api::page.page': {
+          uid: 'api::page.page',
+          info: { displayName: 'Page' },
+          kind: 'collectionType',
+          options: {},
+          attributes: {},
+        },
+      };
+
+      const findArticleDocuments = jest.fn(async () => [
+        {
+          documentId: 'article-1',
+          title: 'Article 1',
+          updatedAt: '2026-01-02T00:00:00.000Z',
+        },
+      ]);
+      const findPageDocuments = jest.fn(async () => [
+        {
+          documentId: 'page-1',
+          title: 'Page 1',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ]);
+      const findConfigurations = jest.fn(async () => [
+        {
+          value: JSON.stringify({
+            uid: 'api::article.article',
+            settings: { mainField: 'title' },
+          }),
+        },
+        {
+          value: JSON.stringify({
+            uid: 'api::page.page',
+            settings: { mainField: 'title' },
+          }),
+        },
+      ]);
+
+      const strapi = {
+        admin: {
+          services: {
+            permission: {
+              findMany: jest.fn(async () => [
+                { subject: 'api::article.article' },
+                { subject: 'api::article.article' },
+                { subject: 'api::page.page' },
+              ]),
+            },
+          },
+        },
+        requestContext: {
+          get: jest.fn(() => ({
+            state: {
+              user: { id: 1 },
+              userAbility: {},
+            },
+          })),
+        },
+        db: {
+          query: jest.fn(() => ({
+            findMany: findConfigurations,
+          })),
+        },
+        plugin: jest.fn(() => ({
+          service: jest.fn(() => ({
+            create: jest.fn(() => ({
+              sanitizedQuery: {
+                read: jest.fn(async (query: unknown) => query),
+              },
+            })),
+          })),
+        })),
+        contentType: jest.fn((uid: keyof typeof contentTypes) => contentTypes[uid]),
+        documents: jest.fn((uid: keyof typeof contentTypes) => ({
+          findMany: uid === 'api::article.article' ? findArticleDocuments : findPageDocuments,
+        })),
+      };
+
+      const service = createHomepageService({ strapi } as any);
+
+      const result = await service.queryLastDocuments({ sort: 'updatedAt:desc' });
+
+      expect(findConfigurations).toHaveBeenCalledWith({
+        where: {
+          key: {
+            $in: [
+              'plugin_content_manager_configuration_content_types::api::article.article',
+              'plugin_content_manager_configuration_content_types::api::page.page',
+            ],
+          },
+        },
+      });
+      expect(findArticleDocuments).toHaveBeenCalledTimes(1);
+      expect(findPageDocuments).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject([
+        { documentId: 'article-1', contentTypeUid: 'api::article.article' },
+        { documentId: 'page-1', contentTypeUid: 'api::page.page' },
+      ]);
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -1,13 +1,12 @@
 import { createHomepageService } from '../homepage';
 
-jest.mock(
-  '@strapi/utils',
-  () => ({
-    contentTypes: {
-      hasDraftAndPublish: jest.fn(() => false),
-    },
-  }),
-);
+jest.mock('@strapi/utils', () => ({
+  ...jest.requireActual('@strapi/utils'),
+  contentTypes: {
+    ...jest.requireActual('@strapi/utils').contentTypes,
+    hasDraftAndPublish: jest.fn(() => false),
+  },
+}));
 
 describe('homepage service', () => {
   describe('queryLastDocuments', () => {
@@ -86,6 +85,9 @@ describe('homepage service', () => {
         plugin: jest.fn(() => ({
           service: jest.fn(() => ({
             create: jest.fn(() => ({
+              cannot: {
+                read: jest.fn(() => false),
+              },
               sanitizedQuery: {
                 read: jest.fn(async (query: unknown) => query),
               },

--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage.test.ts
@@ -7,7 +7,6 @@ jest.mock(
       hasDraftAndPublish: jest.fn(() => false),
     },
   }),
-  { virtual: true }
 );
 
 describe('homepage service', () => {

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -49,9 +49,16 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
       },
     });
 
-    return readPermissions
-      .map((permission) => permission.subject)
-      .filter(Boolean) as RecentDocument['contentTypeUid'][];
+    // Deduplicate subjects using a Set: the JOIN across permission -> role -> users produces one row
+    // per role the user belongs, so a multi-role user gets duplicate subjects.
+    // Using a Set collapses them to unique content type UID.
+    return [
+      ...new Set(
+        readPermissions
+          .map((permission) => permission.subject)
+          .filter(Boolean) as RecentDocument['contentTypeUid'][]
+      ),
+    ];
   };
 
   type ContentTypeMeta = {

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -50,7 +50,7 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     });
 
     // Deduplicate subjects using a Set: the JOIN across permission -> role -> users produces one row
-    // per role the user belongs, so a multi-role user gets duplicate subjects.
+    // per role the user belongs to, so a multi-role user gets duplicate subjects.
     // Using a Set collapses them to unique content type UID.
     return [
       ...new Set(


### PR DESCRIPTION
# fix: homepage dashboard duplicates entries for users with multiple roles

### What does it do?

Deduplicates the list of permitted content type UIDs returned by
`getPermittedContentTypes` in the homepage service using a `Set`.
Wrapping the return data in a `Set` so that only distinct values are returned.

### Why is it needed?

The `getPermittedContentTypes` function fetches read permissions as:

```ts
permissionService.findMany({
  where: {
    role: { users: { id: <current-user-id> } },
    action: 'plugin::content-manager.explorer.read',
  },
});
```

This query JOINs `admin::permission -> role -> users`, which produces
**one row per role** the user belongs to. A user with N roles gets N
duplicate rows per content type subject. As a result, every entry is
fetched and counted N times on the homepage dashboard.

### How to test it?

1. Create a content type and add a few entries
2. Create two admin roles, both with **read** permission
   on the content type
3. Create a new admin user and **assign both roles**
4. Log in as that user- entries should now be **counted and listed once**
   instead of twice

**Before fix:** a user with 2 roles sees each entry 2× (3 entries -> shows 6)  
**After fix:** always shows the correct count regardless of role count

### Related issue(s)/PR(s)

Fixes #25779
