### PR TITLE
fix: throw ValidationError when populate exceeds qs arrayLimit (#25632)

### DIFF
--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -1,4 +1,12 @@
 import { traverseQueryPopulate } from '../traverse';
+import {
+  defaultValidatePopulate,
+  POPULATE_TRAVERSALS,
+  FILTER_TRAVERSALS,
+  SORT_TRAVERSALS,
+  FIELDS_TRAVERSALS,
+  validatePopulate,
+} from '../validate/validators';
 
 describe('traverseQueryPopulate', () => {
   global.strapi = {
@@ -245,6 +253,50 @@ describe('traverseQueryPopulate', () => {
           name: 'test',
         },
       },
+    });
+  });
+
+  /**
+   * When qs parses indexed populate keys beyond arrayLimit (default 100), populate is a plain
+   * object with consecutive numeric string keys instead of an array. Validation runs on that
+   * shape before convert-query-params — see #25632 / PR #25916.
+   */
+  describe('qs arrayLimit exceeded (indexed populate notation)', () => {
+    const schema = {
+      kind: 'collectionType' as const,
+      attributes: {
+        title: { type: 'string' as const },
+        slug: { type: 'string' as const },
+      },
+    };
+
+    const getModel = jest.fn(() => schema);
+
+    const populateAsQsObject = Object.fromEntries(
+      Array.from({ length: 101 }, (_, index) => [String(index), `field${index}`])
+    );
+
+    beforeEach(() => {
+      global.strapi = { getModel } as any;
+    });
+
+    test('defaultValidatePopulate throws a clear arrayLimit error', async () => {
+      await expect(
+        defaultValidatePopulate({ schema, getModel }, populateAsQsObject)
+      ).rejects.toThrow(
+        'Too many populate entries (101). The maximum number of populate entries when using array notation is 100.'
+      );
+    });
+
+    test('validatePopulate does not throw the misleading Invalid key 2 error', async () => {
+      await expect(
+        validatePopulate({ schema, getModel }, populateAsQsObject, {
+          filters: FILTER_TRAVERSALS,
+          sort: SORT_TRAVERSALS,
+          fields: FIELDS_TRAVERSALS,
+          populate: POPULATE_TRAVERSALS,
+        })
+      ).rejects.not.toThrow(/Invalid key 2/);
     });
   });
 });

--- a/packages/core/utils/src/__tests__/query-populate.test.ts
+++ b/packages/core/utils/src/__tests__/query-populate.test.ts
@@ -298,5 +298,15 @@ describe('traverseQueryPopulate', () => {
         })
       ).rejects.not.toThrow(/Invalid key 2/);
     });
+
+    test('does not throw arrayLimit error when numeric-key object is within the limit', async () => {
+      const populateWithinLimit = Object.fromEntries(
+        Array.from({ length: 100 }, (_, index) => [String(index), `field${index}`])
+      );
+
+      await expect(
+        defaultValidatePopulate({ schema, getModel }, populateWithinLimit)
+      ).rejects.not.toThrow(/Too many populate entries/);
+    });
   });
 });

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -23,7 +23,7 @@ import {
   isDynamicZoneAttribute,
   isMorphToRelationalAttribute,
 } from './content-types';
-import { PaginationError } from './errors';
+import { PaginationError, ValidationError } from './errors';
 import { isOperator } from './operators';
 
 import parseType from './parse-type';
@@ -332,6 +332,15 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (_.isPlainObject(populate)) {
+      // Detect when qs converts a large array to an object with numeric keys
+      // (due to arrayLimit). See: https://github.com/strapi/strapi/issues/25632
+      const keys = Object.keys(populate);
+      if (keys.length > 0 && keys.every((k) => String(Number(k)) === k && Number(k) >= 0)) {
+        throw new ValidationError(
+          `Too many populate entries (${keys.length}). The maximum number of populate entries when using array notation is 100. ` +
+            'Consider using object notation (populate[field]=true), nested population, or reducing the number of fields.'
+        );
+      }
       return convertPopulateObject(populate, schema);
     }
 

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -23,7 +23,7 @@ import {
   isDynamicZoneAttribute,
   isMorphToRelationalAttribute,
 } from './content-types';
-import { PaginationError, ValidationError } from './errors';
+import { PaginationError } from './errors';
 import { isOperator } from './operators';
 
 import parseType from './parse-type';
@@ -332,15 +332,6 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
     }
 
     if (_.isPlainObject(populate)) {
-      // Detect when qs converts a large array to an object with numeric keys
-      // (due to arrayLimit). See: https://github.com/strapi/strapi/issues/25632
-      const keys = Object.keys(populate);
-      if (keys.length > 0 && keys.every((k) => String(Number(k)) === k && Number(k) >= 0)) {
-        throw new ValidationError(
-          `Too many populate entries (${keys.length}). The maximum number of populate entries when using array notation is 100. ` +
-            'Consider using object notation (populate[field]=true), nested population, or reducing the number of fields.'
-        );
-      }
       return convertPopulateObject(populate, schema);
     }
 

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -42,7 +42,7 @@ const isQsArrayLimitPopulateObject = (value: unknown): value is Record<string, s
     return false;
   }
 
