### PR TITLE
fix(core/admin | content-manager): combine multi-role field-level permissions

### DIFF
--- a/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
@@ -1,8 +1,9 @@
-import { AbilityBuilder, Ability } from '@casl/ability';
+import { AbilityBuilder, Ability, subject } from '@casl/ability';
 import { pick } from 'lodash/fp';
 import sift from 'sift';
 import { buildStrapiQuery } from '../permission/permissions-manager/query-builders';
 import createPermissionsManager from '../permission/permissions-manager';
+import { createPermissionFieldsCache } from '../permission/permissions-manager/permission-fields';
 
 const allowedOperations = [
   '$or',
@@ -313,6 +314,23 @@ describe('Permissions Manager', () => {
     // @ts-expect-error
     test.each(tests)(`Test n°%#: %s`, (name, input, expected) => {
       expect(buildStrapiQuery(input)).toStrictEqual(expected);
+    });
+  });
+
+  // #26012: an unrestricted rule (fields: undefined) mixed with a restricted rule must
+  // still produce shouldIncludeAll = true, not be narrowed to the restricted fields.
+  describe('Bug #3 — rule.fields || [] collapses unrestricted rule to zero fields', () => {
+    test('shouldIncludeAll is true when any rule has no field restriction', () => {
+      const ability = defineAbility((can: any) => {
+        can('read', 'Article', undefined);
+        can('read', 'Article', ['title']);
+      });
+
+      const { getPermissionFields } = createPermissionFieldsCache(ability);
+      const result = getPermissionFields('read', subject('Article', {}));
+
+      expect(result.shouldIncludeAll).toBe(true);
+      expect(result.permittedFields).toEqual([]);
     });
   });
 });

--- a/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
@@ -328,6 +328,7 @@ describe('Permissions Manager', () => {
       const result = getPermissionFields('read', subject('Article', {}));
 
       expect(result.shouldIncludeAll).toBe(true);
+      expect(result.hasAtLeastOneRegistered).toBe(true);
       expect(result.permittedFields).toEqual([]);
     });
   });

--- a/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/permissions-manager.test.ts
@@ -317,9 +317,7 @@ describe('Permissions Manager', () => {
     });
   });
 
