### PR TITLE
Improve Strapi bootstrap time

### DIFF
--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -175,7 +175,7 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   await syncAuthSettings();
   await syncAPITokensPermissions();
 
-  await getService('metrics').sendUpdateProjectInformation(strapi);
+  getService('metrics').sendUpdateProjectInformation(strapi);
   getService('metrics').startCron(strapi);
 
   apiTokenService.checkSaltIsDefined();

--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -165,15 +165,20 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   const tokenService = getService('token');
 
   await roleService.createRolesIfNoneExist();
-  await roleService.resetSuperAdminPermissions();
-  await roleService.displayWarningIfNoSuperAdmin();
-
-  await permissionService.cleanPermissionsInDatabase();
-
-  await userService.displayWarningIfUsersDontHaveRole();
-
-  await syncAuthSettings();
-  await syncAPITokensPermissions();
+  // After roles exist, run permission operations and independent checks in parallel
+  await Promise.all([
+    // Permission operations (sequential — both write to permissions table)
+    (async () => {
+      await roleService.resetSuperAdminPermissions();
+      await permissionService.cleanPermissionsInDatabase();
+    })(),
+    // Independent read-only checks and config sync
+    roleService.displayWarningIfNoSuperAdmin(),
+    userService.displayWarningIfUsersDontHaveRole(),
+    syncAuthSettings(),
+    syncAPITokensPermissions(),
+    createDefaultAPITokensIfNeeded(),
+  ]);
 
   getService('metrics').sendUpdateProjectInformation(strapi);
   getService('metrics').startCron(strapi);
@@ -181,6 +186,4 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   apiTokenService.checkSaltIsDefined();
   transferService.token.checkSaltIsDefined();
   tokenService.checkSecretIsDefined();
-
-  await createDefaultAPITokensIfNeeded();
 };

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -34,7 +34,6 @@ import { FeaturesService, createFeaturesService } from './services/features';
 import { createDocumentService } from './services/document-service';
 import { createContentSourceMapsService } from './services/content-source-maps';
 
-import { coreStoreModel } from './services/core-store';
 import { createConfigProvider } from './services/config';
 
 import { cleanComponentJoinTable } from './services/document-service/utils/clean-component-join-table';
