### PR TITLE
fix: add responseType to getFetchClient for non-JSON responses

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -150,6 +150,7 @@ const attemptTokenRefresh = async (): Promise<string> => {
 type FetchResponse<TData = any> = {
   data: TData;
   status?: number;
+  headers?: Headers;
 };
 
 type FetchOptions = {
@@ -157,6 +158,7 @@ type FetchOptions = {
   signal?: AbortSignal;
   headers?: Record<string, string>;
   validateStatus?: ((status: number) => boolean) | null;
+  responseType?: 'json' | 'blob' | 'text' | 'arrayBuffer';
 };
 
 type FetchConfig = {
@@ -207,7 +209,15 @@ const getToken = (): string | null => {
 };
 
 type FetchClient = {
-  get: <TData = any>(url: string, config?: FetchOptions) => Promise<FetchResponse<TData>>;
+  get: {
+    (url: string, config: FetchOptions & { responseType: 'blob' }): Promise<FetchResponse<Blob>>;
+    (url: string, config: FetchOptions & { responseType: 'text' }): Promise<FetchResponse<string>>;
+    (
+      url: string,
+      config: FetchOptions & { responseType: 'arrayBuffer' }
+    ): Promise<FetchResponse<ArrayBuffer>>;
+    <TData = any>(url: string, config?: FetchOptions): Promise<FetchResponse<TData>>;
+  };
   put: <TData = any, TSend = any>(
     url: string,
     data?: TSend,
@@ -266,8 +276,28 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
   // Add a response interceptor to return the response
   const responseInterceptor = async <TData = any>(
     response: Response,
-    validateStatus?: FetchOptions['validateStatus']
+    validateStatus?: FetchOptions['validateStatus'],
+    responseType: NonNullable<FetchOptions['responseType']> = 'json'
   ): Promise<FetchResponse<TData>> => {
+    if (responseType !== 'json') {
+      if (!response.ok && !validateStatus?.(response.status)) {
+        const fetchError = new FetchError('Server Error');
+        fetchError.status = response.status;
+        throw fetchError;
+      }
+
+      let result: Blob | string | ArrayBuffer;
+      if (responseType === 'blob') {
+        result = await response.blob();
+      } else if (responseType === 'text') {
+        result = await response.text();
+      } else {
+        result = await response.arrayBuffer();
+      }
+
+      return { data: result as TData, status: response.status, headers: response.headers };
+    }
+
     try {
       const result = await response.json();
 
@@ -359,10 +389,16 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
   const fetchClient: FetchClient = {
     get: async <TData>(url: string, options?: FetchOptions): Promise<FetchResponse<TData>> => {
       const createRequestUrl = makeCreateRequestUrl(options);
+      const responseType = options?.responseType ?? 'json';
 
       const executeRequest = async () => {
+        const { Authorization } = getDefaultHeaders();
+
+        // For non-JSON response types, omit content negotiation headers that imply JSON
+        const defaultHeaders = responseType === 'json' ? getDefaultHeaders() : { Authorization };
+
         const headers = new Headers({
-          ...getDefaultHeaders(),
+          ...defaultHeaders,
           ...options?.headers,
         });
 
@@ -372,7 +408,7 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
           headers,
         });
 
-        return responseInterceptor<TData>(response, options?.validateStatus);
+        return responseInterceptor<TData>(response, options?.validateStatus, responseType);
       };
 
       return withTokenRefresh(url, executeRequest);

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -91,6 +91,131 @@ describe('getFetchClient', () => {
     );
   });
 
+  describe('responseType', () => {
+    it('should return a Blob when responseType is blob', async () => {
+      const blobContent = new Blob(['file content'], { type: 'application/zip' });
+
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          blob: () => Promise.resolve(blobContent),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      const { data } = await fetchClient.get('/api/export', { responseType: 'blob' });
+
+      expect(data).toBe(blobContent);
+    });
+
+    it('should return a string when responseType is text', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          text: () => Promise.resolve('hello world'),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      const { data } = await fetchClient.get('/api/export', { responseType: 'text' });
+
+      expect(data).toBe('hello world');
+    });
+
+    it('should return an ArrayBuffer when responseType is arrayBuffer', async () => {
+      const buffer = new ArrayBuffer(8);
+
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          arrayBuffer: () => Promise.resolve(buffer),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      const { data } = await fetchClient.get('/api/export', { responseType: 'arrayBuffer' });
+
+      expect(data).toBe(buffer);
+    });
+
+    it('should throw a FetchError on non-2xx response for blob requests', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 404,
+          ok: false,
+        })
+      );
+
+      const fetchClient = getFetchClient();
+
+      await expect(fetchClient.get('/api/export', { responseType: 'blob' })).rejects.toMatchObject({
+        name: 'FetchError',
+        status: 404,
+      });
+    });
+
+    it('should not send Accept and Content-Type headers for blob requests', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          blob: () => Promise.resolve(new Blob()),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      await fetchClient.get('/api/export', { responseType: 'blob' });
+
+      const requestHeaders: Headers = (window.fetch as jest.Mock).mock.calls[0][1].headers;
+      expect(requestHeaders.has('Accept')).toBe(false);
+      expect(requestHeaders.has('Content-Type')).toBe(false);
+      expect(requestHeaders.has('Authorization')).toBe(true);
+    });
+
+    it('should still send Accept and Content-Type headers for json requests', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ data: 'ok' }),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      await fetchClient.get('/api/data');
+
+      const requestHeaders: Headers = (window.fetch as jest.Mock).mock.calls[0][1].headers;
+      expect(requestHeaders.has('Accept')).toBe(true);
+      expect(requestHeaders.has('Content-Type')).toBe(true);
+    });
+
+    it('should include the response status and headers in the result', async () => {
+      const responseHeaders = new Headers({
+        'Content-Disposition': 'attachment; filename="export.zip"',
+        'Content-Type': 'application/zip',
+      });
+
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          headers: responseHeaders,
+          blob: () => Promise.resolve(new Blob()),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+      const result = await fetchClient.get('/api/export', { responseType: 'blob' });
+
+      expect(result.status).toBe(200);
+      expect(result.headers).toBe(responseHeaders);
+      expect(result.headers?.get('Content-Disposition')).toBe('attachment; filename="export.zip"');
+    });
+  });
+
   describe('token refresh on 401', () => {
     it('should refresh token and retry on 401 error', async () => {
       // First call returns 401
@@ -285,6 +410,39 @@ describe('getFetchClient', () => {
 
       // Clean up
       setOnTokenUpdate(null);
+    });
+
+    it('should refresh token and retry on 401 for blob requests', async () => {
+      const blobContent = new Blob(['file content'], { type: 'application/zip' });
+
+      (window.fetch as jest.Mock)
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 401,
+            ok: false,
+            json: () => Promise.resolve({ error: { message: 'Unauthorized', status: 401 } }),
+          })
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            json: () => Promise.resolve({ data: { token: 'new-token' } }),
+          })
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            status: 200,
+            ok: true,
+            blob: () => Promise.resolve(blobContent),
+          })
+        );
+
+      const fetchClient = getFetchClient();
+      const { data } = await fetchClient.get('/api/export', { responseType: 'blob' });
+
+      expect(data).toBe(blobContent);
+      expect(window.fetch).toHaveBeenCalledTimes(3);
     });
 
     it('should refresh token for POST requests with FormData', async () => {


### PR DESCRIPTION
## What does it do?

Adds a `responseType` option to `getFetchClient`'s `get` method, allowing plugin developers to receive `Blob`, `string`, or `ArrayBuffer` responses instead of always parsing JSON.

Here are the possible values of `responseType`: `json`, `blob`, `text`, `arrayBuffer`

## Why is it needed?

`getFetchClient` always called `response.json()`, so any non-JSON response (file download, CSV export, zip archive) would silently return `[]` or throw a `SyntaxError`. Plugin developers had to manually read the JWT token from localStorage as a workaround to bypass the fetch client entirely.

### How to test it?

You should be able to pass a `responseType` now when using `useFetchClient`'s `get` method like so:
```
const { get } = useFetchClient();

const { data: blob, headers } = await get(url, { responseType: 'blob' });
```
The response type should change accordingly.

### Related issue(s)/PR(s)

Fixes #21534

🚀