### PR TITLE
fix(content-manager): prevent duplicate React key in homepage recent-documents widget

### DIFF
--- a/packages/core/content-manager/admin/src/components/Widgets.tsx
+++ b/packages/core/content-manager/admin/src/components/Widgets.tsx
@@ -78,7 +78,11 @@ const RecentDocumentsTable = ({
     <Table colCount={5} rowCount={documents?.length ?? 0}>
       <Tbody>
         {documents?.map((document) => (
-          <Tr onClick={handleRowClick(document)} cursor="pointer" key={document.documentId}>
+          <Tr
+            onClick={handleRowClick(document)}
+            cursor="pointer"
+            key={`${document.documentId}-${document.locale ?? 'default'}`}
+          >
             <Td>
               <CellTypography
                 title={document.title}


### PR DESCRIPTION
### What does it do?

The homepage "Last Edited" and "Last Published" widgets were using
`document.documentId` as the React row key. Because the underlying
`/content-manager/homepage/recent-documents` endpoint queries with
`locale: '*'`, localized content types with Draft & Publish return
multiple rows sharing the same `documentId` (one per locale). React
then emits `Encountered two children with the same key, .$<documentId>`
and row identity becomes non-deterministic.

This change includes the locale in the key:

```tsx
key={`${document.documentId}-${document.locale ?? 'default'}`}
```

`'default'` is used as a fallback for non-localized content types
where `document.locale` is `null`.

### Why is it needed?

Users on localized + D&P projects see the React warning in the browser
console as soon as they land on the homepage, and the same entry may
silently re-order or mount/remount on data refreshes because React
cannot disambiguate the rows. Reproduced against a project with
`i18n.localized: true` + `draftAndPublish: true`, where entries exist
in both `en` and `es`:

> Warning: Encountered two children with the same key,
> `.$rocktsq4z2uxf7hulsdmaw40`. Keys should be unique…
>   at tbody
>   at RecentDocumentsTable
>   at LastEditedWidget
>   at WidgetComponent

### How to test it?

1. Create or use a content type with `i18n.localized: true` and
   `draftAndPublish: true`.
2. Create at least one entry with versions in two locales (e.g.
   `en` and `es`), edit both recently so they appear in the "Last
   Edited" widget.
3. Open the admin homepage and check the browser console.

**Before:** React emits `Encountered two children with the same key,
.$<documentId>` for the duplicated rows.
**After:** No warning; both locale rows render with stable, unique keys.

### Related issue(s)/PR(s)

None on file. Happy to open an issue if preferred.

Related to Internal Ticket ID: 8174 (Customer Bug during migration to v5)