### PR TITLE
fix: long component names overflow in dynamic zone picker

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
@@ -35,7 +35,13 @@ const ComponentCard = ({ children, onClick, icon }: ComponentCardProps) => {
   );
 };
 
-const ComponentName = styled<TypographyComponent>(Typography)``;
+const ComponentName = styled<TypographyComponent>(Typography)`
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+`;
 
 const ComponentBox = styled<FlexComponent<'button'>>(Flex)`
   &:focus,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react';
 
-import { Flex, FlexComponent, Typography, TypographyComponent } from '@strapi/design-system';
+import {
+  Flex,
+  FlexComponent,
+  Tooltip,
+  Typography,
+  TypographyComponent,
+} from '@strapi/design-system';
 import { styled } from 'styled-components';
 
 import { ComponentIcon, ComponentIconProps } from '../../../../../components/ComponentIcon';
 
 interface ComponentCardProps extends Pick<ComponentIconProps, 'icon'> {
-  children: React.ReactNode;
+  children: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement> & React.MouseEventHandler<HTMLDivElement>;
 }
 
@@ -27,9 +33,11 @@ const ComponentCard = ({ children, onClick, icon }: ComponentCardProps) => {
       <Flex direction="column" gap={1} alignItems="center" justifyContent="center">
         <ComponentIcon icon={icon} />
 
-        <ComponentName variant="pi" fontWeight="bold" textColor="neutral600">
-          {children}
-        </ComponentName>
+        <Tooltip label={children}>
+          <ComponentName variant="pi" fontWeight="bold" textColor="neutral600">
+            {children}
+          </ComponentName>
+        </Tooltip>
       </Flex>
     </ComponentBox>
   );

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCard.tsx
@@ -12,7 +12,7 @@ import { styled } from 'styled-components';
 import { ComponentIcon, ComponentIconProps } from '../../../../../components/ComponentIcon';
 
 interface ComponentCardProps extends Pick<ComponentIconProps, 'icon'> {
-  children: string;
+  children: React.ReactNode | string;
   onClick?: React.MouseEventHandler<HTMLButtonElement> & React.MouseEventHandler<HTMLDivElement>;
 }
 
@@ -34,7 +34,13 @@ const ComponentCard = ({ children, onClick, icon }: ComponentCardProps) => {
         <ComponentIcon icon={icon} />
 
         <Tooltip label={children}>
-          <ComponentName variant="pi" fontWeight="bold" textColor="neutral600">
+          <ComponentName
+            variant="pi"
+            fontWeight="bold"
+            ellipsis
+            width="100%"
+            textColor="neutral600"
+          >
             {children}
           </ComponentName>
         </Tooltip>
@@ -43,13 +49,7 @@ const ComponentCard = ({ children, onClick, icon }: ComponentCardProps) => {
   );
 };
 
-const ComponentName = styled<TypographyComponent>(Typography)`
-  width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: center;
-`;
+const ComponentName = styled<TypographyComponent>(Typography)``;
 
 const ComponentBox = styled<FlexComponent<'button'>>(Flex)`
   &:focus,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -49,10 +49,18 @@ const ComponentCategory = ({
               shrink={0}
               borderColor="neutral200"
             >
-              <Flex direction="column" gap={1} alignItems="center" justifyContent="center">
+              <Flex
+                direction="column"
+                gap={1}
+                alignItems="center"
+                justifyContent="center"
+                width="100%"
+                paddingLeft={2}
+                paddingRight={2}
+              >
                 <ComponentIcon color="currentColor" background="primary200" icon={icon} />
 
-                <Typography variant="pi" fontWeight="bold">
+                <Typography variant="pi" fontWeight="bold" ellipsis width="100%">
                   {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
                 </Typography>
               </Flex>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Accordion, Box, Flex, FlexComponent, Typography } from '@strapi/design-system';
+import { Accordion, Box, Flex, FlexComponent, Tooltip, Typography } from '@strapi/design-system';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
@@ -60,9 +60,11 @@ const ComponentCategory = ({
               >
                 <ComponentIcon color="currentColor" background="primary200" icon={icon} />
 
-                <Typography variant="pi" fontWeight="bold" ellipsis width="100%">
-                  {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
-                </Typography>
+                <Tooltip label={formatMessage({ id: uid, defaultMessage: displayName ?? uid })}>
+                  <Typography variant="pi" fontWeight="bold" ellipsis width="100%">
+                    {formatMessage({ id: uid, defaultMessage: displayName ?? uid })}
+                  </Typography>
+                </Tooltip>
               </Flex>
             </ComponentBox>
           ))}


### PR DESCRIPTION
What does it do?

Adds max-width, overflow: hidden, text-overflow: ellipsis, and white-space: nowrap to the component name label in the Dynamic Zone component picker cards (ComponentCategory, ComponentCard).

Why is it needed?

Component names without spaces (e.g. SDUIEngagementSimpleMessage) overflow horizontally outside the picker card boundary, bleeding into adjacent cards and becoming unreadable.

Before:
<img width="298" height="168" alt="Screenshot 2026-04-13 at 18 11 00" src="https://github.com/user-attachments/assets/2b5b6699-7a71-43e7-ace2-f7acef92113c" />

After:
<img width="314" height="220" alt="Screenshot 2026-04-13 at 18 11 21" src="https://github.com/user-attachments/assets/8caa8bfe-121e-415d-a60a-3db554d1df2b" />

How to test it?

  1. Create a content type with a Dynamic Zone field
  2. Add a component with a long name without spaces (e.g. SDUIEngagementSimpleMessage)
  3. Go to Content Manager → create a new entry → click + on the Dynamic Zone
  4. The component name should be truncated with ... and stay within the card boundaries

Related issue(s)/PR(s)

Fixes #26009
