### PR TITLE
fix: enable save button when re-ordering components or dynamic zones

### DIFF
--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -368,20 +368,30 @@ const Fields = ({ attributes, fieldSizes, components, metadatas = {} }: FieldsPr
             // If there is absolutely no space left in the target row and the
             // dragged item comes from a different row, add it to a new row
             if (canCreateNewRowForItem) {
-              const insertIndex = overContainerIndex + 1;
-              const existingRow = draft[insertIndex];
+              // Default: insert a new row after the row being hovered (between that row and the
+              // next). For row 0, use index 0 instead so fields that are not full-width can still
+              // be moved above the first row—there is no separate drop area above it in the UI.
+              const insertIndex = overContainerIndex === 0 ? 0 : overContainerIndex + 1;
 
-              if (existingRow) {
-                const nonTempChildren = existingRow.children.filter(
-                  (child) => child.name !== TEMP_FIELD_NAME
-                );
-                const isNextRowEmpty = nonTempChildren.length === 0;
+              /**
+               * When inserting *after* the hovered row, reuse the following row if it only
+               * contains spacers. Skip when inserting at index 0 — draft[0] is the hovered row.
+               */
+              if (insertIndex > overContainerIndex) {
+                const existingRow = draft[insertIndex];
 
-                // If the row directly after is empty (only spacers), reuse it
-                // instead of creating yet another row.
-                if (isNextRowEmpty) {
-                  existingRow.children = [draggedItem];
-                  return;
+                if (existingRow) {
+                  const nonTempChildren = existingRow.children.filter(
+                    (child) => child.name !== TEMP_FIELD_NAME
+                  );
+                  const isNextRowEmpty = nonTempChildren.length === 0;
+
+                  // If the row directly after is empty (only spacers), reuse it
+                  // instead of creating yet another row.
+                  if (isNextRowEmpty) {
+                    existingRow.children = [draggedItem];
+                    return;
+                  }
                 }
               }
 

--- a/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
+++ b/packages/core/content-manager/admin/src/components/ConfigurationForm/Fields.tsx
@@ -431,7 +431,12 @@ const Fields = ({ attributes, fieldSizes, components, metadatas = {} }: FieldsPr
         );
 
         const movedContainerItems = produce(containersAsDictionary, (draft) => {
-          if (activeIndex !== overIndex && activeContainer === overContainer) {
+          if (
+            activeIndex >= 0 &&
+            overIndex >= 0 &&
+            activeIndex !== overIndex &&
+            activeContainer === overContainer
+          ) {
             // Move items around inside their own container
             draft[activeContainer].children = arraySwap(
               draft[activeContainer].children,


### PR DESCRIPTION
### What does it do?
This PR resolves two issues in the Configure the View page:
1. Re-ordering components or dynamic zones didn't trigger the enabling of the Save button, despite the layout having changed.
2. Inability to drop an element not full-width as the first row of the layout.

### Why is it needed?
1. 
When updating the layout of a content-type, by moving a field type Component or Dynamic Zone, the "Save" button was disabled, not allowing users to save their new layout.
**BEFORE**
https://github.com/user-attachments/assets/f57d9bb0-f340-44a2-a2e2-2370628132d7

**AFTER**
https://github.com/user-attachments/assets/8b0f1c21-1e96-4a18-870f-bb5fc12b91df

2. 
When updating the layout of a content-type, we couldn't drop an element of width smaller than 100% above the first row where the element has the full width, only in the row below.
**BEFORE**
https://github.com/user-attachments/assets/73ab303a-65bc-4bea-afce-698f001e23fa

**AFTER**
https://github.com/user-attachments/assets/a4071c9b-e3d7-48a5-9631-a23fc5a273c9


### How to test it?
1. 
* Create a content type with at least one component or dynamic zone + a text field.
* Go to the "Configure the view" page for that component.
* Drag the component or dynamic zone and drop it in another spot in the layout.
=> The "Save" button should be enabled, allowing you to save your new layout.

2. 
* Create content type with at least two Text fields.
* Go to the "Configure the view" page for that component.
* Make the first Text field in the layout full width (100%) and the other 50%.
* Drag the 50% field and drop it above the 100% field.
* The layout should now be: 50% field on the first row, 100% on the second row.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/23161
Closes CMS-574