### PR TITLE
fix(upload-aws-s3): trust S3 response Location URL for compatible providers

### DIFF
--- a/packages/providers/upload-aws-s3/src/index.ts
+++ b/packages/providers/upload-aws-s3/src/index.ts
@@ -410,6 +410,14 @@ export default {
     /**
      * Constructs the correct file URL.
      * Handles S3-compatible providers that return incorrect Location formats.
+     *
+     * Some providers (IONOS, some MinIO configs) return malformed Location
+     * values like "bucket/key" without protocol or domain. For these, we
+     * fall back to constructing the URL from the endpoint config.
+     *
+     * Other providers (AWS, Scaleway, DigitalOcean, Backblaze) return
+     * correct Location URLs that should be trusted as-is, since they
+     * already use the correct URL style (virtual-hosted or path-style).
      */
     const constructFileUrl = (fileKey: string, uploadLocation: string): string => {
       // Priority 1: Use baseUrl if configured (CDN or custom domain)
@@ -418,9 +426,18 @@ export default {
         return `${cleanBase}/${fileKey}`;
       }
 
-      // Priority 2: Construct URL from endpoint if configured
-      // This fixes issues with S3-compatible providers (IONOS, MinIO, etc.)
-      // that return Location in incorrect format for multipart uploads
+      // Priority 2: Use the Location from S3 response if it's a valid URL.
+      // This preserves correct behavior for providers that return proper URLs
+      // (AWS, Scaleway, DigitalOcean, Backblaze, etc.), respecting their
+      // native URL format (virtual-hosted or path-style).
+      if (uploadLocation && assertUrlProtocol(uploadLocation)) {
+        return uploadLocation;
+      }
+
+      // Priority 3: Construct URL from endpoint if configured.
+      // This is a fallback for providers that return malformed Location values
+      // (e.g., IONOS returns "bucket/key" without protocol for multipart uploads,
+      // some MinIO configs return similar malformed values).
       const endpoint = config.endpoint?.toString();
       if (endpoint) {
         const endpointUrl = endpoint.startsWith('http') ? endpoint : `https://${endpoint}`;
@@ -428,13 +445,13 @@ export default {
         return `${cleanEndpoint}/${config.params.Bucket}/${fileKey}`;
       }
 
-      // Priority 3: Use the Location from S3 response
-      if (assertUrlProtocol(uploadLocation)) {
-        return uploadLocation;
+      // Priority 4: Prepend https if Location exists but lacks protocol
+      if (uploadLocation) {
+        return `https://${uploadLocation}`;
       }
 
-      // Priority 4: Prepend https if protocol is missing
-      return `https://${uploadLocation}`;
+      // Priority 5: Construct from AWS default pattern
+      return `https://${config.params.Bucket}.s3.amazonaws.com/${fileKey}`;
     };
 
     const upload = async (file: File, customParams: Partial<PutObjectCommandInput> = {}) => {


### PR DESCRIPTION
## Summary

Fixes #25581 (S3 Upload to Scaleway stopped working with v5.36)
Relates to #25592, #25487

The `constructFileUrl` function introduced in #25263 always constructs URLs from the endpoint config when a custom endpoint is set. This breaks S3-compatible providers like **Scaleway**, **DigitalOcean Spaces**, and **Backblaze B2** that return correct `Location` URLs in their upload responses.

## Root Cause

Priority 2 (endpoint-based URL construction) was placed **before** Priority 3 (S3 response Location), so when a custom endpoint was configured, the code would always build a path-style URL (`endpoint/bucket/key`) instead of trusting the provider's own response URL.

Providers like Scaleway use virtual-hosted URLs (`bucket.endpoint/key`), so the path-style construction produced invalid URLs.

## Fix

Reorder URL construction priorities:
1. `baseUrl` (CDN/custom domain) — unchanged
2. **S3 response `Location`** if it's a valid URL — **moved up**
3. Endpoint-based construction — **now a fallback** for malformed Location
4. Prepend `https://` — for Location without protocol

Providers like IONOS/MinIO that return malformed Location values (e.g., `bucket/key` without protocol) still fall through to endpoint-based construction, preserving the fix from #25263.

## Test plan

- [ ] Existing tests pass (IONOS, MinIO cases still use endpoint fallback)
- [ ] Scaleway/DigitalOcean uploads work (they return valid Location URLs)
- [ ] AWS S3 uploads work (returns valid Location URLs)
- [ ] baseUrl still takes priority over everything