### PR TITLE
fix(i18n): treat component and dynamiczone as localized to prevent cross-locale data overwrite

### DIFF
--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -40,7 +40,9 @@ const isLocalizedAttribute = (attribute: any) => {
   return (
     hasLocalizedOption(attribute) ||
     isRelationalAttribute(attribute) ||
-    isTypedAttribute(attribute, 'uid')
+    isTypedAttribute(attribute, 'uid') ||
+    isTypedAttribute(attribute, 'component') ||
+    isTypedAttribute(attribute, 'dynamiczone')
   );
 };
 


### PR DESCRIPTION
## What
Fixes #25802 - Publishing any locale of an i18n-enabled document silently overwrites `component` and `dynamiczone` field data across all other locales.

## Root Cause
In `packages/plugins/i18n/server/src/services/content-types.ts`, the `isLocalizedAttribute()` function checks for:
- `pluginOptions.i18n.localized: true`
- Relational attributes
- `uid` typed attributes

But it does **not** check for `component` or `dynamiczone` types. This causes `getNonLocalizedAttributes()` to classify these fields as non-localized, and `syncNonLocalizedAttributes` (in `bootstrap.ts`) then copies their data from the updated locale to all other locales on every update/publish.

## Example of Data Corruption
1. Create DE entry with `seo.metaTitle = 'Deutscher Titel'`, publish
2. Update EN `seo.metaTitle = 'Updated English'`, publish
3. Read DE entry - `seo.metaTitle` is now `'Updated English'` (data destroyed)

## Fix
Added `component` and `dynamiczone` to the `isLocalizedAttribute` check:

```diff
 const isLocalizedAttribute = (attribute) => {
   return (
     hasLocalizedOption(attribute) ||
     isRelationalAttribute(attribute) ||
-    isTypedAttribute(attribute, 'uid')
+    isTypedAttribute(attribute, 'uid') ||
+    isTypedAttribute(attribute, 'component') ||
+    isTypedAttribute(attribute, 'dynamiczone')
   );
 };
```

This ensures component fields are treated as locale-specific by default, consistent with how relations and uid fields are already handled.