### PR TITLE
feat: allows having dynamic zones in components

### DIFF
--- a/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveNestedComponents.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/utils/retrieveNestedComponents.ts
@@ -5,17 +5,25 @@ export type NestedComponent = {
   component: UID.Component;
   uidsOfAllParents?: UID.Component[];
   parentCompoUid?: UID.Component;
+  /** UIDs of parents that reference this component via a dynamiczone attribute */
+  dzParentUids?: UID.Component[];
 };
 
+/** Pre-merge entry with edge-type metadata, consumed only by mergeComponents */
+type RawNestedComponent = NestedComponent & { isDzEdge?: boolean };
+
 export const retrieveNestedComponents = (appComponents: Components): NestedComponent[] => {
-  const nestedComponents = Object.keys(appComponents).reduce((acc: NestedComponent[], current) => {
-    const componentAttributes = appComponents?.[current]?.attributes ?? [];
-    const currentComponentNestedCompos = getComponentsNestedWithinComponent(
-      componentAttributes,
-      current as UID.Component
-    );
-    return [...acc, ...currentComponentNestedCompos];
-  }, []);
+  const nestedComponents = Object.keys(appComponents).reduce(
+    (acc: RawNestedComponent[], current) => {
+      const componentAttributes = appComponents?.[current]?.attributes ?? [];
+      const currentComponentNestedCompos = getComponentsNestedWithinComponent(
+        componentAttributes,
+        current as UID.Component
+      );
+      return [...acc, ...currentComponentNestedCompos];
+    },
+    []
+  );
 
   return mergeComponents(nestedComponents);
 };
