### PR TITLE
revert(admin): drop session ability cache and keep content manager batching fix

### DIFF
--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -2,7 +2,6 @@ import { merge, map, difference, uniq } from 'lodash/fp';
 import type { Core } from '@strapi/types';
 import { async } from '@strapi/utils';
 import { getService } from './utils';
-import { clearAdminAuthAbilityCache } from './strategies/admin';
 import { getTokenOptions, expiresInToSeconds } from './services/token';
 import adminActions from './config/admin-actions';
 import adminConditions from './config/admin-conditions';
@@ -43,22 +42,6 @@ const registerModelHooks = () => {
       }
     },
   });
-};
-
-const registerAdminAuthCacheInvalidation = () => {
-  const invalidate = async () => {
-    clearAdminAuthAbilityCache();
-  };
-
-  strapi.eventHub.on('permission.create', invalidate);
-  strapi.eventHub.on('permission.update', invalidate);
-  strapi.eventHub.on('permission.delete', invalidate);
-  strapi.eventHub.on('role.create', invalidate);
-  strapi.eventHub.on('role.update', invalidate);
-  strapi.eventHub.on('role.delete', invalidate);
-  strapi.eventHub.on('user.create', invalidate);
-  strapi.eventHub.on('user.update', invalidate);
-  strapi.eventHub.on('user.delete', invalidate);
 };
 
 const syncAuthSettings = async () => {
@@ -173,7 +156,6 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   await registerAdminConditions();
   await registerPermissionActions();
   registerModelHooks();
-  registerAdminAuthCacheInvalidation();
 
   const permissionService = getService('permission');
   const userService = getService('user');

--- a/packages/core/admin/server/src/strategies/__tests__/admin.test.ts
+++ b/packages/core/admin/server/src/strategies/__tests__/admin.test.ts
@@ -4,17 +4,9 @@
 import createContext from '../../../../../../../tests/helpers/create-context';
 // @ts-expect-error - test purposes
 import { createMockSessionManager } from '../../../../../../../tests/helpers/create-session-manager-mock';
-import adminAuthStrategy, { clearAdminAuthAbilityCache } from '../admin';
+import adminAuthStrategy from '../admin';
 
 describe('Admin Auth Strategy', () => {
-  beforeEach(() => {
-    clearAdminAuthAbilityCache();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   describe('Authenticate a user (sessions-based access token)', () => {
     const request = {
       header: {
@@ -56,135 +48,6 @@ describe('Admin Auth Strategy', () => {
         credentials: user,
         ability: 'ability',
       });
-    });
-
-    test('reuses the generated ability for repeated requests from the same session', async () => {
-      const validateAccessToken = jest.fn(() => ({
-        isValid: true,
-        payload: { userId: '1', sessionId: 'session-123', type: 'access', exp: 0, iat: 0 },
-      }));
-      const isSessionActive = jest.fn(async () => true);
-      const firstCtx = createContext({}, { request, state: {} });
-      const secondCtx = createContext({}, { request, state: {} });
-      const user = { id: 1, isActive: true } as any;
-      const findOne = jest.fn(() => user);
-      const generateUserAbility = jest.fn(() => 'ability');
-
-      const { sessionManager } = createMockSessionManager({ validateAccessToken, isSessionActive });
-
-      global.strapi = {
-        sessionManager: sessionManager as any,
-        admin: {
-          services: {
-            permission: { engine: { generateUserAbility } },
-          },
-        },
-        db: { query: jest.fn(() => ({ findOne })) },
-      } as any;
-
-      await adminAuthStrategy.authenticate(firstCtx);
-      await adminAuthStrategy.authenticate(secondCtx);
-
-      expect(generateUserAbility).toHaveBeenCalledTimes(1);
-    });
-
-    test('recomputes the ability after cache invalidation', async () => {
-      const validateAccessToken = jest.fn(() => ({
-        isValid: true,
-        payload: { userId: '1', sessionId: 'session-123', type: 'access', exp: 0, iat: 0 },
-      }));
-      const isSessionActive = jest.fn(async () => true);
-      const firstCtx = createContext({}, { request, state: {} });
-      const secondCtx = createContext({}, { request, state: {} });
-      const user = { id: 1, isActive: true } as any;
-      const findOne = jest.fn(() => user);
-      const generateUserAbility = jest.fn(() => 'ability');
-
-      const { sessionManager } = createMockSessionManager({ validateAccessToken, isSessionActive });
-
-      global.strapi = {
-        sessionManager: sessionManager as any,
-        admin: {
-          services: {
-            permission: { engine: { generateUserAbility } },
-          },
-        },
-        db: { query: jest.fn(() => ({ findOne })) },
-      } as any;
-
-      await adminAuthStrategy.authenticate(firstCtx);
-      clearAdminAuthAbilityCache();
-      await adminAuthStrategy.authenticate(secondCtx);
-
-      expect(generateUserAbility).toHaveBeenCalledTimes(2);
-    });
-
-    test('treats expired cache entries as misses', async () => {
-      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(61_000);
-
-      const validateAccessToken = jest.fn(() => ({
-        isValid: true,
-        payload: { userId: '1', sessionId: 'session-123', type: 'access', exp: 0, iat: 0 },
-      }));
-      const isSessionActive = jest.fn(async () => true);
-      const firstCtx = createContext({}, { request, state: {} });
-      const secondCtx = createContext({}, { request, state: {} });
-      const user = { id: 1, isActive: true } as any;
-      const findOne = jest.fn(() => user);
-      const generateUserAbility = jest.fn(() => 'ability');
-
-      const { sessionManager } = createMockSessionManager({ validateAccessToken, isSessionActive });
-
-      global.strapi = {
-        sessionManager: sessionManager as any,
-        admin: {
-          services: {
-            permission: { engine: { generateUserAbility } },
-          },
-        },
-        db: { query: jest.fn(() => ({ findOne })) },
-      } as any;
-
-      await adminAuthStrategy.authenticate(firstCtx);
-      await adminAuthStrategy.authenticate(secondCtx);
-
-      expect(generateUserAbility).toHaveBeenCalledTimes(2);
-    });
-
-    test('rejects an inactive session even when the cache was already warmed', async () => {
-      const validateAccessToken = jest.fn(() => ({
-        isValid: true,
-        payload: { userId: '1', sessionId: 'session-123', type: 'access', exp: 0, iat: 0 },
-      }));
-      const isSessionActive = jest
-        .fn(async () => true)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
-      const firstCtx = createContext({}, { request, state: {} });
-      const secondCtx = createContext({}, { request, state: {} });
-      const thirdCtx = createContext({}, { request, state: {} });
-      const user = { id: 1, isActive: true } as any;
-      const findOne = jest.fn(() => user);
-      const generateUserAbility = jest.fn(() => 'ability');
-
-      const { sessionManager } = createMockSessionManager({ validateAccessToken, isSessionActive });
-
-      global.strapi = {
-        sessionManager: sessionManager as any,
-        admin: {
-          services: {
-            permission: { engine: { generateUserAbility } },
-          },
-        },
-        db: { query: jest.fn(() => ({ findOne })) },
-      } as any;
-
-      await adminAuthStrategy.authenticate(firstCtx);
-      const secondResponse = await adminAuthStrategy.authenticate(secondCtx);
-      await adminAuthStrategy.authenticate(thirdCtx);
-
-      expect(secondResponse).toStrictEqual({ authenticated: false });
-      expect(generateUserAbility).toHaveBeenCalledTimes(2);
     });
 
     test('Fails to authenticate if the authorization header is missing', async () => {

--- a/packages/core/admin/server/src/strategies/admin.ts
+++ b/packages/core/admin/server/src/strategies/admin.ts
@@ -1,66 +1,6 @@
 import type { Context } from 'koa';
 import type { Modules } from '@strapi/types';
 import { getService } from '../utils';
-import type { AdminUser } from '../../../shared/contracts/shared';
-import type * as permissionService from '../services/permission';
-
-// Cache admin abilities briefly to avoid rebuilding the same RBAC state for
-// bursts of requests from the same active session. The TTL keeps the stale
-// permission window short, while explicit invalidation on admin user, role,
-// and permission changes handles the common mutation paths sooner.
-const ABILITY_CACHE_TTL_MS = 60_000;
-
-// Bound per-process memory usage so cached admin sessions cannot grow
-// indefinitely under sustained traffic.
-const MAX_CACHED_SESSIONS = 500;
-
-type AdminAbility = Awaited<ReturnType<typeof permissionService.engine.generateUserAbility>>;
-
-type CachedAdminAuth = {
-  ability: AdminAbility;
-  expiresAt: number;
-  user: AdminUser;
-};
-
-// This cache is process-local. In multi-process or multi-replica deployments,
-// invalidation only affects the current process, so other workers may continue
-// serving a stale cached ability until the TTL expires.
-
-const abilityCache = new Map<string, CachedAdminAuth>();
-
-const getCachedAdminAuth = (sessionId: string) => {
-  const cached = abilityCache.get(sessionId);
-
-  if (!cached) {
-    return null;
-  }
-
-  if (cached.expiresAt <= Date.now()) {
-    abilityCache.delete(sessionId);
-    return null;
-  }
-
-  return cached;
-};
-
-const setCachedAdminAuth = (sessionId: string, value: Omit<CachedAdminAuth, 'expiresAt'>) => {
-  if (abilityCache.size >= MAX_CACHED_SESSIONS) {
-    const firstKey = abilityCache.keys().next().value;
-
-    if (firstKey) {
-      abilityCache.delete(firstKey);
-    }
-  }
-
-  abilityCache.set(sessionId, {
-    ...value,
-    expiresAt: Date.now() + ABILITY_CACHE_TTL_MS,
-  });
-};
-
-export const clearAdminAuthAbilityCache = () => {
-  abilityCache.clear();
-};
 
 const getSessionManager = (): Modules.SessionManager.SessionManagerService | null => {
   const manager = strapi.sessionManager as Modules.SessionManager.SessionManagerService | undefined;
@@ -97,23 +37,7 @@ export const authenticate = async (ctx: Context) => {
 
   const isActive = await manager('admin').isSessionActive(result.payload.sessionId);
   if (!isActive) {
-    // A previously cached session can become invalid between requests, so
-    // purge its cached ability immediately once the session is no longer active.
-    abilityCache.delete(result.payload.sessionId);
     return { authenticated: false };
-  }
-
-  const cachedAuth = getCachedAdminAuth(result.payload.sessionId);
-
-  if (cachedAuth) {
-    ctx.state.userAbility = cachedAuth.ability;
-    ctx.state.user = cachedAuth.user;
-
-    return {
-      authenticated: true,
-      credentials: cachedAuth.user,
-      ability: cachedAuth.ability,
-    };
   }
 
   const rawUserId = result.payload.userId;
@@ -128,8 +52,6 @@ export const authenticate = async (ctx: Context) => {
     .findOne({ where: { id: userId }, populate: ['roles'] });
 
   if (!user || !(user.isActive === true)) {
-    // This branch is only reached after a cache miss, so there is no warmed
-    // cache entry from this request path to clear here.
     return { authenticated: false };
   }
 
@@ -139,11 +61,6 @@ export const authenticate = async (ctx: Context) => {
   // ctx.state.userAbility, and remove the assign below
   ctx.state.userAbility = userAbility;
   ctx.state.user = user;
-
-  setCachedAdminAuth(result.payload.sessionId, {
-    ability: userAbility,
-    user,
-  });
 
   return {
     authenticated: true,


### PR DESCRIPTION
### What does it do?

This change keeps the Content Manager admin performance fix on the frontend while removing the server-side admin ability cache.

### Why is it needed?

The original issue was slow admin navigation in Content Manager for users with multiple roles, caused in part by repeated `/admin/permissions/check` calls during Content Manager initialization.

The frontend batching fix addresses that request fan-out and keeps the performance improvement.

The server-side ability cache was removed because it introduced process-local authorization caching, which can lead to stale admin RBAC behavior in horizontally scaled deployments where multiple Strapi instances are running concurrently.

This keeps the safe part of the performance fix while avoiding the horizontal-scaling consistency risk.

### How to test it?

Run the focused tests:

```sh
yarn test:front packages/core/content-manager/admin/src/hooks/tests/useContentManagerInitData.test.tsx
yarn test:unit packages/core/admin/server/src/strategies/__tests__/admin.test.ts
```