### PR TITLE
chore: stop tracking vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,6 @@ dist
 ############################
 
 .vscode/
-!.vscode/settings.json
 front-workspace.code-workspace
 .yarnrc
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "eslint.workingDirectories": [
-    {
-      "mode": "auto"
-    }
-  ]
-}


### PR DESCRIPTION
### What does it do?

stop tracking .vscode/settings.json

### Why is it needed?

it was needed to resolve some build issues, but on the latest version of vscode and the current `develop` code, it is not necessary anymore

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
