### PR TITLE
fix: backport deleteMany nested entity filter fix to v4

### DIFF
--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -548,7 +548,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       const deletedRows = await this.createQueryBuilder(uid)
         .where(where)
         .delete()
-        .execute<number>();
+        .execute<number>({ mapResults: false });
 
       const result = { count: deletedRows };
 

--- a/packages/core/database/src/query/query-builder.ts
+++ b/packages/core/database/src/query/query-builder.ts
@@ -33,6 +33,7 @@ interface State {
   aliasCounter: number;
   filters: any;
   search: string;
+  processed: boolean;
 }
 
 export interface QueryBuilder {
@@ -116,6 +117,7 @@ const createQueryBuilder = (
       aliasCounter: 0,
       filters: null,
       search: null,
+      processed: false,
     },
     initialState
   );
@@ -372,16 +374,22 @@ const createQueryBuilder = (
     },
 
     runSubQuery() {
+      const originalType = state.type;
+
       this.select('id');
       const subQB = this.getKnexQuery();
 
       const nestedSubQuery = db.getConnection().select('id').from(subQB.as('subQuery'));
       const connection = db.getConnection(tableName);
 
-      return (connection[state.type] as Knex)().whereIn('id', nestedSubQuery);
+      return (connection[originalType] as Knex)().whereIn('id', nestedSubQuery);
     },
 
     processState() {
+      if (this.state.processed) {
+        return;
+      }
+
       state.orderBy = helpers.processOrderBy(state.orderBy, { qb: this, uid, db });
 
       if (!_.isNil(state.filters)) {
@@ -402,6 +410,8 @@ const createQueryBuilder = (
       state.data = helpers.toRow(meta, state.data);
 
       this.processSelect();
+
+      this.state.processed = true;
     },
 
     shouldUseDistinct() {
@@ -436,11 +446,13 @@ const createQueryBuilder = (
 
       const qb = db.getConnection(aliasedTableName);
 
+      // The state should always be processed before calling shouldUseSubQuery as it
+      // relies on the presence or absence of joins to determine the need of a subquery
+      this.processState();
+
       if (this.shouldUseSubQuery()) {
         return this.runSubQuery();
       }
-
-      this.processState();
 
       switch (state.type) {
         case 'select': {


### PR DESCRIPTION
## Summary

Backport of #23129 to Strapi v4. Fixes `deleteMany` failing with invalid SQL when filtering by nested/related entities.

### Problem

When calling `deleteMany` with nested entity filters:
```js
await strapi.query(A).deleteMany({
  where: { B: { id: { $eq: params.id } } }
})
```

The query builder generates invalid SQL:
- **SQLite:** `no such column: t2.id`
- **PostgreSQL:** `missing FROM-clause entry for table t0`

### Root Cause

Three issues in `packages/core/database/src/query/query-builder.ts`:

1. **`processState()` called too late** — Called after `shouldUseSubQuery()`, so joins from nested filters were not yet resolved when checking if a subquery was needed.
2. **`runSubQuery()` corrupted `state.type`** — `this.select("id")` changes `state.type` from `"delete"` to `"select"`, causing the final query to be a SELECT instead of DELETE.
3. **Double processing** — `processState()` could be called multiple times due to the recursive `getKnexQuery()` call from `runSubQuery()`.

### Fix

- Move `processState()` before `shouldUseSubQuery()` so joins are resolved first
- Add `processed` flag to prevent double-processing of state
- Save `originalType` in `runSubQuery()` before `select()` mutates it
- Pass `mapResults: false` in entity-manager `deleteMany`

### Test Plan

- [x] Added integration test for `deleteMany` with deep relation filtering
- Test creates two content types with a `manyToOne` relation and verifies that `deleteMany` with nested filter correctly deletes matching entries

Closes #11998