### PR TITLE
fix(data-transfer): pull stage totals, batch limits, and async writable backpressure

### DIFF
--- a/packages/core/data-transfer/src/directory/providers/source/index.ts
+++ b/packages/core/data-transfer/src/directory/providers/source/index.ts
@@ -12,6 +12,7 @@ import type { IAsset, IMetadata, ISourceProvider, ProviderType } from '../../../
 import type { IDiagnosticReporter } from '../../../utils/diagnostic';
 
 import * as utils from '../../../utils';
+import { writeWritableAsync } from '../../../utils/write-writable-async';
 import { ProviderInitializationError, ProviderTransferError } from '../../../errors/providers';
 import { unknownPathToPosix } from '../../../file/providers/source/utils';
 
@@ -196,7 +197,7 @@ class LocalDirectorySourceProvider implements ISourceProvider {
           stats: { size: stat.size },
           stream: fs.createReadStream(absUpload),
         };
-        outStream.write(asset);
+        await writeWritableAsync(outStream, asset);
       }
     }
     outStream.end();
@@ -246,7 +247,7 @@ class LocalDirectorySourceProvider implements ISourceProvider {
 
       try {
         for await (const chunk of stream) {
-          outStream.write(chunk);
+          await writeWritableAsync(outStream, chunk);
         }
       } catch (e: unknown) {
         outStream.destroy(

--- a/packages/core/data-transfer/src/file/providers/source/index.ts
+++ b/packages/core/data-transfer/src/file/providers/source/index.ts
@@ -15,6 +15,7 @@ import type { IAsset, IMetadata, ISourceProvider, ProviderType, IFile } from '..
 import type { IDiagnosticReporter } from '../../../utils/diagnostic';
 
 import * as utils from '../../../utils';
+import { writeWritableAsync } from '../../../utils/write-writable-async';
 import { ProviderInitializationError, ProviderTransferError } from '../../../errors/providers';
 import { isFilePathInDirname, isPathEquivalent, unknownPathToPosix } from './utils';
 
@@ -167,6 +168,9 @@ class LocalFileSourceProvider implements ISourceProvider {
     const loadAssetMetadata = this.#loadAssetMetadata.bind(this);
     this.#reportInfo('creating assets read stream');
 
+    /** Tar parser may finish the pipeline before async onReadEntry work completes; end only after. */
+    let entryWorkChain = Promise.resolve();
+
     pipeline(
       [
         inStream,
@@ -179,27 +183,34 @@ class LocalFileSourceProvider implements ISourceProvider {
             return isFilePathInDirname('assets/uploads', filePath);
           },
           async onReadEntry(entry: ReadEntry) {
-            const { path: filePath, size = 0 } = entry;
-            const normalizedPath = unknownPathToPosix(filePath);
-            const file = path.basename(normalizedPath);
-            let metadata;
-            try {
-              metadata = await loadAssetMetadata(`assets/metadata/${file}.json`);
-            } catch (error) {
-              throw new Error(`Failed to read metadata for ${file}`);
-            }
-            const asset: IAsset = {
-              metadata,
-              filename: file,
-              filepath: normalizedPath,
-              stats: { size },
-              stream: entry as unknown as Readable,
-            };
-            outStream.write(asset);
+            const work = (async () => {
+              const { path: filePath, size = 0 } = entry;
+              const normalizedPath = unknownPathToPosix(filePath);
+              const file = path.basename(normalizedPath);
+              let metadata;
+              try {
+                metadata = await loadAssetMetadata(`assets/metadata/${file}.json`);
+              } catch (error) {
+                throw new Error(`Failed to read metadata for ${file}`);
+              }
+              const asset: IAsset = {
+                metadata,
+                filename: file,
+                filepath: normalizedPath,
+                stats: { size },
+                stream: entry as unknown as Readable,
+              };
+              await writeWritableAsync(outStream, asset);
+            })();
+            entryWorkChain = entryWorkChain.then(() => work);
+            await work;
           },
         }),
       ],
-      () => outStream.end()
+      async () => {
+        await entryWorkChain;
+        outStream.end();
+      }
     );
 
     return outStream;
@@ -233,6 +244,8 @@ class LocalFileSourceProvider implements ISourceProvider {
 
     const outStream = new PassThrough({ objectMode: true });
 
+    let entryWorkChain = Promise.resolve();
+
     pipeline(
       [
         inStream,
@@ -246,41 +259,44 @@ class LocalFileSourceProvider implements ISourceProvider {
           },
 
           async onReadEntry(entry: ReadEntry) {
-            const transforms = [
-              // JSONL parser to read the data chunks one by one (line by line)
-              parser({
-                checkErrors: true,
-              }),
-              // The JSONL parser returns each line as key/value
-              (line: { key: string; value: object }) => line.value,
-            ];
+            const work = (async () => {
+              const transforms = [
+                // JSONL parser to read the data chunks one by one (line by line)
+                parser({
+                  checkErrors: true,
+                }),
+                // The JSONL parser returns each line as key/value
+                (line: { key: string; value: object }) => line.value,
+              ];
 
-            const stream = entry.pipe(chain(transforms));
+              const stream = entry.pipe(chain(transforms));
 
-            try {
-              for await (const chunk of stream) {
-                outStream.write(chunk);
+              try {
+                for await (const chunk of stream) {
+                  await writeWritableAsync(outStream, chunk);
+                }
+              } catch (e: unknown) {
+                outStream.destroy(
+                  new ProviderTransferError(
+                    `Error parsing backup files from backup file ${entry.path}: ${
+                      (e as Error).message
+                    }`,
+                    {
+                      details: {
+                        error: e,
+                      },
+                    }
+                  )
+                );
               }
-            } catch (e: unknown) {
-              outStream.destroy(
-                new ProviderTransferError(
-                  `Error parsing backup files from backup file ${entry.path}: ${
-                    (e as Error).message
-                  }`,
-                  {
-                    details: {
-                      error: e,
-                    },
-                  }
-                )
-              );
-            }
+            })();
+            entryWorkChain = entryWorkChain.then(() => work);
+            await work;
           },
         }),
       ],
       async () => {
-        // Manually send the 'end' event to the out stream
-        // once every entry has finished streaming its content
+        await entryWorkChain;
         outStream.end();
       }
     );

--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-configuration-totals.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-configuration-totals.test.ts
@@ -1,0 +1,41 @@
+import type { Core } from '@strapi/types';
+
+import { estimateConfigurationTotals } from '../estimate-configuration-totals';
+
+describe('estimateConfigurationTotals', () => {
+  test('sums core-store and webhook counts', async () => {
+    const strapi = {
+      db: {
+        query: jest.fn((uid: string) => {
+          if (uid === 'strapi::core-store') {
+            return { count: jest.fn().mockResolvedValue(4) };
+          }
+          if (uid === 'strapi::webhook') {
+            return { count: jest.fn().mockResolvedValue(2) };
+          }
+          return { count: jest.fn().mockResolvedValue(0) };
+        }),
+      },
+    } as unknown as Core.Strapi;
+
+    await expect(estimateConfigurationTotals(strapi)).resolves.toEqual({ totalCount: 6 });
+  });
+
+  test('ignores failures from one store', async () => {
+    const strapi = {
+      db: {
+        query: jest.fn((uid: string) => {
+          if (uid === 'strapi::core-store') {
+            return { count: jest.fn().mockRejectedValue(new Error('no')) };
+          }
+          if (uid === 'strapi::webhook') {
+            return { count: jest.fn().mockResolvedValue(3) };
+          }
+          return { count: jest.fn().mockResolvedValue(0) };
+        }),
+      },
+    } as unknown as Core.Strapi;
+
+    await expect(estimateConfigurationTotals(strapi)).resolves.toEqual({ totalCount: 3 });
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-entity-totals.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-entity-totals.test.ts
@@ -1,0 +1,46 @@
+import type { Core } from '@strapi/types';
+
+import { estimateEntityTotals } from '../estimate-entity-totals';
+
+describe('estimateEntityTotals', () => {
+  test('sums db counts for each content type', async () => {
+    const strapi = {
+      contentTypes: {
+        'api::a.a': { uid: 'api::a.a' },
+        'api::b.b': { uid: 'api::b.b' },
+      },
+      db: {
+        query: jest.fn((uid: string) => {
+          if (uid === 'api::a.a') {
+            return { count: jest.fn().mockResolvedValue(3) };
+          }
+          if (uid === 'api::b.b') {
+            return { count: jest.fn().mockResolvedValue(5) };
+          }
+          return { count: jest.fn().mockResolvedValue(0) };
+        }),
+      },
+    } as unknown as Core.Strapi;
+
+    await expect(estimateEntityTotals(strapi)).resolves.toEqual({ totalCount: 8 });
+  });
+
+  test('skips content types whose count throws', async () => {
+    const strapi = {
+      contentTypes: {
+        'api::ok.ok': { uid: 'api::ok.ok' },
+        'api::bad.bad': { uid: 'api::bad.bad' },
+      },
+      db: {
+        query: jest.fn((uid: string) => {
+          if (uid === 'api::ok.ok') {
+            return { count: jest.fn().mockResolvedValue(2) };
+          }
+          return { count: jest.fn().mockRejectedValue(new Error('no table')) };
+        }),
+      },
+    } as unknown as Core.Strapi;
+
+    await expect(estimateEntityTotals(strapi)).resolves.toEqual({ totalCount: 2 });
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-link-totals.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/__tests__/estimate-link-totals.test.ts
@@ -1,0 +1,32 @@
+import type { Core } from '@strapi/types';
+
+import { estimateLinkTotals } from '../estimate-link-totals';
+
+jest.mock('../../../queries/link', () => ({
+  createLinkQuery: jest.fn(() => () => ({
+    countAllForUid: jest.fn().mockImplementation(async (uid: string) => {
+      if (uid === 'api::a.a') {
+        return 10;
+      }
+      if (uid === 'default.foo') {
+        return 5;
+      }
+      return 0;
+    }),
+  })),
+}));
+
+describe('estimateLinkTotals', () => {
+  test('sums countAllForUid across content types and components', async () => {
+    const strapi = {
+      contentTypes: {
+        'api::a.a': {},
+      },
+      components: {
+        'default.foo': {},
+      },
+    } as unknown as Core.Strapi;
+
+    await expect(estimateLinkTotals(strapi)).resolves.toEqual({ totalCount: 15 });
+  });
+});

--- a/packages/core/data-transfer/src/strapi/providers/local-source/estimate-configuration-totals.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/estimate-configuration-totals.ts
@@ -1,0 +1,26 @@
+import type { Core } from '@strapi/types';
+
+import type { StageTotalsEstimate } from '../../../../types';
+
+/**
+ * Count configuration rows the same scope as {@link createConfigurationStream} (core store + webhooks).
+ */
+export async function estimateConfigurationTotals(
+  strapi: Core.Strapi
+): Promise<StageTotalsEstimate> {
+  let totalCount = 0;
+
+  try {
+    totalCount += await strapi.db.query('strapi::core-store').count();
+  } catch {
+    // Match configuration stream: skip if unavailable
+  }
+
+  try {
+    totalCount += await strapi.db.query('strapi::webhook').count();
+  } catch {
+    // skip
+  }
+
+  return { totalCount };
+}

--- a/packages/core/data-transfer/src/strapi/providers/local-source/estimate-entity-totals.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/estimate-entity-totals.ts
@@ -1,0 +1,20 @@
+import type { Core } from '@strapi/types';
+
+import type { StageTotalsEstimate } from '../../../../types';
+
+/**
+ * Count entities the same scope as {@link createEntitiesStream} (all content types), for progress totals / ETA.
+ */
+export async function estimateEntityTotals(strapi: Core.Strapi): Promise<StageTotalsEstimate> {
+  let totalCount = 0;
+
+  for (const contentType of Object.values(strapi.contentTypes)) {
+    try {
+      totalCount += await strapi.db.query(contentType.uid).count();
+    } catch {
+      // Match createEntitiesStream: skip content types that fail to stream
+    }
+  }
+
+  return { totalCount };
+}

--- a/packages/core/data-transfer/src/strapi/providers/local-source/estimate-link-totals.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/estimate-link-totals.ts
@@ -1,0 +1,24 @@
+import type { Core } from '@strapi/types';
+
+import type { StageTotalsEstimate } from '../../../../types';
+import { createLinkQuery } from '../../queries/link';
+
+/**
+ * Count links the same scope as {@link createLinksStream} (content types + components, owner relations).
+ */
+export async function estimateLinkTotals(strapi: Core.Strapi): Promise<StageTotalsEstimate> {
+  const query = createLinkQuery(strapi)();
+  const uids = [...Object.keys(strapi.contentTypes), ...Object.keys(strapi.components)] as string[];
+
+  let totalCount = 0;
+
+  for (const uid of uids) {
+    try {
+      totalCount += await query.countAllForUid(uid);
+    } catch {
+      // Match createLinksStream: skip uids that fail
+    }
+  }
+
+  return { totalCount };
+}

--- a/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/index.ts
@@ -9,6 +9,9 @@ import { createLinksStream } from './links';
 import { createConfigurationStream } from './configuration';
 import { createAssetsStream } from './assets';
 import { estimateAssetTotals } from './estimate-asset-totals';
+import { estimateConfigurationTotals } from './estimate-configuration-totals';
+import { estimateEntityTotals } from './estimate-entity-totals';
+import { estimateLinkTotals } from './estimate-link-totals';
 import * as utils from '../../../utils';
 import { assertValidStrapi } from '../../../utils/providers';
 
@@ -176,14 +179,29 @@ class LocalStrapiSourceProvider implements ISourceProvider {
   }
 
   async getStageTotals(stage: TransferStage) {
-    if (stage !== 'assets') {
-      return null;
+    if (stage === 'assets') {
+      assertValidStrapi(this.strapi, 'Not able to estimate asset totals');
+      return estimateAssetTotals(this.strapi);
     }
-    assertValidStrapi(this.strapi, 'Not able to estimate asset totals');
-    return estimateAssetTotals(this.strapi);
+    if (stage === 'entities') {
+      assertValidStrapi(this.strapi, 'Not able to estimate entity totals');
+      return estimateEntityTotals(this.strapi);
+    }
+    if (stage === 'links') {
+      assertValidStrapi(this.strapi, 'Not able to estimate link totals');
+      return estimateLinkTotals(this.strapi);
+    }
+    if (stage === 'configuration') {
+      assertValidStrapi(this.strapi, 'Not able to estimate configuration totals');
+      return estimateConfigurationTotals(this.strapi);
+    }
+    return null;
   }
 }
 
 export type ILocalStrapiSourceProvider = InstanceType<typeof LocalStrapiSourceProvider>;
 
 export { estimateAssetTotals } from './estimate-asset-totals';
+export { estimateConfigurationTotals } from './estimate-configuration-totals';
+export { estimateEntityTotals } from './estimate-entity-totals';
+export { estimateLinkTotals } from './estimate-link-totals';

--- a/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
+++ b/packages/core/data-transfer/src/strapi/providers/remote-source/index.ts
@@ -20,6 +20,7 @@ import { Client, Server, Auth } from '../../../../types/remote/protocol';
 import { ProviderTransferError, ProviderValidationError } from '../../../errors/providers';
 import { TRANSFER_PATH } from '../../remote/constants';
 import { decodeTransferAssetStreamItem } from '../../../utils/transfer-asset-chunk';
+import { writeWritableAsync } from '../../../utils/write-writable-async';
 import { ILocalStrapiSourceProviderOptions } from '../local-source';
 import {
   createDispatcher,
@@ -89,13 +90,11 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
 
   #checksumsEnabled = false;
 
-  /** Set from pull server `start` response for `assets` when present (for engine `getStageTotals`). */
-  #cachedAssetsTotals?: StageTotalsEstimate;
+  /** Set from pull server `start` response when `totals` is present (for engine `getStageTotals`). */
+  #cachedStageTotals: Partial<Record<TransferStage, StageTotalsEstimate>> = {};
 
   async #createStageReadStream(stage: Exclude<TransferStage, 'schemas'>) {
-    if (stage === 'assets') {
-      this.#cachedAssetsTotals = undefined;
-    }
+    this.#cachedStageTotals[stage] = undefined;
 
     const startResult = await this.#startStep(stage);
 
@@ -108,8 +107,8 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
       totals?: StageTotalsEstimate;
     };
 
-    if (stage === 'assets' && totals && (totals.totalBytes != null || totals.totalCount != null)) {
-      this.#cachedAssetsTotals = totals;
+    if (totals && (totals.totalBytes != null || totals.totalCount != null)) {
+      this.#cachedStageTotals[stage] = totals;
     }
 
     // Default object-mode HWM (~16 chunks). Do not await `drain` on manual `push` while `pipe()`
@@ -164,17 +163,7 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
     return this.#createStageReadStream('links');
   }
 
-  writeAsync = <T>(stream: Writable, data: T) => {
-    return new Promise<void>((resolve, reject) => {
-      stream.write(data, (error) => {
-        if (error) {
-          reject(error);
-        }
-
-        resolve();
-      });
-    });
-  };
+  writeAsync = (stream: Writable, data: unknown) => writeWritableAsync(stream, data);
 
   async createAssetsReadStream(): Promise<Readable> {
     // Create the streams used to transfer the assets
@@ -611,11 +600,15 @@ class RemoteStrapiSourceProvider implements ISourceProvider {
   }
 
   async getStageTotals(stage: TransferStage): Promise<StageTotalsEstimate | null> {
-    if (stage !== 'assets') {
+    if (
+      stage !== 'assets' &&
+      stage !== 'entities' &&
+      stage !== 'links' &&
+      stage !== 'configuration'
+    ) {
       return null;
     }
-    const cached = this.#cachedAssetsTotals;
-    return cached ?? null;
+    return this.#cachedStageTotals[stage] ?? null;
   }
 
   async #startStep<T extends Client.TransferPullStep>(step: T) {

--- a/packages/core/data-transfer/src/strapi/queries/link.ts
+++ b/packages/core/data-transfer/src/strapi/queries/link.ts
@@ -201,6 +201,95 @@ export const createLinkQuery = (strapi: Core.Strapi, trx?: Knex.Transaction) => 
       }
     }
 
+    /**
+     * Count links for one relational attribute (same branches as {@link generateAllForAttribute}, SQL-only).
+     */
+    async function countLinksForAttribute(uid: string, fieldName: string): Promise<number> {
+      const metadata = strapi.db.metadata.get(uid);
+
+      if (!metadata) {
+        return 0;
+      }
+
+      const attributes = filterValidRelationalAttributes(metadata.attributes);
+
+      if (!(fieldName in attributes)) {
+        return 0;
+      }
+
+      const attribute = attributes[fieldName];
+
+      let n = 0;
+
+      if (attribute.joinColumn) {
+        const joinColumnName: string = attribute.joinColumn.name;
+
+        const qb = connection
+          .queryBuilder()
+          .from(addSchema(metadata.tableName))
+          .whereNotNull(joinColumnName);
+
+        if (trx) {
+          qb.transacting(trx);
+        }
+
+        const rows = await qb.count('* as count');
+        const row = Array.isArray(rows) ? rows[0] : rows;
+        n += Number((row as { count?: string | number })?.count ?? 0);
+      }
+
+      if (attribute.joinTable) {
+        const { name } = attribute.joinTable;
+
+        const qb = connection.queryBuilder().from(addSchema(name));
+
+        if (trx) {
+          qb.transacting(trx);
+        }
+
+        const rows = await qb.count('* as count');
+        const row = Array.isArray(rows) ? rows[0] : rows;
+        n += Number((row as { count?: string | number })?.count ?? 0);
+      }
+
+      if (attribute.morphColumn) {
+        const { typeColumn, idColumn } = attribute.morphColumn;
+
+        const qb = connection
+          .queryBuilder()
+          .from(addSchema(metadata.tableName))
+          .whereNotNull(typeColumn.name)
+          .whereNotNull(idColumn.name);
+
+        if (trx) {
+          qb.transacting(trx);
+        }
+
+        const rows = await qb.count('* as count');
+        const row = Array.isArray(rows) ? rows[0] : rows;
+        n += Number((row as { count?: string | number })?.count ?? 0);
+      }
+
+      return n;
+    }
+
+    async function countAllForUid(uid: string): Promise<number> {
+      const metadata = strapi.db.metadata.get(uid);
+
+      if (!metadata) {
+        return 0;
+      }
+
+      const attributes = filterValidRelationalAttributes(metadata.attributes);
+      let total = 0;
+
+      for (const fieldName of Object.keys(attributes)) {
+        total += await countLinksForAttribute(uid, fieldName);
+      }
+
+      return total;
+    }
+
     async function* generateAll(uid: string): AsyncGenerator<ILink> {
       const metadata = strapi.db.metadata.get(uid);
 
@@ -324,7 +413,7 @@ export const createLinkQuery = (strapi: Core.Strapi, trx?: Knex.Transaction) => 
       }
     };
 
-    return { generateAll, generateAllForAttribute, insert };
+    return { generateAll, generateAllForAttribute, insert, countAllForUid };
   };
 
   return query;

--- a/packages/core/data-transfer/src/strapi/remote/handlers/pull.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/pull.ts
@@ -11,8 +11,15 @@ import {
 import {
   createLocalStrapiSourceProvider,
   estimateAssetTotals,
+  estimateConfigurationTotals,
+  estimateEntityTotals,
+  estimateLinkTotals,
   ILocalStrapiSourceProvider,
 } from '../../providers';
+import {
+  TRANSFER_NON_ASSET_BATCH_MAX_BYTES,
+  TRANSFER_NON_ASSET_BATCH_MAX_ITEMS,
+} from '../../transfer-stream-batch';
 import { ProviderTransferError } from '../../../errors/providers';
 import type { IAsset, StageTotalsEstimate, TransferStage, Protocol } from '../../../../types';
 import { Client } from '../../../../types/remote/protocol';
@@ -185,11 +192,14 @@ export const createPullController = handlerControllerFactory<Partial<PullHandler
 
   async flush(this: PullHandler, stage: Client.TransferPullStep, id) {
     type Stage = typeof stage;
-    const batchSize = 1024 * 1024;
+    const maxBatchBytes = TRANSFER_NON_ASSET_BATCH_MAX_BYTES;
+    const maxBatchItems = TRANSFER_NON_ASSET_BATCH_MAX_ITEMS;
     let batch = [] as Client.GetTransferPullStreamData<Stage>;
     const stream = this.streams?.[stage];
 
     const batchLength = () => Buffer.byteLength(JSON.stringify(batch));
+    const shouldFlush = () =>
+      batch.length >= maxBatchItems || (batch.length > 0 && batchLength() >= maxBatchBytes);
 
     const maybeConfirm = async (data: any) => {
       try {
@@ -223,7 +233,7 @@ export const createPullController = handlerControllerFactory<Partial<PullHandler
       for await (const chunk of stream) {
         if (stage !== 'assets') {
           batch.push(chunk);
-          if (batchLength() >= batchSize) {
+          if (shouldFlush()) {
             await sendBatch();
           }
         } else {
@@ -260,6 +270,12 @@ export const createPullController = handlerControllerFactory<Partial<PullHandler
       let totals: StageTotalsEstimate | undefined;
       if (step === 'assets') {
         totals = await estimateAssetTotals(strapi as Core.Strapi);
+      } else if (step === 'entities') {
+        totals = await estimateEntityTotals(strapi as Core.Strapi);
+      } else if (step === 'links') {
+        totals = await estimateLinkTotals(strapi as Core.Strapi);
+      } else if (step === 'configuration') {
+        totals = await estimateConfigurationTotals(strapi as Core.Strapi);
       }
 
       await this.createReadableStreamForStep(step);

--- a/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
+++ b/packages/core/data-transfer/src/strapi/remote/handlers/push.ts
@@ -7,6 +7,7 @@ import type { TransferStage, IAsset, Protocol } from '../../../../types';
 
 import { ProviderTransferError } from '../../../errors/providers';
 import { decodeTransferAssetStreamItem } from '../../../utils/transfer-asset-chunk';
+import { writeWritableAsync } from '../../../utils/write-writable-async';
 import { createLocalStrapiDestinationProvider } from '../../providers';
 import { createFlow, DEFAULT_TRANSFER_FLOW } from '../flows';
 import { Handler } from './abstract';
@@ -113,18 +114,6 @@ export interface PushHandler extends Handler {
    */
   assertValidStreamTransferStep(stage: TransferStage): void;
 }
-
-const writeAsync = <T>(stream: Writable, data: T) => {
-  return new Promise<void>((resolve, reject) => {
-    stream.write(data, (error) => {
-      if (error) {
-        reject(error);
-      }
-
-      resolve();
-    });
-  });
-};
 
 export const createPushController = handlerControllerFactory<Partial<PushHandler>>((proto) => ({
   isTransferStarted(this: PushHandler) {
@@ -394,7 +383,7 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
       await Promise.all(
         msg.data.map(async (item) => {
           this.stats[stage].started += 1;
-          await writeAsync(stream, item);
+          await writeWritableAsync(stream, item);
           this.stats[stage].finished += 1;
         })
       );
@@ -471,13 +460,13 @@ export const createPushController = handlerControllerFactory<Partial<PushHandler
         strapi.log.debug(
           `[Transfer destination] Asset start #${this.stats.assets.started} id=${assetID} filename=${filename}`
         );
-        writeAsync(assetsStream, this.assets[assetID]);
+        await writeWritableAsync(assetsStream, this.assets[assetID]);
       }
 
       if (action === 'stream') {
         const chunk = decodeTransferAssetStreamItem(item);
         this.assetChecksums?.[assetID]?.update(chunk);
-        await writeAsync(this.assets[assetID].stream, chunk);
+        await writeWritableAsync(this.assets[assetID].stream, chunk);
       }
 
       if (action === 'end') {

--- a/packages/core/data-transfer/src/strapi/transfer-stream-batch.ts
+++ b/packages/core/data-transfer/src/strapi/transfer-stream-batch.ts
@@ -1,0 +1,5 @@
+/** Max serialized JSON size before flushing non-asset transfer chunks over the WebSocket. */
+export const TRANSFER_NON_ASSET_BATCH_MAX_BYTES = 512 * 1024;
+
+/** Max items per WebSocket message for entities / links / configuration (push client + pull server). */
+export const TRANSFER_NON_ASSET_BATCH_MAX_ITEMS = 200;

--- a/packages/core/data-transfer/src/utils/__tests__/write-writable-async.test.ts
+++ b/packages/core/data-transfer/src/utils/__tests__/write-writable-async.test.ts
@@ -1,0 +1,81 @@
+import { Writable } from 'stream';
+
+import { writeWritableAsync } from '../write-writable-async';
+
+describe('writeWritableAsync', () => {
+  test('resolves after each chunk is written (no backpressure)', async () => {
+    const written: Buffer[] = [];
+    const w = new Writable({
+      write(chunk, _enc, cb) {
+        written.push(Buffer.from(chunk));
+        cb();
+      },
+    });
+
+    await writeWritableAsync(w, Buffer.from('x'));
+    await writeWritableAsync(w, Buffer.from('y'));
+
+    expect(written.map((b) => b.toString()).join('')).toBe('xy');
+  });
+
+  test('handles write() returning false by waiting for drain (backpressure)', async () => {
+    const written: Buffer[] = [];
+    let writeCalls = 0;
+
+    const w = new Writable({
+      highWaterMark: 1,
+      write(chunk, _enc, cb) {
+        writeCalls += 1;
+        written.push(Buffer.from(chunk));
+        setImmediate(cb);
+      },
+    });
+
+    const chunks = [Buffer.from('a'), Buffer.from('b'), Buffer.from('c'), Buffer.from('d')];
+    for (const c of chunks) {
+      await writeWritableAsync(w, c);
+    }
+
+    expect(written.map((b) => b.toString()).join('')).toBe('abcd');
+    expect(writeCalls).toBe(4);
+  });
+
+  test('rejects when write callback receives an error', async () => {
+    const w = new Writable({
+      write(_chunk, _enc, cb) {
+        cb(new Error('boom'));
+      },
+    });
+
+    await expect(writeWritableAsync(w, Buffer.from('x'))).rejects.toThrow('boom');
+  });
+
+  test('rejects when stream is not writable', async () => {
+    const w = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+    });
+    w.end();
+
+    await expect(writeWritableAsync(w, Buffer.from('x'))).rejects.toThrow('Stream is not writable');
+  });
+
+  test('objectMode writes preserve order under backpressure', async () => {
+    const written: unknown[] = [];
+    const w = new Writable({
+      objectMode: true,
+      highWaterMark: 1,
+      write(chunk, _enc, cb) {
+        written.push(chunk);
+        setImmediate(cb);
+      },
+    });
+
+    for (const n of [1, 2, 3, 4, 5]) {
+      await writeWritableAsync(w, n);
+    }
+
+    expect(written).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/core/data-transfer/src/utils/write-writable-async.ts
+++ b/packages/core/data-transfer/src/utils/write-writable-async.ts
@@ -1,0 +1,84 @@
+import type { Writable } from 'stream';
+
+/**
+ * Write a chunk to a Node.js {@link Writable} and resolve when it is safe to call
+ * {@link Writable.write} again for the next chunk.
+ *
+ * - If {@link Writable.write} returns `true`, the internal buffer had room; we resolve after the
+ *   write callback succeeds (no error).
+ * - If it returns `false`, the buffer was full; per Node’s contract you must not write again
+ *   until `'drain'` fires. We resolve only after **both** a successful write callback **and**
+ *   `'drain'` (order may vary).
+ */
+export function writeWritableAsync(stream: Writable, chunk: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!stream.writable || stream.writableEnded) {
+      reject(new Error('Stream is not writable'));
+      return;
+    }
+
+    let settled = false;
+    let callbackDone = false;
+    let drainDone = false;
+
+    const cleanup = () => {
+      stream.removeListener('error', onStreamError);
+      stream.removeListener('drain', onDrain);
+    };
+
+    const tryResolve = () => {
+      if (settled) {
+        return;
+      }
+      if (writeReturnedOk) {
+        if (callbackDone) {
+          settled = true;
+          cleanup();
+          resolve();
+        }
+      } else if (callbackDone && drainDone) {
+        settled = true;
+        cleanup();
+        resolve();
+      }
+    };
+
+    const finishWithError = (err: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      // Writable may also emit 'error' after _write invokes callback(err); consume once.
+      stream.once('error', () => {});
+      reject(err);
+    };
+
+    const onStreamError = (err: Error) => finishWithError(err);
+    const onDrain = () => {
+      drainDone = true;
+      tryResolve();
+    };
+
+    stream.once('error', onStreamError);
+
+    let writeReturnedOk: boolean;
+    try {
+      writeReturnedOk = stream.write(chunk, (err) => {
+        callbackDone = true;
+        if (err) {
+          finishWithError(err);
+        } else {
+          tryResolve();
+        }
+      });
+    } catch (e) {
+      finishWithError(e instanceof Error ? e : new Error(String(e)));
+      return;
+    }
+
+    if (!writeReturnedOk) {
+      stream.once('drain', onDrain);
+    }
+  });
+}


### PR DESCRIPTION
### What does it do?

- Adds **stage total estimates** for entities, links, and configuration on the **pull** path (mirroring existing assets behavior), wired through `getStageTotals` and the pull handler’s `start` response.
- Extends the **link query** with `countAllForUid` so link totals can be computed in line with link streaming scope.
- Introduces **shared limits** for non-asset WebSocket batches (`transfer-stream-batch.ts`) and uses them when **flushing** pull streams (byte cap + max items per message).
- Adds **`writeWritableAsync`** so writes to `Writable` streams respect **backpressure** (write callback + `drain` when `write()` returns false); **push** and **remote-source** use it instead of a callback-only helper. **File** and **directory** source providers use it when piping backup/tar output into a `PassThrough`, and **serialize tar `onReadEntry` work** before `outStream.end()` so `pipeline` completion does not race async JSONL draining.
- Adds **unit tests** for the new estimators and for `writeWritableAsync`.

### Why is it needed?

- **Progress / ETA** for pull transfers was only well-defined for assets; entities, links, and configuration lacked comparable totals.
- **Pull batching** needed explicit bounds so large JSON payloads do not overwhelm the WebSocket path.
- **Push and file/directory sources** could **ignore backpressure** or **end the stream too early** relative to async producers, risking memory pressure or “stream not writable” races.

### How to test it?

experimental: `0.0.0-experimental.24685bf33d0f8764aa7e9bdfc756519767546ef0` 

- From the repo root: `yarn workspace @strapi/data-transfer test:unit` (all data-transfer unit tests should pass).
- Optional manual check: run a **pull** (or your usual **transfer** smoke flow) against a seeded app and confirm non-asset stages show sensible totals and the transfer completes; optionally exercise **push** with a non-trivial dataset to confirm no regressions under load.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23479