### PR TITLE
feat: makes the form size of dynamic zones and components flexible in the content manager

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/EditFieldForm.tsx
@@ -246,6 +246,7 @@ const filterFieldsBasedOnAttributeType = (type: Schema.Attribute.Kind) => (field
     case 'component':
       return field.name === 'label' || field.name === 'editable';
     case 'dynamiczone':
+      return field.name !== 'placeholder' && field.name !== 'mainField';
     case 'json':
       return field.name !== 'placeholder' && field.name !== 'mainField' && field.name !== 'size';
     case 'relation':

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/tests/EditFieldForm.test.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/tests/EditFieldForm.test.tsx
@@ -189,29 +189,49 @@ describe('EditFieldForm', () => {
       });
     });
 
-    ['json', 'dynamiczone'].forEach((type) => {
-      it(`should hide the placeholder and size fields for the attribute type: ${type}`, () => {
-        render({
-          attribute: {
-            // @ts-expect-error - ignore the error as we are testing the form for each attribute type
-            type,
-          },
-        });
-
-        expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
-        expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
-
-        expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-
-        expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
-        expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
-        expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
-
-        expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
+    it(`should hide the placeholder and size fields for the attribute type: json`, () => {
+      render({
+        attribute: {
+          type: 'json',
+        },
       });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
+
+      expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
+
+      expect(screen.queryByRole('combobox', { name: 'Size' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
+    });
+
+    it(`should show label, description, editable and size fields for the attribute type: dynamiczone`, () => {
+      render({
+        // @ts-expect-error - ignore the error as we are testing the form for each attribute type
+        attribute: {
+          type: 'dynamiczone',
+        },
+      });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Field' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Edit Field' })).toBeInTheDocument();
+
+      expect(screen.getByRole('button', { name: 'Close modal' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Finish' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+
+      expect(screen.getByRole('textbox', { name: 'Label' })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Description' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Editable' })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: 'Size' })).toBeInTheDocument();
+
+      expect(screen.queryByRole('textbox', { name: 'Placeholder' })).not.toBeInTheDocument();
     });
 
     it("should render the mainField option for relation attributes and have a list of potential mainField attributes from it's targetModel", async () => {

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -246,9 +246,18 @@ const formatEditLayout = (
     { configurations: data.components, schemas: components },
     schemas
   ).reduce<Array<EditFieldLayout[][]>>((panels, row) => {
-    if (row.some((field) => field.type === 'dynamiczone')) {
-      panels.push([row]);
-      currentPanelIndex += 2;
+    const hasDZ = row.some((field) => field.type === 'dynamiczone');
+    if (hasDZ) {
+      // If the previous panel is also a DZ panel, merge into it for side-by-side rendering
+      const prevPanelIdx = currentPanelIndex - 1;
+      const prevPanel = panels[prevPanelIdx];
+      const prevIsDZPanel = prevPanel?.some((r) => r.some((f) => f.type === 'dynamiczone'));
+      if (prevIsDZPanel) {
+        prevPanel.push(row);
+      } else {
+        panels.push([row]);
+        currentPanelIndex += 2;
+      }
     } else {
       if (!panels[currentPanelIndex]) {
         panels.push([row]);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormLayout.tsx
@@ -63,19 +63,27 @@ const FormLayout = ({ layout, document, hasBackground = true }: FormLayoutProps)
     <Flex direction="column" alignItems="stretch" gap={6}>
       {layout.map((panel, index) => {
         if (panel.some((row) => row.some((field) => field.type === 'dynamiczone'))) {
-          const [row] = panel;
-          const [field] = row;
-
           return (
-            <Grid.Root key={field.name} gap={4}>
-              <Grid.Item col={12} s={12} xs={12} direction="column" alignItems="stretch">
-                <InputRenderer
-                  {...field}
-                  label={getLabel(field.name, field.label)}
-                  document={document}
-                />
-              </Grid.Item>
-            </Grid.Root>
+            <ResponsiveGridRoot key={`dz-panel-${index}`} gap={{ initial: 6, medium: 4 }}>
+              {panel.flatMap((row) =>
+                row.map(({ size, ...field }) => (
+                  <ResponsiveGridItem
+                    col={size}
+                    key={field.name}
+                    s={12}
+                    xs={12}
+                    direction="column"
+                    alignItems="stretch"
+                  >
+                    <InputRenderer
+                      {...field}
+                      label={getLabel(field.name, field.label)}
+                      document={document}
+                    />
+                  </ResponsiveGridItem>
+                ))
+              )}
+            </ResponsiveGridRoot>
           );
         }
 

--- a/packages/core/content-manager/server/src/services/field-sizes.ts
+++ b/packages/core/content-manager/server/src/services/field-sizes.ts
@@ -22,11 +22,12 @@ const defaultSize: FieldSize = {
 
 const fieldSizes: Record<string, FieldSize> = {
   // Full row and not resizable
-  dynamiczone: needsFullSize,
-  component: needsFullSize,
   json: needsFullSize,
+  component: needsFullSize,
   richtext: needsFullSize,
   blocks: needsFullSize,
+  // Full row but resizable
+  dynamiczone: { default: 12, isResizable: true },
   // Small and resizable
   checkbox: smallSize,
   boolean: smallSize,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Allows re-sizing dynamic zones similar to normal fields

### Why is it needed?

It adds a nice UI touch if you want to represent multi-column layouts (e.g. for pagebuilding, showcasing a "left" and "right" column):

<img width="1022" height="764" alt="Bildschirmfoto 2026-04-05 um 12 13 38" src="https://github.com/user-attachments/assets/6185345a-17f4-4704-a7c6-a6300c145317" />
<img width="1444" height="558" alt="Bildschirmfoto 2026-04-05 um 12 14 04" src="https://github.com/user-attachments/assets/246a98fc-00c3-4c17-b877-90e74732331d" />

### How to test it?

Use dynamic zones in the content type builder and manager

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
