### PR TITLE
fix(admin): eliminate several browser race conditions

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -172,10 +172,13 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
     // We expose `getValues` as a stable callback so consumers (e.g. conditional/rules logic)
     // can call it without causing extra rerenders from changing function references.
     const valuesRef = React.useRef(state.values);
-
-    React.useEffect(() => {
-      valuesRef.current = state.values;
-    }, [state.values]);
+    /**
+     * Keep the ref aligned with `state.values` during render (not only in an effect) so
+     * `getValues()` / `validate()` always see the latest committed values. Effects run too late
+     * for back-to-back user actions (e.g. fast e2e) where the next handler runs before the
+     * effect has fired.
+     */
+    valuesRef.current = state.values;
 
     const getValues = React.useCallback(() => valuesRef.current, []);
 
@@ -239,16 +242,18 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
       async (shouldSetErrors: boolean = true, options: Record<string, string> = {}) => {
         setErrors({});
 
+        const valuesToValidate = valuesRef.current;
+
         if (!props.validationSchema && !props.validate) {
-          return { data: state.values };
+          return { data: valuesToValidate };
         }
 
         try {
           let data;
           if (props.validationSchema) {
-            data = await props.validationSchema.validate(state.values, { abortEarly: false });
+            data = await props.validationSchema.validate(valuesToValidate, { abortEarly: false });
           } else if (props.validate) {
-            data = await props.validate(state.values, options);
+            data = await props.validate(valuesToValidate, options);
           } else {
             throw new Error('No validation schema or validate function provided');
           }
@@ -276,7 +281,7 @@ const Form = React.forwardRef<HTMLFormElement, FormProps>(
           }
         }
       },