-  // #26012: an unrestricted rule (fields: undefined) mixed with a restricted rule must
-  // still produce shouldIncludeAll = true, not be narrowed to the restricted fields.
-  describe('Bug #3 — rule.fields || [] collapses unrestricted rule to zero fields', () => {
+  describe('unrestricted rules combined with restricted rules', () => {
     test('shouldIncludeAll is true when any rule has no field restriction', () => {
       const ability = defineAbility((can: any) => {
         can('read', 'Article', undefined);

--- a/packages/core/admin/server/src/services/permission/permissions-manager/permission-fields.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/permission-fields.ts
@@ -39,22 +39,32 @@ export const createPermissionFieldsCache = (ability: Ability) => {
       return permissionCache.get(cacheKey)!;
     }
 
-    // Compute permission fields (expensive CASL operation)
-    const permittedFields = permittedFieldsOf(ability, actionOverride, subject, {
-      fieldsFrom: (rule) => rule.fields || [],
-    });
+    let result: PermissionFieldsResult;
 
-    const hasAtLeastOneRegistered = some(
-      (fields) => !isNil(fields),
-      flatMap(prop('fields'), rules)
-    );
-    const shouldIncludeAll = isEmpty(permittedFields) && !hasAtLeastOneRegistered;
+    const allFieldsAllowed = rules.some((r) => isNil(r.fields));
+    if (allFieldsAllowed) {
+      result = {
+        permittedFields: [],
+        hasAtLeastOneRegistered: rules.some((r) => !isNil(r.fields)),
+        shouldIncludeAll: true,
+      };
+    } else {
+      // Compute permission fields (expensive CASL operation)
+      const permittedFields = permittedFieldsOf(ability, actionOverride, subject, {
+        fieldsFrom: (rule) => rule.fields || [],
+      });
 
-    const result: PermissionFieldsResult = {
-      permittedFields,
-      hasAtLeastOneRegistered,
-      shouldIncludeAll,
-    };
+      const hasAtLeastOneRegistered = some(
+        (fields) => !isNil(fields),
+        flatMap(prop('fields'), rules)
+      );
+
+      result = {
+        permittedFields,
+        hasAtLeastOneRegistered,
+        shouldIncludeAll: isEmpty(permittedFields) && !hasAtLeastOneRegistered,
+      };
+    }
 
     // Cache for reuse if no entity-specific conditions
     if (!hasEntityConditions) {

--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -84,7 +84,7 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
     );
     return contentTypePermissions.reduce<Record<string, Permission[]>>((acc, permission) => {
       const [action] = permission.action.split('.').slice(-1);
-      return { ...acc, [action]: [permission] };
+      return { ...acc, [action]: [...(acc[action] ?? []), permission] };
     }, {});
   }, [contentTypeUid, userPermissions]);
 
@@ -165,13 +165,11 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
 /**
  * @internal it's really small, but it's used three times in a row and DRY for something this straight forward.
  */
-const extractAndDedupeFields = (permissions: Permission[] = []) =>
-  permissions
-    .flatMap((permission) => permission.properties?.fields)
-    .filter(
-      (field, index, arr): field is string =>
-        arr.indexOf(field) === index && typeof field === 'string'
-    );
+const extractAndDedupeFields = (permissions: Permission[] = []) => {
+  const allFields = permissions.flatMap((permission) => permission.properties?.fields);
+  if (allFields.some((field) => field === undefined)) return [];
+  return allFields.filter((field, index, arr): field is string => arr.indexOf(field) === index);
+};
 
 /**
  * @internal removes numerical strings from arrays.

--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -167,6 +167,8 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
  */
 const extractAndDedupeFields = (permissions: Permission[] = []) => {
   const allFields = permissions.flatMap((permission) => permission.properties?.fields);
+   // An undefined entry means this permission grants access to all fields
+    // (no field-level restriction). Returning [] signals "no restriction" to callers.
   if (allFields.some((field) => field === undefined)) return [];
   return allFields.filter((field, index, arr): field is string => arr.indexOf(field) === index);
 };

--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -167,8 +167,8 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
  */
 const extractAndDedupeFields = (permissions: Permission[] = []) => {
   const allFields = permissions.flatMap((permission) => permission.properties?.fields);
-   // An undefined entry means this permission grants access to all fields
-    // (no field-level restriction). Returning [] signals "no restriction" to callers.
+  // An undefined entry means this permission grants access to all fields
+  // (no field-level restriction). Returning [] signals "no restriction" to callers.
   if (allFields.some((field) => field === undefined)) return [];
   return allFields.filter((field, index, arr): field is string => arr.indexOf(field) === index);
 };

--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -170,7 +170,8 @@ const extractAndDedupeFields = (permissions: Permission[] = []) => {
   // An undefined entry means this permission grants access to all fields
   // (no field-level restriction). Returning [] signals "no restriction" to callers.
   if (allFields.some((field) => field === undefined)) return [];
-  return allFields.filter((field, index, arr): field is string => arr.indexOf(field) === index);
+  // Deduplicate fields
+  return Array.from(new Set(allFields as string[]));
 };
 
 /**

--- a/packages/core/content-manager/admin/src/features/tests/DocumentRBAC.test.tsx
+++ b/packages/core/content-manager/admin/src/features/tests/DocumentRBAC.test.tsx
@@ -152,6 +152,98 @@ describe('DocumentRBAC', () => {
     });
   });
 
+  // #26012: canReadFields must be the union of all roles' fields, not just the last role's.
+  describe('Bug #1 — multi-role field union: two restricted roles', () => {
+    const role1Read = {
+      id: 900,
+      action: 'plugin::content-manager.explorer.read',
+      actionParameters: {},
+      subject: 'api::article.article',
+      properties: { fields: ['title', 'content'] },
+      conditions: [],
+    } satisfies Permission;
+
+    const role2Read = {
+      id: 901,
+      action: 'plugin::content-manager.explorer.read',
+      actionParameters: {},
+      subject: 'api::article.article',
+      properties: { fields: ['status', 'network'] },
+      conditions: [],
+    } satisfies Permission;
+
+    const permissions = [role1Read, role2Read];
+
+    it('unions canReadFields from all roles instead of keeping only the last one', async () => {
+      const { result } = renderRTLHook(() => useDocumentRBAC('TEST', (state) => state), {
+        wrapper({ children }) {
+          return (
+            <Routes>
+              <Route
+                path="/content-manager/:collectionType/:slug"
+                element={<DocumentRBAC permissions={permissions}>{children}</DocumentRBAC>}
+              />
+            </Routes>
+          );
+        },
+        initialEntries: ['/content-manager/collection-type/api::article.article'],
+        providerOptions: { permissions },
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+      expect(result.current.canReadFields).toEqual(
+        expect.arrayContaining(['title', 'content', 'status', 'network'])
+      );
+      expect(result.current.canReadFields).toHaveLength(4);
+    });
+  });
+
+  // #26012: a role with unrestricted field access (fields: undefined) must not be
+  // narrowed down to the restricted role's field list.
+  describe('Bug #2 — unrestricted role fields (undefined) silenced by typeof check', () => {
+    const permUnrestricted = {
+      id: 902,
+      action: 'plugin::content-manager.explorer.read',
+      actionParameters: {},
+      subject: 'api::article.article',
+      properties: {},
+      conditions: [],
+    } satisfies Permission;
+
+    const permRestricted = {
+      id: 903,
+      action: 'plugin::content-manager.explorer.read',
+      actionParameters: {},
+      subject: 'api::article.article',
+      properties: { fields: ['title'] },
+      conditions: [],
+    } satisfies Permission;
+
+    const permissions = [permUnrestricted, permRestricted];
+
+    it('returns an empty field list when any role has unrestricted access', async () => {
+      const { result } = renderRTLHook(() => useDocumentRBAC('TEST', (state) => state), {
+        wrapper({ children }) {
+          return (
+            <Routes>
+              <Route
+                path="/content-manager/:collectionType/:slug"
+                element={<DocumentRBAC permissions={permissions}>{children}</DocumentRBAC>}
+              />
+            </Routes>
+          );
+        },
+        initialEntries: ['/content-manager/collection-type/api::article.article'],
+        providerOptions: { permissions },
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+      expect(result.current.canReadFields).toHaveLength(0);
+    });
+  });
+
   describe('can not do anything', () => {
     const renderHook = makeRenderHook([]);
 

--- a/packages/core/content-manager/admin/src/features/tests/DocumentRBAC.test.tsx
+++ b/packages/core/content-manager/admin/src/features/tests/DocumentRBAC.test.tsx
@@ -152,8 +152,7 @@ describe('DocumentRBAC', () => {
     });
   });
 
-  // #26012: canReadFields must be the union of all roles' fields, not just the last role's.
-  describe('Bug #1 — multi-role field union: two restricted roles', () => {
+  describe('multi-role field union with restricted roles', () => {
     const role1Read = {
       id: 900,
       action: 'plugin::content-manager.explorer.read',
@@ -199,9 +198,7 @@ describe('DocumentRBAC', () => {
     });
   });
 
-  // #26012: a role with unrestricted field access (fields: undefined) must not be
-  // narrowed down to the restricted role's field list.
-  describe('Bug #2 — unrestricted role fields (undefined) silenced by typeof check', () => {
+  describe('unrestricted field access combined with restricted roles', () => {
     const permUnrestricted = {
       id: 902,
       action: 'plugin::content-manager.explorer.read',

--- a/packages/core/content-manager/admin/tests/utils.tsx
+++ b/packages/core/content-manager/admin/tests/utils.tsx
@@ -41,7 +41,7 @@ const render = (
 const renderHook: typeof renderHookAdmin = (hook, options) =>
   renderHookAdmin(hook, {
     ...options,
-    providerOptions: { storeConfig: storeConfig() },
+    providerOptions: { ...options?.providerOptions, storeConfig: storeConfig() },
   });
 
 export { fireEvent, render, waitFor, act, screen, server, renderHook };


### PR DESCRIPTION
### What does it do?

This PR addresses #26012. It fixes logic on the backend and frontend side where field-level permissions are not combined correctly. 

### Why is it needed?

Users are not permitted to see fields that they should have access to (e.g. a user who should be able to see all fields under 'article' can only see the title). 

### How to test it?

Tests were written to reproduce the cases. These tests now pass.

### Related issues / PRs

- Fixes #26012

### Manual QA

---

## Prerequisites

1. Run Strapi from `examples/getstarted` on the **fix branch** (`fix-26012`):
   ```bash
   cd examples/getstarted
   yarn develop
   ```
2. Log in as **Super Admin** (`admin@strapi.io` / `Welcome1`).
3. Ensure **Article** collection type exists (ships with getstarted). Fields used below:
   - `title`, `markdownContent`, `authorName`, `cover`, `slug`, `categories`
4. Create at least one Article entry with values in all fields above (so hidden fields are obvious).

---

## Scenario 1 — Multi-role field union (primary regression)

**Covers:** Bug 1 — permissions from multiple roles must accumulate, not replace.

### Setup

| Step | Action |
|------|--------|
| 1 | **Settings → Administration panel → Roles** → Create role **Editor** |
| 2 | In **Collection Types → Article**, enable **Read** |
| 3 | Under **Fields → Read**, check only **`title`** and **`markdownContent`** |
| 4 | Save role |
| 5 | Create role **Manager** |
| 6 | In **Collection Types → Article**, enable **Read** |
| 7 | Under **Fields → Read**, check only **`authorName`** and **`cover`** |
| 8 | Save role |
| 9 | **Settings → Administration panel → Users** → Create user `multi-role@test.com` |
| 10 | Assign **both** Editor and Manager roles. Save. |

### Reproduce

| Step | Action |
|------|--------|
| 1 | Log out. Log in as `multi-role@test.com` |
| 2 | **Content Manager → Article** → open existing entry |

### Expected (fixed)

- All four fields visible and readable: `title`, `markdownContent`, `authorName`, `cover`
- No "No permissions to see this field" on fields granted by the *other* role

### Broken (pre-fix)

- Only **one** role's fields visible (whichever role was processed last)
- e.g. only `authorName` + `cover`, or only `title` + `markdownContent`
- Other fields show permission denied state

---

## Scenario 2 — Unrestricted role + restricted role

**Covers:** Bug 2 (frontend) + Bug 3 (backend CASL) — `fields: undefined` means "all fields", must not be narrowed by a sibling restricted role.

### Setup

| Step | Action |
|------|--------|
| 1 | Create role **Full Access** |
| 2 | **Collection Types → Article** → enable **Read** at the content-type row |
| 3 | Do **not** narrow field checkboxes — leave Fields matrix as "all fields allowed" (no per-field restriction) |
| 4 | Save role |
| 5 | Create role **Title Only** |
| 6 | **Collection Types → Article** → enable **Read** |
| 7 | Under **Fields → Read**, check only **`title`** |
| 8 | Save role |
| 9 | Create user `unrestricted@test.com` with **both** Full Access and Title Only roles |

### Reproduce

| Step | Action |
|------|--------|
| 1 | Log in as `unrestricted@test.com` |
| 2 | Open an Article entry in Content Manager |

### Expected (fixed)

- **All** Article fields visible (unrestricted role wins)
- `slug`, `categories`, `cover`, etc. all accessible

### Broken (pre-fix)

- Only `title` visible (restricted role incorrectly narrowed the union)
- Other fields blocked despite Full Access role

---

## Scenario 3 — Update permissions (same union logic)

**Covers:** Issue states bug affects **read and update**, not just read.

### Setup

Extend Scenario 1 roles:

| Role | Additional permission |
|------|----------------------|
| Editor | **Update** → fields `title`, `markdownContent` |
| Manager | **Update** → fields `authorName` |

Use same `multi-role@test.com` user.

### Reproduce

| Step | Action |
|------|--------|
| 1 | Log in as `multi-role@test.com` |
| 2 | Open Article entry → switch to edit mode |

### Expected (fixed)

- Can edit `title`, `markdownContent`, `authorName`
- `cover` read-only (only in Manager read, not in update set) — or hidden if update not granted

### Broken (pre-fix)

- Can only edit fields from one role's update permission set
