### PR TITLE
fix(users-permissions): fix 'occured' -> 'occurred' in error message strings

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
@@ -61,7 +61,7 @@ const AdvancedSettingsPage = () => {
           type: 'danger',
           message: formatMessage({
             id: getTrad('notification.error'),
-            defaultMessage: 'An error occured',
+            defaultMessage: 'An error occurred',
           }),
         });
       },

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -89,7 +89,7 @@ export const RolesListPage = () => {
     } catch (error) {
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
   };


### PR DESCRIPTION
Two `defaultMessage` strings in users-permissions plugin read `An error occured`:
- `packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx` line 64
- `packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx` line 92

Fixed to `occurred`. These strings are user-visible in the admin panel. String-literal-only change.