### PR TITLE
test: verify fix/25465-safari-mail-regex behavior on Chromium

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -268,6 +268,14 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
     response: Response,
     validateStatus?: FetchOptions['validateStatus']
   ): Promise<FetchResponse<TData>> => {
+    /**
+     * Handles responses with no body (e.g., 204 No Content) before attempting JSON parse.
+     * Safari may throw a non-SyntaxError when calling .json() on an empty body,
+     * which would bypass the SyntaxError-specific catch below.
+     */
+    if (response.status === 204) {
+      return { data: [] as unknown as TData, status: response.status };
+    }
     try {
       const result = await response.json();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

This branch cherry-picks the fix from PR [#25885](https://github.com/strapi/strapi/pull/25885) (branch `akash-dabhi-qed:fix/25465-safari-mail-regex`) and runs it against the `getstarted` example app to verify the fix works correctly in Chromium.

## The Fix (cherry-picked from #25885)

In `packages/core/admin/admin/src/utils/getFetchClient.ts`, the `responseInterceptor` now short-circuits on `response.status === 204` **before** calling `response.json()`:

```ts
if (response.status === 204) {
  return { data: [] as unknown as TData, status: response.status };
}
```

**Why this matters:** The `POST /admin/forgot-password` endpoint returns `204 No Content`. In Safari, calling `.json()` on an empty body throws a non-`SyntaxError` (`"The string did not match the expected pattern."`), which bypasses the existing `instanceof SyntaxError` catch and surfaces as a form error — even though the API call succeeded. Chrome/Firefox throw a `SyntaxError` which was already caught correctly.

## Test Results (Chromium)

Spun up the `examples/getstarted` app with the fix applied and tested the forgot-password flow end-to-end in Chromium with email `user@example13good.com` (the exact repro email from the issue).

**Result: form submission succeeds, "Email sent" page is shown — no error.**

[forgot_password_fix_chromium_test.mp4](https://cursor.com/agents/bc-7e611671-b2a0-4675-a16e-758f19f76429/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforgot_password_fix_chromium_test.mp4)

### Step-by-step screenshots

[Forgot password form](https://cursor.com/agents/bc-7e611671-b2a0-4675-a16e-758f19f76429/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_forgot_password_form.webp)
[Email user@example13good.com entered](https://cursor.com/agents/bc-7e611671-b2a0-4675-a16e-758f19f76429/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_email_entered.webp)
[Success page: Email sent](https://cursor.com/agents/bc-7e611671-b2a0-4675-a16e-758f19f76429/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04_success_page.webp)

The API call confirms a `204 No Content` response and the frontend correctly transitions to the success page without any error.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e611671-b2a0-4675-a16e-758f19f76429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e611671-b2a0-4675-a16e-758f19f76429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

