### PR TITLE
ci: do not fail fast on api or cli tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -342,6 +342,7 @@ jobs:
     name: 'CLI Tests (node: ${{ matrix.node }})'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
     steps:
@@ -366,6 +367,7 @@ jobs:
     needs: [conditions, build]
     name: '[CE] API Integration (postgres, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/4, 2/4, 3/4, 4/4]
@@ -406,6 +408,7 @@ jobs:
     needs: [conditions, build]
     name: '[CE] API Integration (mysql:latest, package: mysql2}, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/4, 2/4, 3/4, 4/4]
@@ -445,6 +448,7 @@ jobs:
     needs: [conditions, build]
     name: '[CE] API Integration (sqlite, package: better-sqlite3, node: ${{ matrix.node }}, shard: ${{ matrix.shard }})'
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/4, 2/4, 3/4, 4/4]
@@ -471,6 +475,7 @@ jobs:
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
@@ -514,6 +519,7 @@ jobs:
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
@@ -556,6 +562,7 @@ jobs:
     env:
       STRAPI_LICENSE: ${{ secrets.strapiLicense }}
     strategy:
+      fail-fast: false
       matrix:
         node: [20, 22, 24]
         shard: [1/4, 2/4, 3/4, 4/4]


### PR DESCRIPTION
### What does it do?

set fail-fast to false for API and CLI tests

### Why is it needed?

it trades the confusion of understanding which test(s) actually failed and which passed for a bit of potentially wasted CPU time

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
