### PR TITLE
fix: 403 error when select role when creating a user

### DIFF
--- a/packages/core/admin/server/src/services/permission/sections-builder/handlers.ts
+++ b/packages/core/admin/server/src/services/permission/sections-builder/handlers.ts
@@ -74,11 +74,23 @@ const contentTypesBase = ({
 }) => {
   const { displayName, actionId, subjects, options } = action;
 
+  // Strip non-displayed content types so they don't appear as configurable subjects
+  // in the roles UI (e.g. plugin::users-permissions.role).
+  const allContentTypes = strapi.contentTypes as Record<string, any>;
+  const filteredSubjects = subjects?.filter(
+    (uid) =>
+      (
+        allContentTypes[uid as string]?.pluginOptions?.['content-manager'] as
+          | { visible?: boolean }
+          | undefined
+      )?.visible !== false
+  );
+
   section.actions.push({
     // @ts-expect-error - label should be displayName, TODO: Investigate at which point the label property
     label: displayName,
     actionId,
-    subjects,
+    subjects: filteredSubjects,
     ...getValidOptions(options),
   });
 };
@@ -103,6 +115,14 @@ const subjectsHandlerFor =
       .map(resolveContentType)
       // Only keep specific kind of content-types
       .filter(isOfKind(kind))
+      // Exclude content types hidden from the content manager (e.g. plugin::users-permissions.role).
+      // Those types are valid explorer.read subjects so that super admin can read relation targets,
+      // but they should not appear as configurable permissions in the roles UI.
+      .filter(
+        (ct) =>
+          (ct?.pluginOptions?.['content-manager'] as { visible?: boolean } | undefined)?.visible !==
+          false
+      )
       // Transform the content-types into section's subjects
       .map(toSubjectTemplate);
 

--- a/packages/core/admin/server/src/services/role.ts
+++ b/packages/core/admin/server/src/services/role.ts
@@ -264,10 +264,16 @@ const createRolesIfNoneExist = async () => {
   });
 
   // create content-type permissions for each role
+  // Exclude non-displayed content types (e.g. plugin::users-permissions.role) from Editor/Author
+  // since those types are in explorer.read subjects only for super admin relation reads.
+  const nonDisplayedUids = Object.values(strapi.contentTypes as Record<string, any>)
+    .filter((ct) => ct?.pluginOptions?.['content-manager']?.visible === false)
+    .map((ct) => ct.uid as string);
+
   const editorPermissions = getService('content-type').getPermissionsWithNestedFields(
     contentTypesActions,
     {
-      restrictedSubjects: ['plugin::users-permissions.user'],
+      restrictedSubjects: ['plugin::users-permissions.user', ...nonDisplayedUids],
     }
   );
 

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -51,7 +51,14 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
     return readPermissions
       .map((permission) => permission.subject)
-      .filter(Boolean) as RecentDocument['contentTypeUid'][];
+      .filter((subject): subject is RecentDocument['contentTypeUid'] => {
+        if (!subject) return false;
+        const contentType = strapi.contentTypes[subject as keyof typeof strapi.contentTypes];
+        const contentTypeOptions = contentType?.pluginOptions?.['content-manager'] as
+          | { visible?: boolean }
+          | undefined;
+        return contentTypeOptions?.visible !== false;
+      });
   };
 
   type ContentTypeMeta = {

--- a/packages/core/content-manager/server/src/services/permission.ts
+++ b/packages/core/content-manager/server/src/services/permission.ts
@@ -23,6 +23,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const displayedContentTypes = getService('content-types').findDisplayedContentTypes();
     const contentTypesUids = displayedContentTypes.map(prop('uid'));
 
+    const allContentTypesUids = getService('content-types').findAllContentTypes().map(prop('uid'));
+
     const actions = [
       {
         section: 'contentTypes',
@@ -39,7 +41,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         displayName: 'Read',
         uid: 'explorer.read',
         pluginName: 'content-manager',
-        subjects: contentTypesUids,
+        subjects: allContentTypesUids,
         options: {
           applyToProperties: ['fields'],
         },

--- a/packages/core/content-manager/server/src/services/permission.ts
+++ b/packages/core/content-manager/server/src/services/permission.ts
@@ -20,10 +20,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   },
 
   async registerPermissions() {
-    const displayedContentTypes = getService('content-types').findDisplayedContentTypes();
-    const contentTypesUids = displayedContentTypes.map(prop('uid'));
-
-    const allContentTypesUids = getService('content-types').findAllContentTypes().map(prop('uid'));
+    const allContentTypes = getService('content-types').findAllContentTypes();
+    const allContentTypesUids = allContentTypes.map(prop('uid'));
+    const contentTypesUids = allContentTypes
+      .filter(({ isDisplayed }: { isDisplayed: boolean }) => isDisplayed)
+      .map(prop('uid'));
 
     const actions = [
       {


### PR DESCRIPTION
### What does it do?

Registers all content types (including non-displayed ones) as valid subjects for the `plugin::content-manager.explorer.read` action in `registerPermissions()`.
Previously only content types with `pluginOptions['content-manager'].visible !== false` were registered.

### Why is it needed?

Content types marked `visible: false` (e.g. plugin::users-permissions.role) are hidden from the CM sidebar navigation, but they can appear as relation targets on displayed content types. When a user selects such a relation in the edit view, the CM frontend fetches the related document via GET `/content-manager/collection-types/:model/:id`, which is protected by the hasPermissions policy.

Because plugin::users-permissions.role was never registered as a valid subject for `explorer.read`, resetSuperAdminPermissions never generated a DB permission row for it so even super admins had no read permission on that model.

Result: selecting a role when creating a user in the Content Manager triggered a 403 Policy Failed alert, even for super admins on a fresh project with no custom configuration.

False flag is a UI/navigation concern, not a security boundary. Registering non-displayed types as subjects for `explorer.read` corrects the permission generation without affecting Create, Update, Delete, or Publish actions.

### How to test it?

- Start Strapi and log in as Super Admin
- Go to Content Manager → User (from plugin::users-permissions)
- Click Create new entry
- Fill in username, email, password
- In the Role field, select any available role (e.g. Authenticated)
-> No "Warning: Policy Failed" toast should appear.
- Save the entry — user is created with the correct role

Before this fix: selecting a role triggered a 403 on GET `/content-manager/collection-types/plugin::users-permissions.role/:id` and displayed a "Policy Failed" error notification.

### Related issue(s)/PR(s)

Fixes #23622

🚀