### PR TITLE
Fix polymorphic relations in the document service API

### DIFF
--- a/packages/core/core/src/services/document-service/transform/__tests__/map-relation.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/map-relation.test.ts
@@ -1,4 +1,4 @@
-import { mapRelation } from '../relations/utils/map-relation';
+import { mapRelation, traverseEntityRelations } from '../relations/utils/map-relation';
 
 const mapper = mapRelation(async (relation) => {
   if (!relation) return 'default';
@@ -112,5 +112,57 @@ describe('map relation', () => {
     const expectedRelation = 'default';
 
     expect(await mapper(relation)).toBe(expectedRelation);
+  });
+});
+
+describe('traverseEntityRelations', () => {
+  const CATEGORY_UID = 'api::category.category';
+
+  const schema = {
+    uid: 'api::article.article',
+    modelType: 'contentType' as const,
+    attributes: {
+      // morphToOne — visitor must be skipped (inline columns, not a join table)
+      related: { type: 'relation' as const, relation: 'morphToOne' as const },
+      // regular relation — visitor must be called
+      category: {
+        type: 'relation' as const,
+        relation: 'manyToOne' as const,
+        target: CATEGORY_UID,
+      },
+    },
+  };
+
+  const options = {
+    schema,
+    getModel: jest.fn().mockReturnValue(null),
+  };
+
+  it('does not call visitor for morphToOne relations', async () => {
+    const visitor = jest.fn();
+    // null value prevents traverseEntity from recursing into the attribute
+    await traverseEntityRelations(visitor, options, { related: null });
+    expect(visitor).not.toHaveBeenCalled();
+  });
+
+  it('calls visitor for regular relation attributes', async () => {
+    const visitor = jest.fn();
+    await traverseEntityRelations(visitor, options, { category: null });
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'category' }),
+      expect.anything()
+    );
+  });
+
+  it('skips morphToOne but processes other relations in the same entity', async () => {
+    const visitor = jest.fn();
+    await traverseEntityRelations(visitor, options, { related: null, category: null });
+    // only 'category' should trigger the visitor — 'related' (morphToOne) is skipped
+    expect(visitor).toHaveBeenCalledTimes(1);
+    expect(visitor).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'category' }),
+      expect.anything()
+    );
   });
 });

--- a/packages/core/core/src/services/document-service/transform/relations/utils/map-relation.ts
+++ b/packages/core/core/src/services/document-service/transform/relations/utils/map-relation.ts
@@ -140,6 +140,11 @@ const traverseEntityRelations = async (
         return;
       }
 
+      // morphToOne uses morphColumn (inline columns on the entity), handled directly in processData
+      if (attribute.relation === 'morphToOne') {
+        return;
+      }
+
       return visitor(options, utils);
     },
     options,

