### PR TITLE
chore(examples/getstarted): delete config.server.url to restore port override capability

### DIFF
--- a/examples/getstarted/config/server.js
+++ b/examples/getstarted/config/server.js
@@ -5,7 +5,6 @@ const cronTasks = require('./src/cron-tasks');
 module.exports = ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
-  url: 'http://localhost:1337',
   cron: {
     enabled: true,
     tasks: cronTasks,


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes the hardcoded `url: 'http://localhost:1337'` from `examples/getstarted/config/server.js`.

### Why is it needed?

When `server.url` is set to an absolute `http://...` value, `getAbsoluteServerUrl()` (`packages/core/core/src/configuration/urls.ts`) returns it verbatim — bypassing the actual `server.port` value derived from env. As a result, the startup log always displayed `http://localhost:1337` regardless of the `PORT` env var, making it appear as though the override had no effect.

The server itself was correctly listening on the overridden port (`Strapi.ts:373` uses `config.server.port` which does read `process.env.PORT`). The bug was purely in the displayed URL.

Without an explicit `url`, Strapi derives `absoluteUrl` dynamically from `host` + `port`, which correctly reflects any `PORT` override. This is already the pattern used by all other example apps (`complex`, `empty`, `kitchensink`, `kitchensink-ts`, `experimental-dev`).

### How to test it?

From the `examples/getstarted` directory, start Strapi with a custom port:

```bash
PORT=8080 yarn develop
```

**Before**: startup log showed `http://localhost:1337` regardless of `PORT`.

**After**: startup log shows `http://localhost:8080`.

### Related issue(s)/PR(s)

N/A