### PR TITLE
chore(scripts/release): fix experimental peer dependencies install

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,5 +1,7 @@
 const { releaseChangelog, releasePublish, releaseVersion } = require('nx/release');
 const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
 const yargs = require('yargs');
 
 (async () => {
@@ -75,6 +77,21 @@ const yargs = require('yargs');
     });
     workspaceVersion = versionResult.workspaceVersion;
     projectsVersionData = versionResult.projectsVersionData;
+
+    /**
+     * Nx's releaseVersion updates `dependencies`, `devDependencies`, and `optionalDependencies`
+     * but intentionally skips `peerDependencies` (see: https://github.com/nrwl/nx/issues/22776).
+     *
+     * For experimental/nightly releases (e.g. 0.0.0-experimental.<sha>), peer dep ranges like
+     * `^5.0.0` cannot satisfy `0.0.0-experimental.*` — semver prerelease matching is tuple-locked,
+     * so no range notation can express "any 5.x stable OR any 0.0.0-experimental.*".
+     *
+     * We fix this by rewriting internal @strapi/* peerDependencies to the exact experimental
+     * version after Nx versioning completes, but before the build step.
+     */
+    if (options.version !== undefined && /^0\.0\.0-.+/.test(options.version)) {
+      rewriteInternalPeerDependencies(options.version, options.dryRun);
+    }
   }
 
   // Run clean and build
@@ -114,3 +131,103 @@ const yargs = require('yargs');
     process.exit();
   }
 })();
+
+/**
+ * Rewrites internal @strapi/* peerDependencies across all workspace packages to an exact version.
+ *
+ * Why: Nx release does not update peerDependencies (by design). For prerelease versions like
+ * `0.0.0-experimental.<sha>`, ranges such as `^5.0.0` can never match due to semver's
+ * tuple-locked prerelease matching rules. This causes npm ERESOLVE failures at install time.
+ *
+ * When: Only called for versions matching `0.0.0-*` (experimental, nightly).
+ * Where: After releaseVersion() bumps all `version` fields, before the build/publish steps.
+ */
+function rewriteInternalPeerDependencies(version, dryRun) {
+  const rootDir = path.resolve(__dirname, '..');
+  const rootPkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+  const workspacePatterns = rootPkg.workspaces || [];
+
+  // Only process packages/ — examples/, .github/, scripts/ are not published to npm
+  const publishablePatterns = workspacePatterns.filter((p) => p.startsWith('packages/'));
+
+  // Collect all publishable package.json paths
+  const packageJsonPaths = [];
+  for (const pattern of publishablePatterns) {
+    // pattern is a simple glob like "packages/*" or "packages/*/*"
+    // Resolve it by listing matching directories
+    const parts = pattern.split('/');
+    const resolved = resolveGlobDirs(rootDir, parts);
+    for (const dir of resolved) {
+      const candidate = path.join(dir, 'package.json');
+      if (fs.existsSync(candidate)) {
+        packageJsonPaths.push(candidate);
+      }
+    }
+  }
+
+  // First pass: collect all @strapi/* package names in the workspace
+  const workspacePackageNames = new Set();
+  for (const pkgPath of packageJsonPaths) {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    if (pkg.name !== undefined && pkg.name.startsWith('@strapi/')) {
+      workspacePackageNames.add(pkg.name);
+    }
+  }
+
+  // Second pass: rewrite peerDependencies
+  let updatedCount = 0;
+  for (const pkgPath of packageJsonPaths) {
+    const raw = fs.readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(raw);
+
+    if (pkg.peerDependencies === undefined) {
+      continue;
+    }
+
+    let changed = false;
+    for (const dep of Object.keys(pkg.peerDependencies)) {
+      if (workspacePackageNames.has(dep)) {
+        pkg.peerDependencies[dep] = version;
+        changed = true;
+      }
+    }
+
+    if (changed === true) {
+      if (dryRun === true) {
+        console.log(
+          `[dry-run] Would rewrite peerDependencies in ${path.relative(rootDir, pkgPath)}`
+        );
+      } else {
+        fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+        console.log(`Rewrote peerDependencies in ${path.relative(rootDir, pkgPath)}`);
+      }
+      updatedCount++;
+    }
+  }
+
+  console.log(
+    `${dryRun === true ? '[dry-run] ' : ''}Rewrote @strapi/* peerDependencies to "${version}" in ${updatedCount} packages`
+  );
+}
+
+/**
+ * Resolves a simple workspace glob pattern (e.g. ["packages", "*", "*"]) into actual directories.
+ */
+function resolveGlobDirs(base, parts) {
+  if (parts.length === 0) {
+    return [base];
+  }
+
+  const [current, ...rest] = parts;
+
+  if (current === '*') {
+    if (fs.existsSync(base) === false) {
+      return [];
+    }
+    const entries = fs.readdirSync(base, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => path.join(base, e.name));
+    return dirs.flatMap((dir) => resolveGlobDirs(dir, rest));
+  }
+
+  return resolveGlobDirs(path.join(base, current), rest);
+}


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

After `releaseVersion()` bumps all `version` fields and before the build step in `scripts/release.js`, detects experimental version patterns (`0.0.0-*`) and rewrites all internal `@strapi/*` `peerDependencies` to the exact experimental version.

This is conditional — only triggers for `0.0.0-*` patterns; stable releases are unaffected.

15 packages are impacted (full list in `EXPERIMENTAL_VERSION_NPM_WARNINGS.md`).

### Why is it needed?

Installing `0.0.0-experimental.<sha>` (or `0.0.0-next.<sha>`) fails with `npm ERESOLVE` because:

1. Packages declare peer deps like `@strapi/admin@"^5.0.0"`
2. Experimental versions are `0.0.0-experimental.<sha>` — does **not** satisfy `^5.0.0`
3. Nx release updates `dependencies`/`devDependencies` but [intentionally skips `peerDependencies`](https://github.com/nrwl/nx/issues/22776)
4. Semver prerelease matching is **tuple-locked** — no range can express "any `5.x` stable OR any `0.0.0-*`"

No semver range can fix this: `^5.0.0-0` only unlocks prereleases on the `5.0.0` tuple, not on `5.42.1` or `0.0.0`.

### How to test it?

**Dry run** — verify which packages would be rewritten:

```bash
node scripts/release.js --version 0.0.0-experimental.test --dryRun --publish false --changelog false
```

**After a real experimental publish** — verify from consumer side:

```bash
npm install @strapi/strapi@0.0.0-experimental.<sha>
# Should complete with zero ERESOLVE warnings
```

### Related issue(s)/PR(s)

-