### PR TITLE
fix(openapi): documentation plugin generates OpenAPI with incorrect I…

### DIFF
--- a/packages/plugins/documentation/server/src/services/helpers/build-api-endpoint-path.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/build-api-endpoint-path.ts
@@ -62,7 +62,7 @@ const getPathParams = (routePath: string): OpenAPIV3.ParameterObject[] => {
       description: '',
       deprecated: false,
       required: true,
-      schema: { type: 'number' },
+      schema: { type: param.name === 'id' ? 'string' : 'number' },
     });
 
     return acc;


### PR DESCRIPTION
…D parameter

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated type of `id` parameter generated for OpenAPI documentation to match type of `documentId` attribute from `number` to `string`.

### Why is it needed?

`full_documentation.json` file containing OpenAPI documentation contains incorrect `id` parameter definition. Per documentation https://docs.strapi.io/dev-docs/api/rest#update and https://docs.strapi.io/dev-docs/api/rest#delete the ID of resource should be `documentId` (`string` type) but generated documentation defines it as `number`:

```
"parameters": [
          {
            "name": "id",
            "in": "path",
            "description": "",
            "deprecated": false,
            "required": true,
            "schema": {
              "type": "number"
            }
          }
        ],
```

### How to test it?

After creating any collection the generated type of `id` should be `string`:

```
Parameter should be defined as string to match documentId type:

"parameters": [
          {
            "name": "id",
            "in": "path",
            "description": "",
            "deprecated": false,
            "required": true,
            "schema": {
              "type": "string"
            }
          }
        ],
```

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/22599
