### PR TITLE
fix(content-manager): make drag-and-drop drop indicator match component height

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx
@@ -9,7 +9,6 @@ import {
   Accordion,
   IconButton,
   useComposedRefs,
-  BoxComponent,
 } from '@strapi/design-system';
 import { Plus, Drag, Trash, ArrowUp, ArrowDown } from '@strapi/icons';
 import { getEmptyImage } from 'react-dnd-html5-backend';
@@ -468,6 +467,15 @@ const Component = ({
     dragPreviewRef(getEmptyImage(), { captureDraggingState: false });
   }, [dragPreviewRef, index]);
 
+  // Capture the component's height before it's replaced by the Preview so the
+  // drop indicator fills the same space and the drop position stays visible.
+  const previewHeightRef = React.useRef<number | undefined>(undefined);
+  React.useLayoutEffect(() => {
+    if (!isDragging && boxRef.current) {
+      previewHeightRef.current = (boxRef.current as HTMLElement).offsetHeight;
+    }
+  });
+
   const composedAccordionRefs = useComposedRefs<HTMLButtonElement>(accordionRef, dragRef);
   const composedBoxRefs = useComposedRefs<HTMLDivElement>(
     boxRef as React.RefObject<HTMLDivElement>,
@@ -483,7 +491,7 @@ const Component = ({
   return (
     <>
       {isDragging ? (
-        <Preview />
+        <Preview $height={previewHeightRef.current} />
       ) : (
         <Accordion.Item ref={composedBoxRefs} value={__temp_key__}>
           <Accordion.Header>
@@ -581,14 +589,18 @@ const Component = ({
   );
 };
 
-const Preview = () => {
-  return <StyledSpan tag="span" padding={6} background="primary100" />;
+const Preview = ({ $height }: { $height?: number }) => {
+  return <StyledSpan $height={$height} />;
 };
 
-const StyledSpan = styled<BoxComponent<'span'>>(Box)`
+const StyledSpan = styled.span<{ $height?: number }>`
   display: block;
-  outline: 1px dashed ${({ theme }) => theme.colors.primary500};
+  background-color: ${({ theme }) => theme.colors.primary100};
+  outline: 1px dashed ${({ theme }) => theme.colors.primary600};
   outline-offset: -1px;
+  border-radius: ${({ theme }) => theme.borderRadius};
+  ${({ $height, theme }) =>
+    $height !== undefined ? `height: ${$height}px;` : `padding: ${theme.spaces[6]};`}
 `;
 
 const MemoizedComponent = React.memo(Component);

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -98,6 +98,15 @@ const DynamicComponent = ({
     dragPreviewRef(getEmptyImage(), { captureDraggingState: false });
   }, [dragPreviewRef, index]);
 
+  // Capture the component's height before it's replaced by the Preview so the
+  // drop indicator fills the same space and the drop position stays visible.
+  const previewHeightRef = React.useRef<number | undefined>(undefined);
+  React.useLayoutEffect(() => {
+    if (!isDragging && boxRef.current) {
+      previewHeightRef.current = (boxRef.current as HTMLElement).offsetHeight;
+    }
+  });
+
   /**
    * We don't need the accordion's to communicate with each other,
    * so a unique value for their state is enough.
@@ -267,7 +276,7 @@ const DynamicComponent = ({
       </Flex>
       <StyledBox ref={composedBoxRefs} hasRadius>
         {isDragging ? (
-          <Preview />
+          <Preview $height={previewHeightRef.current} />
         ) : (
           <Accordion.Root value={collapseToOpen} onValueChange={setCollapseToOpen}>
             <Accordion.Item value={accordionValue}>
@@ -320,12 +329,14 @@ const Rectangle = styled<BoxComponent>(Box)`
   height: ${({ theme }) => theme.spaces[4]};
 `;
 
-const Preview = styled.span`
+const Preview = styled.span<{ $height?: number }>`
   display: block;
   background-color: ${({ theme }) => theme.colors.primary100};
-  outline: 1px dashed ${({ theme }) => theme.colors.primary500};
+  outline: 1px dashed ${({ theme }) => theme.colors.primary600};
   outline-offset: -1px;
-  padding: ${({ theme }) => theme.spaces[6]};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  ${({ $height, theme }) =>
+    $height !== undefined ? `height: ${$height}px;` : `padding: ${theme.spaces[6]};`}
 `;
 
 const ComponentContainer = styled<BoxComponent<'li'>>(Box)`


### PR DESCRIPTION
## Summary

- Fixes #26087: when dragging a component in a Dynamic Zone or Repeatable component, the drop-target placeholder shrank to a small padded box, making it hard to see where the item would land — especially when the source component was expanded or tall.
- Captures the component's rendered height via a layout effect before it's replaced by the `Preview` placeholder, and applies it as the placeholder height so the drop indicator fills the same vertical space the dragged component occupied.
- Aligns the dashed outline colour with the Relations list placeholder (`primary600`) and adds a matching border-radius for visual consistency across drag-and-drop surfaces.

### Before / After
- **Before**: placeholder is a small dashed box (~48px), list layout collapses and jumps while dragging — drop position unclear.
- **After**: placeholder matches the dragged component's previous height, drop position is visible throughout the drag.

### Files changed
- `packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx`
- `packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Repeatable.tsx`

### Why a layout effect (and not `height: 100%`)
The Relations list ([Relations.tsx:1368](../blob/develop/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx)) already uses `height: calc(100% - gutter)` but only works there because rows have a fixed height from react-window virtualization. Dynamic-zone and repeatable rows have variable heights and no height-constrained parent, so the placeholder must carry the height explicitly — captured from `boxRef.current.offsetHeight` in a `useLayoutEffect` while the element is still mounted and non-dragging.

## Test plan
- [ ] In an entry with a Dynamic Zone containing several components, drag a **collapsed** component across siblings — placeholder height matches the collapsed accordion.
- [ ] Repeat with an **expanded** component — placeholder now spans the full expanded height, no list collapse during drag.
- [ ] Same checks inside a **Repeatable component**.
- [ ] Relations drag-and-drop is unaffected (not touched).
- [ ] Keyboard drag-and-drop (Space + Arrow keys) still reorders items.
- [ ] Existing DynamicZone and Repeatable tests still pass.