### PR TITLE
test(cli): openapi generations

### DIFF
--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -60,3 +60,9 @@ module.exports = () => {
 ### How to run and test CLI commands
 
 See the available tests in the `tests` directory for examples.
+
+### Updating Jest snapshots
+
+Some CLI tests (for example `strapi/strapi/openapi-generate.test.cli.ts`) commit **Jest snapshot** files. After intentional changes to the app template or generator output, regenerate snapshots with `jest … -u` instead of editing `.snap` files by hand.
+
+See **[tests/strapi/strapi/README.md](tests/strapi/strapi/README.md)** for the exact `openapi:generate` snapshot workflow, including when to run `yarn test:cli:clean` / `yarn test:cli --setup`.

--- a/tests/cli/tests/strapi/strapi/README.md
+++ b/tests/cli/tests/strapi/strapi/README.md
@@ -2,6 +2,41 @@
 
 These are the CLI tests for the simple strapi commands that aren't covered by another test domain
 
+## Update OpenAPI snapshots (`openapi-generate.test.cli.ts`)
+
+The `openapi:generate` test compares the generated OpenAPI document to a **Jest snapshot** (`strapi/__snapshots__/openapi-generate.test.cli.ts.snap`). Volatile datetime `default` values are normalized in the test, but any intentional change to the CLI test app template, plugins, content-types, or to the OpenAPI generator will usually require **regenerating that snapshot**.
+
+### When you need to update
+
+- You changed `tests/app-template` (or anything that affects how `test-apps/cli/test-app-0` is built).
+- You intentionally changed `@strapi/openapi` or the `strapi openapi generate` command and expect different JSON output.
+
+### Steps (from the repository root)
+
+1. **Recreate the CLI test app** if the template or setup inputs changed (otherwise the on-disk app may not match what CI uses):
+
+   ```bash
+   yarn test:cli:clean
+   yarn test:cli --setup
+   ```
+
+   You can omit `test:cli:clean` if you only need to refresh snapshots and the test app is already up to date.
+
+2. **Regenerate the snapshot** with Jest’s update flag. The CLI runner sets `TEST_APPS` and `JWT_SECRET`; you must pass the same when running Jest alone:
+
+   ```bash
+   TEST_APPS="$PWD/test-apps/cli/test-app-0" JWT_SECRET=test-jwt-secret \
+     npx jest \
+       --config jest.config.cli.js \
+       --rootDir tests/cli/tests/strapi \
+       tests/cli/tests/strapi/strapi/openapi-generate.test.cli.ts \
+       -u
+   ```
+
+3. **Review the diff** in `tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap` and commit it with your intentional product or template change.
+
+If you skip step 1 after a template edit, you may update the snapshot against a stale `test-app-0` and get a surprise failure in CI.
+
 ## Update list snapshots
 
 To update the \*:list command snapshots:

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -1,0 +1,26508 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`openapi:generate should generate a spec describing i18n and users-permissions content API routes 1`] = `
+{
+  "components": {
+    "schemas": {
+      "AdminUserDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "AdminUserDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "firstname": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "lastname": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "preferedLanguage": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "username": {
+            "description": "A string field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiArticleArticleDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiArticleArticleDocument",
+        "properties": {
+          "authors": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+            },
+            "type": "array",
+          },
+          "content": {
+            "description": "A blocks field",
+            "items": {},
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiArticleArticleDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "seo": {
+            "$ref": "#/components/schemas/MetaSeoEntry",
+            "description": "A component field",
+          },
+          "slug": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "content",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiAuthorAuthorDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiAuthorAuthorDocument",
+        "properties": {
+          "articles": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiArticleArticleDocument",
+            },
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "profile": {
+            "$ref": "#/components/schemas/PluginUploadFileDocument",
+            "description": "A media field",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiCategoryCategoryDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiCategoryCategoryDocument",
+        "properties": {
+          "complexes": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiComplexComplexDocument",
+            },
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "shorttext": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiComplexComplexDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiComplexComplexDocument",
+        "properties": {
+          "admin_users_o2m": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/AdminUserDocument",
+            },
+            "type": "array",
+          },
+          "blocks": {
+            "description": "A blocks field",
+            "items": {},
+            "type": "array",
+          },
+          "boolean": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "A boolean field",
+          },
+          "categories_m2m": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+            },
+            "type": "array",
+          },
+          "component_single": {
+            "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+            "description": "A component field",
+          },
+          "component_two": {
+            "description": "A component field",
+            "items": {
+              "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+            },
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "date": {
+            "description": "A date field",
+            "type": "string",
+          },
+          "datetime": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "dynamic_zone": {
+            "description": "A dynamic zone field",
+            "items": {},
+            "type": "array",
+          },
+          "email": {
+            "description": "An email field",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            "type": "string",
+          },
+          "enum": {
+            "description": "An enum field",
+            "enum": [
+              "first value",
+              "second value",
+              "third value",
+              "fourth value",
+            ],
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "json": {
+            "description": "A JSON field",
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiComplexComplexDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "longtext": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "mediamultiple": {
+            "description": "A media field",
+            "items": {
+              "$ref": "#/components/schemas/PluginUploadFileDocument",
+            },
+            "type": "array",
+          },
+          "mediasingle": {
+            "$ref": "#/components/schemas/PluginUploadFileDocument",
+            "description": "A media field",
+          },
+          "morph2many": {},
+          "morph_to_many": {},
+          "nonlocal_text": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "numberbiginteger": {
+            "description": "A biginteger field",
+            "type": "string",
+          },
+          "numberdecimal": {
+            "description": "A decimal field",
+            "type": "number",
+          },
+          "numberfloat": {
+            "description": "A float field",
+            "type": "number",
+          },
+          "numberinteger": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "required": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "shorttext": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "time": {
+            "description": "A time field",
+            "type": "string",
+          },
+          "uidlongtext": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "uidshorttext": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "uidunattached": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "unique": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "up_user_o2o": {
+            "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+            "description": "A relational field",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "blocks",
+          "required",
+          "publishedAt",
+          "morph2many",
+          "morph_to_many",
+        ],
+        "type": "object",
+      },
+      "ApiCountryCountryDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiCountryCountryDocument",
+        "properties": {
+          "code": {
+            "description": "A string field",
+            "maxLength": 3,
+            "minLength": 2,
+            "type": "string",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiCountryCountryDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "product": {
+            "$ref": "#/components/schemas/ApiProductProductDocument",
+            "description": "A relational field",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "visible": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "A boolean field",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "code",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiHomepageHomepageDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiHomepageHomepageDocument",
+        "properties": {
+          "admin_user": {
+            "$ref": "#/components/schemas/AdminUserDocument",
+            "description": "A relational field",
+          },
+          "content": {
+            "description": "A blocks field",
+            "items": {},
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiHomepageHomepageDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "seo": {
+            "$ref": "#/components/schemas/MetaSeoEntry",
+            "description": "A component field",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "content",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiProductProductDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiProductProductDocument",
+        "properties": {
+          "countries": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiCountryCountryDocument",
+            },
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "description": {
+            "description": "A blocks field",
+            "items": {},
+            "type": "array",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "images": {
+            "description": "A media field",
+            "items": {
+              "$ref": "#/components/schemas/PluginUploadFileDocument",
+            },
+            "type": "array",
+          },
+          "isAvailable": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": true,
+            "description": "A boolean field",
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiProductProductDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "seo": {
+            "$ref": "#/components/schemas/MetaSeoEntry",
+            "description": "A component field",
+          },
+          "sku": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "slug": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "type": {
+            "description": "An enum field",
+            "enum": [
+              "standard",
+              "custom",
+              "cheap",
+              "fancy",
+            ],
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "variations": {
+            "description": "A component field",
+            "items": {
+              "$ref": "#/components/schemas/ProductVariationsEntry",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "slug",
+          "isAvailable",
+          "description",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiShopShopDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiShopShopDocument",
+        "properties": {
+          "content": {
+            "description": "A dynamic zone field",
+            "items": {},
+            "type": "array",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiShopShopDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "seo": {
+            "$ref": "#/components/schemas/MetaSeoEntry",
+            "description": "A component field",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "title",
+          "publishedAt",
+          "content",
+        ],
+        "type": "object",
+      },
+      "ApiSingleTypeLocalizedSingleTypeLocalizedDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiSingleTypeLocalizedSingleTypeLocalizedDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiSingleTypeLocalizedSingleTypeLocalizedDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "shorttext": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiTeamTeamDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiTeamTeamDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "founded": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiTeamTeamDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ApiUniqueUniqueDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ApiUniqueUniqueDocument",
+        "properties": {
+          "UID": {
+            "description": "A UID field",
+            "type": "string",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "identifiers": {
+            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+            "description": "A component field",
+          },
+          "locale": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "localizations": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+            },
+            "readOnly": true,
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "repeatableIdentifiers": {
+            "description": "A component field",
+            "items": {
+              "$ref": "#/components/schemas/UniqueTopLevelEntry",
+            },
+            "type": "array",
+          },
+          "uniqueDate": {
+            "description": "A date field",
+            "type": "string",
+          },
+          "uniqueEmail": {
+            "description": "An email field",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            "type": "string",
+          },
+          "uniqueNumber": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "uniqueString": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ComponentCategoryComponentEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ComponentCategoryComponentEntry",
+        "properties": {
+          "blocks": {
+            "description": "A blocks field",
+            "items": {},
+            "type": "array",
+          },
+          "boolean": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "description": "A boolean field",
+          },
+          "date": {
+            "description": "A date field",
+            "type": "string",
+          },
+          "email": {
+            "description": "An email field",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            "type": "string",
+          },
+          "enum": {
+            "description": "An enum field",
+            "enum": [
+              "first comp value",
+              "second comp value",
+              "third comp value",
+            ],
+            "type": "string",
+          },
+          "json": {
+            "description": "A JSON field",
+          },
+          "longtext": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "markdown": {
+            "description": "A richtext field",
+            "type": "string",
+          },
+          "numberinteger": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "password": {
+            "description": "A password field",
+            "type": "string",
+          },
+          "shorttext": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "user": {
+            "$ref": "#/components/schemas/AdminUserDocument",
+            "description": "A relational field",
+          },
+        },
+        "required": [
+          "blocks",
+        ],
+        "type": "object",
+      },
+      "ComponentCategoryComponentTwoEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ComponentCategoryComponentTwoEntry",
+        "properties": {
+          "nested_component": {
+            "description": "A component field",
+            "items": {
+              "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+            },
+            "type": "array",
+          },
+          "shorttext": {
+            "description": "A string field",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "MetaSeoEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "MetaSeoEntry",
+        "properties": {
+          "description": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "image": {
+            "description": "A media field",
+            "items": {
+              "$ref": "#/components/schemas/PluginUploadFileDocument",
+            },
+            "type": "array",
+          },
+          "indexable": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": false,
+            "description": "A boolean field",
+          },
+          "title": {
+            "description": "A string field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "indexable",
+        ],
+        "type": "object",
+      },
+      "PluginUploadFileDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "PluginUploadFileDocument",
+        "properties": {
+          "alternativeText": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "caption": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "ext": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "focalPoint": {
+            "description": "A JSON field",
+          },
+          "formats": {
+            "description": "A JSON field",
+          },
+          "hash": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "height": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "mime": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "previewUrl": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "provider": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "provider_metadata": {
+            "description": "A JSON field",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "related": {},
+          "size": {
+            "description": "A decimal field",
+            "type": "number",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "url": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "width": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "hash",
+          "mime",
+          "size",
+          "url",
+          "provider",
+          "publishedAt",
+          "related",
+        ],
+        "type": "object",
+      },
+      "PluginUsersPermissionsPermissionDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "PluginUsersPermissionsPermissionDocument",
+        "properties": {
+          "action": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "role": {
+            "$ref": "#/components/schemas/PluginUsersPermissionsRoleDocument",
+            "description": "A relational field",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "action",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "PluginUsersPermissionsRoleDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "PluginUsersPermissionsRoleDocument",
+        "properties": {
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "description": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "permissions": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/PluginUsersPermissionsPermissionDocument",
+            },
+            "type": "array",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "type": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "users": {
+            "description": "A relational field",
+            "items": {
+              "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "name",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "PluginUsersPermissionsUserDocument": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "PluginUsersPermissionsUserDocument",
+        "properties": {
+          "blocked": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": false,
+            "description": "A boolean field",
+          },
+          "confirmed": {
+            "anyOf": [
+              {
+                "type": "boolean",
+              },
+              {
+                "type": "null",
+              },
+            ],
+            "default": false,
+            "description": "A boolean field",
+          },
+          "createdAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "documentId": {
+            "description": "The document ID, represented by a UUID",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+            "type": "string",
+          },
+          "email": {
+            "description": "An email field",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            "type": "string",
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+          "provider": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "publishedAt": {
+            "default": "<generated-at-runtime>",
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "role": {
+            "$ref": "#/components/schemas/PluginUsersPermissionsRoleDocument",
+            "description": "A relational field",
+          },
+          "updatedAt": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "username": {
+            "description": "A string field",
+            "type": "string",
+          },
+        },
+        "required": [
+          "documentId",
+          "id",
+          "username",
+          "email",
+          "confirmed",
+          "blocked",
+          "publishedAt",
+        ],
+        "type": "object",
+      },
+      "ProductVariationsEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "ProductVariationsEntry",
+        "properties": {
+          "description": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "name": {
+            "description": "A string field",
+            "type": "string",
+          },
+          "price": {
+            "description": "A decimal field",
+            "type": "number",
+          },
+          "sku": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+        },
+        "type": "object",
+      },
+      "UniqueAllEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "UniqueAllEntry",
+        "properties": {
+          "ComponentDateDate": {
+            "description": "A date field",
+            "type": "string",
+          },
+          "ComponentDateDateTime": {
+            "description": "A datetime field",
+            "type": "string",
+          },
+          "ComponentDateTime": {
+            "description": "A time field",
+            "type": "string",
+          },
+          "ComponentEmail": {
+            "description": "An email field",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+            "type": "string",
+          },
+          "ComponentNumberBigInteger": {
+            "description": "A biginteger field",
+            "type": "string",
+          },
+          "ComponentNumberDecimal": {
+            "description": "A decimal field",
+            "type": "number",
+          },
+          "ComponentNumberFloat": {
+            "description": "A float field",
+            "type": "number",
+          },
+          "ComponentNumberInteger": {
+            "description": "An integer field",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer",
+          },
+          "ComponentTextLong": {
+            "description": "A text field",
+            "type": "string",
+          },
+          "ComponentTextShort": {
+            "description": "A string field",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "UniqueTopLevelEntry": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "id": "UniqueTopLevelEntry",
+        "properties": {
+          "nestedUnique": {
+            "$ref": "#/components/schemas/UniqueAllEntry",
+            "description": "A component field",
+          },
+        },
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "description": "API documentation for test-app-0 v0.1.0",
+    "title": "test-app-0",
+    "version": "0.1.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/articles": {
+      "get": {
+        "operationId": "article/get/articles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "content",
+                    "slug",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "content",
+                      "slug",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "content",
+                      "slug",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "content",
+                        "slug",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "authors",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "authors",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "authors": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+                            },
+                            "type": "array",
+                          },
+                          "content": {
+                            "description": "A blocks field",
+                            "items": {},
+                            "type": "array",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "seo": {
+                            "$ref": "#/components/schemas/MetaSeoEntry",
+                            "description": "A component field",
+                          },
+                          "slug": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "title": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "content",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "article",
+        ],
+      },
+      "post": {
+        "operationId": "article/post/articles",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "authors",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "authors",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "authors": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "content": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "slug": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "content",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "authors": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+                          },
+                          "type": "array",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "article",
+        ],
+      },
+    },
+    "/articles/{id}": {
+      "delete": {
+        "operationId": "article/delete/articles_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "authors",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "authors",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "authors": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+                          },
+                          "type": "array",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "article",
+        ],
+      },
+      "get": {
+        "operationId": "article/get/articles_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "authors",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "authors",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "title",
+                    "content",
+                    "slug",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "title",
+                      "content",
+                      "slug",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "title",
+                      "content",
+                      "slug",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "title",
+                        "content",
+                        "slug",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "authors": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+                          },
+                          "type": "array",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "article",
+        ],
+      },
+      "put": {
+        "operationId": "article/put/articles_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "slug",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "authors",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "authors",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "authors": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "content": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "slug": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "authors": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiAuthorAuthorDocument",
+                          },
+                          "type": "array",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "article",
+        ],
+      },
+    },
+    "/auth/change-password": {
+      "post": {
+        "operationId": "users-permissions/post/auth_change_password",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "currentPassword": {
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                  "passwordConfirmation": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "currentPassword",
+                  "password",
+                  "passwordConfirmation",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "jwt": {
+                      "type": "string",
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                    },
+                    "user": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "blocked": {
+                          "type": "boolean",
+                        },
+                        "confirmed": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "type": "string",
+                        },
+                        "email": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                        },
+                        "role": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "createdAt": {
+                                  "type": "string",
+                                },
+                                "description": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                },
+                                "id": {
+                                  "type": "number",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "type",
+                                "createdAt",
+                                "updatedAt",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "username": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "username",
+                        "email",
+                        "provider",
+                        "confirmed",
+                        "blocked",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "jwt",
+                    "user",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/email-confirmation": {
+      "get": {
+        "operationId": "users-permissions/get/auth_email_confirmation",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/forgot-password": {
+      "post": {
+        "operationId": "users-permissions/post/auth_forgot_password",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "email",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/local": {
+      "post": {
+        "operationId": "users-permissions/post/auth_local",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "identifier",
+                  "password",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "jwt": {
+                      "type": "string",
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                    },
+                    "user": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "blocked": {
+                          "type": "boolean",
+                        },
+                        "confirmed": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "type": "string",
+                        },
+                        "email": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                        },
+                        "role": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "createdAt": {
+                                  "type": "string",
+                                },
+                                "description": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                },
+                                "id": {
+                                  "type": "number",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "type",
+                                "createdAt",
+                                "updatedAt",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "username": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "username",
+                        "email",
+                        "provider",
+                        "confirmed",
+                        "blocked",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "jwt",
+                    "user",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/local/register": {
+      "post": {
+        "operationId": "users-permissions/post/auth_local_register",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                  "username": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "username",
+                  "email",
+                  "password",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "jwt": {
+                          "type": "string",
+                        },
+                        "refreshToken": {
+                          "type": "string",
+                        },
+                        "user": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "blocked": {
+                              "type": "boolean",
+                            },
+                            "confirmed": {
+                              "type": "boolean",
+                            },
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "documentId": {
+                              "type": "string",
+                            },
+                            "email": {
+                              "type": "string",
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "provider": {
+                              "type": "string",
+                            },
+                            "publishedAt": {
+                              "type": "string",
+                            },
+                            "role": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "createdAt": {
+                                      "type": "string",
+                                    },
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                        },
+                                        {
+                                          "type": "null",
+                                        },
+                                      ],
+                                    },
+                                    "id": {
+                                      "type": "number",
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "description",
+                                    "type",
+                                    "createdAt",
+                                    "updatedAt",
+                                  ],
+                                  "type": "object",
+                                },
+                              ],
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                            "username": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "documentId",
+                            "username",
+                            "email",
+                            "provider",
+                            "confirmed",
+                            "blocked",
+                            "createdAt",
+                            "updatedAt",
+                            "publishedAt",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "jwt",
+                        "user",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "user": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "blocked": {
+                              "type": "boolean",
+                            },
+                            "confirmed": {
+                              "type": "boolean",
+                            },
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "documentId": {
+                              "type": "string",
+                            },
+                            "email": {
+                              "type": "string",
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "provider": {
+                              "type": "string",
+                            },
+                            "publishedAt": {
+                              "type": "string",
+                            },
+                            "role": {
+                              "anyOf": [
+                                {
+                                  "type": "number",
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "createdAt": {
+                                      "type": "string",
+                                    },
+                                    "description": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string",
+                                        },
+                                        {
+                                          "type": "null",
+                                        },
+                                      ],
+                                    },
+                                    "id": {
+                                      "type": "number",
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "description",
+                                    "type",
+                                    "createdAt",
+                                    "updatedAt",
+                                  ],
+                                  "type": "object",
+                                },
+                              ],
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                            "username": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "documentId",
+                            "username",
+                            "email",
+                            "provider",
+                            "confirmed",
+                            "blocked",
+                            "createdAt",
+                            "updatedAt",
+                            "publishedAt",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "user",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/logout": {
+      "post": {
+        "operationId": "users-permissions/post/auth_logout",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/refresh": {
+      "post": {
+        "operationId": "users-permissions/post/auth_refresh",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/reset-password": {
+      "post": {
+        "operationId": "users-permissions/post/auth_reset_password",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "code": {
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                  "passwordConfirmation": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "code",
+                  "password",
+                  "passwordConfirmation",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "jwt": {
+                      "type": "string",
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                    },
+                    "user": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "blocked": {
+                          "type": "boolean",
+                        },
+                        "confirmed": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "type": "string",
+                        },
+                        "email": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                        },
+                        "role": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "createdAt": {
+                                  "type": "string",
+                                },
+                                "description": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                },
+                                "id": {
+                                  "type": "number",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "type",
+                                "createdAt",
+                                "updatedAt",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "username": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "username",
+                        "email",
+                        "provider",
+                        "confirmed",
+                        "blocked",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "jwt",
+                    "user",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/send-email-confirmation": {
+      "post": {
+        "operationId": "users-permissions/post/auth_send_email_confirmation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "email",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                    },
+                    "sent": {
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "email",
+                    "sent",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/auth/{provider}/callback": {
+      "get": {
+        "operationId": "users-permissions/get/auth_by_provider_callback",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "jwt": {
+                      "type": "string",
+                    },
+                    "refreshToken": {
+                      "type": "string",
+                    },
+                    "user": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "blocked": {
+                          "type": "boolean",
+                        },
+                        "confirmed": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "type": "string",
+                        },
+                        "email": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                        },
+                        "role": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "createdAt": {
+                                  "type": "string",
+                                },
+                                "description": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                },
+                                "id": {
+                                  "type": "number",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "description",
+                                "type",
+                                "createdAt",
+                                "updatedAt",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "username": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "username",
+                        "email",
+                        "provider",
+                        "confirmed",
+                        "blocked",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "jwt",
+                    "user",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/authors": {
+      "get": {
+        "operationId": "author/get/authors",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "profile",
+                    "articles",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "profile",
+                      "articles",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "articles": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                            },
+                            "type": "array",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "profile": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                            "description": "A media field",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "author",
+        ],
+      },
+      "post": {
+        "operationId": "author/post/authors",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "profile",
+                    "articles",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "profile",
+                      "articles",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "articles": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "profile": {
+                        "description": "A media field",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "articles": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "profile": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "author",
+        ],
+      },
+    },
+    "/authors/{id}": {
+      "delete": {
+        "operationId": "author/delete/authors_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "profile",
+                    "articles",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "profile",
+                      "articles",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "articles": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "profile": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "author",
+        ],
+      },
+      "get": {
+        "operationId": "author/get/authors_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "profile",
+                    "articles",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "profile",
+                      "articles",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "articles": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "profile": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "author",
+        ],
+      },
+      "put": {
+        "operationId": "author/put/authors_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "profile",
+                    "articles",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "profile",
+                      "articles",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "articles": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "profile": {
+                        "description": "A media field",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "articles": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "profile": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "author",
+        ],
+      },
+    },
+    "/categories": {
+      "get": {
+        "operationId": "category/get/categories",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "shorttext",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "shorttext",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "shorttext",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "shorttext",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complexes",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complexes",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "complexes": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                            },
+                            "type": "array",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "shorttext": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "category",
+        ],
+      },
+      "post": {
+        "operationId": "category/post/categories",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complexes",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complexes",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "complexes": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complexes": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "category",
+        ],
+      },
+    },
+    "/categories/{id}": {
+      "delete": {
+        "operationId": "category/delete/categories_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complexes",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complexes",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complexes": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "category",
+        ],
+      },
+      "get": {
+        "operationId": "category/get/categories_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complexes",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complexes",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "shorttext",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "shorttext",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "shorttext",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "shorttext",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complexes": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "category",
+        ],
+      },
+      "put": {
+        "operationId": "category/put/categories_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complexes",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complexes",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "complexes": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complexes": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "category",
+        ],
+      },
+    },
+    "/complexes": {
+      "get": {
+        "operationId": "complex/get/complexes",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "shorttext",
+                    "longtext",
+                    "boolean",
+                    "blocks",
+                    "json",
+                    "numberinteger",
+                    "numberbiginteger",
+                    "numberdecimal",
+                    "numberfloat",
+                    "email",
+                    "date",
+                    "datetime",
+                    "time",
+                    "password",
+                    "enum",
+                    "uidunattached",
+                    "uidshorttext",
+                    "uidlongtext",
+                    "nonlocal_text",
+                    "required",
+                    "unique",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "shorttext",
+                      "longtext",
+                      "boolean",
+                      "blocks",
+                      "json",
+                      "numberinteger",
+                      "numberbiginteger",
+                      "numberdecimal",
+                      "numberfloat",
+                      "email",
+                      "date",
+                      "datetime",
+                      "time",
+                      "password",
+                      "enum",
+                      "uidunattached",
+                      "uidshorttext",
+                      "uidlongtext",
+                      "nonlocal_text",
+                      "required",
+                      "unique",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "shorttext",
+                      "longtext",
+                      "boolean",
+                      "blocks",
+                      "json",
+                      "numberinteger",
+                      "numberbiginteger",
+                      "numberdecimal",
+                      "numberfloat",
+                      "email",
+                      "date",
+                      "datetime",
+                      "time",
+                      "password",
+                      "enum",
+                      "uidunattached",
+                      "uidshorttext",
+                      "uidlongtext",
+                      "nonlocal_text",
+                      "required",
+                      "unique",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "shorttext",
+                        "longtext",
+                        "boolean",
+                        "blocks",
+                        "json",
+                        "numberinteger",
+                        "numberbiginteger",
+                        "numberdecimal",
+                        "numberfloat",
+                        "email",
+                        "date",
+                        "datetime",
+                        "time",
+                        "password",
+                        "enum",
+                        "uidunattached",
+                        "uidshorttext",
+                        "uidlongtext",
+                        "nonlocal_text",
+                        "required",
+                        "unique",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "morph2many",
+                    "mediamultiple",
+                    "mediasingle",
+                    "component_single",
+                    "up_user_o2o",
+                    "admin_users_o2m",
+                    "categories_m2m",
+                    "morph_to_many",
+                    "component_two",
+                    "dynamic_zone",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "morph2many",
+                      "mediamultiple",
+                      "mediasingle",
+                      "component_single",
+                      "up_user_o2o",
+                      "admin_users_o2m",
+                      "categories_m2m",
+                      "morph_to_many",
+                      "component_two",
+                      "dynamic_zone",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "admin_users_o2m": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/AdminUserDocument",
+                            },
+                            "type": "array",
+                          },
+                          "blocks": {
+                            "description": "A blocks field",
+                            "items": {},
+                            "type": "array",
+                          },
+                          "boolean": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "A boolean field",
+                          },
+                          "categories_m2m": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                            },
+                            "type": "array",
+                          },
+                          "component_single": {
+                            "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+                            "description": "A component field",
+                          },
+                          "component_two": {
+                            "description": "A component field",
+                            "items": {
+                              "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+                            },
+                            "type": "array",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "date": {
+                            "description": "A date field",
+                            "type": "string",
+                          },
+                          "datetime": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "dynamic_zone": {
+                            "description": "A dynamic zone field",
+                            "items": {},
+                            "type": "array",
+                          },
+                          "email": {
+                            "description": "An email field",
+                            "format": "email",
+                            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                            "type": "string",
+                          },
+                          "enum": {
+                            "description": "An enum field",
+                            "enum": [
+                              "first value",
+                              "second value",
+                              "third value",
+                              "fourth value",
+                            ],
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "json": {
+                            "description": "A JSON field",
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "longtext": {
+                            "description": "A text field",
+                            "type": "string",
+                          },
+                          "mediamultiple": {
+                            "description": "A media field",
+                            "items": {
+                              "$ref": "#/components/schemas/PluginUploadFileDocument",
+                            },
+                            "type": "array",
+                          },
+                          "mediasingle": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                            "description": "A media field",
+                          },
+                          "morph2many": {},
+                          "morph_to_many": {},
+                          "nonlocal_text": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "numberbiginteger": {
+                            "description": "A biginteger field",
+                            "type": "string",
+                          },
+                          "numberdecimal": {
+                            "description": "A decimal field",
+                            "type": "number",
+                          },
+                          "numberfloat": {
+                            "description": "A float field",
+                            "type": "number",
+                          },
+                          "numberinteger": {
+                            "description": "An integer field",
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "required": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "shorttext": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "time": {
+                            "description": "A time field",
+                            "type": "string",
+                          },
+                          "uidlongtext": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "uidshorttext": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "uidunattached": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "unique": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "up_user_o2o": {
+                            "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+                            "description": "A relational field",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "blocks",
+                          "required",
+                          "publishedAt",
+                          "morph2many",
+                          "morph_to_many",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "complex",
+        ],
+      },
+      "post": {
+        "operationId": "complex/post/complexes",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "morph2many",
+                    "mediamultiple",
+                    "mediasingle",
+                    "component_single",
+                    "up_user_o2o",
+                    "admin_users_o2m",
+                    "categories_m2m",
+                    "morph_to_many",
+                    "component_two",
+                    "dynamic_zone",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "morph2many",
+                      "mediamultiple",
+                      "mediasingle",
+                      "component_single",
+                      "up_user_o2o",
+                      "admin_users_o2m",
+                      "categories_m2m",
+                      "morph_to_many",
+                      "component_two",
+                      "dynamic_zone",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "admin_users_o2m": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "blocks": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "boolean": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                      "categories_m2m": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "component_single": {
+                        "description": "A component field",
+                      },
+                      "component_two": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "date": {
+                        "description": "A date field",
+                        "type": "string",
+                      },
+                      "datetime": {
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "dynamic_zone": {
+                        "description": "A dynamic zone field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "email": {
+                        "description": "An email field",
+                        "format": "email",
+                        "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                        "type": "string",
+                      },
+                      "enum": {
+                        "description": "An enum field",
+                        "enum": [
+                          "first value",
+                          "second value",
+                          "third value",
+                          "fourth value",
+                        ],
+                        "type": "string",
+                      },
+                      "json": {
+                        "description": "A JSON field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "longtext": {
+                        "description": "A text field",
+                        "type": "string",
+                      },
+                      "mediamultiple": {
+                        "description": "A media field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "mediasingle": {
+                        "description": "A media field",
+                      },
+                      "morph2many": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "morph_to_many": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "nonlocal_text": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "numberbiginteger": {
+                        "description": "A biginteger field",
+                        "type": "string",
+                      },
+                      "numberdecimal": {
+                        "description": "A decimal field",
+                        "type": "number",
+                      },
+                      "numberfloat": {
+                        "description": "A float field",
+                        "type": "number",
+                      },
+                      "numberinteger": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "password": {
+                        "description": "A password field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "required": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "time": {
+                        "description": "A time field",
+                        "type": "string",
+                      },
+                      "uidlongtext": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "uidshorttext": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "uidunattached": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "unique": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "up_user_o2o": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "blocks",
+                      "required",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_users_o2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/AdminUserDocument",
+                          },
+                          "type": "array",
+                        },
+                        "blocks": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "boolean": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "categories_m2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "component_single": {
+                          "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+                          "description": "A component field",
+                        },
+                        "component_two": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "date": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "datetime": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "dynamic_zone": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "email": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "enum": {
+                          "description": "An enum field",
+                          "enum": [
+                            "first value",
+                            "second value",
+                            "third value",
+                            "fourth value",
+                          ],
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "json": {
+                          "description": "A JSON field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "longtext": {
+                          "description": "A text field",
+                          "type": "string",
+                        },
+                        "mediamultiple": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "mediasingle": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "morph2many": {},
+                        "morph_to_many": {},
+                        "nonlocal_text": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "numberbiginteger": {
+                          "description": "A biginteger field",
+                          "type": "string",
+                        },
+                        "numberdecimal": {
+                          "description": "A decimal field",
+                          "type": "number",
+                        },
+                        "numberfloat": {
+                          "description": "A float field",
+                          "type": "number",
+                        },
+                        "numberinteger": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "required": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "time": {
+                          "description": "A time field",
+                          "type": "string",
+                        },
+                        "uidlongtext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidshorttext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidunattached": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "unique": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "up_user_o2o": {
+                          "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+                          "description": "A relational field",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "blocks",
+                        "required",
+                        "publishedAt",
+                        "morph2many",
+                        "morph_to_many",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "complex",
+        ],
+      },
+    },
+    "/complexes/{id}": {
+      "delete": {
+        "operationId": "complex/delete/complexes_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "morph2many",
+                    "mediamultiple",
+                    "mediasingle",
+                    "component_single",
+                    "up_user_o2o",
+                    "admin_users_o2m",
+                    "categories_m2m",
+                    "morph_to_many",
+                    "component_two",
+                    "dynamic_zone",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "morph2many",
+                      "mediamultiple",
+                      "mediasingle",
+                      "component_single",
+                      "up_user_o2o",
+                      "admin_users_o2m",
+                      "categories_m2m",
+                      "morph_to_many",
+                      "component_two",
+                      "dynamic_zone",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_users_o2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/AdminUserDocument",
+                          },
+                          "type": "array",
+                        },
+                        "blocks": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "boolean": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "categories_m2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "component_single": {
+                          "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+                          "description": "A component field",
+                        },
+                        "component_two": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "date": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "datetime": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "dynamic_zone": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "email": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "enum": {
+                          "description": "An enum field",
+                          "enum": [
+                            "first value",
+                            "second value",
+                            "third value",
+                            "fourth value",
+                          ],
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "json": {
+                          "description": "A JSON field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "longtext": {
+                          "description": "A text field",
+                          "type": "string",
+                        },
+                        "mediamultiple": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "mediasingle": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "morph2many": {},
+                        "morph_to_many": {},
+                        "nonlocal_text": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "numberbiginteger": {
+                          "description": "A biginteger field",
+                          "type": "string",
+                        },
+                        "numberdecimal": {
+                          "description": "A decimal field",
+                          "type": "number",
+                        },
+                        "numberfloat": {
+                          "description": "A float field",
+                          "type": "number",
+                        },
+                        "numberinteger": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "required": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "time": {
+                          "description": "A time field",
+                          "type": "string",
+                        },
+                        "uidlongtext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidshorttext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidunattached": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "unique": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "up_user_o2o": {
+                          "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+                          "description": "A relational field",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "blocks",
+                        "required",
+                        "publishedAt",
+                        "morph2many",
+                        "morph_to_many",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "complex",
+        ],
+      },
+      "get": {
+        "operationId": "complex/get/complexes_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "morph2many",
+                    "mediamultiple",
+                    "mediasingle",
+                    "component_single",
+                    "up_user_o2o",
+                    "admin_users_o2m",
+                    "categories_m2m",
+                    "morph_to_many",
+                    "component_two",
+                    "dynamic_zone",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "morph2many",
+                      "mediamultiple",
+                      "mediasingle",
+                      "component_single",
+                      "up_user_o2o",
+                      "admin_users_o2m",
+                      "categories_m2m",
+                      "morph_to_many",
+                      "component_two",
+                      "dynamic_zone",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "shorttext",
+                    "longtext",
+                    "boolean",
+                    "blocks",
+                    "json",
+                    "numberinteger",
+                    "numberbiginteger",
+                    "numberdecimal",
+                    "numberfloat",
+                    "email",
+                    "date",
+                    "datetime",
+                    "time",
+                    "password",
+                    "enum",
+                    "uidunattached",
+                    "uidshorttext",
+                    "uidlongtext",
+                    "nonlocal_text",
+                    "required",
+                    "unique",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "shorttext",
+                      "longtext",
+                      "boolean",
+                      "blocks",
+                      "json",
+                      "numberinteger",
+                      "numberbiginteger",
+                      "numberdecimal",
+                      "numberfloat",
+                      "email",
+                      "date",
+                      "datetime",
+                      "time",
+                      "password",
+                      "enum",
+                      "uidunattached",
+                      "uidshorttext",
+                      "uidlongtext",
+                      "nonlocal_text",
+                      "required",
+                      "unique",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "shorttext",
+                      "longtext",
+                      "boolean",
+                      "blocks",
+                      "json",
+                      "numberinteger",
+                      "numberbiginteger",
+                      "numberdecimal",
+                      "numberfloat",
+                      "email",
+                      "date",
+                      "datetime",
+                      "time",
+                      "password",
+                      "enum",
+                      "uidunattached",
+                      "uidshorttext",
+                      "uidlongtext",
+                      "nonlocal_text",
+                      "required",
+                      "unique",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "shorttext",
+                        "longtext",
+                        "boolean",
+                        "blocks",
+                        "json",
+                        "numberinteger",
+                        "numberbiginteger",
+                        "numberdecimal",
+                        "numberfloat",
+                        "email",
+                        "date",
+                        "datetime",
+                        "time",
+                        "password",
+                        "enum",
+                        "uidunattached",
+                        "uidshorttext",
+                        "uidlongtext",
+                        "nonlocal_text",
+                        "required",
+                        "unique",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_users_o2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/AdminUserDocument",
+                          },
+                          "type": "array",
+                        },
+                        "blocks": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "boolean": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "categories_m2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "component_single": {
+                          "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+                          "description": "A component field",
+                        },
+                        "component_two": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "date": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "datetime": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "dynamic_zone": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "email": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "enum": {
+                          "description": "An enum field",
+                          "enum": [
+                            "first value",
+                            "second value",
+                            "third value",
+                            "fourth value",
+                          ],
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "json": {
+                          "description": "A JSON field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "longtext": {
+                          "description": "A text field",
+                          "type": "string",
+                        },
+                        "mediamultiple": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "mediasingle": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "morph2many": {},
+                        "morph_to_many": {},
+                        "nonlocal_text": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "numberbiginteger": {
+                          "description": "A biginteger field",
+                          "type": "string",
+                        },
+                        "numberdecimal": {
+                          "description": "A decimal field",
+                          "type": "number",
+                        },
+                        "numberfloat": {
+                          "description": "A float field",
+                          "type": "number",
+                        },
+                        "numberinteger": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "required": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "time": {
+                          "description": "A time field",
+                          "type": "string",
+                        },
+                        "uidlongtext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidshorttext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidunattached": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "unique": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "up_user_o2o": {
+                          "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+                          "description": "A relational field",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "blocks",
+                        "required",
+                        "publishedAt",
+                        "morph2many",
+                        "morph_to_many",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "complex",
+        ],
+      },
+      "put": {
+        "operationId": "complex/put/complexes_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "longtext",
+                  "boolean",
+                  "blocks",
+                  "json",
+                  "numberinteger",
+                  "numberbiginteger",
+                  "numberdecimal",
+                  "numberfloat",
+                  "email",
+                  "date",
+                  "datetime",
+                  "time",
+                  "password",
+                  "enum",
+                  "uidunattached",
+                  "uidshorttext",
+                  "uidlongtext",
+                  "nonlocal_text",
+                  "required",
+                  "unique",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "morph2many",
+                    "mediamultiple",
+                    "mediasingle",
+                    "component_single",
+                    "up_user_o2o",
+                    "admin_users_o2m",
+                    "categories_m2m",
+                    "morph_to_many",
+                    "component_two",
+                    "dynamic_zone",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "morph2many",
+                      "mediamultiple",
+                      "mediasingle",
+                      "component_single",
+                      "up_user_o2o",
+                      "admin_users_o2m",
+                      "categories_m2m",
+                      "morph_to_many",
+                      "component_two",
+                      "dynamic_zone",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "admin_users_o2m": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "blocks": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "boolean": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                      "categories_m2m": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "component_single": {
+                        "description": "A component field",
+                      },
+                      "component_two": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "date": {
+                        "description": "A date field",
+                        "type": "string",
+                      },
+                      "datetime": {
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "dynamic_zone": {
+                        "description": "A dynamic zone field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "email": {
+                        "description": "An email field",
+                        "format": "email",
+                        "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                        "type": "string",
+                      },
+                      "enum": {
+                        "description": "An enum field",
+                        "enum": [
+                          "first value",
+                          "second value",
+                          "third value",
+                          "fourth value",
+                        ],
+                        "type": "string",
+                      },
+                      "json": {
+                        "description": "A JSON field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "longtext": {
+                        "description": "A text field",
+                        "type": "string",
+                      },
+                      "mediamultiple": {
+                        "description": "A media field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "mediasingle": {
+                        "description": "A media field",
+                      },
+                      "morph2many": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "morph_to_many": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "nonlocal_text": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "numberbiginteger": {
+                        "description": "A biginteger field",
+                        "type": "string",
+                      },
+                      "numberdecimal": {
+                        "description": "A decimal field",
+                        "type": "number",
+                      },
+                      "numberfloat": {
+                        "description": "A float field",
+                        "type": "number",
+                      },
+                      "numberinteger": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "password": {
+                        "description": "A password field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "required": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "time": {
+                        "description": "A time field",
+                        "type": "string",
+                      },
+                      "uidlongtext": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "uidshorttext": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "uidunattached": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "unique": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "up_user_o2o": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_users_o2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/AdminUserDocument",
+                          },
+                          "type": "array",
+                        },
+                        "blocks": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "boolean": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "categories_m2m": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCategoryCategoryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "component_single": {
+                          "$ref": "#/components/schemas/ComponentCategoryComponentEntry",
+                          "description": "A component field",
+                        },
+                        "component_two": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ComponentCategoryComponentTwoEntry",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "date": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "datetime": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "dynamic_zone": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "email": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "enum": {
+                          "description": "An enum field",
+                          "enum": [
+                            "first value",
+                            "second value",
+                            "third value",
+                            "fourth value",
+                          ],
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "json": {
+                          "description": "A JSON field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "longtext": {
+                          "description": "A text field",
+                          "type": "string",
+                        },
+                        "mediamultiple": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "mediasingle": {
+                          "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          "description": "A media field",
+                        },
+                        "morph2many": {},
+                        "morph_to_many": {},
+                        "nonlocal_text": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "numberbiginteger": {
+                          "description": "A biginteger field",
+                          "type": "string",
+                        },
+                        "numberdecimal": {
+                          "description": "A decimal field",
+                          "type": "number",
+                        },
+                        "numberfloat": {
+                          "description": "A float field",
+                          "type": "number",
+                        },
+                        "numberinteger": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "required": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "time": {
+                          "description": "A time field",
+                          "type": "string",
+                        },
+                        "uidlongtext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidshorttext": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "uidunattached": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "unique": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "up_user_o2o": {
+                          "$ref": "#/components/schemas/PluginUsersPermissionsUserDocument",
+                          "description": "A relational field",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "blocks",
+                        "required",
+                        "publishedAt",
+                        "morph2many",
+                        "morph_to_many",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "complex",
+        ],
+      },
+    },
+    "/conditions": {
+      "get": {
+        "operationId": "condition/get/conditions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "isActive",
+                    "roles",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "isActive",
+                      "roles",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "isActive",
+                      "roles",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "isActive",
+                        "roles",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "country",
+                    "Author",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "country",
+                      "Author",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "Author": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                            },
+                            "type": "array",
+                          },
+                          "country": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                            "description": "A relational field",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "isActive": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "A boolean field",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "roles": {
+                            "description": "An enum field",
+                            "enum": [
+                              "tank",
+                              "dps",
+                              "heal",
+                            ],
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "condition",
+        ],
+      },
+      "post": {
+        "operationId": "condition/post/conditions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "country",
+                    "Author",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "country",
+                      "Author",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "Author": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "country": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "isActive": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "roles": {
+                        "description": "An enum field",
+                        "enum": [
+                          "tank",
+                          "dps",
+                          "heal",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "Author": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "country": {
+                          "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          "description": "A relational field",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "isActive": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "roles": {
+                          "description": "An enum field",
+                          "enum": [
+                            "tank",
+                            "dps",
+                            "heal",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "condition",
+        ],
+      },
+    },
+    "/conditions/{id}": {
+      "delete": {
+        "operationId": "condition/delete/conditions_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "country",
+                    "Author",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "country",
+                      "Author",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "Author": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "country": {
+                          "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          "description": "A relational field",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "isActive": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "roles": {
+                          "description": "An enum field",
+                          "enum": [
+                            "tank",
+                            "dps",
+                            "heal",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "condition",
+        ],
+      },
+      "get": {
+        "operationId": "condition/get/conditions_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "country",
+                    "Author",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "country",
+                      "Author",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "isActive",
+                    "roles",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "isActive",
+                      "roles",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "isActive",
+                      "roles",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "isActive",
+                        "roles",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "Author": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "country": {
+                          "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          "description": "A relational field",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "isActive": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "roles": {
+                          "description": "An enum field",
+                          "enum": [
+                            "tank",
+                            "dps",
+                            "heal",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "condition",
+        ],
+      },
+      "put": {
+        "operationId": "condition/put/conditions_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "isActive",
+                  "roles",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "country",
+                    "Author",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "country",
+                      "Author",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "Author": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "country": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "isActive": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "roles": {
+                        "description": "An enum field",
+                        "enum": [
+                          "tank",
+                          "dps",
+                          "heal",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "Author": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiArticleArticleDocument",
+                          },
+                          "type": "array",
+                        },
+                        "country": {
+                          "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          "description": "A relational field",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "isActive": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "roles": {
+                          "description": "An enum field",
+                          "enum": [
+                            "tank",
+                            "dps",
+                            "heal",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "condition",
+        ],
+      },
+    },
+    "/config/permissions/prune": {
+      "post": {
+        "operationId": "config/post/config_permissions_prune",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "config",
+        ],
+      },
+    },
+    "/config/ratelimit/enable": {
+      "post": {
+        "operationId": "config/post/config_ratelimit_enable",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "config",
+        ],
+      },
+    },
+    "/config/resettransfertoken": {
+      "post": {
+        "operationId": "config/post/config_resettransfertoken",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "config",
+        ],
+      },
+    },
+    "/connect/(.*)": {
+      "get": {
+        "operationId": "users-permissions/get/connect_____",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/content-type-builder/components": {
+      "get": {
+        "operationId": "content-type-builder/get/content_type_builder_components",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "apiId": {
+                            "type": "string",
+                          },
+                          "category": {
+                            "type": "string",
+                          },
+                          "schema": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "attributes": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "allowedTypes": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "multiple": {
+                                          "type": "boolean",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "media",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "multiple",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "autoPopulate": {
+                                          "type": "boolean",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "inversedBy": {
+                                          "type": "string",
+                                        },
+                                        "mappedBy": {
+                                          "type": "string",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "relation": {
+                                          "type": "string",
+                                        },
+                                        "target": {
+                                          "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                                          "type": "string",
+                                        },
+                                        "targetAttribute": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string",
+                                            },
+                                            {
+                                              "type": "null",
+                                            },
+                                          ],
+                                        },
+                                        "type": {
+                                          "const": "relation",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "relation",
+                                        "target",
+                                        "targetAttribute",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "component": {
+                                          "type": "string",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "max": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "repeatable": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "component",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "component",
+                                        "repeatable",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "components": {
+                                          "items": {
+                                            "pattern": "^[\\w-]+\\.[\\w-]+$",
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "max": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "dynamiczone",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "components",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "targetField": {
+                                          "type": "string",
+                                        },
+                                        "type": {
+                                          "const": "uid",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "configurable": {
+                                          "type": "boolean",
+                                        },
+                                        "default": {},
+                                        "enum": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "max": {
+                                          "anyOf": [
+                                            {
+                                              "type": "number",
+                                            },
+                                            {
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "maxLength": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "anyOf": [
+                                            {
+                                              "type": "number",
+                                            },
+                                            {
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "minLength": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "regex": {
+                                          "type": "string",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "type": "string",
+                                        },
+                                        "unique": {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  ],
+                                },
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              "collectionName": {
+                                "type": "string",
+                              },
+                              "connection": {
+                                "type": "string",
+                              },
+                              "description": {
+                                "type": "string",
+                              },
+                              "displayName": {
+                                "type": "string",
+                              },
+                              "icon": {
+                                "type": "string",
+                              },
+                              "pluginOptions": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "displayName",
+                              "description",
+                              "attributes",
+                            ],
+                            "type": "object",
+                          },
+                          "uid": {
+                            "pattern": "^[\\w-]+\\.[\\w-]+$",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "uid",
+                          "category",
+                          "apiId",
+                          "schema",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "content-type-builder",
+        ],
+      },
+    },
+    "/content-type-builder/components/{uid}": {
+      "get": {
+        "operationId": "content-type-builder/get/content_type_builder_components_by_uid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uid",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "pattern": "^[\\w-]+\\.[\\w-]+$",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "apiId": {
+                          "type": "string",
+                        },
+                        "category": {
+                          "type": "string",
+                        },
+                        "schema": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "attributes": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "allowedTypes": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "multiple": {
+                                        "type": "boolean",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "media",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "multiple",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "autoPopulate": {
+                                        "type": "boolean",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "inversedBy": {
+                                        "type": "string",
+                                      },
+                                      "mappedBy": {
+                                        "type": "string",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "relation": {
+                                        "type": "string",
+                                      },
+                                      "target": {
+                                        "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                                        "type": "string",
+                                      },
+                                      "targetAttribute": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "null",
+                                          },
+                                        ],
+                                      },
+                                      "type": {
+                                        "const": "relation",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "relation",
+                                      "target",
+                                      "targetAttribute",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "component": {
+                                        "type": "string",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "max": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "repeatable": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "component",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "component",
+                                      "repeatable",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "components": {
+                                        "items": {
+                                          "pattern": "^[\\w-]+\\.[\\w-]+$",
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "max": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "dynamiczone",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "components",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "targetField": {
+                                        "type": "string",
+                                      },
+                                      "type": {
+                                        "const": "uid",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "configurable": {
+                                        "type": "boolean",
+                                      },
+                                      "default": {},
+                                      "enum": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "max": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number",
+                                          },
+                                          {
+                                            "type": "string",
+                                          },
+                                        ],
+                                      },
+                                      "maxLength": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number",
+                                          },
+                                          {
+                                            "type": "string",
+                                          },
+                                        ],
+                                      },
+                                      "minLength": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "regex": {
+                                        "type": "string",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                      },
+                                      "unique": {
+                                        "type": "boolean",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            "collectionName": {
+                              "type": "string",
+                            },
+                            "connection": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "type": "string",
+                            },
+                            "displayName": {
+                              "type": "string",
+                            },
+                            "icon": {
+                              "type": "string",
+                            },
+                            "pluginOptions": {
+                              "additionalProperties": {},
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "displayName",
+                            "description",
+                            "attributes",
+                          ],
+                          "type": "object",
+                        },
+                        "uid": {
+                          "pattern": "^[\\w-]+\\.[\\w-]+$",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "uid",
+                        "category",
+                        "apiId",
+                        "schema",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "content-type-builder",
+        ],
+      },
+    },
+    "/content-type-builder/content-types": {
+      "get": {
+        "operationId": "content-type-builder/get/content_type_builder_content_types",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "enum": [
+                "collectionType",
+                "singleType",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "apiID": {
+                            "type": "string",
+                          },
+                          "plugin": {
+                            "type": "string",
+                          },
+                          "schema": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "attributes": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "allowedTypes": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "multiple": {
+                                          "type": "boolean",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "media",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "multiple",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "autoPopulate": {
+                                          "type": "boolean",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "inversedBy": {
+                                          "type": "string",
+                                        },
+                                        "mappedBy": {
+                                          "type": "string",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "relation": {
+                                          "type": "string",
+                                        },
+                                        "target": {
+                                          "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                                          "type": "string",
+                                        },
+                                        "targetAttribute": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string",
+                                            },
+                                            {
+                                              "type": "null",
+                                            },
+                                          ],
+                                        },
+                                        "type": {
+                                          "const": "relation",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "relation",
+                                        "target",
+                                        "targetAttribute",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "component": {
+                                          "type": "string",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "max": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "repeatable": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "component",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "component",
+                                        "repeatable",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "components": {
+                                          "items": {
+                                            "pattern": "^[\\w-]+\\.[\\w-]+$",
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "max": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "const": "dynamiczone",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                        "components",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "configurable": {
+                                          "const": false,
+                                          "type": "boolean",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "targetField": {
+                                          "type": "string",
+                                        },
+                                        "type": {
+                                          "const": "uid",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "configurable": {
+                                          "type": "boolean",
+                                        },
+                                        "default": {},
+                                        "enum": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "max": {
+                                          "anyOf": [
+                                            {
+                                              "type": "number",
+                                            },
+                                            {
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "maxLength": {
+                                          "type": "number",
+                                        },
+                                        "min": {
+                                          "anyOf": [
+                                            {
+                                              "type": "number",
+                                            },
+                                            {
+                                              "type": "string",
+                                            },
+                                          ],
+                                        },
+                                        "minLength": {
+                                          "type": "number",
+                                        },
+                                        "pluginOptions": {
+                                          "additionalProperties": {},
+                                          "propertyNames": {
+                                            "type": "string",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "private": {
+                                          "type": "boolean",
+                                        },
+                                        "regex": {
+                                          "type": "string",
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                        },
+                                        "type": {
+                                          "type": "string",
+                                        },
+                                        "unique": {
+                                          "type": "boolean",
+                                        },
+                                      },
+                                      "required": [
+                                        "type",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  ],
+                                },
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              "collectionName": {
+                                "type": "string",
+                              },
+                              "comment": {
+                                "type": "string",
+                              },
+                              "description": {
+                                "type": "string",
+                              },
+                              "displayName": {
+                                "type": "string",
+                              },
+                              "draftAndPublish": {
+                                "type": "boolean",
+                              },
+                              "kind": {
+                                "enum": [
+                                  "collectionType",
+                                  "singleType",
+                                ],
+                                "type": "string",
+                              },
+                              "options": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              "pluginOptions": {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              "pluralName": {
+                                "type": "string",
+                              },
+                              "populateCreatorFields": {
+                                "type": "boolean",
+                              },
+                              "restrictRelationsTo": {
+                                "anyOf": [
+                                  {
+                                    "items": {
+                                      "type": "string",
+                                    },
+                                    "type": "array",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                              },
+                              "reviewWorkflows": {
+                                "type": "boolean",
+                              },
+                              "singularName": {
+                                "type": "string",
+                              },
+                              "version": {
+                                "type": "string",
+                              },
+                              "visible": {
+                                "type": "boolean",
+                              },
+                            },
+                            "required": [
+                              "displayName",
+                              "singularName",
+                              "pluralName",
+                              "description",
+                              "draftAndPublish",
+                              "kind",
+                              "attributes",
+                              "visible",
+                              "restrictRelationsTo",
+                            ],
+                            "type": "object",
+                          },
+                          "uid": {
+                            "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "uid",
+                          "apiID",
+                          "schema",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "content-type-builder",
+        ],
+      },
+    },
+    "/content-type-builder/content-types/{uid}": {
+      "get": {
+        "operationId": "content-type-builder/get/content_type_builder_content_types_by_uid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uid",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "apiID": {
+                          "type": "string",
+                        },
+                        "plugin": {
+                          "type": "string",
+                        },
+                        "schema": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "attributes": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "allowedTypes": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "multiple": {
+                                        "type": "boolean",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "media",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "multiple",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "autoPopulate": {
+                                        "type": "boolean",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "inversedBy": {
+                                        "type": "string",
+                                      },
+                                      "mappedBy": {
+                                        "type": "string",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "relation": {
+                                        "type": "string",
+                                      },
+                                      "target": {
+                                        "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                                        "type": "string",
+                                      },
+                                      "targetAttribute": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "null",
+                                          },
+                                        ],
+                                      },
+                                      "type": {
+                                        "const": "relation",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "relation",
+                                      "target",
+                                      "targetAttribute",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "component": {
+                                        "type": "string",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "max": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "repeatable": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "component",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "component",
+                                      "repeatable",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "components": {
+                                        "items": {
+                                          "pattern": "^[\\w-]+\\.[\\w-]+$",
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "max": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "const": "dynamiczone",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                      "components",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "configurable": {
+                                        "const": false,
+                                        "type": "boolean",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "targetField": {
+                                        "type": "string",
+                                      },
+                                      "type": {
+                                        "const": "uid",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "configurable": {
+                                        "type": "boolean",
+                                      },
+                                      "default": {},
+                                      "enum": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "max": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number",
+                                          },
+                                          {
+                                            "type": "string",
+                                          },
+                                        ],
+                                      },
+                                      "maxLength": {
+                                        "type": "number",
+                                      },
+                                      "min": {
+                                        "anyOf": [
+                                          {
+                                            "type": "number",
+                                          },
+                                          {
+                                            "type": "string",
+                                          },
+                                        ],
+                                      },
+                                      "minLength": {
+                                        "type": "number",
+                                      },
+                                      "pluginOptions": {
+                                        "additionalProperties": {},
+                                        "propertyNames": {
+                                          "type": "string",
+                                        },
+                                        "type": "object",
+                                      },
+                                      "private": {
+                                        "type": "boolean",
+                                      },
+                                      "regex": {
+                                        "type": "string",
+                                      },
+                                      "required": {
+                                        "type": "boolean",
+                                      },
+                                      "type": {
+                                        "type": "string",
+                                      },
+                                      "unique": {
+                                        "type": "boolean",
+                                      },
+                                    },
+                                    "required": [
+                                      "type",
+                                    ],
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            "collectionName": {
+                              "type": "string",
+                            },
+                            "comment": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "type": "string",
+                            },
+                            "displayName": {
+                              "type": "string",
+                            },
+                            "draftAndPublish": {
+                              "type": "boolean",
+                            },
+                            "kind": {
+                              "enum": [
+                                "collectionType",
+                                "singleType",
+                              ],
+                              "type": "string",
+                            },
+                            "options": {
+                              "additionalProperties": {},
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            "pluginOptions": {
+                              "additionalProperties": {},
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            "pluralName": {
+                              "type": "string",
+                            },
+                            "populateCreatorFields": {
+                              "type": "boolean",
+                            },
+                            "restrictRelationsTo": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "reviewWorkflows": {
+                              "type": "boolean",
+                            },
+                            "singularName": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                            "visible": {
+                              "type": "boolean",
+                            },
+                          },
+                          "required": [
+                            "displayName",
+                            "singularName",
+                            "pluralName",
+                            "description",
+                            "draftAndPublish",
+                            "kind",
+                            "attributes",
+                            "visible",
+                            "restrictRelationsTo",
+                          ],
+                          "type": "object",
+                        },
+                        "uid": {
+                          "pattern": "^((strapi|admin)::[\\w-]+|(api|plugin)::[\\w-]+\\.[\\w-]+)$",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "uid",
+                        "apiID",
+                        "schema",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "content-type-builder",
+        ],
+      },
+    },
+    "/countries": {
+      "get": {
+        "operationId": "country/get/countries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "code",
+                    "visible",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "code",
+                      "visible",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "code",
+                      "visible",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "code",
+                        "visible",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "product",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "product",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "code": {
+                            "description": "A string field",
+                            "maxLength": 3,
+                            "minLength": 2,
+                            "type": "string",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "product": {
+                            "$ref": "#/components/schemas/ApiProductProductDocument",
+                            "description": "A relational field",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "visible": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "A boolean field",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "name",
+                          "code",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "country",
+        ],
+      },
+      "post": {
+        "operationId": "country/post/countries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "product",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "product",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "code": {
+                        "description": "A string field",
+                        "maxLength": 3,
+                        "minLength": 2,
+                        "type": "string",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "product": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "visible": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "code",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "description": "A string field",
+                          "maxLength": 3,
+                          "minLength": 2,
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "product": {
+                          "$ref": "#/components/schemas/ApiProductProductDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "visible": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "code",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "country",
+        ],
+      },
+    },
+    "/countries/{id}": {
+      "delete": {
+        "operationId": "country/delete/countries_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "product",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "product",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "description": "A string field",
+                          "maxLength": 3,
+                          "minLength": 2,
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "product": {
+                          "$ref": "#/components/schemas/ApiProductProductDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "visible": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "code",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "country",
+        ],
+      },
+      "get": {
+        "operationId": "country/get/countries_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "product",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "product",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "code",
+                    "visible",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "code",
+                      "visible",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "code",
+                      "visible",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "code",
+                        "visible",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "description": "A string field",
+                          "maxLength": 3,
+                          "minLength": 2,
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "product": {
+                          "$ref": "#/components/schemas/ApiProductProductDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "visible": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "code",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "country",
+        ],
+      },
+      "put": {
+        "operationId": "country/put/countries_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "code",
+                  "visible",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "product",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "product",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "code": {
+                        "description": "A string field",
+                        "maxLength": 3,
+                        "minLength": 2,
+                        "type": "string",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "product": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "visible": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "description": "A boolean field",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "code": {
+                          "description": "A string field",
+                          "maxLength": 3,
+                          "minLength": 2,
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "product": {
+                          "$ref": "#/components/schemas/ApiProductProductDocument",
+                          "description": "A relational field",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "visible": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "description": "A boolean field",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "code",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "country",
+        ],
+      },
+    },
+    "/email": {
+      "post": {
+        "operationId": "email/post/email",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": {
+                  "type": "string",
+                },
+                "properties": {
+                  "bcc": {
+                    "type": "string",
+                  },
+                  "cc": {
+                    "type": "string",
+                  },
+                  "from": {
+                    "type": "string",
+                  },
+                  "html": {
+                    "type": "string",
+                  },
+                  "replyTo": {
+                    "type": "string",
+                  },
+                  "subject": {
+                    "type": "string",
+                  },
+                  "text": {
+                    "type": "string",
+                  },
+                  "to": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "to",
+                  "subject",
+                  "text",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {},
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "email",
+        ],
+      },
+    },
+    "/homepage": {
+      "delete": {
+        "operationId": "homepage/delete/homepage",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "admin_user",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "admin_user",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_user": {
+                          "$ref": "#/components/schemas/AdminUserDocument",
+                          "description": "A relational field",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiHomepageHomepageDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "homepage",
+        ],
+      },
+      "get": {
+        "operationId": "homepage/get/homepage",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "admin_user",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "admin_user",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "content",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_user": {
+                          "$ref": "#/components/schemas/AdminUserDocument",
+                          "description": "A relational field",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiHomepageHomepageDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "homepage",
+        ],
+      },
+      "put": {
+        "operationId": "homepage/put/homepage",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "content",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "admin_user",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "admin_user",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "admin_user": {
+                        "description": "A relational field",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "content": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "admin_user": {
+                          "$ref": "#/components/schemas/AdminUserDocument",
+                          "description": "A relational field",
+                        },
+                        "content": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiHomepageHomepageDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "content",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "homepage",
+        ],
+      },
+    },
+    "/i18n/locales": {
+      "get": {
+        "operationId": "i18n/get/i18n_locales",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "code": {
+                        "maxLength": 2,
+                        "minLength": 2,
+                        "type": "string",
+                      },
+                      "createdAt": {
+                        "type": "string",
+                      },
+                      "documentId": {
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "id": {
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991,
+                        "type": "integer",
+                      },
+                      "isDefault": {
+                        "type": "boolean",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "documentId",
+                      "name",
+                      "code",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "isDefault",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "i18n",
+        ],
+      },
+    },
+    "/products": {
+      "get": {
+        "operationId": "product/get/products",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "slug",
+                    "isAvailable",
+                    "description",
+                    "sku",
+                    "type",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "slug",
+                      "isAvailable",
+                      "description",
+                      "sku",
+                      "type",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "slug",
+                      "isAvailable",
+                      "description",
+                      "sku",
+                      "type",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "sku",
+                        "type",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "images",
+                    "seo",
+                    "variations",
+                    "countries",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "images",
+                      "seo",
+                      "variations",
+                      "countries",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "countries": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                            },
+                            "type": "array",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "description": {
+                            "description": "A blocks field",
+                            "items": {},
+                            "type": "array",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "images": {
+                            "description": "A media field",
+                            "items": {
+                              "$ref": "#/components/schemas/PluginUploadFileDocument",
+                            },
+                            "type": "array",
+                          },
+                          "isAvailable": {
+                            "anyOf": [
+                              {
+                                "type": "boolean",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "default": true,
+                            "description": "A boolean field",
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiProductProductDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "seo": {
+                            "$ref": "#/components/schemas/MetaSeoEntry",
+                            "description": "A component field",
+                          },
+                          "sku": {
+                            "description": "An integer field",
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "slug": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "type": {
+                            "description": "An enum field",
+                            "enum": [
+                              "standard",
+                              "custom",
+                              "cheap",
+                              "fancy",
+                            ],
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "variations": {
+                            "description": "A component field",
+                            "items": {
+                              "$ref": "#/components/schemas/ProductVariationsEntry",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "name",
+                          "slug",
+                          "isAvailable",
+                          "description",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "product",
+        ],
+      },
+      "post": {
+        "operationId": "product/post/products",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "images",
+                    "seo",
+                    "variations",
+                    "countries",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "images",
+                      "seo",
+                      "variations",
+                      "countries",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "countries": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "description": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "images": {
+                        "description": "A media field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "isAvailable": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "default": true,
+                        "description": "A boolean field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "sku": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "slug": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "type": {
+                        "description": "An enum field",
+                        "enum": [
+                          "standard",
+                          "custom",
+                          "cheap",
+                          "fancy",
+                        ],
+                        "type": "string",
+                      },
+                      "variations": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "slug",
+                      "isAvailable",
+                      "description",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "countries": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "images": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "isAvailable": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "default": true,
+                          "description": "A boolean field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiProductProductDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "sku": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "An enum field",
+                          "enum": [
+                            "standard",
+                            "custom",
+                            "cheap",
+                            "fancy",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "variations": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ProductVariationsEntry",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "product",
+        ],
+      },
+    },
+    "/products/{id}": {
+      "delete": {
+        "operationId": "product/delete/products_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "images",
+                    "seo",
+                    "variations",
+                    "countries",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "images",
+                      "seo",
+                      "variations",
+                      "countries",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "countries": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "images": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "isAvailable": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "default": true,
+                          "description": "A boolean field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiProductProductDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "sku": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "An enum field",
+                          "enum": [
+                            "standard",
+                            "custom",
+                            "cheap",
+                            "fancy",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "variations": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ProductVariationsEntry",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "product",
+        ],
+      },
+      "get": {
+        "operationId": "product/get/products_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "images",
+                    "seo",
+                    "variations",
+                    "countries",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "images",
+                      "seo",
+                      "variations",
+                      "countries",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "slug",
+                    "isAvailable",
+                    "description",
+                    "sku",
+                    "type",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "slug",
+                      "isAvailable",
+                      "description",
+                      "sku",
+                      "type",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "slug",
+                      "isAvailable",
+                      "description",
+                      "sku",
+                      "type",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "sku",
+                        "type",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "countries": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "images": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "isAvailable": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "default": true,
+                          "description": "A boolean field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiProductProductDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "sku": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "An enum field",
+                          "enum": [
+                            "standard",
+                            "custom",
+                            "cheap",
+                            "fancy",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "variations": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ProductVariationsEntry",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "product",
+        ],
+      },
+      "put": {
+        "operationId": "product/put/products_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "slug",
+                  "isAvailable",
+                  "description",
+                  "sku",
+                  "type",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "images",
+                    "seo",
+                    "variations",
+                    "countries",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "images",
+                      "seo",
+                      "variations",
+                      "countries",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "countries": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "description": {
+                        "description": "A blocks field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "images": {
+                        "description": "A media field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "isAvailable": {
+                        "anyOf": [
+                          {
+                            "enum": [
+                              "0",
+                              "1",
+                              "t",
+                              "true",
+                              "f",
+                              "false",
+                            ],
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                        "default": true,
+                        "description": "A boolean field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "sku": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "slug": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "type": {
+                        "description": "An enum field",
+                        "enum": [
+                          "standard",
+                          "custom",
+                          "cheap",
+                          "fancy",
+                        ],
+                        "type": "string",
+                      },
+                      "variations": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "countries": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiCountryCountryDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "A blocks field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "images": {
+                          "description": "A media field",
+                          "items": {
+                            "$ref": "#/components/schemas/PluginUploadFileDocument",
+                          },
+                          "type": "array",
+                        },
+                        "isAvailable": {
+                          "anyOf": [
+                            {
+                              "type": "boolean",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                          "default": true,
+                          "description": "A boolean field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiProductProductDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "sku": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "slug": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "An enum field",
+                          "enum": [
+                            "standard",
+                            "custom",
+                            "cheap",
+                            "fancy",
+                          ],
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "variations": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/ProductVariationsEntry",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "name",
+                        "slug",
+                        "isAvailable",
+                        "description",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "product",
+        ],
+      },
+    },
+    "/shop": {
+      "delete": {
+        "operationId": "shop/delete/shop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "content",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "content",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "content": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiShopShopDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                        "content",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "shop",
+        ],
+      },
+      "get": {
+        "operationId": "shop/get/shop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "content",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "content",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "content": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiShopShopDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                        "content",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "shop",
+        ],
+      },
+      "put": {
+        "operationId": "shop/put/shop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "content",
+                    "seo",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "content",
+                      "seo",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "content": {
+                        "description": "A dynamic zone field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "seo": {
+                        "description": "A component field",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "content": {
+                          "description": "A dynamic zone field",
+                          "items": {},
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiShopShopDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "seo": {
+                          "$ref": "#/components/schemas/MetaSeoEntry",
+                          "description": "A component field",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "title",
+                        "publishedAt",
+                        "content",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "shop",
+        ],
+      },
+    },
+    "/single-type-localized": {
+      "delete": {
+        "operationId": "single-type-localized/delete/single_type_localized",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiSingleTypeLocalizedSingleTypeLocalizedDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-localized",
+        ],
+      },
+      "get": {
+        "operationId": "single-type-localized/get/single_type_localized",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiSingleTypeLocalizedSingleTypeLocalizedDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-localized",
+        ],
+      },
+      "put": {
+        "operationId": "single-type-localized/put/single_type_localized",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiSingleTypeLocalizedSingleTypeLocalizedDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-localized",
+        ],
+      },
+    },
+    "/single-type-non-local": {
+      "delete": {
+        "operationId": "single-type-non-local/delete/single_type_non_local",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complex_contents",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complex_contents",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complex_contents": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-non-local",
+        ],
+      },
+      "get": {
+        "operationId": "single-type-non-local/get/single_type_non_local",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complex_contents",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complex_contents",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complex_contents": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-non-local",
+        ],
+      },
+      "put": {
+        "operationId": "single-type-non-local/put/single_type_non_local",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "complex_contents",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "complex_contents",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "complex_contents": {
+                        "description": "A relational field",
+                        "items": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "complex_contents": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiComplexComplexDocument",
+                          },
+                          "type": "array",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-non-local",
+        ],
+      },
+    },
+    "/single-type-unpublished": {
+      "delete": {
+        "operationId": "single-type-unpublished/delete/single_type_unpublished",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-unpublished",
+        ],
+      },
+      "get": {
+        "operationId": "single-type-unpublished/get/single_type_unpublished",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-unpublished",
+        ],
+      },
+      "put": {
+        "operationId": "single-type-unpublished/put/single_type_unpublished",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "shorttext",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "shorttext": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "shorttext": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "single-type-unpublished",
+        ],
+      },
+    },
+    "/teams": {
+      "get": {
+        "operationId": "team/get/teams",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "founded",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "founded",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "founded",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "founded",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "founded": {
+                            "description": "An integer field",
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiTeamTeamDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "name": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "team",
+        ],
+      },
+      "post": {
+        "operationId": "team/post/teams",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "founded": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "founded": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiTeamTeamDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "team",
+        ],
+      },
+    },
+    "/teams/{id}": {
+      "delete": {
+        "operationId": "team/delete/teams_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "founded": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiTeamTeamDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "team",
+        ],
+      },
+      "get": {
+        "operationId": "team/get/teams_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "name",
+                    "founded",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "name",
+                      "founded",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "name",
+                      "founded",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "name",
+                        "founded",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "founded": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiTeamTeamDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "team",
+        ],
+      },
+      "put": {
+        "operationId": "team/put/teams_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "name",
+                  "founded",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "founded": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "founded": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiTeamTeamDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "name": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "team",
+        ],
+      },
+    },
+    "/uniques": {
+      "get": {
+        "operationId": "unique/get/uniques",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "_q",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "uniqueString",
+                    "uniqueNumber",
+                    "uniqueEmail",
+                    "uniqueDate",
+                    "UID",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "uniqueString",
+                      "uniqueNumber",
+                      "uniqueEmail",
+                      "uniqueDate",
+                      "UID",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "uniqueString",
+                      "uniqueNumber",
+                      "uniqueEmail",
+                      "uniqueDate",
+                      "UID",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "uniqueString",
+                        "uniqueNumber",
+                        "uniqueEmail",
+                        "uniqueDate",
+                        "UID",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "identifiers",
+                    "repeatableIdentifiers",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "identifiers",
+                      "repeatableIdentifiers",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "UID": {
+                            "description": "A UID field",
+                            "type": "string",
+                          },
+                          "createdAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "documentId": {
+                            "description": "The document ID, represented by a UUID",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "id": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                          "identifiers": {
+                            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                            "description": "A component field",
+                          },
+                          "locale": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "localizations": {
+                            "description": "A relational field",
+                            "items": {
+                              "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+                            },
+                            "readOnly": true,
+                            "type": "array",
+                          },
+                          "publishedAt": {
+                            "default": "<generated-at-runtime>",
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                          "repeatableIdentifiers": {
+                            "description": "A component field",
+                            "items": {
+                              "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                            },
+                            "type": "array",
+                          },
+                          "uniqueDate": {
+                            "description": "A date field",
+                            "type": "string",
+                          },
+                          "uniqueEmail": {
+                            "description": "An email field",
+                            "format": "email",
+                            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                            "type": "string",
+                          },
+                          "uniqueNumber": {
+                            "description": "An integer field",
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "uniqueString": {
+                            "description": "A string field",
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "description": "A datetime field",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "documentId",
+                          "id",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "unique",
+        ],
+      },
+      "post": {
+        "operationId": "unique/post/uniques",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "identifiers",
+                    "repeatableIdentifiers",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "identifiers",
+                      "repeatableIdentifiers",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "UID": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "identifiers": {
+                        "description": "A component field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "repeatableIdentifiers": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "uniqueDate": {
+                        "description": "A date field",
+                        "type": "string",
+                      },
+                      "uniqueEmail": {
+                        "description": "An email field",
+                        "format": "email",
+                        "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                        "type": "string",
+                      },
+                      "uniqueNumber": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "uniqueString": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "UID": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "identifiers": {
+                          "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          "description": "A component field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "repeatableIdentifiers": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          },
+                          "type": "array",
+                        },
+                        "uniqueDate": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "uniqueEmail": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "uniqueNumber": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "uniqueString": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "unique",
+        ],
+      },
+    },
+    "/uniques/{id}": {
+      "delete": {
+        "operationId": "unique/delete/uniques_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "identifiers",
+                    "repeatableIdentifiers",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "identifiers",
+                      "repeatableIdentifiers",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "UID": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "identifiers": {
+                          "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          "description": "A component field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "repeatableIdentifiers": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          },
+                          "type": "array",
+                        },
+                        "uniqueDate": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "uniqueEmail": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "uniqueNumber": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "uniqueString": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "unique",
+        ],
+      },
+      "get": {
+        "operationId": "unique/get/uniques_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "identifiers",
+                    "repeatableIdentifiers",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "identifiers",
+                      "repeatableIdentifiers",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "enum": [
+                    "uniqueString",
+                    "uniqueNumber",
+                    "uniqueEmail",
+                    "uniqueDate",
+                    "UID",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                    "locale",
+                  ],
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "enum": [
+                      "uniqueString",
+                      "uniqueNumber",
+                      "uniqueEmail",
+                      "uniqueDate",
+                      "UID",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "enum": [
+                      "uniqueString",
+                      "uniqueNumber",
+                      "uniqueEmail",
+                      "uniqueDate",
+                      "UID",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                      "locale",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "enum": [
+                        "uniqueString",
+                        "uniqueNumber",
+                        "uniqueEmail",
+                        "uniqueDate",
+                        "UID",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                        "locale",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the result",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "UID": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "identifiers": {
+                          "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          "description": "A component field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "repeatableIdentifiers": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          },
+                          "type": "array",
+                        },
+                        "uniqueDate": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "uniqueEmail": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "uniqueNumber": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "uniqueString": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "unique",
+        ],
+      },
+      "put": {
+        "operationId": "unique/put/uniques_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The document ID, represented by a UUID",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "uniqueString",
+                  "uniqueNumber",
+                  "uniqueEmail",
+                  "uniqueDate",
+                  "UID",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                  "locale",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [
+                    "identifiers",
+                    "repeatableIdentifiers",
+                    "localizations",
+                  ],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [
+                      "identifiers",
+                      "repeatableIdentifiers",
+                      "localizations",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Select a locale",
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "UID": {
+                        "description": "A UID field",
+                        "type": "string",
+                      },
+                      "identifiers": {
+                        "description": "A component field",
+                      },
+                      "locale": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "repeatableIdentifiers": {
+                        "description": "A component field",
+                        "items": {},
+                        "type": "array",
+                      },
+                      "uniqueDate": {
+                        "description": "A date field",
+                        "type": "string",
+                      },
+                      "uniqueEmail": {
+                        "description": "An email field",
+                        "format": "email",
+                        "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                        "type": "string",
+                      },
+                      "uniqueNumber": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "uniqueString": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "UID": {
+                          "description": "A UID field",
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "identifiers": {
+                          "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          "description": "A component field",
+                        },
+                        "locale": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "localizations": {
+                          "description": "A relational field",
+                          "items": {
+                            "$ref": "#/components/schemas/ApiUniqueUniqueDocument",
+                          },
+                          "readOnly": true,
+                          "type": "array",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "repeatableIdentifiers": {
+                          "description": "A component field",
+                          "items": {
+                            "$ref": "#/components/schemas/UniqueTopLevelEntry",
+                          },
+                          "type": "array",
+                        },
+                        "uniqueDate": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "uniqueEmail": {
+                          "description": "An email field",
+                          "format": "email",
+                          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                          "type": "string",
+                        },
+                        "uniqueNumber": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "uniqueString": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "unique",
+        ],
+      },
+    },
+    "/upcoming-match": {
+      "delete": {
+        "operationId": "upcoming-match/delete/upcoming_match",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "number_of_upcoming_matches",
+                  "next_match",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "next_match": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "number_of_upcoming_matches": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upcoming-match",
+        ],
+      },
+      "get": {
+        "operationId": "upcoming-match/get/upcoming_match",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "number_of_upcoming_matches",
+                  "next_match",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Filters to apply to the query",
+              "propertyNames": {
+                "enum": [
+                  "title",
+                  "number_of_upcoming_matches",
+                  "next_match",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "next_match": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "number_of_upcoming_matches": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upcoming-match",
+        ],
+      },
+      "put": {
+        "operationId": "upcoming-match/put/upcoming_match",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "The fields to return, this doesn't include populatable fields like relations, components, files, or dynamic zones",
+              "items": {
+                "enum": [
+                  "title",
+                  "number_of_upcoming_matches",
+                  "next_match",
+                  "createdAt",
+                  "updatedAt",
+                  "publishedAt",
+                ],
+                "type": "string",
+              },
+              "readOnly": true,
+              "type": "array",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "description": "Populate all the first level relations, components, files, and dynamic zones for the entry",
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a single relation, component, file, or dynamic zone",
+                  "enum": [],
+                  "readOnly": true,
+                  "type": "string",
+                },
+                {
+                  "description": "Populate a selection of multiple relations, components, files, or dynamic zones",
+                  "items": {
+                    "enum": [],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "description": "Fetch documents based on their status. Default to "published" if not specified.",
+              "enum": [
+                "draft",
+                "published",
+              ],
+              "type": "string",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "hasPublishedVersion",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "boolean",
+                },
+                {
+                  "enum": [
+                    "true",
+                    "false",
+                  ],
+                  "type": "string",
+                },
+              ],
+              "description": "Filter documents by whether they have a published version. Use with status=draft to find documents that have never been published",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "data": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "next_match": {
+                        "description": "A date field",
+                        "type": "string",
+                      },
+                      "number_of_upcoming_matches": {
+                        "description": "A float field",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "publishedAt": {
+                        "default": "<generated-at-runtime>",
+                        "description": "A datetime field",
+                        "type": "string",
+                      },
+                      "title": {
+                        "description": "A string field",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "documentId": {
+                          "description": "The document ID, represented by a UUID",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "number",
+                            },
+                          ],
+                        },
+                        "next_match": {
+                          "description": "A date field",
+                          "type": "string",
+                        },
+                        "number_of_upcoming_matches": {
+                          "description": "An integer field",
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "publishedAt": {
+                          "default": "<generated-at-runtime>",
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                        "title": {
+                          "description": "A string field",
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "description": "A datetime field",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "documentId",
+                        "id",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upcoming-match",
+        ],
+      },
+    },
+    "/upload": {
+      "post": {
+        "operationId": "upload/post/upload",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alternativeText": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "caption": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "createdBy": {
+                          "type": "number",
+                        },
+                        "documentId": {
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                          "type": "string",
+                        },
+                        "ext": {
+                          "type": "string",
+                        },
+                        "folder": {
+                          "type": "number",
+                        },
+                        "folderPath": {
+                          "type": "string",
+                        },
+                        "formats": {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string",
+                          },
+                          "type": "object",
+                        },
+                        "hash": {
+                          "type": "string",
+                        },
+                        "height": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                        "id": {
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "mime": {
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "previewUrl": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                        "provider_metadata": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": {},
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "size": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "updatedBy": {
+                          "type": "number",
+                        },
+                        "url": {
+                          "type": "string",
+                        },
+                        "width": {
+                          "maximum": 9007199254740991,
+                          "minimum": -9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "name",
+                        "hash",
+                        "mime",
+                        "size",
+                        "url",
+                        "folderPath",
+                        "provider",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "alternativeText": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "caption": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "createdAt": {
+                            "type": "string",
+                          },
+                          "createdBy": {
+                            "type": "number",
+                          },
+                          "documentId": {
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "ext": {
+                            "type": "string",
+                          },
+                          "folder": {
+                            "type": "number",
+                          },
+                          "folderPath": {
+                            "type": "string",
+                          },
+                          "formats": {
+                            "additionalProperties": {},
+                            "propertyNames": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "id": {
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "type": "integer",
+                          },
+                          "mime": {
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                          "previewUrl": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "provider": {
+                            "type": "string",
+                          },
+                          "provider_metadata": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "size": {
+                            "type": "number",
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                          },
+                          "updatedBy": {
+                            "type": "number",
+                          },
+                          "url": {
+                            "type": "string",
+                          },
+                          "width": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "documentId",
+                          "name",
+                          "hash",
+                          "mime",
+                          "size",
+                          "url",
+                          "folderPath",
+                          "provider",
+                          "createdAt",
+                          "updatedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upload",
+        ],
+      },
+    },
+    "/upload/files": {
+      "get": {
+        "operationId": "upload/get/upload_files",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the results by specified fields",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Apply filters to the query",
+              "propertyNames": {
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "alternativeText": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "caption": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "createdAt": {
+                        "type": "string",
+                      },
+                      "createdBy": {
+                        "type": "number",
+                      },
+                      "documentId": {
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                        "type": "string",
+                      },
+                      "ext": {
+                        "type": "string",
+                      },
+                      "folder": {
+                        "type": "number",
+                      },
+                      "folderPath": {
+                        "type": "string",
+                      },
+                      "formats": {
+                        "additionalProperties": {},
+                        "propertyNames": {
+                          "type": "string",
+                        },
+                        "type": "object",
+                      },
+                      "hash": {
+                        "type": "string",
+                      },
+                      "height": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                      "id": {
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991,
+                        "type": "integer",
+                      },
+                      "mime": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "previewUrl": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "provider": {
+                        "type": "string",
+                      },
+                      "provider_metadata": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": {},
+                            "propertyNames": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          {
+                            "type": "null",
+                          },
+                        ],
+                      },
+                      "size": {
+                        "type": "number",
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                      },
+                      "updatedBy": {
+                        "type": "number",
+                      },
+                      "url": {
+                        "type": "string",
+                      },
+                      "width": {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "documentId",
+                      "name",
+                      "hash",
+                      "mime",
+                      "size",
+                      "url",
+                      "folderPath",
+                      "provider",
+                      "createdAt",
+                      "updatedAt",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upload",
+        ],
+      },
+    },
+    "/upload/files/{id}": {
+      "delete": {
+        "operationId": "upload/delete/upload_files_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "alternativeText": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "caption": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "createdBy": {
+                      "type": "number",
+                    },
+                    "documentId": {
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                      "type": "string",
+                    },
+                    "ext": {
+                      "type": "string",
+                    },
+                    "folder": {
+                      "type": "number",
+                    },
+                    "folderPath": {
+                      "type": "string",
+                    },
+                    "formats": {
+                      "additionalProperties": {},
+                      "propertyNames": {
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "hash": {
+                      "type": "string",
+                    },
+                    "height": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer",
+                    },
+                    "id": {
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
+                      "type": "integer",
+                    },
+                    "mime": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "previewUrl": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "provider_metadata": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string",
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "size": {
+                      "type": "number",
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "updatedBy": {
+                      "type": "number",
+                    },
+                    "url": {
+                      "type": "string",
+                    },
+                    "width": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "name",
+                    "hash",
+                    "mime",
+                    "size",
+                    "url",
+                    "folderPath",
+                    "provider",
+                    "createdAt",
+                    "updatedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upload",
+        ],
+      },
+      "get": {
+        "operationId": "upload/get/upload_files_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "type": "integer",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "alternativeText": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "caption": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "createdBy": {
+                      "type": "number",
+                    },
+                    "documentId": {
+                      "format": "uuid",
+                      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                      "type": "string",
+                    },
+                    "ext": {
+                      "type": "string",
+                    },
+                    "folder": {
+                      "type": "number",
+                    },
+                    "folderPath": {
+                      "type": "string",
+                    },
+                    "formats": {
+                      "additionalProperties": {},
+                      "propertyNames": {
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "hash": {
+                      "type": "string",
+                    },
+                    "height": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer",
+                    },
+                    "id": {
+                      "exclusiveMinimum": 0,
+                      "maximum": 9007199254740991,
+                      "type": "integer",
+                    },
+                    "mime": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "previewUrl": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "provider_metadata": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string",
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "size": {
+                      "type": "number",
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "updatedBy": {
+                      "type": "number",
+                    },
+                    "url": {
+                      "type": "string",
+                    },
+                    "width": {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "name",
+                    "hash",
+                    "mime",
+                    "size",
+                    "url",
+                    "folderPath",
+                    "provider",
+                    "createdAt",
+                    "updatedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upload",
+        ],
+      },
+    },
+    "/users": {
+      "get": {
+        "operationId": "users-permissions/get/users",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the results by specified fields",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Apply filters to the query",
+              "propertyNames": {
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "blocked": {
+                        "type": "boolean",
+                      },
+                      "confirmed": {
+                        "type": "boolean",
+                      },
+                      "createdAt": {
+                        "type": "string",
+                      },
+                      "documentId": {
+                        "type": "string",
+                      },
+                      "email": {
+                        "type": "string",
+                      },
+                      "id": {
+                        "type": "number",
+                      },
+                      "provider": {
+                        "type": "string",
+                      },
+                      "publishedAt": {
+                        "type": "string",
+                      },
+                      "role": {
+                        "anyOf": [
+                          {
+                            "type": "number",
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "createdAt": {
+                                "type": "string",
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "null",
+                                  },
+                                ],
+                              },
+                              "id": {
+                                "type": "number",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                              "type": {
+                                "type": "string",
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "description",
+                              "type",
+                              "createdAt",
+                              "updatedAt",
+                            ],
+                            "type": "object",
+                          },
+                        ],
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                      },
+                      "username": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "documentId",
+                      "username",
+                      "email",
+                      "provider",
+                      "confirmed",
+                      "blocked",
+                      "createdAt",
+                      "updatedAt",
+                      "publishedAt",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+      "post": {
+        "operationId": "users-permissions/post/users",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                  "role": {
+                    "type": "number",
+                  },
+                  "username": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "username",
+                  "email",
+                  "password",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean",
+                    },
+                    "confirmed": {
+                      "type": "boolean",
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "documentId": {
+                      "type": "string",
+                    },
+                    "email": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "publishedAt": {
+                      "type": "string",
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "description",
+                            "type",
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "username": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "username",
+                    "email",
+                    "provider",
+                    "confirmed",
+                    "blocked",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users-permissions/permissions": {
+      "get": {
+        "operationId": "users-permissions/get/users_permissions_permissions",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "permissions": {
+                      "additionalProperties": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "controllers": {
+                            "additionalProperties": {
+                              "additionalProperties": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                  },
+                                  "policy": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "enabled",
+                                  "policy",
+                                ],
+                                "type": "object",
+                              },
+                              "propertyNames": {
+                                "type": "string",
+                              },
+                              "type": "object",
+                            },
+                            "propertyNames": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "controllers",
+                        ],
+                        "type": "object",
+                      },
+                      "propertyNames": {
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "permissions",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users-permissions/roles": {
+      "get": {
+        "operationId": "users-permissions/get/users_permissions_roles",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "roles": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "createdAt": {
+                            "type": "string",
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "documentId": {
+                            "type": "string",
+                          },
+                          "id": {
+                            "type": "number",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                          "nb_users": {
+                            "type": "number",
+                          },
+                          "permissions": {
+                            "additionalProperties": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "controllers": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "enabled": {
+                                          "type": "boolean",
+                                        },
+                                        "policy": {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "enabled",
+                                        "policy",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "propertyNames": {
+                                      "type": "string",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "propertyNames": {
+                                    "type": "string",
+                                  },
+                                  "type": "object",
+                                },
+                              },
+                              "required": [
+                                "controllers",
+                              ],
+                              "type": "object",
+                            },
+                            "propertyNames": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          "publishedAt": {
+                            "type": "string",
+                          },
+                          "type": {
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                          },
+                          "users": {
+                            "items": {},
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "documentId",
+                          "name",
+                          "description",
+                          "type",
+                          "createdAt",
+                          "updatedAt",
+                          "publishedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "roles",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+      "post": {
+        "operationId": "users-permissions/post/users_permissions_roles",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "permissions": {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "name",
+                  "type",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users-permissions/roles/{id}": {
+      "get": {
+        "operationId": "users-permissions/get/users_permissions_roles_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "createdAt": {
+                          "type": "string",
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                            },
+                            {
+                              "type": "null",
+                            },
+                          ],
+                        },
+                        "documentId": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "nb_users": {
+                          "type": "number",
+                        },
+                        "permissions": {
+                          "additionalProperties": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "controllers": {
+                                "additionalProperties": {
+                                  "additionalProperties": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "enabled": {
+                                        "type": "boolean",
+                                      },
+                                      "policy": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "enabled",
+                                      "policy",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "propertyNames": {
+                                    "type": "string",
+                                  },
+                                  "type": "object",
+                                },
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "controllers",
+                            ],
+                            "type": "object",
+                          },
+                          "propertyNames": {
+                            "type": "string",
+                          },
+                          "type": "object",
+                        },
+                        "publishedAt": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                        },
+                        "users": {
+                          "items": {},
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "documentId",
+                        "name",
+                        "description",
+                        "type",
+                        "createdAt",
+                        "updatedAt",
+                        "publishedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "role",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users-permissions/roles/{role}": {
+      "delete": {
+        "operationId": "users-permissions/delete/users_permissions_roles_by_role",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "role",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+      "put": {
+        "operationId": "users-permissions/put/users_permissions_roles_by_role",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "role",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "permissions": {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                    },
+                  },
+                  "required": [
+                    "ok",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users/count": {
+      "get": {
+        "operationId": "users-permissions/get/users_count",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Apply filters to the query",
+              "propertyNames": {
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "number",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users/me": {
+      "get": {
+        "operationId": "users-permissions/get/users_me",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean",
+                    },
+                    "confirmed": {
+                      "type": "boolean",
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "documentId": {
+                      "type": "string",
+                    },
+                    "email": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "publishedAt": {
+                      "type": "string",
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "description",
+                            "type",
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "username": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "username",
+                    "email",
+                    "provider",
+                    "confirmed",
+                    "blocked",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+    "/users/{id}": {
+      "delete": {
+        "operationId": "users-permissions/delete/users_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean",
+                    },
+                    "confirmed": {
+                      "type": "boolean",
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "documentId": {
+                      "type": "string",
+                    },
+                    "email": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "publishedAt": {
+                      "type": "string",
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "description",
+                            "type",
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "username": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "username",
+                    "email",
+                    "provider",
+                    "confirmed",
+                    "blocked",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+      "get": {
+        "operationId": "users-permissions/get/users_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean",
+                    },
+                    "confirmed": {
+                      "type": "boolean",
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "documentId": {
+                      "type": "string",
+                    },
+                    "email": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "publishedAt": {
+                      "type": "string",
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "description",
+                            "type",
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "username": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "username",
+                    "email",
+                    "provider",
+                    "confirmed",
+                    "blocked",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+      "put": {
+        "operationId": "users-permissions/put/users_by_id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+                    "type": "string",
+                  },
+                  "password": {
+                    "type": "string",
+                  },
+                  "role": {
+                    "type": "number",
+                  },
+                  "username": {
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean",
+                    },
+                    "confirmed": {
+                      "type": "boolean",
+                    },
+                    "createdAt": {
+                      "type": "string",
+                    },
+                    "documentId": {
+                      "type": "string",
+                    },
+                    "email": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "provider": {
+                      "type": "string",
+                    },
+                    "publishedAt": {
+                      "type": "string",
+                    },
+                    "role": {
+                      "anyOf": [
+                        {
+                          "type": "number",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "createdAt": {
+                              "type": "string",
+                            },
+                            "description": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                },
+                                {
+                                  "type": "null",
+                                },
+                              ],
+                            },
+                            "id": {
+                              "type": "number",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "description",
+                            "type",
+                            "createdAt",
+                            "updatedAt",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                    },
+                    "username": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "documentId",
+                    "username",
+                    "email",
+                    "provider",
+                    "confirmed",
+                    "blocked",
+                    "createdAt",
+                    "updatedAt",
+                    "publishedAt",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "users-permissions",
+        ],
+      },
+    },
+  },
+  "x-powered-by": "strapi",
+  "x-strapi-version": "5.41.1",
+}
+`;

