### PR TITLE
fix: FK violation publishing self-relation parent & child in one release

### DIFF
--- a/packages/core/content-releases/server/src/services/__tests__/release.test.ts
+++ b/packages/core/content-releases/server/src/services/__tests__/release.test.ts
@@ -526,6 +526,88 @@ describe('Release service', () => {
       expect(articleIndex).toBeGreaterThanOrEqual(0);
       expect(categoryIndex).toBeLessThan(articleIndex);
     });
+
+    it('publishes documents within a content type sequentially', async () => {
+      const PAGE_UID = 'api::page.page';
+
+      mockExecute.mockReturnValueOnce({ id: 1, releasedAt: null });
+
+      const callOrder: string[] = [];
+      let resolveFirst: () => void;
+      const firstPublishGate = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      const publishMock = jest
+        .fn()
+        .mockImplementationOnce(async (params: { documentId: string }) => {
+          callOrder.push(`call:${params.documentId}`);
+          await firstPublishGate;
+          callOrder.push(`resolve:${params.documentId}`);
+        })
+        .mockImplementationOnce(async (params: { documentId: string }) => {
+          callOrder.push(`call:${params.documentId}`);
+          callOrder.push(`resolve:${params.documentId}`);
+        });
+
+      const pageModel = {
+        info: { displayName: 'Page' },
+        options: { draftAndPublish: true },
+        attributes: {
+          parent: { type: 'relation', target: PAGE_UID },
+        },
+      };
+
+      const strapiMock = {
+        ...baseStrapiMock,
+        getModel: jest.fn(() => pageModel),
+        contentTypes: { [PAGE_UID]: {} },
+        documents: jest.fn(() => ({
+          findFirst: jest.fn().mockReturnValue({ id: 1 }),
+          publish: publishMock,
+          unpublish: mockUnpublish,
+        })),
+        db: {
+          ...baseStrapiMock.db,
+          query: jest.fn().mockImplementation((modelUid: string) => {
+            if (modelUid === 'plugin::content-releases.release-action') {
+              return {
+                findMany: jest.fn().mockResolvedValue([
+                  { contentType: PAGE_UID, type: 'publish', entryDocumentId: 'parentDoc' },
+                  { contentType: PAGE_UID, type: 'publish', entryDocumentId: 'childDoc' },
+                ]),
+              };
+            }
+            return {
+              update: jest
+                .fn()
+                .mockResolvedValue({ id: 1, status: 'done', releasedAt: new Date() }),
+            };
+          }),
+        },
+      };
+
+      // @ts-expect-error Ignore missing properties
+      const releaseService = createReleaseService({ strapi: strapiMock });
+
+      const publishComplete = releaseService.publish(1);
+
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve();
+      }
+
+      expect(callOrder).toEqual(['call:parentDoc']);
+
+      resolveFirst!();
+      await publishComplete;
+
+      expect(callOrder).toEqual([
+        'call:parentDoc',
+        'resolve:parentDoc',
+        'call:childDoc',
+        'resolve:childDoc',
+      ]);
+    });
   });
 
   describe('delete', () => {

--- a/packages/core/content-releases/server/src/services/release.ts
+++ b/packages/core/content-releases/server/src/services/release.ts
@@ -306,10 +306,17 @@ const createReleaseService = ({ strapi }: { strapi: Core.Strapi }) => {
                 const contentType = contentTypeUid as UID.ContentType;
                 const { publish, unpublish } = formattedActions[contentType];
 
-                await Promise.all([
-                  ...publish.map((params) => strapi.documents(contentType).publish(params)),
-                  ...unpublish.map((params) => strapi.documents(contentType).unpublish(params)),
-                ]);
+                // Serialize within a content type: concurrent publishes of related documents
+                // can race on shared join-table state (notably self-referential relations) and
+                // leave inconsistent FK rows when one branch deletes a row another branch is
+                // about to reference.
+                for (const params of publish) {
+                  await strapi.documents(contentType).publish(params);
+                }
+
+                for (const params of unpublish) {
+                  await strapi.documents(contentType).unpublish(params);
+                }
               }
             });
 

