### PR TITLE
feat: support bun

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,28 @@ jobs:
       - name: Monorepo build
         uses: ./.github/actions/run-build
 
+  bun_smoke:
+    name: 'bun smoke (${{ github.event_name }})'
+    runs-on: ubuntu-latest
+    needs: [build]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - name: Bun smoke (examples/getstarted — build, start, GET /_health)
+        run: yarn test:bun:smoke
+        env:
+          STRAPI_TELEMETRY_DISABLED: 'true'
+
   docs_build:
     name: 'docs build (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
@@ -624,6 +646,7 @@ jobs:
         pretty,
         lint,
         build,
+        bun_smoke,
         docs_build,
         typescript,
         unit_back,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,15 @@ The Strapi core team will review your pull request and either merge it, request 
 - You have [Node.js](https://nodejs.org/en/) at version `>= v20 and <= v24` and [Yarn](https://yarnpkg.com/en/) at v1.2.0+ installed.
 - You are familiar with [Git](https://git-scm.com).
 
+### Optional: [Bun](https://bun.sh) (runtime and lockfile)
+
+Bun is not required for the main workflow, but you can use it to install dependencies and run app scripts (e.g. `bun run develop` in an example) after the monorepo is built with Yarn + Nx.
+
+1. Install Bun: see [bun.sh](https://bun.sh) (e.g. `curl -fsSL https://bun.sh/install | bash`) and ensure `bun` is on your `PATH` (often `~/.bun/bin`).
+2. At the repository root, run `bun install`. This uses `bun.lock` and may show a notice that the Yarn 4 `yarn.lock` could not be migrated; that is expected. The primary, CI-driven install path remains `yarn install` with `yarn.lock`.
+3. Build packages as usual: `yarn build` (or `yarn setup` for a full first-time setup). Then, in an example app: `bun run develop` or `bun run start` (after `bun run build` for production).
+4. To verify that Strapi starts under Bun, from the repo root: `yarn test:bun:smoke` (builds the default `examples/getstarted` app with Bun, starts it, checks `GET /_health`).
+
 **Before submitting your pull request** make sure the following requirements are fulfilled:
 
 - Fork the repository and create your new branch from `develop`.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "test:front:coverage": "cross-env IS_EE=true jest --config jest.config.front.js --runInBand --coverage",
     "test:coverage": "yarn test:unit:coverage && yarn test:front:coverage",
     "test:unit:vitest": "vitest run",
-    "test:unit:vitest:watch": "vitest --watch"
+    "test:unit:vitest:watch": "vitest --watch",
+    "test:bun:smoke": "node tests/scripts/run-bun-smoke.js"
   },
   "resolutions": {
     "@types/koa": "2.13.4",

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -34,6 +34,7 @@ const command = new commander.Command('create-strapi-app')
   .option('--use-npm', 'Use npm as the project package manager')
   .option('--use-yarn', 'Use yarn as the project package manager')
   .option('--use-pnpm', 'Use pnpm as the project package manager')
+  .option('--use-bun', 'Use bun as the project package manager')
 
   // dependencies options
   .option('--install', 'Install dependencies')
@@ -107,9 +108,11 @@ async function run(args: string[]): Promise<void> {
     logger.fatal(`Template name ${chalk.bold(`"${options.template}"`)} is invalid`);
   }
 
-  if ([options.useNpm, options.usePnpm, options.useYarn].filter(Boolean).length > 1) {
+  if (
+    [options.useNpm, options.usePnpm, options.useYarn, options.useBun].filter(Boolean).length > 1
+  ) {
     logger.fatal(
-      `You cannot specify multiple package managers at the same time ${chalk.bold('(--use-npm, --use-pnpm, --use-yarn)')}`
+      `You cannot specify multiple package managers at the same time ${chalk.bold('(--use-npm, --use-pnpm, --use-yarn, --use-bun)')}`
     );
   }
 
@@ -254,6 +257,10 @@ function getPkgManager(options: Options) {
     return 'yarn';
   }
 
+  if (options.useBun === true) {
+    return 'bun';
+  }
+
   const userAgent = process.env.npm_config_user_agent || '';
 
   if (userAgent.startsWith('yarn')) {
@@ -262,6 +269,14 @@ function getPkgManager(options: Options) {
 
   if (userAgent.startsWith('pnpm')) {
     return 'pnpm';
+  }
+
+  if (userAgent.startsWith('bun')) {
+    return 'bun';
+  }
+
+  if (process.versions.bun) {
+    return 'bun';
   }
 
   return 'npm';

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -2,6 +2,7 @@ export interface Options {
   useNpm?: boolean;
   usePnpm?: boolean;
   useYarn?: boolean;
+  useBun?: boolean;
   quickstart?: boolean;
   run?: boolean;
   dbclient?: DBClient;
@@ -40,7 +41,7 @@ export type DBConfig = {
   };
 };
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm';
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 export interface Scope {
   name: string;

--- a/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
+++ b/packages/cli/create-strapi-app/src/utils/get-package-manager-args.ts
@@ -25,6 +25,9 @@ const installArgumentsMap: {
   pnpm: {
     '*': [],
   },
+  bun: {
+    '*': [],
+  },
 };
 
 // Set environment variables for specific package managers, with full semver ranges
@@ -39,6 +42,9 @@ const installEnvMap: {
     '*': {},
   },
   pnpm: {
+    '*': {},
+  },
+  bun: {
     '*': {},
   },
 };

--- a/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
+++ b/packages/core/admin/ee/server/src/audit-logs/services/audit-logs.ts
@@ -11,6 +11,16 @@ interface Log extends Omit<Event, 'userId'> {
   user: string | number;
 }
 
+interface AuditLogsService {
+  saveEvent(event: Event): Promise<AuditLogsService>;
+  findMany(query: unknown): Promise<{
+    results: Record<string, unknown>[];
+    pagination: Record<string, unknown>;
+  }>;
+  findOne(id: unknown): Promise<Record<string, unknown> | null>;
+  deleteExpiredEvents(expirationDate: Date): Promise<unknown>;
+}
+
 const getSanitizedUser = (user: any) => {
   let displayName = user.email;
 
@@ -31,7 +41,7 @@ const getSanitizedUser = (user: any) => {
  * @description
  * Manages audit logs interaction with the database. Accessible via strapi.get('audit-logs')
  */
-const createAuditLogsService = (strapi: Core.Strapi) => {
+const createAuditLogsService = (strapi: Core.Strapi): AuditLogsService => {
   return {
     async saveEvent(event: Event) {
       const { userId, ...rest } = event;

--- a/packages/core/review-workflows/server/src/index.ts
+++ b/packages/core/review-workflows/server/src/index.ts
@@ -6,7 +6,17 @@ import routes from './routes';
 import services from './services';
 import controllers from './controllers';
 
-const getPlugin = () => {
+type ReviewWorkflowsPlugin = {
+  register?: unknown;
+  bootstrap?: unknown;
+  destroy?: unknown;
+  contentTypes: unknown;
+  services?: unknown;
+  controllers?: unknown;
+  routes?: unknown;
+};
+
+const getPlugin = (): ReviewWorkflowsPlugin => {
   if (strapi.ee.features.isEnabled('review-workflows')) {
     return {
       register,
@@ -26,4 +36,6 @@ const getPlugin = () => {
   };
 };
 
-export default getPlugin();
+const plugin: ReviewWorkflowsPlugin = getPlugin();
+
+export default plugin;

--- a/packages/core/review-workflows/server/src/services/index.ts
+++ b/packages/core/review-workflows/server/src/services/index.ts
@@ -8,7 +8,9 @@ import reviewWorkflowsWeeklyMetrics from './metrics/weekly-metrics';
 import documentServiceMiddleware from './document-service-middleware';
 import homepage from '../homepage';
 
-export default {
+type ReviewWorkflowsServices = Record<string, unknown>;
+
+const services: ReviewWorkflowsServices = {
   workflows,
   stages,
   'stage-permissions': stagePermissions,
@@ -19,3 +21,5 @@ export default {
   'workflow-weekly-metrics': reviewWorkflowsWeeklyMetrics,
   ...homepage.services,
 };
+
+export default services;

--- a/packages/core/review-workflows/server/src/services/stages.ts
+++ b/packages/core/review-workflows/server/src/services/stages.ts
@@ -12,11 +12,13 @@ interface PopulatedPermission {
   actionParameters?: { from?: number; to?: number };
 }
 
+type StagesServiceFactory = (args: { strapi: Core.Strapi }) => Record<string, unknown>;
+
 const { ApplicationError, ValidationError } = errors;
 const sanitizedStageFields = ['id', 'name', 'workflow', 'color'];
 const sanitizeStageFields = pick(sanitizedStageFields);
 
-export default ({ strapi }: { strapi: Core.Strapi }) => {
+const createStagesService = ({ strapi }: { strapi: Core.Strapi }) => {
   const metrics = getService('workflow-metrics', { strapi });
   const stagePermissionsService = getService('stage-permissions', { strapi });
   const workflowValidator = getService('validation', { strapi });
@@ -369,6 +371,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     },
   };
 };
+
+export default createStagesService as StagesServiceFactory;
 
 const normalizeStageForDiff = (stage: {
   name?: string;

--- a/packages/plugins/sentry/server/src/index.ts
+++ b/packages/plugins/sentry/server/src/index.ts
@@ -2,8 +2,16 @@ import bootstrap from './bootstrap';
 import services from './services';
 import config from './config';
 
-export default () => ({
+type SentryPlugin = () => {
+  bootstrap: unknown;
+  config: unknown;
+  services: unknown;
+};
+
+const plugin: SentryPlugin = () => ({
   bootstrap,
   config,
   services,
 });
+
+export default plugin;

--- a/packages/plugins/sentry/server/src/services/index.ts
+++ b/packages/plugins/sentry/server/src/services/index.ts
@@ -1,5 +1,9 @@
 import sentry from './sentry';
 
-export default {
+type SentryServices = Record<string, unknown>;
+
+const services: SentryServices = {
   sentry,
 };
+
+export default services;

--- a/tests/scripts/run-bun-smoke.js
+++ b/tests/scripts/run-bun-smoke.js
@@ -11,6 +11,9 @@
  * Env:
  * - BUN_SMOKE_APP_DIR — absolute or repo-relative path to the Strapi app (default: examples/getstarted)
  * - PORT / HOST — bind address (default PORT 4310, HOST 127.0.0.1)
+ *
+ * Secrets: `examples/getstarted/.env` is gitignored, so CI has no JWT_SECRET. This script sets safe
+ * defaults (override with env) — same idea as tests/scripts/run-api-tests.js (`JWT_SECRET`).
  */
 
 const { spawn } = require('child_process');
@@ -120,8 +123,13 @@ async function main() {
     ...process.env,
     HOST: host,
     PORT: String(port),
-    STRAPI_TELEMETRY_DISABLED: 'true',
-    NODE_ENV: 'production',
+    STRAPI_TELEMETRY_DISABLED: process.env.STRAPI_TELEMETRY_DISABLED ?? 'true',
+    NODE_ENV: process.env.NODE_ENV ?? 'production',
+    // Required by @strapi/plugin-users-permissions bootstrap when no .env is present (e.g. GitHub Actions).
+    JWT_SECRET: process.env.JWT_SECRET ?? 'aSecret',
+    STRAPI_DISABLE_EE: process.env.STRAPI_DISABLE_EE ?? 'true',
+    STRAPI_GRAPHQL_V4_COMPATIBILITY_MODE:
+      process.env.STRAPI_GRAPHQL_V4_COMPATIBILITY_MODE ?? 'true',
   };
 
   console.error(`bun smoke: building app at ${appDir}`);

--- a/tests/scripts/run-bun-smoke.js
+++ b/tests/scripts/run-bun-smoke.js
@@ -1,0 +1,164 @@
+'use strict';
+
+/**
+ * Smoke test: Strapi built and started with Bun, responds on GET /_health.
+ *
+ * Prerequisites:
+ * - Bun installed (https://bun.sh)
+ * - Dependencies installed (`bun install` or `yarn install` at repo root)
+ * - Workspace packages compiled (`yarn build` at repo root — required so `strapi build` resolves @strapi/*)
+ *
+ * Env:
+ * - BUN_SMOKE_APP_DIR — absolute or repo-relative path to the Strapi app (default: examples/getstarted)
+ * - PORT / HOST — bind address (default PORT 4310, HOST 127.0.0.1)
+ */
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const defaultApp = path.join(repoRoot, 'examples/getstarted');
+
+const appDir = path.resolve(repoRoot, process.env.BUN_SMOKE_APP_DIR || defaultApp);
+const port = Number(process.env.PORT || process.env.BUN_SMOKE_PORT || 4310);
+const host = process.env.HOST || '127.0.0.1';
+
+async function resolveBunBinary() {
+  const tryBin = (cmd) =>
+    new Promise((resolve) => {
+      const child = spawn(cmd, ['--version'], { stdio: 'ignore' });
+      child.on('exit', (code) => resolve(code === 0 ? cmd : null));
+      child.on('error', () => resolve(null));
+    });
+
+  let resolved = await tryBin('bun');
+  if (resolved) {
+    return resolved;
+  }
+
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const fallback = path.join(home, '.bun/bin/bun');
+  if (fs.existsSync(fallback)) {
+    resolved = await tryBin(fallback);
+    if (resolved) {
+      return fallback;
+    }
+  }
+
+  return null;
+}
+
+function httpHealthCheck() {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: host,
+        port,
+        path: '/_health',
+        method: 'GET',
+        timeout: 5000,
+      },
+      (res) => {
+        const result = { status: res.statusCode, strapiHeader: res.headers.strapi };
+        res.resume();
+        res.on('end', () => resolve(result));
+      }
+    );
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('health request timeout'));
+    });
+    req.end();
+  });
+}
+
+async function waitForHealth(timeoutMs = 180000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await httpHealthCheck();
+      if (r.status === 204 && r.strapiHeader) {
+        return;
+      }
+    } catch {
+      /* retry */
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 750);
+    });
+  }
+  throw new Error(`Timed out waiting for GET http://${host}:${port}/_health (204 + strapi header)`);
+}
+
+function run(cmd, args, opts) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, opts);
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code} signal ${signal}`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const bun = await resolveBunBinary();
+  if (!bun) {
+    console.error(
+      'Bun is not installed or not on PATH. Install from https://bun.sh (e.g. curl -fsSL https://bun.sh/install | bash), then reopen your terminal or add ~/.bun/bin to PATH.'
+    );
+    process.exit(2);
+  }
+
+  const env = {
+    ...process.env,
+    HOST: host,
+    PORT: String(port),
+    STRAPI_TELEMETRY_DISABLED: 'true',
+    NODE_ENV: 'production',
+  };
+
+  console.error(`bun smoke: building app at ${appDir}`);
+  await run(bun, ['run', 'build'], { cwd: appDir, stdio: 'inherit', env });
+
+  console.error(`bun smoke: starting server on ${host}:${port}`);
+  const startProc = spawn(bun, ['run', 'start'], {
+    cwd: appDir,
+    env,
+    stdio: 'inherit',
+  });
+
+  if (!startProc.pid) {
+    throw new Error('failed to spawn bun run start');
+  }
+
+  try {
+    await waitForHealth();
+    console.error('bun smoke: OK — GET /_health returned 204');
+  } finally {
+    try {
+      startProc.kill('SIGTERM');
+    } catch {
+      /* ignore */
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+    try {
+      startProc.kill('SIGKILL');
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
### What does it do?

Adds official support for running Strapi with bun

- smoke test on the CI to ensure strapi runs with `bun`
- create-strapi-app supports 'bun' (in addition to pnpm, yarn, and npm)
- various typescript fixes (still need to investigate, I don't think these are strictly necessary, it was from when I also tried building the monorepo with bun)

### Why is it needed?

Describe the issue you are solving.

### How to test it?

experimental: `0.0.0-experimental.c6e7562b5dc46fb1f0274087fef904b25ba10bfd`

run `bunx create-strapi-app@0.0.0-experimental.c6e7562b5dc46fb1f0274087fef904b25ba10bfd` and see that it uses bun and Strapi runs properly with `bun run develop`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