-  return keys.every((key) => typeof value[key] === 'string');
+  return Object.values(value).every((entry) => typeof entry === 'string');
 };
 
 const throwQsArrayLimitPopulateError = (entryCount: number) => {

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -17,6 +17,40 @@ import {
 import traverseFactory, { type Parent } from './factory';
 import { Attribute } from '../types';
 import { isMorphToRelationalAttribute } from '../content-types';
+import { ValidationError } from '../errors';
+
+const DEFAULT_QS_ARRAY_LIMIT = 100;
+
+/**
+ * Detects objects with consecutive numeric string keys and string values — the shape `qs`
+ * produces when indexed array notation exceeds `arrayLimit` (see #25632).
+ */
+const isQsArrayLimitPopulateObject = (value: unknown): value is Record<string, string> => {
+  if (!isObject(value) || isArray(value)) {
+    return false;
+  }
+
+  const keys = Object.keys(value);
+
+  if (keys.length === 0) {
+    return false;
+  }
+
+  const hasConsecutiveNumericKeys = keys.every((key, index) => key === String(index));
+
+  if (!hasConsecutiveNumericKeys) {
+    return false;
+  }
+
+  return keys.every((key) => typeof value[key] === 'string');
+};
+
+const throwQsArrayLimitPopulateError = (entryCount: number) => {
+  throw new ValidationError(
+    `Too many populate entries (${entryCount}). The maximum number of populate entries when using array notation is ${DEFAULT_QS_ARRAY_LIMIT}. ` +
+      'Consider using object notation (populate[field]=true), nested population, or reducing the number of fields.'
+  );
+};
 
 const isKeyword = (keyword: string) => {
   return ({ key, attribute }: { key: string; attribute: Attribute }) => {
@@ -54,6 +88,9 @@ const populate = traverseFactory()
     );
 
     return paths.filter((item) => !isNil(item));
+  })
+  .intercept(isQsArrayLimitPopulateObject, async (_visitor, _options, populate) => {
+    throwQsArrayLimitPopulateError(Object.keys(populate).length);
   })
   // for wildcard, generate custom utilities to modify the values
   .parse(isWildcard, () => ({

--- a/packages/core/utils/src/traverse/query-populate.ts
+++ b/packages/core/utils/src/traverse/query-populate.ts
@@ -32,7 +32,7 @@ const isQsArrayLimitPopulateObject = (value: unknown): value is Record<string, s
 
   const keys = Object.keys(value);
 
-  if (keys.length === 0) {
+  if (keys.length === 0 || keys.length <= DEFAULT_QS_ARRAY_LIMIT) {
     return false;
   }
 

--- a/tests/api/core/strapi/api/populate/query-array-limit-populate.test.api.js
+++ b/tests/api/core/strapi/api/populate/query-array-limit-populate.test.api.js
@@ -128,13 +128,18 @@ describe('Content API | populate (qs arrayLimit)', () => {
       if (builder) await builder.cleanup();
     });
 
-    test('does not return 200 when the request has more than 100 indexed populate keys', async () => {
+    test('returns 400 with a clear arrayLimit error when the request has more than 100 indexed populate keys', async () => {
       const res = await rq({
         method: 'GET',
         url: `/pop-array-limit-hubs?${buildIndexedPopulateQuery(INDEXED_POPULATE_COUNT)}`,
       });
 
-      expect(res.statusCode).not.toBe(200);
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toMatchObject({
+        name: 'ValidationError',
+        message: expect.stringContaining(`Too many populate entries (${INDEXED_POPULATE_COUNT})`),
+      });
+      expect(res.body.error.message).not.toMatch(/Invalid key 2/);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #25632

When a `populate` query parameter has more than 100 entries using array notation (`populate[0]=...&populate[1]=...`), the `qs` parser (configured with `arrayLimit: 100`) converts the array to an object with numeric string keys instead of an array.

**Before**: The object was passed through populate query validation, which treated numeric keys as field names, producing a confusing `"Invalid key 2"` error (500 Internal Server Error).

**After**: We detect this case early and throw a clear `ValidationError` (400 Bad Request) with actionable guidance:

```
Too many populate entries (101). The maximum number of populate entries when using array notation is 100.
Consider using object notation (populate[field]=true), nested population, or reducing the number of fields.
```

## Changes

1. Added `ValidationError` import from `./errors` in `traverse/query-populate.ts`
2. Added numeric-key detection in `traverseQueryPopulate()` (via an intercept) before numeric keys are validated as field names

## Context

As discussed in [#25632](https://github.com/strapi/strapi/issues/25632) and previous PRs #25633, #25736 — the `arrayLimit` of 100 is intentional for DoS protection and should not be increased. Instead, the error message should clearly communicate the limit to users (per @innerdvations feedback).