### PR TITLE
fix(content-manager): pass component schemas when rebuilding list view headers

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/convertListLayoutToFieldLayouts.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/convertListLayoutToFieldLayouts.test.ts
@@ -1,0 +1,95 @@
+import { convertListLayoutToFieldLayouts } from '../useDocumentLayout';
+
+import type { Component } from '../../../../shared/contracts/components';
+import type { ContentType } from '../../../../shared/contracts/content-types';
+
+/**
+ * List column conversion must pass the same optional arguments as `formatListLayout` so
+ * `getMainField` can resolve types for component and relation columns.
+ */
+describe('convertListLayoutToFieldLayouts', () => {
+  const componentUid = 'blog.test-como';
+
+  const contentTypeAttributes: ContentType['attributes'] = {
+    user: {
+      type: 'component',
+      component: componentUid,
+      repeatable: false,
+      required: true,
+      pluginOptions: {},
+    },
+  };
+
+  const listMetadatas = {
+    user: {
+      label: 'User',
+      mainField: 'name',
+      searchable: true,
+      sortable: true,
+    },
+  };
+
+  const componentSchemas: Record<string, Component> = {
+    [componentUid]: {
+      uid: componentUid,
+      category: 'blog',
+      isDisplayed: true,
+      apiID: 'test-como',
+      info: {
+        displayName: 'test comp',
+        icon: 'paint',
+        description: '',
+      },
+      options: {},
+      attributes: {
+        name: {
+          type: 'string',
+          default: 'toto',
+        },
+      },
+    } as unknown as Component,
+  };
+
+  const componentConfigurations = {
+    [componentUid]: {
+      uid: componentUid,
+      category: 'blog',
+      settings: {
+        bulkable: true,
+        filterable: true,
+        searchable: true,
+        pageSize: 10,
+        mainField: 'name',
+        defaultSortBy: 'name',
+        defaultSortOrder: 'ASC' as const,
+      },
+      metadatas: {},
+      layouts: { list: [], edit: [] },
+      isComponent: true,
+    },
+  };
+
+  const columns = ['user'];
+
+  it('throws when configurations and schemas are omitted but list metadata defines mainField', () => {
+    expect(() =>
+      convertListLayoutToFieldLayouts(columns, contentTypeAttributes, listMetadatas)
+    ).toThrow(TypeError);
+  });
+
+  it('resolves component mainField when configurations, component schemas, and content-type schemas are provided', () => {
+    const result = convertListLayoutToFieldLayouts(
+      columns,
+      contentTypeAttributes,
+      listMetadatas,
+      {
+        configurations: componentConfigurations,
+        schemas: componentSchemas,
+      },
+      []
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].mainField).toEqual({ name: 'name', type: 'string' });
+  });
+});

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -27,6 +27,8 @@ describe('useDocumentLayout', () => {
       },
     });
 
