### PR TITLE
fix(upload): sharp concurrency and cache leads to OOM 

### DIFF
--- a/packages/core/upload/server/src/__tests__/register.test.ts
+++ b/packages/core/upload/server/src/__tests__/register.test.ts
@@ -92,7 +92,7 @@ describe('Upload plugin register', () => {
       jest.clearAllMocks();
     });
 
-    test('uses sharpCache false and sharpConcurrency 1 from defaults', async () => {
+    test('uses sharp.cache false and sharp.concurrency 1 from defaults', async () => {
       const registerRoute = jest.fn();
 
       global.strapi = {
@@ -113,7 +113,7 @@ describe('Upload plugin register', () => {
       expect(sharp.concurrency).toHaveBeenCalledWith(1);
     });
 
-    test('forwards plugin::upload sharpCache and sharpConcurrency to sharp', async () => {
+    test('forwards plugin::upload sharp.cache and sharp.concurrency to sharp', async () => {
       const registerRoute = jest.fn();
 
       global.strapi = {
@@ -124,7 +124,7 @@ describe('Upload plugin register', () => {
         config: {
           get: jest
             .fn()
-            .mockReturnValue({ provider: 'local', sharpCache: true, sharpConcurrency: 4 }),
+            .mockReturnValue({ provider: 'local', sharp: { cache: true, concurrency: 4 } }),
           set: jest.fn(),
         },
         get: jest.fn().mockReturnValue({ add: jest.fn() }),

--- a/packages/core/upload/server/src/__tests__/register.test.ts
+++ b/packages/core/upload/server/src/__tests__/register.test.ts
@@ -1,5 +1,19 @@
 import { join } from 'path';
+
+jest.mock('sharp', () => {
+  return {
+    __esModule: true,
+    default: Object.assign(jest.fn(), {
+      cache: jest.fn(),
+      concurrency: jest.fn(),
+    }),
+  };
+});
+
+/* eslint-disable import/first -- mock runs before `sharp` import */
+import sharp from 'sharp';
 import { register } from '../register';
+/* eslint-enable import/first */
 
 const exampleMiddlewaresConfig = [
   {
@@ -30,44 +44,123 @@ jest.mock('@strapi/provider-upload-local', () => ({
   },
 }));
 
-describe('Upload plugin register function', () => {
-  test('The upload plugin registers the /upload route', async () => {
-    const registerRoute = jest.fn();
+describe('Upload plugin register', () => {
+  describe('routes and provider middlewares', () => {
+    test('The upload plugin registers the /upload route', async () => {
+      const registerRoute = jest.fn();
 
-    global.strapi = {
-      dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
-      plugins: { upload: {} },
-      server: { app: { on: jest.fn() }, routes: registerRoute },
-      admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
-      config: {
-        get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
-        set: jest.fn(),
-      },
-      get: jest.fn().mockReturnValue({ add: jest.fn() }),
-    } as any;
+      global.strapi = {
+        dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
+        plugins: { upload: {} },
+        server: { app: { on: jest.fn() }, routes: registerRoute },
+        admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
+        config: {
+          get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
+          set: jest.fn(),
+        },
+        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+      } as any;
 
-    await register({ strapi });
+      await register({ strapi });
 
-    expect(registerRoute).toHaveBeenCalledTimes(1);
+      expect(registerRoute).toHaveBeenCalledTimes(1);
+    });
+
+    test('Strapi config can programatically be extended by providers', async () => {
+      const setConfig = jest.fn();
+
+      global.strapi = {
+        dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
+        plugins: { upload: {} },
+        server: { app: { on: jest.fn() }, routes: jest.fn() },
+        admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
+        config: {
+          get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
+          set: setConfig,
+        },
+        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+      } as any;
+
+      await register({ strapi });
+
+      expect(setConfig).toHaveBeenCalledWith('middlewares', exampleMiddlewaresConfig);
+    });
   });
 
-  test('Strapi config can programatically be extended by providers', async () => {
-    const setConfig = jest.fn();
+  describe('sharp', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-    global.strapi = {
-      dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
-      plugins: { upload: {} },
-      server: { app: { on: jest.fn() }, routes: jest.fn() },
-      admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
-      config: {
-        get: jest.fn().mockReturnValueOnce({ provider: 'local' }),
-        set: setConfig,
-      },
-      get: jest.fn().mockReturnValue({ add: jest.fn() }),
-    } as any;
+    test('uses sharpCache false and sharpConcurrency 1 from defaults', async () => {
+      const registerRoute = jest.fn();
 
-    await register({ strapi });
+      global.strapi = {
+        dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
+        plugins: { upload: {} },
+        server: { app: { on: jest.fn() }, routes: registerRoute },
+        admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
+        config: {
+          get: jest.fn().mockReturnValue({ provider: 'local' }),
+          set: jest.fn(),
+        },
+        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+      } as any;
 
-    expect(setConfig).toHaveBeenCalledWith('middlewares', exampleMiddlewaresConfig);
+      await register({ strapi });
+
+      expect(sharp.cache).toHaveBeenCalledWith(false);
+      expect(sharp.concurrency).toHaveBeenCalledWith(1);
+    });
+
+    test('forwards plugin::upload sharpCache and sharpConcurrency to sharp', async () => {
+      const registerRoute = jest.fn();
+
+      global.strapi = {
+        dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
+        plugins: { upload: {} },
+        server: { app: { on: jest.fn() }, routes: registerRoute },
+        admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
+        config: {
+          get: jest
+            .fn()
+            .mockReturnValue({ provider: 'local', sharpCache: true, sharpConcurrency: 4 }),
+          set: jest.fn(),
+        },
+        get: jest.fn().mockReturnValue({ add: jest.fn() }),
+      } as any;
+
+      await register({ strapi });
+
+      expect(sharp.cache).toHaveBeenCalledWith(true);
+      expect(sharp.concurrency).toHaveBeenCalledWith(4);
+    });
+  });
+
+  describe('plugin::upload config', () => {
+    test('null/undefined plugin::upload: register runs, sharp cache and concurrency use defaults', async () => {
+      for (const uploadFromConfig of [null, undefined]) {
+        const registerRoute = jest.fn();
+        (sharp.cache as jest.Mock).mockClear();
+        (sharp.concurrency as jest.Mock).mockClear();
+
+        global.strapi = {
+          dirs: { app: { root: process.cwd() }, static: { public: join(process.cwd(), 'public') } },
+          plugins: { upload: {} },
+          server: { app: { on: jest.fn() }, routes: registerRoute },
+          admin: { services: { permission: { actionProvider: { registerMany: jest.fn() } } } },
+          config: {
+            get: jest.fn().mockReturnValue(uploadFromConfig as any),
+            set: jest.fn(),
+          },
+          get: jest.fn().mockReturnValue({ add: jest.fn() }),
+        } as any;
+
+        await expect(register({ strapi })).resolves.toBeUndefined();
+
+        expect(sharp.cache).toHaveBeenCalledWith(false);
+        expect(sharp.concurrency).toHaveBeenCalledWith(1);
+      }
+    });
   });
 });

--- a/packages/core/upload/server/src/config.ts
+++ b/packages/core/upload/server/src/config.ts
@@ -4,6 +4,8 @@ export const config = {
     provider: 'local',
     sizeLimit: 1000000000, // 1GB
     actionOptions: {},
+    sharpCache: false,
+    sharpConcurrency: 1,
   },
   validator() {},
 };

--- a/packages/core/upload/server/src/config.ts
+++ b/packages/core/upload/server/src/config.ts
@@ -4,8 +4,10 @@ export const config = {
     provider: 'local',
     sizeLimit: 1000000000, // 1GB
     actionOptions: {},
-    sharpCache: false,
-    sharpConcurrency: 1,
+    sharp: {
+      cache: false,
+      concurrency: 1,
+    },
   },
   validator() {},
 };

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import sharp from 'sharp';
 
 import { errors, file } from '@strapi/utils';
 import type { Core } from '@strapi/types';
@@ -18,7 +19,14 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   // Register AI metadata job model
   strapi.get('models').add(aiMetadataJob);
 
-  strapi.plugin('upload').provider = createProvider(strapi.config.get<Config>('plugin::upload'));
+  const uploadConfig = strapi.config.get<Config>('plugin::upload');
+
+  // Configure sharp memory management
+  const { sharpCache = false, sharpConcurrency = 1 } = uploadConfig;
+  sharp.cache(sharpCache);
+  sharp.concurrency(sharpConcurrency);
+
+  strapi.plugin('upload').provider = createProvider(uploadConfig);
 
   await registerUploadMiddleware({ strapi });
 

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -29,9 +29,9 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   } as Config;
 
   // Configure sharp memory management
-  const { sharpCache = false, sharpConcurrency = 1 } = uploadConfig;
-  sharp.cache(sharpCache);
-  sharp.concurrency(sharpConcurrency);
+  const { cache = false, concurrency = 1 } = uploadConfig.sharp ?? {};
+  sharp.cache(cache);
+  sharp.concurrency(concurrency);
 
   strapi.plugin('upload').provider = createProvider(uploadConfig);
 

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -19,7 +19,14 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   // Register AI metadata job model
   strapi.get('models').add(aiMetadataJob);
 
-  const uploadConfig = strapi.config.get<Config>('plugin::upload');
+  const raw = strapi.config.get<Partial<Config> | null | undefined>('plugin::upload') ?? {};
+  // createProvider needs a provider; empty get() (e.g. in tests) still has defaults.
+  const uploadConfig = {
+    provider: 'local' as const,
+    providerOptions: {} as Config['providerOptions'],
+    actionOptions: {} as Config['actionOptions'],
+    ...raw,
+  } as Config;
 
   // Configure sharp memory management
   const { sharpCache = false, sharpConcurrency = 1 } = uploadConfig;

--- a/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/responsive-parallelism.test.ts
@@ -1,0 +1,138 @@
+// Mocked sharp: responsive format generation must not run multiple toFile in parallel
+// (github.com/strapi/strapi#26046).
+import _ from 'lodash';
+
+jest.mock('sharp', () => {
+  const toFileState = { inFlight: 0, maxInFlight: 0 };
+  // `__setNextMetadata` — per-test image dimensions
+  const nextMetadata: {
+    value: { width: number | null; height: number | null; format: string };
+  } = { value: { width: 2000, height: 2000, format: 'jpeg' } };
+
+  const toFile = jest.fn().mockImplementation(async function toFileWithTracking() {
+    toFileState.inFlight += 1;
+    toFileState.maxInFlight = Math.max(toFileState.maxInFlight, toFileState.inFlight);
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    toFileState.inFlight -= 1;
+    return { width: 100, height: 100, size: 1000 };
+  });
+
+  const makeChain = () => ({
+    metadata: jest.fn().mockImplementation(() => Promise.resolve({ ...nextMetadata.value })),
+    resize: jest.fn().mockReturnThis(),
+    toFile,
+    on: jest.fn().mockReturnThis(),
+  });
+
+  return {
+    __esModule: true,
+    default: Object.assign(
+      jest.fn(() => makeChain()),
+      {
+        cache: jest.fn(),
+        concurrency: jest.fn(),
+        __getToFile: () => toFile,
+        __getToFileState: () => toFileState,
+        __setNextMetadata(m: { width: number | null; height: number | null; format: string }) {
+          nextMetadata.value = m;
+        },
+      }
+    ),
+  };
+});
+
+/* eslint-disable import/first -- mock runs before `sharp` import */
+import sharp from 'sharp';
+import imageManipulation from '../../image-manipulation';
+/* eslint-enable import/first */
+
+const defaultConfig: Record<string, unknown> = {
+  'plugin::upload': {
+    breakpoints: { large: 1000, medium: 750, small: 500 },
+  },
+};
+
+const uploadSettings = { responsiveDimensions: true };
+
+const resetStrapi = () => {
+  global.strapi = {
+    config: {
+      get: (key: string, defaultValue: unknown) => _.get(defaultConfig, key, defaultValue),
+    },
+    plugins: {
+      upload: {
+        services: {
+          'image-manipulation': imageManipulation,
+          upload: {
+            getSettings: async () => ({
+              responsiveDimensions: uploadSettings.responsiveDimensions,
+            }),
+          },
+        },
+      },
+    },
+  } as any;
+};
+
+const testFile: Parameters<typeof imageManipulation.generateResponsiveFormats>[0] = {
+  name: 'huge.jpg',
+  hash: 'a1b2',
+  ext: '.jpg',
+  mime: 'image/jpeg',
+  filepath: '/var/tmp/strapi-huge-mock.jpg',
+  path: null,
+  getStream() {
+    throw new Error('unused (filepath set)');
+  },
+};
+
+beforeEach(() => {
+  uploadSettings.responsiveDimensions = true;
+  const s = sharp as any;
+  s.__setNextMetadata({ width: 2000, height: 2000, format: 'jpeg' });
+  resetStrapi();
+  s.__getToFile().mockClear();
+  s.__getToFileState().inFlight = 0;
+  s.__getToFileState().maxInFlight = 0;
+});
+
+const getToFile = () => (sharp as any).__getToFile() as jest.Mock;
+const getToFileState = () => (sharp as any).__getToFileState() as { maxInFlight: number };
+
+describe('generateResponsiveFormats (sequential resizes)', () => {
+  test('never runs more than one toFile at a time for all breakpoints', async () => {
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).toHaveBeenCalledTimes(3);
+    expect(getToFileState().maxInFlight).toBe(1);
+  });
+});
+
+describe('generateResponsiveFormats (no toFile when nothing to resize)', () => {
+  test('does nothing when responsive dimensions are off', async () => {
+    uploadSettings.responsiveDimensions = false;
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).not.toHaveBeenCalled();
+    expect(getToFileState().maxInFlight).toBe(0);
+  });
+
+  test('skips breakpoints when image is smaller than all of them', async () => {
+    (sharp as any).__setNextMetadata({ width: 200, height: 200, format: 'jpeg' });
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).not.toHaveBeenCalled();
+  });
+
+  test('no sizes when width and height are null in metadata', async () => {
+    (sharp as any).__setNextMetadata({ width: null, height: null, format: 'jpeg' });
+
+    await imageManipulation.generateResponsiveFormats(testFile);
+
+    expect(getToFile()).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/upload/server/src/services/__tests__/upload/uploadImage.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/uploadImage.test.ts
@@ -1,3 +1,4 @@
+// _uploadImage with real sharp; responsive sequencing is in responsive-parallelism.test.ts.
 import path from 'path';
 import fs from 'fs';
 import fse from 'fs-extra';

--- a/packages/core/upload/server/src/services/image-manipulation.ts
+++ b/packages/core/upload/server/src/services/image-manipulation.ts
@@ -200,17 +200,17 @@ const generateResponsiveFormats = async (file: UploadableFile) => {
   const originalDimensions = await getDimensions(file);
 
   const breakpoints = getBreakpoints();
-  return Promise.all(
-    Object.keys(breakpoints).map((key) => {
-      const breakpoint = breakpoints[key];
+  const results = [];
 
-      if (breakpointSmallerThan(breakpoint, originalDimensions)) {
-        return generateBreakpoint(key, { file, breakpoint });
-      }
+  for (const key of Object.keys(breakpoints)) {
+    const breakpoint = breakpoints[key];
 
-      return undefined;
-    })
-  );
+    if (breakpointSmallerThan(breakpoint, originalDimensions)) {
+      results.push(await generateBreakpoint(key, { file, breakpoint }));
+    }
+  }
+
+  return results;
 };
 
 const generateBreakpoint = async (

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -65,6 +65,8 @@ export interface Config {
   sizeLimit?: number;
   providerOptions: Record<string, unknown>;
   actionOptions: Record<string, unknown>;
+  sharpCache?: boolean;
+  sharpConcurrency?: number;
 }
 
 export interface UploadableFile extends Omit<File, 'id'> {

--- a/packages/core/upload/server/src/types.ts
+++ b/packages/core/upload/server/src/types.ts
@@ -65,8 +65,10 @@ export interface Config {
   sizeLimit?: number;
   providerOptions: Record<string, unknown>;
   actionOptions: Record<string, unknown>;
-  sharpCache?: boolean;
-  sharpConcurrency?: number;
+  sharp?: {
+    cache?: boolean;
+    concurrency?: number;
+  };
 }
 
 export interface UploadableFile extends Omit<File, 'id'> {


### PR DESCRIPTION

### What does it do?

  - Serializes responsive breakpoint generation (large, medium, small) so resizes run sequentially instead of in parallel via Promise.all
  - Disables sharp's internal decoded image cache (sharp.cache(false)) and limits libvips thread pool to 1 (sharp.concurrency(1)) at plugin registration
  - Makes both sharp settings configurable via config/plugins.ts (sharpCache, sharpConcurrency)

 ### Why is it needed?

Uploading a large image (e.g. 50MP) causes high peak memory usage because sharp/libvips decodes the full source image for each responsive breakpoint resize concurrently, while also retaining cached pixel data between operations. On constrained environments like Strapi Cloud (512MB), this causes the process to be OOM-killed before it can respond.

###  How to test it?

1. Deploy a strapi cloud free project (it has constrained memory allocation)
2. Enable responsive friendly in upload settings
3. Upload a large image like this one [github.com/user-attachments/assets/04e623b0-a7f2-4ca5-8f06-68abc1fb990d](https://github.com/user-attachments/assets/04e623b0-a7f2-4ca5-8f06-68abc1fb990d)
4. It should throw an error
5. Redeploy on this experimental 0.0.0-experimental.c2a30c30861681f520db3b7a9528750b09ac561e
6. Re-test and it should work

The sharp cache and concurrency is now configurable for more powerful environments

```
  upload: {
    config: {
      sharp: {
        cache: true,
        concurrency: 2
      }
    },
  },
```

  Related issue(s)/PR(s)

  - Relates to #25199
  - Relates to #24745