### PR TITLE
test(api): add test for extendFields

### DIFF
--- a/packages/core/content-type-builder/admin/src/utils/tests/formAPI.test.ts
+++ b/packages/core/content-type-builder/admin/src/utils/tests/formAPI.test.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 
+import { forms } from '../../components/FormModal/forms/forms';
 import { formsAPI } from '../formAPI';
 
 describe('formsAPI', () => {
@@ -60,6 +61,77 @@ describe('formsAPI', () => {
 
       expect(mutation).toHaveBeenCalledWith({ ok: true }, { ok: false });
       expect(returnedData).toEqual({ ok: true });
+    });
+  });
+
+  /**
+   * extendFields advanced callbacks receive `customField` in args (built-in: falsy; custom field modal: metadata).
+   * @see https://github.com/strapi/strapi/pull/22521
+   */
+  describe('extendFields and customField in getAdvancedForm args', () => {
+    it('passes falsy customField for built-in attribute forms', () => {
+      const advanced = jest.fn((_args: Record<string, unknown>) => []);
+
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires -- isolateModules needs a fresh CommonJS load of the singleton
+        const { formsAPI: api } = require('../formAPI');
+        api.extendFields(['text'], {
+          form: { advanced },
+        });
+
+        forms.attribute.form.advanced({
+          data: {},
+          type: 'text',
+          step: '0',
+          extensions: api,
+          forTarget: 'contentType',
+          attributes: [],
+        });
+      });
+
+      expect(advanced).toHaveBeenCalled();
+      const args = advanced.mock.calls[0]?.[0];
+      expect(args).toBeDefined();
+      expect(args).toMatchObject({
+        data: {},
+        type: 'text',
+        step: '0',
+        forTarget: 'contentType',
+      });
+      expect(args!.customField == null).toBe(true);
+    });
+
+    it('passes customField metadata for custom field modals', () => {
+      const advanced = jest.fn((_args: Record<string, unknown>) => []);
+
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires -- isolateModules needs a fresh CommonJS load of the singleton
+        const { formsAPI: api } = require('../formAPI');
+        const mockCustomField = {
+          type: 'json',
+          intlLabel: { id: 'test.cf', defaultMessage: 'Test' },
+          options: { base: [], advanced: [] },
+        };
+
+        api.extendFields(['json'], {
+          form: { advanced },
+        });
+
+        forms.customField.form.advanced({
+          data: {},
+          step: '0',
+          customField: mockCustomField,
+          extensions: api,
+        });
+      });
+
+      expect(advanced).toHaveBeenCalled();
+      const args = advanced.mock.calls[0]?.[0];
+      expect(args).toBeDefined();
+      expect(args!.customField).toMatchObject({
+        type: 'json',
+        intlLabel: { id: 'test.cf', defaultMessage: 'Test' },
+      });
     });
   });
 });


### PR DESCRIPTION
### What does it do?

adds automated test for extendFields and customField

### Why is it needed?

more test coverage

### How to test it?

run it

### Related issue(s)/PR(s)

missing test from enhancement #22521 
