### PR TITLE
chore(tests): msw v2 compatibility

### DIFF
--- a/packages/admin-test-utils/src/environment.ts
+++ b/packages/admin-test-utils/src/environment.ts
@@ -1,168 +1,101 @@
 import { TestEnvironment } from 'jest-environment-jsdom';
 
+import { applyNodeGlobals } from './patches/node-globals';
+import { patchResponseJsonRealm } from './patches/response-json-realm';
+import { patchRequestBodyStash } from './patches/request-body-stash';
+import type { Global, Teardown } from './patches/types';
+
+// Derive the constructor types from `TestEnvironment` itself rather than
+// importing `@jest/environment` directly
+type EnvConfig = ConstructorParameters<typeof TestEnvironment>[0];
+type EnvContext = ConstructorParameters<typeof TestEnvironment>[1];
+
 /* -------------------------------------------------------------------------------------------------
- * JSDOM env
+ * CustomJSDOMEnvironment
  *
- * Mirrors `jest-fixed-jsdom`: jsdom omits or replaces several Node globals with browser/DOM
- * implementations that MSW v2's `@mswjs/interceptors` cannot construct or patch. Re-bind to
- * Node's native versions before any test code runs.
- * See: https://mswjs.io/docs/migrations/1.x-to-2.x#frequent-issues
+ * Thin orchestrator over three independently-deletable patches that make
+ * jsdom+msw-v2 work:
  *
- * Polyfill scope is deliberately narrower than `jest-fixed-jsdom`:
+ *   1. `applyNodeGlobals`       — re-bind Node's fetch/Request/Response/
+ *                                 streams onto jsdom's global so MSW v2's
+ *                                 `@mswjs/interceptors` can install.
+ *   2. `patchResponseJsonRealm` — make Response bodies parse into jsdom-
+ *                                 realm objects (so `instanceof Array` /
+ *                                 `toStrictEqual` behave).
+ *   3. `patchRequestBodyStash`  — work around undici's
+ *                                 `Request.clone() locks original stream`
+ *                                 behaviour that msw triggers on every
+ *                                 handler dispatch.
  *
- *   - `fetch` / `Request` / `Response` / `Headers` — REQUIRED. MSW v2's interceptor patches
- *     the global `fetch` before dispatching to handlers; without Node's `fetch` the
- *     interceptor never installs and requests escape to the real network. Cost: tests no
- *     longer exercise the browser-fetch credential model (`credentials: 'include'` +
- *     `document.cookie`). Fine for Strapi — the admin reads/writes the JWT cookie via
- *     `document.cookie` directly (`getFetchClient.ts`) and surfaces it as an `Authorization`
- *     header, rather than relying on automatic cookie propagation through `fetch`. A future
- *     hook that does rely on it would need a different test strategy (Playwright, real-
- *     browser msw).
+ * Each patch owns its own state, its own sanity checks, and its own teardown.
+ * The orchestrator keeps the teardown stack in setup order and pops in
+ * reverse. A future msw / undici / jest-environment-jsdom release that fixes
+ * any of these concerns upstream should let the corresponding patch be
+ * deleted in a single commit, without touching the orchestrator or the other
+ * patches.
  *
- *   - `Blob` / `File` / `FormData` — NOT polyfilled. Strapi app code threads these through
- *     jsdom-only APIs that only accept the matching realm:
- *       * `LogoInput.tsx` does `new FormData(htmlFormElement)`. Node's `FormData` (undici)
- *         doesn't accept HTMLFormElement; jsdom's does.
- *       * `LogoInput.tsx` does `axios.get(url, { responseType: 'blob' })` then
- *         `new File([res.data], …)`. The `File` constructor only reads bytes from a `Blob`
- *         of its own realm — jsdom-File reading a Node-Blob falls back to `toString`
- *         (`"[object Blob]"` → size 13). Polyfilling `File` too "fixes" that chain but
- *         breaks the next: jsdom's `FileReader` / `Image` only accept jsdom-realm
- *         `File`/`Blob`.
+ * Opt-out
+ * -------
+ * The MSW-specific patches (2 and 3) add cost that non-msw test suites do
+ * not benefit from. Disable them via `testEnvironmentOptions.strapi.msw =
+ * false` in a jest config. `applyNodeGlobals` is always applied — it is
+ * cheap, and some Strapi app code touches fetch/Request directly.
  *
- *   - `URL` / `URLSearchParams` — NOT polyfilled. jsdom already provides browser-spec
- *     versions, and Node's `URL.createObjectURL` only accepts Node-realm `Blob` —
- *     replacing it breaks jsdom's `File` → `URL.createObjectURL` flow used by
- *     `LogoInput.tsx` ("from computer" upload path). MSW v2's interceptor doesn't require
- *     these to come from Node.
+ *   // jest.config.js for a workspace that does NOT use msw
+ *   module.exports = {
+ *     testEnvironment: '@strapi/admin-test-utils/environment',
+ *     testEnvironmentOptions: { strapi: { msw: false } },
+ *   };
  *
- * Net rule: polyfill what MSW v2's interceptor needs (fetch/streams/Request/Response/
- * Headers/AbortController/BroadcastChannel); leave alone what app code hands off to
- * jsdom-only APIs (Blob/File/FormData/URL).
+ * See `jest-preset.front.js` for the other half of the msw/node resolution
+ * (`testEnvironmentOptions.customExportConditions: ['']`) — both halves are
+ * required for `msw/node` to resolve under jsdom.
  * -----------------------------------------------------------------------------------------------*/
 
