### PR TITLE
test(cli): fix snapshot updating and replace fixed versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:cli": "node tests/scripts/run-cli-tests.js",
     "test:cli:clean": "node tests/scripts/run-cli-tests.js clean",
     "test:cli:debug": "node tests/scripts/run-cli-tests.js --debug",
+    "test:cli:update": "node tests/scripts/run-cli-tests.js -u",
     "test:e2e": "node tests/scripts/run-e2e-tests.js",
     "test:e2e:clean": "node tests/scripts/run-e2e-tests.js clean",
     "test:front": "cross-env IS_EE=true jest --config jest.config.front.js --runInBand",

--- a/tests/cli/README.md
+++ b/tests/cli/README.md
@@ -63,6 +63,9 @@ See the available tests in the `tests` directory for examples.
 
 ### Updating Jest snapshots
 
-Some CLI tests (for example `strapi/strapi/openapi-generate.test.cli.ts`) commit **Jest snapshot** files. After intentional changes to the app template, generator output, or CLI output, regenerate snapshots with `jest … -u` instead of editing `.snap` files by hand.
+Some CLI tests (for example `strapi/strapi/openapi-generate.test.cli.ts`) commit **Jest snapshot** files. After intentional changes to the app template, generator output, or CLI output, regenerate snapshots with Jest’s `-u` instead of editing `.snap` files by hand.
+
+- **From the repo root:** `yarn test:cli:update` runs the CLI test runner with `-u` forwarded to Jest (same as `yarn test:cli -u`). Limit domains or add extra Jest flags when needed, for example `yarn test:cli -d strapi -u -- --testPathPattern=openapi-generate`.
+- **Direct Jest** (single file or when you only want to refresh snapshots without touching every domain): see **[tests/strapi/strapi/README.md](tests/strapi/strapi/README.md)** — you must set `TEST_APPS` and `JWT_SECRET` like the runner does.
 
 See **[tests/strapi/strapi/README.md](tests/strapi/strapi/README.md)** for how snapshots work in the `strapi` domain (including OpenAPI and list-output tests) and when to run `yarn test:cli:clean` / `yarn test:cli --setup`.

--- a/tests/cli/tests/strapi/strapi/README.md
+++ b/tests/cli/tests/strapi/strapi/README.md
@@ -24,7 +24,17 @@ The `openapi:generate` test compares the generated OpenAPI document to a **Jest 
 
    You can omit `test:cli:clean` if you only need to refresh snapshots and the test app is already up to date.
 
-2. **Regenerate the snapshot** with Jest’s update flag. The CLI runner sets `TEST_APPS` and `JWT_SECRET`; you must pass the same when running Jest alone:
+2. **Regenerate the snapshot** with Jest’s update flag.
+
+   **Using the CLI test runner** (recommended; it sets `TEST_APPS`, `JWT_SECRET`, and yalc like a normal run):
+
+   ```bash
+   yarn test:cli -d strapi -u -- --testPathPattern=openapi-generate
+   ```
+
+   Or run all snapshot tests in every domain: `yarn test:cli:update` (same as `yarn test:cli -u`).
+
+   **Using Jest alone:** the runner sets `TEST_APPS` and `JWT_SECRET`; you must pass the same when running Jest directly:
 
    ```bash
    TEST_APPS="$PWD/test-apps/cli/test-app-0" JWT_SECRET=test-jwt-secret \
@@ -61,7 +71,13 @@ You can skip `test:cli:clean` if the app is already current and you only need to
 
 **Regenerating snapshots**
 
-The CLI runner sets `TEST_APPS` and `JWT_SECRET`; pass the same when running Jest alone from the **repository root**:
+From the repo root, `yarn test:cli -u` (or `yarn test:cli:update`) forwards `-u` to Jest. Narrow the run with domains and extra Jest args after `--`:
+
+```bash
+yarn test:cli -d strapi -u -- --testPathPattern='openapi-generate'
+```
+
+The CLI runner sets `TEST_APPS` and `JWT_SECRET`. If you use **Jest alone** instead, pass the same env vars:
 
 ```bash
 TEST_APPS="$PWD/test-apps/cli/test-app-0" JWT_SECRET=test-jwt-secret \

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -26503,6 +26503,6 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
     },
   },
   "x-powered-by": "strapi",
