### PR TITLE
chore(ci): add Claude-powered auto-labeler for new issues

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Auto-label issue with Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.PR_REVIEW_ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ISSUE_AUTO_LABELLER }}
 
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,89 @@
+name: Auto-label New Issues
+
+# Triggers when a new issue is opened and uses Claude to analyze the issue
+# content, then apply appropriate labels from the repository's existing label set.
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Auto-label issue with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.PR_REVIEW_ANTHROPIC_API_KEY }}
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+
+            A new issue has just been opened. Your task is to analyze the issue
+            and apply the appropriate labels according to the Strapi labeling
+            conventions below.
+
+            Steps:
+
+            1. Fetch the issue details:
+               `gh issue view ${{ github.event.issue.number }} --json title,body,author`
+
+            2. List all available labels in this repository:
+               `gh label list --limit 200`
+
+            3. Determine which labels apply based on the labeling conventions.
+
+            4. Apply the labels with:
+               `gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2,..."`
+
+            ## Labeling conventions
+
+            Assume the reporter is on Strapi 5.31.0 or later unless they
+            explicitly state otherwise.
+
+            Every valid issue should receive:
+
+            - **Exactly one `issue:` type** — `issue: bug` is by far the most
+              common; others include things like `issue: feature request`,
+              `issue: question`, `issue: documentation`. Pick the single best fit.
+            - **Exactly one `source:` label** — identifies the affected area of
+              code (e.g. `source: content-manager`, `source: admin`,
+              `source: upload`, `source: i18n`). Infer from the issue content;
+              if the issue spans multiple areas, pick the most central one.
+            - **A `version:` label** — `version: 5` if the reporter mentions
+              v5 or a version >= 5.0.0, `version: 4` if they explicitly mention
+              v4 or a 4.x version. If no version is mentioned, default to
+              `version: 5` (current supported major).
+            - **`status: pending reproduction`** — apply this on any new bug
+              issue by default, since it has not yet been reproduced by a
+              maintainer. Do NOT apply `status: confirmed` — that is a
+              maintainer judgement.
+            - **`scope: relations`** — only if the issue is clearly about the
+              relations initiative. This is currently the only `scope:` label.
+
+            Do NOT apply:
+
+            - `severity: *` labels — these require maintainer judgement.
+            - `status: confirmed` or any other triage status.
+            - Any `priority:` label.
+            - `flag: invalid template` — leave this to the template validation
+              automation; applying it triggers issue closure.
+            - Any label that does not already exist in the repository.
+
+            Additional rules:
+
+            - Only apply labels that already exist. Do not create new labels.
+            - If you cannot confidently determine a `source:` or `issue:` type
+              from the content, apply whatever you CAN determine and skip the
+              rest rather than guessing.
+            - Do not post a comment on the issue. Only apply labels.
+
+          claude_args: |
+            --allowedTools "Bash(gh issue view:*),Bash(gh label list:*),Bash(gh issue edit:*)"


### PR DESCRIPTION
### What does it do?

Adds a new GitHub Actions workflow (`.github/workflows/issue-labeler.yml`) that triggers on `issues: opened` and uses [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) to automatically apply labels to newly opened issues.

The workflow follows Strapi's existing labeling conventions:

- Applies exactly one `issue:` type (`issue: bug`, `issue: feature request`, etc.)
- Applies exactly one `source:` area label (`source: content-manager`, `source: admin`, etc.)
- Applies a `version:` label — defaults to `version: 5` (assuming 5.31.0+) when no version is stated
- Applies `status: pending reproduction` on new bugs by default
- Applies `scope: relations` only when clearly relevant

Maintainer-reserved labels are explicitly excluded from auto-application:

- `status: confirmed` (requires reproduction)
- `severity: *` (requires maintainer judgement)
- `priority: *`
- `flag: invalid template` (applying this triggers the auto-close workflow)

The workflow reuses the existing `PR_REVIEW_ANTHROPIC_API_KEY` secret already used by `pr-reviewer.yml`, and restricts Claude's tool access to only `gh issue view`, `gh label list`, and `gh issue edit`.

### Why is it needed?

Manually triaging and labeling new issues is repetitive work. An auto-labeler gives maintainers a pre-sorted inbox so they can focus their attention on reproduction and judgement calls (severity, confirmation) instead of mechanical categorization.

### How to test it?

1. Merge this PR.
2. Open a test issue on strapi/strapi describing a bug in a specific area (e.g. content-manager, upload).
3. Within a minute, the workflow should run and the issue should receive \`issue: bug\`, a \`source: *\` label, \`version: 5\`, and \`status: pending reproduction\`.
4. Review the workflow run logs in Actions → "Auto-label New Issues" to see Claude's reasoning.

If labels are consistently off-target, the prompt in the workflow file can be tuned without code changes.

### Related issue(s)/PR(s)

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)