-const NODE_GLOBALS = {
-  TextDecoder,
-  TextEncoder,
-  TextDecoderStream,
-  TextEncoderStream,
-  ReadableStream,
-  TransformStream,
-  WritableStream,
-  Headers,
-  Request,
-  Response,
-  fetch,
-  AbortController,
-  AbortSignal,
-  structuredClone,
-  BroadcastChannel,
-} as const;
-
-// Non-enumerable slot on a Request instance holding the original stringified body. See
-// the body-stash note in `setup()` below.
-const BODY_STASH = Symbol('strapi.mswBodyStash');
-
-type Stashed = Request & { [BODY_STASH]?: string };
+interface StrapiEnvOptions {
+  /**
+   * Whether to install the msw-v2-specific Response/Request prototype patches.
+   * Defaults to `true`. Set to `false` for test suites that never import msw.
+   */
+  msw?: boolean;
+}
 
 // https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string
 export default class CustomJSDOMEnvironment extends TestEnvironment {
-  // Snapshot of jsdom's originals, captured in setup before overwrite. Restored in
-  // teardown so a test that mutates one of these globals can't leak the mutation into
-  // the next file sharing this Jest worker.
-  private readonly originalGlobals = new Map<string, PropertyDescriptor | undefined>();
+  private readonly strapiOptions: StrapiEnvOptions;
 
-  private originalResponseJson: typeof Response.prototype.json | undefined;
+  private teardowns: Teardown[] = [];
 
-  private originalRequestJson: typeof Request.prototype.json | undefined;
-
-  private originalRequestText: typeof Request.prototype.text | undefined;
+  constructor(config: EnvConfig, context: EnvContext) {
+    super(config, context);
+    // `testEnvironmentOptions` is not exposed on the parent class's public
+    // surface, so grab it from the jest config handed to the constructor.
+    const raw = config.projectConfig.testEnvironmentOptions as {
+      strapi?: StrapiEnvOptions;
+    };
+    this.strapiOptions = raw.strapi ?? {};
+  }
 
   async setup(): Promise<void> {
     await super.setup();
 
-    for (const [name, value] of Object.entries(NODE_GLOBALS)) {
-      this.originalGlobals.set(name, Object.getOwnPropertyDescriptor(this.global, name));
-      (this.global as unknown as Record<string, unknown>)[name] = value;
+    const global = this.global as unknown as Global;
+    const mswPatchesEnabled = this.strapiOptions.msw !== false;
+
+    this.teardowns.push(applyNodeGlobals(global));
+    if (mswPatchesEnabled) {
+      this.teardowns.push(patchResponseJsonRealm(global));
+      this.teardowns.push(patchRequestBodyStash(global));
     }
-
-    // `Response` is Node-realm (undici). Its `.json()` uses Node's `JSON.parse`, so the
-    // returned object/array have Node's `Object`/`Array` prototypes. In tests running
-    // under jsdom, `instanceof Array`, `expect.any(Array)`, and `toStrictEqual` all
-    // check against jsdom's prototypes and fail. Patch `Response.prototype.json` to
-    // parse with jsdom-realm `JSON` so response bodies land in the right realm.
-    const jsdomJSON = (this.global as unknown as { JSON: typeof JSON }).JSON;
-    this.originalResponseJson = Response.prototype.json;
-    Response.prototype.json = async function realmAgnosticJson() {
-      const text = await this.text();
-      return jsdomJSON.parse(text);
-    };
-
-    // MSW v2's `RequestHandler.run()` calls `request.clone()` *before* invoking the
-    // resolver (to keep a copy around for post-hoc logging). Under Node's undici,
-    // `Request.clone()` tees the underlying `ReadableStream`, which locks the original
-    // body — so when the resolver then does `await request.json()`, undici throws
-    // `TypeError: Body is unusable: Body has already been read`.
-    //
-    // Stash the stringified body on every `new Request(…)` and have `.json()` / `.text()`
-    // return the stash when present. Handlers get what the test fired off regardless of
-    // how many times msw clones the request internally.
-    const GlobalRequest = (this.global as unknown as { Request: typeof Request }).Request;
-    const NativeRequest = GlobalRequest;
-    const PatchedRequest = function PatchedRequest(
-      this: unknown,
-      input?: RequestInfo | URL,
-      init?: RequestInit
-    ) {
-      const request = Reflect.construct(NativeRequest, [input, init], PatchedRequest) as Stashed;
-      if (init && typeof init.body === 'string') {
-        Object.defineProperty(request, BODY_STASH, { value: init.body });
-      } else if (input && typeof (input as Stashed)[BODY_STASH] === 'string') {
-        Object.defineProperty(request, BODY_STASH, { value: (input as Stashed)[BODY_STASH] });
-      }
-      return request;
-    } as unknown as typeof Request;
-    PatchedRequest.prototype = NativeRequest.prototype;
-    Object.setPrototypeOf(PatchedRequest, NativeRequest);
-    (this.global as unknown as { Request: typeof Request }).Request = PatchedRequest;
-
-    this.originalRequestText = Request.prototype.text;
-    const nativeText = this.originalRequestText;
-    Request.prototype.text = async function stashedText(this: Stashed) {
-      const stashed = this[BODY_STASH];
-      if (typeof stashed === 'string') return stashed;
-      return nativeText.call(this);
-    } as typeof Request.prototype.text;
-    this.originalRequestJson = Request.prototype.json;
-    Request.prototype.json = async function stashedJson(this: Stashed) {
-      return jsdomJSON.parse(await this.text());
-    };
   }
 
   async teardown(): Promise<void> {
-    if (this.originalRequestJson) {
-      Request.prototype.json = this.originalRequestJson;
-      this.originalRequestJson = undefined;
-    }
-    if (this.originalRequestText) {
-      Request.prototype.text = this.originalRequestText;
-      this.originalRequestText = undefined;
-    }
-    if (this.originalResponseJson) {
-      Response.prototype.json = this.originalResponseJson;
-      this.originalResponseJson = undefined;
-    }
-
-    for (const [name, descriptor] of this.originalGlobals) {
-      if (descriptor) {
-        Object.defineProperty(this.global, name, descriptor);
-      } else {
-        delete (this.global as unknown as Record<string, unknown>)[name];
+    while (this.teardowns.length > 0) {
+      const fn = this.teardowns.pop();
+      if (fn) {
+        fn();
       }
     }
-    this.originalGlobals.clear();
-
     await super.teardown();
   }
 }

--- a/packages/admin-test-utils/src/patches/node-globals.ts
+++ b/packages/admin-test-utils/src/patches/node-globals.ts
@@ -1,0 +1,94 @@
+import type { Global, Teardown } from './types';
+
+/* -------------------------------------------------------------------------------------------------
+ * Node globals → jsdom global
+ *
+ * jsdom omits or replaces several Node globals with browser/DOM implementations
+ * that MSW v2's `@mswjs/interceptors` cannot construct or patch. Re-bind Node's
+ * native versions onto `env.global` before any test code runs. The snapshot of
+ * jsdom's originals (captured per-patch-instance, not at module scope) is
+ * restored in teardown, so a test that mutates one of these globals cannot leak
+ * the mutation into the next file sharing the same Jest worker.
+ *
+ * Mirrors the `jest-fixed-jsdom` package, but with a deliberately narrower scope:
+ *
+ *   - `fetch` / `Request` / `Response` / `Headers` — REQUIRED. MSW v2's
+ *     interceptor patches the global `fetch` before dispatching to handlers;
+ *     without Node's `fetch` the interceptor never installs and requests escape
+ *     to the real network. Cost: tests no longer exercise the browser-fetch
+ *     credential model (`credentials: 'include'` + `document.cookie`). Fine for
+ *     Strapi — the admin reads/writes the JWT cookie via `document.cookie`
+ *     directly (`getFetchClient.ts`) and surfaces it as an `Authorization`
+ *     header, rather than relying on automatic cookie propagation through
+ *     `fetch`. A future hook that does rely on it would need a different test
+ *     strategy (Playwright, real-browser msw).
+ *
+ *   - `Blob` / `File` / `FormData` — NOT polyfilled. Strapi app code threads
+ *     these through jsdom-only APIs that only accept the matching realm:
+ *       * `LogoInput.tsx` does `new FormData(htmlFormElement)`. Node's
+ *         `FormData` (undici) doesn't accept HTMLFormElement; jsdom's does.
+ *       * `LogoInput.tsx` does `axios.get(url, { responseType: 'blob' })` then
+ *         `new File([res.data], …)`. The `File` constructor only reads bytes
+ *         from a `Blob` of its own realm — jsdom-File reading a Node-Blob
+ *         falls back to `toString` (`"[object Blob]"` → size 13).
+ *         Polyfilling `File` too "fixes" that chain but breaks the next:
+ *         jsdom's `FileReader` / `Image` only accept jsdom-realm `File`/`Blob`.
+ *
+ *   - `URL` / `URLSearchParams` — NOT polyfilled. jsdom already provides
+ *     browser-spec versions, and Node's `URL.createObjectURL` only accepts
+ *     Node-realm `Blob` — replacing it breaks jsdom's `File` →
+ *     `URL.createObjectURL` flow used by `LogoInput.tsx` ("from computer"
+ *     upload path). MSW v2's interceptor doesn't require these to come from
+ *     Node.
+ *
+ * Net rule: polyfill what MSW v2's interceptor needs (fetch/streams/Request/
+ * Response/Headers/AbortController/BroadcastChannel); leave alone what app
+ * code hands off to jsdom-only APIs (Blob/File/FormData/URL).
+ *
+ * The other half of the msw/node puzzle lives in `jest-preset.front.js` as
+ * `testEnvironmentOptions.customExportConditions: ['']` — both halves are
+ * required for `msw/node` to resolve under jsdom.
+ * -----------------------------------------------------------------------------------------------*/
+
+/**
+ * Captured at module load, BEFORE `jest-environment-jsdom` has a chance to set
+ * up and shadow these with jsdom's equivalents. Frozen so a patch author can't
+ * accidentally reassign and drift.
+ */
+const NODE_GLOBALS = Object.freeze({
+  TextDecoder,
+  TextEncoder,
+  TextDecoderStream,
+  TextEncoderStream,
+  ReadableStream,
+  TransformStream,
+  WritableStream,
+  Headers,
+  Request,
+  Response,
+  fetch,
+  AbortController,
+  AbortSignal,
+  structuredClone,
+  BroadcastChannel,
+} as const);
+
+export function applyNodeGlobals(global: Global): Teardown {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+
+  for (const [name, value] of Object.entries(NODE_GLOBALS)) {
+    originals.set(name, Object.getOwnPropertyDescriptor(global, name));
+    global[name] = value;
+  }
+
+  return function teardownNodeGlobals() {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) {
+        Object.defineProperty(global, name, descriptor);
+      } else {
+        delete global[name];
+      }
+    }
+    originals.clear();
+  };
+}

--- a/packages/admin-test-utils/src/patches/request-body-stash.ts
+++ b/packages/admin-test-utils/src/patches/request-body-stash.ts
@@ -1,0 +1,109 @@
+import type { Global, Teardown } from './types';
+
+/* -------------------------------------------------------------------------------------------------
+ * Request body stash for msw v2 + undici
+ *
+ * The problem
+ * -----------
+ * MSW v2's `RequestHandler.run()` calls `request.clone()` BEFORE invoking the
+ * resolver (to keep a copy around for post-hoc logging). Under Node's undici,
+ * `Request.clone()` tees the underlying `ReadableStream`, which locks the
+ * original body — so when the resolver then does `await request.json()`,
+ * undici throws `TypeError: Body is unusable: Body has already been read`.
+ *
+ * The fix
+ * -------
+ * Stash the stringified body on every `new Request(…)` under a private Symbol,
+ * and have `.text()` / `.json()` return the stash when present. Handlers get
+ * what the test fired off regardless of how many times msw clones the request
+ * internally. The stash is read-through: if an existing stashed Request is
+ * passed as the first argument to `new Request(original, init)`, the stash
+ * propagates to the new instance.
+ *
+ * Scope
+ * -----
+ * Only string bodies are stashed. `FormData` / `Blob` / `ArrayBuffer` bodies
+ * are not — no current handler in the repo reads those shapes, and extending
+ * the stash to cover them needs realm-aware handling (see node-globals.ts).
+ * A handler that calls `request.formData()` or `request.arrayBuffer()` under
+ * this env will hit the undici "Body is unusable" error directly; widen this
+ * patch if that case arises.
+ * -----------------------------------------------------------------------------------------------*/
+
+const BODY_STASH = Symbol('strapi.mswBodyStash');
+const PATCH_MARKER = '__strapiStashedBody';
+
+type Stashed = Request & { [BODY_STASH]?: string };
+
+type PatchedText = typeof Request.prototype.text & { [PATCH_MARKER]?: true };
+type PatchedJson = typeof Request.prototype.json & { [PATCH_MARKER]?: true };
+
+/**
+ * Extract the stashable representation of a Request body:
+ *   - The explicit string body on `init.body`, if provided.
+ *   - Otherwise the propagated stash from an existing Request passed as input.
+ *   - `undefined` for anything else (non-string body, URL-only input, etc.).
+ */
+function stashFor(
+  input: RequestInfo | URL | undefined,
+  init: RequestInit | undefined,
+  RequestCtor: typeof Request
+): string | undefined {
+  if (init && typeof init.body === 'string') return init.body;
+  if (input instanceof RequestCtor) {
+    const inherited = (input as Stashed)[BODY_STASH];
+    if (typeof inherited === 'string') return inherited;
+  }
+  return undefined;
+}
+
+export function patchRequestBodyStash(global: Global): Teardown {
+  const NativeRequest = global.Request as typeof Request;
+  const jsdomJSON = global.JSON as typeof JSON;
+
+  // Wrap the Request constructor via Proxy. Preserves `instanceof`, the
+  // prototype chain, and static members automatically — no need to manually
+  // reassign `prototype` or thread `Reflect.construct`'s `newTarget`.
+  const PatchedRequest = new Proxy(NativeRequest, {
+    construct(target, args) {
+      const [input, init] = args as [RequestInfo | URL | undefined, RequestInit | undefined];
+      const request = Reflect.construct(target, args) as Stashed;
+      const body = stashFor(input, init, NativeRequest);
+      if (body !== undefined) {
+        Object.defineProperty(request, BODY_STASH, { value: body });
+      }
+      return request;
+    },
+  });
+  global.Request = PatchedRequest;
+
+  const originalText = Request.prototype.text;
+  const originalJson = Request.prototype.json;
+
+  if ((originalText as PatchedText)[PATCH_MARKER] || (originalJson as PatchedJson)[PATCH_MARKER]) {
+    throw new Error(
+      '@strapi/admin-test-utils: patchRequestBodyStash was applied without a ' +
+        'matching teardown. setup() was likely called twice in the same worker.'
+    );
+  }
+
+  const patchedText: PatchedText = async function stashedText(this: Stashed) {
+    const stashed = this[BODY_STASH];
+    if (typeof stashed === 'string') return stashed;
+    return originalText.call(this);
+  };
+  patchedText[PATCH_MARKER] = true;
+  Request.prototype.text = patchedText;
+
+  const patchedJson: PatchedJson = async function stashedJson(this: Stashed) {
+    return jsdomJSON.parse(await this.text());
+  };
+  patchedJson[PATCH_MARKER] = true;
+  Request.prototype.json = patchedJson;
+
+  return function teardownRequestBodyStash() {
+    global.Request = NativeRequest;
+    Request.prototype.text = originalText;
+    Request.prototype.json = originalJson;
+  };
+}

--- a/packages/admin-test-utils/src/patches/response-json-realm.ts
+++ b/packages/admin-test-utils/src/patches/response-json-realm.ts
@@ -1,0 +1,44 @@
+import type { Global, Teardown } from './types';
+
+/* -------------------------------------------------------------------------------------------------
+ * Response.prototype.json → jsdom realm
+ *
+ * Once `applyNodeGlobals` has bound undici's `Response` onto the jsdom global,
+ * `Response.prototype.json()` parses with Node's `JSON`. The returned value has
+ * Node's `Object` / `Array` prototypes. Tests running under jsdom check against
+ * jsdom's prototypes, so `instanceof Array`, `expect.any(Array)`, and
+ * `toStrictEqual` all fail with confusing "objects look equal but aren't"
+ * errors.
+ *
+ * Patch `Response.prototype.json` to parse with jsdom-realm `JSON` so response
+ * bodies land in the right realm. The patch is idempotent-guarded — if it's
+ * applied twice without a teardown in between, the second call throws rather
+ * than silently stacking.
+ * -----------------------------------------------------------------------------------------------*/
+
+const PATCH_MARKER = '__strapiRealmAgnosticJson';
+
+type PatchedJson = typeof Response.prototype.json & { [PATCH_MARKER]?: true };
+
+export function patchResponseJsonRealm(global: Global): Teardown {
+  const jsdomJSON = global.JSON as typeof JSON;
+  const original = Response.prototype.json;
+
+  if ((original as PatchedJson)[PATCH_MARKER]) {
+    throw new Error(
+      '@strapi/admin-test-utils: patchResponseJsonRealm was applied without a ' +
+        'matching teardown. setup() was likely called twice in the same worker.'
+    );
+  }
+
+  const patched: PatchedJson = async function realmAgnosticJson(this: Response) {
+    const text = await this.text();
+    return jsdomJSON.parse(text);
+  };
+  patched[PATCH_MARKER] = true;
+  Response.prototype.json = patched;
+
+  return function teardownResponseJsonRealm() {
+    Response.prototype.json = original;
+  };
+}

--- a/packages/admin-test-utils/src/patches/types.ts
+++ b/packages/admin-test-utils/src/patches/types.ts
@@ -1,0 +1,15 @@
+/**
+ * A `Global` is the jsdom-constructed global object that `jest-environment-jsdom`
+ * exposes as `env.global`. We only ever read/write string-keyed properties on it,
+ * so a loose `Record<string, unknown>` keeps the patches honest — they should never
+ * assume the shape of the broader DOM surface.
+ */
+export type Global = Record<string, unknown>;
+
+/**
+ * Every patch returns a teardown function. The orchestrator pushes them onto a
+ * stack and pops in reverse order, mirroring how the patches were applied. That
+ * way setup order is automatically the inverse of teardown order, and a patch
+ * only needs to close over its own captured originals — no cross-patch state.
+ */
+export type Teardown = () => void;


### PR DESCRIPTION
I've mirrored https://github.com/strapi/strapi/pull/26065 on the branch [tmp/msw-origin-mirror](https://github.com/strapi/strapi/tree/tmp/msw-origin-mirror) so we can discuss this diff internally.

#26065 seems to have cracked the msw v2 migration but makes quite a lot of changes in `packages/admin-test-utils/`. I thought this diff makes the changes clearer and hopefully easier to maintain in the future?

If we go ahead with this, branching wise we can either get this diff added to #26065 or wait for that to be merged and change the target to `develop`