### PR TITLE
chore(data-transfer): isIgnoredContentType helper for filtering

### DIFF
--- a/docs/docs/docs/01-core/data-transfer/01-engine/01-engine.mdx
+++ b/docs/docs/docs/01-core/data-transfer/01-engine/01-engine.mdx
@@ -185,7 +185,7 @@ Once all stages have been completed, the transfer waits for all providers to clo
 
 A transfer engine object is created by using `createTransferEngine`, which accepts a [source provider](../02-providers/01-source-providers.md), a [destination provider](../02-providers/02-destination-providers.md), and an options object.
 
-Note: By default, a transfer engine will transfer ALL data, including admin data, api tokens, etc. Transform filters must be used if you wish to exclude, as seen in the example below. An array called `DEFAULT_IGNORED_CONTENT_TYPES` is available from @strapi/data-transfer containing the uids that are excluded by default from the import, export, and transfer commands. If you intend to transfer admin data, be aware that this behavior will likely change in the future to automatically exclude the entire `admin::` uid namespace and will instead require them to be explicitly included.
+Note: By default, a transfer engine will transfer ALL data, including admin data, api tokens, etc. Transform filters must be used if you wish to exclude, as seen in the example below. A helper function called `isIgnoredContentType` is available from the CLI utils and is used by the import, export, and transfer commands to exclude content types that should not be transferred. All content types in the `admin::` namespace are automatically excluded by prefix, along with certain explicitly listed types (such as content releases). If you need to transfer admin data, you must implement your own engine transforms without this filter.
 
 ```typescript
 const engine = createTransferEngine(source, destination, options);
@@ -209,19 +209,16 @@ const options = {
       {
         // exclude all relations to ignored content types
         filter(link) {
-          return (
-            !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.left.type) &&
-            !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.right.type)
-          );
+          return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
         },
       },
       // Note: map exists for links but is not recommended
     ],
     entities: [
       {
-        // exclude all ignored content types
+        // exclude all ignored content types (admin:: prefix and explicit list)
         filter(entity) {
-          return !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type);
+          return !isIgnoredContentType(entity.type);
         },
       },
       {
@@ -444,9 +441,9 @@ const options = {
   transforms: {
     entities: [
       {
-        // exclude all ignored admin content types
+        // exclude all ignored content types (admin:: prefix and explicit list)
         filter(entity) {
-          return !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type);
+          return !isIgnoredContentType(entity.type);
         },
       },
       {
@@ -460,10 +457,7 @@ const options = {
       {
         // exclude all relations to ignored content types
         filter(link) {
-          return (
-            !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.left.type) &&
-            !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.right.type)
-          );
+          return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
         },
       },
       {
@@ -491,9 +485,9 @@ const options = {
   transforms: {
     entities: [
       {
-        // exclude all ignored content types
+        // exclude all ignored content types (admin:: prefix and explicit list)
         filter(entity) {
-          return !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type);
+          return !isIgnoredContentType(entity.type);
         },
       },
       {

--- a/packages/core/strapi/src/cli/commands/export/action.ts
+++ b/packages/core/strapi/src/cli/commands/export/action.ts
@@ -14,7 +14,7 @@ import {
 import {
   getDefaultExportName,
   buildTransferTable,
-  DEFAULT_IGNORED_CONTENT_TYPES,
+  isIgnoredContentType,
   createStrapiInstance,
   formatDiagnostic,
   loadersFactory,
@@ -83,17 +83,14 @@ export default async (opts: CmdOptions) => {
       links: [
         {
           filter(link) {
-            return (
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.left.type) &&
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.right.type)
-            );
+            return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
           filter(entity) {
-            return !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type);
+            return !isIgnoredContentType(entity.type);
           },
         },
       ],

--- a/packages/core/strapi/src/cli/commands/import/__tests__/import.test.ts
+++ b/packages/core/strapi/src/cli/commands/import/__tests__/import.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../../utils/data-transfer', () => {
         send: jest.fn(),
       },
       destroy: jest.fn(),
+      contentTypes: {},
     }),
     buildTransferTable: jest.fn(() => {
       return {

--- a/packages/core/strapi/src/cli/commands/import/action.ts
+++ b/packages/core/strapi/src/cli/commands/import/action.ts
@@ -13,7 +13,7 @@ import {
 
 import {
   buildTransferTable,
-  DEFAULT_IGNORED_CONTENT_TYPES,
+  isIgnoredContentType,
   createStrapiInstance,
   formatDiagnostic,
   loadersFactory,
@@ -90,16 +90,13 @@ export default async (opts: CmdOptions) => {
       links: [
         {
           filter(link) {
-            return (
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.left.type) &&
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.right.type)
-            );
+            return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
-          filter: (entity) => !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type),
+          filter: (entity) => !isIgnoredContentType(entity.type),
         },
       ],
     },
@@ -111,7 +108,7 @@ export default async (opts: CmdOptions) => {
     },
     autoDestroy: false,
     strategy: opts.conflictStrategy || DEFAULT_CONFLICT_STRATEGY,
-    restore: parseRestoreFromOptions(engineOptions),
+    restore: parseRestoreFromOptions(engineOptions, strapiInstance),
   };
 
   const destination = createLocalStrapiDestinationProvider(destinationOptions);

--- a/packages/core/strapi/src/cli/commands/transfer/__tests__/transfer.test.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/__tests__/transfer.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../utils/data-transfer', () => {
         telemetry: {
           send: jest.fn(),
         },
+        contentTypes: {},
       };
     },
     getDefaultExportName: jest.fn(() => 'default'),

--- a/packages/core/strapi/src/cli/commands/transfer/action.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/action.ts
@@ -4,7 +4,7 @@ import { engine as engineDataTransfer, strapi as strapiDataTransfer } from '@str
 import {
   buildTransferTable,
   createStrapiInstance,
-  DEFAULT_IGNORED_CONTENT_TYPES,
+  isIgnoredContentType,
   formatDiagnostic,
   loadersFactory,
   exitMessageText,
@@ -84,7 +84,7 @@ export default async (opts: CmdOptions) => {
     destination = createLocalStrapiDestinationProvider({
       getStrapi: () => strapi,
       strategy: 'restore',
-      restore: parseRestoreFromOptions(opts),
+      restore: parseRestoreFromOptions(opts, strapi),
     });
   }
   // if URL provided, set up a remote destination provider
@@ -100,7 +100,7 @@ export default async (opts: CmdOptions) => {
         token: opts.toToken,
       },
       strategy: 'restore',
-      restore: parseRestoreFromOptions(opts),
+      restore: parseRestoreFromOptions(opts, strapi),
     });
   }
 
@@ -118,17 +118,14 @@ export default async (opts: CmdOptions) => {
       links: [
         {
           filter(link) {
-            return (
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.left.type) &&
-              !DEFAULT_IGNORED_CONTENT_TYPES.includes(link.right.type)
-            );
+            return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
           filter(entity) {
-            return !DEFAULT_IGNORED_CONTENT_TYPES.includes(entity.type);
+            return !isIgnoredContentType(entity.type);
           },
         },
       ],

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -107,18 +107,16 @@ const buildTransferTable = (resultData: ResultData) => {
   return table;
 };
 
-const DEFAULT_IGNORED_CONTENT_TYPES = [
-  'admin::permission',
-  'admin::user',
-  'admin::role',
-  'admin::api-token',
-  'admin::api-token-permission',
-  'admin::transfer-token',
-  'admin::transfer-token-permission',
-  'admin::audit-log',
+const IGNORED_CONTENT_TYPE_PREFIXES = ['admin::'];
+
+const IGNORED_CONTENT_TYPES = [
   'plugin::content-releases.release',
   'plugin::content-releases.release-action',
 ];
+
+const isIgnoredContentType = (type: string) =>
+  IGNORED_CONTENT_TYPE_PREFIXES.some((prefix) => type.startsWith(prefix)) ||
+  IGNORED_CONTENT_TYPES.includes(type);
 
 const abortTransfer = async ({
   engine,
@@ -466,9 +464,15 @@ type RestoreConfig = NonNullable<
 >;
 
 // Based on exclude/only from options, create the restore object to match
-const parseRestoreFromOptions = (opts: Partial<engineDataTransfer.ITransferEngineOptions>) => {
+const parseRestoreFromOptions = (
+  opts: Partial<engineDataTransfer.ITransferEngineOptions>,
+  strapi: Core.Strapi
+) => {
   const entitiesOptions: RestoreConfig['entities'] = {
-    exclude: DEFAULT_IGNORED_CONTENT_TYPES,
+    exclude: [
+      ...Object.keys(strapi.contentTypes).filter(isIgnoredContentType),
+      ...IGNORED_CONTENT_TYPES,
+    ],
     include: undefined,
   };
 
@@ -495,7 +499,7 @@ export {
   buildTransferTable,
   getDefaultExportName,
   getTransferTelemetryPayload,
-  DEFAULT_IGNORED_CONTENT_TYPES,
+  isIgnoredContentType,
   createStrapiInstance,
   excludeOption,
   exitMessageText,


### PR DESCRIPTION
### What does it do?

- Replaces the static `DEFAULT_IGNORED_CONTENT_TYPES` array with an `isIgnoredContentType` helper, which ignores content types based on the `admin::` prefix rather than an explicit UID list.
- All content types within the `admin::` namespace are now detected and excluded automatically, removing the need to update the ignored list for new admin types.

### Why is this needed?

Previously, admin content types were filtered using a hardcoded list of their UIDs. If new admin types were added (by plugins or future Strapi releases), they would not be excluded automatically

### Related issue(s)/PR(s)
fixes CMS-589