### PR TITLE
fix: normalize BCP 47 locale tags to prevent zh-Hans dropdown omission

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -87,6 +87,18 @@ interface Library {
   components: Record<Component['name'], Component['Component']>;
 }
 
+/**
+ * Normalizes a BCP 47 locale tag to its canonical casing (e.g. "zh-hans" → "zh-Hans",
+ * "pt-br" → "pt-BR"). Falls back to the original string for unrecognized tags.
+ */
+const normalizeLocale = (locale: string): string => {
+  try {
+    return new Intl.Locale(locale).baseName;
+  } catch {
+    return locale;
+  }
+};
+
 class StrapiApp {
   appPlugins: Record<string, StrapiAppPlugin>;
   plugins: Record<string, Plugin> = {};
@@ -253,7 +265,7 @@ class StrapiApp {
     if (customConfig.locales) {
       this.configurations.locales = [
         'en',
-        ...(customConfig.locales?.filter((loc) => loc !== 'en') || []),
+        ...(customConfig.locales?.filter((loc) => loc !== 'en').map(normalizeLocale) || []),
       ];
     }
 
@@ -419,6 +431,9 @@ class StrapiApp {
    * with the default ones.
    */
   async loadTrads(customTranslations: Record<string, Record<string, string>> = {}) {
+    const normalizedCustomTranslations = Object.fromEntries(
+      Object.entries(customTranslations).map(([key, value]) => [normalizeLocale(key), value])
+    );
     const adminTranslations = await this.loadAdminTrads();
 
     const arrayOfPromises = Object.keys(this.appPlugins)
@@ -460,7 +475,7 @@ class StrapiApp {
       acc[current] = {
         ...adminTranslations[current],
         ...(mergedTrads[current] || {}),
-        ...(customTranslations[current] ?? {}),
+        ...(normalizedCustomTranslations[current] ?? {}),
       };
 
       return acc;

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -527,6 +527,42 @@ describe('ADMIN | new StrapiApp', () => {
       expect(app.configurations.locales).toEqual(['en', 'fr']);
     });
 
+    it('should normalize locale tags to BCP 47 canonical casing', () => {
+      const app = new StrapiApp({ config: { locales: ['zh-hans', 'pt-br', 'en-gb'] } });
+
+      expect(app.configurations.locales).toEqual(['en', 'zh-Hans', 'pt-BR', 'en-GB']);
+    });
+
+    it('should leave correctly-cased locale tags unchanged', () => {
+      const app = new StrapiApp({ config: { locales: ['zh-Hans', 'pt-BR'] } });
+
+      expect(app.configurations.locales).toEqual(['en', 'zh-Hans', 'pt-BR']);
+    });
+
+    it('should include zh-Hans in render() localeNames when configured', () => {
+      const app = new StrapiApp({ config: { locales: ['zh-Hans'] } });
+      app.render();
+
+      const state = app.store!.getState();
+
+      expect(state.admin_app.language.localeNames).toEqual({
+        en: 'English',
+        'zh-Hans': '中文 (简体)',
+      });
+    });
+
+    it('should include zh-Hans in render() localeNames even when configured as zh-hans (lowercase)', () => {
+      const app = new StrapiApp({ config: { locales: ['zh-hans'] } });
+      app.render();
+
+      const state = app.store!.getState();
+
+      expect(state.admin_app.language.localeNames).toEqual({
+        en: 'English',
+        'zh-Hans': '中文 (简体)',
+      });
+    });
+
     it('should override the authLogo', () => {
       const app = new StrapiApp({ config: { auth: { logo: 'fr' } } });
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

 Adds a normalizeLocale helper that uses Intl.Locale.baseName to canonicalize BCP 47 locale tags. Applies it in two places in StrapiApp.tsx:                                                                   
  - createCustomConfigurations — normalizes tags in config.locales before storing them (e.g. zh-hans → zh-Hans, pt-br → pt-BR)
  - loadTrads — normalizes keys in user-supplied config.translations so they match the normalized locale keys

[25768.webm](https://github.com/user-attachments/assets/d836bb16-803b-4f99-9416-1ad047fd5025)

### Why is it needed?

pick(languageNativeNames, this.configurations.locales) seems to be case-sensitive lookup. If a user configures locales: ['zh-hans'] instead of the canonical zh-Hans, the pick silently returns nothing and the locale never appears in the Interface language dropdown on the Profile page. The same silent failure applies to any locale tag with wrong casing (e.g. pt-br, en-gb).

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #25768 