-  "x-strapi-version": "5.42.0",
+  "x-strapi-version": "<current-strapi-version>",
 }
 `;

--- a/tests/cli/tests/strapi/strapi/openapi-generate.test.cli.ts
+++ b/tests/cli/tests/strapi/strapi/openapi-generate.test.cli.ts
@@ -22,25 +22,37 @@ const sortKeysDeep = (value: unknown): unknown => {
   return sorted;
 };
 
-/** OpenAPI generator fills `default` on datetime fields with "now", which changes every run. */
+/** Values that change between runs or releases; replaced before snapshot so CLI output stays stable. */
 const ISO_DATETIME_DEFAULT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
-const replaceVolatileDatetimeDefaults = (value: unknown): unknown => {
+const volatileSnapshotReplacements: {
+  test: (key: string, value: unknown) => boolean;
+  placeholder: string;
+}[] = [
+  {
+    test: (key, value) =>
+      key === 'default' && typeof value === 'string' && ISO_DATETIME_DEFAULT.test(value),
+    placeholder: '<generated-at-runtime>',
+  },
+  {
+    test: (key, value) => key === 'x-strapi-version' && typeof value === 'string',
+    placeholder: '<current-strapi-version>',
+  },
+];
+
+const replaceVolatileSnapshotValues = (value: unknown): unknown => {
   if (value === null || typeof value !== 'object') {
     return value;
   }
   if (Array.isArray(value)) {
-    return value.map(replaceVolatileDatetimeDefaults);
+    return value.map(replaceVolatileSnapshotValues);
   }
   const obj = value as Record<string, unknown>;
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(obj)) {
     const v = obj[key];
-    if (key === 'default' && typeof v === 'string' && ISO_DATETIME_DEFAULT.test(v)) {
-      out[key] = '<generated-at-runtime>';
-    } else {
-      out[key] = replaceVolatileDatetimeDefaults(v);
-    }
+    const rule = volatileSnapshotReplacements.find((r) => r.test(key, v));
+    out[key] = rule ? rule.placeholder : replaceVolatileSnapshotValues(v);
   }
   return out;
 };
@@ -86,8 +98,8 @@ describe('openapi:generate', () => {
     expect(hasPathEndingWith('/users')).toBe(true);
     expect(hasPathEndingWith('/users/{id}')).toBe(true);
 
-    // Full document snapshot (stable key order, volatile datetime defaults normalized)
-    expect(sortKeysDeep(replaceVolatileDatetimeDefaults(spec))).toMatchSnapshot();
+    // Full document snapshot (stable key order, volatile fields normalized)
+    expect(sortKeysDeep(replaceVolatileSnapshotValues(spec))).toMatchSnapshot();
 
     const plainOut = stripAnsi(stdout);
     const plainErr = stripAnsi(stderr);

--- a/tests/scripts/run-tests.js
+++ b/tests/scripts/run-tests.js
@@ -99,9 +99,15 @@ yargs
             type: 'boolean',
             default: false,
           })
+          .option('updateSnapshot', {
+            alias: 'u',
+            describe: 'Pass -u to Jest to update snapshots',
+            type: 'boolean',
+            default: false,
+          })
           .parse();
 
-        const { concurrency, domains: selectedDomains, setup } = testYargs;
+        const { concurrency, domains: selectedDomains, setup, updateSnapshot } = testYargs;
 
         /**
          * Publishing all packages to the yalc store
@@ -432,7 +438,7 @@ module.exports = config
                     domainDir,
                     jestConfigPath,
                     testApps,
-                    testArgs: testYargs._,
+                    testArgs: [...(updateSnapshot ? ['-u'] : []), ...testYargs._],
                   });
                 } catch (err) {
                   console.error('Test suite failed for', domain);


### PR DESCRIPTION
### What does it do?

- allows passing the `-u` to jest to allow updating snapshots
- adds a `yarn test:cli:update` to do it automatically
- replaces the fixed version number in openapi snapshots with a fixed generic

### Why is it needed?

CLI tests were recently updated to use snapshots, but these pieces were missing

### How to test it?

Make a change that would affect a snapshot then run `yarn test:cli:update`

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/25969