### PR TITLE
fix(content-manager): optimize document layout hooks

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
@@ -262,4 +262,46 @@ describe('usePersistentPartialQueryParams', () => {
 
     expect(mockSetQuery).not.toHaveBeenCalled();
   });
+
+  describe('isHydrated', () => {
+    it('flips to true after the hydration effect runs when localStorage is populated', async () => {
+      window.localStorage.setItem(key, JSON.stringify({ page: 2, pageSize: 20, sort: 'name:asc' }));
+
+      const { result } = renderHook(() =>
+        usePersistentPartialQueryParams({
+          [key]: { paths: keysToPersist },
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+    });
+
+    it('flips to true even when localStorage is empty', async () => {
+      const { result } = renderHook(() =>
+        usePersistentPartialQueryParams({
+          [key]: { paths: keysToPersist },
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+    });
+
+    it('flips to true even when localStorage holds invalid JSON', async () => {
+      window.localStorage.setItem(key, 'invalid-json');
+
+      const { result } = renderHook(() =>
+        usePersistentPartialQueryParams({
+          [key]: { paths: keysToPersist },
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.isHydrated).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/core/content-manager/admin/src/hooks/useDocument.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocument.ts
@@ -262,7 +262,7 @@ const useDocument: UseDocument = (args, opts) => {
  * @internal this hook uses the router to extract the model, collection type & id from the url.
  * therefore, it shouldn't be used outside of the content-manager because it won't work as intended.
  */
-const useDoc = () => {
+const useDoc = (opts?: UseDocumentOpts) => {
   const { id, slug, collectionType, origin } = useParams<{
     id: string;
     origin: string;
@@ -283,7 +283,8 @@ const useDoc = () => {
   const document = useDocument(
     { documentId: origin || id, model: slug, collectionType, params },
     {
-      skip: id === 'create' || (!origin && !id && collectionType !== SINGLE_TYPES),
+      ...opts,
+      skip: id === 'create' || (!origin && !id && collectionType !== SINGLE_TYPES) || opts?.skip,
     }
   );
 

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -159,14 +159,9 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { isLoading: isLoadingSchemas, schemas } = useContentTypeSchema();
 
-  const {
-    data,
-    isLoading: isLoadingConfigs,
-    error,
-    isFetching: isFetchingConfigs,
-  } = useGetContentTypeConfigurationQuery(model);
+  const { data, isLoading: isLoadingConfigs, error } = useGetContentTypeConfigurationQuery(model);
 
-  const isLoading = isLoadingSchemas || isFetchingConfigs || isLoadingConfigs;
+  const isLoading = isLoadingSchemas || isLoadingConfigs;
 
   React.useEffect(() => {
     if (error) {

--- a/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
+++ b/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { usePersistentStateScope, useQueryParams } from '@strapi/admin/strapi-admin';
 import get from 'lodash/get';
@@ -25,34 +25,6 @@ const filterObjectKeys = (obj: object, keys: PropertyPath[]) => {
   return result;
 };
 
-/**
- * Synchronously reads persisted query params from localStorage.
- * Use this during render to seed `useQueryParams` initialParams so the first
- * render already has the correct values (avoiding an extra request caused by
- * the deferred useEffect restoration in `usePersistentPartialQueryParams`).
- */
-export const readPersistedQueryParams = (
-  key: string,
-  keysToPersist: PropertyPath[]
-): Record<string, unknown> => {
-  const saved = window.localStorage.getItem(key);
-  if (!saved) {
-    return {};
-  }
-
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(saved);
-  } catch {
-    return {};
-  }
-  if (Object.keys(parsed).length === 0) {
-    return {};
-  }
-
-  return filterObjectKeys(parsed, keysToPersist);
-};
-
 export type PersistentQueryConfig = Record<string, PersistentQueryConfigEntry>;
 
 const normalizeConfigEntry = (
@@ -73,6 +45,7 @@ export const usePersistentPartialQueryParams = (config: PersistentQueryConfig) =
   const scope = usePersistentStateScope();
   const [{ query }, setQuery] = useQueryParams();
   const clonedConfig = JSON.stringify(config);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   // load query params from local storge
   useEffect(() => {
@@ -96,9 +69,10 @@ export const usePersistentPartialQueryParams = (config: PersistentQueryConfig) =
       Object.assign(mergedFilteredQuery, filteredQuery);
     }
 
-    if (Object.keys(mergedFilteredQuery).length === 0) return;
-
-    setQuery({ ...mergedFilteredQuery, ...query }, 'push', true);
+    if (Object.keys(mergedFilteredQuery).length > 0) {
+      setQuery({ ...mergedFilteredQuery, ...query }, 'push', true);
+    }
+    setIsHydrated(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clonedConfig, scope]);
 
@@ -113,4 +87,6 @@ export const usePersistentPartialQueryParams = (config: PersistentQueryConfig) =
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, clonedConfig, scope]);
+
+  return { isHydrated };
 };

--- a/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
+++ b/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
@@ -25,6 +25,34 @@ const filterObjectKeys = (obj: object, keys: PropertyPath[]) => {
   return result;
 };
 
+/**
+ * Synchronously reads persisted query params from localStorage.
+ * Use this during render to seed `useQueryParams` initialParams so the first
+ * render already has the correct values (avoiding an extra request caused by
+ * the deferred useEffect restoration in `usePersistentPartialQueryParams`).
+ */
+export const readPersistedQueryParams = (
+  key: string,
+  keysToPersist: PropertyPath[]
+): Record<string, unknown> => {
+  const saved = window.localStorage.getItem(key);
+  if (!saved) {
+    return {};
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(saved);
+  } catch {
+    return {};
+  }
+  if (Object.keys(parsed).length === 0) {
+    return {};
+  }
+
+  return filterObjectKeys(parsed, keysToPersist);
+};
+
 export type PersistentQueryConfig = Record<string, PersistentQueryConfigEntry>;
 
 const normalizeConfigEntry = (

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -25,6 +25,7 @@ import { useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { useLazyComponents } from '../../hooks/useLazyComponents';
 import { useOnce } from '../../hooks/useOnce';
 import {
+  readPersistedQueryParams,
   PersistentQueryConfig,
   usePersistentPartialQueryParams,
 } from '../../hooks/usePersistentQueryParams';
@@ -43,6 +44,13 @@ import { handleInvisibleAttributes } from './utils/data';
 
 const EditViewPage = () => {
   const location = useLocation();
+  // Read persisted locale synchronously so the first document fetch
+  // already includes the locale param, avoiding a duplicate request when the
+  // usePersistentPartialQueryParams effect restores it post-render.
+  const persistedLocale = React.useMemo(
+    () => readPersistedQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale']),
+    []
+  );
   const [
     {
       query: { status },
@@ -50,6 +58,7 @@ const EditViewPage = () => {
     setQuery,
   ] = useQueryParams<{ status: 'draft' | 'published' }>({
     status: 'draft',
+    ...persistedLocale,
   });
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();

--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -25,7 +25,6 @@ import { useDocumentLayout } from '../../hooks/useDocumentLayout';
 import { useLazyComponents } from '../../hooks/useLazyComponents';
 import { useOnce } from '../../hooks/useOnce';
 import {
-  readPersistedQueryParams,
   PersistentQueryConfig,
   usePersistentPartialQueryParams,
 } from '../../hooks/usePersistentQueryParams';
@@ -44,13 +43,6 @@ import { handleInvisibleAttributes } from './utils/data';
 
 const EditViewPage = () => {
   const location = useLocation();
-  // Read persisted locale synchronously so the first document fetch
-  // already includes the locale param, avoiding a duplicate request when the
-  // usePersistentPartialQueryParams effect restores it post-render.
-  const persistedLocale = React.useMemo(
-    () => readPersistedQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale']),
-    []
-  );
   const [
     {
       query: { status },
@@ -58,7 +50,6 @@ const EditViewPage = () => {
     setQuery,
   ] = useQueryParams<{ status: 'draft' | 'published' }>({
     status: 'draft',
-    ...persistedLocale,
   });
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
@@ -77,9 +68,9 @@ const EditViewPage = () => {
     []
   );
 
-  usePersistentPartialQueryParams(persistentQueryConfigs);
+  const { isHydrated } = usePersistentPartialQueryParams(persistentQueryConfigs);
 
-  const doc = useDoc();
+  const doc = useDoc({ skip: !isHydrated });
   const {
     document,
     meta,
@@ -133,7 +124,8 @@ const EditViewPage = () => {
 
   const { isLazyLoading } = useLazyComponents([]);
 
-  const isLoading = isLoadingActionsRBAC || isLoadingDocument || isLoadingLayout || isLazyLoading;
+  const isLoading =
+    !isHydrated || isLoadingActionsRBAC || isLoadingDocument || isLoadingLayout || isLazyLoading;
 
   const initialValues = getInitialFormValues(isCreatingDocument);
 

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -47,7 +47,6 @@ import {
   useDocumentLayout,
 } from '../../hooks/useDocumentLayout';
 import {
-  readPersistedQueryParams,
   type PersistentQueryConfig,
   usePersistentPartialQueryParams,
 } from '../../hooks/usePersistentQueryParams';
@@ -106,23 +105,6 @@ const ListViewPage = () => {
   const { collectionType, model, schema } = useDoc();
   const { list, listViewConversionContext, isLoading: isLoadingLayout } = useDocumentLayout(model);
 
-  // Read persisted params synchronously so the first render already has
-  // the correct values. Without this, the useEffect in usePersistentPartialQueryParams
-  // restores them post-render, changing the query args and triggering extra requests.
-  const persistedSettings = React.useMemo(
-    () =>
-      readPersistedQueryParams(`STRAPI_LIST_VIEW_SETTINGS:${model}`, [
-        'sort',
-        'filters',
-        'pageSize',
-      ]),
-    [model]
-  );
-  const persistedLocale = React.useMemo(
-    () => readPersistedQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale']),
-    []
-  );
-
   const persistentQueryConfigs: PersistentQueryConfig = React.useMemo(
     () => ({
       [`STRAPI_LIST_VIEW_SETTINGS:${model}`]: {
@@ -136,7 +118,7 @@ const ListViewPage = () => {
     }),
     [model]
   );
-  usePersistentPartialQueryParams(persistentQueryConfigs);
+  const { isHydrated } = usePersistentPartialQueryParams(persistentQueryConfigs);
 
   const [displayedHeaderNames, setDisplayedHeaderNames] = useScopedPersistentState<string[] | null>(
     `STRAPI_LIST_VIEW_DISPLAYED_HEADERS:${model}`,
@@ -203,44 +185,28 @@ const ListViewPage = () => {
     }
   }, [displayedHeaderNames]);
 
-  const initialQueryParams = React.useMemo(
-    () => ({
-      page: '1',
-      pageSize: list.settings.pageSize.toString(),
-      sort: list.settings.defaultSortBy
-        ? `${list.settings.defaultSortBy}:${list.settings.defaultSortOrder}`
-        : '',
-      ...persistedSettings,
-      ...persistedLocale,
-    }),
-    [
-      list.settings.pageSize,
-      list.settings.defaultSortBy,
-      list.settings.defaultSortOrder,
-      persistedSettings,
-      persistedLocale,
-    ]
-  );
-
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
     page?: string;
     pageSize?: string;
     sort?: string;
-  }>(initialQueryParams);
+  }>({
+    page: '1',
+    pageSize: list.settings.pageSize.toString(),
+    sort: list.settings.defaultSortBy
+      ? `${list.settings.defaultSortBy}:${list.settings.defaultSortOrder}`
+      : '',
+  });
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
   const hasAppliedFilters = Boolean((query as any)?.filters?.$and?.length);
 
-  // Skip the query while layout config is loading. Before this fix the
-  // query fired immediately with DEFAULT_SETTINGS params (pageSize=10, sort=''),
-  // then re-fired with the real params once config arrived.
   const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery(
     {
       model,
       params,
     },
-    { skip: isLoadingLayout }
+    { skip: isLoadingLayout || !isHydrated }
   );
 
   /**
@@ -332,7 +298,7 @@ const ListViewPage = () => {
     model,
   ]);
 
-  if (isLoadingLayout || isLoading) {
+  if (isLoadingLayout || !isHydrated || isLoading) {
     return <Page.Loading />;
   }
 

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -47,6 +47,7 @@ import {
   useDocumentLayout,
 } from '../../hooks/useDocumentLayout';
 import {
+  readPersistedQueryParams,
   type PersistentQueryConfig,
   usePersistentPartialQueryParams,
 } from '../../hooks/usePersistentQueryParams';
@@ -103,7 +104,24 @@ const ListViewPage = () => {
   );
 
   const { collectionType, model, schema } = useDoc();
-  const { list, listViewConversionContext } = useDocumentLayout(model);
+  const { list, listViewConversionContext, isLoading: isLoadingLayout } = useDocumentLayout(model);
+
+  // Read persisted params synchronously so the first render already has
+  // the correct values. Without this, the useEffect in usePersistentPartialQueryParams
+  // restores them post-render, changing the query args and triggering extra requests.
+  const persistedSettings = React.useMemo(
+    () =>
+      readPersistedQueryParams(`STRAPI_LIST_VIEW_SETTINGS:${model}`, [
+        'sort',
+        'filters',
+        'pageSize',
+      ]),
+    [model]
+  );
+  const persistedLocale = React.useMemo(
+    () => readPersistedQueryParams('STRAPI_LOCALE', ['plugins.i18n.locale']),
+    []
+  );
 
   const persistentQueryConfigs: PersistentQueryConfig = React.useMemo(
     () => ({
@@ -185,26 +203,45 @@ const ListViewPage = () => {
     }
   }, [displayedHeaderNames]);
 
+  const initialQueryParams = React.useMemo(
+    () => ({
+      page: '1',
+      pageSize: list.settings.pageSize.toString(),
+      sort: list.settings.defaultSortBy
+        ? `${list.settings.defaultSortBy}:${list.settings.defaultSortOrder}`
+        : '',
+      ...persistedSettings,
+      ...persistedLocale,
+    }),
+    [
+      list.settings.pageSize,
+      list.settings.defaultSortBy,
+      list.settings.defaultSortOrder,
+      persistedSettings,
+      persistedLocale,
+    ]
+  );
+
   const [{ query }] = useQueryParams<{
     plugins?: Record<string, unknown>;
     page?: string;
     pageSize?: string;
     sort?: string;
-  }>({
-    page: '1',
-    pageSize: list.settings.pageSize.toString(),
-    sort: list.settings.defaultSortBy
-      ? `${list.settings.defaultSortBy}:${list.settings.defaultSortOrder}`
-      : '',
-  });
+  }>(initialQueryParams);
 
   const params = React.useMemo(() => buildValidParams(query), [query]);
   const hasAppliedFilters = Boolean((query as any)?.filters?.$and?.length);
 
-  const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery({
-    model,
-    params,
-  });
+  // Skip the query while layout config is loading. Before this fix the
+  // query fired immediately with DEFAULT_SETTINGS params (pageSize=10, sort=''),
+  // then re-fired with the real params once config arrived.
+  const { data, error, isLoading, isFetching } = useGetAllDocumentsQuery(
+    {
+      model,
+      params,
+    },
+    { skip: isLoadingLayout }
+  );
 
   /**
    * If the API returns an error, display a notification
@@ -295,7 +332,7 @@ const ListViewPage = () => {
     model,
   ]);
 
-  if (isLoading) {
+  if (isLoadingLayout || isLoading) {
     return <Page.Loading />;
   }
 


### PR DESCRIPTION
### What does it do?

Prevents duplicate network requests when loading Edit or List view in the content manager.

Key changes:

1. Reads persisted query params from localStorage during render to avoid extra fetches.
2. Defers document list queries until layout config is loaded to prevent unnecessary initial requests.

### Why is it needed?

Previously, both views would make redundant requests—first with default params, then again with the correct ones—causing duplicate loads and wasted resources.

### Note 

#25437 fixed a data overwrite bug. This PR optimizes performance

