### PR TITLE
fix(content-manager): accumulate permissions per action in DocumentRBAC

### DIFF
--- a/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
+++ b/packages/core/content-manager/admin/src/features/DocumentRBAC.tsx
@@ -84,7 +84,7 @@ const DocumentRBAC = ({ children, permissions, model }: DocumentRBACProps) => {
     );
     return contentTypePermissions.reduce<Record<string, Permission[]>>((acc, permission) => {
       const [action] = permission.action.split('.').slice(-1);
-      return { ...acc, [action]: [permission] };
+      return { ...acc, [action]: [...(acc[action] ?? []), permission] };
     }, {});
   }, [contentTypeUid, userPermissions]);
 


### PR DESCRIPTION
### What does it do?

This fix accumulates all permissions per action, so `extractAndDedupeFields` correctly unions the fields across all roles.

### Why is it needed?

When a user has multiple roles, such as **Super Admin**, **Editor**, and **Author**, the backend returns one permission row per role for each action. Previously, the `reduce` in `DocumentRBAC` was overwriting the permission array for each action key instead of accumulating it. 

As a result, only the last permission encountered was kept. Because the backend query has no `ORDER BY`, the last permission is non-deterministic. Sometimes the **Super Admin** permission, which grants access to all fields, is returned last and everything works as expected. Other times, a restricted role’s permission is returned last, causing fields the user should be able to see to be hidden behind the message:
> No permissions to see this field

### How to test it?

1. Create an admin user and assign all three roles to them: Super Admin, Editor, and Author.
2. For the Editor and Author roles, assign full permissions for a specific content type, except remove the read permission for one particular field.
3. In the current release, this causes the field to become unavailable, even though the user has all three roles, including Super Admin. With the fix, the field behaves as expected and remains available.

### Related issue(s)/PR(s)

Related TID: 8762