### PR TITLE
fix(content-manager): prevent crash on detached DZ component

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/data.ts
@@ -81,6 +81,15 @@ const traverseData =
           return acc;
         }
 
+        // The schema may not contain the attribute when historical data references a
+        // component or field that no longer exists (e.g. a component detached from a
+        // dynamic zone via the content-type-builder). Pass the value through so the
+        // History view can still render the rest of the document.
+        if (!attribute) {
+          acc[key] = value;
+          return acc;
+        }
+
         if (attribute.type === 'component') {
           if (attribute.repeatable) {
             const componentValue = (

--- a/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
+++ b/packages/core/content-manager/admin/src/pages/EditView/utils/tests/data.test.ts
@@ -1,5 +1,10 @@
 import { testData } from '../../../../tests/data';
-import { getDirectParent, handleInvisibleAttributes, removeProhibitedFields } from '../data';
+import {
+  getDirectParent,
+  handleInvisibleAttributes,
+  prepareTempKeys,
+  removeProhibitedFields,
+} from '../data';
 
 const defaultFieldsValues = {
   name: 'name',
@@ -523,6 +528,37 @@ describe('data', () => {
       });
       expect(result.data).not.toHaveProperty('internationalCode');
       expect(result.removedAttributes).toEqual(['internationalCode']);
+    });
+  });
+
+  describe('prepareTempKeys', () => {
+    it('does not crash when DZ data references a component missing from the schemas dict', () => {
+      const schema = {
+        attributes: {
+          dz: {
+            type: 'dynamiczone',
+            components: ['shared.kept'],
+          },
+        },
+      } as const;
+
+      const components = {
+        'shared.kept': {
+          attributes: {
+            label: { type: 'string' as const },
+          },
+        },
+      };
+
+      const data = {
+        dz: [
+          { __component: 'shared.kept', id: 1, label: 'still here' },
+          { __component: 'shared.detached', id: 2, label: 'gone from schema' },
+        ],
+      };
+
+      // @ts-expect-error - test data shape doesn't need full schema typing
+      expect(() => prepareTempKeys(schema, components)(data)).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
### What does it do?

Adds an early return in `traverseData` (`packages/core/content-manager/admin/src/pages/EditView/utils/data.ts`) when an attribute is absent from the schema dict. The traversal now passes the value through unchanged instead of crashing on `attribute.type`.

### Why is it needed?

When a component is detached from a dynamic zone (or deleted) via the content-type-builder, `extractContentTypeComponents` rebuilds the component dictionary from the current content type only — the orphaned component is dropped. Stored history version `data` still references it via `__component`.
The recursive traversal in `prepareTempKeys` lands on `attributes = {}` and throws `Cannot read properties of undefined (reading 'type')` at line 84, blocking the entire History page.

### How to test it?

1. Create a content type with a dynamic zone and add 2 or more components
2. Create an entry, add at least one of each component to the DZ, save
3. Open the content-type-builder → edit the DZ → remove one component from the allowed list → save
4. Go back to the entry → open Content History
→ Before the fix: the page crashes with `Cannot read properties of undefined (reading 'type')`                                                         
→ After the fix: history versions render. Orphaned DZ items are present in the data without per-field rendering.

Unit test: `yarn test:front --testPathPattern="EditView/utils/tests/data.test"`

### Related issue(s)/PR(s)

Fix #23300

🚀