### PR TITLE
fix(content-manager): guard against undefined component schema in formatEditLayout

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -285,6 +285,10 @@ const formatEditLayout = (
 
   const componentEditAttributes = Object.entries(data.components).reduce<EditLayout['components']>(
     (acc, [uid, configuration]) => {
+      if (!components[uid]) {
+        return acc;
+      }
+
       acc[uid] = {
         layout: convertEditLayoutToFieldLayouts(
           configuration.layouts.edit,


### PR DESCRIPTION
## What does it do?
Adds a null-check guard in `formatEditLayout` inside `useDocumentLayout.ts` to skip components that are not yet present in the client-side schema cache.
## Why is it needed?
When a new component is created inline through an existing single type in the Content-Type Builder, the component schema is not immediately available in the client-side `components` cache dictionary.

`formatEditLayout` was iterating over `data.components` (from the API response) and directly accessing `components[uid].attributes` without checking if the schema existed in cache, causing a fatal crash:

TypeError: Cannot read properties of undefined (reading 'attributes')

This crash shows the "Something went wrong" error screen in the Content Manager, making the single type inaccessible until Strapi is restarted.
## How to test it?
1. Open Content-Type Builder
2. Create a new Single Type (e.g. HomePage)
3. Add a field, then click "Add another field to this type"
4. Create a new component inline (not from existing components)
5. Add fields to the component and save
6. Navigate to Content Manager → the Single Type
7. Previously: crash with "Something went wrong" error
8. Now: page loads correctly with the component field visible

Environment:
- Strapi v5
- SQLite
- TypeScript
## Related issue(s)/PR(s)
Fix #25790