### PR TITLE
fix(core): reject 'status' attribute when draftAndPublish is enabled

### DIFF
--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/content-type.test.ts
@@ -57,13 +57,13 @@ describe('Content type validator', () => {
         expect(err).toMatchObject({
           name: 'ValidationError',
           message:
-            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, status, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*',
+            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
           details: {
             errors: [
               {
                 path: ['contentType', 'attributes', 'entryId'],
                 message:
-                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, status, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*',
+                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
                 name: 'ValidationError',
               },
             ],
@@ -93,13 +93,13 @@ describe('Content type validator', () => {
         expect(err).toMatchObject({
           name: 'ValidationError',
           message:
-            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, status, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*',
+            'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
           details: {
             errors: [
               {
                 path: ['contentType', 'attributes', 'ENTRY_ID'],
                 message:
-                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, status, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*',
+                  'Attribute keys cannot be one of id, document_id, created_at, updated_at, published_at, created_by_id, updated_by_id, created_by, updated_by, entry_id, localizations, meta, locale, __component, __contentType, strapi*, _strapi*, __strapi*, status',
                 name: 'ValidationError',
               },
             ],

--- a/packages/core/content-type-builder/server/src/services/builder.ts
+++ b/packages/core/content-type-builder/server/src/services/builder.ts
@@ -1,54 +1,14 @@
-import { snakeCase } from 'lodash/fp';
+import { contentTypes } from '@strapi/utils';
 
-// use snake_case
-export const reservedAttributes = [
-  // TODO: these need to come from a centralized place so we don't break things accidentally in the future and can share them outside the CTB, for example on Strapi bootstrap prior to schema db sync
-
-  // ID fields
-  'id',
-  'document_id',
-
-  // Creator fields
-  'created_at',
-  'updated_at',
-  'published_at',
-  // V6: we will need to add first_published_at when it becomes the default behaviour
-  'created_by_id',
-  'updated_by_id',
-  // does not actually conflict because the fields are called *_by_id but we'll leave it to avoid confusion
-  'created_by',
-  'updated_by',
-
-  // Used for Strapi functionality
-  'entry_id',
-  'status',
-  'localizations',
-  'meta',
-  'locale',
-  '__component',
-  '__contentType',
-
-  // We support ending with * to denote prefixes
-  'strapi*',
-  '_strapi*',
-  '__strapi*',
-];
-
-// use snake_case
-export const reservedModels = [
-  'boolean',
-  'date',
-  'date_time',
-  'time',
-  'upload',
-  'document',
-  'then', // no longer an issue but still restricting for being a javascript keyword
-
-  // We support ending with * to denote prefixes
-  'strapi*',
-  '_strapi*',
-  '__strapi*',
-];
+/**
+ * Reserved names are centralised in `@strapi/utils` so the bootstrap validator,
+ * the schema-to-model transform and this CTB service all share a single source.
+ *
+ * The arrays exported here are kept for backwards compatibility with consumers
+ * that import them directly. New call sites should import from `@strapi/utils`.
+ */
+export const reservedAttributes = contentTypes.getReservedAttributeNames();
+export const reservedModels = contentTypes.getReservedModelNames();
 
 export const getReservedNames = () => {
   return {
@@ -57,40 +17,8 @@ export const getReservedNames = () => {
   };
 };
 
-// compare snake case to check the actual column names that will be used in the database
-export const isReservedModelName = (name: string) => {
-  const snakeCaseName = snakeCase(name);
-  if (reservedModels.includes(snakeCaseName)) {
-    return true;
-  }
+export const isReservedModelName = (name: string): boolean =>
+  contentTypes.isReservedModelName(name);
 
-  if (
-    reservedModels
-      .filter((key) => key.endsWith('*'))
-      .map((key) => key.slice(0, -1))
-      .some((prefix) => snakeCaseName.startsWith(prefix))
-  ) {
-    return true;
-  }
-
-  return false;
-};
-
-// compare snake case to check the actual column names that will be used in the database
-export const isReservedAttributeName = (name: string) => {
-  const snakeCaseName = snakeCase(name);
-  if (reservedAttributes.includes(snakeCaseName)) {
-    return true;
-  }
-
-  if (
-    reservedAttributes
-      .filter((key) => key.endsWith('*'))
-      .map((key) => key.slice(0, -1))
-      .some((prefix) => snakeCaseName.startsWith(prefix))
-  ) {
-    return true;
-  }
-
-  return false;
-};
+export const isReservedAttributeName = (name: string): boolean =>
+  contentTypes.isReservedAttributeName(name);

--- a/packages/core/core/src/domain/content-type/__tests__/validator.test.ts
+++ b/packages/core/core/src/domain/content-type/__tests__/validator.test.ts
@@ -1,0 +1,82 @@
+import { validateContentTypeDefinition } from '../validator';
+
+const baseSchema = {
+  info: {
+    displayName: 'Article',
+    singularName: 'article',
+    pluralName: 'articles',
+  },
+  options: {
+    draftAndPublish: false,
+  },
+  attributes: {} as Record<string, unknown>,
+};
+
+const wrap = (schema: typeof baseSchema) => ({
+  schema,
+  actions: {},
+  lifecycles: {},
+});
+
+describe('validateContentTypeDefinition - reserved attribute names', () => {
+  it('rejects a `status` attribute when draftAndPublish is enabled', () => {
+    const data = wrap({
+      ...baseSchema,
+      options: { draftAndPublish: true },
+      attributes: {
+        status: { type: 'string' },
+      },
+    });
+
+    expect(() => validateContentTypeDefinition(data)).toThrow(/reserved/);
+    expect(() => validateContentTypeDefinition(data)).toThrow(/draftAndPublish/);
+  });
+
+  it('allows a `status` attribute when draftAndPublish is disabled', () => {
+    const data = wrap({
+      ...baseSchema,
+      options: { draftAndPublish: false },
+      attributes: {
+        status: { type: 'string' },
+      },
+    });
+
+    expect(() => validateContentTypeDefinition(data)).not.toThrow();
+  });
+
+  it('allows non-reserved attributes when draftAndPublish is enabled', () => {
+    const data = wrap({
+      ...baseSchema,
+      options: { draftAndPublish: true },
+      attributes: {
+        title: { type: 'string' },
+      },
+    });
+
+    expect(() => validateContentTypeDefinition(data)).not.toThrow();
+  });
+
+  it('matches reserved names case-insensitively via snake_case', () => {
+    const data = wrap({
+      ...baseSchema,
+      options: { draftAndPublish: true },
+      attributes: {
+        Status: { type: 'string' },
+      },
+    });
+
+    expect(() => validateContentTypeDefinition(data)).toThrow(/reserved/);
+  });
+
+  it('does not block always-reserved names so internal CTs (e.g. release-action.locale) keep working', () => {
+    const data = wrap({
+      ...baseSchema,
+      options: { draftAndPublish: false },
+      attributes: {
+        locale: { type: 'string' },
+      },
+    });
+
+    expect(() => validateContentTypeDefinition(data)).not.toThrow();
+  });
+});

--- a/packages/core/core/src/domain/content-type/validator.ts
+++ b/packages/core/core/src/domain/content-type/validator.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { yup, strings } from '@strapi/utils';
+import { yup, strings, contentTypes } from '@strapi/utils';
 import type { Schema } from '@strapi/types';
 
 const LIFECYCLES = [
@@ -52,9 +52,21 @@ const contentTypeSchemaValidator = yup.object().shape({
     attributes: yup.object().test({
       name: 'valuesCollide',
       message: 'Some values collide when normalized',
-      test(attributes: Schema.ContentType['attributes']) {
+      test(attributes: Schema.ContentType['attributes'], context: yup.TestContext) {
+        const schema = context.parent as Schema.ContentType;
+        const draftAndPublish = schema.options?.draftAndPublish === true;
+
         for (const attrName of Object.keys(attributes)) {
           const attr = attributes[attrName];
+
+          if (
+            draftAndPublish &&
+            contentTypes.RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH.includes(_.snakeCase(attrName))
+          ) {
+            const message = `The attribute name '${attrName}' is reserved when 'draftAndPublish' is enabled. Rename the attribute or disable the 'draftAndPublish' option.`;
+            return this.createError({ message });
+          }
+
           if (attr.type === 'enumeration') {
             const regressedValues = attr.enum.map(strings.toRegressedEnumValue);
 

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -48,30 +48,34 @@ const RELATION_OPERATION_KEYS: string[] = ['connect', 'disconnect', 'set', 'opti
 
 /**
  * Reserved attribute names that cannot be used by user-defined content-type fields.
- * Stored in snake_case so we compare against normalised database column names.
  * Entries ending with `*` are treated as prefix matchers (e.g. `strapi*` blocks `strapi_foo`).
  */
+// use snake_case
 const RESERVED_ATTRIBUTE_NAMES: string[] = [
   // ID fields
   'id',
   'document_id',
+
   // Creator fields
   'created_at',
   'updated_at',
   'published_at',
-  // V6: add first_published_at when it becomes the default behaviour
+  // V6: we will need to add first_published_at when it becomes the default behaviour
   'created_by_id',
   'updated_by_id',
+  // does not actually conflict because the fields are called *_by_id but we'll leave it to avoid confusion
   'created_by',
   'updated_by',
-  // Strapi internals
+
+  // Used for Strapi functionality
   'entry_id',
   'localizations',
   'meta',
   'locale',
   '__component',
   '__contentType',
-  // Prefix matchers
+
+  // We support ending with * to denote prefixes
   'strapi*',
   '_strapi*',
   '__strapi*',
@@ -81,9 +85,11 @@ const RESERVED_ATTRIBUTE_NAMES: string[] = [
  * Reserved attribute names that only conflict when draftAndPublish is enabled.
  * `status` is the v5 Document Service / REST query parameter for draft/published filtering.
  */
+// use snake_case
 const RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH: string[] = ['status'];
 
 /** Reserved model (collection) names that cannot be used by user-defined content-types. */
+// use snake_case
 const RESERVED_MODEL_NAMES: string[] = [
   'boolean',
   'date',
@@ -91,7 +97,9 @@ const RESERVED_MODEL_NAMES: string[] = [
   'time',
   'upload',
   'document',
-  'then', // JS reserved-ish keyword retained for safety
+  'then', // no longer an issue but still restricting for being a javascript keyword
+
+  // We support ending with * to denote prefixes
   'strapi*',
   '_strapi*',
   '__strapi*',
@@ -113,6 +121,7 @@ interface IsReservedAttributeNameOptions {
   draftAndPublish?: boolean;
 }
 
+// compare snake case to check the actual column names that will be used in the database
 const isReservedAttributeName = (
   name: string,
   { draftAndPublish = true }: IsReservedAttributeNameOptions = {}
@@ -133,6 +142,7 @@ const isReservedAttributeName = (
   return false;
 };
 
+// compare snake case to check the actual column names that will be used in the database
 const isReservedModelName = (name: string): boolean => {
   return matchesReservedName(snakeCase(name), RESERVED_MODEL_NAMES);
 };

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { has, getOr, union } from 'lodash/fp';
+import { has, getOr, union, snakeCase } from 'lodash/fp';
 import type {
   Model,
   Kind,
@@ -45,6 +45,107 @@ const MORPH_TO_KEYS: string[] = ['__type'];
 const DYNAMIC_ZONE_KEYS: string[] = ['__component'];
 /** Relation operation keys (connect, disconnect, set, options). */
 const RELATION_OPERATION_KEYS: string[] = ['connect', 'disconnect', 'set', 'options'];
+
+/**
+ * Reserved attribute names that cannot be used by user-defined content-type fields.
+ * Stored in snake_case so we compare against normalised database column names.
+ * Entries ending with `*` are treated as prefix matchers (e.g. `strapi*` blocks `strapi_foo`).
+ */
+const RESERVED_ATTRIBUTE_NAMES: string[] = [
+  // ID fields
+  'id',
+  'document_id',
+  // Creator fields
+  'created_at',
+  'updated_at',
+  'published_at',
+  // V6: add first_published_at when it becomes the default behaviour
+  'created_by_id',
+  'updated_by_id',
+  'created_by',
+  'updated_by',
+  // Strapi internals
+  'entry_id',
+  'localizations',
+  'meta',
+  'locale',
+  '__component',
+  '__contentType',
+  // Prefix matchers
+  'strapi*',
+  '_strapi*',
+  '__strapi*',
+];
+
+/**
+ * Reserved attribute names that only conflict when draftAndPublish is enabled.
+ * `status` is the v5 Document Service / REST query parameter for draft/published filtering.
+ */
+const RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH: string[] = ['status'];
+
+/** Reserved model (collection) names that cannot be used by user-defined content-types. */
+const RESERVED_MODEL_NAMES: string[] = [
+  'boolean',
+  'date',
+  'date_time',
+  'time',
+  'upload',
+  'document',
+  'then', // JS reserved-ish keyword retained for safety
+  'strapi*',
+  '_strapi*',
+  '__strapi*',
+];
+
+const matchesReservedName = (snakeCaseName: string, list: string[]): boolean => {
+  if (list.includes(snakeCaseName)) {
+    return true;
+  }
+
+  return list
+    .filter((entry) => entry.endsWith('*'))
+    .map((entry) => entry.slice(0, -1))
+    .some((prefix) => snakeCaseName.startsWith(prefix));
+};
+
+interface IsReservedAttributeNameOptions {
+  /** When true, draft-and-publish-specific names (e.g. `status`) are also reserved. Defaults to true. */
+  draftAndPublish?: boolean;
+}
+
+const isReservedAttributeName = (
+  name: string,
+  { draftAndPublish = true }: IsReservedAttributeNameOptions = {}
+): boolean => {
+  const snakeCaseName = snakeCase(name);
+
+  if (matchesReservedName(snakeCaseName, RESERVED_ATTRIBUTE_NAMES)) {
+    return true;
+  }
+
+  if (
+    draftAndPublish &&
+    matchesReservedName(snakeCaseName, RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH)
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+const isReservedModelName = (name: string): boolean => {
+  return matchesReservedName(snakeCase(name), RESERVED_MODEL_NAMES);
+};
+
+const getReservedAttributeNames = ({
+  draftAndPublish = true,
+}: IsReservedAttributeNameOptions = {}): string[] => {
+  return draftAndPublish
+    ? [...RESERVED_ATTRIBUTE_NAMES, ...RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH]
+    : [...RESERVED_ATTRIBUTE_NAMES];
+};
+
+const getReservedModelNames = (): string[] => [...RESERVED_MODEL_NAMES];
 
 const getTimestamps = (model: Model) => {
   const attributes: string[] = [];
@@ -298,6 +399,13 @@ export {
   MORPH_TO_KEYS,
   DYNAMIC_ZONE_KEYS,
   RELATION_OPERATION_KEYS,
+  RESERVED_ATTRIBUTE_NAMES,
+  RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH,
+  RESERVED_MODEL_NAMES,
+  isReservedAttributeName,
+  isReservedModelName,
+  getReservedAttributeNames,
+  getReservedModelNames,
   getNonWritableAttributes,
   getComponentAttributes,
   getMediaAttributes,


### PR DESCRIPTION
### What does it do?

- Bootstrap content-type validator (`packages/core/core/src/domain/content-type/validator.ts`) now rejects an attribute named `status` when the content type has `draftAndPublish: true`. Error message points the user at either renaming the attribute or disabling draft-and-publish.
- Centralizes reserved attribute / model name lists in `@strapi/utils` (`packages/core/utils/src/content-types.ts`). New exports: `RESERVED_ATTRIBUTE_NAMES`, `RESERVED_ATTRIBUTE_NAMES_DRAFT_PUBLISH`, `RESERVED_MODEL_NAMES`, `isReservedAttributeName(name, { draftAndPublish })`, `isReservedModelName`, `getReservedAttributeNames`, `getReservedModelNames`.
- `@strapi/content-type-builder`'s `services/builder.ts` now re-exports from `@strapi/utils`. Public surface (`reservedAttributes`, `reservedModels`, `getReservedNames`, `isReservedAttributeName`, `isReservedModelName`) is unchanged.
- Adds unit tests for the validator and updates one CTB test that asserted the exact ordering of the reserved-attribute list.

### Why is it needed?

In Strapi v5 the `status` query parameter on REST / GraphQL / Document Service APIs filters draft vs published versions of a document (see https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/publication-state-removed). A user-defined attribute named `status` on a draft-and-publish content type therefore collides with the framework's own query parameter, leading to confusing API behavior.

The CTB UI already blocked this name at content-type creation time, but hand-edited `schema.json` files bypassed that check and only failed later, in less obvious ways. The bootstrap validator now catches the conflict at startup with a clear message.

The reserved-name lists were previously duplicated between CTB and the runtime transform with a TODO to consolidate. Moving them into `@strapi/utils` removes that drift risk and lets the bootstrap validator share the same source.

### How to test it?

1. In any Strapi v5 project (e.g. `examples/getstarted`), pick a content type with `draftAndPublish: true` and add an attribute named `status` to its `schema.json`.
2. Start the server (`yarn develop`). Boot fails with:
   > The attribute name 'status' is reserved when 'draftAndPublish' is enabled. Rename the attribute or disable the 'draftAndPublish' option.
3. Either rename the attribute or set `options.draftAndPublish: false` and confirm the server boots normally.
4. Internal content types that legitimately declare always-reserved names (e.g. `release-action` declaring `locale`) continue to boot — the bootstrap check is intentionally scoped to the draft-and-publish-conditional list.
5. Run the tests:
   - `yarn workspace @strapi/core test:unit src/domain/content-type` (5 cases)
   - `yarn workspace @strapi/content-type-builder test:unit` (93 cases)
   - `yarn workspace @strapi/utils jest` (428 cases)

### Related issue(s)/PR(s)

- Related to https://github.com/strapi/strapi/issues/23177 — "Issue with Reserved Field Names in Strapi 5 (After Upgrading from Version 4)". This PR addresses the `status` × `draftAndPublish` collision specifically; broader bootstrap enforcement of always-reserved names was deferred because internal content types (e.g. `release-action.locale`) legitimately declare some of them.
- Resolves the runtime side of the v5 `publicationState` → `status` migration: https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/publication-state-removed
- Addresses the centralization TODOs at `packages/core/content-type-builder/server/src/services/builder.ts` and `packages/core/core/src/utils/transform-content-types-to-models.ts:291` (the latter still left for a follow-up).