### PR TITLE
Restructure SECURITY.md supported versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,14 +4,13 @@
 
 As of May 2026 (and until this document is updated), v5.x.x _GA_ or _STABLE_ releases of Strapi are supported for updates and bug fixes. Any previous versions are not supported and users are advised to use them "at their own risk".
 
-| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes       |
-| ------- | ----------- | -------------- | -------------- | ---------------------- | ----------- |
-| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS         |
-| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life |
-| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life |
-| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life |
-| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | End Of Life |
-| 3.x.x   | GA / Stable | May 2020       | November 2022  | November 2022          | End Of Life |
+| Version | Support Starts | Support Ends  | Security Updates Until | Notes       |
+| ------- | -------------- | ------------- | ---------------------- | ----------- |
+| 5.x.x   | September 2024 |               |                        | LTS         |
+| 4.x.x   | November 2021  | October 2025  | April 2026             | End Of Life |
+| 3.x.x   | May 2020       | November 2022 | November 2022          | End Of Life |
+
+Non-stable releases (RC, Beta, Alpha) are considered End Of Life once the corresponding GA/Stable version is released.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,16 +6,13 @@ As of October 2025 (and until this document is updated), v5.x.x _GA_ or _STABLE_
 
 **Note**: The v4.x.x LTS version will only receive high/critical severity **SECURITY** fixes until April 2026. No further bug fixes releases will be made.
 
-| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes         |
-| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------- |
-| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS           |
-| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | End Of Life   |
-| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life   |
-| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life   |
-| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | Security Only |
-| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | End Of Life   |
-| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | End Of Life   |
-| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life   |
+| Version | Support Starts | Support Ends   | Security Updates Until | Notes         |
+| ------- | -------------- | -------------- | ---------------------- | ------------- |
+| 5.x.x   | September 2024 |                |                        | LTS           |
+| 4.x.x   | November 2021  | October 2025   | April 2026             | Security Only |
+| 3.x.x   | May 2020       | February 2022  | February 2022          | End Of Life   |
+
+Non-stable releases (RC, Beta, Alpha) are considered End Of Life once the corresponding GA/Stable version is released.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

This PR restructures the supported versions table in SECURITY.md to have one row per major version (GA/Stable only), making it more concise and machine-readable.

## Changes

- Remove RC/Beta/Alpha rows from the table — these are implicitly End Of Life once the corresponding GA/Stable version is released, so documenting them separately adds noise
- Replace `Further Notice` with empty cells (unknown/TBD dates)
- Add actual dates for v3 instead of `N/A`
- Add a single sentence clarifying the non-stable release policy

## Motivation

This is requested as part of adding Strapi to [endoflife.date](https://endoflife.date), a community website that tracks end-of-life dates for software products. The restructured table can be automatically parsed by the endoflife.date bot to keep EOL dates up to date without manual intervention.

See: https://github.com/endoflife-date/endoflife.date/pull/9978