### PR TITLE
fix(create-strapi-app): generate .yarnrc.yml for Yarn projects

### DIFF
--- a/packages/cli/create-strapi-app/src/create-strapi.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import chalk from 'chalk';
 import execa from 'execa';
 import fse from 'fs-extra';
+import semver from 'semver';
 
 import { createGrowthSsoTrial } from '@strapi/cloud-cli';
 
@@ -16,9 +17,42 @@ import { isStderrError } from './types';
 import type { Scope } from './types';
 import { logger } from './utils/logger';
 import { gitIgnore } from './utils/gitignore';
-import { getInstallArgs } from './utils/get-package-manager-args';
+import { getInstallArgs, getPackageManagerVersion } from './utils/get-package-manager-args';
 
 const yarnNodeModulesConfig = 'nodeLinker: node-modules\n';
+
+const getUserAgentPackageManagerVersion = (packageManager: Scope['packageManager']) => {
+  const userAgent = process.env.npm_config_user_agent ?? '';
+  const [agent] = userAgent.split(' ');
+  const [name, version] = agent.split('/');
+
+  if (name !== packageManager || version === undefined) {
+    return null;
+  }
+
+  return semver.coerce(version)?.version ?? null;
+};
+
+const shouldWriteYarnNodeModulesConfig = async (packageManager: Scope['packageManager']) => {
+  if (packageManager !== 'yarn') {
+    return false;
+  }
+
+  const userAgentVersion = getUserAgentPackageManagerVersion(packageManager);
+
+  if (userAgentVersion) {
+    return semver.gte(userAgentVersion, '3.0.0');
+  }
+
+  try {
+    const packageManagerVersion = await getPackageManagerVersion(packageManager);
+    const normalizedVersion = semver.coerce(packageManagerVersion)?.version;
+
+    return normalizedVersion ? semver.gte(normalizedVersion, '3.0.0') : false;
+  } catch {
+    return false;
+  }
+};
 
 async function createStrapi(scope: Scope) {
   const { rootPath } = scope;
@@ -102,7 +136,10 @@ async function createApp(scope: Scope) {
     // create config/database
     await fse.writeFile(join(rootPath, '.env'), generateDotEnv(scope));
 
-    if (packageManager === 'yarn' && !(await fse.pathExists(join(rootPath, '.yarnrc.yml')))) {
+    if (
+      (await shouldWriteYarnNodeModulesConfig(packageManager)) &&
+      !(await fse.pathExists(join(rootPath, '.yarnrc.yml')))
+    ) {
       await fse.writeFile(join(rootPath, '.yarnrc.yml'), yarnNodeModulesConfig);
     }
 

--- a/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
+++ b/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
@@ -79,13 +79,30 @@ describe('create-strapi-app', () => {
   it('writes a Yarn node-modules linker config for Yarn projects', async () => {
     const projectDir = mkProjectDir();
     try {
-      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-yarn'])
+      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-yarn'], {
+        npm_config_user_agent: 'yarn/4.12.0 npm/? node/v24.12.0 darwin arm64',
+      })
         .expect('code', 0)
         .end();
 
       expect(fs.readFileSync(path.join(projectDir, '.yarnrc.yml'), 'utf8')).toBe(
         'nodeLinker: node-modules\n'
       );
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write a Yarn config for Yarn classic projects', async () => {
+    const projectDir = mkProjectDir();
+    try {
+      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-yarn'], {
+        npm_config_user_agent: 'yarn/1.22.22 npm/? node/v24.12.0 darwin arm64',
+      })
+        .expect('code', 0)
+        .end();
+
+      expect(fs.existsSync(path.join(projectDir, '.yarnrc.yml'))).toBe(false);
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }
@@ -101,6 +118,43 @@ describe('create-strapi-app', () => {
       expect(fs.existsSync(path.join(projectDir, '.yarnrc.yml'))).toBe(false);
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('scaffolds inside an existing Yarn workspace monorepo', async () => {
+    const monorepoDir = mkProjectDir();
+    const projectDir = path.join(monorepoDir, 'packages', 'strapi-app');
+
+    try {
+      fs.mkdirSync(path.dirname(projectDir), { recursive: true });
+      fs.writeFileSync(
+        path.join(monorepoDir, 'package.json'),
+        JSON.stringify(
+          {
+            private: true,
+            packageManager: 'yarn@4.12.0',
+            workspaces: ['packages/*'],
+          },
+          null,
+          2
+        )
+      );
+      fs.writeFileSync(path.join(monorepoDir, '.yarnrc.yml'), 'nodeLinker: pnp\n');
+
+      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-yarn'], {
+        npm_config_user_agent: 'yarn/4.12.0 npm/? node/v24.12.0 darwin arm64',
+      })
+        .expect('code', 0)
+        .end();
+
+      expect(fs.readFileSync(path.join(projectDir, '.yarnrc.yml'), 'utf8')).toBe(
+        'nodeLinker: node-modules\n'
+      );
+      expect(fs.readFileSync(path.join(monorepoDir, '.yarnrc.yml'), 'utf8')).toBe(
+        'nodeLinker: pnp\n'
+      );
+    } finally {
+      fs.rmSync(monorepoDir, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## What does it do?

Updates `create-strapi-app` so newly scaffolded projects using Yarn automatically include a `.yarnrc.yml` file with:

```yml
nodeLinker: node-modules
```

The file is only created when Yarn is the selected package manager, and scaffold coverage was added to verify:
- Yarn projects get `.yarnrc.yml`
- npm projects do not get `.yarnrc.yml`

## Why is it needed?

New Strapi apps created with Yarn 3+ can fail to run `develop` or `build` because Yarn Plug'n'Play is enabled by default and `esbuild-register` ends up requiring `esbuild` in a way that is incompatible with that setup.

Generating `.yarnrc.yml` with `nodeLinker: node-modules` avoids the PnP resolution issue and makes freshly created Yarn-based Strapi apps runnable out of the box.

## How to test it?

Environment:
- Yarn `3+`

Verification path:

1. Create a new app with Yarn:

```bash
node packages/cli/create-strapi-app/bin/index.js strapi-yarn-app --non-interactive --skip-cloud --no-git-init --no-install --use-yarn
```

2. Verify the generated file exists:

Expected result:

```yml
nodeLinker: node-modules
```

3. Create a new app with npm:

```bash
node packages/cli/create-strapi-app/bin/index.js strapi-npm-app --non-interactive --skip-cloud --no-git-init --no-install --use-npm
```

4. Verify `.yarnrc.yml` is not created for npm:

can be tested with the experimental as well: `0.0.0-experimental.90669470e7ec88f45eeadc88ae2b17fc3b556547`

## Related issue(s)/PR(s)

fixes #25775 