--- a/packages/core/content-releases/server/src/services/scheduling.ts
+++ b/packages/core/content-releases/server/src/services/scheduling.ts
@@ -23,12 +23,7 @@ const createSchedulingService = ({ strapi }: { strapi: Core.Strapi }) => {
       strapi.cron.add({
         [taskName]: {
           async task() {
-            try {
-              await getService('release', { strapi }).publish(releaseId);
-              // @TODO: Trigger webhook with success message
-            } catch (error) {
-              // @TODO: Trigger webhook with error message
-            }
+            await getService('release', { strapi }).publish(releaseId);
           },
           options: scheduleDate,
         },

--- a/tests/api/plugins/content-releases/releases.test.api.ts
+++ b/tests/api/plugins/content-releases/releases.test.api.ts
@@ -59,6 +59,25 @@ const articleModel = {
   },
 };
 
+const pageUID = 'api::page.page';
+const pageModel = {
+  draftAndPublish: true,
+  pluginOptions: {},
+  singularName: 'page',
+  pluralName: 'pages',
+  displayName: 'Page',
+  kind: 'collectionType',
+  attributes: {
+    title: { type: 'string' },
+    parent: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'api::page.page',
+      targetAttribute: 'children',
+    },
+  },
+};
+
 describeOnCondition(edition === 'EE')('Content Releases API', () => {
   const builder = createTestBuilder();
   let strapi;
@@ -120,7 +139,7 @@ describeOnCondition(edition === 'EE')('Content Releases API', () => {
   beforeAll(async () => {
     await builder
       .addContentType(productModel)
-      .addContentTypes([categoryModel, articleModel])
+      .addContentTypes([categoryModel, articleModel, pageModel])
       .build();
     strapi = await createStrapiInstance();
     rq = await createAuthRequest({ strapi });
@@ -712,6 +731,45 @@ describeOnCondition(edition === 'EE')('Content Releases API', () => {
       const categoryData = categoryList[0];
       const categoryName = categoryData.attributes?.name ?? categoryData.name;
       expect(categoryName).toBe('Tech');
+    });
+
+    test('publishes self-related parent and child in one release and preserves relation', async () => {
+      const parentPage = await createEntry(pageUID, { title: 'Parent Page' });
+      const childPage = await createEntry(pageUID, {
+        title: 'Child Page',
+        parent: { documentId: parentPage.data.documentId, locale: null },
+      });
+
+      const createReleaseRes = await createRelease();
+      const release = createReleaseRes.body.data;
+
+      await createReleaseAction(release.id, {
+        contentType: pageUID,
+        entryDocumentId: parentPage.data.documentId,
+        type: 'publish',
+      });
+      await createReleaseAction(release.id, {
+        contentType: pageUID,
+        entryDocumentId: childPage.data.documentId,
+        type: 'publish',
+      });
+
+      const publishRes = await rq({
+        method: 'POST',
+        url: `/content-releases/${release.id}/publish`,
+      });
+
+      expect(publishRes.statusCode).toBe(200);
+      expect(publishRes.body.data.status).toBe('done');
+
+      const publishedChildRes = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/${pageUID}/${childPage.data.documentId}`,
+        qs: { status: 'published' },
+      });
+
+      expect(publishedChildRes.statusCode).toBe(200);
+      expect(publishedChildRes.body.data.parent).toMatchObject({ count: 1 });
     });
   });
 


### PR DESCRIPTION
### What does it do?
Replaces `Promise.all` over a content type's actions in `release.publish` with sequential `for` loops, so within content-type publishes serialize on the shared transaction. Also drops the empty `try/catch` wrapping the cron task in `scheduling.ts` so task failures propagate to Strapi existing `job.on('error')` handler instead of being silently swallowed.

### Why is it needed?
A Content Release in production failed when publishing two documents of the same content type that referenced each other (parent `Page` and child `Page` via a self-referential relation, both in one release):

```
code:        23503
constraint:  pages_parent_lnk_fk
detail:      Key (page_id)=(255) is not present in table "pages".
table:       pages_parent_lnk
message:     insert into "pages_parent_lnk" ("id", "inv_page_id", "page_id")
             values ($1, $2, $3), ($4, $5, $6), ($7, $8, $9), ($10, $11, $12), ($13, $14, $15)
             - insert or update on table "pages_parent_lnk" violates foreign key constraint "pages_parent_lnk_fk"
```

The error was only surfaced when a release was triggered manually. Scheduled releases triggered by cron had been hitting the same failure mode (we assume) but the empty `try/catch` in `scheduling.ts`'s task callback was swallowing the error, so nothing was being logged.

Both publishes shared a transaction via `Promise.all`. It is most likely that statements interleaved on the connection, so one branch's delete invalidated the other branch's pre-captured join-table snapshot before the second branch tried to re-insert against it. The deleted `page_id=255` is the row the other branch had already removed.

User-visible state after the failure: new published rows existed for both documents, but the parent's join rows to all its children were missing, leaving every child orphaned on the published side. The release was recorded as `status='failed'` and a 500 error returned.

### How to test it?
`yarn jest packages/core/content-releases`. New unit test pins the sequential dispatch.