### PR TITLE
chore: add .claude directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ tests/cli/.env
 # AI tools
 ############################
 CLAUDE.local.md
+.claude
 
 ############################
 # Strapi


### PR DESCRIPTION
## Summary
- Add `.claude` directory to `.gitignore` to prevent Claude Code workspace files from being committed

## Test plan
- [x] Verify `.claude` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)