--- a/tests/cli/tests/strapi/strapi/openapi-generate.test.cli.ts
+++ b/tests/cli/tests/strapi/strapi/openapi-generate.test.cli.ts
@@ -1,20 +1,57 @@
-import path from 'node:path';
 import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import coffee from 'coffee';
+import stripAnsi from 'strip-ansi';
 
 import { getTestApps } from '../../../../utils/get-test-apps';
 
-/**
- * This test ensures that `strapi openapi generate` includes content API routes
- * from the i18n and users-permissions plugins in the generated specification.
- */
+/** Recursively sort object keys for stable JSON snapshots (arrays keep order). */
+const sortKeysDeep = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    sorted[key] = sortKeysDeep(obj[key]);
+  }
+  return sorted;
+};
+
+/** OpenAPI generator fills `default` on datetime fields with "now", which changes every run. */
+const ISO_DATETIME_DEFAULT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const replaceVolatileDatetimeDefaults = (value: unknown): unknown => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(replaceVolatileDatetimeDefaults);
+  }
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    const v = obj[key];
+    if (key === 'default' && typeof v === 'string' && ISO_DATETIME_DEFAULT.test(v)) {
+      out[key] = '<generated-at-runtime>';
+    } else {
+      out[key] = replaceVolatileDatetimeDefaults(v);
+    }
+  }
+  return out;
+};
+
 describe('openapi:generate', () => {
-  let appPath;
+  let appPath: string;
   const OUTPUT_FILE = 'openapi-spec.json';
 
   beforeAll(async () => {
     const testApps = getTestApps();
-    appPath = testApps.at(0);
+    appPath = testApps.at(0) as string;
   });
 
   afterEach(async () => {
@@ -24,14 +61,13 @@ describe('openapi:generate', () => {
   });
 
   it('should generate a spec describing i18n and users-permissions content API routes', async () => {
-    await coffee
+    const { stdout, stderr } = await coffee
       .spawn('npm', ['run', '-s', 'strapi', 'openapi', 'generate', '--', '-o', OUTPUT_FILE], {
         cwd: appPath,
       })
       .expect('code', 0)
       .end();
 
-    // Generate an openapi spec for the test app and read it's contents
     const specPath = path.join(appPath, OUTPUT_FILE);
     const raw = await fs.readFile(specPath, 'utf8');
     const spec = JSON.parse(raw);
@@ -43,17 +79,39 @@ describe('openapi:generate', () => {
 
     const hasPathEndingWith = (suffix: string) => paths.some((p) => p.endsWith(suffix));
 
-    // Checking for known plugin routes - ensuring the plugins are covered by
-    // the openapi spec
-
-    // i18n
     expect(hasPathEndingWith('/locales')).toBe(true);
-
-    // users-permissions
     expect(hasPathEndingWith('/auth/local')).toBe(true);
     expect(hasPathEndingWith('/auth/local/register')).toBe(true);
     expect(hasPathEndingWith('/auth/{provider}/callback')).toBe(true);
     expect(hasPathEndingWith('/users')).toBe(true);
     expect(hasPathEndingWith('/users/{id}')).toBe(true);
+
+    // Full document snapshot (stable key order, volatile datetime defaults normalized)
+    expect(sortKeysDeep(replaceVolatileDatetimeDefaults(spec))).toMatchSnapshot();
+
+    const plainOut = stripAnsi(stdout);
+    const plainErr = stripAnsi(stderr);
+
+    expect(plainOut).toMatch(/Generated an OpenAPI specification for/);
+    expect(plainOut).toMatch(/in \d+ms/);
+    expect(plainErr).toMatch(/OpenAPI generation feature is currently experimental/);
+  });
+
+  it('should print debug logs when DEBUG matches strapi OpenAPI namespaces', async () => {
+    const { stderr } = await coffee
+      .spawn('npm', ['run', '-s', 'strapi', 'openapi', 'generate', '--', '-o', OUTPUT_FILE], {
+        cwd: appPath,
+        env: {
+          ...process.env,
+          // Sub-loggers use strapi:core:openapi:<section>; wildcard enables them all
+          DEBUG: 'strapi:core:openapi*',
+        },
+      })
+      .expect('code', 0)
+      .end();
+
+    const plainErr = stripAnsi(stderr);
+    expect(plainErr).toMatch(/strapi:core:openapi:generator/);
+    expect(plainErr).toMatch(/generating a new OpenAPI document/);
   });
 });


### PR DESCRIPTION
### What does it do?

- adds openapi generate CLI tests

### Why is it needed?

they were not implemented yet

### How to test it?

`yarn test:cli`

### Related issue(s)/PR(s)

Closes CMS-28
