### PR TITLE
feat(admin): Make Entry Action card sticky in Content Manager

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/EditViewPage.tsx
@@ -239,7 +239,9 @@ const EditViewPage = () => {
                 </Grid.Item>
                 {isDesktop && (
                   <Grid.Item col={3} direction="column" alignItems="stretch">
-                    <Panels />
+                    <Box position="sticky" top={5} width="100%">
+                      <Panels />
+                    </Box>
                   </Grid.Item>
                 )}
               </Grid.Root>


### PR DESCRIPTION
### What does it do?

I have updated the `ContentManager` layout to improve the accessibility of the entry actions. Specifically:
* Wrapped the `<Panels />` component (which contains the Save, Publish, and Entry information) in a `<Box />` component.
* Applied `position="sticky"` with a `top={5}` offset to the container.
* Ensured the sticky behavior is scoped within the `{isDesktop}` condition to prevent layout breakage on mobile devices where the sidebar stacks vertically.

### Why is it needed?

Currently, the Strapi Content Manager requires users to scroll back to the top of the page to save or publish changes. For pages with many dynamic components or long-form content, this creates a repetitive and frustrating user experience.

By making the Action Panels sticky, we ensure that:
1.  **Primary actions** (Save/Publish) are always visible.
2.  **Content editing flow** is uninterrupted, especially on complex pages with many blocks.
3.  **Efficiency** is increased for content editors who frequently toggle between editing and saving.

### How to test it?

1.  Open the **Content Manager** in a local development environment.
2.  Select a **Single Type** (e.g., an "About") that has multiple content blocks or dynamic zones.
3.  On a desktop screen, scroll down through the content.
4.  **Verification:** The right-hand "Entry" sidebar should remain fixed at the top of the viewport (`top={5}`) as you scroll.
5.  **Responsiveness:** Verify that on mobile viewports, the sticky behavior is disabled and the panels stack naturally at the bottom of the content.

**[Screen Recording here]**

### Before

https://github.com/user-attachments/assets/389bf303-7108-47dd-94ba-904ff26c92ba


### After

https://github.com/user-attachments/assets/af987a0c-14d3-46ae-ac7d-6809b341137d