### PR TITLE
fix(tests): build fails causing tests to fail

### DIFF
--- a/packages/core/strapi/src/cli/utils/commander.ts
+++ b/packages/core/strapi/src/cli/utils/commander.ts
@@ -86,7 +86,7 @@ const promptEncryptionKey = async (thisCommand: Command) => {
           type: 'password',
           message: 'Please enter an encryption key',
           name: 'key',
-          validate(key) {
+          validate(key: string) {
             if (key.length > 0) return true;
 
             return 'Key must be present when using the encrypt option';

--- a/packages/core/strapi/src/cli/utils/get-inquirer.ts
+++ b/packages/core/strapi/src/cli/utils/get-inquirer.ts
@@ -1,4 +1,4 @@
-type InquirerAPI = typeof import('inquirer').default;
+type InquirerAPI = typeof import('inquirer');
 
 let cached: Promise<InquirerAPI> | undefined;
 


### PR DESCRIPTION
### What does it do?

  1. commander.ts:89 — Added string type annotation to validate(key) parameter (was implicit any, fails with noImplicitAny)
  2. get-inquirer.ts:1 — Changed typeof import('inquirer').default to typeof import('inquirer') (the installed @types/inquirer v8 doesn't export default)

### Why is it needed?


These type errors were causing build:types to fail, which meant yarn build never completed, leaving all dist files stale. With the fixes, yarn build succeeds and all CLI tests pass.

### How to test it?

Tests should pass in CLI


