### PR TITLE
fix(content-manager): blocks editor errors when image has formats: null

### DIFF
--- a/packages/core/core/src/services/entity-validator/__tests__/blocks-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/blocks-validators.test.ts
@@ -58,6 +58,16 @@ const validImage = [
     },
   },
 ];
+const validImageWithNullFormats = [
+  {
+    type: 'image',
+    children: [{ type: 'text', text: '' }],
+    image: {
+      ...validImage[0].image,
+      formats: null,
+    },
+  },
+];
 const validQuote = [
   {
     type: 'quote',
@@ -353,6 +363,17 @@ describe('Blocks validator', () => {
         )
       );
       expect(await validator(validImage)).toEqual(validImage);
+    });
+    it('Should accept an image with null formats (small image without responsive formats)', async () => {
+      const validator = strapiUtils.validateYupSchema(
+        Validators.blocks(
+          {
+            attr: { type: 'blocks' },
+          },
+          { isDraft: false }
+        )
+      );
+      expect(await validator(validImageWithNullFormats)).toEqual(validImageWithNullFormats);
     });
     it('Should throw an error given an invalid image schema', async () => {
       const validator = strapiUtils.validateYupSchema(

--- a/packages/core/core/src/services/entity-validator/blocks-validator.ts
+++ b/packages/core/core/src/services/entity-validator/blocks-validator.ts
@@ -128,7 +128,7 @@ const imageNodeValidator = yup.object().shape({
     caption: yup.string().nullable(),
     width: yup.number().required(),
     height: yup.number().required(),
-    formats: yup.object().required(),
+    formats: yup.object().nullable(),
     hash: yup.string().required(),
     ext: yup.string().required(),
     mime: yup.string().required(),


### PR DESCRIPTION
### What does it do?

Make formats nullable since it's possible for images to have formats: null

### Why is it needed?

Otherwise small images throw an error on save if the image does not have a formats object

### How to test it?

Take a really small screenshot
Upload it to the media lib
Confirm on the API the formats prop is null
Go to the content manager with a content-type that has blocks
Add your small image to the blocks editor
Save the entry, it should NOT throw an error

### Related issue(s)/PR(s)

resolves https://github.com/strapi/strapi/issues/19400

https://github.com/strapi/strapi/issues/23970
