### PR TITLE
fix: handle 204 response before parsing JSON

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -268,6 +268,14 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
     response: Response,
     validateStatus?: FetchOptions['validateStatus']
   ): Promise<FetchResponse<TData>> => {
+    /**
+     * Handles responses with no body (e.g., 204 No Content) before attempting JSON parse.
+     * Safari may throw a non-SyntaxError when calling .json() on an empty body,
+     * which would bypass the SyntaxError-specific catch below.
+     */
+    if (response.status === 204) {
+      return { data: [] as unknown as TData, status: response.status };
+    }
     try {
       const result = await response.json();
 


### PR DESCRIPTION
Resolve forgot-password error on safari

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds an early return in `responseInterceptor` inside `getFetchClient.ts` to handle 204 responses before attempting to call `response.json()`.

https://github.com/user-attachments/assets/6527946a-1b68-427b-87a8-c54ea38af44a


### Why is it needed?

On Safari, calling `response.json()` on a response with an empty body (e.g. 204 No content) throws a non-`SyntaxError` with the message "The string did not match the expected pattern."  The existing catch block only handles `instanceof SyntaxError`, so Safari's error bypasses it and propagates as a mutation error, displaying the message in the UI even though the API call succeeded.

On Chrome and Firefox, the same call throws a `SyntaxError`, which is caught correctly.

The forgot-password endpoint (`POST /admin/forgot-password`) returns 204 on success, Safari users would see "The string did not match the expected pattern." after submitting a valid email, while the API had actually succeeded.

 The fix checks for status 204 explicitly before attempting JSON parsing, short-circuiting the problematic `response.json()` call entirely. 

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)
Fixes #25465 
