### PR TITLE
fix: contain absolute descendants in OverflowingItem

### DIFF
--- a/packages/core/admin/admin/src/components/Layouts/Layout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/Layout.tsx
@@ -41,6 +41,7 @@ const SideNavContainer = styled(Flex)`
 `;
 
 const OverflowingItem = styled(Box)`
+  position: relative;
   overflow-x: hidden;
 
   ${({ theme }) => theme.breakpoints.medium} {

--- a/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.tsx.snap
+++ b/packages/core/upload/admin/src/pages/App/ConfigureTheView/tests/__snapshots__/ConfigureTheView.test.tsx.snap
@@ -323,6 +323,7 @@ exports[`Upload - Configure initial render renders and matches the snapshot 1`] 
 }
 
 .c2 {
+  position: relative;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
…w scroll on list view

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds position: relative to the `OverflowingItem` styled component in `packages/core/admin/admin/src/components/Layouts/Layout.tsx`. This makes `OverflowingItem` the containing block for any absolutely-positioned descendants (VisuallyHidden a11y spans, Radix overlays, etc.) rendered inside the main content area.

### Why is it needed?

Large collection types caused a double scrollbar on the list view in Chromium browsers, letting users scroll past the entries.
`OverflowingItem` and every ancestor up to <html> were `position: static`. Absolutely-positioned descendants inside the main content therefore resolved their containing block to the initial containing block (the viewport / <html>). Their absolute coordinates inflated `html.scrollHeight` , which Chrome surfaces as a real window-level scrollbar — appearing alongside the intended `OverflowingItem` scroll. Firefox computes `html.scrollHeight` differently and doesn't include those descendants, which is why the bug only reproduced in Chromium.
Making `OverflowingItem` a containing block anchors those descendants inside it (and inside its overflow: hidden clipping region), collapsing `html.scrollHeight` back to viewport height and removing the second scrollbar.

[26109-fix.webm](https://github.com/user-attachments/assets/d98f8b41-0238-4294-9921-68dc9083be2a)

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #26109 