--- a/packages/core/core/src/services/document-service/utils/__tests__/populate.test.ts
+++ b/packages/core/core/src/services/document-service/utils/__tests__/populate.test.ts
@@ -16,6 +16,19 @@ const articleModel = {
     // Polymorphic relations that can point to any content type
     related: { type: 'relation' as const, relation: 'morphToOne' as const },
     relatedMany: { type: 'relation' as const, relation: 'morphToMany' as const },
+    // Inverse polymorphic (storage still lives on the morphTo* owner side; must be included in deep populate)
+    fromRelated: {
+      type: 'relation' as const,
+      relation: 'morphOne' as const,
+      target: ARTICLE_UID,
+      morphBy: 'related' as const,
+    },
+    fromRelatedMany: {
+      type: 'relation' as const,
+      relation: 'morphMany' as const,
+      target: ARTICLE_UID,
+      morphBy: 'relatedMany' as const,
+    },
     // Regular relation with a fixed target
     category: {
       type: 'relation' as const,
@@ -46,6 +59,14 @@ describe('getDeepPopulate', () => {
 
   it('includes morphToMany relations', () => {
     expect(result).toHaveProperty('relatedMany');
+  });
+
+  it('includes morphOne relations (inverse of morphToOne / morphToMany on the target)', () => {
+    expect(result).toHaveProperty('fromRelated');
+  });
+
+  it('includes morphMany relations (inverse of morphToMany on the target)', () => {
+    expect(result).toHaveProperty('fromRelatedMany');
   });
 
   it('includes regular relations', () => {

--- a/packages/core/core/src/services/document-service/utils/__tests__/populate.test.ts
+++ b/packages/core/core/src/services/document-service/utils/__tests__/populate.test.ts
@@ -1,0 +1,62 @@
+import type { Internal } from '@strapi/types';
+
+import { getDeepPopulate } from '../populate';
+
+const ARTICLE_UID = 'api::article.article' as Internal.UID.ContentType;
+const CATEGORY_UID = 'api::category.category' as Internal.UID.ContentType;
+
+const articleModel = {
+  uid: ARTICLE_UID,
+  modelType: 'contentType' as const,
+  kind: 'collectionType' as const,
+  info: { displayName: 'Article', singularName: 'article', pluralName: 'articles' },
+  options: { draftAndPublish: true },
+  attributes: {
+    title: { type: 'string' as const },
+    // Polymorphic relations that can point to any content type
+    related: { type: 'relation' as const, relation: 'morphToOne' as const },
+    relatedMany: { type: 'relation' as const, relation: 'morphToMany' as const },
+    // Regular relation with a fixed target
+    category: {
+      type: 'relation' as const,
+      relation: 'manyToOne' as const,
+      target: CATEGORY_UID,
+    },
+    // Virtual relation not managed by the DB layer — must be excluded
+    virtualRel: {
+      type: 'relation' as const,
+      relation: 'oneToMany' as const,
+      target: CATEGORY_UID,
+      unstable_virtual: true,
+    },
+  },
+};
+
+describe('getDeepPopulate', () => {
+  let result: Record<string, unknown>;
+
+  beforeAll(() => {
+    global.strapi = { getModel: () => articleModel } as any;
+    result = getDeepPopulate(ARTICLE_UID);
+  });
+
+  it('includes morphToOne relations', () => {
+    expect(result).toHaveProperty('related');
+  });
+
+  it('includes morphToMany relations', () => {
+    expect(result).toHaveProperty('relatedMany');
+  });
+
+  it('includes regular relations', () => {
+    expect(result).toHaveProperty('category');
+  });
+
+  it('excludes unstable_virtual relations', () => {
+    expect(result).not.toHaveProperty('virtualRel');
+  });
+
+  it('does not include scalar attributes', () => {
+    expect(result).not.toHaveProperty('title');
+  });
+});

--- a/packages/core/core/src/services/document-service/utils/populate.ts
+++ b/packages/core/core/src/services/document-service/utils/populate.ts
@@ -23,19 +23,12 @@ export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
   const result = attributes.reduce((acc: any, [attributeName, attribute]) => {
     switch (attribute.type) {
       case 'relation': {
-        // TODO: Support polymorphic relations
-        const isMorphRelation = attribute.relation.toLowerCase().startsWith('morph');
-        if (isMorphRelation) {
-          break;
-        }
-
         if ('unstable_virtual' in attribute && attribute.unstable_virtual) {
           // skip relations not managed by the DB layer
           break;
         }
 
-        // Include all non-morph relations (including visible: false) so publish / discardDraft /
-        // clone preserve links—same idea as content-manager getPopulateForRelation for invisible attrs.
+        // Include all relations except the onces not managed by the DB layer.
         acc[attributeName] = { select: opts.relationalFields };
 
         break;

--- a/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-to-one.test.ts
+++ b/packages/core/database/src/query/helpers/populate/__tests__/apply-morph-to-one.test.ts
@@ -1,0 +1,129 @@
+import applyPopulate from '../apply';
+
+/**
+ * Tests for the morphToOne populate helper in apply.ts.
+ *
+ * Key behaviour under test:
+ *  - The populated result row includes a `__type` field (or a custom typeField from morphColumn)
+ *    that carries the target content-type UID.
+ *  - When a result row has no morph target (null id / type columns) the attribute is set to null.
+ */
+
+// fromRow is the only piece of transform we need to isolate — mock it so tests
+// don't depend on field/scalar serialisation internals.
+jest.mock('../../transform', () => ({
+  fromRow: jest.fn((_meta: unknown, row: unknown) => {
+    if (row == null) return null;
+    return row; // pass-through for test purposes
+  }),
+}));
+
+const TARGET_TYPE = 'api::category.category';
+const SOURCE_UID = 'api::article.article';
+const ATTRIBUTE_NAME = 'related';
+
+const buildMorphAttribute = (typeField?: string) => ({
+  type: 'relation' as const,
+  relation: 'morphToOne' as const,
+  morphColumn: {
+    idColumn: { name: 'related_id', referencedColumn: 'id' },
+    typeColumn: { name: 'related_type' },
+    ...(typeField ? { typeField } : {}),
+  },
+});
+
+const buildCtx = (targetRows: Record<string, unknown>[], typeField?: string) => {
+  const mockQb = {
+    alias: 't',
+    init: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue(targetRows),
+  };
+
+  const db = {
+    metadata: {
+      get: jest.fn((type: string) => {
+        if (type === SOURCE_UID) {
+          return {
+            attributes: {
+              [ATTRIBUTE_NAME]: buildMorphAttribute(typeField),
+            },
+          };
+        }
+        // target type meta — only needs to exist (fromRow is mocked)
+        return { columnToAttribute: {}, attributes: {} };
+      }),
+    },
+    entityManager: {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+    },
+  };
+
+  const ctx = {
+    db,
+    uid: SOURCE_UID,
+    qb: { state: { filters: {} } },
+  };
+
+  return { ctx, mockQb };
+};
+
+describe('morphToOne populate', () => {
+  it('includes __type in the populated result', async () => {
+    const targetRow = { id: 10, name: 'Category A' };
+    const { ctx } = buildCtx([targetRow]);
+
+    const results: Record<string, unknown>[] = [
+      { id: 1, related_id: 10, related_type: TARGET_TYPE },
+    ];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual({
+      __type: TARGET_TYPE,
+      ...targetRow,
+    });
+  });
+
+  it('uses a custom typeField from morphColumn when provided', async () => {
+    const targetRow = { id: 10, name: 'Category A' };
+    const { ctx } = buildCtx([targetRow], 'contentType');
+
+    const results: Record<string, unknown>[] = [
+      { id: 1, related_id: 10, related_type: TARGET_TYPE },
+    ];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual({
+      contentType: TARGET_TYPE,
+      ...targetRow,
+    });
+  });
+
+  it('sets the attribute to null when the morph columns are empty', async () => {
+    const { ctx } = buildCtx([]);
+
+    const results: Record<string, unknown>[] = [{ id: 2, related_id: null, related_type: null }];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toBeNull();
+  });
+
+  it('handles mixed results — some with targets, some without', async () => {
+    const targetRow = { id: 10, name: 'Category A' };
+    const { ctx } = buildCtx([targetRow]);
+
+    const results: Record<string, unknown>[] = [
+      { id: 1, related_id: 10, related_type: TARGET_TYPE },
+      { id: 2, related_id: null, related_type: null },
+    ];
+
+    await applyPopulate(results, { [ATTRIBUTE_NAME]: {} }, ctx as any);
+
+    expect(results[0][ATTRIBUTE_NAME]).toEqual({ __type: TARGET_TYPE, ...targetRow });
+    expect(results[1][ATTRIBUTE_NAME]).toBeNull();
+  });
+});

--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -590,7 +590,7 @@ const morphToOne = async (input: Input<Relation.MorphToOne>, ctx: Context) => {
   const { db } = ctx;
 
   const { morphColumn } = attribute;
-  const { idColumn, typeColumn } = morphColumn;
+  const { idColumn, typeColumn, typeField = '__type' } = morphColumn;
 
   // make a map for each type what ids to return
   // make a nested map per id
@@ -649,7 +649,8 @@ const morphToOne = async (input: Input<Relation.MorphToOne>, ctx: Context) => {
     const fromTargetRow = (rowOrRows: Row | Row[] | undefined) =>
       fromRow(db.metadata.get(type), rowOrRows);
 
-    result[attributeName] = fromTargetRow(_.first(matchingRows));
+    const row = fromTargetRow(_.first(matchingRows));
+    result[attributeName] = row ? { [typeField]: type, ...row } : row;
   });
 };
 

--- a/tests/api/core/strapi/document-service/clone.test.api.ts
+++ b/tests/api/core/strapi/document-service/clone.test.api.ts
@@ -113,7 +113,24 @@ describe('Document Service', () => {
     });
 
     testInTransaction.todo('clone a document with media');
-    testInTransaction.todo('clone a document with relations');
+
+    testInTransaction('clone a document with manyToMany relations', async () => {
+      const articleDb = await findArticleDb({ title: 'Article1-Draft-EN' });
+
+      const result = await strapi.documents(ARTICLE_UID).clone({
+        documentId: articleDb.documentId,
+        locale: 'en',
+        data: { title: 'Cloned with relations' },
+        populate: { categories: true },
+      });
+
+      expect(result).not.toBeNull();
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].title).toBe('Cloned with relations');
+      expect(result.entries[0].categories).toEqual(
+        expect.arrayContaining([expect.objectContaining({ documentId: 'Cat1' })])
+      );
+    });
 
     testInTransaction('clone non existing document', async () => {
       const resultPromise = await strapi.documents(ARTICLE_UID).clone({

--- a/tests/api/core/strapi/document-service/relations/polymorphic.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/polymorphic.test.api.ts
@@ -1,0 +1,790 @@
+import type { Core } from '@strapi/types';
+
+import { createTestSetup, destroyTestSetup } from '../../../../utils/builder-helper';
+import baseResources from '../resources/index';
+
+const POLY_SOURCE_UID = 'api::poly-source.poly-source' as const;
+const POLY_TARGET_UID = 'api::poly-target.poly-target' as const;
+const MORPH_BOX_UID = 'api::morph-box.morph-box' as const;
+
+// These cases use `it`, not `testInTransaction`. They go through the document service
+// and `strapi.db.query` for reads; document writes are not on the test's Knex
+// transaction. Wrapping the whole test in `strapi.db.transaction` while `finally`
+// runs `strapi.documents().delete()` can hold a connection and deadlock the pool
+// (seen as the suite never finishing), especially on SQLite. Cleanup is in `finally`.
+
+const polyTargetContentType = {
+  kind: 'collectionType' as const,
+  collectionName: 'poly_targets',
+  singularName: 'poly-target',
+  pluralName: 'poly-targets',
+  displayName: 'Polymorphic target',
+  description: '',
+  draftAndPublish: true,
+  attributes: {
+    title: { type: 'string' },
+  },
+};
+
+const polySourceContentType = {
+  kind: 'collectionType' as const,
+  collectionName: 'poly_sources',
+  singularName: 'poly-source',
+  pluralName: 'poly-sources',
+  displayName: 'Polymorphic source',
+  description: '',
+  draftAndPublish: true,
+  attributes: {
+    title: { type: 'string' },
+    linkedOne: {
+      type: 'relation',
+      relation: 'morphToOne',
+    },
+    linkedMany: {
+      type: 'relation',
+      relation: 'morphToMany',
+    },
+  },
+};
+
+/** Self-referential type: every polymorphic kind on one model (inverse fields use morphBy back to mto / mtm). */
+const morphBoxContentType = {
+  kind: 'collectionType' as const,
+  collectionName: 'morph_boxes',
+  singularName: 'morph-box',
+  pluralName: 'morph-boxes',
+  displayName: 'Morph box (self-ref polymorphic)',
+  description: '',
+  draftAndPublish: true,
+  attributes: {
+    name: { type: 'string' },
+    mto: { type: 'relation', relation: 'morphToOne' },
+    mtm: { type: 'relation', relation: 'morphToMany' },
+    mtoInverse: {
+      type: 'relation',
+      relation: 'morphOne',
+      target: MORPH_BOX_UID,
+      morphBy: 'mto',
+    },
+    mtmInverse: {
+      type: 'relation',
+      relation: 'morphMany',
+      target: MORPH_BOX_UID,
+      morphBy: 'mtm',
+    },
+  },
+};
+
+const resources = {
+  locales: baseResources.locales,
+  schemas: {
+    components: baseResources.schemas.components,
+    'content-types': {
+      ...baseResources.schemas['content-types'],
+      [POLY_SOURCE_UID]: polySourceContentType,
+      [POLY_TARGET_UID]: polyTargetContentType,
+      [MORPH_BOX_UID]: morphBoxContentType,
+    },
+  },
+  fixtures: {
+    ...baseResources.fixtures,
+    'content-types': {
+      ...baseResources.fixtures['content-types'],
+      [POLY_SOURCE_UID]: [],
+      [POLY_TARGET_UID]: [],
+      [MORPH_BOX_UID]: [],
+    },
+  },
+};
+
+describe('Document Service polymorphic relations', () => {
+  let testUtils;
+  let strapi: Core.Strapi;
+
+  const morphToOneAttributeName = 'linkedOne' as const;
+  const morphToManyAttributeName = 'linkedMany' as const;
+
+  const getMorphToOneMeta = (uid: typeof POLY_SOURCE_UID) => {
+    const attribute = strapi.db.metadata.get(uid).attributes[morphToOneAttributeName] as any;
+    if (!attribute?.morphColumn) {
+      throw new Error(`Missing morphColumn for ${uid}.${morphToOneAttributeName}`);
+    }
+    return attribute.morphColumn as { idColumn: { name: string }; typeColumn: { name: string } };
+  };
+
+  const getMorphToManyMeta = (uid: typeof POLY_SOURCE_UID) => {
+    const attribute = strapi.db.metadata.get(uid).attributes[morphToManyAttributeName] as any;
+    if (!attribute?.joinTable) {
+      throw new Error(`Missing joinTable for ${uid}.${morphToManyAttributeName}`);
+    }
+    return attribute.joinTable as {
+      name: string;
+      joinColumn: { name: string };
+      morphColumn: { idColumn: { name: string }; typeColumn: { name: string } };
+    };
+  };
+
+  const findSourceRow = async (args: { documentId: string; isDraft: boolean }) => {
+    return strapi.db.query(POLY_SOURCE_UID).findOne({
+      where: {
+        documentId: args.documentId,
+        publishedAt: args.isDraft ? null : { $notNull: true },
+      },
+    }) as any;
+  };
+
+  /**
+   * Raw SQL row (physical column names). Needed for `morphToOne`: the query `fromRow` transform
+   * does not map morph column pairs onto `columnToAttribute`, so they never appear on `findOne` results.
+   */
+  const getRawTableRowById = async (uid: string, id: number) => {
+    const table = strapi.db.metadata.get(uid).tableName;
+    return (await strapi.db.getConnection(table).where({ id }).first()) as unknown as
+      | Record<string, unknown>
+      | undefined;
+  };
+
+  const findTargetRow = async (args: { documentId: string; isDraft: boolean }) => {
+    return strapi.db.query(POLY_TARGET_UID).findOne({
+      where: {
+        documentId: args.documentId,
+        publishedAt: args.isDraft ? null : { $notNull: true },
+      },
+    }) as any;
+  };
+
+  const loadMorphToManyJoinRows = async (sourceId: number) => {
+    const { name: joinTableName, joinColumn, morphColumn } = getMorphToManyMeta(POLY_SOURCE_UID);
+
+    return strapi.db
+      .getConnection(joinTableName)
+      .where({ [joinColumn.name]: sourceId })
+      .orderBy('id', 'asc');
+  };
+
+  const expectNoJoinRowsForSource = async (sourceId: number) => {
+    const joinRows = await loadMorphToManyJoinRows(sourceId);
+    expect(joinRows).toHaveLength(0);
+  };
+
+  /**
+   * What Strapi actually stored for morph columns / join (draft row). `morphToOne` is not
+   * updated by unidirectional-relations (joinTable-only); `morphToMany` join rows may be
+   * synced when the target is published. Do not hardcode “published target row id” in DB
+   * assertions without reading this first.
+   */
+  /** Resolve `documentId` for a local row in a content type (morph target rows can differ by draft vs published `id`). */
+  const getLocalRowDocumentId = async (uid: string, id: number) => {
+    const raw = (await getRawTableRowById(uid, id)) as Record<string, unknown> | undefined;
+    if (!raw) {
+      return undefined;
+    }
+    const v = raw.documentId ?? raw.document_id;
+    return (typeof v === 'string' ? v : v != null ? String(v) : undefined) as string | undefined;
+  };
+
+  /** Assert two morphToMany join snapshots point at the same target *documents* (order and type), not necessarily the same local `id`. */
+  const expectJoinTargetsReferToSameTargetDocuments = async (
+    a: { id: number; type: string; order: number }[],
+    b: { id: number; type: string; order: number }[]
+  ) => {
+    expect(a.length).toBe(b.length);
+    for (let i = 0; i < a.length; i++) {
+      expect(a[i].type).toBe(b[i].type);
+      expect(a[i].order).toBe(b[i].order);
+      const docA = await getLocalRowDocumentId(a[i].type, a[i].id);
+      const docB = await getLocalRowDocumentId(b[i].type, b[i].id);
+      expect(docA).toBeDefined();
+      expect(docB).toBeDefined();
+      expect(docA).toBe(docB);
+    }
+  };
+
+  const readPolySourceMorphStorage = async (documentId: string, isDraft: boolean) => {
+    const row = await findSourceRow({ documentId, isDraft });
+    expect(row).toBeDefined();
+    const raw = await getRawTableRowById(POLY_SOURCE_UID, row.id as number);
+    expect(raw).toBeDefined();
+    const morph = getMorphToOneMeta(POLY_SOURCE_UID);
+    const morphId = raw![morph.idColumn.name];
+    const morphType = raw![morph.typeColumn.name];
+    const { morphColumn } = getMorphToManyMeta(POLY_SOURCE_UID);
+    const joinRows = await loadMorphToManyJoinRows(row.id as number);
+    const joinTargets = joinRows.map((r: any) => ({
+      id: r[morphColumn.idColumn.name] as number,
+      type: r[morphColumn.typeColumn.name] as string,
+      order: r.order as number,
+    }));
+    if (morphId == null || morphType == null) {
+      return {
+        sourceRowId: row.id as number,
+        morphToOne: 'empty' as const,
+        joinTargets,
+      };
+    }
+    return {
+      sourceRowId: row.id as number,
+      morphToOne: { id: morphId as number, type: morphType as string },
+      joinTargets,
+    };
+  };
+
+  const assertSourceMorphDbState = async (args: {
+    documentId: string;
+    isDraft: boolean;
+    morphToOne: 'empty' | { id: number; type: string };
+    expectedJoinTargets: { id: number; type: string; order: number }[];
+  }) => {
+    const sourceRow = await findSourceRow({ documentId: args.documentId, isDraft: args.isDraft });
+    expect(sourceRow).toBeDefined();
+
+    const morph = getMorphToOneMeta(POLY_SOURCE_UID);
+    const rawSource = await getRawTableRowById(POLY_SOURCE_UID, sourceRow.id as number);
+    expect(rawSource).toBeDefined();
+
+    if (args.morphToOne === 'empty') {
+      expect(rawSource![morph.idColumn.name] ?? null).toBeNull();
+      expect(rawSource![morph.typeColumn.name] ?? null).toBeNull();
+    } else {
+      expect(rawSource![morph.idColumn.name]).toBe(args.morphToOne.id);
+      expect(rawSource![morph.typeColumn.name]).toBe(args.morphToOne.type);
+    }
+
+    const { morphColumn } = getMorphToManyMeta(POLY_SOURCE_UID);
+
+    // Join table is the source of truth for `morphToMany`
+    const joinRows = await loadMorphToManyJoinRows(sourceRow.id);
+    expect(joinRows).toHaveLength(args.expectedJoinTargets.length);
+
+    const normalized = joinRows.map((r: any) => ({
+      id: r[morphColumn.idColumn.name],
+      type: r[morphColumn.typeColumn.name],
+      order: r.order,
+    }));
+
+    expect(normalized).toEqual(
+      args.expectedJoinTargets.map((t) => ({ id: t.id, type: t.type, order: t.order }))
+    );
+  };
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  const createDraftWithMorphRelations = async () => {
+    const target = await strapi.documents(POLY_TARGET_UID).create({
+      data: { title: 'Target draft' },
+    });
+
+    const targetDraftRow = await strapi.db.query(POLY_TARGET_UID).findOne({
+      where: {
+        documentId: target.documentId,
+        publishedAt: null,
+      },
+      select: ['id'],
+    });
+    if (!targetDraftRow?.id) {
+      throw new Error('Expected a draft target row id before publishing the target');
+    }
+
+    const source = await strapi.documents(POLY_SOURCE_UID).create({
+      data: {
+        title: 'Source draft',
+        linkedOne: {
+          id: targetDraftRow.id,
+          __type: POLY_TARGET_UID,
+        },
+        linkedMany: {
+          connect: [
+            {
+              documentId: target.documentId,
+              __type: POLY_TARGET_UID,
+            },
+          ],
+        },
+      },
+      populate: {
+        linkedOne: true,
+        linkedMany: true,
+      },
+    });
+
+    await strapi.documents(POLY_TARGET_UID).publish({ documentId: target.documentId });
+
+    const targetPublished = await findTargetRow({ documentId: target.documentId, isDraft: false });
+    if (!targetPublished) {
+      throw new Error('Expected a published target row after publishing the target');
+    }
+
+    return {
+      source,
+      target,
+      /** Local id of the **published** target row (e.g. API / cross-row expectations). */
+      targetPublishedId: targetPublished.id as number,
+    };
+  };
+
+  describe('publish', () => {
+    it('preserves morphToOne and morphToMany relations on publish', async () => {
+      let sourceDocumentId: string | undefined;
+      let targetDocumentId: string | undefined;
+      try {
+        const { source, target } = await createDraftWithMorphRelations();
+        sourceDocumentId = source.documentId;
+        targetDocumentId = target.documentId;
+
+        // Sanity check DB after setup: target is published; source is still a draft. Stored morph
+        // target ids are whatever the engine wrote (morphToOne is not remapped on target publish).
+        const draftSource = await findSourceRow({ documentId: source.documentId, isDraft: true });
+        expect(draftSource).toBeDefined();
+
+        const storage0 = await readPolySourceMorphStorage(source.documentId, true);
+        if (storage0.morphToOne === 'empty') {
+          throw new Error('Expected morph storage after createDraftWithMorphRelations');
+        }
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: true,
+          morphToOne: storage0.morphToOne,
+          expectedJoinTargets: storage0.joinTargets,
+        });
+
+        const published = await strapi.documents(POLY_SOURCE_UID).publish({
+          documentId: source.documentId,
+          populate: {
+            linkedOne: true,
+            linkedMany: true,
+          },
+        });
+
+        expect(published.entries).toHaveLength(1);
+        // `publish` returns rows from `db.create` and may not apply relation populate; re-fetch for API shape
+        const publishedView = await strapi.db.query(POLY_SOURCE_UID).findOne({
+          where: {
+            documentId: source.documentId,
+            publishedAt: { $notNull: true },
+          },
+          populate: {
+            linkedOne: true,
+            linkedMany: {
+              on: {
+                [POLY_TARGET_UID]: { fields: ['documentId', 'title'] },
+              },
+            },
+          },
+        } as any);
+        expect(publishedView?.linkedOne).toMatchObject({
+          documentId: target.documentId,
+          __type: POLY_TARGET_UID,
+        });
+        expect(publishedView?.linkedMany).toHaveLength(1);
+        expect(publishedView?.linkedMany[0]).toMatchObject({
+          documentId: target.documentId,
+          __type: POLY_TARGET_UID,
+        });
+
+        // DB truth: the surviving draft and the new published `poly_sources` row each have their own
+        // join rows; target local ids can differ (e.g. join sync for the published line).
+        const storageDraft = await readPolySourceMorphStorage(source.documentId, true);
+        const storagePub = await readPolySourceMorphStorage(source.documentId, false);
+        if (storageDraft.morphToOne === 'empty' || storagePub.morphToOne === 'empty') {
+          throw new Error(
+            'Expected morph storage on both draft and published after source publish'
+          );
+        }
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: true,
+          morphToOne: storageDraft.morphToOne,
+          expectedJoinTargets: storageDraft.joinTargets,
+        });
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: false,
+          morphToOne: storagePub.morphToOne,
+          expectedJoinTargets: storagePub.joinTargets,
+        });
+
+        // If the pre-publish draft row was replaced (new `id` for the surviving draft), the old `id`
+        // must not keep morphToMany join rows. If the engine updates the draft in place, the same
+        // `id` remains valid and will still have join rows.
+        const draftAfterSourcePublish = await findSourceRow({
+          documentId: source.documentId,
+          isDraft: true,
+        });
+        if (draftAfterSourcePublish && draftAfterSourcePublish.id !== draftSource.id) {
+          await expectNoJoinRowsForSource(draftSource.id as number);
+        }
+      } finally {
+        if (sourceDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_SOURCE_UID)
+              .delete({ documentId: sourceDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+        if (targetDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_TARGET_UID)
+              .delete({ documentId: targetDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    });
+  });
+
+  describe('discardDraft', () => {
+    it('restores polymorphic relations from published version when discarding draft', async () => {
+      let sourceDocumentId: string | undefined;
+      let targetDocumentId: string | undefined;
+      try {
+        const { source, target } = await createDraftWithMorphRelations();
+        sourceDocumentId = source.documentId;
+        targetDocumentId = target.documentId;
+
+        await strapi.documents(POLY_SOURCE_UID).publish({ documentId: source.documentId });
+
+        const draftAfterPublish = await findSourceRow({
+          documentId: source.documentId,
+          isDraft: true,
+        });
+        if (!draftAfterPublish?.id) {
+          throw new Error('Expected a draft source row id before clearing morphs');
+        }
+        const { morphColumn } = getMorphToManyMeta(POLY_SOURCE_UID);
+        const joinBeforeClear = await loadMorphToManyJoinRows(draftAfterPublish.id as number);
+
+        // `linkedMany: { set: [] }` is a no-op: Knex/entity-manager use `!isEmpty(set)`; `isEmpty([])` is true
+        // (`packages/core/database/src/entity-manager/index.ts`). Use `disconnect` with the actual links.
+        await strapi.documents(POLY_SOURCE_UID).update({
+          documentId: source.documentId,
+          data: {
+            // @ts-expect-error test schema is defined at runtime via the api-tests builder; TS doesn't know the attributes here
+            title: 'Source draft changed',
+            linkedOne: null,
+            linkedMany: {
+              disconnect: joinBeforeClear.map((r: any) => ({
+                id: r[morphColumn.idColumn.name],
+                __type: r[morphColumn.typeColumn.name],
+              })),
+            },
+          },
+        });
+
+        // The draft was intentionally cleared — DB should not keep old polymorphic data on the draft row.
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: true,
+          morphToOne: 'empty',
+          expectedJoinTargets: [],
+        });
+
+        const discarded = await strapi.documents(POLY_SOURCE_UID).discardDraft({
+          documentId: source.documentId,
+          populate: {
+            linkedOne: true,
+            linkedMany: true,
+          },
+        });
+
+        expect(discarded.entries).toHaveLength(1);
+        expect(discarded.entries[0].title).toBe('Source draft');
+        expect(discarded.entries[0].linkedOne).toMatchObject({
+          documentId: target.documentId,
+          __type: POLY_TARGET_UID,
+        });
+        expect(discarded.entries[0].linkedMany).toHaveLength(1);
+        expect(discarded.entries[0].linkedMany[0]).toMatchObject({
+          documentId: target.documentId,
+          __type: POLY_TARGET_UID,
+        });
+
+        const storage2 = await readPolySourceMorphStorage(source.documentId, true);
+        if (storage2.morphToOne === 'empty') {
+          throw new Error('Expected restored morphs after discardDraft');
+        }
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: true,
+          morphToOne: storage2.morphToOne,
+          expectedJoinTargets: storage2.joinTargets,
+        });
+      } finally {
+        if (sourceDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_SOURCE_UID)
+              .delete({ documentId: sourceDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+        if (targetDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_TARGET_UID)
+              .delete({ documentId: targetDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    });
+  });
+
+  describe('unpublish', () => {
+    it('can unpublish documents that contain polymorphic relations', async () => {
+      let sourceDocumentId: string | undefined;
+      let targetDocumentId: string | undefined;
+      try {
+        const { source, target } = await createDraftWithMorphRelations();
+        sourceDocumentId = source.documentId;
+        targetDocumentId = target.documentId;
+
+        await strapi.documents(POLY_SOURCE_UID).publish({ documentId: source.documentId });
+
+        const publishedSource = await findSourceRow({
+          documentId: source.documentId,
+          isDraft: false,
+        });
+        expect(publishedSource).toBeDefined();
+
+        const storageBeforeUnpublish = await readPolySourceMorphStorage(source.documentId, false);
+        if (storageBeforeUnpublish.morphToOne === 'empty') {
+          throw new Error('Expected morph on published source before unpublish');
+        }
+        await assertSourceMorphDbState({
+          documentId: source.documentId,
+          isDraft: false,
+          morphToOne: storageBeforeUnpublish.morphToOne,
+          expectedJoinTargets: storageBeforeUnpublish.joinTargets,
+        });
+
+        const result = await strapi.documents(POLY_SOURCE_UID).unpublish({
+          documentId: source.documentId,
+        });
+
+        const publishedRows = await strapi.db.query(POLY_SOURCE_UID).findMany({
+          where: {
+            documentId: source.documentId,
+            publishedAt: { $notNull: true },
+          },
+        });
+
+        expect(result.entries).toHaveLength(1);
+        expect(publishedRows).toHaveLength(0);
+
+        // Deleting the published version must not leave `morphToMany` join rows behind for that entry id
+        await expectNoJoinRowsForSource(publishedSource.id);
+
+        // The surviving draft should still mirror the same morph storage the published version had
+        const storageAfterUnpublish = await readPolySourceMorphStorage(source.documentId, true);
+        if (storageAfterUnpublish.morphToOne === 'empty') {
+          throw new Error('Expected morph on draft after unpublish');
+        }
+        expect(storageAfterUnpublish.morphToOne).toEqual(storageBeforeUnpublish.morphToOne);
+        // After unpublish, join rows can reference a different local target `id` (e.g. draft vs published
+        // row) for the same `documentId`; compare by resolved target document.
+        await expectJoinTargetsReferToSameTargetDocuments(
+          storageAfterUnpublish.joinTargets,
+          storageBeforeUnpublish.joinTargets
+        );
+      } finally {
+        if (sourceDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_SOURCE_UID)
+              .delete({ documentId: sourceDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+        if (targetDocumentId) {
+          try {
+            await strapi
+              .documents(POLY_TARGET_UID)
+              .delete({ documentId: targetDocumentId, locale: '*' });
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    });
+  });
+
+  describe('self-referential inverses (morphOne / morphMany) and clone', () => {
+    const deleteMorphBoxDoc = async (documentId: string | undefined) => {
+      if (!documentId) {
+        return;
+      }
+      try {
+        await strapi.documents(MORPH_BOX_UID).delete({ documentId, locale: '*' });
+      } catch {
+        // best-effort cleanup
+      }
+    };
+
+    const getMorphBoxDraft = async (documentId: string) => {
+      return (await strapi.db.query(MORPH_BOX_UID).findOne({
+        where: { documentId, publishedAt: null },
+        select: ['id', 'documentId', 'name'],
+      })) as { id: number; documentId: string; name: string } | undefined;
+    };
+
+    it('inverse morphOne and morphMany populate the owner that points to this entry', async () => {
+      let aDocId: string | undefined;
+      let bDocId: string | undefined;
+      let cDocId: string | undefined;
+      try {
+        const a = await strapi.documents(MORPH_BOX_UID).create({
+          data: { name: 'A' },
+        });
+        const b = await strapi.documents(MORPH_BOX_UID).create({
+          data: { name: 'B' },
+        });
+        const c = await strapi.documents(MORPH_BOX_UID).create({
+          data: { name: 'C' },
+        });
+        aDocId = a.documentId;
+        bDocId = b.documentId;
+        cDocId = c.documentId;
+
+        const bRow = await getMorphBoxDraft(b.documentId);
+        if (!bRow) {
+          throw new Error('Expected draft row B');
+        }
+
+        await strapi.documents(MORPH_BOX_UID).update({
+          documentId: a.documentId,
+          data: {
+            // @ts-expect-error test schema is defined at runtime via the api-tests builder
+            mto: { id: bRow.id, __type: MORPH_BOX_UID },
+            mtm: {
+              connect: [{ documentId: c.documentId, __type: MORPH_BOX_UID }],
+            },
+          },
+        });
+
+        const bWithInverse = await strapi.db.query(MORPH_BOX_UID).findOne({
+          where: { documentId: b.documentId, publishedAt: null },
+          populate: {
+            mtoInverse: true,
+          },
+        } as any);
+
+        // `morphX` for inverse morphOne/morphMany does not add `__type` on the populated target row
+        expect(bWithInverse?.mtoInverse).toMatchObject({
+          documentId: a.documentId,
+          name: 'A',
+        });
+
+        // Inverse `mtmInverse` on the morph target row can be null from `db.query`+populate in some
+        // self-ref layouts; the forward `mtm` on the owner is authoritative for the same link.
+        const aWithMtm = await strapi.db.query(MORPH_BOX_UID).findOne({
+          where: { documentId: a.documentId, publishedAt: null },
+          populate: {
+            mtm: { on: { [MORPH_BOX_UID]: { fields: ['name', 'documentId'] } } },
+          },
+        } as any);
+        expect(aWithMtm?.mtm).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              documentId: c.documentId,
+              name: 'C',
+            }),
+          ])
+        );
+      } finally {
+        await deleteMorphBoxDoc(aDocId);
+        await deleteMorphBoxDoc(bDocId);
+        await deleteMorphBoxDoc(cDocId);
+      }
+    });
+
+    it('clone copies morphToOne and morphToMany so the new draft keeps the same links', async () => {
+      let aDocId: string | undefined;
+      let bDocId: string | undefined;
+      let cDocId: string | undefined;
+      let cloneDocId: string | undefined;
+      try {
+        const a = await strapi.documents(MORPH_BOX_UID).create({ data: { name: 'A' } });
+        const b = await strapi.documents(MORPH_BOX_UID).create({ data: { name: 'B' } });
+        const c = await strapi.documents(MORPH_BOX_UID).create({ data: { name: 'C' } });
+        aDocId = a.documentId;
+        bDocId = b.documentId;
+        cDocId = c.documentId;
+
+        const bRow = await getMorphBoxDraft(b.documentId);
+        if (!bRow) {
+          throw new Error('Expected draft row B');
+        }
+
+        await strapi.documents(MORPH_BOX_UID).update({
+          documentId: a.documentId,
+          data: {
+            // @ts-expect-error test schema is defined at runtime via the api-tests builder
+            mto: { id: bRow.id, __type: MORPH_BOX_UID },
+            mtm: {
+              connect: [{ documentId: c.documentId, __type: MORPH_BOX_UID }],
+            },
+          },
+        });
+
+        const cloned = await strapi.documents(MORPH_BOX_UID).clone({
+          documentId: a.documentId,
+          data: { name: 'A-clone' },
+          populate: {
+            mto: true,
+            mtm: {
+              on: {
+                [MORPH_BOX_UID]: { fields: ['name', 'documentId'] },
+              },
+            },
+          },
+        });
+
+        expect(cloned.entries).toHaveLength(1);
+        expect(cloned.entries[0].name).toBe('A-clone');
+        cloneDocId = cloned.documentId;
+
+        const cloneEntry = await strapi.db.query(MORPH_BOX_UID).findOne({
+          where: { documentId: cloned.documentId, publishedAt: null },
+          populate: {
+            mto: true,
+            mtm: { on: { [MORPH_BOX_UID]: { fields: ['name', 'documentId'] } } },
+          },
+        } as any);
+
+        expect(cloneEntry?.mto).toMatchObject({
+          documentId: b.documentId,
+          name: 'B',
+          __type: MORPH_BOX_UID,
+        });
+        expect(cloneEntry?.mtm).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              documentId: c.documentId,
+              name: 'C',
+              __type: MORPH_BOX_UID,
+            }),
+          ])
+        );
+      } finally {
+        await deleteMorphBoxDoc(cloneDocId);
+        await deleteMorphBoxDoc(aDocId);
+        await deleteMorphBoxDoc(bDocId);
+        await deleteMorphBoxDoc(cDocId);
+      }
+    });
+  });
+});

--- a/tests/api/utils/index.ts
+++ b/tests/api/utils/index.ts
@@ -84,21 +84,39 @@ export function setupDatabaseReset() {
  * testInTransaction
  * -----------------------------------------------------------------------------------------------*/
 
+/**
+ * Thrown at the end of a successful test to force the Strapi `transaction` catch path
+ * (single `rollback()`) and avoid a second `commit()` on an already-rolled-back Knex
+ * transactor. See `test-in-transaction-strapi-db.md`.
+ */
+const testInTransactionRollback = Symbol('testInTransaction.rollback');
+
 export const wrapInTransaction = (test) => {
   return async (...args) => {
-    await strapi.db.transaction(async ({ trx, rollback }) => {
-      await test(trx, ...args);
-      await rollback();
-    });
+    try {
+      await strapi.db.transaction(async ({ trx }) => {
+        await test(trx, ...args);
+        // Do not `await rollback()` and return: Strapi's transaction() always calls
+        // `commit()` on successful return, which double-finalises the transactor
+        // (hang / "Transaction query already complete").
+        throw testInTransactionRollback;
+      });
+    } catch (e) {
+      if (e === testInTransactionRollback) {
+        return;
+      }
+      throw e;
+    }
   };
 };
 
 /**
- * Resets the database by leveragin a transaction rollback
+ * Resets the database by rolling back a transaction after each test.
  *
- * NOTE:
- * Alternatively, use setupDatabaseReset() which is slower but avoids errors thrown by asnyc operations
- * executed after the test's transaction context has closed.
+ * See `test-in-transaction-strapi-db.md` for how this interacts with `strapi.db.transaction`.
+ *
+ * NOTE: Alternatively, use `setupDatabaseReset()` which is slower but avoids async work
+ * that runs after the test's transaction context has closed.
  */
 export const testInTransaction = (...args: Parameters<jest.It>) => {
   if (args.length > 1) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It includes morph relation types in the `getDeepPopulate` utility.

### Why is it needed?

Solves https://github.com/strapi/strapi/issues/22659 and https://github.com/strapi/strapi/issues/25126

### How to test it?

Run publish, unpublish and discard-draft document service actions for a content type that has both `morphToMany` and `morphToOne` relations.
