### PR TITLE
fix(review-workflows): pass locale params to useDocument in StageSelect and AssigneeSelect

### DIFF
--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/AssigneeSelect.tsx
@@ -47,6 +47,7 @@ const AssigneeSelect = ({ isCompact }: { isCompact?: boolean }) => {
       collectionType,
       model,
       documentId: id,
+      params,
     },
     {
       skip: !id && collectionType !== 'single-types',

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/id/components/StageSelect.tsx
@@ -173,6 +173,7 @@ export const StageSelect = ({ isCompact }: { isCompact?: boolean }) => {
       collectionType,
       model,
       documentId: id,
+      params,
     },
     {
       skip: !id && collectionType !== 'single-types',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
`StageSelect` and `AssigneeSelect` were calling `unstable_useDocument` without the query `params` (which carry the active locale). Because RTK Query uses the full args object as its cache key, a call without `params` is a separate cache entry from a call with `params: { locale: 'fr' }` — it makes its own request and gets the default locale's document back.

This change passes params to unstable_useDocument in both components:

`unstable_useDocument({ collectionType, model, documentId: id, params }`

### Why is it needed?

When editing a non-default locale entry with review workflows enabled, the stage and assignee panel reads from a document fetch that has no locale — so it always reflects the default locale's values. After updating the stage or assignee (both mutations already pass `params` correctly), the cache invalidation triggers a refetch that still omits the locale, so the panel appears unchanged even though the backend was updated correctly.

This aligns `unstable_useDocument` with the locale already used by `useUpdateStageMutation`, `useUpdateAssigneeMutation`, and `useGetStagesQuery` in those same components.

### How to test it?

1. Enable i18n on a content type that has review workflows assigned.
2. Create an entry with both a default locale and a non-default locale (e.g. fr).
3. Switch to the French locale in the content manager edit view and open the Review Workflows panel.
4. **Before**: the stage and assignee shown reflect the default locale, not French. Updating the stage appears to have no effect — the panel doesn't change after save.
5. **After**: the panel correctly reflects the French locale's stage and assignee, and updates are visible immediately after save.

### Related issue(s)/PR(s)

None on file. Happy to open an issue if preferred.

Related to Internal Ticket ID: 7885

