### PR TITLE
fix(database): make 5.0.0-02-created-document-id migration idempotent

### DIFF
--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-02-document-id.ts
@@ -143,10 +143,25 @@ const migrationDocumentIds = async (db: Database, knex: Knex, meta: Meta) => {
   } while (updatedRows > 0);
 };
 
+const isDuplicateColumnError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as { code?: string; errno?: number; message?: string };
+  if (e.code === '42701') return true;
+  if (e.errno === 1060) return true;
+  if (typeof e.message === 'string' && /duplicate column/i.test(e.message)) return true;
+  return false;
+};
+
 const createDocumentIdColumn = async (knex: Knex, tableName: string) => {
-  await knex.schema.alterTable(tableName, (table) => {
-    table.string('document_id');
-  });
+  try {
+    await knex.schema.alterTable(tableName, (table) => {
+      table.string('document_id');
+    });
+  } catch (error) {
+    if (!isDuplicateColumnError(error)) {
+      throw error;
+    }
+  }
 };
 
 const hasLocalizationsJoinTable = async (knex: Knex, tableName: string) => {
@@ -166,14 +181,11 @@ export const createdDocumentId: Migration = {
       }
 
       if ('documentId' in meta.attributes) {
-        // add column if doesn't exist
         const hasDocumentIdColumn = await knex.schema.hasColumn(meta.tableName, 'document_id');
 
-        if (hasDocumentIdColumn) {
-          continue;
+        if (!hasDocumentIdColumn) {
+          await createDocumentIdColumn(knex, meta.tableName);
         }
-
-        await createDocumentIdColumn(knex, meta.tableName);
 
         if (await hasLocalizationsJoinTable(knex, meta.tableName)) {
           await migrateDocumentIdsWithLocalizations(db, knex, meta);

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-02-document-id.test.ts
@@ -1,0 +1,145 @@
+import type { Knex } from 'knex';
+
+import { createdDocumentId } from '../5.0.0-02-document-id';
+
+type UpdateCall = { table: string; ids: number[] };
+
+const buildHarness = (
+  options: {
+    existingColumns?: string[];
+    rawAddColumnError?: Error;
+    rowsNeedingBackfill?: number;
+  } = {}
+) => {
+  const existingColumns = new Set(options.existingColumns ?? []);
+  const alterTableCalls: string[] = [];
+  const updateCalls: UpdateCall[] = [];
+  let remainingRowsToBackfill = options.rowsNeedingBackfill ?? 0;
+
+  const knexBuilder: any = jest.fn((tableName: string) => {
+    const builder: any = {
+      update: jest.fn(() => builder),
+      whereIn: jest.fn((_column: string, ids: number[]) => {
+        updateCalls.push({ table: tableName, ids });
+        if (remainingRowsToBackfill > 0) {
+          remainingRowsToBackfill -= 1;
+          return Promise.resolve(1);
+        }
+        return Promise.resolve(0);
+      }),
+      select: jest.fn(() => builder),
+      from: jest.fn(() => builder),
+      whereNull: jest.fn(() => builder),
+      limit: jest.fn(() => builder),
+      as: jest.fn(() => builder),
+    };
+    return builder;
+  });
+
+  knexBuilder.schema = {
+    hasTable: jest.fn(async (tableName: string) => {
+      return !tableName.endsWith('_localizations_links');
+    }),
+    hasColumn: jest.fn(async (tableName: string, column: string) => {
+      if (column !== 'document_id') return false;
+      return existingColumns.has(tableName);
+    }),
+    alterTable: jest.fn(async (tableName: string, tableBuilder: (t: any) => void) => {
+      alterTableCalls.push(tableName);
+      tableBuilder({ string: jest.fn() });
+      if (options.rawAddColumnError) {
+        existingColumns.add(tableName);
+        throw options.rawAddColumnError;
+      }
+      existingColumns.add(tableName);
+    }),
+  };
+
+  const db: any = {
+    dialect: { client: 'postgres' },
+    metadata: {
+      values: () => [
+        {
+          tableName: 'files',
+          singularName: 'file',
+          attributes: { documentId: {} },
+        },
+      ],
+    },
+  };
+
+  return {
+    knex: knexBuilder as unknown as Knex.Transaction,
+    db,
+    get alterTableCalls() {
+      return alterTableCalls;
+    },
+    get updateCalls() {
+      return updateCalls;
+    },
+    get remainingRowsToBackfill() {
+      return remainingRowsToBackfill;
+    },
+  };
+};
+
+describe('createdDocumentId migration — idempotent recovery (CMS-689)', () => {
+  it('creates the column and backfills document_id on a fresh run', async () => {
+    const h = buildHarness({ rowsNeedingBackfill: 2 });
+
+    await expect(createdDocumentId.up(h.knex, h.db)).resolves.not.toThrow();
+
+    expect(h.alterTableCalls).toEqual(['files']);
+    expect(h.remainingRowsToBackfill).toBe(0);
+    expect(h.updateCalls.length).toBeGreaterThan(0);
+  });
+
+  it('still backfills NULL document_id rows when the column already exists', async () => {
+    const h = buildHarness({
+      existingColumns: ['files'],
+      rowsNeedingBackfill: 3,
+    });
+
+    await createdDocumentId.up(h.knex, h.db);
+
+    expect(h.alterTableCalls).toEqual([]);
+    expect(h.remainingRowsToBackfill).toBe(0);
+    expect(h.updateCalls.length).toBeGreaterThan(0);
+  });
+
+  it('tolerates Postgres 42701 "column already exists" during ADD COLUMN and still backfills', async () => {
+    const duplicateColumnError = Object.assign(
+      new Error('column "document_id" of relation "files" already exists'),
+      { code: '42701' }
+    );
+    const h = buildHarness({
+      rawAddColumnError: duplicateColumnError,
+      rowsNeedingBackfill: 2,
+    });
+
+    await expect(createdDocumentId.up(h.knex, h.db)).resolves.not.toThrow();
+
+    expect(h.alterTableCalls).toEqual(['files']);
+    expect(h.remainingRowsToBackfill).toBe(0);
+  });
+
+  it('tolerates MySQL 1060 "Duplicate column name" during ADD COLUMN', async () => {
+    const duplicateColumnError = Object.assign(new Error("Duplicate column name 'document_id'"), {
+      errno: 1060,
+    });
+    const h = buildHarness({
+      rawAddColumnError: duplicateColumnError,
+      rowsNeedingBackfill: 1,
+    });
+
+    await expect(createdDocumentId.up(h.knex, h.db)).resolves.not.toThrow();
+    expect(h.remainingRowsToBackfill).toBe(0);
+  });
+
+  it('rethrows non-duplicate-column errors during ADD COLUMN', async () => {
+    const otherError = Object.assign(new Error('disk full'), { code: '53100' });
+    const h = buildHarness({ rawAddColumnError: otherError });
+
+    await expect(createdDocumentId.up(h.knex, h.db)).rejects.toThrow('disk full');
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds idempotency handling to the 5.0.0-02-created-document-id migration so it tolerates duplicate-column errors (PostgreSQL 42701, MySQL 1060) and always runs the document_id backfill even when the column already exists.

### Why is it needed?

During Strapi 4→5 upgrade on PostgreSQL, the internal migration 5.0.0-02-created-document-id can fail or be interrupted (e.g., statement_timeout on large files table, or process killed mid-migration). 
On retry, the migration crashes with "column document_id already exists" because the column was created but the migration wasn't recorded. Additionally, when hasColumn returns true, the migration early-exited via continue, silently skipping the backfill and leaving rows with NULL document_id.

### How to test it?

Run the new unit tests:
```bash
yarn workspace @strapi/database test:unit --testPathPattern="5.0.0-02-document-id"
```
All 5 tests should pass.

### Related issue(s)/PR(s)


#25966 
Fix CMS-689