### PR TITLE
test(api): add REST tests for relation documentId shorthand

### DIFF
--- a/tests/api/core/strapi/api/relations.test.api.ts
+++ b/tests/api/core/strapi/api/relations.test.api.ts
@@ -1494,4 +1494,92 @@ describe('Relations', () => {
       expect(updatedShop.data).toMatchObject(expectedShop);
     });
   });
+
+  /**
+   * GH#22611: REST create/update must accept relation values as `{ documentId }` objects
+   * (not only scalars or `{ connect: [...] }`). Previously this failed validation with
+   * "Invalid key documentId".
+   */
+  describe('GH#22611: direct relation object { documentId } (REST shorthand, no connect/set)', () => {
+    test('creates a shop with oneToOne relation using { documentId } object', async () => {
+      const res = await createEntry(
+        'shops',
+        {
+          name: 'GH22611 direct docId',
+          products_ow: { documentId: docid1 },
+        },
+        populateShop
+      );
+
+      expect(res.error).toBeUndefined();
+      expect(res.data).toMatchObject({
+        name: 'GH22611 direct docId',
+        products_ow: { documentId: docid1 },
+      });
+    });
+
+    test('updates oneToOne relation using { documentId } object', async () => {
+      const created = await createEntry(
+        'shops',
+        {
+          name: 'GH22611 update',
+          products_ow: { documentId: docid1 },
+        },
+        populateShop
+      );
+
+      expect(created.error).toBeUndefined();
+
+      const updated = await updateEntry(
+        'shops',
+        created.data.documentId,
+        {
+          name: 'GH22611 update',
+          products_ow: { documentId: docid2 },
+        },
+        populateShop
+      );
+
+      expect(updated.error).toBeUndefined();
+      expect(updated.data.products_ow).toMatchObject({ documentId: docid2 });
+    });
+
+    test('creates with manyToOne and oneToMany using { documentId } object form', async () => {
+      const res = await createEntry(
+        'shops',
+        {
+          name: 'GH22611 mixed',
+          products_mo: { documentId: docid1 },
+          products_om: [{ documentId: docid2 }, { documentId: docid3 }],
+        },
+        populateShop
+      );
+
+      expect(res.error).toBeUndefined();
+      expect(res.data).toMatchObject({
+        products_mo: { documentId: docid1 },
+        products_om: [{ documentId: docid2 }, { documentId: docid3 }],
+      });
+    });
+
+    test('creates nested component relation using { documentId } object (non-repeatable myCompo)', async () => {
+      const res = await createEntry(
+        'shops',
+        {
+          name: 'GH22611 component',
+          myCompo: {
+            name: 'inner',
+            compo_products_ow: { documentId: docid1 },
+          },
+        },
+        populateShop
+      );
+
+      expect(res.error).toBeUndefined();
+      expect(res.data.myCompo).toMatchObject({
+        name: 'inner',
+        compo_products_ow: { documentId: docid1 },
+      });
+    });
+  });
 });


### PR DESCRIPTION
### What does it do?

adds a test for direction relation object documentId shorthand; the fix already exists but this proves it

### Why is it needed?

closes https://github.com/strapi/strapi/issues/22611

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

closes https://github.com/strapi/strapi/issues/22611