### PR TITLE
fix(admin): respect custom admin path on 401 redirect

### DIFF
--- a/packages/core/admin/admin/src/core/store/configure.ts
+++ b/packages/core/admin/admin/src/core/store/configure.ts
@@ -10,6 +10,7 @@ import {
 
 import { reducer as appReducer, AppState, logout } from '../../reducer';
 import { adminApi } from '../../services/api';
+import { getBasename } from '../utils/basename';
 
 /**
  * @description Static reducers are ones we know, they live in the admin package.
@@ -92,7 +93,7 @@ const rtkQueryUnauthorizedMiddleware: Middleware =
     // isRejectedWithValue Or isRejected
     if (isRejected(action) && action.payload?.status === 401) {
       dispatch(logout());
-      window.location.href = '/admin/auth/login';
+      window.location.href = `${window.location.origin}${getBasename()}/auth/login`;
       return;
     }
 

--- a/packages/core/admin/admin/src/tests/configureStore.test.ts
+++ b/packages/core/admin/admin/src/tests/configureStore.test.ts
@@ -1,0 +1,41 @@
+import { configureStore } from '../core/store/configure';
+
+jest.mock('../core/utils/basename', () => ({
+  getBasename: jest.fn(() => '/custom-admin'),
+}));
+
+describe('configureStore unauthorized redirect', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'https://example.com',
+        href: 'https://example.com/custom-admin',
+      } as Location,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the configured admin login path on 401 responses', () => {
+    const store = configureStore();
+
+    store.dispatch({
+      type: 'test/rejected',
+      payload: { status: 401 },
+      meta: { requestStatus: 'rejected', requestId: '1' },
+      error: { message: 'Rejected' },
+    } as any);
+
+    expect(window.location.href).toBe('https://example.com/custom-admin/auth/login');
+  });
+});


### PR DESCRIPTION
### What does it do?

This PR fixes the admin 401 redirect to respect the configured admin base path.

Previously, when the admin received a 401 response, the unauthorized middleware redirected users to the hardcoded path `/admin/auth/login`. This breaks setups that use a custom admin URL, because the rest of the admin app already uses the configured basename.

This change replaces the hardcoded redirect with a redirect built from `getBasename()`, so expired sessions are sent to the correct login page for the configured admin path.

It also adds a regression test covering a custom admin path such as `/custom-admin`.

### Why is it needed?

Strapi supports configuring a custom admin URL, but on session expiry or other 401 responses the admin store middleware still redirected to `/admin/auth/login`.

As a result, users with a custom admin path could be sent to a non-existent login route instead of the actual admin login page. This makes re-authentication fail until they manually navigate back to the custom admin URL.

### How to test it?

1. Configure a custom admin URL, for example `/custom-admin`.
2. Start Strapi and open the admin at `/custom-admin`.
3. Authenticate successfully.
4. Trigger a 401 response in the admin after authentication expires or becomes invalid.
5. Confirm the app redirects to `/custom-admin/auth/login` instead of `/admin/auth/login`.

Regression test added:

- `yarn test:front:ce packages/core/admin/admin/src/tests/configureStore.test.ts`

### Related issue(s)/PR(s)

Fixes the hardcoded custom-admin redirect behavior reported in related issues about `/admin/auth/login` being used even when a custom admin path is configured.