@@ -24,7 +32,7 @@ const getComponentsNestedWithinComponent = (
   componentAttributes: Component['attributes'],
   parentCompoUid: UID.Component
 ) => {
-  return componentAttributes.reduce((acc: NestedComponent[], current) => {
+  return componentAttributes.reduce((acc: RawNestedComponent[], current) => {
     const { type } = current;
 
     if (type === 'component') {
@@ -34,26 +42,41 @@ const getComponentsNestedWithinComponent = (
       });
     }
 
+    if (type === 'dynamiczone' && 'components' in current && current.components) {
+      for (const dzComponentUid of current.components) {
+        acc.push({
+          component: dzComponentUid as UID.Component,
+          parentCompoUid,
+          isDzEdge: true,
+        });
+      }
+    }
+
     return acc;
   }, []);
 };
 
 // Merge duplicate components
-const mergeComponents = (originalComponents: NestedComponent[]): NestedComponent[] => {
+const mergeComponents = (originalComponents: RawNestedComponent[]): NestedComponent[] => {
   const componentMap = new Map();
   // Populate the map with component and its parents
-  originalComponents.forEach(({ component, parentCompoUid }) => {
+  originalComponents.forEach(({ component, parentCompoUid, isDzEdge }) => {
     if (!componentMap.has(component)) {
-      componentMap.set(component, new Set());
+      componentMap.set(component, { parents: new Set(), dzParents: new Set() });
     }
-    componentMap.get(component).add(parentCompoUid);
+    const entry = componentMap.get(component)!;
+    entry.parents.add(parentCompoUid);
+    if (isDzEdge) {
+      entry.dzParents.add(parentCompoUid);
+    }
   });
 
   // Convert the map to the desired array format
   const transformedComponents: NestedComponent[] = Array.from(componentMap.entries()).map(
-    ([component, parentCompoUidSet]) => ({
+    ([component, { parents, dzParents }]) => ({
       component,
-      uidsOfAllParents: Array.from(parentCompoUidSet),
+      uidsOfAllParents: Array.from(parents),
+      dzParentUids: Array.from(dzParents),
     })
   );
 

--- a/packages/core/content-type-builder/admin/src/components/DataManager/utils/tests/retrieveNestedComponents.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/utils/tests/retrieveNestedComponents.test.ts
@@ -61,6 +61,7 @@ describe('CONTENT TYPE BUILDER | COMPONENTS | DataManagerProvider | utils | retr
       {
         component: 'default.dish',
         uidsOfAllParents: ['default.closingperiod'],
+        dzParentUids: [],
       },
     ];
 
@@ -141,6 +142,7 @@ describe('CONTENT TYPE BUILDER | COMPONENTS | DataManagerProvider | utils | retr
       {
         component: 'default.dish',
         uidsOfAllParents: ['default.closingperiod', 'default.openingperiod'],
+        dzParentUids: [],
       },
     ];
 

--- a/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/FormModal.tsx
@@ -204,7 +204,7 @@ export const FormModal = () => {
       // then goes to step 1 (the modal is addComponentToDynamicZone) and finally reloads the app.
       // In this particular if the user tries to add components to the zone it will pop an error since the dz is unknown
       const foundDynamicZoneTarget =
-        findAttribute(get(type, 'schema.attributes', []), dynamicZoneTarget) || null;
+        findAttribute(get(type, 'attributes', []), dynamicZoneTarget) || null;
 
       // Create content type we need to add the default option draftAndPublish
       if (modalType === 'contentType' && actionType === 'create') {

--- a/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModal/utils/getAttributesToDisplay.ts
@@ -1,5 +1,5 @@
-import { MAX_COMPONENT_DEPTH } from '../../../constants';
-import { getComponentDepth } from '../../../utils/getMaxDepth';
+import { MAX_COMPONENT_DEPTH, MAX_DZ_DEPTH } from '../../../constants';
+import { getComponentDepth, getDzDepth } from '../../../utils/getMaxDepth';
 
 import type { IconByType } from '../../AttributeIcon';
 import type { NestedComponent } from '../../DataManager/utils/retrieveNestedComponents';
@@ -42,7 +42,13 @@ export const getAttributesToDisplay = (
     const canAddComponentInAnotherComponent =
       !isPickingAttributeForAContentType && !isNestedInAnotherComponent;
     if (canAddComponentInAnotherComponent) {
-      return [defaultAttributes, ['component']];
+      const dzDepth = getDzDepth(targetUid, nestedComponents);
+      const canAddDzInComponent = dzDepth < MAX_DZ_DEPTH;
+      const extraTypes: IconByType[] = ['component'];
+      if (canAddDzInComponent) {
+        extraTypes.push('dynamiczone');
+      }
+      return [defaultAttributes, extraTypes];
     }
   }
 

--- a/packages/core/content-type-builder/admin/src/components/SelectComponents.tsx
+++ b/packages/core/content-type-builder/admin/src/components/SelectComponents.tsx
@@ -1,8 +1,10 @@
 import { Field, MultiSelectNested } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 
+import { MAX_DZ_DEPTH } from '../constants';
 import { getTrad } from '../utils';
 import { findAttribute } from '../utils/findAttribute';
+import { getDzDepth, getMaxDownwardDzDepth } from '../utils/getMaxDepth';
 
 import { useDataManager } from './DataManager/useDataManager';
 
@@ -25,7 +27,7 @@ type SelectComponentsProps = {
     };
   }) => void;
   value: string[];
-  targetUid: Internal.UID.ContentType;
+  targetUid: Internal.UID.Schema;
 };
 
 export const SelectComponents = ({
@@ -37,8 +39,15 @@ export const SelectComponents = ({
   targetUid,
 }: SelectComponentsProps) => {
   const { formatMessage } = useIntl();
-  const { componentsGroupedByCategory, contentTypes } = useDataManager();
-  const dzSchema = findAttribute(contentTypes[targetUid].attributes, dynamicZoneTarget);
+  const { componentsGroupedByCategory, contentTypes, components, nestedComponents } =
+    useDataManager();
+
+  // The DZ may live inside a component (not just a content-type), so check both maps.
+  const isTargetAComponent = !!components[targetUid as Internal.UID.Component];
+  const schema = isTargetAComponent
+    ? components[targetUid as Internal.UID.Component]
+    : contentTypes[targetUid as Internal.UID.ContentType];
+  const dzSchema = findAttribute(schema?.attributes ?? [], dynamicZoneTarget);
 
   if (!dzSchema) {
     return null;
@@ -48,9 +57,23 @@ export const SelectComponents = ({
 
   const filteredComponentsGroupedByCategory = Object.keys(componentsGroupedByCategory).reduce(
     (acc, current) => {
-      const filteredComponents = componentsGroupedByCategory[current].filter(({ uid }) => {
+      let filteredComponents = componentsGroupedByCategory[current].filter(({ uid }) => {
         return !alreadyUsedComponents.includes(uid);
       });
+
+      // When the DZ lives inside a component, exclude candidates whose downward
+      // DZ depth would exceed MAX_DZ_DEPTH when combined with the current depth.
+      if (isTargetAComponent) {
+        const currentDzDepth = getDzDepth(targetUid, nestedComponents);
+        // Budget remaining for DZ nesting below the candidate (+1 for the edge we're creating).
+        const remainingBudget = MAX_DZ_DEPTH - currentDzDepth - 1;
+
+        filteredComponents = filteredComponents.filter(({ uid }) => {
+          return (
+            getMaxDownwardDzDepth(uid as Internal.UID.Component, components) <= remainingBudget
+          );
+        });
+      }
 
       if (filteredComponents.length > 0) {
         acc[current] = filteredComponents;
@@ -62,10 +85,10 @@ export const SelectComponents = ({
   );
   const options = Object.entries(filteredComponentsGroupedByCategory).reduce(
     (acc, current) => {
-      const [categoryName, components] = current;
+      const [categoryName, categoryComponents] = current;
       const section = {
         label: categoryName,
-        children: components.map(({ uid, info: { displayName } }) => {
+        children: categoryComponents.map(({ uid, info: { displayName } }) => {
           return { label: displayName, value: uid };
         }),
       };

--- a/packages/core/content-type-builder/admin/src/constants.ts
+++ b/packages/core/content-type-builder/admin/src/constants.ts
@@ -7,3 +7,4 @@ export const PERMISSIONS = {
 };
 
 export const MAX_COMPONENT_DEPTH = 6;
+export const MAX_DZ_DEPTH = 1;

--- a/packages/core/content-type-builder/admin/src/utils/getMaxDepth.ts
+++ b/packages/core/content-type-builder/admin/src/utils/getMaxDepth.ts
@@ -1,5 +1,6 @@
 import type { ComponentWithChildren } from '../components/DataManager/utils/retrieveComponentsThatHaveComponents';
 import type { NestedComponent } from '../components/DataManager/utils/retrieveNestedComponents';
+import type { Components } from '../types';
 import type { Internal } from '@strapi/types';
 
 const findComponent = <T extends { component: Internal.UID.Component }>(
@@ -43,6 +44,106 @@ export const getChildrenMaxDepth = (
   });
 
   return maxDepth;
+};
+
+/**
+ * Returns the dynamic zone nesting depth for a component.
+ *
+ * Counts the maximum number of dynamiczone-type edges in any path from a root
+ * component down to the given component within the component graph.
+ *
+ * Examples:
+ * - ComponentA -> (component) -> ComponentB: getDzDepth(B) = 0
+ * - ComponentA -> (dz) -> ComponentB: getDzDepth(B) = 1
+ * - ComponentA -> (dz) -> ComponentB -> (component) -> ComponentC: getDzDepth(C) = 1
+ * - ComponentA -> (dz) -> ComponentB -> (dz) -> ComponentC: getDzDepth(C) = 2
+ *
+ * @param component - The UID of the component to check.
+ * @param components - The array of all nested components (from retrieveNestedComponents).
+ * @returns The number of dynamiczone transitions in the deepest parent chain.
+ */
+export const getDzDepth = (
+  component: Internal.UID.Schema,
+  components: Array<NestedComponent>
+): number => {
+  const inStack = new Set<Internal.UID.Schema>();
+
+  const walk = (uid: Internal.UID.Schema): number => {
+    // Cycle guard
+    if (inStack.has(uid)) return 0;
+
+    const comp = findComponent(uid, components);
+    if (!comp) return 0;
+
+    inStack.add(uid);
+
+    let maxDepth = 0;
+
+    if (comp.uidsOfAllParents) {
+      const dzParents = new Set(comp.dzParentUids ?? []);
+
+      for (const parentUid of comp.uidsOfAllParents) {
+        const isDzEdge = dzParents.has(parentUid);
+        const parentDepth = walk(parentUid);
+        const depth = parentDepth + (isDzEdge ? 1 : 0);
+        if (depth > maxDepth) {
+          maxDepth = depth;
+        }
+      }
+    }
+
+    inStack.delete(uid);
+    return maxDepth;
+  };
+
+  return walk(component);
+};
+
+/**
+ * Returns the maximum number of dynamic-zone edges reachable by walking
+ * *downward* through a component's attributes.
+ *
+ * - Component-type attributes are traversed without incrementing the counter.
+ * - Dynamic-zone attributes increment the counter by 1 for each child.
+ *
+ * This is the mirror of `getDzDepth` (which walks upward through parents).
+ *
+ * @param componentUid - The UID of the component to inspect.
+ * @param components   - The full component map (keyed by UID).
+ * @param visited      - Cycle guard (internal).
+ * @returns The deepest DZ chain below this component.
+ */
+export const getMaxDownwardDzDepth = (
+  componentUid: Internal.UID.Component,
+  components: Components,
+  visited = new Set<Internal.UID.Component>()
+): number => {
+  if (visited.has(componentUid)) return 0;
+  const comp = components[componentUid];
+  if (!comp) return 0;
+
+  visited.add(componentUid);
+  let max = 0;
+
+  for (const attr of comp.attributes) {
+    if (attr.type === 'dynamiczone' && 'components' in attr && Array.isArray(attr.components)) {
+      for (const childUid of attr.components) {
+        const depth =
+          1 +
+          getMaxDownwardDzDepth(childUid as Internal.UID.Component, components, new Set(visited));
+        if (depth > max) max = depth;
+      }
+    } else if (attr.type === 'component' && 'component' in attr) {
+      const depth = getMaxDownwardDzDepth(
+        attr.component as Internal.UID.Component,
+        components,
+        new Set(visited)
+      );
+      if (depth > max) max = depth;
+    }
+  }
+
+  return max;
 };
 
 /**

--- a/packages/core/content-type-builder/admin/src/utils/tests/getMaxDepth.test.ts
+++ b/packages/core/content-type-builder/admin/src/utils/tests/getMaxDepth.test.ts
@@ -1,7 +1,13 @@
-import { getChildrenMaxDepth, getComponentDepth } from '../getMaxDepth';
+import {
+  getChildrenMaxDepth,
+  getComponentDepth,
+  getDzDepth,
+  getMaxDownwardDzDepth,
+} from '../getMaxDepth';
 
 import type { ComponentWithChildren } from '../../components/DataManager/utils/retrieveComponentsThatHaveComponents';
 import type { NestedComponent } from '../../components/DataManager/utils/retrieveNestedComponents';
+import type { Components } from '../../types';
 
 const componentsWithChildComponents: Array<ComponentWithChildren> = [
   {
@@ -138,6 +144,125 @@ describe('Component Depth Calculations', () => {
       expect(getComponentDepth('basic.nested-compo1', nestedComponents)).toEqual(1);
       expect(getComponentDepth('basic.nested-compo4', nestedComponents)).toEqual(4);
       expect(getComponentDepth('basic.nested-compo6', nestedComponents)).toEqual(6);
+    });
+  });
+
+  describe('getDzDepth', () => {
+    it('should return 0 for a component not in the list', () => {
+      expect(getDzDepth('unknown.component', [])).toEqual(0);
+    });
+
+    it('should return 0 for a component nested only via component attributes', () => {
+      const components: Array<NestedComponent> = [
+        {
+          component: 'basic.child',
+          uidsOfAllParents: ['basic.parent'],
+          dzParentUids: [],
+        },
+      ];
+      expect(getDzDepth('basic.child', components)).toEqual(0);
+    });
+
+    it('should return 1 for a component directly inside a DZ', () => {
+      // ComponentA -> (dz) -> ComponentB
+      const components: Array<NestedComponent> = [
+        {
+          component: 'basic.comp-b',
+          uidsOfAllParents: ['basic.comp-a'],
+          dzParentUids: ['basic.comp-a'],
+        },
+      ];
+      expect(getDzDepth('basic.comp-b', components)).toEqual(1);
+    });
+
+    it('should propagate DZ depth through component edges', () => {
+      // ComponentA -> (dz) -> ComponentB -> (component) -> ComponentC
+      // ComponentC's DZ depth = 1 (inherits B's DZ nesting)
+      const components: Array<NestedComponent> = [
+        {
+          component: 'basic.comp-b',
+          uidsOfAllParents: ['basic.comp-a'],
+          dzParentUids: ['basic.comp-a'],
+        },
+        {
+          component: 'basic.comp-c',
+          uidsOfAllParents: ['basic.comp-b'],
+          dzParentUids: [],
+        },
+      ];
+      expect(getDzDepth('basic.comp-c', components)).toEqual(1);
+    });
+
+    it('should count multiple DZ transitions in a chain', () => {
+      // ComponentA -> (dz) -> ComponentB -> (dz) -> ComponentC
+      // ComponentC's DZ depth = 2
+      const components: Array<NestedComponent> = [
+        {
+          component: 'basic.comp-b',
+          uidsOfAllParents: ['basic.comp-a'],
+          dzParentUids: ['basic.comp-a'],
+        },
+        {
+          component: 'basic.comp-c',
+          uidsOfAllParents: ['basic.comp-b'],
+          dzParentUids: ['basic.comp-b'],
+        },
+      ];
+      expect(getDzDepth('basic.comp-c', components)).toEqual(2);
+    });
+  });
+
+  describe('getMaxDownwardDzDepth', () => {
+    const makeComp = (attrs: Array<Record<string, unknown>>) =>
+      ({ attributes: attrs }) as unknown as Components[string];
+
+    it('should return 0 for an unknown component', () => {
+      expect(getMaxDownwardDzDepth('unknown.comp' as any, {})).toEqual(0);
+    });
+
+    it('should return 0 for a component with no DZ attributes', () => {
+      const components = {
+        'basic.leaf': makeComp([{ type: 'text' }]),
+      } as unknown as Components;
+      expect(getMaxDownwardDzDepth('basic.leaf' as any, components)).toEqual(0);
+    });
+
+    it('should return 1 for a component that has a DZ with leaf children', () => {
+      // A -> (dz) -> [B]   where B has no DZ
+      const components = {
+        'basic.a': makeComp([{ type: 'dynamiczone', components: ['basic.b'] }]),
+        'basic.b': makeComp([{ type: 'text' }]),
+      } as unknown as Components;
+      expect(getMaxDownwardDzDepth('basic.a' as any, components)).toEqual(1);
+    });
+
+    it('should return 0 for a component whose child (via component attr) has no DZ', () => {
+      // A -> (component) -> B   where B has no DZ
+      const components = {
+        'basic.a': makeComp([{ type: 'component', component: 'basic.b' }]),
+        'basic.b': makeComp([{ type: 'text' }]),
+      } as unknown as Components;
+      expect(getMaxDownwardDzDepth('basic.a' as any, components)).toEqual(0);
+    });
+
+    it('should count DZ depth through component edges', () => {
+      // A -> (component) -> B -> (dz) -> [C]
+      const components = {
+        'basic.a': makeComp([{ type: 'component', component: 'basic.b' }]),
+        'basic.b': makeComp([{ type: 'dynamiczone', components: ['basic.c'] }]),
+        'basic.c': makeComp([{ type: 'text' }]),
+      } as unknown as Components;
+      expect(getMaxDownwardDzDepth('basic.a' as any, components)).toEqual(1);
+    });
+
+    it('should count chained DZ transitions', () => {
+      // A -> (dz) -> [B] -> (dz) -> [C]
+      const components = {
+        'basic.a': makeComp([{ type: 'dynamiczone', components: ['basic.b'] }]),
+        'basic.b': makeComp([{ type: 'dynamiczone', components: ['basic.c'] }]),
+        'basic.c': makeComp([{ type: 'text' }]),
+      } as unknown as Components;
+      expect(getMaxDownwardDzDepth('basic.a' as any, components)).toEqual(2);
     });
   });
 });

--- a/packages/core/content-type-builder/server/src/controllers/validation/component.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/component.ts
@@ -8,7 +8,7 @@ import { createSchema } from './model-schema';
 import { removeEmptyDefaults } from './data-transform';
 
 export const VALID_RELATIONS = ['oneToOne', 'oneToMany'];
-export const VALID_TYPES = [...DEFAULT_TYPES, 'component', 'customField'];
+export const VALID_TYPES = [...DEFAULT_TYPES, 'component', 'dynamiczone', 'customField'];
 
 export const componentSchema = createSchema(VALID_TYPES, VALID_RELATIONS, {
   modelType: modelTypes.COMPONENT,

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -578,7 +578,8 @@ const attributePropertiesSchema = (meta: SchemaMeta) => {
   ]);
 
   if (meta.modelType === 'component') {
-    return base
+    return z
+      .union([...base.options, dynamicZoneSchema])
       .superRefine(enumRefinement)
       .superRefine(checkUserTarget)
       .superRefine(maxGreaterThanMin)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows adding dynamic zones in components, making the overall data model more flexible.

### Why is it needed?

This solves a typical use case where strapi is being used as a pagebuilding CMS, closing the gap to other solutions like storyblok.

A typical pagebuilding approach looks like:

1. Have a `page` data model
2. Have multiple `blocks` defined as components (such as a `HeroBlock`, `ImageAndText`, `CtaBlock`, ...) which are rendered in the frontend, e.g. as individual react components
3. On the `page`, have some sort of `contentBlocks` dynamic zone where those `blocks` can be placed to build up the page.

Now, the current issue is that those blocks cannot contain dynamic zones themselves. However, for proper pagebuilding, one does need it:

- Imagine a `TwoColumnBlock` that just implements a two-column layout without having to care about what is contained "in it" (= defined a `leftColumn` and `rightColumn` dynamic zone).
- Imagine a `CtaBlock` that stands out visually, which however may contain other content elements itself
- ...

This PR solves this issue by allowing those dynamic zones in components.

<img width="731" height="704" alt="Bildschirmfoto 2026-04-05 um 11 51 55" src="https://github.com/user-attachments/assets/62eedbb0-3507-4bd4-a77e-c0dc3b43f1d0" />


### How to test it?

1. You should be able to define dynamic zones in the content type builder inside a component
2. You should then be able to place a component and elements within its dynamic zones.

### Related issue(s)/PR(s)

- https://feedback.strapi.io/developer-experience/p/dynamic-zone-in-components
