### PR TITLE
fix(users-permissions): correct 'occured' typo to 'occurred' in notifications

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
@@ -61,7 +61,7 @@ const AdvancedSettingsPage = () => {
           type: 'danger',
           message: formatMessage({
             id: getTrad('notification.error'),
-            defaultMessage: 'An error occured',
+            defaultMessage: 'An error occurred',
           }),
         });
       },

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -89,7 +89,7 @@ export const RolesListPage = () => {
     } catch (error) {
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
   };


### PR DESCRIPTION

**Repo:** strapi/strapi (⭐ 62000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes a spelling typo in user-facing error notification messages within the `users-permissions` plugin admin UI. Two `defaultMessage` strings used the misspelling "An error occured" — corrected to the proper "An error occurred".

## Why
These `defaultMessage` values are the English fallback strings rendered by `react-intl` when no translation is found for the `notification.error` id. The typo is user-visible in the Strapi admin panel (Advanced Settings save failure and Roles list-page fetch failure). This is a small but real polish fix to user-facing copy.

## Testing
Change is limited to two English string literals used as i18n `defaultMessage` fallbacks — no logic change. Verification: `grep -rn "occured" packages/plugins/users-permissions/admin` returns no matches after the change. Existing tests unaffected.

## Risk
Low — string-only change in `defaultMessage` fallbacks; translation keys unchanged.