+    expect(result.current.listViewConversionContext).toBeNull();
+
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.edit.components).toEqual({
@@ -334,10 +336,14 @@ describe('useDocumentLayout', () => {
       },
     });
 
+    expect(result.current.listViewConversionContext).toBeNull();
+
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     // list layouts don't need the components.
     expect(result.current.list.components).toBeUndefined();
+
+    expect(result.current.listViewConversionContext).not.toBeNull();
 
     const expectedListLayout = [
       {

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -92,6 +92,16 @@ interface EditLayout {
   settings: LayoutSettings;
 }
 
+/**
+ * Data required to resolve `mainField` when converting list column names to field layouts for
+ * component and relation attributes; mirrors the fourth and fifth arguments of `formatListLayout`.
+ */
+type ListViewConversionContext = {
+  componentConfigurations: FindContentTypeConfiguration.Response['data']['components'];
+  componentSchemas: ComponentsDictionary;
+  contentTypeSchemas: Schema[];
+};
+
 type UseDocumentLayout = (model: string) => {
   error?: BaseQueryError | SerializedError;
   isLoading: boolean;
@@ -100,6 +110,11 @@ type UseDocumentLayout = (model: string) => {
    */
   edit: EditLayout;
   list: ListLayout;
+  /**
+   * Populated when configuration is loaded; pass into `convertListLayoutToFieldLayouts` with
+   * `list.metadatas` when mapping persisted list column names (e.g. custom displayed headers).
+   */
+  listViewConversionContext: ListViewConversionContext | null;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -196,11 +211,24 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
     [editLayout, query, runHookWaterfall]
   );
 
+  const listViewConversionContext = React.useMemo((): ListViewConversionContext | null => {
+    if (!data || isLoading) {
+      return null;
+    }
+
+    return {
+      componentConfigurations: data.components,
+      componentSchemas: components,
+      contentTypeSchemas: schemas,
+    };
+  }, [data, isLoading, components, schemas]);
+
   return {
     error,
     isLoading,
     edit,
     list: listLayout,
+    listViewConversionContext,
   } satisfies ReturnType<UseDocumentLayout>;
 };
 

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -103,7 +103,7 @@ const ListViewPage = () => {
   usePersistentPartialQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale'], false);
 
   const { collectionType, model, schema } = useDoc();
-  const { list } = useDocumentLayout(model);
+  const { list, listViewConversionContext } = useDocumentLayout(model);
 
   const [displayedHeaderNames, setDisplayedHeaderNames] = useScopedPersistentState<string[] | null>(
     `STRAPI_LIST_VIEW_DISPLAYED_HEADERS:${model}`,
@@ -117,12 +117,22 @@ const ListViewPage = () => {
       !displayedHeaderNames ||
       !list.metadatas ||
       Object.keys(list.metadatas).length <= 0 ||
-      !schema?.attributes
+      !schema?.attributes ||
+      !listViewConversionContext
     )
       return [];
 
-    return convertListLayoutToFieldLayouts(displayedHeaderNames, schema.attributes, list.metadatas);
-  }, [displayedHeaderNames, schema, list]);
+    return convertListLayoutToFieldLayouts(
+      displayedHeaderNames,
+      schema.attributes,
+      list.metadatas,
+      {
+        configurations: listViewConversionContext.componentConfigurations,
+        schemas: listViewConversionContext.componentSchemas,
+      },
+      listViewConversionContext.contentTypeSchemas
+    );
+  }, [displayedHeaderNames, schema, list, listViewConversionContext]);
 
   const handleSetHeaders = (headers: string[]) => {
     setDisplayedHeaderNames(headers);


### PR DESCRIPTION
### What does it do?

- Exposes **`listViewConversionContext`** from `useDocumentLayout`: component configuration from the content-type config, component schemas from `useDocument`, and all content-type schemas (same data `formatListLayout` already passes into `convertListLayoutToFieldLayouts`).
- Updates **`ListViewPage`** so when it rebuilds **persisted list column names** into field layouts, it calls `convertListLayoutToFieldLayouts` with that full context—not only `(columns, attributes, metadatas)`.
- Adds **`convertListLayoutToFieldLayouts` unit tests** and extends **`useDocumentLayout` tests** to cover the new hook field.

### Why is it needed?

Renaming a **component field label** in Content Manager → Configure the view (label only) could break the **list view** with `TypeError: Cannot read properties of undefined (reading 'attributes')` in `getMainField`. That path re-ran `convertListLayoutToFieldLayouts` without component schemas, so `getMainField` could not read the nested component attribute used for `mainField`. The server layout path already passed the right arguments; the persisted-header path did not.

### How to test it?

1. Create a collection type with a **component** field; add fields inside the component (e.g. `name`).
2. Create at least one entry so the component has data.
3. Open **Configure the view** for that collection type and **change only the component field’s label** (e.g. `user` → `User`), save.
4. Go back to the **list view** for that collection type.

**Expected:** List loads without error; component column still shows correctly.

**Automated:** From the repo root, build the content-manager package if your workflow requires it, then run the content-manager front tests (e.g. Jest for `convertListLayoutToFieldLayouts.test.ts` and `useDocumentLayout.test.ts`).

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/issues/25509
