### PR TITLE
Remove yarn from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Strapi Community Edition is a free and open-source headless CMS enabling you to 
 Use the **Quickstart** command below to create a new Strapi project instantly:
 
 ```bash
-npx create-strapi-app@latest my-project
+npx create-strapi@latest my-project
 ```
 
 This command generates a brand new project with the default features (authentication, permissions, content management, content type builder & file upload).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes `yarn` from the Readme.

### Why is it needed?

As opposed to `npx`, `yarn` does not (necessarily) use the latest version of Strapi. Therefore, users who installed Strapi previously do not benefit from the latest version of Strapi and can face errors (e.g. Node.js version conflicts).

### How to test it?

Look at the Readme file.