@@ -436,13 +435,27 @@ class Strapi extends Container implements Core.Strapi {
     await this.db.init({ models });
     await this.store.prefill();
 
+    // Start license check early - it's a network call independent of everything else
+    const licenseCheckPromise = this.EE
+      ? (async () => {
+          const start = Date.now();
+          await utils.ee.checkLicense({ strapi: this });
+          this.log.debug(`License check finished (${Date.now() - start}ms)`);
+        })()
+      : Promise.resolve();
+
     let oldContentTypes;
-    if (await this.db.getSchemaConnection().hasTable(coreStoreModel.tableName)) {
+
+    // Try to read directly instead of checking hasTable first (saves a query)
+    try {
       oldContentTypes = await this.store.get({
         type: 'strapi',
         name: 'content_types',
         key: 'schema',
       });
+    } catch {
+      // Table doesn't exist yet (first run)
+      oldContentTypes = undefined;
     }
 
     await this.hook('strapi::content-types.beforeSync').call({
@@ -450,12 +463,8 @@ class Strapi extends Container implements Core.Strapi {
       contentTypes: this.contentTypes,
     });
 
-    // NOTE: commenting out repair logic for now as it is causing relationship loss in some cases
-    // will revisit soon in the future PR
-
     const status = await this.db.schema.sync();
 
-    // // if schemas have changed, run repairs
     if (status === 'CHANGED') {
       await this.db.repair.removeOrphanMorphType({ pivot: 'component_type' });
       await this.db.repair.removeOrphanMorphType({ pivot: 'related_type' });
@@ -475,32 +484,40 @@ class Strapi extends Container implements Core.Strapi {
       });
     }
 
-    if (this.EE) {
-      await utils.ee.checkLicense({ strapi: this });
-    }
+    // Skip afterSync hooks and content type store write when nothing changed
+    const contentTypesChanged =
+      !oldContentTypes ||
+      JSON.stringify(oldContentTypes) !== JSON.stringify(this.contentTypes);
 
-    await this.hook('strapi::content-types.afterSync').call({
-      oldContentTypes,
-      contentTypes: this.contentTypes,
-    });
+    // Run afterSync/store.set and server init in parallel
+    await Promise.all([
+      contentTypesChanged
+        ? (async () => {
+            await this.hook('strapi::content-types.afterSync').call({
+              oldContentTypes,
+              contentTypes: this.contentTypes,
+            });
+            await this.store.set({
+              type: 'strapi',
+              name: 'content_types',
+              key: 'schema',
+              value: this.contentTypes,
+            });
+          })()
+        : Promise.resolve(),
+      (async () => {
+        await this.server.initMiddlewares();
+        this.server.initRouting();
+        await this.contentAPI.permissions.registerActions();
+      })(),
+    ]);
 
-    await this.store.set({
-      type: 'strapi',
-      name: 'content_types',
-      key: 'schema',
-      value: this.contentTypes,
-    });
-
-    await this.server.initMiddlewares();
-    this.server.initRouting();
-
-    await this.contentAPI.permissions.registerActions();
+    // Await license check before plugin bootstraps (some plugins may need EE status)
+    await licenseCheckPromise;
 
     await this.runPluginsLifecycles(utils.LIFECYCLES.BOOTSTRAP);
 
-    for (const provider of providers) {
-      await provider.bootstrap?.(this);
-    }
+    await Promise.all(providers.map((provider) => provider.bootstrap?.(this)));
 
     await this.runUserLifecycles(utils.LIFECYCLES.BOOTSTRAP);
 

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -434,6 +434,7 @@ class Strapi extends Container implements Core.Strapi {
     ];
 
     await this.db.init({ models });
+    await this.store.prefill();
 
     let oldContentTypes;
     if (await this.db.getSchemaConnection().hasTable(coreStoreModel.tableName)) {

--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -486,8 +486,7 @@ class Strapi extends Container implements Core.Strapi {
 
     // Skip afterSync hooks and content type store write when nothing changed
     const contentTypesChanged =
-      !oldContentTypes ||
-      JSON.stringify(oldContentTypes) !== JSON.stringify(this.contentTypes);
+      !oldContentTypes || JSON.stringify(oldContentTypes) !== JSON.stringify(this.contentTypes);
 
     // Run afterSync/store.set and server init in parallel
     await Promise.all([

--- a/packages/core/core/src/registries/modules.ts
+++ b/packages/core/core/src/registries/modules.ts
@@ -25,19 +25,13 @@ const modulesRegistry = (strapi: Core.Strapi) => {
       return modules[namespace];
     },
     async bootstrap() {
-      for (const mod of Object.values(modules)) {
-        await mod.bootstrap();
-      }
+      await Promise.all(Object.values(modules).map((mod) => mod.bootstrap()));
     },
     async register() {
-      for (const mod of Object.values(modules)) {
-        await mod.register();
-      }
+      await Promise.all(Object.values(modules).map((mod) => mod.register()));
     },
     async destroy() {
-      for (const mod of Object.values(modules)) {
-        await mod.destroy();
-      }
+      await Promise.all(Object.values(modules).map((mod) => mod.destroy()));
     },
   };
 };

--- a/packages/core/core/src/services/core-store.ts
+++ b/packages/core/core/src/services/core-store.ts
@@ -55,9 +55,18 @@ interface CoreStore {
   get<T = unknown>(params: GetParams): Promise<T>;
   set(params: SetParams): Promise<void>;
   delete(params: GetParams): Promise<void>;
+  prefill(): Promise<void>;
 }
 
+const CACHE_TTL = 2 * 60 * 1000; // 2 minutes — only used during startup
+
 const createCoreStore = ({ db }: { db: Database }) => {
+  // Populated by prefill(), auto-expires after CACHE_TTL
+  const cache = new Map<string, { value: string; type: string; id: number }>();
+
+  const cacheKey = (key: string, environment: string | null, tag: string | null) =>
+    `${key}\0${environment ?? ''}\0${tag ?? ''}`;
+
   const mergeParams = (defaultParams: Partial<Params>, params: Params): Params => {
     return {
       ...defaultParams,
@@ -65,34 +74,7 @@ const createCoreStore = ({ db }: { db: Database }) => {
     };
   };
 
-  const store: CoreStore = function (defaultParams: Partial<Params>) {
-    return {
-      get: (params: Params) => store.get(mergeParams(defaultParams, params)),
-      set: (params: Params) => store.set(mergeParams(defaultParams, params)),
-      delete: (params: Params) => store.delete(mergeParams(defaultParams, params)),
-    };
-  };
-
-  /**
-   * Get value from the core store
-   */
-  store.get = async (params) => {
-    const { key, type = 'core', environment, name, tag } = params;
-
-    const prefix = `${type}${name ? `_${name}` : ''}`;
-
-    const where = {
-      key: `${prefix}_${key}`,
-      environment: environment || null,
-      tag: tag || null,
-    };
-
-    const data = await db.query('strapi::core-store').findOne({ where });
-
-    if (!data) {
-      return null;
-    }
-
+  const parseValue = (data: { value: string; type: string }) => {
     if (
       data.type === 'object' ||
       data.type === 'array' ||
@@ -111,6 +93,67 @@ const createCoreStore = ({ db }: { db: Database }) => {
     }
   };
 
+  const store: CoreStore = function (defaultParams: Partial<Params>) {
+    return {
+      get: (params: Params) => store.get(mergeParams(defaultParams, params)),
+      set: (params: Params) => store.set(mergeParams(defaultParams, params)),
+      delete: (params: Params) => store.delete(mergeParams(defaultParams, params)),
+    };
+  };
+
+  /**
+   * Bulk-load all rows into cache. Call once early in bootstrap to avoid
+   * N individual SELECT round-trips to the database.
+   *
+   * Cache entries auto-expire after CACHE_TTL since this is only meant to save
+   * queries during startup
+   */
+  store.prefill = async () => {
+    try {
+      const rows = await db.query('strapi::core-store').findMany({});
+      cache.clear();
+
+      for (const row of rows) {
+        const ck = cacheKey(row.key, row.environment ?? null, row.tag ?? null);
+        cache.set(ck, { value: row.value, type: row.type, id: row.id });
+      }
+
+      // Auto-expire cache after TTL — it's only meant for startup
+      setTimeout(() => {
+        cache.clear();
+      }, CACHE_TTL).unref();
+    } catch {
+      // Table may not exist on first run — that's fine, cache stays empty
+    }
+  };
+
+  /**
+   * Get value from the core store
+   */
+  store.get = async (params) => {
+    const { key, type = 'core', environment, name, tag } = params;
+
+    const prefix = `${type}${name ? `_${name}` : ''}`;
+    const fullKey = `${prefix}_${key}`;
+    const env = environment || null;
+    const t = tag || null;
+    const cached = cache.get(cacheKey(fullKey, env, t));
+
+    // Serve from cache when available
+    if (cached) {
+      return parseValue(cached);
+    }
+
+    const where = { key: fullKey, environment: env, tag: t };
+    const data = await db.query('strapi::core-store').findOne({ where });
+
+    if (!data) {
+      return null;
+    }
+
+    return parseValue(data);
+  };
+
   /**
    * Set value in the core store
    * @param {Object} params
@@ -120,6 +163,8 @@ const createCoreStore = ({ db }: { db: Database }) => {
     const { key, value, type, environment, name, tag } = params;
 
     const prefix = `${type}${name ? `_${name}` : ''}`;
+
+    cache.delete(cacheKey(`${prefix}_${key}`, environment || null, tag || null));
 
     const where = {
       key: `${prefix}_${key}`,
@@ -157,12 +202,12 @@ const createCoreStore = ({ db }: { db: Database }) => {
     const { key, environment, type, name, tag } = params;
 
     const prefix = `${type}${name ? `_${name}` : ''}`;
+    const fullKey = `${prefix}_${key}`;
+    const env = environment || null;
+    const t = tag || null;
+    const where = { key: fullKey, environment: env, tag: t };
 
-    const where = {
-      key: `${prefix}_${key}`,
-      environment: environment || null,
-      tag: tag || null,
-    };
+    cache.delete(cacheKey(fullKey, env, t));
 
     return db.query('strapi::core-store').delete({ where });
   };

--- a/packages/core/database/src/dialects/postgresql/schema-inspector.ts
+++ b/packages/core/database/src/dialects/postgresql/schema-inspector.ts
@@ -2,11 +2,8 @@ import type { Database } from '../..';
 import type { Schema, Column, Index, ForeignKey } from '../../schema/types';
 import type { SchemaInspector } from '../dialect';
 
-interface RawTable {
-  table_name: string;
-}
-
 interface RawColumn {
+  table_name: string;
   data_type: string;
   column_name: string;
   character_maximum_length: number;
@@ -15,6 +12,7 @@ interface RawColumn {
 }
 
 interface RawIndex {
+  table_name: string;
   indexrelid: string;
   index_name: string;
   column_name: string;
@@ -22,8 +20,8 @@ interface RawIndex {
   is_primary: boolean;
 }
 
-interface RawForeignKey {
-  constraint_name: string;
+interface RawTable {
+  table_name: string;
 }
 
 const SQL_QUERIES = {
@@ -36,13 +34,14 @@ const SQL_QUERIES = {
       AND table_name != 'geometry_columns'
       AND table_name != 'spatial_ref_sys';
   `,
-  LIST_COLUMNS: /* sql */ `
-    SELECT data_type, column_name, character_maximum_length, column_default, is_nullable
+  BULK_COLUMNS: /* sql */ `
+    SELECT table_name, data_type, column_name, character_maximum_length, column_default, is_nullable
     FROM information_schema.columns
-    WHERE table_schema = ? AND table_name = ?;
+    WHERE table_schema = ? AND table_name = ANY(?);
   `,
-  INDEX_LIST: /* sql */ `
+  BULK_INDEXES: /* sql */ `
     SELECT
+      t.relname as table_name,
       ix.indexrelid,
       i.relname as index_name,
       a.attname as column_name,
@@ -62,45 +61,32 @@ const SQL_QUERIES = {
       AND t.relkind = 'r'
       AND t.relnamespace = s.oid
       AND s.nspname = ?
-      AND t.relname = ?;
+      AND t.relname = ANY(?);
   `,
-  FOREIGN_KEY_LIST: /* sql */ `
+  BULK_FOREIGN_KEYS: /* sql */ `
     SELECT
-      tco."constraint_name" as constraint_name
+      tco.table_name,
+      tco.constraint_name,
+      kcu.column_name,
+      rco.update_rule as on_update,
+      rco.delete_rule as on_delete,
+      rel_kcu.table_name as foreign_table,
+      rel_kcu.column_name as fk_column_name
     FROM information_schema.table_constraints tco
-    WHERE
-      tco.constraint_type = 'FOREIGN KEY'
+    JOIN information_schema.key_column_usage kcu
+      ON tco.constraint_name = kcu.constraint_name
+      AND tco.constraint_schema = kcu.constraint_schema
+      AND tco.table_name = kcu.table_name
+    JOIN information_schema.referential_constraints rco
+      ON tco.constraint_name = rco.constraint_name
+      AND tco.constraint_schema = rco.constraint_schema
+    JOIN information_schema.key_column_usage rel_kcu
+      ON rco.unique_constraint_name = rel_kcu.constraint_name
+      AND rco.unique_constraint_schema = rel_kcu.constraint_schema
+    WHERE tco.constraint_type = 'FOREIGN KEY'
       AND tco.constraint_schema = ?
-      AND tco.table_name = ?
+      AND tco.table_name = ANY(?);
   `,
-  FOREIGN_KEY_REFERENCES: /* sql */ `
-    SELECT
-      kcu."constraint_name" as constraint_name,
-      kcu."column_name" as column_name
-
-    FROM information_schema.key_column_usage kcu
-    WHERE kcu.constraint_name=ANY(?)
-    AND kcu.table_schema = ?
-    AND kcu.table_name = ?;
-  `,
-
-  FOREIGN_KEY_REFERENCES_CONSTRAIN: /* sql */ `
-  SELECT
-  rco.update_rule as on_update,
-  rco.delete_rule as on_delete,
-  rco."unique_constraint_name" as unique_constraint_name
-  FROM information_schema.referential_constraints rco
-  WHERE rco.constraint_name=ANY(?)
-  AND rco.constraint_schema = ?
-`,
-  FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE: /* sql */ `
-  SELECT
-  rel_kcu."table_name" as foreign_table,
-  rel_kcu."column_name" as fk_column_name
-    FROM information_schema.key_column_usage rel_kcu
-    WHERE rel_kcu.constraint_name=?
-    AND rel_kcu.table_schema = ?
-`,
 };
 
 const toStrapiType = (column: RawColumn) => {
@@ -167,23 +153,27 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
 
   async getSchema() {
     const schema: Schema = { tables: [] };
+    const dbSchema = this.getDatabaseSchema();
 
     const tables = await this.getTables();
 
-    schema.tables = await Promise.all(
-      tables.map(async (tableName) => {
-        const columns = await this.getColumns(tableName);
-        const indexes = await this.getIndexes(tableName);
-        const foreignKeys = await this.getForeignKeys(tableName);
+    if (tables.length === 0) {
+      return schema;
+    }
 
-        return {
-          name: tableName,
-          columns,
-          indexes,
-          foreignKeys,
-        };
-      })
-    );
+    // Run 3 bulk queries in parallel instead of N+1 per-table queries
+    const [allColumns, allIndexes, allForeignKeys] = await Promise.all([
+      this.getBulkColumns(dbSchema, tables),
+      this.getBulkIndexes(dbSchema, tables),
+      this.getBulkForeignKeys(dbSchema, tables),
+    ]);
+
+    schema.tables = tables.map((tableName) => ({
+      name: tableName,
+      columns: allColumns.get(tableName) ?? [],
+      indexes: allIndexes.get(tableName) ?? [],
+      foreignKeys: allForeignKeys.get(tableName) ?? [],
+    }));
 
     return schema;
   }
@@ -200,19 +190,20 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
     return rows.map((row) => row.table_name);
   }
 
-  async getColumns(tableName: string): Promise<Column[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.LIST_COLUMNS, [
-      this.getDatabaseSchema(),
-      tableName,
+  async getBulkColumns(dbSchema: string, tableNames: string[]): Promise<Map<string, Column[]>> {
+    const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.BULK_COLUMNS, [
+      dbSchema,
+      tableNames,
     ]);
 
-    return rows.map((row) => {
-      const { type, args = [], ...rest } = toStrapiType(row);
+    const result = new Map<string, Column[]>();
 
+    for (const row of rows) {
+      const { type, args = [], ...rest } = toStrapiType(row);
       const defaultTo =
         row.column_default && row.column_default.includes('nextval(') ? null : row.column_default;
 
-      return {
+      const column: Column = {
         type,
         args,
         defaultTo,
@@ -221,88 +212,122 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
         unsigned: false,
         ...rest,
       };
-    });
+
+      const existing = result.get(row.table_name);
+      if (existing) {
+        existing.push(column);
+      } else {
+        result.set(row.table_name, [column]);
+      }
+    }
+
+    return result;
   }
 
-  async getIndexes(tableName: string): Promise<Index[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.INDEX_LIST, [
-      this.getDatabaseSchema(),
-      tableName,
+  async getBulkIndexes(dbSchema: string, tableNames: string[]): Promise<Map<string, Index[]>> {
+    const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.BULK_INDEXES, [
+      dbSchema,
+      tableNames,
     ]);
 
-    const ret: Record<RawIndex['indexrelid'], Index> = {};
+    // Group by table, then by indexrelid
+    const byTable = new Map<string, Map<string, Index>>();
 
     for (const index of rows) {
       if (index.column_name === 'id') {
         continue;
       }
 
-      if (!ret[index.indexrelid]) {
-        ret[index.indexrelid] = {
+      let tableIndexes = byTable.get(index.table_name);
+      if (!tableIndexes) {
+        tableIndexes = new Map();
+        byTable.set(index.table_name, tableIndexes);
+      }
+
+      const existing = tableIndexes.get(index.indexrelid);
+      if (existing) {
+        existing.columns.push(index.column_name);
+      } else {
+        tableIndexes.set(index.indexrelid, {
           columns: [index.column_name],
           name: index.index_name,
           type: getIndexType(index),
-        };
-      } else {
-        ret[index.indexrelid].columns.push(index.column_name);
+        });
       }
     }
 
-    return Object.values(ret);
+    const result = new Map<string, Index[]>();
+    for (const [tableName, tableIndexes] of byTable) {
+      result.set(tableName, Array.from(tableIndexes.values()));
+    }
+
+    return result;
+  }
+
+  async getIndexes(tableName: string): Promise<Index[]> {
+    const dbSchema = this.getDatabaseSchema();
+    const result = await this.getBulkIndexes(dbSchema, [tableName]);
+    return result.get(tableName) ?? [];
   }
 
   async getForeignKeys(tableName: string): Promise<ForeignKey[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawForeignKey[] }>(
-      SQL_QUERIES.FOREIGN_KEY_LIST,
-      [this.getDatabaseSchema(), tableName]
-    );
-
-    const ret: Record<RawForeignKey['constraint_name'], ForeignKey> = {};
-
-    for (const fk of rows) {
-      ret[fk.constraint_name] = {
-        name: fk.constraint_name,
-        columns: [],
-        referencedColumns: [],
-        referencedTable: null,
-        onUpdate: null,
-        onDelete: null,
-      } as unknown as ForeignKey;
-    }
-
-    const constraintNames = Object.keys(ret);
     const dbSchema = this.getDatabaseSchema();
-    if (constraintNames.length > 0) {
-      const { rows: fkReferences } = await this.db.connection.raw(
-        SQL_QUERIES.FOREIGN_KEY_REFERENCES,
-        [[constraintNames], dbSchema, tableName]
-      );
+    const result = await this.getBulkForeignKeys(dbSchema, [tableName]);
+    return result.get(tableName) ?? [];
+  }
 
-      for (const fkReference of fkReferences) {
-        ret[fkReference.constraint_name].columns.push(fkReference.column_name);
+  async getBulkForeignKeys(
+    dbSchema: string,
+    tableNames: string[]
+  ): Promise<Map<string, ForeignKey[]>> {
+    const { rows } = await this.db.connection.raw<{
+      rows: Array<{
+        table_name: string;
+        constraint_name: string;
+        column_name: string;
+        on_update: string;
+        on_delete: string;
+        foreign_table: string;
+        fk_column_name: string;
+      }>;
+    }>(SQL_QUERIES.BULK_FOREIGN_KEYS, [dbSchema, tableNames]);
 
-        const { rows: fkReferencesConstraint } = await this.db.connection.raw(
-          SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN,
-          [[fkReference.constraint_name], dbSchema]
-        );
+    // Group by table_name, then by constraint_name
+    const byTable = new Map<string, Map<string, ForeignKey>>();
 
-        for (const fkReferenceC of fkReferencesConstraint) {
-          const { rows: fkReferencesConstraintReferece } = await this.db.connection.raw(
-            SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE,
-            [fkReferenceC.unique_constraint_name, dbSchema]
-          );
-          for (const fkReferenceConst of fkReferencesConstraintReferece) {
-            ret[fkReference.constraint_name].referencedTable = fkReferenceConst.foreign_table;
-            ret[fkReference.constraint_name].referencedColumns.push(
-              fkReferenceConst.fk_column_name
-            );
-          }
-          ret[fkReference.constraint_name].onUpdate = fkReferenceC.on_update.toUpperCase();
-          ret[fkReference.constraint_name].onDelete = fkReferenceC.on_delete.toUpperCase();
+    for (const row of rows) {
+      let tableFKs = byTable.get(row.table_name);
+      if (!tableFKs) {
+        tableFKs = new Map();
+        byTable.set(row.table_name, tableFKs);
+      }
+
+      let fk = tableFKs.get(row.constraint_name);
+      if (!fk) {
+        fk = {
+          name: row.constraint_name,
+          columns: [row.column_name],
+          referencedColumns: [row.fk_column_name],
+          referencedTable: row.foreign_table,
+          onUpdate: row.on_update?.toUpperCase() ?? null,
+          onDelete: row.on_delete?.toUpperCase() ?? null,
+        };
+        tableFKs.set(row.constraint_name, fk);
+      } else {
+        if (!fk.columns.includes(row.column_name)) {
+          fk.columns.push(row.column_name);
+        }
+        if (!fk.referencedColumns.includes(row.fk_column_name)) {
+          fk.referencedColumns.push(row.fk_column_name);
         }
       }
     }
 
-    return Object.values(ret);
+    const result = new Map<string, ForeignKey[]>();
+    for (const [tableName, tableFKs] of byTable) {
+      result.set(tableName, Array.from(tableFKs.values()));
+    }
+
+    return result;
   }
 }

--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -6,21 +6,24 @@ import type { Schema } from './types';
 const TABLE_NAME = 'strapi_database_schema';
 
 export default (db: Database) => {
-  const hasSchemaTable = () => db.getSchemaConnection().hasTable(TABLE_NAME);
-
-  const createSchemaTable = () => {
-    return db.getSchemaConnection().createTable(TABLE_NAME, (t) => {
-      t.increments('id');
-      t.json('schema');
-      t.datetime('time', { useTz: false });
-      t.string('hash');
-    });
-  };
+  let tableExists = false;
 
   const checkTableExists = async () => {
-    if (!(await hasSchemaTable())) {
-      await createSchemaTable();
+    if (tableExists) {
+      return;
     }
+
+    const exists = await db.getSchemaConnection().hasTable(TABLE_NAME);
+    if (!exists) {
+      await db.getSchemaConnection().createTable(TABLE_NAME, (t) => {
+        t.increments('id');
+        t.json('schema');
+        t.datetime('time', { useTz: false });
+        t.string('hash');
+      });
+    }
+
+    tableExists = true;
   };
 
   return {
@@ -65,7 +68,12 @@ export default (db: Database) => {
     },
 
     hashSchema(schema: Schema) {
-      return crypto.createHash('sha256').update(JSON.stringify(schema)).digest('hex');
+      // Sort tables by name for deterministic hashing regardless of insertion order
+      const sorted = {
+        ...schema,
+        tables: schema.tables.sort((a, b) => a.name.localeCompare(b.name)),
+      };
+      return crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
     },
 
     async add(schema: Schema) {

--- a/packages/core/types/src/modules/core-store.ts
+++ b/packages/core/types/src/modules/core-store.ts
@@ -26,4 +26,5 @@ export interface CoreStore {
   get(params: GetParams): Promise<unknown>;
   set(params: SetParams): Promise<void>;
   delete(params: GetParams): Promise<void>;
+  prefill(): Promise<void>;
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Reduce by about ~50% the startup time of Strapi (depending of the schema size), by saving DB roundtrips and parallelizing init tasks.

The first 3 commits are the most important:

- e394c2198a05ec084756d281342de09a5b87dc0d make the schema hash deterministic, to **avoid re-sync on almost each restart**
- 9850931bbfb4d7808545811aa0556b845fa85ad7 Use single query to retrieve the schema, instead of one query per tables. **Avoiding N+1 issue when syncing schema** (the more wide the schema is, the more the gain will be)
- 929019a0d7150c7550e021eec94bfda0decf62ef At startup we do ~60 lookups in the core settings table, this commit cache all settings keys for 2minutes after startup so we **save ~60 queries**

Other commits are parallelization things.

I can split in multiple PRs to lighten review if you prefer.

### Why is it needed?

Strapi often takes ~10/15s to bootstrap, with a bootstrap time that depends on the size of the schema.

This PR should make it more around ~4s.

The gains I've seen locally with the getstarted example, using a Postgres Neon database located in my region (Europe):

Before:
- schema sync needed: **~15s**
- no schema sync: **~9s**

After:
- schema sync needed: **~6s**
- no schema sync: **~3.5s**

With SQLite, the gains aren't really visible because there is zero latency between the DB and Strapi. But the main Strapi use case involves a remote DB, which is why I focused on improving network latency.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
