### PR TITLE
fix(review-workflows): add assignee and review stage to list view filters

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -34,6 +34,7 @@ import type { DefaultTheme } from 'styled-components';
 
 const {
   INJECT_COLUMN_IN_TABLE,
+  INJECT_LIST_VIEW_FILTERS,
   MUTATE_COLLECTION_TYPES_LINKS,
   MUTATE_EDIT_VIEW_LAYOUT,
   MUTATE_SINGLE_TYPES_LINKS,
@@ -129,6 +130,7 @@ class StrapiApp {
     this.createCustomConfigurations(config ?? {});
 
     this.createHook(INJECT_COLUMN_IN_TABLE);
+    this.createHook(INJECT_LIST_VIEW_FILTERS);
     this.createHook(MUTATE_COLLECTION_TYPES_LINKS);
     this.createHook(MUTATE_SINGLE_TYPES_LINKS);
     this.createHook(MUTATE_EDIT_VIEW_LAYOUT);

--- a/packages/core/admin/admin/src/constants.ts
+++ b/packages/core/admin/admin/src/constants.ts
@@ -114,6 +114,13 @@ export const HOOKS = {
   INJECT_COLUMN_IN_TABLE: 'Admin/CM/pages/ListView/inject-column-in-table',
 
   /**
+   * Hook that allows to mutate the displayed filters of the list view
+   * @constant
+   * @type {string}
+   */
+  INJECT_LIST_VIEW_FILTERS: 'Admin/CM/pages/ListView/inject-in-filters',
+
+  /**
    * Hook that allows to mutate the CM's collection types links pre-set filters
    * @constant
    * @type {string}

--- a/packages/core/content-manager/admin/src/constants/hooks.ts
+++ b/packages/core/content-manager/admin/src/constants/hooks.ts
@@ -7,6 +7,13 @@ export const HOOKS = {
   INJECT_COLUMN_IN_TABLE: 'Admin/CM/pages/ListView/inject-column-in-table',
 
   /**
+   * Hook that allows to mutate the displayed filters of the list view
+   * @constant
+   * @type {string}
+   */
+  INJECT_LIST_VIEW_FILTERS: 'Admin/CM/pages/ListView/inject-in-filters',
+
+  /**
    * Hook that allows to mutate the CM's collection types links pre-set filters
    * @constant
    * @type {string}

--- a/packages/core/content-manager/admin/src/constants/hooks.ts
+++ b/packages/core/content-manager/admin/src/constants/hooks.ts
@@ -1,3 +1,19 @@
+import type { Filters } from '@strapi/admin/strapi-admin';
+import type { MessageDescriptor } from 'react-intl';
+
+/**
+ * Shape of a filter passed through the `INJECT_LIST_VIEW_FILTERS` hook.
+ *
+ * Plugin-injected filters may use react-intl `MessageDescriptor` labels so
+ * they carry their own translations. The list view consumer resolves them to
+ * plain strings (which is what the underlying `Filters.Filter` contract
+ * expects) before rendering.
+ */
+export type InjectableListViewFilter = Omit<Filters.Filter, 'label' | 'operators'> & {
+  label: string | MessageDescriptor;
+  operators?: Array<{ value: string; label: string | MessageDescriptor }>;
+};
+
 export const HOOKS = {
   /**
    * Hook that allows to mutate the displayed headers of the list view table

--- a/packages/core/content-manager/admin/src/exports.ts
+++ b/packages/core/content-manager/admin/src/exports.ts
@@ -20,6 +20,7 @@ export type {
   ListFieldLayout,
   ListLayout,
 } from './hooks/useDocumentLayout';
+export type { InjectableListViewFilter } from './constants/hooks';
 export * from './features/DocumentRBAC';
 export type {
   EditViewContext,

--- a/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/ListViewPage.tsx
@@ -387,7 +387,7 @@ const ListViewPage = () => {
 
   const actions =
     list.settings.filterable && schema ? (
-      <Filters.Root schema={schema}>
+      <Filters.Root schema={schema} layout={list}>
         <Layouts.Action
           endActions={endActions}
           startActions={startActions}

--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -22,19 +22,10 @@ import { getMainField } from '../../../utils/attributes';
 import { getTranslation } from '../../../utils/translations';
 import { getDisplayName } from '../../../utils/users';
 
+import type { InjectableListViewFilter } from '../../../constants/hooks';
 import type { ListLayout } from '../../../hooks/useDocumentLayout';
 
 const { INJECT_LIST_VIEW_FILTERS } = HOOKS;
-
-/**
- * Plugin-injected filters may use react-intl `MessageDescriptor` labels so they
- * carry their own translations. Convert them to strings here, since the
- * underlying `Filters.Filter` contract expects plain strings.
- */
-type InjectableFilter = Omit<Filters.Filter, 'label' | 'operators'> & {
-  label: string | MessageDescriptor;
-  operators?: Array<{ value: string; label: string | MessageDescriptor }>;
-};
 
 /**
  * If new attributes are added, this list needs to be updated.
@@ -257,7 +248,7 @@ const Root = ({ disabled, schema, layout, children }: FiltersProps) => {
     // `layout.options` is a merge of schema/pluginOptions/contentType options —
     // mirrors the column-injection hook contract.
     const { displayedFilters: extendedFilters } = runHookWaterfall(INJECT_LIST_VIEW_FILTERS, {
-      displayedFilters: baseFilters as InjectableFilter[],
+      displayedFilters: baseFilters as InjectableListViewFilter[],
       layout,
     });
 

--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -7,11 +7,13 @@ import {
   useTracking,
   useQueryParams,
   useAdminUsers,
+  useStrapiApp,
 } from '@strapi/admin/strapi-admin';
 import { Combobox, ComboboxOption, useCollator } from '@strapi/design-system';
-import { useIntl } from 'react-intl';
+import { type MessageDescriptor, useIntl } from 'react-intl';
 
 import { CREATOR_FIELDS } from '../../../constants/attributes';
+import { HOOKS } from '../../../constants/hooks';
 import { useContentTypeSchema } from '../../../hooks/useContentTypeSchema';
 import { useDebounce } from '../../../hooks/useDebounce';
 import { Schema } from '../../../hooks/useDocument';
@@ -19,6 +21,20 @@ import { useGetContentTypeConfigurationQuery } from '../../../services/contentTy
 import { getMainField } from '../../../utils/attributes';
 import { getTranslation } from '../../../utils/translations';
 import { getDisplayName } from '../../../utils/users';
+
+import type { ListLayout } from '../../../hooks/useDocumentLayout';
+
+const { INJECT_LIST_VIEW_FILTERS } = HOOKS;
+
+/**
+ * Plugin-injected filters may use react-intl `MessageDescriptor` labels so they
+ * carry their own translations. Convert them to strings here, since the
+ * underlying `Filters.Filter` contract expects plain strings.
+ */
+type InjectableFilter = Omit<Filters.Filter, 'label' | 'operators'> & {
+  label: string | MessageDescriptor;
+  operators?: Array<{ value: string; label: string | MessageDescriptor }>;
+};
 
 /**
  * If new attributes are added, this list needs to be updated.
@@ -41,16 +57,18 @@ const USER_FILTER_ATTRIBUTES = [...CREATOR_FIELDS, 'strapi_assignee'];
 interface FiltersProps {
   disabled?: boolean;
   schema: Schema;
+  layout: ListLayout;
   children: React.ReactNode;
 }
 
-const Root = ({ disabled, schema, children }: FiltersProps) => {
+const Root = ({ disabled, schema, layout, children }: FiltersProps) => {
   const { attributes, uid: model, options } = schema;
   const { formatMessage, locale } = useIntl();
   const { trackUsage } = useTracking();
   const allPermissions = useAuth('FiltersImpl', (state) => state.permissions);
   const [{ query }] = useQueryParams<Filters.Query>();
   const { schemas } = useContentTypeSchema();
+  const runHookWaterfall = useStrapiApp('FiltersImpl', ({ runHookWaterfall }) => runHookWaterfall);
 
   const canReadAdminUsers = React.useMemo(
     () =>
@@ -112,130 +130,161 @@ const Root = ({ disabled, schema, children }: FiltersProps) => {
       return attribute.type && !NOT_ALLOWED_FILTERS.includes(attribute.type);
     });
 
-    return (
-      [
-        'id',
-        'documentId',
-        ...allowedFields,
-        ...DEFAULT_ALLOWED_FILTERS,
-        ...(canReadAdminUsers ? CREATOR_FIELDS : []),
-        ...(options?.draftAndPublish === true ? ['__status'] : []),
-      ]
-        .map((name) => {
-          if (name === '__status') {
-            return {
-              name: '__status',
-              type: 'enumeration',
-              label: formatMessage({
-                id: getTranslation('containers.list.filters.status'),
-                defaultMessage: 'Status',
-              }),
-              operators: [
-                {
-                  label: formatMessage({
-                    id: 'components.FilterOptions.FILTER_TYPES.$eq',
-                    defaultMessage: 'is',
-                  }),
-                  value: '$eq',
-                },
-              ],
-              options: [
-                {
-                  label: formatMessage({
-                    id: getTranslation('containers.List.statusFilter.draft'),
-                    defaultMessage: 'Draft (never published)',
-                  }),
-                  value: 'draft',
-                },
-                {
-                  label: formatMessage({
-                    id: getTranslation('containers.List.statusFilter.published'),
-                    defaultMessage: 'Published (all)',
-                  }),
-                  value: 'published',
-                },
-                {
-                  label: formatMessage({
-                    id: getTranslation('containers.List.statusFilter.publishedModified'),
-                    defaultMessage: 'Published (modified)',
-                  }),
-                  value: 'published-modified',
-                },
-                {
-                  label: formatMessage({
-                    id: getTranslation('containers.List.statusFilter.publishedUnmodified'),
-                    defaultMessage: 'Published (unmodified)',
-                  }),
-                  value: 'published-unmodified',
-                },
-              ],
-            } satisfies Filters.Filter;
-          }
-
-          const attribute = attributes[name];
-
-          if (NOT_ALLOWED_FILTERS.includes(attribute.type)) {
-            return null;
-          }
-
-          const { mainField: mainFieldName = '', label } = metadata[name].list;
-
-          let filter: Filters.Filter = {
-            name,
-            label: label ?? '',
-            mainField: getMainField(attribute, mainFieldName, { schemas, components: {} }),
-            type: attribute.type as Filters.Filter['type'],
-          };
-
-          if (
-            attribute.type === 'relation' &&
-            'target' in attribute &&
-            attribute.target === 'admin::user'
-          ) {
-            filter = {
-              ...filter,
-              input: AdminUsersFilter,
-              options: users.map((user) => ({
-                label: getDisplayName(user),
-                value: user.id.toString(),
-              })),
-              operators: [
-                {
-                  label: formatMessage({
-                    id: 'components.FilterOptions.FILTER_TYPES.$eq',
-                    defaultMessage: 'is',
-                  }),
-                  value: '$eq',
-                },
-                {
-                  label: formatMessage({
-                    id: 'components.FilterOptions.FILTER_TYPES.$ne',
-                    defaultMessage: 'is not',
-                  }),
-                  value: '$ne',
-                },
-              ],
-              mainField: {
-                name: 'id',
-                type: 'integer',
+    const baseFilters = [
+      'id',
+      'documentId',
+      ...allowedFields,
+      ...DEFAULT_ALLOWED_FILTERS,
+      ...(canReadAdminUsers ? CREATOR_FIELDS : []),
+      ...(options?.draftAndPublish === true ? ['__status'] : []),
+    ]
+      .map((name) => {
+        if (name === '__status') {
+          return {
+            name: '__status',
+            type: 'enumeration',
+            label: formatMessage({
+              id: getTranslation('containers.list.filters.status'),
+              defaultMessage: 'Status',
+            }),
+            operators: [
+              {
+                label: formatMessage({
+                  id: 'components.FilterOptions.FILTER_TYPES.$eq',
+                  defaultMessage: 'is',
+                }),
+                value: '$eq',
               },
-            };
-          }
+            ],
+            options: [
+              {
+                label: formatMessage({
+                  id: getTranslation('containers.List.statusFilter.draft'),
+                  defaultMessage: 'Draft (never published)',
+                }),
+                value: 'draft',
+              },
+              {
+                label: formatMessage({
+                  id: getTranslation('containers.List.statusFilter.published'),
+                  defaultMessage: 'Published (all)',
+                }),
+                value: 'published',
+              },
+              {
+                label: formatMessage({
+                  id: getTranslation('containers.List.statusFilter.publishedModified'),
+                  defaultMessage: 'Published (modified)',
+                }),
+                value: 'published-modified',
+              },
+              {
+                label: formatMessage({
+                  id: getTranslation('containers.List.statusFilter.publishedUnmodified'),
+                  defaultMessage: 'Published (unmodified)',
+                }),
+                value: 'published-unmodified',
+              },
+            ],
+          } satisfies Filters.Filter;
+        }
 
-          if (attribute.type === 'enumeration') {
-            filter = {
-              ...filter,
-              options: attribute.enum.map((value) => ({
-                label: value,
-                value,
-              })),
-            };
-          }
+        const attribute = attributes[name];
 
-          return filter;
-        })
-        .filter(Boolean) as Filters.Filter[]
-    ).toSorted((a, b) => formatter.compare(a.label, b.label));
+        if (NOT_ALLOWED_FILTERS.includes(attribute.type)) {
+          return null;
+        }
+
+        const { mainField: mainFieldName = '', label } = metadata[name].list;
+
+        let filter: Filters.Filter = {
+          name,
+          label: label ?? '',
+          mainField: getMainField(attribute, mainFieldName, { schemas, components: {} }),
+          type: attribute.type as Filters.Filter['type'],
+        };
+
+        if (
+          attribute.type === 'relation' &&
+          'target' in attribute &&
+          attribute.target === 'admin::user'
+        ) {
+          filter = {
+            ...filter,
+            input: AdminUsersFilter,
+            options: users.map((user) => ({
+              label: getDisplayName(user),
+              value: user.id.toString(),
+            })),
+            operators: [
+              {
+                label: formatMessage({
+                  id: 'components.FilterOptions.FILTER_TYPES.$eq',
+                  defaultMessage: 'is',
+                }),
+                value: '$eq',
+              },
+              {
+                label: formatMessage({
+                  id: 'components.FilterOptions.FILTER_TYPES.$ne',
+                  defaultMessage: 'is not',
+                }),
+                value: '$ne',
+              },
+            ],
+            mainField: {
+              name: 'id',
+              type: 'integer',
+            },
+          };
+        }
+
+        if (attribute.type === 'enumeration') {
+          filter = {
+            ...filter,
+            options: attribute.enum.map((value) => ({
+              label: value,
+              value,
+            })),
+          };
+        }
+
+        return filter;
+      })
+      .filter(Boolean) as Filters.Filter[];
+
+    // Let plugins inject their own filters.
+    // `layout.options` is a merge of schema/pluginOptions/contentType options —
+    // mirrors the column-injection hook contract.
+    const { displayedFilters: extendedFilters } = runHookWaterfall(INJECT_LIST_VIEW_FILTERS, {
+      displayedFilters: baseFilters as InjectableFilter[],
+      layout,
+    });
+
+    const resolveLabel = (label: string | MessageDescriptor): string =>
+      typeof label === 'string' ? label : formatMessage(label);
+
+    const userOptions = users.map((user) => ({
+      label: getDisplayName(user),
+      value: user.id.toString(),
+    }));
+
+    const formatted = extendedFilters.map<Filters.Filter>((filter) => {
+      const next: Filters.Filter = {
+        ...filter,
+        label: resolveLabel(filter.label),
+        operators: filter.operators?.map((op) => ({ ...op, label: resolveLabel(op.label) })),
+      };
+
+      // User-typed filters need user options so the chip can render the display name instead of the id.
+      if (USER_FILTER_ATTRIBUTES.includes(filter.name) && !next.options?.length) {
+        next.options = userOptions;
+      }
+
+      return next;
+    });
+
+    return formatted.toSorted((a, b) => formatter.compare(a.label, b.label));
   }, [
     allPermissions,
     canReadAdminUsers,
@@ -243,9 +292,12 @@ const Root = ({ disabled, schema, children }: FiltersProps) => {
     attributes,
     metadata,
     schemas,
+    layout,
     users,
     formatMessage,
     formatter,
+    options?.draftAndPublish,
+    runHookWaterfall,
   ]);
 
   const onOpenChange = (isOpen: boolean) => {

--- a/packages/core/review-workflows/admin/src/index.ts
+++ b/packages/core/review-workflows/admin/src/index.ts
@@ -3,7 +3,7 @@ import { SealCheck } from '@strapi/icons';
 import { PLUGIN_ID, FEATURE_ID } from './constants';
 import { Header } from './routes/content-manager/model/id/components/Header';
 import { Panel } from './routes/content-manager/model/id/components/Panel';
-import { addColumnToTableHook } from './utils/cm-hooks';
+import { addColumnToTableHook, addFilterToListViewHook } from './utils/cm-hooks';
 import { prefixPluginTranslations } from './utils/translations';
 
 import type { StrapiApp, WidgetArgs } from '@strapi/admin/strapi-admin';
@@ -13,6 +13,7 @@ const admin: Plugin.Config.AdminInput = {
   register(app: StrapiApp) {
     if (window.strapi.features.isEnabled(FEATURE_ID)) {
       app.registerHook('Admin/CM/pages/ListView/inject-column-in-table', addColumnToTableHook);
+      app.registerHook('Admin/CM/pages/ListView/inject-in-filters', addFilterToListViewHook);
 
       const contentManagerPluginApis = app.getPlugin('content-manager').apis;
 

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
@@ -10,11 +10,9 @@ interface AssigneeFilterProps extends Pick<ComboboxProps, 'value' | 'onChange'> 
 
 const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
   const [page, setPage] = React.useState(1);
+  const [hasOpened, setHasOpened] = React.useState(false);
   const { formatMessage } = useIntl();
-  const { data, isLoading } = useAdminUsers({
-    page,
-  });
-  const users = data?.users || [];
+  const { data, isLoading } = useAdminUsers({ page }, { skip: !hasOpened });
 
   const field = useField(name);
 
@@ -22,6 +20,21 @@ const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
     setPage(1);
     field.onChange(name, value);
   };
+
+  const handleOpenChange = (isOpen?: boolean) => {
+    if (isOpen && !hasOpened) {
+      setHasOpened(true);
+    }
+  };
+
+  const options = React.useMemo(
+    () =>
+      (data?.users ?? []).map((user) => ({
+        id: user.id,
+        label: getDisplayName(user),
+      })),
+    [data?.users]
+  );
 
   return (
     <Combobox
@@ -31,16 +44,15 @@ const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
         defaultMessage: 'Search and select an user to filter',
       })}
       onChange={handleChange}
+      onOpenChange={handleOpenChange}
       loading={isLoading}
       onLoadMore={() => setPage((prev) => prev + 1)}
     >
-      {users.map((user) => {
-        return (
-          <ComboboxOption key={user.id} value={user.id.toString()}>
-            {getDisplayName(user)}
-          </ComboboxOption>
-        );
-      })}
+      {options.map((option) => (
+        <ComboboxOption key={option.id} value={option.id.toString()}>
+          {option.label}
+        </ComboboxOption>
+      ))}
     </Combobox>
   );
 };

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
@@ -8,16 +8,18 @@ import { getDisplayName } from '../../../../utils/users';
 
 interface AssigneeFilterProps extends Pick<ComboboxProps, 'value' | 'onChange'> {}
 
+const PAGE_SIZE = 10;
+
 const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
-  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(PAGE_SIZE);
   const [hasOpened, setHasOpened] = React.useState(false);
   const { formatMessage } = useIntl();
   const field = useField(name);
   const shouldFetch = hasOpened || Boolean(field.value);
-  const { data, isLoading } = useAdminUsers({ page }, { skip: !shouldFetch });
+  const { data, isLoading } = useAdminUsers({ pageSize }, { skip: !shouldFetch });
 
   const handleChange = (value?: string) => {
-    setPage(1);
+    setPageSize(PAGE_SIZE);
     field.onChange(name, value);
   };
 
@@ -25,6 +27,16 @@ const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
     if (isOpen && !hasOpened) {
       setHasOpened(true);
     }
+  };
+
+  const { pageCount = 1, page = 1 } = data?.pagination ?? {};
+  const hasMoreItems = page < pageCount;
+
+  const handleLoadMore = () => {
+    if (!hasMoreItems) {
+      return;
+    }
+    setPageSize((prev) => prev + PAGE_SIZE);
   };
 
   const options = React.useMemo(
@@ -46,7 +58,8 @@ const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
       onChange={handleChange}
       onOpenChange={handleOpenChange}
       loading={isLoading}
-      onLoadMore={() => setPage((prev) => prev + 1)}
+      onLoadMore={handleLoadMore}
+      hasMoreItems={hasMoreItems}
     >
       {options.map((option) => (
         <ComboboxOption key={option.id} value={option.id.toString()}>

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/components/AssigneeFilter.tsx
@@ -12,9 +12,9 @@ const AssigneeFilter = ({ name }: Filters.ValueInputProps) => {
   const [page, setPage] = React.useState(1);
   const [hasOpened, setHasOpened] = React.useState(false);
   const { formatMessage } = useIntl();
-  const { data, isLoading } = useAdminUsers({ page }, { skip: !hasOpened });
-
   const field = useField(name);
+  const shouldFetch = hasOpened || Boolean(field.value);
+  const { data, isLoading } = useAdminUsers({ page }, { skip: !shouldFetch });
 
   const handleChange = (value?: string) => {
     setPage(1);

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/components/tests/AssigneeFilter.test.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/components/tests/AssigneeFilter.test.tsx
@@ -3,13 +3,10 @@ import { render as renderRTL, screen } from '@tests/utils';
 
 import { AssigneeFilter, AssigneeFilterProps } from '../AssigneeFilter';
 
-/**
- * Filters are not currently supported
- */
-describe.skip('AssigneeFilter', () => {
+describe('AssigneeFilter', () => {
   const render = (props?: Partial<AssigneeFilterProps>) =>
     renderRTL(
-      <AssigneeFilter name="assignee" type="enumeration" aria-label="Assignee" {...props} />,
+      <AssigneeFilter name="strapi_assignee" type="relation" aria-label="Assignee" {...props} />,
       {
         renderOptions: {
           wrapper({ children }) {

--- a/packages/core/review-workflows/admin/src/routes/content-manager/model/constants.tsx
+++ b/packages/core/review-workflows/admin/src/routes/content-manager/model/constants.tsx
@@ -17,7 +17,7 @@ export const REVIEW_WORKFLOW_COLUMNS = [
     },
     label: {
       id: 'review-workflows.containers.list.table-headers.reviewWorkflows.stage',
-      defaultMessage: 'Review stage',
+      defaultMessage: 'review stage',
     },
     searchable: false,
     sortable: true,
@@ -36,7 +36,7 @@ export const REVIEW_WORKFLOW_COLUMNS = [
     },
     label: {
       id: 'review-workflows.containers.list.table-headers.reviewWorkflows.assignee',
-      defaultMessage: 'Assignee',
+      defaultMessage: 'assignee',
     },
     searchable: false,
     sortable: true,
@@ -57,7 +57,7 @@ export const REVIEW_WORKFLOW_FILTERS = [
     input: StageFilter,
     label: {
       id: 'review-workflows.containers.list.table-headers.reviewWorkflows.stage',
-      defaultMessage: 'Review stage',
+      defaultMessage: 'review stage',
     },
     name: 'strapi_stage',
     type: 'relation',
@@ -85,10 +85,24 @@ export const REVIEW_WORKFLOW_FILTERS = [
         },
         value: '$ne',
       },
+      {
+        label: {
+          id: 'components.FilterOptions.FILTER_TYPES.$null',
+          defaultMessage: 'is null',
+        },
+        value: '$null',
+      },
+      {
+        label: {
+          id: 'components.FilterOptions.FILTER_TYPES.$notNull',
+          defaultMessage: 'is not null',
+        },
+        value: '$notNull',
+      },
     ],
     label: {
-      id: 'review-workflows.containers.list.table-headers.reviewWorkflows.assignee.label',
-      defaultMessage: 'Assignee',
+      id: 'review-workflows.containers.list.table-headers.reviewWorkflows.assignee',
+      defaultMessage: 'assignee',
     },
     name: 'strapi_assignee',
   },

--- a/packages/core/review-workflows/admin/src/translations/en.json
+++ b/packages/core/review-workflows/admin/src/translations/en.json
@@ -13,5 +13,7 @@
   "settings.page.purchase.perks2": "Manage user permissions",
   "settings.page.purchase.perks3": "Support for webhooks",
   "widget.assigned.title": "Assigned to me",
-  "widget.assigned.no-data": "No entries"
+  "widget.assigned.no-data": "No entries",
+  "containers.list.table-headers.reviewWorkflows.stage": "review stage",
+  "containers.list.table-headers.reviewWorkflows.assignee": "assignee"
 }

--- a/packages/core/review-workflows/admin/src/utils/cm-hooks.ts
+++ b/packages/core/review-workflows/admin/src/utils/cm-hooks.ts
@@ -3,15 +3,11 @@ import {
   REVIEW_WORKFLOW_FILTERS,
 } from '../routes/content-manager/model/constants';
 
-import type { Filters } from '@strapi/admin/strapi-admin';
-import type { ListFieldLayout, ListLayout } from '@strapi/content-manager/strapi-admin';
-import type { MessageDescriptor } from 'react-intl';
-
-/** Matches CM list-view injectable filters (`Filters.tsx`): labels may be intl descriptors. */
-type InjectableListViewFilter = Omit<Filters.Filter, 'label' | 'operators'> & {
-  label: string | MessageDescriptor;
-  operators?: Array<{ value: string; label: string | MessageDescriptor }>;
-};
+import type {
+  InjectableListViewFilter,
+  ListFieldLayout,
+  ListLayout,
+} from '@strapi/content-manager/strapi-admin';
 
 /* -------------------------------------------------------------------------------------------------
  * addColumnToTableHook

--- a/packages/core/review-workflows/admin/src/utils/cm-hooks.ts
+++ b/packages/core/review-workflows/admin/src/utils/cm-hooks.ts
@@ -1,6 +1,17 @@
-import { REVIEW_WORKFLOW_COLUMNS } from '../routes/content-manager/model/constants';
+import {
+  REVIEW_WORKFLOW_COLUMNS,
+  REVIEW_WORKFLOW_FILTERS,
+} from '../routes/content-manager/model/constants';
 
+import type { Filters } from '@strapi/admin/strapi-admin';
 import type { ListFieldLayout, ListLayout } from '@strapi/content-manager/strapi-admin';
+import type { MessageDescriptor } from 'react-intl';
+
+/** Matches CM list-view injectable filters (`Filters.tsx`): labels may be intl descriptors. */
+type InjectableListViewFilter = Omit<Filters.Filter, 'label' | 'operators'> & {
+  label: string | MessageDescriptor;
+  operators?: Array<{ value: string; label: string | MessageDescriptor }>;
+};
 
 /* -------------------------------------------------------------------------------------------------
  * addColumnToTableHook
@@ -23,4 +34,23 @@ const addColumnToTableHook = ({ displayedHeaders, layout }: AddColumnToTableHook
   };
 };
 
-export { addColumnToTableHook };
+/* -------------------------------------------------------------------------------------------------
+ * addFilterToListViewHook
+ * -----------------------------------------------------------------------------------------------*/
+interface AddFilterToListViewHookArgs {
+  displayedFilters: InjectableListViewFilter[];
+  layout: ListLayout;
+}
+
+const addFilterToListViewHook = ({ displayedFilters, layout }: AddFilterToListViewHookArgs) => {
+  if (!layout?.options?.reviewWorkflows) {
+    return { displayedFilters, layout };
+  }
+
+  return {
+    displayedFilters: [...displayedFilters, ...REVIEW_WORKFLOW_FILTERS],
+    layout,
+  };
+};
+
+export { addColumnToTableHook, addFilterToListViewHook };

--- a/packages/core/review-workflows/admin/src/utils/tests/cm-hooks.test.ts
+++ b/packages/core/review-workflows/admin/src/utils/tests/cm-hooks.test.ts
@@ -1,0 +1,75 @@
+import { REVIEW_WORKFLOW_FILTERS } from '../../routes/content-manager/model/constants';
+import { addColumnToTableHook, addFilterToListViewHook } from '../cm-hooks';
+
+const baseLayout = {
+  layout: [],
+  settings: {},
+  metadatas: {},
+} as any;
+
+describe('cm-hooks', () => {
+  describe('addColumnToTableHook', () => {
+    it('returns headers unchanged when reviewWorkflows is not enabled', () => {
+      const layout = { ...baseLayout, options: { reviewWorkflows: false } };
+      const headers = [{ name: 'title' }] as any;
+
+      const result = addColumnToTableHook({ displayedHeaders: headers, layout });
+
+      expect(result.displayedHeaders).toBe(headers);
+    });
+
+    it('appends review-workflow columns when reviewWorkflows is enabled', () => {
+      const layout = { ...baseLayout, options: { reviewWorkflows: true } };
+      const headers = [{ name: 'title' }] as any;
+
+      const result = addColumnToTableHook({ displayedHeaders: headers, layout });
+
+      expect(result.displayedHeaders).toHaveLength(headers.length + 2);
+      expect(result.displayedHeaders.map((h: any) => h.name)).toEqual(
+        expect.arrayContaining(['strapi_stage', 'strapi_assignee'])
+      );
+    });
+  });
+
+  describe('addFilterToListViewHook', () => {
+    it('returns filters unchanged when reviewWorkflows is not enabled', () => {
+      const layout = { ...baseLayout, options: { reviewWorkflows: false } };
+      const filters = [{ name: 'title' }] as any;
+
+      const result = addFilterToListViewHook({ displayedFilters: filters, layout });
+
+      expect(result.displayedFilters).toBe(filters);
+    });
+
+    it('returns filters unchanged when layout.options is missing', () => {
+      const layout = { ...baseLayout, options: undefined };
+      const filters = [{ name: 'title' }] as any;
+
+      const result = addFilterToListViewHook({ displayedFilters: filters, layout });
+
+      expect(result.displayedFilters).toBe(filters);
+    });
+
+    it('appends review-workflow filters (stage + assignee) when reviewWorkflows is enabled', () => {
+      const layout = { ...baseLayout, options: { reviewWorkflows: true } };
+      const filters = [{ name: 'title' }] as any;
+
+      const result = addFilterToListViewHook({ displayedFilters: filters, layout });
+
+      expect(result.displayedFilters).toHaveLength(filters.length + REVIEW_WORKFLOW_FILTERS.length);
+      expect(result.displayedFilters.map((f: any) => f.name)).toEqual(
+        expect.arrayContaining(['strapi_stage', 'strapi_assignee'])
+      );
+    });
+
+    it('does not mutate the input array', () => {
+      const layout = { ...baseLayout, options: { reviewWorkflows: true } };
+      const filters = [{ name: 'title' }] as any;
+      const originalLength = filters.length;
+
+      addFilterToListViewHook({ displayedFilters: filters, layout });
+
+      expect(filters).toHaveLength(originalLength);
+    });
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds **Assignee** and **Review stage** to the list of filters in the Content Manager list view (only when Review Workflows is enabled on the content type).

<img width="1215" height="345" alt="Screenshot 2026-04-30 at 11 15 18" src="https://github.com/user-attachments/assets/d987fae9-446b-42bc-9084-51ee540474bf" />

Also exposes a new admin hook `Admin/CM/pages/ListView/inject-in-filters` so plugins can inject their own filters into the list view (mirroring the existing column-injection hook).

The Assignee filter supports `is`, `is not`, `is null`, `is not null` operators. The admin users fetch is deferred until the combobox opens to avoid an extra request when the user only clicks the Filters button.

### Why is it needed?

Filtering by assignee/stage is a feature expected with Review Workflows (EE). Previously only columns were injected — filters were missing.

### How to test it?

ℹ️ EE should be enabled and review workflows configured to a content type
1. Go to any content type setup with review workflows
2. Assign entries to users and set them to different stages
3. Go to the list view and open the filters

You should see two new filters:
- **Assignee** — pick `is`, `is not`, `is null`, `is not null`. Verify the chip displays the user display name (not the id).
- **Review stage** — verify the list filters by the picked stage.

Sanity checks:
- Open the Filters popover but do not pick the Assignee filter → no admin users request fires (Network tab).
- Switching between filters does not re-fetch users on every click (cached).

### Related issue(s)/PR(s)

Fixes #21790

🚀