### PR TITLE
fix(content-manager): render ID column without number grouping

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -15,6 +15,8 @@ interface CellContentProps extends Omit<ListFieldLayout, 'cellFormatter'> {
 }
 
 const CellContent = ({ content, mainField, attribute, rowId, name }: CellContentProps) => {
+  const isIdColumn = name === 'id';
+
   if (!hasContent(content, mainField, attribute)) {
     return (
       <Typography
@@ -54,7 +56,7 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
       return (
         <Tooltip label={content}>
           <Typography maxWidth="30rem" ellipsis textColor="neutral800">
-            <CellValue type={attribute.type} value={content} />
+            <CellValue isIdColumn={isIdColumn} type={attribute.type} value={content} />
           </Typography>
         </Tooltip>
       );
@@ -62,7 +64,7 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
     default:
       return (
         <Typography maxWidth="30rem" ellipsis textColor="neutral800">
-          <CellValue type={attribute.type} value={content} />
+          <CellValue isIdColumn={isIdColumn} type={attribute.type} value={content} />
         </Typography>
       );
   }

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
@@ -5,11 +5,12 @@ import { useIntl } from 'react-intl';
 import type { Schema } from '@strapi/types';
 
 interface CellValueProps {
+  isIdColumn?: boolean;
   type: Schema.Attribute.Kind | 'custom';
   value: any;
 }
 
-const CellValue = ({ type, value }: CellValueProps) => {
+const CellValue = ({ isIdColumn = false, type, value }: CellValueProps) => {
   const { formatDate, formatTime, formatNumber, formatMessage } = useIntl();
   let formattedValue = value;
 
@@ -51,7 +52,7 @@ const CellValue = ({ type, value }: CellValueProps) => {
   }
 
   if (['integer', 'biginteger'].includes(type)) {
-    formattedValue = formatNumber(value, { maximumFractionDigits: 0, useGrouping: false });
+    formattedValue = formatNumber(value, { maximumFractionDigits: 0, useGrouping: !isIdColumn });
   }
 
   return toString(formattedValue);

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellValue.tsx
@@ -51,7 +51,7 @@ const CellValue = ({ type, value }: CellValueProps) => {
   }
 
   if (['integer', 'biginteger'].includes(type)) {
-    formattedValue = formatNumber(value, { maximumFractionDigits: 0 });
+    formattedValue = formatNumber(value, { maximumFractionDigits: 0, useGrouping: false });
   }
 
   return toString(formattedValue);

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
@@ -87,4 +87,18 @@ describe('CellValue', () => {
 
     expect(getByText('1000000000000')).toBeInTheDocument();
   });
+
+  it('should return a biginteger string without losing precision', () => {
+    const { getByText } = render(CellValueWithProvider('biginteger', '900719925474099312345'));
+
+    expect(getByText('900,719,925,474,099,312,345')).toBeInTheDocument();
+  });
+
+  it('should return an ID column biginteger string without losing precision', () => {
+    const { getByText } = render(
+      CellValueWithProvider('biginteger', '900719925474099312345', true)
+    );
+
+    expect(getByText('900719925474099312345')).toBeInTheDocument();
+  });
 });

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
@@ -3,10 +3,14 @@ import { IntlProvider } from 'react-intl';
 
 import { CellValue, CellValueProps } from '../CellValue';
 
-const CellValueWithProvider = (type: CellValueProps['type'], value: CellValueProps['value']) => {
+const CellValueWithProvider = (
+  type: CellValueProps['type'],
+  value: CellValueProps['value'],
+  isIdColumn?: CellValueProps['isIdColumn']
+) => {
   return (
     <IntlProvider messages={{}} defaultLocale="en" textComponent="span" locale="en">
-      <CellValue type={type} value={value} />
+      <CellValue isIdColumn={isIdColumn} type={type} value={value} />
     </IntlProvider>
   );
 };
@@ -42,14 +46,20 @@ describe('CellValue', () => {
     expect(getByText('3')).toBeInTheDocument();
   });
 
-  it('should return a large integer without thousands separator', () => {
+  it('should return a large integer with thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('integer', 314159265359));
 
-    expect(getByText('314159265359')).toBeInTheDocument();
+    expect(getByText('314,159,265,359')).toBeInTheDocument();
   });
 
-  it('should return a very large integer without thousands separator', () => {
+  it('should return a very large integer with thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('integer', 1000000000000));
+
+    expect(getByText('1,000,000,000,000')).toBeInTheDocument();
+  });
+
+  it('should return an ID column integer without thousands separator', () => {
+    const { getByText } = render(CellValueWithProvider('integer', 1000000000000, true));
 
     expect(getByText('1000000000000')).toBeInTheDocument();
   });
@@ -60,14 +70,20 @@ describe('CellValue', () => {
     expect(getByText('3')).toBeInTheDocument();
   });
 
-  it('should return a large biginteger without thousands separator', () => {
+  it('should return a large biginteger with thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('biginteger', 314159265359));
 
-    expect(getByText('314159265359')).toBeInTheDocument();
+    expect(getByText('314,159,265,359')).toBeInTheDocument();
   });
 
-  it('should return a very large biginteger without thousands separator', () => {
+  it('should return a very large biginteger with thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('biginteger', 1000000000000));
+
+    expect(getByText('1,000,000,000,000')).toBeInTheDocument();
+  });
+
+  it('should return an ID column biginteger without thousands separator', () => {
+    const { getByText } = render(CellValueWithProvider('biginteger', 1000000000000, true));
 
     expect(getByText('1000000000000')).toBeInTheDocument();
   });

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/tests/CellValue.test.tsx
@@ -42,10 +42,16 @@ describe('CellValue', () => {
     expect(getByText('3')).toBeInTheDocument();
   });
 
-  it('should return a number with 0 decimals', () => {
+  it('should return a large integer without thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('integer', 314159265359));
 
-    expect(getByText('314,159,265,359')).toBeInTheDocument();
+    expect(getByText('314159265359')).toBeInTheDocument();
+  });
+
+  it('should return a very large integer without thousands separator', () => {
+    const { getByText } = render(CellValueWithProvider('integer', 1000000000000));
+
+    expect(getByText('1000000000000')).toBeInTheDocument();
   });
 
   it('should return a number with 0 decimals', () => {
@@ -54,9 +60,15 @@ describe('CellValue', () => {
     expect(getByText('3')).toBeInTheDocument();
   });
 
-  it('should return a number with 0 decimals', () => {
+  it('should return a large biginteger without thousands separator', () => {
     const { getByText } = render(CellValueWithProvider('biginteger', 314159265359));
 
-    expect(getByText('314,159,265,359')).toBeInTheDocument();
+    expect(getByText('314159265359')).toBeInTheDocument();
+  });
+
+  it('should return a very large biginteger without thousands separator', () => {
+    const { getByText } = render(CellValueWithProvider('biginteger', 1000000000000));
+
+    expect(getByText('1000000000000')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

Fixes #25985

## Why

`CellValue.tsx` uses `formatNumber` (react-intl's `Intl.NumberFormat` wrapper) to render numeric values in the list view. This adds locale-specific grouping separators. That behavior is fine for regular integer fields, but confusing for the ID column, where a value like `17236` renders as `17,236`.

## How

Pass `useGrouping: false` only when rendering the top-level `id` column for integer-like values. Regular `integer` and `biginteger` fields keep their existing localized grouping behavior.

```ts
// Regular integer/biginteger fields keep grouping
formattedValue = formatNumber(value, { maximumFractionDigits: 0, useGrouping: true });

// ID column disables grouping
formattedValue = formatNumber(value, { maximumFractionDigits: 0, useGrouping: false });
```

## Test plan

- [ ] Open an existing collection type with a large numeric ID (e.g. `17236`) -> should display as `17236`, not `17,236`
- [ ] Non-ID integer/biginteger fields still display with their existing localized grouping behavior
- [ ] Float/decimal fields still display with locale-correct decimal formatting
- [ ] `CellValue` tests cover grouped non-ID values and ungrouped ID-column values