### PR TITLE
fix: prevent trailing ? in URL when params is empty object (#25724)

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -370,7 +370,10 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
          * It's considered a breaking change because it impacts any API request, including the user's custom code
          */
         const serializedParams = qs.stringify(params, { encode: false });
-        return `${url}?${serializedParams}`;
+        if (serializedParams) {
+          return `${url}?${serializedParams}`;
+        }
+        return url;
       }
       return url;
     };

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -52,6 +52,22 @@ describe('getFetchClient', () => {
     );
   });
 
+  it('should not append a trailing ? when params is an empty object', async () => {
+    (window.fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({ data: 'success response' }),
+      })
+    );
+    const fetchClient = getFetchClient();
+    await fetchClient.get('test-fetch-client', { params: {} });
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://localhost:1337/test-fetch-client',
+      expect.anything()
+    );
+  });
+
   it('should serialize a params object to a string', async () => {
     (window.fetch as jest.Mock).mockImplementationOnce(() =>
       Promise.resolve({

--- a/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
+++ b/packages/core/content-manager/server/src/history/services/__tests__/lifecycles.test.ts
@@ -15,7 +15,14 @@ const mockGetRequestContext = jest.fn(() => {
   };
 });
 
+const mockHistoryVersionCreate = jest.fn();
+
 const mockStrapi = {
+  admin: {
+    services: {
+      'persist-tables': { persistTablesWithPrefix: jest.fn() },
+    },
+  },
   service: jest.fn((name: string) => {
     if (name === 'admin::persist-tables') {
       return { persistTablesWithPrefix: jest.fn() };
@@ -23,15 +30,23 @@ const mockStrapi = {
   }),
   plugins: {
     'content-manager': {
-      service: jest.fn(() => ({
-        getMetadata: jest.fn().mockResolvedValue([]),
-        getStatus: jest.fn(),
-      })),
+      services: {
+        'document-metadata': {
+          getMetadata: jest.fn().mockResolvedValue([]),
+          getStatus: jest.fn(),
+        },
+      },
     },
     i18n: {
-      service: jest.fn(() => ({
-        getDefaultLocale: jest.fn().mockReturnValue('en'),
-      })),
+      services: {
+        locales: {
+          getDefaultLocale: jest.fn().mockReturnValue('en'),
+          find: jest.fn().mockResolvedValue([]),
+        },
+        'content-types': {
+          isLocalizedContentType: jest.fn().mockReturnValue(false),
+        },
+      },
     },
   },
   // @ts-expect-error - Ignore
@@ -40,9 +55,10 @@ const mockStrapi = {
     query(uid: UID.ContentType) {
       if (uid === HISTORY_VERSION_UID) {
         return {
-          create: jest.fn(),
+          create: mockHistoryVersionCreate,
         };
       }
+      return { findMany: jest.fn().mockResolvedValue([]) };
     },
     transaction(cb: any) {
       const opt = {
@@ -62,6 +78,10 @@ const mockStrapi = {
   documents: jest.fn(() => ({
     findOne: jest.fn(),
   })),
+  getModel: jest.fn(() => ({ attributes: {} })),
+  contentTypes: {
+    'api::article.article': { options: { draftAndPublish: true } },
+  },
   requestContext: {
     get: mockGetRequestContext,
   },
@@ -74,6 +94,10 @@ const mockStrapi = {
 };
 // @ts-expect-error - ignore
 mockStrapi.documents.use = jest.fn();
+
+// shouldCreateHistoryVersion reads from the global `strapi`, not the param.
+// @ts-expect-error - global strapi
+global.strapi = mockStrapi;
 
 // @ts-expect-error - we're not mocking the full Strapi object
 const lifecyclesService = createLifecyclesService({ strapi: mockStrapi });
@@ -101,5 +125,53 @@ describe('history lifecycles service', () => {
         }),
       })
     );
+  });
+
+  describe('publish dedup guard', () => {
+    // The middleware suppresses the `update` history version that the publish
+    // action emits as a side-effect on the draft, so users see one version per
+    // publish. The guard checks the request URL — query strings (e.g. `?locale=en`
+    // for i18n) must not break it. Issue #25724.
+    let useMiddleware: (context: any, next: () => Promise<any>) => Promise<any>;
+
+    beforeAll(async () => {
+      await lifecyclesService.bootstrap();
+      // @ts-expect-error - mock
+      useMiddleware = mockStrapi.documents.use.mock.calls[0][0];
+    });
+
+    beforeEach(() => {
+      mockHistoryVersionCreate.mockClear();
+    });
+
+    const callMiddleware = async (url: string) => {
+      mockGetRequestContext.mockReturnValue({
+        state: { user: { id: '123' } },
+        request: { url },
+      });
+
+      await useMiddleware(
+        {
+          action: 'update',
+          contentType: { uid: 'api::article.article' },
+          params: { documentId: 'doc-1', locale: 'en' },
+        },
+        async () => ({ documentId: 'doc-1' })
+      );
+    };
+
+    it('skips creating a history version when URL ends with /actions/publish', async () => {
+      await callMiddleware(
+        '/content-manager/collection-types/api::article.article/doc-1/actions/publish'
+      );
+      expect(mockHistoryVersionCreate).not.toHaveBeenCalled();
+    });
+
+    it('skips creating a history version when URL has /actions/publish followed by query params', async () => {
+      await callMiddleware(
+        '/content-manager/collection-types/api::article.article/doc-1/actions/publish?locale=en'
+      );
+      expect(mockHistoryVersionCreate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/content-manager/server/src/history/services/lifecycles.ts
+++ b/packages/core/content-manager/server/src/history/services/lifecycles.ts
@@ -43,7 +43,7 @@ const shouldCreateHistoryVersion = (
    */
   if (
     context.action === 'update' &&
-    strapi.requestContext.get()?.request.url.endsWith('/actions/publish')
+    strapi.requestContext.get()?.request.url.split('?')[0].endsWith('/actions/publish')
   ) {
     return false;
   }


### PR DESCRIPTION
## What does it do?

When `params` is an empty object `{}`, `qs.stringify({})` returns an empty string `""`, resulting in URLs like `/actions/publish?` with a trailing `?`.

## Why is it needed?

The trailing `?` breaks the deduplication guard in the content-manager history lifecycles service:

```typescript
// lifecycles.ts line 46
strapi.requestContext.get()?.request.url.endsWith('/actions/publish')
```

This check fails because the actual URL is `/actions/publish?` (with trailing `?`), causing duplicate history versions to be created on publish.

## How to test it?

1. Create any collection type entry with Draft & Publish enabled
2. Save the draft
3. Click Publish
4. Open Content History for the document
5. Verify: only ONE history version is created (not two)

## Related issue(s)

Fixes #25724

## Root Cause

The `paramsSerializer` in `getFetchClient.ts` doesn't check if `qs.stringify()` returns an empty string before appending `?` to the URL.