### PR TITLE
chore(ci): add Claude-powered issue response suggester

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -1,0 +1,92 @@
+name: Suggest Response to Issue
+
+# Triggers when a maintainer adds the 'AI Response' label to an issue.
+# Claude drafts a single suggested response comment (similar to Dosu).
+# Claude has read-only access to the repository so it can reference code
+# and docs when answering.
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  suggest-response:
+    if: ${{ github.event.label.name == 'AI Response' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Draft suggested response with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.PR_REVIEW_ANTHROPIC_API_KEY }}
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+
+            A maintainer has added the 'AI Response' label to this issue,
+            asking you to draft a suggested response (similar to how Dosu
+            works). Post a single helpful comment. The maintainer will review
+            it and decide whether to keep, edit, or delete it.
+
+            Assume the reporter is on Strapi 5.31.0 or later unless they
+            explicitly state otherwise.
+
+            ## Steps
+
+            1. Read the issue:
+               `gh issue view ${{ github.event.issue.number }} --json title,body,author,labels`
+
+            2. Search the repository for relevant code, docs, or prior art that
+               might help answer the issue. Use Grep, Glob, and Read. Keep this
+               exploration focused — don't exhaustively search, just gather
+               enough context to give a useful answer.
+
+            3. Post a single comment on the issue with:
+               `gh issue comment ${{ github.event.issue.number }} --body-file <path>`
+               (Write the body to a file first to preserve formatting.)
+
+            ## Required comment format
+
+            The comment MUST begin with this exact sentence, verbatim, as the
+            first line:
+
+            > Hi! I'm Claude and I'm helping the Strapi team, but I am an AI and often get things wrong, so please excuse me when I do!
+
+            Then a blank line, then your suggested response.
+
+            The comment MUST end with a confidence rating on its own line, in
+            this exact format:
+
+            > **Confidence: High | Medium | Low** — one-sentence justification.
+
+            Pick exactly one level:
+            - **High**: you found clear supporting evidence in the codebase or docs, and the issue is well-scoped.
+            - **Medium**: the answer is plausible but you could not fully verify it, or the issue is ambiguous.
+            - **Low**: you are guessing, the issue lacks reproduction details, or you could not find relevant code.
+
+            ## Response guidelines
+
+            - Be concise. A few paragraphs at most. Prefer linking to specific
+              files in the repo (with paths) over pasting long code blocks.
+            - If the issue looks like a bug, suggest likely causes or ask for
+              the specific reproduction info that is missing (version, steps,
+              minimal repro repo).
+            - If it is a feature request or question, answer it directly or
+              point to relevant docs/discussions.
+            - If you cannot confidently help, say so briefly and ask targeted
+              clarifying questions rather than speculating.
+            - Do NOT close the issue, apply labels, or take any action besides
+              posting the single comment.
+            - Do NOT claim the fix is in progress or promise maintainer action.
+              You are a suggestion from an AI, not a commitment from the team.
+
+          claude_args: |
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue comment:*),Read,Grep,Glob"


### PR DESCRIPTION
### What does it do?

Adds a new GitHub Actions workflow (`.github/workflows/issue-responder.yml`) that lets maintainers opt-in to an AI-drafted reply on any issue by applying the `AI Response` label (similar to how `pr-reviewer.yml` uses the `AI Review` label).

When the label is applied, [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) runs and Claude:

1. Reads the issue title, body, and existing labels
2. Searches the repo (read-only) for relevant code, docs, or prior art
3. Posts a single comment drafted in a Dosu-style format

Every suggestion is required to:

- **Open with a fixed disclaimer**:
  > Hi! I'm Claude and I'm helping the Strapi team, but I am an AI and often get things wrong, so please excuse me when I do!
- **End with an explicit confidence rating**:
  > **Confidence: High | Medium | Low** — one-sentence justification.

So maintainers can judge at a glance whether to keep, edit, or delete the suggestion.

Claude's tool access is scoped tightly: `gh issue view`, `gh issue comment`, `Read`, `Grep`, `Glob`. It cannot close issues, apply labels, push code, or modify anything other than posting one comment.

Reuses the existing `PR_REVIEW_ANTHROPIC_API_KEY` secret.

### Why is it needed?

Some issues are answerable from existing docs or code but still consume maintainer time. A Dosu-style AI reply — gated behind a label so it only runs when a maintainer wants it — gives the reporter a fast initial response with references to relevant files, and maintainers can edit or delete the reply in one click if it's off-target.

The confidence rating and upfront AI disclaimer are there specifically to avoid the failure mode of a plausible-sounding wrong answer being mistaken for an official answer.

### How to test it?

1. Merge this PR.
2. Create the \`AI Response\` label in the repository (one-time setup):
   \`\`\`sh
   gh label create "AI Response" --description "Request an AI-drafted response suggestion" --color "1f6feb"
   \`\`\`
3. Apply the \`AI Response\` label to any existing issue.
4. Within a minute, the workflow should run and Claude should post a comment starting with the disclaimer and ending with a confidence line.
5. Inspect the workflow run under Actions → "Suggest Response to Issue" to see what Claude searched.

### Related issue(s)/PR(s)

Follow-up to #26056 (Claude-powered auto-labeler). Same action, different trigger and scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)