### PR TITLE
fix: fixed 9 typos, spelling errors, and duplicate words.

### DIFF
--- a/docs/docs/docs/01-core/content-manager/00-intro.md
+++ b/docs/docs/docs/01-core/content-manager/00-intro.md
@@ -8,7 +8,7 @@ tags:
 
 ## What is the Content Manager?
 
-The content-manager is a plugin that allows users to write / update & delete their content, it's currently held within the `@strapi/admin` package, but from V5 will be removed back to to its own plugin. At its very basic form, the CM is just a table & a few forms. There are a few public APIs to manipulate these forms & tables as well as some universal hooks exported for user's to additionally interact with within their own plugins outside of the CM plugin & within.
+The content-manager is a plugin that allows users to write / update & delete their content, it's currently held within the `@strapi/admin` package, but from V5 will be removed back to its own plugin. At its very basic form, the CM is just a table & a few forms. There are a few public APIs to manipulate these forms & tables as well as some universal hooks exported for user's to additionally interact with within their own plugins outside of the CM plugin & within.
 
 ## Sections
 

--- a/packages/core/admin/admin/src/features/Widgets.tsx
+++ b/packages/core/admin/admin/src/features/Widgets.tsx
@@ -105,7 +105,7 @@ const saveLayout = async ({
   } catch {
     toggleNotification({
       type: 'danger',
-      message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+      message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
     });
   }
 };

--- a/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
+++ b/packages/core/admin/admin/src/pages/InternalErrorPage.tsx
@@ -38,7 +38,7 @@ export const InternalErrorPage = () => {
           }
           content={formatMessage({
             id: 'notification.error',
-            defaultMessage: 'An error occured',
+            defaultMessage: 'An error occurred',
           })}
           hasRadius
           icon={<EmptyPictures width="16rem" />}

--- a/packages/core/admin/admin/src/pages/ProfilePage.tsx
+++ b/packages/core/admin/admin/src/pages/ProfilePage.tsx
@@ -94,7 +94,7 @@ const ProfilePage = () => {
     } else {
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
   }, [formatMessage, notifyStatus, toggleNotification, user]);
@@ -165,7 +165,7 @@ const ProfilePage = () => {
       } else {
         toggleNotification({
           type: 'danger',
-          message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+          message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
         });
       }
     }

--- a/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/TransferTokens/ListView.tsx
@@ -133,7 +133,7 @@ const ListView = () => {
     } catch {
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
   };

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -62,7 +62,7 @@ const getDirectParent = (data: unknown, path: string): unknown => {
  * It is possible to break the ContentManager by using this function incorrectly, for example,
  * if you transform a number into a string but the attribute type is a number, the ContentManager
  * will not be able to save the data and the Form will likely crash because the component it's
- * passing the data too won't succesfully be able to handle the value.
+ * passing the data too won't successfully be able to handle the value.
  */
 const traverseData =
   (predicate: Predicate, transform: Transform) =>

--- a/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.tsx
+++ b/packages/core/upload/admin/src/components/AssetCard/UploadingAssetCard.tsx
@@ -142,7 +142,7 @@ export const UploadingAssetCard = ({
                 }
               : {
                   id: getTrad('upload.generic-error'),
-                  defaultMessage: 'An error occured while uploading the file.',
+                  defaultMessage: 'An error occurred while uploading the file.',
                 }
           )}
         </Typography>

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromUrlForm.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/AddAssetStep/FromUrlForm.tsx
@@ -60,7 +60,7 @@ export const FromUrlForm = ({ onClose, onAddAsset, trackedLocation }: FromUrlFor
               error={
                 error?.message ||
                 (errors.urls
-                  ? formatMessage({ id: errors.urls, defaultMessage: 'An error occured' })
+                  ? formatMessage({ id: errors.urls, defaultMessage: 'An error occurred' })
                   : undefined)
               }
             >

--- a/packages/plugins/sentry/README.md
+++ b/packages/plugins/sentry/README.md
@@ -84,7 +84,7 @@ try {
 
 ### `getInstance()`
 
-Use it if you need direct access to the Sentry instance, which should already already be initialized. It's useful if `sendError` doesn't suit your needs.
+Use it if you need direct access to the Sentry instance, which should already be initialized. It's useful if `sendError` doesn't suit your needs.
 
 **Example**
 


### PR DESCRIPTION
### What does it do?
Fixes spelling typos across several packages:

- `occured` → `occurred` in six user-facing error message strings across the admin and upload packages
- `succesfully` → `successfully` in a JSDoc comment in the content-manager package
- `already already` → `already` (doubled word) in the sentry plugin README
- `back to to` → `back to` (doubled word) in the content-manager intro doc

### Why is it needed?
Keeps user-facing strings and documentation correct and professional.

### How to test it?
No functional changes — a quick grep confirms the typos are gone:
```sh
grep -r "occured\|succesfully\|already already\|back to to" packages/ docs/
```

### Related issue(s)/PR(s)
N/A