-      [props, setErrors, state.values]
+      [props, setErrors]
     );
 
     const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {

--- a/packages/core/admin/admin/src/components/GuidedTour/Context.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Context.tsx
@@ -197,8 +197,9 @@ const GuidedTourContext = ({
     dispatch({ type: 'set_hidden', payload: !isDesktop });
   }, [isDesktop]);
 
-  // Sync local storage
-  React.useEffect(() => {
+  // Sync into usePersistentState in the layout phase so localStorage is updated before the
+  // browser follows an external link (e.g. Strapi Cloud "Read documentation").
+  React.useLayoutEffect(() => {
     setStoredTours(state);
   }, [state, setStoredTours]);
 

--- a/packages/core/admin/admin/src/hooks/usePersistentState.ts
+++ b/packages/core/admin/admin/src/hooks/usePersistentState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { useInitQuery } from '../services/admin';
 
@@ -27,8 +27,9 @@ const usePersistentState = <T>(key: string, defaultValue: T) => {
     // include defaultValue in case it changes across models
   }, [key, defaultValue]);
 
-  // persist whenever (key, value) change — but only for the active key
-  useEffect(() => {
+  // Persist synchronously after commit so values survive same-tab navigation (e.g. external
+  // links) before the next paint — useEffect can run after unload and skip writing.
+  useLayoutEffect(() => {
     if (currentKeyRef.current !== key) return; // safety guard
 
     window.localStorage.setItem(key, JSON.stringify(value));

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -766,6 +766,7 @@ const PublishAction: DocumentActionComponent = ({
       /**
        * Yield one microtask so React can flush any pending field updates from the same task
        * (common with fast local runners / Playwright) before we read values and validate.
+       * TODO: replace with an explicit form flush contract when we can (same concern as Save flow).
        */
       await Promise.resolve();
 
@@ -1046,7 +1047,6 @@ const UpdateAction: DocumentActionComponent = ({
   const setSubmitting = useForm('UpdateAction', ({ setSubmitting }) => setSubmitting);
   const initialValues = useForm('UpdateAction', ({ initialValues }) => initialValues);
   const getValues = useForm('UpdateAction', (state) => state.getValues);
-  const document = useForm('UpdateAction', ({ values }) => values);
   const validate = useForm('UpdateAction', (state) => state.validate);
   const setErrors = useForm('UpdateAction', (state) => state.setErrors);
   const resetForm = useForm('UpdateAction', ({ resetForm }) => resetForm);
@@ -1103,12 +1103,14 @@ const UpdateAction: DocumentActionComponent = ({
 
       // Blur the active element so inputs that debounce into the form (e.g. blocks editor) flush
       // before validate/getValues — on fast clients Save can otherwise read stale field state.
-      (document.activeElement as HTMLElement | null)?.blur();
+      // Use the global DOM document — form values are not in scope here (avoid shadowing `document`).
+      (globalThis.document?.activeElement as HTMLElement | undefined)?.blur();
 
-      // Let React run onBlur handlers (and any flushSync inside them) before we read the form.
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
+      // Yield microtasks so batched React updates after blur/onChange can settle before validate
+      // (same idea as performPublish; two ticks vs one gives a bit more room after focus/blur).
+      // TODO: replace with an explicit field/form flush contract when available.
+      await Promise.resolve();
+      await Promise.resolve();
 
       const { errors } = await validate(true, {
         status: 'draft',

--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -621,6 +621,7 @@ const PublishAction: DocumentActionComponent = ({
   const isSubmitting = useForm('PublishAction', ({ isSubmitting }) => isSubmitting);
   const validate = useForm('PublishAction', (state) => state.validate);
   const setErrors = useForm('PublishAction', (state) => state.setErrors);
+  const getValues = useForm('PublishAction', (state) => state.getValues);
   const formValues = useForm('PublishAction', ({ values }) => values);
   const initialValues = useForm('PublishAction', ({ initialValues }) => initialValues);
   const resetForm = useForm('PublishAction', ({ resetForm }) => resetForm);
@@ -762,12 +763,13 @@ const PublishAction: DocumentActionComponent = ({
     setSubmitting(true);
 
     try {
-      const { data: filteredData } = handleInvisibleAttributes(transformData(formValues), {
-        schema,
-        components,
-      });
+      /**
+       * Yield one microtask so React can flush any pending field updates from the same task
+       * (common with fast local runners / Playwright) before we read values and validate.
+       */
+      await Promise.resolve();
+
       const { errors } = await validate(true, {
-        ...filteredData,
         status: 'published',
       });
       if (errors) {
@@ -809,8 +811,11 @@ const PublishAction: DocumentActionComponent = ({
         }
         return;
       }
-      // filteredData is already used for validation, so use it for publishing as well
-      const data = filteredData;
+
+      const { data } = handleInvisibleAttributes(transformData(getValues()), {
+        schema,
+        components,
+      });
       const res = await publish(
         {
           collectionType,
@@ -823,7 +828,7 @@ const PublishAction: DocumentActionComponent = ({
 
       // Reset form with current values as new initial values (clears errors/submitting and sets modified to false)
       if ('data' in res) {
-        resetForm(formValues);
+        resetForm(getValues());
         dispatchGuidedTour({
           type: 'set_completed_actions',
           payload: [GUIDED_TOUR_REQUIRED_ACTIONS.contentManager.createContent],
@@ -1040,6 +1045,7 @@ const UpdateAction: DocumentActionComponent = ({
   const modified = useForm('UpdateAction', ({ modified }) => modified);
   const setSubmitting = useForm('UpdateAction', ({ setSubmitting }) => setSubmitting);
   const initialValues = useForm('UpdateAction', ({ initialValues }) => initialValues);
+  const getValues = useForm('UpdateAction', (state) => state.getValues);
   const document = useForm('UpdateAction', ({ values }) => values);
   const validate = useForm('UpdateAction', (state) => state.validate);
   const setErrors = useForm('UpdateAction', (state) => state.setErrors);
@@ -1095,6 +1101,15 @@ const UpdateAction: DocumentActionComponent = ({
         return;
       }
 
+      // Blur the active element so inputs that debounce into the form (e.g. blocks editor) flush
+      // before validate/getValues — on fast clients Save can otherwise read stale field state.
+      (document.activeElement as HTMLElement | null)?.blur();
+
+      // Let React run onBlur handlers (and any flushSync inside them) before we read the form.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
       const { errors } = await validate(true, {
         status: 'draft',
       });
@@ -1111,6 +1126,9 @@ const UpdateAction: DocumentActionComponent = ({
 
         return;
       }
+
+      const latestValues = getValues();
+
       if (isCloning) {
         const res = await clone(
           {
@@ -1118,7 +1136,7 @@ const UpdateAction: DocumentActionComponent = ({
             documentId: cloneMatch.params.origin!,
             params: currentDocumentMeta.params,
           },
-          transformData(document)
+          transformData(latestValues)
         );
 
         if ('data' in res) {
@@ -1137,7 +1155,7 @@ const UpdateAction: DocumentActionComponent = ({
           setErrors(formatValidationErrors(res.error));
         }
       } else if (documentId || collectionType === SINGLE_TYPES) {
-        const { data } = handleInvisibleAttributes(transformData(document), {
+        const { data } = handleInvisibleAttributes(transformData(latestValues), {
           schema: fromRelationModal ? relationalModalSchema : schema,
           initialValues,
           components,
@@ -1155,10 +1173,10 @@ const UpdateAction: DocumentActionComponent = ({
         if ('error' in res && isBaseQueryError(res.error) && res.error.name === 'ValidationError') {
           setErrors(formatValidationErrors(res.error));
         } else {
-          resetForm(document);
+          resetForm(latestValues);
         }
       } else {
-        const { data } = handleInvisibleAttributes(transformData(document), {
+        const { data } = handleInvisibleAttributes(transformData(latestValues), {
           schema: fromRelationModal ? relationalModalSchema : schema,
           initialValues,
           components,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Wrapper.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/Blocks/tests/Wrapper.tsx
@@ -46,6 +46,7 @@ const Wrapper = ({ children, baseEditor = defaultBaseEditor }: WrapperProps) => 
             name="blocks"
             setLiveText={() => {}}
             isExpandedMode={false}
+            flushPendingFormSync={() => {}}
           >
             {children}
           </BlocksEditorProvider>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -375,7 +375,7 @@ interface BlocksContentProps {
 }
 
 const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
-  const { editor, disabled, blocks, modifiers, setLiveText, isExpandedMode } =
+  const { editor, disabled, blocks, modifiers, setLiveText, isExpandedMode, flushPendingFormSync } =
     useBlocksEditorContext('BlocksContent');
   const isMobile = useIsMobile();
   const blocksRef = React.useRef<HTMLDivElement>(null);
@@ -626,6 +626,7 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
         renderLeaf={renderLeaf}
         onKeyDown={handleKeyDown}
         scrollSelectionIntoView={handleScrollSelectionIntoView}
+        onBlur={flushPendingFormSync}
         // As we have our own handler to drag and drop the elements returing true will skip slate's own event handler
         onDrop={dragNoop}
         onDragStart={dragNoop}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksEditor.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { createContext, type FieldValue, useIsMobile } from '@strapi/admin/strapi-admin';
 import { IconButton, Divider, VisuallyHidden } from '@strapi/design-system';
 import { Expand } from '@strapi/icons';
+import { flushSync } from 'react-dom';
 import { MessageDescriptor, useIntl } from 'react-intl';
 import { Editor, type Descendant, createEditor, Transforms, Element } from 'slate';
 import { withHistory } from 'slate-history';
@@ -97,6 +98,8 @@ interface BlocksEditorContextValue {
   name: string;
   setLiveText: (text: string) => void;
   isExpandedMode: boolean;
+  /** Push debounced Slate → form sync immediately (e.g. on Editable blur before Save). */
+  flushPendingFormSync: () => void;
 }
 
 const [BlocksEditorProvider, usePartialBlocksEditorContext] =
@@ -236,6 +239,22 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
 
     const debounceTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
+    const flushPendingFormSync = React.useCallback(() => {
+      if (!debounceTimeout.current) {
+        return;
+      }
+      clearTimeout(debounceTimeout.current);
+      debounceTimeout.current = null;
+      incrementSlateUpdatesCount();
+      // Ensure Strapi Form state updates before the next event (e.g. Save click) reads values.
+      flushSync(() => {
+        onChange(
+          name,
+          normalizeBlocksState(editor, editor.children) as Schema.Attribute.BlocksValue
+        );
+      });
+    }, [editor, incrementSlateUpdatesCount, name, onChange]);
+
     const handleSlateChange = React.useCallback(
       (state: Descendant[]) => {
         const isAstChange = editor.operations.some((op) => op.type !== 'set_selection');
@@ -319,6 +338,7 @@ const BlocksEditor = React.forwardRef<{ focus: () => void }, BlocksEditorProps>(
             name={name}
             setLiveText={setLiveText}
             isExpandedMode={isExpandedMode}
+            flushPendingFormSync={flushPendingFormSync}
           >
             <EditorLayout
               error={error}

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksToolbar.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/tests/BlocksToolbar.test.tsx
@@ -101,6 +101,7 @@ const Wrapper = ({
         name="blocks"
         setLiveText={jest.fn()}
         isExpandedMode={false}
+        flushPendingFormSync={jest.fn()}
       >
         {children}
       </BlocksEditorProvider>

--- a/packages/core/content-manager/admin/src/services/documents.ts
+++ b/packages/core/content-manager/admin/src/services/documents.ts
@@ -181,9 +181,10 @@ const documentApi = contentManagerApi.injectEndpoints({
         }
     >({
       query: ({ collectionType, model, documentId, params }) => ({
-        url: documentId
-          ? `/content-manager/${collectionType}/${model}/${documentId}/actions/discard`
-          : `/content-manager/${collectionType}/${model}/actions/discard`,
+        url:
+          documentId && collectionType !== SINGLE_TYPES
+            ? `/content-manager/${collectionType}/${model}/${documentId}/actions/discard`
+            : `/content-manager/${collectionType}/${model}/actions/discard`,
         method: 'POST',
         config: {
           params,
@@ -247,9 +248,10 @@ const documentApi = contentManagerApi.injectEndpoints({
       }
     >({
       query: ({ collectionType, model, documentId, params }) => ({
-        url: documentId
-          ? `/content-manager/${collectionType}/${model}/${documentId}/actions/countDraftRelations`
-          : `/content-manager/${collectionType}/${model}/actions/countDraftRelations`,
+        url:
+          documentId && collectionType !== SINGLE_TYPES
+            ? `/content-manager/${collectionType}/${model}/${documentId}/actions/countDraftRelations`
+            : `/content-manager/${collectionType}/${model}/actions/countDraftRelations`,
         method: 'GET',
         config: {
           params,
@@ -272,7 +274,9 @@ const documentApi = contentManagerApi.injectEndpoints({
         baseQuery
       ) => {
         const res = await baseQuery({
-          url: `/content-manager/${collectionType}/${model}${documentId ? `/${documentId}` : ''}`,
+          url: `/content-manager/${collectionType}/${model}${
+            documentId && collectionType !== SINGLE_TYPES ? `/${documentId}` : ''
+          }`,
           method: 'GET',
           config: {
             params,
@@ -336,9 +340,10 @@ const documentApi = contentManagerApi.injectEndpoints({
         }
     >({
       query: ({ collectionType, model, documentId, params, data }) => ({
-        url: documentId
-          ? `/content-manager/${collectionType}/${model}/${documentId}/actions/publish`
-          : `/content-manager/${collectionType}/${model}/actions/publish`,
+        url:
+          documentId && collectionType !== SINGLE_TYPES
+            ? `/content-manager/${collectionType}/${model}/${documentId}/actions/publish`
+            : `/content-manager/${collectionType}/${model}/actions/publish`,
         method: 'POST',
         data,
         config: {
@@ -394,7 +399,9 @@ const documentApi = contentManagerApi.injectEndpoints({
         }
     >({
       query: ({ collectionType, model, documentId, data, params }) => ({
-        url: `/content-manager/${collectionType}/${model}${documentId ? `/${documentId}` : ''}`,
+        url: `/content-manager/${collectionType}/${model}${
+          documentId && collectionType !== SINGLE_TYPES ? `/${documentId}` : ''
+        }`,
         method: 'PUT',
         data,
         config: {
@@ -461,9 +468,10 @@ const documentApi = contentManagerApi.injectEndpoints({
         }
     >({
       query: ({ collectionType, model, documentId, params, data }) => ({
-        url: documentId
-          ? `/content-manager/${collectionType}/${model}/${documentId}/actions/unpublish`
-          : `/content-manager/${collectionType}/${model}/actions/unpublish`,
+        url:
+          documentId && collectionType !== SINGLE_TYPES
+            ? `/content-manager/${collectionType}/${model}/${documentId}/actions/unpublish`
+            : `/content-manager/${collectionType}/${model}/actions/unpublish`,
         method: 'POST',
         data,
         config: {

--- a/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/formModalNavigationProvider.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/formModalNavigationProvider.test.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { CTBSessionProvider } from '../../CTBSession/ctbSession';
 import {
@@ -34,7 +34,7 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(INITIAL_STATE_DATA);
   });
 
-  it('updates the state when selecting a custom field for a new attribute', async () => {
+  it('updates the state when selecting a custom field for a new attribute', () => {
     const Wrapper = ({ children }: { children?: React.ReactNode }) =>
       React.createElement(
         CTBSessionProvider,
@@ -46,12 +46,12 @@ describe('FromModalNavigationProvider', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() =>
+    act(() => {
       result.current.onClickSelectCustomField({
         attributeType: 'text',
         customFieldUid: 'plugin::mycustomfields.color',
-      })
-    );
+      });
+    });
 
     const currentStateWithoutFunctions = removeFunctionsFromObject(result.current);
     const expected = {
@@ -65,7 +65,7 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(expected);
   });
 
-  it('updates the state when editing a custom field attribute', async () => {
+  it('updates the state when editing a custom field attribute', () => {
     const Wrapper = ({ children }: { children?: React.ReactNode }) =>
       React.createElement(
         CTBSessionProvider,
@@ -77,7 +77,7 @@ describe('FromModalNavigationProvider', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
+    act(() => {
       result.current.onOpenModalEditCustomField({
         forTarget: 'contentType',
         targetUid: 'api::test.test',

--- a/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/index.test.ts
+++ b/packages/core/content-type-builder/admin/src/components/FormModalNavigation/tests/index.test.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 
 import { CTBSessionProvider } from '../../CTBSession/ctbSession';
 import {
@@ -35,7 +35,7 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(INITIAL_STATE_DATA);
   });
 
-  it('updates the state when selecting a custom field for a new attribute', async () => {
+  it('updates the state when selecting a custom field for a new attribute', () => {
     const Wrapper = ({ children }: { children?: React.ReactNode }) =>
       React.createElement(
         CTBSessionProvider,
@@ -47,7 +47,7 @@ describe('FromModalNavigationProvider', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
+    act(() => {
       result.current.onClickSelectCustomField({
         attributeType: 'text',
         customFieldUid: 'plugin::mycustomfields.color',
@@ -66,7 +66,7 @@ describe('FromModalNavigationProvider', () => {
     expect(currentStateWithoutFunctions).toEqual(expected);
   });
 
-  it('updates the state when editing a custom field attribute', async () => {
+  it('updates the state when editing a custom field attribute', () => {
     const Wrapper = ({ children }: { children?: React.ReactNode }) =>
       React.createElement(
         CTBSessionProvider,
@@ -78,7 +78,7 @@ describe('FromModalNavigationProvider', () => {
       wrapper: Wrapper,
     });
 
-    await waitFor(() => {
+    act(() => {
       result.current.onOpenModalEditCustomField({
         forTarget: 'contentType',
         targetUid: 'api::test.test',


### PR DESCRIPTION
### What does it do?

- **`Form.tsx`**: Keeps `valuesRef` in sync with `state.values` during render (not only in an effect) so `getValues()` / `validate()` always see the latest committed values. Validation reads from that ref snapshot and the validate callback no longer depends on `state.values` in a way that can go stale on fast back-to-back actions.
- **`GuidedTour/Context.tsx`**: Persists guided-tour state with `useLayoutEffect` so storage is updated before the browser follows external links (e.g. documentation).
- **`usePersistentState.ts`**: Switches persistence to `useLayoutEffect` so `localStorage` is written synchronously after commit, reducing loss on quick navigation/unload.
- **`DocumentActions.tsx`**:
  - **Publish**: Yields a microtask before `validate`, then builds publish payload and `resetForm` from `getValues()` after validation so reads match the form’s latest state.
  - **Update (Save)**: Blurs the active element and waits one macrotask so debounced inputs (e.g. Blocks) flush before `validate` / `getValues`; clone/update/unpublish paths use `getValues()` for payloads and `resetForm`.
- **Blocks editor**: Adds `flushPendingFormSync` (clears debounce, `flushSync` + `onChange` with normalized Slate state) and wires it to the editable surface `onBlur` so pending debounced sync runs before Save when focus moves.
- **Blocks tests**: Passes `flushPendingFormSync` into test wrappers.
- **`documents.ts` (RTK Query)**: For `single-types`, URL builders no longer insert a `/${documentId}` segment on discard, draft-relation count, get, publish, update, and unpublish—matching the admin API routes and the same pattern already used elsewhere in this file.

### Why is it needed?

- Fast automation (E2E tests) and quick user actions could hit **Save/Publish** before React effects, debounced Slate→form sync, or `localStorage` writes completed, causing **stale validation**, **empty payloads**, or **flaky E2E** (toasts vs API, guided tour state, Blocks field).
- **Single-type** document calls could build **incorrect paths** (`…/single-types/:model/:documentId/…`) whenever `documentId` was set, which does not match the registered admin routes (`…/single-types/:model/…`).
 

### How to test it?

- **Automated**: Run the admin / content-manager test suites you normally use (e.g. unit tests for Blocks toolbar; Playwright e2e for admin CM, guided tour, blocks, conditional fields if applicable).
- **Manual (admin UI)**:
  - **Collection type**: Edit an entry with **Blocks**, save/publish quickly; confirm data persists and there are no false validation errors.
  - **Single type**: Open a single-type entry; confirm **save / publish / discard / unpublish** (and draft-relation UI if used) still work; confirm network URLs are under `/content-manager/single-types/<model>/…` without an extra document id segment.
  - **Guided tour**: Complete a step that opens an external link; reload admin and confirm tour progress persists as expected.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/26019