### PR TITLE
fix: prevent browser defaults for Ctrl+I  shortcut in Firefox

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/BlocksInput/BlocksContent.tsx
@@ -544,6 +544,7 @@ const BlocksContent = ({ placeholder, ariaLabelId }: BlocksContentProps) => {
       // Check if there's a modifier to toggle
       Object.values(modifiers).forEach((value) => {
         if (value.isValidEventKey(event)) {
+          event.preventDefault();
           value.handleToggle(editor);
           return;
         }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds event.preventDefault() in handleKeyboardShortcuts before toggling the modifier (italics), so the browser's default action for that key combo is suppressed once the editor has handled it. 

[26016-FF-fixed.webm](https://github.com/user-attachments/assets/e4dd2082-a0a0-49f4-b6a0-965c53615349)


### Why is it needed?

In Firefox, Ctrl+I is bound to "Page Info" at the browser level. Because the handler called handleToggle but never preventDefault, both actions fired — Slate applied italic formatting AND Firefox opened Page Info. 

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)
Fixes #26016 
