### PR TITLE
feat(*): introduce core strapi.ai.mcp API

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -30,11 +30,12 @@ jobs:
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
 
-      - name: Monorepo build
-        uses: ./.github/actions/run-build
+      - name: Create install-and-build script
+        run: printf '#!/bin/sh\nset -e\nyarn install\nyarn build\n' > /tmp/install-and-build.sh
 
       - uses: preactjs/compressed-size-action@v2
         with:
+          install-script: 'sh /tmp/install-and-build.sh'
           build-script: 'build:size'
           pattern: '**/build/**/*.{js,css,html,svg}'
           strip-hash: "-([-\\w]{8})(\\.\\w+)$"

--- a/examples/getstarted/config/server.js
+++ b/examples/getstarted/config/server.js
@@ -41,4 +41,7 @@ module.exports = ({ env }) => ({
       // enabled: false,
     },
   },
+  mcp: {
+    enabled: true,
+  },
 });

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@paralleldrive/cuid2": "2.2.2",
     "@strapi/admin": "5.46.0",
     "@strapi/database": "5.46.0",

--- a/packages/core/core/src/providers/index.ts
+++ b/packages/core/core/src/providers/index.ts
@@ -2,6 +2,7 @@ import admin from './admin';
 import ai from './ai';
 import coreStore from './coreStore';
 import cron from './cron';
+import mcp from './mcp';
 import registries from './registries';
 import sessionManager from './session-manager';
 import telemetry from './telemetry';
@@ -18,4 +19,5 @@ export const providers: Provider[] = [
   webhooks,
   telemetry,
   cron,
+  mcp,
 ];

--- a/packages/core/core/src/providers/mcp.ts
+++ b/packages/core/core/src/providers/mcp.ts
@@ -1,0 +1,30 @@
+import { defineProvider } from './provider';
+import { createMcpService } from '../services/mcp/index';
+
+export default defineProvider({
+  init(strapi) {
+    strapi.add('ai.mcp', () => createMcpService(strapi));
+  },
+  async bootstrap(strapi) {
+    if (strapi.ai.mcp.isEnabled()) {
+      try {
+        strapi.log.info('[MCP] Starting MCP server...');
+        await strapi.ai.mcp.start();
+      } catch (error) {
+        strapi.log.error('[MCP] Failed to start MCP server', { error });
+      }
+    } else {
+      strapi.log.debug('[MCP] MCP server is disabled in configuration');
+    }
+  },
+  async destroy(strapi) {
+    if (strapi.ai.mcp.isRunning()) {
+      try {
+        strapi.log.info('[MCP] Stopping MCP server...');
+        await strapi.ai.mcp.stop();
+      } catch (error) {
+        strapi.log.error('[MCP] Failed to stop MCP server', { error });
+      }
+    }
+  },
+});

--- a/packages/core/core/src/services/__tests__/ai.test.ts
+++ b/packages/core/core/src/services/__tests__/ai.test.ts
@@ -1,42 +1,60 @@
 import { createAiNamespace } from '../ai';
 
-const createMockStrapi = (aiAdminService?: unknown) =>
+const createMockStrapi = (services: Record<string, unknown>) =>
   ({
     get: jest.fn((name: string) => {
-      if (name === 'ai.admin') return aiAdminService;
+      if (name in services) return services[name];
       throw new Error(`Could not resolve service ${name}`);
     }),
   }) as any;
 
 describe('createAiNamespace', () => {
-  it('returns a namespace with an admin property', () => {
-    const ns = createAiNamespace(createMockStrapi({}));
+  it('returns a namespace with admin and mcp properties', () => {
+    const ns = createAiNamespace(createMockStrapi({ 'ai.admin': {}, 'ai.mcp': {} }));
     expect(ns.admin).toBeDefined();
+    expect(ns.mcp).toBeDefined();
   });
 
   describe('container delegation', () => {
-    it('returns the service registered under ai.admin', () => {
+    it('returns the services registered under ai.admin and ai.mcp', () => {
       const aiAdminService = {
         isEnabled: jest.fn().mockReturnValue(true),
         getAiToken: jest.fn(),
         getAiUsage: jest.fn(),
         getAiFeatureConfig: jest.fn(),
       };
+      const mcpService = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        isRunning: jest.fn().mockReturnValue(false),
+        start: jest.fn(),
+        stop: jest.fn(),
+      };
 
-      const ns = createAiNamespace(createMockStrapi(aiAdminService));
+      const ns = createAiNamespace(
+        createMockStrapi({ 'ai.admin': aiAdminService, 'ai.mcp': mcpService })
+      );
       expect(ns.admin).toBe(aiAdminService);
+      expect(ns.mcp).toBe(mcpService);
     });
 
     it('calls get() on each access (no stale cache)', () => {
-      const mockStrapi = createMockStrapi({});
+      const mockStrapi = createMockStrapi({ 'ai.admin': {}, 'ai.mcp': {} });
       const ns = createAiNamespace(mockStrapi);
 
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       ns.admin;
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       ns.admin;
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      ns.mcp;
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      ns.mcp;
 
-      expect(mockStrapi.get).toHaveBeenCalledTimes(2);
+      expect(mockStrapi.get).toHaveBeenCalledTimes(4);
+      expect(mockStrapi.get).toHaveBeenNthCalledWith(1, 'ai.admin');
+      expect(mockStrapi.get).toHaveBeenNthCalledWith(2, 'ai.admin');
+      expect(mockStrapi.get).toHaveBeenNthCalledWith(3, 'ai.mcp');
+      expect(mockStrapi.get).toHaveBeenNthCalledWith(4, 'ai.mcp');
     });
   });
 });

--- a/packages/core/core/src/services/ai.ts
+++ b/packages/core/core/src/services/ai.ts
@@ -4,4 +4,8 @@ export const createAiNamespace = (strapi: Core.Strapi): Modules.AI.AiNamespace =
   get admin(): Modules.AI.AiAdminService {
     return strapi.get('ai.admin');
   },
+
+  get mcp(): Modules.MCP.McpService {
+    return strapi.get('ai.mcp');
+  },
 });

--- a/packages/core/core/src/services/mcp/__tests__/routes.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/routes.test.ts
@@ -1,0 +1,187 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from '../internal/McpConfiguration';
+
+import { type McpRouteHandlers, createMcpRoutes } from '../routes';
+
+describe('MCP Routes', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockHandlers: McpRouteHandlers;
+
+  beforeEach(() => {
+    mockStrapi = {
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    mockHandlers = {
+      handlePost: jest.fn(),
+      handleGet: jest.fn(),
+      handleDelete: jest.fn(),
+    };
+  });
+
+  describe('createMcpRoutes', () => {
+    test('should create routes with correct structure', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes).toHaveLength(11);
+      expect(routes).toStrictEqual([
+        {
+          method: 'POST',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'GET',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'DELETE',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PUT',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PATCH',
+          path: '/mcp',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'GET',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'POST',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PUT',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'DELETE',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'PATCH',
+          path: '/.well-known/oauth-authorization-server',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+        {
+          method: 'POST',
+          path: '/register',
+          handler: expect.any(Function),
+          config: {
+            auth: false,
+          },
+        },
+      ]);
+    });
+
+    test('should use path from config', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].path).toBe('/mcp');
+      expect(routes[1].path).toBe('/mcp');
+      expect(routes[2].path).toBe('/mcp');
+    });
+
+    test('should disable auth for all routes', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      routes.forEach((route) => {
+        expect(route.config?.auth).toBe(false);
+      });
+    });
+
+    test('should have correct HTTP methods', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].method).toBe('POST');
+      expect(routes[1].method).toBe('GET');
+      expect(routes[2].method).toBe('DELETE');
+    });
+
+    test('should assign correct handlers', () => {
+      const routes = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes[0].handler).toBe(mockHandlers.handlePost);
+      expect(routes[1].handler).toBe(mockHandlers.handleGet);
+      expect(routes[2].handler).toBe(mockHandlers.handleDelete);
+    });
+  });
+
+  describe('route configuration', () => {
+    test('should use default path when config does not override', () => {
+      const defaultStrapi = {
+        config: {
+          get: jest.fn((key, defaultValue) => defaultValue),
+        } as any,
+      };
+      const defaultConfig = new McpConfiguration(defaultStrapi as Core.Strapi);
+      const routes = createMcpRoutes(defaultConfig, mockHandlers);
+
+      expect(routes[0].path).toBe('/mcp');
+    });
+  });
+
+  describe('handler assignment', () => {
+    test('should not mutate handlers object', () => {
+      const originalHandlers = { ...mockHandlers };
+
+      createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(mockHandlers).toEqual(originalHandlers);
+    });
+
+    test('should create independent route objects', () => {
+      const routes1 = createMcpRoutes(mockConfig, mockHandlers);
+      const routes2 = createMcpRoutes(mockConfig, mockHandlers);
+
+      expect(routes1).not.toBe(routes2);
+      expect(routes1[0]).not.toBe(routes2[0]);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -1,0 +1,241 @@
+import type { Core } from '@strapi/types';
+import { createMcpService } from '../index';
+
+jest.mock('../utils/createManagedInterval', () => ({
+  createManagedInterval: () => ({
+    start: jest.fn(),
+    clear: jest.fn(),
+  }),
+}));
+
+describe('MCP Service Integration', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockServerRoutes: jest.Mock;
+  let logDebugSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logDebugSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    logErrorSpy = jest.fn();
+    mockServerRoutes = jest.fn();
+
+    mockStrapi = {
+      log: {
+        debug: logDebugSpy,
+        info: logInfoSpy,
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => {
+          if (key === 'server.mcp.enabled') {
+            return true;
+          }
+          if (key === 'autoReload') {
+            return true; // Required for isEnabled() to return true
+          }
+          if (key === 'server.url') {
+            return 'http://localhost:1337';
+          }
+          return defaultValue;
+        }),
+      } as any,
+      server: {
+        routes: mockServerRoutes,
+      } as any,
+    };
+  });
+
+  describe('route registration on start', () => {
+    test('should register all routes when service starts', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(mockServerRoutes).toHaveBeenCalledTimes(1);
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      expect(registeredRoutes).toHaveLength(11);
+    });
+
+    test('should register POST route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const postRoute = registeredRoutes.find((r: any) => r.method === 'POST');
+
+      expect(postRoute).toBeDefined();
+      expect(postRoute.path).toBe('/mcp');
+      expect(postRoute.config.auth).toBe(false);
+      expect(typeof postRoute.handler).toBe('function');
+    });
+
+    test('should register GET route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const getRoute = registeredRoutes.find((r: any) => r.method === 'GET');
+
+      expect(getRoute).toBeDefined();
+      expect(getRoute.path).toBe('/mcp');
+      expect(getRoute.config.auth).toBe(false);
+      expect(typeof getRoute.handler).toBe('function');
+    });
+
+    test('should register DELETE route with correct configuration', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+      const deleteRoute = registeredRoutes.find((r: any) => r.method === 'DELETE');
+
+      expect(deleteRoute).toBeDefined();
+      expect(deleteRoute.path).toBe('/mcp');
+      expect(deleteRoute.config.auth).toBe(false);
+      expect(typeof deleteRoute.handler).toBe('function');
+    });
+
+    test('should use hardcoded /mcp path', async () => {
+      // Path is currently hardcoded in McpConfiguration
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      const expectedMCPRoutesCount = registeredRoutes.filter((r: any) =>
+        r.path.includes('/mcp')
+      ).length;
+      expect(expectedMCPRoutesCount).toBe(5);
+    });
+
+    test('should not register routes when service is disabled', async () => {
+      const disabledStrapi = {
+        ...mockStrapi,
+        config: {
+          get: jest.fn((key: string, defaultValue?: any) => {
+            if (key === 'server.mcp.enabled') {
+              return false;
+            }
+            if (key === 'autoReload') {
+              return false; // Disabled will also require autoReload to be false
+            }
+            return defaultValue;
+          }),
+        } as any,
+      };
+
+      const service = createMcpService(disabledStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(mockServerRoutes).not.toHaveBeenCalled();
+      expect(logDebugSpy).toHaveBeenCalledWith('[MCP] Server is disabled');
+    });
+
+    test('should log correct endpoint URL after starting', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[MCP] Server available at http://localhost:1337/mcp'
+      );
+    });
+  });
+
+  describe('route authentication', () => {
+    test('should disable authentication for all routes', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      const registeredRoutes = mockServerRoutes.mock.calls[0][0];
+
+      registeredRoutes.forEach((route: any) => {
+        expect(route.config).toBeDefined();
+        expect(route.config.auth).toBe(false);
+      });
+    });
+  });
+
+  describe('service state management', () => {
+    test('should update status to running after registering routes', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      expect(service.isRunning()).toBe(false);
+
+      await service.start();
+
+      expect(service.isRunning()).toBe(true);
+    });
+
+    test('should prevent registration before routes are registered', () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      // Tools can be registered before start
+      expect(() => {
+        service.registerTool({
+          name: 'test-tool',
+          title: 'Test Tool',
+          description: 'Test tool',
+          outputSchema: {} as any,
+          devModeOnly: false,
+          createHandler: jest.fn(),
+        });
+      }).not.toThrow();
+    });
+
+    test('should throw error when registering tools after start', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(() => {
+        service.registerTool({
+          name: 'test-tool',
+          title: 'Test Tool',
+          description: 'Test tool',
+          outputSchema: {} as any,
+          devModeOnly: false,
+          createHandler: jest.fn(),
+        });
+      }).toThrow('[MCP] Tools must be registered before MCP server starts');
+    });
+  });
+
+  describe('error state handling', () => {
+    test('should handle start/stop lifecycle correctly', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      // Start service
+      await service.start();
+      expect(mockServerRoutes).toHaveBeenCalledTimes(1);
+      expect(service.isRunning()).toBe(true);
+
+      // Stop service successfully
+      await service.stop();
+      expect(service.isRunning()).toBe(false);
+
+      // Should be able to start again after clean stop
+      await service.start();
+      expect(mockServerRoutes).toHaveBeenCalledTimes(2);
+      expect(service.isRunning()).toBe(true);
+    });
+
+    test('should prevent starting twice in a row', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      // Try to start again without stopping
+      await expect(service.start()).rejects.toThrow('[MCP] Server already started or starting');
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
@@ -1,0 +1,218 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { JSON_RPC_ERRORS } from '../../utils/jsonRpcErrors';
+import { createDeleteHandler } from '../handleDelete';
+import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../utils/withTimeout', () => ({
+  withTimeout: jest.fn((promise) => promise),
+}));
+
+describe('handleDelete', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  test('should return error when session ID is missing', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {},
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.SESSION_REQUIRED.code,
+          message: JSON_RPC_ERRORS.SESSION_REQUIRED.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+          message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should handle delete request when session is valid', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const res = {
+      headersSent: false,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
+  });
+
+  test('should handle errors during delete request', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const error = new Error('Delete failed');
+    const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      '[MCP] Error handling DELETE request',
+      expect.objectContaining({
+        error: 'Delete failed',
+      })
+    );
+    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
@@ -1,0 +1,218 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { JSON_RPC_ERRORS } from '../../utils/jsonRpcErrors';
+import { createGetHandler } from '../handleGet';
+import type { McpHandlerDependencies } from '../types';
+
+describe('handleGet', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  test('should return error when session ID is missing', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {},
+    } as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.SESSION_REQUIRED.code,
+          message: JSON_RPC_ERRORS.SESSION_REQUIRED.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+          message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should handle request when session is valid', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const updateActivitySpy = jest.fn();
+    const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      updateActivity: updateActivitySpy,
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const res = {
+      headersSent: false,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(updateActivitySpy).toHaveBeenCalled();
+    expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
+  });
+
+  test('should handle errors during request processing', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const error = new Error('Request failed');
+    const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+    const mockSession = {
+      lastActivity: Date.now(),
+      updateActivity: jest.fn(),
+      transport: {
+        handleRequest: handleRequestSpy,
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      '[MCP] Error handling GET request',
+      expect.objectContaining({
+        error: 'Request failed',
+      })
+    );
+    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -1,0 +1,364 @@
+import type { Core } from '@strapi/types';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { McpConfiguration } from '../../internal/McpConfiguration';
+import { McpSessionManager } from '../../internal/McpSessionManager';
+import { McpSession } from '../../session';
+import { createPostHandler } from '../handlePost';
+import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../utils/withTimeout', () => ({
+  withTimeout: jest.fn((promise) => promise),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: jest.fn(),
+}));
+
+describe('handlePost', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let mockSessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+        info: logInfoSpy,
+      } as any,
+      config: {
+        get: jest.fn((key, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  describe('existing session', () => {
+    test('should handle request with existing session', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const updateActivitySpy = jest.fn();
+      const handleRequestSpy = jest.fn().mockResolvedValue(undefined);
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: updateActivitySpy,
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const requestBody = { method: 'test' };
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const res = {
+        headersSent: false,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {
+          body: requestBody,
+        },
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(updateActivitySpy).toHaveBeenCalled();
+      expect(handleRequestSpy).toHaveBeenCalledWith(req, res, requestBody);
+    });
+
+    test('should return error when session is invalid', async () => {
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid session'));
+    });
+  });
+
+  describe('new session', () => {
+    test('should create new session when no session ID provided', async () => {
+      const mockMcpServer = {
+        connect: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const mockTransport = {
+        handleRequest: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const mockRegistries = {
+        toolRegistry: {},
+        promptRegistry: {},
+        resourceRegistry: {},
+      };
+
+      const createServerWithRegistries = jest.fn().mockReturnValue({
+        mcpServer: mockMcpServer,
+        registries: mockRegistries,
+      });
+
+      // Mock the StreamableHTTPServerTransport constructor
+      const { StreamableHTTPServerTransport } = jest.requireMock(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      StreamableHTTPServerTransport.mockImplementation((options: any) => {
+        // Immediately initialize session for testing
+        setTimeout(() => {
+          if (options.onsessioninitialized) {
+            options.onsessioninitialized('new-session-id');
+          }
+        }, 0);
+        return mockTransport;
+      });
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries,
+        capabilityDefinitions: {
+          tools: {} as any,
+          prompts: {} as any,
+          resources: {} as any,
+        },
+      };
+
+      const handler = createPostHandler(deps);
+
+      const requestBody = { method: 'initialize' };
+      const req = {
+        headers: {},
+      } as unknown as IncomingMessage;
+
+      const res = {
+        headersSent: false,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {
+          body: requestBody,
+        },
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(createServerWithRegistries).toHaveBeenCalledWith({
+        strapi: mockStrapi,
+        definitions: deps.capabilityDefinitions,
+        isDevMode: mockConfig.isDevMode(),
+      });
+      expect(mockMcpServer.connect).toHaveBeenCalledWith(mockTransport);
+      expect(mockTransport.handleRequest).toHaveBeenCalledWith(req, res, requestBody);
+    });
+
+    test('should return error when max sessions reached', async () => {
+      // Fill up session manager to max
+      const maxSessions = mockConfig.maxSessions;
+      for (let i = 0; i < maxSessions; i += 1) {
+        mockSessionManager.set(`session-${i}`, {
+          lastActivity: Date.now(),
+        } as any as McpSession);
+      }
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {},
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(503, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Maximum number of sessions reached')
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    test('should handle errors during request processing', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const error = new Error('Request failed');
+      const handleRequestSpy = jest.fn().mockRejectedValue(error);
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: jest.fn(),
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        '[MCP] Error handling POST request',
+        expect.objectContaining({
+          error: 'Request failed',
+        })
+      );
+      expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    });
+
+    test('should handle non-Error exceptions', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const handleRequestSpy = jest.fn().mockRejectedValue('String error');
+
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: jest.fn(),
+        transport: {
+          handleRequest: handleRequestSpy,
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        '[MCP] Error handling POST request',
+        expect.objectContaining({
+          error: 'Unknown error',
+        })
+      );
+      expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/handlers/handleDelete.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleDelete.ts
@@ -1,0 +1,41 @@
+import type { Core } from '@strapi/types';
+import { extractSessionId } from '../internal/extractSessionId';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import { withTimeout } from '../utils/withTimeout';
+import type { McpHandlerDependencies } from './types';
+
+export const createDeleteHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager, config } = deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    if (sessionId === undefined) {
+      sendJsonRpcError(res, 'SESSION_REQUIRED');
+      return;
+    }
+
+    const session = sessionManager.get(sessionId);
+    if (session === undefined) {
+      sendJsonRpcError(res, 'INVALID_SESSION');
+      return;
+    }
+
+    try {
+      await withTimeout(
+        session.transport.handleRequest(req, res, null),
+        config.requestTimeoutMs,
+        'transport.handleRequest'
+      );
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling DELETE request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 'INTERNAL_ERROR');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/handleGet.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleGet.ts
@@ -1,0 +1,39 @@
+import type { Core } from '@strapi/types';
+import { extractSessionId } from '../internal/extractSessionId';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import type { McpHandlerDependencies } from './types';
+
+export const createGetHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager } = deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    if (sessionId === undefined) {
+      sendJsonRpcError(res, 'SESSION_REQUIRED');
+      return;
+    }
+
+    const session = sessionManager.get(sessionId);
+    if (session === undefined) {
+      sendJsonRpcError(res, 'INVALID_SESSION');
+      return;
+    }
+
+    // GET requests establish long-lived SSE streams; transport manages their lifecycle.
+    session.updateActivity();
+
+    try {
+      await session.transport.handleRequest(req, res, null);
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling GET request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 'INTERNAL_ERROR');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/handlePost.ts
+++ b/packages/core/core/src/services/mcp/handlers/handlePost.ts
@@ -1,0 +1,96 @@
+// eslint-disable-next-line import/extensions
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Core } from '@strapi/types';
+import { randomUUID } from 'node:crypto';
+import { extractSessionId } from '../internal/extractSessionId';
+import { McpSession } from '../session';
+import { sendJsonRpcError } from '../utils/sendJsonRpcError';
+import { withTimeout } from '../utils/withTimeout';
+import type { McpHandlerDependencies } from './types';
+
+export const createPostHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
+  const { strapi, sessionManager, config, createServerWithRegistries, capabilityDefinitions } =
+    deps;
+
+  return async (ctx) => {
+    const req = ctx.req;
+    const res = ctx.res;
+    const sessionId = extractSessionId(req);
+
+    try {
+      let transport: StreamableHTTPServerTransport;
+
+      // Existing session handling
+      if (sessionId !== undefined) {
+        const existingSession = sessionManager.get(sessionId);
+        if (existingSession === undefined) {
+          sendJsonRpcError(res, 'INVALID_SESSION');
+          return;
+        }
+        existingSession.updateActivity();
+        transport = existingSession.transport;
+
+        // Handle request with existing session
+        const requestBody = ctx.request.body ?? null;
+        await withTimeout(
+          transport.handleRequest(req, res, requestBody),
+          config.requestTimeoutMs,
+          'transport.handleRequest'
+        );
+      } else {
+        if (sessionManager.hasReachedMaxSessions() === true) {
+          sendJsonRpcError(res, 'MAX_SESSIONS_REACHED');
+          return;
+        }
+
+        // New session initialization
+        const requestBody = ctx.request.body ?? null;
+
+        const { mcpServer, registries } = createServerWithRegistries({
+          strapi,
+          definitions: capabilityDefinitions,
+          isDevMode: config.isDevMode(),
+        });
+
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized(id) {
+            sessionManager.set(
+              id,
+              new McpSession({
+                server: mcpServer,
+                transport,
+                toolRegistry: registries.toolRegistry,
+                promptRegistry: registries.promptRegistry,
+                resourceRegistry: registries.resourceRegistry,
+              })
+            );
+            strapi.log.info('[MCP] Session initialized', { sessionId: id });
+          },
+          onsessionclosed(id) {
+            sessionManager.delete(id);
+            strapi.log.info('[MCP] Session closed', { sessionId: id });
+          },
+        });
+
+        await withTimeout(
+          mcpServer.connect(transport),
+          config.requestTimeoutMs,
+          'mcpServer.connect'
+        );
+        await withTimeout(
+          transport.handleRequest(req, res, requestBody),
+          config.requestTimeoutMs,
+          'transport.handleRequest'
+        );
+      }
+    } catch (error) {
+      strapi.log.error('[MCP] Error handling POST request', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      sendJsonRpcError(res, 'INTERNAL_ERROR');
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/handlers/types.ts
+++ b/packages/core/core/src/services/mcp/handlers/types.ts
@@ -1,0 +1,15 @@
+import type { Core } from '@strapi/types';
+import type { McpConfiguration } from '../internal/McpConfiguration';
+import type {
+  McpCapabilityDefinitions,
+  createMcpServerWithRegistries,
+} from '../internal/McpServerFactory';
+import type { McpSessionManager } from '../internal/McpSessionManager';
+
+export type McpHandlerDependencies = {
+  strapi: Core.Strapi;
+  sessionManager: McpSessionManager;
+  config: McpConfiguration;
+  createServerWithRegistries: typeof createMcpServerWithRegistries;
+  capabilityDefinitions: McpCapabilityDefinitions;
+};

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -1,0 +1,169 @@
+import type { Core, Modules } from '@strapi/types';
+import { createDeleteHandler } from './handlers/handleDelete';
+import { createGetHandler } from './handlers/handleGet';
+import { createPostHandler } from './handlers/handlePost';
+import type { McpHandlerDependencies } from './handlers/types';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import { McpConfiguration } from './internal/McpConfiguration';
+import { createMcpServerWithRegistries } from './internal/McpServerFactory';
+import { McpSessionManager } from './internal/McpSessionManager';
+import { createMcpRoutes } from './routes';
+import { logToolDefinition } from './tools/log';
+import { createManagedInterval } from './utils/createManagedInterval';
+
+/**
+ * Creates an MCP service instance for Strapi Core
+ */
+export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService => {
+  // Initialize configuration
+  const config = new McpConfiguration(strapi);
+
+  // Initialize session manager
+  const sessionManager = new McpSessionManager(config, strapi);
+
+  // Status tracking
+  let serverStatus: Modules.MCP.McpServiceStatus = 'idle';
+
+  // Cleanup interval management
+  const cleanupSessionsInterval = createManagedInterval();
+
+  // Definition registries
+  const toolDefinitions = new McpCapabilityDefinitionRegistry<
+    'tool',
+    Modules.MCP.McpToolDefinition
+  >('tool');
+
+  const promptDefinitions = new McpCapabilityDefinitionRegistry<
+    'prompt',
+    Modules.MCP.McpPromptDefinition
+  >('prompt');
+
+  const resourceDefinitions = new McpCapabilityDefinitionRegistry<
+    'resource',
+    Modules.MCP.McpResourceDefinition
+  >('resource');
+
+  // Prepare handler dependencies
+  const handlerDependencies: McpHandlerDependencies = {
+    strapi,
+    sessionManager,
+    config,
+    createServerWithRegistries: createMcpServerWithRegistries,
+    capabilityDefinitions: {
+      tools: toolDefinitions,
+      prompts: promptDefinitions,
+      resources: resourceDefinitions,
+    },
+  };
+
+  // Create HTTP handlers
+  const handlePost = createPostHandler(handlerDependencies);
+  const handleGet = createGetHandler(handlerDependencies);
+  const handleDelete = createDeleteHandler(handlerDependencies);
+
+  const service: Modules.MCP.McpService = {
+    isEnabled() {
+      return config.isEnabled();
+    },
+
+    isRunning() {
+      return serverStatus === 'running';
+    },
+
+    registerTool(tool) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Tools must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      const { inputSchema, ...rest } = tool;
+      toolDefinitions.define({
+        ...rest,
+        inputSchema,
+      });
+    },
+
+    registerPrompt(prompt) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Prompts must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      const { argsSchema, ...rest } = prompt;
+      promptDefinitions.define({
+        ...rest,
+        argsSchema,
+      });
+    },
+
+    registerResource(resource) {
+      if (serverStatus !== 'idle') {
+        throw new Error(
+          '[MCP] Resources must be registered before MCP server starts. Register during plugin register().'
+        );
+      }
+      resourceDefinitions.define(resource);
+    },
+
+    async start() {
+      if (service.isEnabled() === false) {
+        strapi.log.debug('[MCP] Server is disabled');
+        return;
+      }
+      if (serverStatus === 'error') {
+        throw new Error('[MCP] Cannot start server: previous error state');
+      }
+      if (serverStatus !== 'idle') {
+        throw new Error(`[MCP] Server already started or starting (status: ${serverStatus})`);
+      }
+      serverStatus = 'starting';
+
+      const routes = createMcpRoutes(config, { handlePost, handleGet, handleDelete });
+      strapi.server.routes(routes);
+
+      // Set status to 'running' after routes are registered
+      serverStatus = 'running';
+
+      // Start periodic cleanup of idle sessions
+      cleanupSessionsInterval.start(() => {
+        sessionManager.cleanupIdleSessions();
+      }, config.cleanupIntervalMs);
+
+      const baseUrl = strapi.config.get('server.url', 'http://localhost:1337');
+      strapi.log.info(`[MCP] Server available at ${baseUrl}${config.path}`);
+    },
+
+    async stop() {
+      serverStatus = 'stopping';
+
+      try {
+        const { erroredSessionMessages, hasErrors } = await sessionManager.closeAllSessions();
+
+        // Log any errors encountered during session closures
+        if (hasErrors === true) {
+          strapi.log.error(
+            `[MCP] Errors occurred while stopping sessions:\n${erroredSessionMessages.join('\n')}`
+          );
+          serverStatus = 'error';
+        } else {
+          serverStatus = 'idle';
+        }
+      } catch (error) {
+        strapi.log.error('[MCP] Error stopping service', {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+        serverStatus = 'error';
+      } finally {
+        // Clear cleanup interval
+        cleanupSessionsInterval.clear();
+
+        strapi.log.info('[MCP] Service stopped');
+      }
+    },
+  };
+
+  service.registerTool(logToolDefinition);
+
+  return service;
+};

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
@@ -1,0 +1,40 @@
+import type { Modules } from '@strapi/types';
+
+export class McpCapabilityDefinitionRegistry<
+  CapabilityName extends 'tool' | 'prompt' | 'resource',
+  Definition extends Modules.MCP.McpCapabilityDefinition,
+> {
+  capability: CapabilityName;
+
+  #definitions = new Map<string, Definition>();
+
+  constructor(capability: CapabilityName) {
+    this.capability = capability;
+  }
+
+  define(definition: Definition) {
+    const existing = this.#definitions.get(definition.name);
+    if (existing !== undefined) {
+      throw new Error(
+        `[MCP] ${this.capability} with name "${definition.name}" is already registered. Names must be unique.`
+      );
+    }
+    this.#definitions.set(definition.name, definition);
+  }
+
+  get(name: string): Definition | undefined {
+    return this.#definitions.get(name);
+  }
+
+  delete(name: string): boolean {
+    return this.#definitions.delete(name);
+  }
+
+  getAll(): Definition[] {
+    return Array.from(this.#definitions.values());
+  }
+
+  get size(): number {
+    return this.#definitions.size;
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
@@ -1,0 +1,133 @@
+import type { Modules } from '@strapi/types';
+// eslint-disable-next-line import/extensions
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpCapabilityDefinitionRegistry } from './McpCapabilityDefinitionRegistry';
+
+export interface McpCapabilityRegistry {
+  bind: (mcpServer: McpServer) => void;
+}
+
+export type RegisteredCapability = {
+  enabled: boolean;
+  enable(): void;
+  disable(): void;
+  remove(): void;
+};
+
+export class McpCapabilityRegistryBase<
+  CapabilityName extends 'tool' | 'prompt' | 'resource',
+  Definition extends Modules.MCP.McpCapabilityDefinition,
+  Registered extends RegisteredCapability,
+> {
+  #definitions: McpCapabilityDefinitionRegistry<CapabilityName, Definition>;
+
+  #registered = new Map<string, Registered>();
+
+  constructor(definitions: McpCapabilityDefinitionRegistry<CapabilityName, Definition>) {
+    this.#definitions = definitions;
+  }
+
+  protected register<LocallyRegistered extends Registered>(
+    registerFn: (definition: Definition) => LocallyRegistered
+  ) {
+    for (const definition of this.#definitions.getAll()) {
+      const existing = this.#registered.get(definition.name);
+      if (existing !== undefined) {
+        throw new Error(
+          `[MCP] ${this.#definitions.capability} with name "${definition.name}" is already registered. Names must be unique.`
+        );
+      }
+
+      const registered = registerFn(definition);
+
+      // Disable the capability until explicitly enabled depending on devModeOnly and authorization
+      registered.disable();
+
+      this.#registered.set(definition.name, registered);
+    }
+  }
+
+  list(ctx?: {
+    filter?: {
+      status?: ('enabled' | 'disabled' | 'defined' | 'undefined')[];
+    };
+  }) {
+    const { filter } = ctx ?? {};
+    return this.#definitions.getAll().reduce<
+      {
+        name: string;
+        status: 'enabled' | 'disabled' | 'defined' | 'undefined';
+        devModeOnly: boolean;
+      }[]
+    >((acc, curr) => {
+      const status = this.status(curr.name);
+      if (filter?.status !== undefined && !filter.status.includes(status)) {
+        return acc;
+      }
+      acc.push({ name: curr.name, status, devModeOnly: curr.devModeOnly });
+      return acc;
+    }, []);
+  }
+
+  status(name: string): 'enabled' | 'disabled' | 'defined' | 'undefined' {
+    const registered = this.#registered.get(name);
+    if (registered !== undefined) {
+      return registered.enabled === true ? 'enabled' : 'disabled';
+    }
+    const definition = this.#definitions.get(name);
+    if (definition !== undefined) {
+      return 'defined';
+    }
+    return 'undefined';
+  }
+
+  enable(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.enable();
+  }
+
+  enableAll() {
+    for (const registered of this.#registered.values()) {
+      registered.enable();
+    }
+  }
+
+  disable(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.disable();
+  }
+
+  disableAll() {
+    for (const registered of this.#registered.values()) {
+      registered.disable();
+    }
+  }
+
+  remove(name: string) {
+    const registered = this.#registered.get(name);
+    if (!registered) {
+      throw new Error(
+        `[MCP] ${this.#definitions.capability} with name "${name}" is not registered.`
+      );
+    }
+    registered.remove();
+    this.#registered.delete(name);
+  }
+
+  removeAll() {
+    for (const registered of this.#registered.values()) {
+      registered.remove();
+    }
+    this.#registered.clear();
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
+++ b/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
@@ -1,0 +1,39 @@
+import type { Core } from '@strapi/types';
+
+export class McpConfiguration {
+  readonly path: string;
+
+  readonly sessionIdleTimeoutMs: number;
+
+  readonly maxSessions: number;
+
+  readonly cleanupIntervalMs: number;
+
+  readonly requestTimeoutMs: number;
+
+  #strapi: Core.Strapi;
+
+  constructor(strapi: Core.Strapi) {
+    this.#strapi = strapi;
+    this.path = '/mcp';
+    this.sessionIdleTimeoutMs = strapi.config.get(
+      'server.mcp.sessionIdleTimeoutMs',
+      30 * 60 * 1000
+    ); // 30 minutes
+    this.maxSessions = strapi.config.get('server.mcp.maxSessions', 100);
+    this.cleanupIntervalMs = strapi.config.get('server.mcp.cleanupIntervalMs', 5 * 60 * 1000); // 5 minutes
+    this.requestTimeoutMs = strapi.config.get('server.mcp.requestTimeoutMs', 30 * 1000); // 30 seconds
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.#strapi.config.get('server.mcp.enabled', false) &&
+      // Only enabled in development mode until Auth is implemented
+      this.#strapi.config.get('autoReload') === true
+    );
+  }
+
+  isDevMode(): boolean {
+    return this.#strapi.config.get('autoReload', false);
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
+++ b/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
@@ -1,0 +1,113 @@
+// eslint-disable-next-line import/extensions
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { McpPromptRegistry } from '../prompt-registry';
+import { McpResourceRegistry } from '../resource-registry';
+import { McpToolRegistry } from '../tool-registry';
+import { McpCapabilityDefinitionRegistry } from './McpCapabilityDefinitionRegistry';
+
+export type McpCapabilityDefinitions = {
+  tools: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  prompts: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  resources: McpCapabilityDefinitionRegistry<'resource', Modules.MCP.McpResourceDefinition>;
+};
+
+export type McpRegistries = {
+  toolRegistry: McpToolRegistry;
+  promptRegistry: McpPromptRegistry;
+  resourceRegistry: McpResourceRegistry;
+};
+
+export type McpServerWithRegistries = {
+  mcpServer: McpServer;
+  registries: McpRegistries;
+};
+
+export type CreateMcpServerWithRegistriesParams = {
+  strapi: Core.Strapi;
+  definitions: McpCapabilityDefinitions;
+  isDevMode: boolean;
+};
+
+export const createMcpServerWithRegistries = ({
+  strapi,
+  definitions,
+  isDevMode,
+}: CreateMcpServerWithRegistriesParams): McpServerWithRegistries => {
+  const capabilities: {
+    logging?: Record<string, unknown>;
+    tools?: Record<string, unknown>;
+    prompts?: Record<string, unknown>;
+    resources?: Record<string, unknown>;
+  } = {
+    logging: {},
+  };
+  if (definitions.tools.size > 0) {
+    capabilities.tools = {};
+  }
+  if (definitions.prompts.size > 0) {
+    capabilities.prompts = {};
+  }
+  if (definitions.resources.size > 0) {
+    capabilities.resources = {};
+  }
+
+  const mcpServer = new McpServer(
+    {
+      name: 'strapi-mcp-server',
+      version: '1.0.0',
+    },
+    {
+      capabilities,
+    }
+  );
+
+  // Bootstrap registries with current definitions
+  const toolRegistry = new McpToolRegistry({
+    strapi,
+    definitions: definitions.tools,
+  });
+  const promptRegistry = new McpPromptRegistry({
+    strapi,
+    definitions: definitions.prompts,
+  });
+  const resourceRegistry = new McpResourceRegistry({
+    strapi,
+    definitions: definitions.resources,
+  });
+
+  // Register capabilities (disabled by default)
+  toolRegistry.bind(mcpServer);
+  promptRegistry.bind(mcpServer);
+  resourceRegistry.bind(mcpServer);
+
+  // TODO @Nico: Manage Permissions from Auth
+
+  // Enable devModeOnly capabilities when running in dev mode
+  if (isDevMode === true) {
+    toolRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        toolRegistry.enable(cap.name);
+      }
+    });
+    promptRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        promptRegistry.enable(cap.name);
+      }
+    });
+    resourceRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
+      if (cap.devModeOnly === true) {
+        resourceRegistry.enable(cap.name);
+      }
+    });
+  }
+
+  return {
+    mcpServer,
+    registries: {
+      toolRegistry,
+      promptRegistry,
+      resourceRegistry,
+    },
+  };
+};

--- a/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
+++ b/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
@@ -1,0 +1,120 @@
+import type { Core } from '@strapi/types';
+import { McpSession } from '../session';
+import { McpConfiguration } from './McpConfiguration';
+
+export class McpSessionManager {
+  #sessions = new Map<string, McpSession>();
+
+  #config: McpConfiguration;
+
+  #strapi: Core.Strapi;
+
+  constructor(config: McpConfiguration, strapi: Core.Strapi) {
+    this.#config = config;
+    this.#strapi = strapi;
+  }
+
+  get(id: string): McpSession | undefined {
+    return this.#sessions.get(id);
+  }
+
+  set(id: string, session: McpSession): void {
+    this.#sessions.set(id, session);
+  }
+
+  async delete(id: string): Promise<void> {
+    const session = this.#sessions.get(id);
+    if (session === undefined) {
+      return;
+    }
+    try {
+      await session.server.close();
+    } catch (err) {
+      this.#strapi.log.error('[MCP] Error closing server for session', {
+        sessionId: id,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    } finally {
+      this.#sessions.delete(id);
+    }
+  }
+
+  hasReachedMaxSessions(): boolean {
+    return this.#sessions.size >= this.#config.maxSessions;
+  }
+
+  get size(): number {
+    return this.#sessions.size;
+  }
+
+  cleanupIdleSessions(): string[] {
+    const now = Date.now();
+    const expiredSessions: string[] = [];
+
+    for (const [sessionId, session] of this.#sessions.entries()) {
+      const idleTime = now - session.lastActivity;
+      if (idleTime >= this.#config.sessionIdleTimeoutMs) {
+        expiredSessions.push(sessionId);
+      }
+    }
+
+    for (const sessionId of expiredSessions) {
+      const session = this.#sessions.get(sessionId);
+      if (session !== undefined) {
+        session.server.close().catch((err) => {
+          this.#strapi.log.error('[MCP] Error closing expired session', {
+            sessionId,
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+        });
+        this.#sessions.delete(sessionId);
+        this.#strapi.log.info('[MCP] Expired session cleaned up', { sessionId });
+      }
+    }
+
+    return expiredSessions;
+  }
+
+  async closeAllSessions(): Promise<{
+    erroredSessionMessages: string[];
+    hasErrors: boolean;
+  }> {
+    const closeSessionPromises = Array.from(this.#sessions.entries()).map(
+      async ([sessionId, { server, transport }]) =>
+        Promise.allSettled([transport.close(), server.close()]).then(
+          ([transportResult, serverResult]) => ({
+            sessionId,
+            transportResult,
+            serverResult,
+          })
+        )
+    );
+
+    const closedSessions = await Promise.all(closeSessionPromises);
+
+    const erroredSessionMessages = closedSessions
+      .filter(
+        ({ transportResult, serverResult }) =>
+          transportResult.status === 'rejected' || serverResult.status === 'rejected'
+      )
+      .map(
+        ({ sessionId, transportResult, serverResult }) =>
+          `session ${sessionId}: ${
+            transportResult.status === 'rejected'
+              ? `Transport error: ${transportResult.reason instanceof Error ? transportResult.reason.message : String(transportResult.reason)}.`
+              : ''
+          } ${
+            serverResult.status === 'rejected'
+              ? `Server error: ${serverResult.reason instanceof Error ? serverResult.reason.message : String(serverResult.reason)}.`
+              : ''
+          }`
+      );
+
+    this.#sessions.clear();
+
+    return {
+      erroredSessionMessages,
+      hasErrors: erroredSessionMessages.length > 0,
+    };
+  }
+}

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
@@ -1,0 +1,89 @@
+import type { Modules } from '@strapi/types';
+
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+
+describe('McpCapabilityDefinitionRegistry', () => {
+  test('stores capability type', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    expect(registry.capability).toBe('tool');
+  });
+
+  test('define() registers a definition and get() returns it', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    const definition: Modules.MCP.McpCapabilityDefinition = {
+      name: 'my-capability',
+      devModeOnly: false,
+    };
+
+    registry.define(definition);
+
+    expect(registry.get('my-capability')).toBe(definition);
+    expect(registry.get('unknown')).toBeUndefined();
+    expect(registry.size).toBe(1);
+    expect(registry.getAll()).toEqual([definition]);
+  });
+
+  test('define() throws when name is already registered', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'prompt',
+      Modules.MCP.McpCapabilityDefinition
+    >('prompt');
+
+    const definitionA: Modules.MCP.McpCapabilityDefinition = {
+      name: 'duplicate',
+      devModeOnly: true,
+    };
+    const definitionB: Modules.MCP.McpCapabilityDefinition = {
+      name: 'duplicate',
+      devModeOnly: false,
+    };
+
+    registry.define(definitionA);
+
+    expect(() => registry.define(definitionB)).toThrow(
+      '[MCP] prompt with name "duplicate" is already registered. Names must be unique.'
+    );
+
+    expect(registry.get('duplicate')).toBe(definitionA);
+    expect(registry.size).toBe(1);
+  });
+
+  test('delete() removes definitions and reports success', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'resource',
+      Modules.MCP.McpCapabilityDefinition
+    >('resource');
+
+    const definitionA: Modules.MCP.McpCapabilityDefinition = {
+      name: 'a',
+      devModeOnly: false,
+    };
+    const definitionB: Modules.MCP.McpCapabilityDefinition = {
+      name: 'b',
+      devModeOnly: true,
+    };
+
+    registry.define(definitionA);
+    registry.define(definitionB);
+
+    expect(registry.size).toBe(2);
+    expect(registry.getAll()).toEqual([definitionA, definitionB]);
+
+    expect(registry.delete('a')).toBe(true);
+    expect(registry.get('a')).toBeUndefined();
+    expect(registry.size).toBe(1);
+    expect(registry.getAll()).toEqual([definitionB]);
+
+    expect(registry.delete('a')).toBe(false);
+    expect(registry.delete('unknown')).toBe(false);
+    expect(registry.size).toBe(1);
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
@@ -1,0 +1,562 @@
+import type { Modules } from '@strapi/types';
+import { McpCapabilityRegistryBase, RegisteredCapability } from '../McpCapabilityRegistry';
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+
+// Mock definition type for testing
+type MockDefinition = Modules.MCP.McpCapabilityDefinition<string> & {
+  title: string;
+  description: string;
+};
+
+// Mock registered capability for testing
+class MockRegisteredCapability implements RegisteredCapability {
+  enabled: boolean = false;
+
+  enable = jest.fn(() => {
+    this.enabled = true;
+  });
+
+  disable = jest.fn(() => {
+    this.enabled = false;
+  });
+
+  remove = jest.fn();
+}
+
+// Concrete implementation for testing
+class TestCapabilityRegistry extends McpCapabilityRegistryBase<
+  'tool',
+  MockDefinition,
+  MockRegisteredCapability
+> {
+  registerDefinitions() {
+    this.register(() => new MockRegisteredCapability());
+  }
+}
+
+describe('McpCapabilityRegistryBase', () => {
+  let definitionRegistry: McpCapabilityDefinitionRegistry<'tool', MockDefinition>;
+  let registry: TestCapabilityRegistry;
+
+  beforeEach(() => {
+    definitionRegistry = new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool');
+    registry = new TestCapabilityRegistry(definitionRegistry);
+  });
+
+  describe('register', () => {
+    test('should register all definitions from the definition registry', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+
+      registry.registerDefinitions();
+
+      const list = registry.list();
+      expect(list).toHaveLength(2);
+      expect(list[0].name).toBe('tool-1');
+      expect(list[1].name).toBe('tool-2');
+    });
+
+    test('should disable capabilities by default after registration', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+
+      registry.registerDefinitions();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should throw error when registering a capability with duplicate name', () => {
+      definitionRegistry.define({
+        name: 'duplicate-tool',
+        title: 'Tool',
+        description: 'Tool',
+        devModeOnly: false,
+      });
+
+      registry.registerDefinitions();
+
+      // Try to register again
+      expect(() => {
+        registry.registerDefinitions();
+      }).toThrow(
+        '[MCP] tool with name "duplicate-tool" is already registered. Names must be unique.'
+      );
+    });
+  });
+
+  describe('list', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      definitionRegistry.define({
+        name: 'tool-3',
+        title: 'Tool 3',
+        description: 'Third tool',
+        devModeOnly: false,
+      });
+    });
+
+    test('should list all capabilities with status', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list();
+
+      expect(list).toHaveLength(3);
+      expect(list).toEqual([
+        { name: 'tool-1', status: 'disabled', devModeOnly: false },
+        { name: 'tool-2', status: 'disabled', devModeOnly: true },
+        { name: 'tool-3', status: 'disabled', devModeOnly: false },
+      ]);
+    });
+
+    test('should list capabilities filtered by enabled status', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['enabled'] },
+      });
+
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual({ name: 'tool-1', status: 'enabled', devModeOnly: false });
+    });
+
+    test('should list capabilities filtered by disabled status', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['disabled'] },
+      });
+
+      expect(list).toHaveLength(2);
+      expect(list[0].name).toBe('tool-2');
+      expect(list[1].name).toBe('tool-3');
+    });
+
+    test('should list capabilities filtered by defined status', () => {
+      // Don't register, only define
+      const list = registry.list({
+        filter: { status: ['defined'] },
+      });
+
+      expect(list).toHaveLength(3);
+      expect(list[0]).toEqual({ name: 'tool-1', status: 'defined', devModeOnly: false });
+      expect(list[1]).toEqual({ name: 'tool-2', status: 'defined', devModeOnly: true });
+      expect(list[2]).toEqual({ name: 'tool-3', status: 'defined', devModeOnly: false });
+    });
+
+    test('should list capabilities filtered by multiple statuses', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      const list = registry.list({
+        filter: { status: ['enabled', 'disabled'] },
+      });
+
+      expect(list).toHaveLength(3);
+    });
+
+    test('should return empty array when no capabilities match filter', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list({
+        filter: { status: ['enabled'] },
+      });
+
+      expect(list).toHaveLength(0);
+    });
+
+    test('should include devModeOnly flag in list results', () => {
+      registry.registerDefinitions();
+
+      const list = registry.list();
+
+      expect(list[0].devModeOnly).toBe(false);
+      expect(list[1].devModeOnly).toBe(true);
+      expect(list[2].devModeOnly).toBe(false);
+    });
+  });
+
+  describe('status', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+    });
+
+    test('should return "disabled" for registered but disabled capability', () => {
+      registry.registerDefinitions();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should return "enabled" for registered and enabled capability', () => {
+      registry.registerDefinitions();
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should return "defined" for defined but not registered capability', () => {
+      // Don't call registerDefinitions
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should return "undefined" for unknown capability', () => {
+      expect(registry.status('unknown-tool')).toBe('undefined');
+    });
+  });
+
+  describe('enable', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should enable a disabled capability', () => {
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should call enable method on registered capability', () => {
+      registry.enable('tool-1');
+
+      // The enable method should have been called through the internal registered capability
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should throw error when enabling unregistered capability', () => {
+      expect(() => {
+        registry.enable('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+  });
+
+  describe('enableAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should enable all registered capabilities', () => {
+      registry.enableAll();
+
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('enabled');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.enableAll();
+      }).not.toThrow();
+    });
+  });
+
+  describe('disable', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should disable an enabled capability', () => {
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+
+      registry.disable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should call disable method on registered capability', () => {
+      registry.enable('tool-1');
+
+      registry.disable('tool-1');
+
+      // The disable method should have been called through the internal registered capability
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+
+    test('should throw error when disabling unregistered capability', () => {
+      expect(() => {
+        registry.disable('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+  });
+
+  describe('disableAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should disable all registered capabilities', () => {
+      registry.enableAll();
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('enabled');
+
+      registry.disableAll();
+
+      expect(registry.status('tool-1')).toBe('disabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.disableAll();
+      }).not.toThrow();
+    });
+  });
+
+  describe('remove', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should remove a registered capability', () => {
+      expect(registry.status('tool-1')).toBe('disabled');
+
+      registry.remove('tool-1');
+
+      // Should now be "defined" since it's only in definition registry
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should call remove method on registered capability', () => {
+      registry.remove('tool-1');
+
+      // Verify it was removed by checking it's no longer in the list of registered
+      expect(registry.status('tool-1')).toBe('defined');
+    });
+
+    test('should throw error when removing unregistered capability', () => {
+      expect(() => {
+        registry.remove('unknown-tool');
+      }).toThrow('[MCP] tool with name "unknown-tool" is not registered.');
+    });
+
+    test('should allow removing and re-registering a capability', () => {
+      registry.remove('tool-1');
+      expect(registry.status('tool-1')).toBe('defined');
+
+      registry.registerDefinitions();
+      expect(registry.status('tool-1')).toBe('disabled');
+    });
+  });
+
+  describe('removeAll', () => {
+    beforeEach(() => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+    });
+
+    test('should remove all registered capabilities', () => {
+      expect(registry.status('tool-1')).toBe('disabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+
+      registry.removeAll();
+
+      // Should now be "defined" since they're only in definition registry
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('defined');
+    });
+
+    test('should call remove method on all registered capabilities', () => {
+      registry.removeAll();
+
+      // Verify they were removed by checking status
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('defined');
+    });
+
+    test('should work when called on empty registry', () => {
+      const emptyRegistry = new TestCapabilityRegistry(
+        new McpCapabilityDefinitionRegistry<'tool', MockDefinition>('tool')
+      );
+
+      expect(() => {
+        emptyRegistry.removeAll();
+      }).not.toThrow();
+    });
+
+    test('should clear the registered capabilities map', () => {
+      registry.removeAll();
+
+      const list = registry.list({ filter: { status: ['disabled', 'enabled'] } });
+      expect(list).toHaveLength(0);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    test('should handle enable-disable-enable cycle', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+
+      registry.disable('tool-1');
+      expect(registry.status('tool-1')).toBe('disabled');
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+    });
+
+    test('should handle enableAll-disableAll cycle', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enableAll();
+      expect(registry.list({ filter: { status: ['enabled'] } })).toHaveLength(2);
+
+      registry.disableAll();
+      expect(registry.list({ filter: { status: ['enabled'] } })).toHaveLength(0);
+    });
+
+    test('should handle partial enable and selective removal', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+
+      registry.remove('tool-1');
+      expect(registry.status('tool-1')).toBe('defined');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+
+    test('should maintain separate state for each capability', () => {
+      definitionRegistry.define({
+        name: 'tool-1',
+        title: 'Tool 1',
+        description: 'First tool',
+        devModeOnly: false,
+      });
+      definitionRegistry.define({
+        name: 'tool-2',
+        title: 'Tool 2',
+        description: 'Second tool',
+        devModeOnly: true,
+      });
+      registry.registerDefinitions();
+
+      registry.enable('tool-1');
+
+      expect(registry.status('tool-1')).toBe('enabled');
+      expect(registry.status('tool-2')).toBe('disabled');
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
@@ -1,0 +1,121 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from '../McpConfiguration';
+
+describe('McpConfiguration', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let configGetSpy: jest.Mock;
+
+  beforeEach(() => {
+    configGetSpy = jest.fn();
+    mockStrapi = {
+      config: {
+        get: configGetSpy,
+      } as any,
+    };
+  });
+
+  test('should initialize with default values when config is not set', () => {
+    configGetSpy.mockImplementation((key, defaultValue) => defaultValue);
+
+    const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    expect(config.path).toBe('/mcp');
+    expect(config.sessionIdleTimeoutMs).toBe(30 * 60 * 1000);
+    expect(config.maxSessions).toBe(100);
+    expect(config.cleanupIntervalMs).toBe(5 * 60 * 1000);
+    expect(config.requestTimeoutMs).toBe(30 * 1000);
+  });
+
+  test('should use custom config values when provided', () => {
+    configGetSpy.mockImplementation((key, defaultValue) => {
+      const customConfig: Record<string, any> = {
+        'server.mcp.sessionIdleTimeoutMs': 10 * 60 * 1000,
+        'server.mcp.maxSessions': 50,
+        'server.mcp.cleanupIntervalMs': 2 * 60 * 1000,
+        'server.mcp.requestTimeoutMs': 60 * 1000,
+      };
+      return customConfig[key] ?? defaultValue;
+    });
+
+    const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+    expect(config.sessionIdleTimeoutMs).toBe(10 * 60 * 1000);
+    expect(config.maxSessions).toBe(50);
+    expect(config.cleanupIntervalMs).toBe(2 * 60 * 1000);
+    expect(config.requestTimeoutMs).toBe(60 * 1000);
+  });
+
+  describe('isEnabled', () => {
+    test('should return true when both mcp.enabled and autoReload are true', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return true;
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(true);
+    });
+
+    test('should return false when mcp.enabled is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return false;
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+
+    test('should return false when autoReload is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return true;
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+
+    test('should return false when both are false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'server.mcp.enabled') return false;
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('isDevMode', () => {
+    test('should return true when autoReload is true', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'autoReload') return true;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isDevMode()).toBe(true);
+    });
+
+    test('should return false when autoReload is false', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => {
+        if (key === 'autoReload') return false;
+        return defaultValue;
+      });
+
+      const config = new McpConfiguration(mockStrapi as Core.Strapi);
+
+      expect(config.isDevMode()).toBe(false);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
@@ -1,0 +1,149 @@
+import type { Core, Modules } from '@strapi/types';
+import { z } from '@strapi/utils';
+import type { RegisteredCapability } from '../McpCapabilityRegistry';
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+import { createMcpServerWithRegistries } from '../McpServerFactory';
+
+// Mock registered capability for testing
+class MockRegisteredCapability implements RegisteredCapability {
+  enabled: boolean = false;
+
+  enable = jest.fn(() => {
+    this.enabled = true;
+  });
+
+  disable = jest.fn(() => {
+    this.enabled = false;
+  });
+
+  remove = jest.fn();
+}
+
+// Mock the MCP SDK
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: jest.fn().mockImplementation(() => ({
+    registerTool() {
+      return new MockRegisteredCapability();
+    },
+    registerPrompt() {
+      return new MockRegisteredCapability();
+    },
+    registerResource() {
+      return new MockRegisteredCapability();
+    },
+  })),
+}));
+
+describe('createMcpServerWithRegistries', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let toolDefinitions: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  let promptDefinitions: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  let resourceDefinitions: McpCapabilityDefinitionRegistry<
+    'resource',
+    Modules.MCP.McpResourceDefinition
+  >;
+
+  beforeEach(() => {
+    mockStrapi = {} as Core.Strapi;
+    toolDefinitions = new McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>(
+      'tool'
+    );
+    promptDefinitions = new McpCapabilityDefinitionRegistry<
+      'prompt',
+      Modules.MCP.McpPromptDefinition
+    >('prompt');
+    resourceDefinitions = new McpCapabilityDefinitionRegistry<
+      'resource',
+      Modules.MCP.McpResourceDefinition
+    >('resource');
+  });
+
+  test('should create MCP server with registries', () => {
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    expect(result.mcpServer).toBeDefined();
+    expect(result.registries.toolRegistry).toBeDefined();
+    expect(result.registries.promptRegistry).toBeDefined();
+    expect(result.registries.resourceRegistry).toBeDefined();
+  });
+
+  test('should enable devModeOnly capabilities when in dev mode', () => {
+    // Add a devModeOnly tool
+    toolDefinitions.define({
+      name: 'dev-tool',
+      title: 'Dev Tool',
+      description: 'A dev-only tool',
+      devModeOnly: true,
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: true,
+    });
+
+    // The tool should be enabled
+    const enabledTools = result.registries.toolRegistry.list({ filter: { status: ['enabled'] } });
+    expect(enabledTools.some((t) => t.name === 'dev-tool')).toBe(true);
+  });
+
+  test('should not enable devModeOnly capabilities when not in dev mode', () => {
+    // Add a devModeOnly tool
+    toolDefinitions.define({
+      name: 'dev-tool',
+      title: 'Dev Tool',
+      description: 'A dev-only tool',
+      devModeOnly: true,
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    // The tool should remain disabled
+    const disabledTools = result.registries.toolRegistry.list({
+      filter: { status: ['disabled'] },
+    });
+    expect(disabledTools.some((t) => t.name === 'dev-tool')).toBe(true);
+  });
+
+  test('should handle empty definitions', () => {
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+    });
+
+    expect(result.registries.toolRegistry.list().length).toBe(0);
+    expect(result.registries.promptRegistry.list().length).toBe(0);
+    expect(result.registries.resourceRegistry.list().length).toBe(0);
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
@@ -1,0 +1,206 @@
+import type { Core } from '@strapi/types';
+import { McpSession } from '../../session';
+import { McpConfiguration } from '../McpConfiguration';
+import { McpSessionManager } from '../McpSessionManager';
+
+describe('McpSessionManager', () => {
+  let mockStrapi: Partial<Core.Strapi>;
+  let mockConfig: McpConfiguration;
+  let sessionManager: McpSessionManager;
+  let logErrorSpy: jest.Mock;
+  let logInfoSpy: jest.Mock;
+
+  beforeEach(() => {
+    logErrorSpy = jest.fn();
+    logInfoSpy = jest.fn();
+    mockStrapi = {
+      log: {
+        error: logErrorSpy,
+        info: logInfoSpy,
+      } as any,
+      config: {
+        get: jest.fn((_, defaultValue) => defaultValue),
+      } as any,
+    };
+    mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
+    sessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+  });
+
+  describe('get and set', () => {
+    test('should store and retrieve sessions', () => {
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: jest.fn() },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      expect(sessionManager.get('session-1')).toBe(mockSession);
+    });
+
+    test('should return undefined for non-existent session', () => {
+      expect(sessionManager.get('non-existent')).toBeUndefined();
+    });
+  });
+
+  describe('delete', () => {
+    test('should delete session and close server', async () => {
+      const closeSpy = jest.fn().mockResolvedValue(undefined);
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: closeSpy },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      await sessionManager.delete('session-1');
+
+      expect(closeSpy).toHaveBeenCalled();
+      expect(sessionManager.get('session-1')).toBeUndefined();
+    });
+
+    test('should handle errors when closing server', async () => {
+      const error = new Error('Close failed');
+      const closeSpy = jest.fn().mockRejectedValue(error);
+      const mockSession = {
+        lastActivity: Date.now(),
+        server: { close: closeSpy },
+      } as any as McpSession;
+
+      sessionManager.set('session-1', mockSession);
+
+      await sessionManager.delete('session-1');
+
+      expect(logErrorSpy).toHaveBeenCalledWith('[MCP] Error closing server for session', {
+        sessionId: 'session-1',
+        error: 'Close failed',
+      });
+      expect(sessionManager.get('session-1')).toBeUndefined();
+    });
+
+    test('should do nothing if session does not exist', async () => {
+      await sessionManager.delete('non-existent');
+
+      expect(logErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasReachedMaxSessions', () => {
+    test('should return false when below max sessions', () => {
+      expect(sessionManager.hasReachedMaxSessions()).toBe(false);
+    });
+
+    test('should return true when at max sessions', () => {
+      const maxSessions = mockConfig.maxSessions;
+      for (
+        let i = 0;
+        i < maxSessions;
+        // eslint-disable-next-line no-plusplus
+        i++
+      ) {
+        sessionManager.set(`session-${i}`, {
+          lastActivity: Date.now(),
+        } as any as McpSession);
+      }
+
+      expect(sessionManager.hasReachedMaxSessions()).toBe(true);
+    });
+  });
+
+  describe('size', () => {
+    test('should return the number of active sessions', () => {
+      expect(sessionManager.size).toBe(0);
+
+      sessionManager.set('session-1', { lastActivity: Date.now() } as any as McpSession);
+      expect(sessionManager.size).toBe(1);
+
+      sessionManager.set('session-2', { lastActivity: Date.now() } as any as McpSession);
+      expect(sessionManager.size).toBe(2);
+    });
+  });
+
+  describe('cleanupIdleSessions', () => {
+    test('should remove idle sessions', () => {
+      const now = Date.now();
+      const idleTime = mockConfig.sessionIdleTimeoutMs + 1000;
+
+      const activeSession = {
+        lastActivity: now,
+        server: { close: jest.fn() },
+      } as any as McpSession;
+
+      const idleSession = {
+        lastActivity: now - idleTime,
+        server: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession;
+
+      sessionManager.set('active', activeSession);
+      sessionManager.set('idle', idleSession);
+
+      const expired = sessionManager.cleanupIdleSessions();
+
+      expect(expired).toEqual(['idle']);
+      expect(sessionManager.get('active')).toBe(activeSession);
+      expect(sessionManager.get('idle')).toBeUndefined();
+    });
+
+    test('should handle errors when closing idle sessions', () => {
+      const now = Date.now();
+      const idleTime = mockConfig.sessionIdleTimeoutMs + 1000;
+
+      const idleSession = {
+        lastActivity: now - idleTime,
+        server: { close: jest.fn().mockRejectedValue(new Error('Close failed')) },
+      } as any as McpSession;
+
+      sessionManager.set('idle', idleSession);
+
+      const expired = sessionManager.cleanupIdleSessions();
+
+      expect(expired).toEqual(['idle']);
+      expect(sessionManager.get('idle')).toBeUndefined();
+    });
+  });
+
+  describe('closeAllSessions', () => {
+    test('should close all sessions successfully', async () => {
+      const closeSpy1 = jest.fn().mockResolvedValue(undefined);
+      const closeSpy2 = jest.fn().mockResolvedValue(undefined);
+
+      sessionManager.set('session-1', {
+        server: { close: closeSpy1 },
+        transport: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession);
+
+      sessionManager.set('session-2', {
+        server: { close: closeSpy2 },
+        transport: { close: jest.fn().mockResolvedValue(undefined) },
+      } as any as McpSession);
+
+      const result = await sessionManager.closeAllSessions();
+
+      expect(result.hasErrors).toBe(false);
+      expect(result.erroredSessionMessages).toEqual([]);
+      expect(sessionManager.size).toBe(0);
+    });
+
+    test('should handle errors when closing sessions', async () => {
+      const serverError = new Error('Server close failed');
+      const transportError = new Error('Transport close failed');
+
+      sessionManager.set('session-1', {
+        server: { close: jest.fn().mockRejectedValue(serverError) },
+        transport: { close: jest.fn().mockRejectedValue(transportError) },
+      } as any as McpSession);
+
+      const result = await sessionManager.closeAllSessions();
+
+      expect(result.hasErrors).toBe(true);
+      expect(result.erroredSessionMessages.length).toBe(1);
+      expect(result.erroredSessionMessages[0]).toContain('session-1');
+      expect(result.erroredSessionMessages[0]).toContain('Transport error');
+      expect(result.erroredSessionMessages[0]).toContain('Server error');
+      expect(sessionManager.size).toBe(0);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/extractSessionId.ts
+++ b/packages/core/core/src/services/mcp/internal/extractSessionId.ts
@@ -1,0 +1,19 @@
+import type { IncomingMessage } from 'node:http';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_LENGTH = 36;
+
+function isValidUUID(str: string): boolean {
+  return str.length === UUID_LENGTH && UUID_REGEX.test(str);
+}
+
+export const extractSessionId = (req: IncomingMessage): string | undefined => {
+  const maybeSessionId = req.headers['mcp-session-id'];
+  if (typeof maybeSessionId === 'string' && maybeSessionId.length !== 0) {
+    if (isValidUUID(maybeSessionId) === true) {
+      return maybeSessionId;
+    }
+    return undefined;
+  }
+  return undefined;
+};

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -1,0 +1,91 @@
+// eslint-disable-next-line import/extensions
+import type { McpServer, RegisteredPrompt } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { z } from '@strapi/utils';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpPromptDefinition = <
+  Name extends string,
+  Title extends string,
+  Description extends string,
+  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+>(prompt: {
+  name: Name;
+  title: Title;
+  description: Description;
+  argsSchema?: ArgsSchema;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpPromptCallback<ArgsSchema>;
+}): Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description> =>
+  prompt as Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description>;
+
+export class McpPromptRegistry
+  extends McpCapabilityRegistryBase<'prompt', Modules.MCP.McpPromptDefinition, RegisteredPrompt>
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, title, description, argsSchema, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Prompt',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async () => ({
+            messages: [
+              {
+                role: 'user' as const,
+                content: {
+                  type: 'text' as const,
+                  text: `Prompt "${name}" failed to initialize: ${errorMessage}`,
+                },
+              },
+            ],
+          });
+        },
+        createErrorResult(error) {
+          return {
+            messages: [
+              {
+                role: 'user' as const,
+                content: {
+                  type: 'text' as const,
+                  text: `Prompt "${name}" execution failed: ${error.message}`,
+                },
+              },
+            ],
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerPrompt(
+            name,
+            {
+              title,
+              description,
+              // @ts-expect-error - Internal handler type mismatch due to optional argsSchema
+              argsSchema,
+            },
+            safeHandler
+          );
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -1,0 +1,78 @@
+import type {
+  McpServer,
+  RegisteredResource,
+  ResourceMetadata,
+  // eslint-disable-next-line import/extensions
+} from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpResourceDefinition = <Name extends string>(resource: {
+  name: Name;
+  uri: string;
+  metadata: ResourceMetadata;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpResourceCallback;
+}): Modules.MCP.McpResourceDefinition<Name> => resource as Modules.MCP.McpResourceDefinition<Name>;
+
+export class McpResourceRegistry
+  extends McpCapabilityRegistryBase<
+    'resource',
+    Modules.MCP.McpResourceDefinition,
+    RegisteredResource
+  >
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'resource', Modules.MCP.McpResourceDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, uri, metadata, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Resource',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async (resourceUri) => ({
+            contents: [
+              {
+                uri: resourceUri.href,
+                text: `Resource "${name}" failed to initialize: ${errorMessage}`,
+                mimeType: 'text/plain',
+              },
+            ],
+          });
+        },
+        createErrorResult(error, args) {
+          return {
+            contents: [
+              {
+                uri: args[0] instanceof URL ? args[0].href : uri,
+                text: `Resource "${name}" execution failed: ${error.message}`,
+                mimeType: 'text/plain',
+              },
+            ],
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerResource(name, uri, metadata, safeHandler);
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/routes.ts
+++ b/packages/core/core/src/services/mcp/routes.ts
@@ -1,0 +1,85 @@
+import type { Core } from '@strapi/types';
+import { McpConfiguration } from './internal/McpConfiguration';
+import { sendJsonRpcError } from './utils/sendJsonRpcError';
+
+/**
+ * Handler for unsupported HTTP methods on /mcp endpoint.
+ * Returns JSON-RPC error instead of plain text so MCP clients can parse it.
+ */
+const handleMethodNotAllowed: Core.MiddlewareHandler = async (ctx) => {
+  ctx.set('Allow', 'GET, POST, DELETE');
+  sendJsonRpcError(ctx.res, 'METHOD_NOT_ALLOWED');
+};
+/**
+ * Handler for OAuth discovery endpoints.
+ * Returns JSON 404 so MCP clients skip OAuth and use Bearer token auth.
+ */
+const handleOAuthNotSupported: Core.MiddlewareHandler = async (ctx) => {
+  ctx.status = 404;
+  ctx.set('Content-Type', 'application/json');
+  ctx.body = { error: 'not_found', error_description: 'OAuth not supported' };
+};
+
+export type McpRouteHandlers = {
+  handlePost: Core.MiddlewareHandler;
+  handleGet: Core.MiddlewareHandler;
+  handleDelete: Core.MiddlewareHandler;
+};
+
+/**
+ * Creates MCP route definitions for registration with Strapi server.
+ * @internal
+ */
+export const createMcpRoutes = (
+  config: McpConfiguration,
+  handlers: McpRouteHandlers
+): Omit<Core.Route, 'info'>[] => {
+  const noAuth = { auth: false } as const;
+
+  return [
+    // Core MCP endpoints
+    { method: 'POST', path: config.path, handler: handlers.handlePost, config: noAuth },
+    { method: 'GET', path: config.path, handler: handlers.handleGet, config: noAuth },
+    { method: 'DELETE', path: config.path, handler: handlers.handleDelete, config: noAuth },
+    // Unsupported methods on /mcp - return JSON error for MCP client compatibility
+    { method: 'PUT', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
+    { method: 'PATCH', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
+    // OAuth discovery endpoints - return 404 JSON so clients fall back to Bearer auth
+    {
+      method: 'GET',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'POST',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'PUT',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'DELETE',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    {
+      method: 'PATCH',
+      path: '/.well-known/oauth-authorization-server',
+      handler: handleOAuthNotSupported,
+      config: noAuth,
+    },
+    /**
+     * OAuth Dynamic Client Registration endpoint (RFC 7591).
+     * Claude Code's MCP client probes this endpoint; without a JSON response,
+     * Strapi returns plain text "Method Not Allowed" which breaks the client.
+     */
+    { method: 'POST', path: '/register', handler: handleOAuthNotSupported, config: noAuth },
+  ];
+};

--- a/packages/core/core/src/services/mcp/session.ts
+++ b/packages/core/core/src/services/mcp/session.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/extensions
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+// eslint-disable-next-line import/extensions
+import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpPromptRegistry } from './prompt-registry';
+import { McpResourceRegistry } from './resource-registry';
+import { McpToolRegistry } from './tool-registry';
+
+export class McpSession {
+  server: McpServer;
+
+  transport: StreamableHTTPServerTransport;
+
+  toolRegistry: McpToolRegistry;
+
+  promptRegistry: McpPromptRegistry;
+
+  resourceRegistry: McpResourceRegistry;
+
+  lastActivity: number;
+
+  constructor(params: {
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+    toolRegistry: McpToolRegistry;
+    promptRegistry: McpPromptRegistry;
+    resourceRegistry: McpResourceRegistry;
+  }) {
+    this.server = params.server;
+    this.transport = params.transport;
+    this.toolRegistry = params.toolRegistry;
+    this.promptRegistry = params.promptRegistry;
+    this.resourceRegistry = params.resourceRegistry;
+    this.lastActivity = Date.now();
+  }
+
+  updateActivity(): void {
+    this.lastActivity = Date.now();
+  }
+}

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -1,0 +1,87 @@
+// eslint-disable-next-line import/extensions
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Core, Modules } from '@strapi/types';
+import { z } from '@strapi/utils';
+import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
+import {
+  type McpCapabilityRegistry,
+  McpCapabilityRegistryBase,
+} from './internal/McpCapabilityRegistry';
+import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+
+export const makeMcpToolDefinition = <
+  Name extends string,
+  Title extends string,
+  Description extends string,
+  OutputSchema extends z.ZodObject<z.ZodRawShape>,
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+>(tool: {
+  name: Name;
+  title: Title;
+  description: Description;
+  inputSchema?: InputSchema;
+  outputSchema: OutputSchema;
+  devModeOnly: boolean;
+  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpToolCallback<InputSchema, OutputSchema>;
+}): Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description> =>
+  tool as Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description>;
+
+export class McpToolRegistry
+  extends McpCapabilityRegistryBase<'tool', Modules.MCP.McpToolDefinition, RegisteredTool>
+  implements McpCapabilityRegistry
+{
+  #strapi: Core.Strapi;
+
+  constructor(ctx: {
+    strapi: Core.Strapi;
+    definitions: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
+  }) {
+    super(ctx.definitions);
+    this.#strapi = ctx.strapi;
+  }
+
+  bind(mcpServer: McpServer) {
+    super.register((definition) => {
+      const { name, title, description, inputSchema, outputSchema, createHandler } = definition;
+
+      return createSafeCapabilityRegistration({
+        strapi: this.#strapi,
+        capabilityType: 'Tool',
+        name,
+        createHandler,
+        createFallbackHandler(errorMessage) {
+          return async () => ({
+            content: [
+              {
+                type: 'text' as const,
+                text: `Tool "${name}" failed to initialize: ${errorMessage}`,
+              },
+            ],
+            structuredContent: {},
+            isError: true,
+          });
+        },
+        createErrorResult(error) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Tool "${name}" execution failed: ${error.message}`,
+              },
+            ],
+            structuredContent: {},
+            isError: true,
+          };
+        },
+        registerWithSdk(safeHandler) {
+          return mcpServer.registerTool(
+            name,
+            { title, description, inputSchema, outputSchema },
+            // @ts-expect-error - Internal handler type mismatch due to optional inputSchema
+            safeHandler
+          );
+        },
+      });
+    });
+  }
+}

--- a/packages/core/core/src/services/mcp/tools/log.ts
+++ b/packages/core/core/src/services/mcp/tools/log.ts
@@ -1,0 +1,85 @@
+import { z } from '@strapi/utils';
+
+import { makeMcpToolDefinition } from '../tool-registry';
+
+export const logToolDefinition = makeMcpToolDefinition({
+  name: 'log',
+  title: 'Strapi Log',
+  description: 'Logs a message to the Strapi logger with specified level',
+  inputSchema: z.object({
+    message: z.string().describe('Message to log'),
+    level: z
+      .enum(['info', 'http', 'warn', 'error', 'log'])
+      .optional()
+      .describe('Log level (default: info)'),
+  }),
+  outputSchema: z.object({
+    status: z.string(),
+    message: z.string(),
+    level: z.string(),
+    timestamp: z.string(),
+  }),
+  devModeOnly: true,
+  createHandler: (strapi) => async (params) => {
+    const { message, level = 'info' } = params;
+
+    // Security: Sanitize message to prevent log injection
+    // 1. Limit length to prevent log spam (10KB max)
+    const MAX_MESSAGE_LENGTH = 10 * 1024;
+    let sanitizedMessage =
+      message.length > MAX_MESSAGE_LENGTH
+        ? `${message.substring(0, MAX_MESSAGE_LENGTH)}...[truncated]`
+        : message;
+
+    // 2. Remove control characters (including ANSI escape codes)
+    // This regex matches: \x00-\x1F (C0 controls), \x7F (DEL), \x80-\x9F (C1 controls)
+    // and ANSI escape sequences (\x1B[ followed by parameters and command)
+    sanitizedMessage = sanitizedMessage
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x1B\[[0-9;]*[A-Za-z]/g, '') // Remove ANSI escape sequences
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1F\x7F-\x9F]/g, ''); // Remove control characters
+
+    // 3. Replace newlines with spaces to prevent fake log entry injection
+    sanitizedMessage = sanitizedMessage.replace(/[\r\n]+/g, ' ');
+
+    // 4. Trim whitespace
+    sanitizedMessage = sanitizedMessage.trim();
+
+    // Map level to appropriate logger method
+    switch (level) {
+      case 'http':
+        strapi.log.http(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'warn':
+        strapi.log.warn(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'error':
+        strapi.log.error(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'log':
+        strapi.log.info(`[MCP] ${sanitizedMessage}`);
+        break;
+      case 'info':
+      default:
+        strapi.log.info(`[MCP] ${sanitizedMessage}`);
+        break;
+    }
+
+    const result = {
+      status: 'logged',
+      message: sanitizedMessage,
+      level,
+      timestamp: new Date().toISOString(),
+    };
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      structuredContent: result,
+    };
+  },
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/createManagedInterval.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/createManagedInterval.test.ts
@@ -1,0 +1,107 @@
+import { createManagedInterval } from '../createManagedInterval';
+
+describe('createManagedInterval', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('starts interval and calls callback at specified interval', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  test('clears interval when clear is called', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    interval.clear();
+
+    jest.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(1); // Should not increase
+  });
+
+  test('clears existing interval when start is called again', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const interval = createManagedInterval();
+
+    // Start first interval
+    interval.start(callback1, 1000);
+
+    jest.advanceTimersByTime(1000);
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Start second interval - should clear first one
+    interval.start(callback2, 500);
+
+    // Advance by first interval time
+    jest.advanceTimersByTime(1000);
+    // First callback should not be called again
+    expect(callback1).toHaveBeenCalledTimes(1);
+    // Second callback should be called twice (500ms * 2 = 1000ms)
+    expect(callback2).toHaveBeenCalledTimes(2);
+  });
+
+  test('handles clear when no interval is active', () => {
+    const interval = createManagedInterval();
+
+    // Should not throw
+    expect(() => interval.clear()).not.toThrow();
+  });
+
+  test('handles multiple clear calls', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+    interval.clear();
+    interval.clear(); // Second clear
+
+    // Should not throw and callback should not be called
+    expect(() => interval.clear()).not.toThrow();
+    jest.advanceTimersByTime(2000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('can restart interval after clearing', () => {
+    const callback = jest.fn();
+    const interval = createManagedInterval();
+
+    interval.start(callback, 1000);
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    interval.clear();
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1); // No additional calls
+
+    // Restart
+    interval.start(callback, 1000);
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(2); // Called again
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/createSafeCapabilityRegistration.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/createSafeCapabilityRegistration.test.ts
@@ -1,0 +1,229 @@
+import {
+  createSafeCapabilityRegistration,
+  FAILED_REGISTERED_CAPABILITY,
+} from '../createSafeCapabilityRegistration';
+
+const createMockStrapi = () =>
+  ({
+    log: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  }) as any;
+
+describe('createSafeCapabilityRegistration', () => {
+  describe('when all handlers succeed', () => {
+    test('creates handler, wraps it safely, and registers with SDK', () => {
+      const strapi = createMockStrapi();
+      const mockHandler = jest.fn().mockResolvedValue({ result: 'ok' });
+      const createHandler = jest.fn().mockReturnValue(mockHandler);
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'my-tool',
+        createHandler,
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(createHandler).toHaveBeenCalledWith(strapi);
+      expect(registerWithSdk).toHaveBeenCalled();
+      expect(result).toEqual({ registered: true });
+      expect(strapi.log.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Level 1: createHandler throws during factory invocation', () => {
+    test('catches error, logs it, and uses fallback handler', () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        throw new Error('factory explosion');
+      });
+      const fallbackHandler = jest.fn().mockResolvedValue({ fallback: true });
+      const createFallbackHandler = jest.fn().mockReturnValue(fallbackHandler);
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'my-prompt',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Prompt "my-prompt" handler factory threw during initialization: factory explosion'
+      );
+      expect(createFallbackHandler).toHaveBeenCalledWith('factory explosion');
+      expect(registerWithSdk).toHaveBeenCalled();
+      expect(result).toEqual({ registered: true });
+    });
+
+    test('handles non-Error throws', () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'string error';
+      });
+      const createFallbackHandler = jest.fn().mockReturnValue(jest.fn());
+      const registerWithSdk = jest.fn().mockReturnValue({ registered: true });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Resource',
+        name: 'my-resource',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(createFallbackHandler).toHaveBeenCalledWith('string error');
+    });
+  });
+
+  describe('Level 2: handler throws during runtime execution', () => {
+    test('wraps handler and catches runtime errors', async () => {
+      const strapi = createMockStrapi();
+      const mockHandler = jest.fn().mockRejectedValue(new Error('runtime boom'));
+      const createHandler = jest.fn().mockReturnValue(mockHandler);
+      const createErrorResult = jest.fn().mockReturnValue({ error: 'handled' });
+      let capturedSafeHandler: (...args: any[]) => any;
+      const registerWithSdk = jest.fn().mockImplementation((handler) => {
+        capturedSafeHandler = handler;
+        return { registered: true };
+      });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'fail-tool',
+        createHandler,
+        createFallbackHandler: jest.fn(),
+        createErrorResult,
+        registerWithSdk,
+      });
+
+      // Execute the wrapped handler that was registered
+      const result = await capturedSafeHandler!('arg1', 'arg2');
+
+      expect(result).toEqual({ error: 'handled' });
+      expect(createErrorResult).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'runtime boom' }),
+        ['arg1', 'arg2']
+      );
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Tool "fail-tool" threw an error during execution',
+        expect.objectContaining({ error: 'runtime boom' })
+      );
+    });
+  });
+
+  describe('Level 3: SDK registration throws', () => {
+    test('catches SDK error, logs it, and returns FAILED_REGISTERED_CAPABILITY', () => {
+      const strapi = createMockStrapi();
+      const registerWithSdk = jest.fn().mockImplementation(() => {
+        throw new Error('SDK rejected registration');
+      });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'bad-prompt',
+        createHandler: jest.fn().mockReturnValue(jest.fn()),
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Failed to register prompt "bad-prompt" with MCP server: SDK rejected registration'
+      );
+      expect(result).toEqual({
+        enabled: false,
+        enable: expect.any(Function),
+        disable: expect.any(Function),
+        remove: expect.any(Function),
+      });
+    });
+
+    test('FAILED_REGISTERED_CAPABILITY methods are no-ops', () => {
+      const strapi = createMockStrapi();
+      const registerWithSdk = jest.fn().mockImplementation(() => {
+        throw new Error('rejection');
+      });
+
+      const result = createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'rejected-tool',
+        createHandler: jest.fn().mockReturnValue(jest.fn()),
+        createFallbackHandler: jest.fn(),
+        createErrorResult: jest.fn(),
+        registerWithSdk,
+      });
+
+      // These should not throw
+      expect(() => result.enable()).not.toThrow();
+      expect(() => result.disable()).not.toThrow();
+      expect(() => result.remove()).not.toThrow();
+      expect(result.enabled).toBe(false);
+    });
+  });
+
+  describe('integration: all three levels protect independently', () => {
+    test('Level 1 error does not prevent Level 2 wrapping', async () => {
+      const strapi = createMockStrapi();
+      const createHandler = jest.fn().mockImplementation(() => {
+        throw new Error('factory fail');
+      });
+      const fallbackHandler = jest.fn().mockRejectedValue(new Error('fallback fail'));
+      const createFallbackHandler = jest.fn().mockReturnValue(fallbackHandler);
+      const createErrorResult = jest.fn().mockReturnValue({ error: 'from level 2' });
+      let capturedSafeHandler: (...args: any[]) => any;
+      const registerWithSdk = jest.fn().mockImplementation((handler) => {
+        capturedSafeHandler = handler;
+        return { registered: true };
+      });
+
+      createSafeCapabilityRegistration({
+        strapi,
+        capabilityType: 'Tool',
+        name: 'cascade-tool',
+        createHandler,
+        createFallbackHandler,
+        createErrorResult,
+        registerWithSdk,
+      });
+
+      // Even though the fallback handler fails, Level 2 should catch it
+      const result = await capturedSafeHandler!();
+
+      expect(result).toEqual({ error: 'from level 2' });
+      expect(strapi.log.error).toHaveBeenCalledTimes(2); // Once for Level 1, once for Level 2
+    });
+  });
+});
+
+describe('FAILED_REGISTERED_CAPABILITY', () => {
+  test('has enabled set to false', () => {
+    expect(FAILED_REGISTERED_CAPABILITY.enabled).toBe(false);
+  });
+
+  test('enable/disable/remove are no-ops that do not throw', () => {
+    expect(() => FAILED_REGISTERED_CAPABILITY.enable()).not.toThrow();
+    expect(() => FAILED_REGISTERED_CAPABILITY.disable()).not.toThrow();
+    expect(() => FAILED_REGISTERED_CAPABILITY.remove()).not.toThrow();
+  });
+
+  test('is frozen (immutable)', () => {
+    expect(Object.isFrozen(FAILED_REGISTERED_CAPABILITY)).toBe(true);
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/safeHandlerWrapper.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/safeHandlerWrapper.test.ts
@@ -1,0 +1,186 @@
+import { wrapSafeHandler } from '../safeHandlerWrapper';
+
+const createMockStrapi = () =>
+  ({
+    log: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  }) as any;
+
+describe('wrapSafeHandler', () => {
+  describe('when the handler succeeds', () => {
+    test('returns the handler result as-is', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockResolvedValue({ content: 'ok' });
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'my-tool',
+        createErrorResult: () => ({ content: 'error' }),
+      });
+
+      const result = await safe('arg1', 'arg2');
+
+      expect(result).toEqual({ content: 'ok' });
+      expect(handler).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(strapi.log.error).not.toHaveBeenCalled();
+    });
+
+    test('passes through all arguments to the original handler', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockResolvedValue('result');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'my-prompt',
+        createErrorResult: () => 'error',
+      });
+
+      await safe('a', 'b', 'c');
+
+      expect(handler).toHaveBeenCalledWith('a', 'b', 'c');
+    });
+  });
+
+  describe('when the handler throws an Error', () => {
+    test('catches the error and returns the error result', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(new Error('something broke'));
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'bad-tool',
+        createErrorResult: (error) => ({ errorMessage: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ errorMessage: 'something broke' });
+    });
+
+    test('logs the error with full detail via strapi logger', async () => {
+      const strapi = createMockStrapi();
+      const error = new Error('db connection lost');
+      const handler = jest.fn().mockRejectedValue(error);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Resource',
+        name: 'my-resource',
+        createErrorResult: () => 'fallback',
+      });
+
+      await safe();
+
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Resource "my-resource" threw an error during execution',
+        {
+          error: 'db connection lost',
+          stack: error.stack,
+        }
+      );
+    });
+  });
+
+  describe('when the handler throws a non-Error value', () => {
+    test('normalizes a string throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue('raw string error');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'string-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'raw string error' });
+      expect(strapi.log.error).toHaveBeenCalledWith(
+        '[MCP] Tool "string-throw" threw an error during execution',
+        expect.objectContaining({ error: 'raw string error' })
+      );
+    });
+
+    test('normalizes a number throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(42);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Prompt',
+        name: 'number-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: '42' });
+    });
+
+    test('normalizes undefined throw into an Error', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(undefined);
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'undefined-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'undefined' });
+    });
+  });
+
+  describe('when the handler throws synchronously', () => {
+    test('catches synchronous errors', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockImplementation(() => {
+        throw new Error('sync explosion');
+      });
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Tool',
+        name: 'sync-throw',
+        createErrorResult: (error) => ({ msg: error.message }),
+      });
+
+      const result = await safe();
+
+      expect(result).toEqual({ msg: 'sync explosion' });
+      expect(strapi.log.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('createErrorResult receives args', () => {
+    test('passes the original call args to createErrorResult', async () => {
+      const strapi = createMockStrapi();
+      const handler = jest.fn().mockRejectedValue(new Error('fail'));
+
+      const createErrorResult = jest.fn().mockReturnValue('error');
+
+      const safe = wrapSafeHandler(handler, {
+        strapi,
+        capabilityType: 'Resource',
+        name: 'res',
+        createErrorResult,
+      });
+
+      const fakeUri = new URL('https://example.com/resource');
+      await safe(fakeUri, { extra: true });
+
+      expect(createErrorResult).toHaveBeenCalledWith(expect.any(Error), [fakeUri, { extra: true }]);
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
@@ -1,0 +1,71 @@
+import { ServerResponse } from 'node:http';
+import { JSON_RPC_ERRORS } from '../jsonRpcErrors';
+import { sendJsonRpcError } from '../sendJsonRpcError';
+
+describe('sendJsonRpcError', () => {
+  let mockResponse: Partial<ServerResponse>;
+  let writeHeadSpy: jest.Mock;
+  let endSpy: jest.Mock;
+
+  beforeEach(() => {
+    writeHeadSpy = jest.fn();
+    endSpy = jest.fn();
+    mockResponse = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    };
+  });
+
+  test('should send JSON-RPC error response with correct format', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 'INVALID_SESSION', 'Invalid request');
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: JSON_RPC_ERRORS.INVALID_SESSION.code, message: 'Invalid request' },
+        id: null,
+      })
+    );
+  });
+
+  test('should not send response if headers already sent', () => {
+    // @ts-expect-error - we want to test the behavior when headers are already sent
+    mockResponse.headersSent = true;
+
+    sendJsonRpcError(mockResponse as ServerResponse, 'INTERNAL_ERROR');
+
+    expect(writeHeadSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  test('should use default message from catalog when custom message is not provided', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 'MAX_SESSIONS_REACHED');
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(503, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.MAX_SESSIONS_REACHED.code,
+          message: JSON_RPC_ERRORS.MAX_SESSIONS_REACHED.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should override catalog message when custom message is provided', () => {
+    sendJsonRpcError(mockResponse as ServerResponse, 'SESSION_REQUIRED', 'Session ID required');
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code: JSON_RPC_ERRORS.SESSION_REQUIRED.code, message: 'Session ID required' },
+        id: null,
+      })
+    );
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/__tests__/withTimeout.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/withTimeout.test.ts
@@ -1,0 +1,114 @@
+import { withTimeout } from '../withTimeout';
+
+describe('withTimeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('resolves when promise resolves before timeout', async () => {
+    const promise = Promise.resolve('success');
+    const result = withTimeout(promise, 1000, 'test-operation');
+
+    await expect(result).resolves.toBe('success');
+  });
+
+  test('rejects when timeout is reached before promise resolves', async () => {
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('success'), 2000);
+    });
+    const result = withTimeout(promise, 1000, 'test-operation');
+
+    jest.advanceTimersByTime(1000);
+
+    await expect(result).rejects.toThrow("Operation 'test-operation' timed out after 1000ms");
+  });
+
+  test('error message includes operation name and timeout duration', async () => {
+    const promise = new Promise<string>(() => {
+      // Never resolves
+    });
+    const result = withTimeout(promise, 500, 'my-custom-operation');
+
+    jest.advanceTimersByTime(500);
+
+    await expect(result).rejects.toThrow("Operation 'my-custom-operation' timed out after 500ms");
+  });
+
+  test('rejects with original error when promise rejects before timeout', async () => {
+    const originalError = new Error('Original error message');
+    const promise = Promise.reject(originalError);
+    const result = withTimeout(promise, 1000, 'reject-op');
+
+    await expect(result).rejects.toThrow('Original error message');
+  });
+
+  test('handles promise rejection after timeout', async () => {
+    let rejectPromise: (error: Error) => void;
+    const promise = new Promise<string>((_, reject) => {
+      rejectPromise = reject;
+    });
+    const result = withTimeout(promise, 1000, 'delayed-reject');
+
+    jest.advanceTimersByTime(1000);
+
+    // Timeout should win the race
+    await expect(result).rejects.toThrow("Operation 'delayed-reject' timed out after 1000ms");
+
+    // Rejecting after timeout should not affect the result
+    rejectPromise!(new Error('Too late'));
+  });
+
+  test('handles promise that resolves after timeout', async () => {
+    let resolvePromise: (value: string) => void;
+    const promise = new Promise<string>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const result = withTimeout(promise, 1000, 'delayed-resolve');
+
+    jest.advanceTimersByTime(1000);
+
+    // Timeout should win the race
+    await expect(result).rejects.toThrow("Operation 'delayed-resolve' timed out after 1000ms");
+
+    // Resolving after timeout should not affect the result
+    resolvePromise!('Too late');
+  });
+
+  test('handles zero timeout before promise resolves', async () => {
+    const promise = new Promise(() => {
+      // Never resolves
+    });
+    const result = withTimeout(promise, 0, 'zero-timeout');
+
+    jest.advanceTimersByTime(0);
+
+    await expect(result).rejects.toThrow("Operation 'zero-timeout' timed out after 0ms");
+  });
+
+  test('handles zero timeout after promise resolves', async () => {
+    const promise = new Promise<string>((resolve) => {
+      resolve('success');
+    });
+    const result = withTimeout(promise, 0, 'zero-timeout');
+
+    jest.advanceTimersByTime(0);
+
+    await expect(result).resolves.toBe('success');
+  });
+
+  test('preserves promise value when resolved quickly', async () => {
+    const promise = new Promise<number>((resolve) => {
+      setTimeout(() => resolve(123), 100);
+    });
+    const result = withTimeout(promise, 1000, 'quick-resolve');
+
+    jest.advanceTimersByTime(100);
+
+    await expect(result).resolves.toBe(123);
+  });
+});

--- a/packages/core/core/src/services/mcp/utils/createManagedInterval.ts
+++ b/packages/core/core/src/services/mcp/utils/createManagedInterval.ts
@@ -1,0 +1,33 @@
+export type ManagedInterval = {
+  start: (callback: () => void, intervalMs: number) => void;
+  clear: () => void;
+};
+
+/**
+ * Creates a managed interval that automatically clears any existing interval before starting a new one
+ */
+export const createManagedInterval = (): ManagedInterval => {
+  let intervalId: NodeJS.Timeout | undefined;
+
+  return {
+    /**
+     * Starts the interval, clearing any existing interval first
+     */
+    start(callback, intervalMs) {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+      }
+      intervalId = setInterval(callback, intervalMs);
+    },
+
+    /**
+     * Clears the current interval if one exists
+     */
+    clear() {
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+        intervalId = undefined;
+      }
+    },
+  };
+};

--- a/packages/core/core/src/services/mcp/utils/createSafeCapabilityRegistration.ts
+++ b/packages/core/core/src/services/mcp/utils/createSafeCapabilityRegistration.ts
@@ -1,0 +1,90 @@
+import type { Core } from '@strapi/types';
+import type { RegisteredCapability } from '../internal/McpCapabilityRegistry';
+import { wrapSafeHandler } from './safeHandlerWrapper';
+
+/**
+ * A no-op registered capability used as fallback when SDK registration fails.
+ *
+ * This prevents one broken capability from aborting the entire registration loop.
+ * The capability will appear as "disabled" and cannot be enabled.
+ */
+export const FAILED_REGISTERED_CAPABILITY: RegisteredCapability = Object.freeze({
+  enabled: false,
+  enable() {},
+  disable() {},
+  remove() {},
+});
+
+/**
+ * Configuration for creating a safe capability registration
+ */
+export type SafeCapabilityRegistrationConfig<THandler, TErrorResult, TRegistered> = {
+  strapi: Core.Strapi;
+  capabilityType: string;
+  name: string;
+  createHandler: (strapi: Core.Strapi) => THandler;
+  createFallbackHandler: (errorMessage: string) => NoInfer<THandler>;
+  createErrorResult: (error: Error, args: unknown[]) => TErrorResult;
+  registerWithSdk: (safeHandler: THandler) => TRegistered;
+};
+
+/**
+ * Creates a safe capability registration that protects Strapi core from user callback errors
+ * at three levels:
+ *
+ * - Level 1: Catch factory invocation errors (createHandler throws)
+ * - Level 2: Catch runtime execution errors (handler throws during invocation)
+ * - Level 3: Catch MCP SDK registration errors (SDK rejects the registration)
+ *
+ * This prevents one broken capability from:
+ * - Aborting the entire registration loop
+ * - Crashing the MCP server
+ * - Leaking unhandled errors to the user
+ */
+export const createSafeCapabilityRegistration = <THandler, TErrorResult, TRegistered>(
+  config: SafeCapabilityRegistrationConfig<THandler, TErrorResult, TRegistered>
+): TRegistered => {
+  const {
+    strapi,
+    capabilityType,
+    name,
+    createHandler,
+    createFallbackHandler,
+    createErrorResult,
+    registerWithSdk,
+  } = config;
+
+  try {
+    // Level 1: Safe factory invocation — catch errors from user's createHandler
+    let rawHandler: THandler;
+
+    try {
+      rawHandler = createHandler(strapi);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      strapi.log.error(
+        `[MCP] ${capabilityType} "${name}" handler factory threw during initialization: ${message}`
+      );
+
+      // Substitute a fallback handler that always returns an error to the MCP client
+      rawHandler = createFallbackHandler(message);
+    }
+
+    // Level 2: Safe runtime wrapping — catch errors from user's handler during execution
+    const safeHandler = wrapSafeHandler(rawHandler as (...args: unknown[]) => Promise<unknown>, {
+      strapi,
+      capabilityType,
+      name,
+      createErrorResult,
+    });
+
+    return registerWithSdk(safeHandler as THandler);
+  } catch (error) {
+    // Level 3: Catch MCP SDK registration errors — prevent one broken capability from aborting all others
+    const message = error instanceof Error ? error.message : String(error);
+    strapi.log.error(
+      `[MCP] Failed to register ${capabilityType.toLowerCase()} "${name}" with MCP server: ${message}`
+    );
+    return FAILED_REGISTERED_CAPABILITY as unknown as TRegistered;
+  }
+};

--- a/packages/core/core/src/services/mcp/utils/jsonRpcErrors.ts
+++ b/packages/core/core/src/services/mcp/utils/jsonRpcErrors.ts
@@ -1,0 +1,31 @@
+/**
+ * JSON-RPC error codes and messages
+ * @see https://json-rpc.dev/docs/reference/error-codes
+ */
+export const JSON_RPC_ERRORS = {
+  INTERNAL_ERROR: {
+    code: -32603, // 	Internal error
+    message: 'Internal error',
+    httpStatus: 500,
+  },
+  INVALID_SESSION: {
+    code: -32003, // Session expired
+    message: 'Invalid session',
+    httpStatus: 400,
+  },
+  MAX_SESSIONS_REACHED: {
+    code: -32001, // Server overloaded
+    message: 'Maximum number of sessions reached',
+    httpStatus: 503,
+  },
+  SESSION_REQUIRED: {
+    code: -32000, // Server error
+    message: 'Session required',
+    httpStatus: 400,
+  },
+  METHOD_NOT_ALLOWED: {
+    code: -32601, // Method not found
+    message: 'Method not allowed',
+    httpStatus: 405,
+  },
+} as const;

--- a/packages/core/core/src/services/mcp/utils/safeHandlerWrapper.ts
+++ b/packages/core/core/src/services/mcp/utils/safeHandlerWrapper.ts
@@ -1,0 +1,38 @@
+import type { Core } from '@strapi/types';
+
+/**
+ * Wraps an MCP capability handler to catch and log errors from user-provided callbacks.
+ *
+ * This prevents externally-registered capabilities (from plugin developers)
+ * from crashing Strapi core when they throw during execution.
+ *
+ * Errors are:
+ * - Logged with full detail (message + stack) via Strapi's logger
+ * - Returned to the MCP client as a safe error response (no stack trace leak)
+ */
+export const wrapSafeHandler = <TArgs extends unknown[], TResult>(
+  handler: (...args: TArgs) => Promise<TResult>,
+  options: {
+    strapi: Core.Strapi;
+    capabilityType: string;
+    name: string;
+    createErrorResult: (error: Error, args: TArgs) => TResult;
+  }
+): ((...args: TArgs) => Promise<TResult>) => {
+  const { strapi, capabilityType, name, createErrorResult } = options;
+
+  return async (...args: TArgs): Promise<TResult> => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error(String(error));
+
+      strapi.log.error(`[MCP] ${capabilityType} "${name}" threw an error during execution`, {
+        error: normalized.message,
+        stack: normalized.stack,
+      });
+
+      return createErrorResult(normalized, args);
+    }
+  };
+};

--- a/packages/core/core/src/services/mcp/utils/sendJsonRpcError.ts
+++ b/packages/core/core/src/services/mcp/utils/sendJsonRpcError.ts
@@ -1,0 +1,21 @@
+import type { ServerResponse } from 'node:http';
+import { JSON_RPC_ERRORS } from './jsonRpcErrors';
+
+export const sendJsonRpcError = (
+  res: ServerResponse,
+  errorKey: keyof typeof JSON_RPC_ERRORS,
+  customMessage?: string
+): void => {
+  if (res.headersSent === false) {
+    const { code, message, httpStatus } = JSON_RPC_ERRORS[errorKey];
+
+    res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: { code, message: customMessage ?? message },
+        id: null,
+      })
+    );
+  }
+};

--- a/packages/core/core/src/services/mcp/utils/withTimeout.ts
+++ b/packages/core/core/src/services/mcp/utils/withTimeout.ts
@@ -1,0 +1,16 @@
+/**
+ * Wraps a promise with a timeout to prevent hanging operations
+ */
+export const withTimeout = <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string
+): Promise<T> =>
+  Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Operation '${operation}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }),
+  ]);

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -47,6 +47,7 @@
     "@casl/ability": "6.7.5",
     "@koa/cors": "5.0.0",
     "@koa/router": "12.0.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@strapi/database": "5.46.0",
     "@strapi/logger": "5.46.0",
     "@strapi/permissions": "5.46.0",

--- a/packages/core/types/src/core/config/server.ts
+++ b/packages/core/types/src/core/config/server.ts
@@ -65,6 +65,10 @@ export interface Http {
   [key: string]: unknown;
 }
 
+export interface McpConfig {
+  enabled: boolean;
+}
+
 export interface Server {
   // required
   host: string;
@@ -85,4 +89,5 @@ export interface Server {
   admin?: ServerAdmin;
   webhooks?: Webhooks;
   http?: Http;
+  mcp: McpConfig;
 }

--- a/packages/core/types/src/core/config/server.ts
+++ b/packages/core/types/src/core/config/server.ts
@@ -89,5 +89,5 @@ export interface Server {
   admin?: ServerAdmin;
   webhooks?: Webhooks;
   http?: Http;
-  mcp: McpConfig;
+  mcp?: McpConfig;
 }

--- a/packages/core/types/src/modules/ai.ts
+++ b/packages/core/types/src/modules/ai.ts
@@ -1,3 +1,5 @@
+import type * as MCP from './mcp';
+
 /**
  * AI service for the admin panel. Only present at runtime when EE + cms-ai feature is active
  */
@@ -26,4 +28,5 @@ export type AiAdminService = {
 
 export type AiNamespace = {
   admin: AiAdminService;
+  mcp: MCP.McpService;
 };

--- a/packages/core/types/src/modules/index.ts
+++ b/packages/core/types/src/modules/index.ts
@@ -13,6 +13,7 @@ export type * as EntityValidator from './entity-validator';
 export type * as EventHub from './event-hub';
 export type * as Features from './features';
 export type * as Fetch from './fetch';
+export type * as MCP from './mcp';
 export type * as Metrics from './metrics';
 export type * as RequestContext from './request-context';
 export type * as SessionManager from './session-manager';

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -1,0 +1,189 @@
+import { z } from '@strapi/utils';
+// eslint-disable-next-line import/extensions
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type {
+  ServerNotification,
+  ServerRequest,
+  ContentBlock,
+  GetPromptResult,
+  ReadResourceResult,
+  // eslint-disable-next-line import/extensions
+} from '@modelcontextprotocol/sdk/types.js';
+// eslint-disable-next-line import/extensions
+import type { ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type * as Core from '../core';
+
+/**
+ * Base definition for Strapi MCP capabilities
+ */
+export interface McpCapabilityDefinition<Name extends string = string> {
+  name: Name;
+  devModeOnly: boolean;
+}
+
+/**
+ * Callback function for Strapi MCP tools
+ */
+export type McpToolCallback<
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+  OutputSchema extends z.ZodObject<z.ZodRawShape>,
+> = InputSchema extends z.ZodTypeAny
+  ? (
+      args: z.infer<InputSchema>,
+      extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+    ) => Promise<{
+      content: ContentBlock[];
+      structuredContent: z.infer<OutputSchema>;
+      isError?: boolean;
+    }>
+  : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => Promise<{
+      content: ContentBlock[];
+      structuredContent: z.infer<OutputSchema>;
+      isError?: boolean;
+    }>;
+
+/**
+ * Definition for Strapi MCP tools
+ */
+export interface McpToolDefinition<
+  Name extends string = string,
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  OutputSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
+  Title extends string = string,
+  Description extends string = string,
+> extends McpCapabilityDefinition<Name> {
+  title: Title;
+  description: Description;
+  inputSchema: InputSchema;
+  outputSchema: OutputSchema;
+  createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
+}
+
+/**
+ * Callback function for Strapi MCP prompts
+ */
+export type McpPromptCallback<ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined> =
+  ArgsSchema extends z.ZodTypeAny
+    ? (
+        args: z.infer<ArgsSchema>,
+        extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+      ) => Promise<GetPromptResult>
+    : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => Promise<GetPromptResult>;
+
+/**
+ * Definition for Strapi MCP prompts
+ */
+export interface McpPromptDefinition<
+  Name extends string = string,
+  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  Title extends string = string,
+  Description extends string = string,
+> extends McpCapabilityDefinition<Name> {
+  title: Title;
+  description: Description;
+  argsSchema?: ArgsSchema;
+  createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+}
+
+/**
+ * Callback function for Strapi MCP resources
+ */
+export type McpResourceCallback = (
+  uri: URL,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+) => Promise<ReadResourceResult>;
+
+/**
+ * Definition for Strapi MCP resources
+ */
+export interface McpResourceDefinition<Name extends string = string>
+  extends McpCapabilityDefinition<Name> {
+  uri: string;
+  metadata: ResourceMetadata;
+  createHandler: (strapi: Core.Strapi) => McpResourceCallback;
+}
+
+export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
+
+/**
+ * Service providing Model Context Protocol (MCP) capabilities.
+ * Available on strapi.ai.mcp.
+ */
+export interface McpService {
+  /**
+   * Check if the MCP service is enabled in configuration
+   */
+  isEnabled(): boolean;
+
+  /**
+   * Check if the MCP server is currently running
+   */
+  isRunning(): boolean;
+
+  /**
+   * Register a single MCP tool.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerTool<
+    Name extends string,
+    OutputSchema extends z.ZodObject<z.ZodRawShape>,
+    Title extends string,
+    Description extends string,
+    InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+  >(tool: {
+    name: Name;
+    title: Title;
+    description: Description;
+    inputSchema?: InputSchema;
+    outputSchema: OutputSchema;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
+  }): void;
+
+  /**
+   * Register a single MCP prompt.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerPrompt<
+    Name extends string,
+    ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+    Title extends string,
+    Description extends string,
+  >(prompt: {
+    name: Name;
+    title: Title;
+    description: Description;
+    argsSchema?: ArgsSchema;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+  }): void;
+
+  /**
+   * Register a single MCP resource.
+   * Must be called during plugin register() phase, before MCP server starts.
+   * @throws Error if called after MCP server has started
+   */
+  registerResource<Name extends string>(resource: {
+    name: Name;
+    uri: string;
+    metadata: ResourceMetadata;
+    devModeOnly: boolean;
+    createHandler: (strapi: Core.Strapi) => McpResourceCallback;
+  }): void;
+
+  /**
+   * Start the MCP server
+   */
+  start(): Promise<void>;
+
+  /**
+   * Stop the MCP server
+   */
+  stop(): Promise<void>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:^3.972.10, @aws-sdk/middleware-host-header@npm:^3.972.8":
+"@aws-sdk/middleware-host-header@npm:^3.972.10":
   version: 3.972.10
   resolution: "@aws-sdk/middleware-host-header@npm:3.972.10"
   dependencies:
@@ -809,6 +809,18 @@ __metadata:
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e631b48f8d8fd40f8977da8d1fc012208f953000dd5645dc0a700c7283af8fafb996c9c1c50e40b8392c402ad98d11e0ddddb949896db5163a7f06e2385e619a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:^3.972.8":
+  version: 3.972.9
+  resolution: "@aws-sdk/middleware-host-header@npm:3.972.9"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.7"
+    "@smithy/protocol-http": "npm:^5.3.13"
+    "@smithy/types": "npm:^4.14.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6be32e17a1355456705767178e6d17498295a7e84570759feaa27d53b74b6cfa8b8c5ef1dbfab41a0f9dc9342fb2d618de3eaf36f1859f111b0167b648938394
   languageName: node
   linkType: hard
 
@@ -823,7 +835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:^3.972.10, @aws-sdk/middleware-logger@npm:^3.972.8":
+"@aws-sdk/middleware-logger@npm:^3.972.10":
   version: 3.972.10
   resolution: "@aws-sdk/middleware-logger@npm:3.972.10"
   dependencies:
@@ -831,6 +843,17 @@ __metadata:
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/a24e0c98b3cf6c9b7960bf8979d2ab8f839fb89294ba8943136d99dbe7370cc45b010460ed7f5bf14ab6ad8e113ccec6387cf1bda655bcbdb58722df21d9b713
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:^3.972.8":
+  version: 3.972.9
+  resolution: "@aws-sdk/middleware-logger@npm:3.972.9"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.7"
+    "@smithy/types": "npm:^4.14.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ed909c5265a14843a9768f9495eb2f05e7eb313eebe1f63d2ff31cc358bd9cdfd9b504d272c14c40dd4b39d8b2d0d2b499b9cd7935b3f7d4c04ae69fc38f2bdb
   languageName: node
   linkType: hard
 
@@ -1021,6 +1044,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/types@npm:^3.973.7":
+  version: 3.973.7
+  resolution: "@aws-sdk/types@npm:3.973.7"
+  dependencies:
+    "@smithy/types": "npm:^4.14.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4dfe5933ec3624dcc7ecf1154fad67999c9b5ddb010a456edd3cb94e6112e9330e0bb3c03218040ee15bc91b7f8ba5e4c63f82074fef26f4616f74212c732aa7
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/util-arn-parser@npm:^3.972.3":
   version: 3.972.3
   resolution: "@aws-sdk/util-arn-parser@npm:3.972.3"
@@ -1064,7 +1097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:^3.972.10, @aws-sdk/util-user-agent-browser@npm:^3.972.8":
+"@aws-sdk/util-user-agent-browser@npm:^3.972.10":
   version: 3.972.10
   resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.10"
   dependencies:
@@ -1073,6 +1106,18 @@ __metadata:
     bowser: "npm:^2.11.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e139dda2cb51a0a3553c80ec6f89c39cb1292876c116f8449f21a7fdbe39bd7b545ef8ea69a447dd9fa2aa43c99f625ee6a55cbf6d8e6cf2094d0ef00ceb1e36
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:^3.972.8":
+  version: 3.972.9
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.9"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.7"
+    "@smithy/types": "npm:^4.14.0"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/49b1c013cac8c89f6da4217eb34623ea206432d9fdb476e2337d857b02680c404a3cd83f10647aef459a78bd743383b1d66d2a8f3ed4c4c7ab38bc47f7da555e
   languageName: node
   linkType: hard
 
@@ -1114,7 +1159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.26.2":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
   dependencies:
@@ -1411,10 +1456,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.26.5, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.28.6
   resolution: "@babel/helper-plugin-utils@npm:7.28.6"
   checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-plugin-utils@npm:7.25.9"
+  checksum: 10c0/483066a1ba36ff16c0116cd24f93de05de746a603a777cd695ac7a1b034928a65a4ecb35f255761ca56626435d7abdb73219eba196f9aa83b6c3c3169325599d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/helper-plugin-utils@npm:7.26.5"
+  checksum: 10c0/cdaba71d4b891aa6a8dfbe5bac2f94effb13e5fa4c2c487667fdbaa04eae059b78b28d85a885071f45f7205aeb56d16759e1bed9c118b94b16e4720ef1ab0f65
   languageName: node
   linkType: hard
 
@@ -1444,6 +1503,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-simple-access@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: 10c0/3f1bcdb88ee3883ccf86959869a867f6bbf8c4737cd44fb9f799c38e54f67474590bc66802500ae9fe18161792875b2cfb7ec15673f48ed6c8663f6d09686ca8
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.25.9"
@@ -1451,6 +1520,13 @@ __metadata:
     "@babel/traverse": "npm:^7.25.9"
     "@babel/types": "npm:^7.25.9"
   checksum: 10c0/09ace0c6156961624ac9524329ce7f45350bab94bbe24335cbe0da7dfaa1448e658771831983cb83fe91cf6635b15d0a3cab57c03b92657480bfb49fb56dd184
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-string-parser@npm:7.25.9"
+  checksum: 10c0/7244b45d8e65f6b4338a6a68a8556f2cb161b782343e97281a5f2b9b93e420cad0d9f5773a59d79f61d0c448913d06f6a2358a87f2e203cf112e3c5b53522ee6
   languageName: node
   linkType: hard
 
@@ -1503,7 +1579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.27.0, @babel/parser@npm:^7.29.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.29.0":
   version: 7.29.2
   resolution: "@babel/parser@npm:7.29.2"
   dependencies:
@@ -1511,6 +1587,28 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/e5a4e69e3ac7acdde995f37cf299a68458cfe7009dff66bd0962fd04920bef287201169006af365af479c08ff216bfefbb595e331f87f6ae7283858aebbc3317
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.25.9":
+  version: 7.26.5
+  resolution: "@babel/parser@npm:7.26.5"
+  dependencies:
+    "@babel/types": "npm:^7.26.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/2e77dd99ee028ee3c10fa03517ae1169f2432751adf71315e4dc0d90b61639d51760d622f418f6ac665ae4ea65f8485232a112ea0e76f18e5900225d3d19a61e
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.27.0":
+  version: 7.27.0
+  resolution: "@babel/parser@npm:7.27.0"
+  dependencies:
+    "@babel/types": "npm:^7.27.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/ba2ed3f41735826546a3ef2a7634a8d10351df221891906e59b29b0a0cd748f9b0e7a6f07576858a9de8e77785aad925c8389ddef146de04ea2842047c9d2859
   languageName: node
   linkType: hard
 
@@ -2111,7 +2209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.24.7, @babel/plugin-transform-modules-commonjs@npm:^7.25.9":
+"@babel/plugin-transform-modules-commonjs@npm:^7.24.7":
   version: 7.26.3
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.26.3"
   dependencies:
@@ -2120,6 +2218,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/82e59708f19f36da29531a64a7a94eabbf6ff46a615e0f5d9b49f3f59e8ef10e2bac607d749091508d3fa655146c9e5647c3ffeca781060cdabedb4c7a33c6f2
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-simple-access": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/6ce771fb04d4810257fc8900374fece877dacaed74b05eaa16ad9224b390f43795c4d046cbe9ae304e1eb5aad035d37383895e3c64496d647c2128d183916e74
   languageName: node
   linkType: hard
 
@@ -2172,7 +2283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.25.9":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7":
   version: 7.26.6
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.26.6"
   dependencies:
@@ -2180,6 +2291,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/574d6db7cbc5c092db5d1dece8ce26195e642b9c40dbfeaf3082058a78ad7959c1c333471cdd45f38b784ec488850548075d527b178c5010ee9bff7aa527cc7a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/eb623db5be078a1c974afe7c7797b0309ba2ea9e9237c0b6831ade0f56d8248bb4ab3432ab34495ff8c877ec2fe412ff779d1e9b3c2b8139da18e1753d950bc3
   languageName: node
   linkType: hard
 
@@ -2687,7 +2809,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.25.9, @babel/template@npm:^7.27.0, @babel/template@npm:^7.3.3":
+"@babel/template@npm:^7.25.9, @babel/template@npm:^7.3.3":
+  version: 7.25.9
+  resolution: "@babel/template@npm:7.25.9"
+  dependencies:
+    "@babel/code-frame": "npm:^7.25.9"
+    "@babel/parser": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: 10c0/ebe677273f96a36c92cc15b7aa7b11cc8bc8a3bb7a01d55b2125baca8f19cae94ff3ce15f1b1880fb8437f3a690d9f89d4e91f16fc1dc4d3eb66226d128983ab
+  languageName: node
+  linkType: hard
+
+"@babel/template@npm:^7.27.0":
   version: 7.27.0
   resolution: "@babel/template@npm:7.27.0"
   dependencies:
@@ -2739,13 +2872,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.19.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.27.0, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.19.0, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.9, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.26.5":
+  version: 7.26.5
+  resolution: "@babel/types@npm:7.26.5"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+  checksum: 10c0/0278053b69d7c2b8573aa36dc5242cad95f0d965e1c0ed21ccacac6330092e59ba5949753448f6d6eccf6ad59baaef270295cc05218352e060ea8c68388638c4
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.27.0":
+  version: 7.27.0
+  resolution: "@babel/types@npm:7.27.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+  checksum: 10c0/6f1592eabe243c89a608717b07b72969be9d9d2fce1dee21426238757ea1fa60fdfc09b29de9e48d8104311afc6e6fb1702565a9cc1e09bc1e76f2b2ddb0f6e1
   languageName: node
   linkType: hard
 
@@ -3191,7 +3344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0, @emnapi/core@npm:^1.1.0":
+"@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
   dependencies:
@@ -3201,12 +3354,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0, @emnapi/runtime@npm:^1.1.0, @emnapi/runtime@npm:^1.2.0":
+"@emnapi/core@npm:^1.1.0":
+  version: 1.6.0
+  resolution: "@emnapi/core@npm:1.6.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/40e384f39104a9f8260e671c0110f8618961afc564afb2e626af79175717a8b5e2d8b2ae3d30194d318a71247e0fc833601666233adfeb244c46cadc06c58a51
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.1.0, @emnapi/runtime@npm:^1.2.0":
+  version: 1.6.0
+  resolution: "@emnapi/runtime@npm:1.6.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e3d2452a8fb83bb59fe60dfcf4cff99f9680c13c07dff8ad28639ccc8790151841ef626a67014bde132939bad73dfacc440ade8c3db2ab12693ea9c8ba4d37fb
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
   languageName: node
   linkType: hard
 
@@ -4352,6 +4533,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.9
+  resolution: "@hono/node-server@npm:1.19.9"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/de18c06b6b266dc45fe55fb82053bd1da8fe84939c49b6fbab4d2448b679d54ab5affbf8b15de9bead26f29b1755284d770aafb5ad14a8e4b3cfb4f79334554e
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.10":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -4977,13 +5167,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
   checksum: 10c0/9a7d65fb13bd9aec1fbab74cda08496839b7e2ceb31f5ab922b323e94d7c481ce0fc4fd7e12e2610915ed8af51178bdc61e168e92a8c8b8303b030b03489b13b
+  languageName: node
+  linkType: hard
+
+"@jridgewell/gen-mapping@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
+  dependencies:
+    "@jridgewell/set-array": "npm:^1.2.1"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+    "@jridgewell/trace-mapping": "npm:^0.3.24"
+  checksum: 10c0/1be4fd4a6b0f41337c4f5fdf4afc3bd19e39c3691924817108b82ffcb9c9e609c273f936932b9fba4b3a298ce2eb06d9bff4eb1cc3bd81c4f4ee1b4917e25feb
   languageName: node
   linkType: hard
 
@@ -5004,6 +5205,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/set-array@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jridgewell/set-array@npm:1.2.1"
+  checksum: 10c0/2a5aa7b4b5c3464c895c802d8ae3f3d2b92fcbe84ad12f8d0bfbb1f5ad006717e7577ee1fd2eac00c088abe486c7adb27976f45d2941ff6b0b92b2c3302c60f4
+  languageName: node
+  linkType: hard
+
 "@jridgewell/source-map@npm:^0.3.3":
   version: 0.3.6
   resolution: "@jridgewell/source-map@npm:0.3.6"
@@ -5014,10 +5222,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
   languageName: node
   linkType: hard
 
@@ -5149,6 +5364,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ljharb/through@npm:^2.3.13":
+  version: 2.3.13
+  resolution: "@ljharb/through@npm:2.3.13"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+  checksum: 10c0/fb60b2fb2c674a674d8ebdb8972ccf52f8a62a9c1f5a2ac42557bc0273231c65d642aa2d7627cbb300766a25ae4642acd0f95fba2f8a1ff891086f0cb15807c3
+  languageName: node
+  linkType: hard
+
 "@microsoft/api-extractor-model@npm:7.33.4":
   version: 7.33.4
   resolution: "@microsoft/api-extractor-model@npm:7.33.4"
@@ -5200,6 +5424,39 @@ __metadata:
   version: 0.16.0
   resolution: "@microsoft/tsdoc@npm:0.16.0"
   checksum: 10c0/8883bb0ed22753af7360e9222687fda4eb448f0a574ea34b4596c11e320148b3ae0d24e00f8923df8ba7bc62a46a6f53b9343243a348640d923dfd55d52cd6bb
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:1.29.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
   languageName: node
   linkType: hard
 
@@ -9610,6 +9867,7 @@ __metadata:
   dependencies:
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
+    "@modelcontextprotocol/sdk": "npm:1.29.0"
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/admin": "npm:5.46.0"
     "@strapi/database": "npm:5.46.0"
@@ -10439,6 +10697,7 @@ __metadata:
     "@casl/ability": "npm:6.7.5"
     "@koa/cors": "npm:5.0.0"
     "@koa/router": "npm:12.0.2"
+    "@modelcontextprotocol/sdk": "npm:1.29.0"
     "@strapi/database": "npm:5.46.0"
     "@strapi/logger": "npm:5.46.0"
     "@strapi/permissions": "npm:5.46.0"
@@ -10699,9 +10958,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-darwin-arm64@npm:1.9.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-x64@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core-darwin-x64@npm:1.13.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-darwin-x64@npm:1.9.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -10713,9 +10986,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm-gnueabihf@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.9.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-arm64-gnu@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core-linux-arm64-gnu@npm:1.13.5"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.9.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -10727,9 +11014,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-arm64-musl@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-linux-arm64-musl@npm:1.9.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-linux-x64-gnu@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core-linux-x64-gnu@npm:1.13.5"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-linux-x64-gnu@npm:1.9.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -10741,9 +11042,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-linux-x64-musl@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-linux-x64-musl@npm:1.9.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-arm64-msvc@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core-win32-arm64-msvc@npm:1.13.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.9.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -10755,6 +11070,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-win32-ia32-msvc@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.9.3"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@swc/core-win32-x64-msvc@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core-win32-x64-msvc@npm:1.13.5"
@@ -10762,7 +11084,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:1.13.5, @swc/core@npm:^1.3.107":
+"@swc/core-win32-x64-msvc@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@swc/core-win32-x64-msvc@npm:1.9.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:1.13.5":
   version: 1.13.5
   resolution: "@swc/core@npm:1.13.5"
   dependencies:
@@ -10808,6 +11137,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core@npm:^1.3.107":
+  version: 1.9.3
+  resolution: "@swc/core@npm:1.9.3"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.9.3"
+    "@swc/core-darwin-x64": "npm:1.9.3"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.9.3"
+    "@swc/core-linux-arm64-gnu": "npm:1.9.3"
+    "@swc/core-linux-arm64-musl": "npm:1.9.3"
+    "@swc/core-linux-x64-gnu": "npm:1.9.3"
+    "@swc/core-linux-x64-musl": "npm:1.9.3"
+    "@swc/core-win32-arm64-msvc": "npm:1.9.3"
+    "@swc/core-win32-ia32-msvc": "npm:1.9.3"
+    "@swc/core-win32-x64-msvc": "npm:1.9.3"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.17"
+  peerDependencies:
+    "@swc/helpers": "*"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10c0/a9507a5be580518d51cf7f41821a89e1044be6f72930efbdf3877366c27e9ff1dbca3e1a7f18698679f8c345b6698f43cd80d7dfa24ba30dcab493de9b7a336e
+  languageName: node
+  linkType: hard
+
 "@swc/counter@npm:^0.1.3":
   version: 0.1.3
   resolution: "@swc/counter@npm:0.1.3"
@@ -10815,12 +11190,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:0.5.17, @swc/helpers@npm:^0.5.0":
+"@swc/helpers@npm:0.5.17":
   version: 0.5.17
   resolution: "@swc/helpers@npm:0.5.17"
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/fe1f33ebb968558c5a0c595e54f2e479e4609bff844f9ca9a2d1ffd8dd8504c26f862a11b031f48f75c95b0381c2966c3dd156e25942f90089badd24341e7dbb
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "@swc/helpers@npm:0.5.7"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/1f52e76668e12b5b991b9fc9e74e433bad671406812473c1639f79e4f46e72c85d37397adabaf9a8bbac54386ac0c887f067ceb8aaf51bcb99de697831eb4921
   languageName: node
   linkType: hard
 
@@ -10834,6 +11218,15 @@ __metadata:
   peerDependencies:
     "@swc/core": "*"
   checksum: 10c0/2df5f215bb7a3f31e1db606e3ac01c4e67900e8db004b38dbfaa09f87bcc2b054070211086e095eddcd174ee561b696fcf679ea38263fa6daf69fee37dacbdc9
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@swc/types@npm:0.1.17"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10c0/29f5c8933a16042956f1adb7383e836ed7646cbf679826e78b53fdd0c08e8572cb42152e527b6b530a9bd1052d33d0972f90f589761ccd252c12652c9b7a72fc
   languageName: node
   linkType: hard
 
@@ -11555,7 +11948,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+  version: 7.0.13
+  resolution: "@types/json-schema@npm:7.0.13"
+  checksum: 10c0/446fe6722899333ff647b5853fdcc9f039156d56abe517166154d3578d641841cc869f61e8b7822c24a1daeb7dfbd4fdcea84bf07c0858e2f9cca415e2ca8dd4
+  languageName: node
+  linkType: hard
+
+"@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -11843,13 +12243,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.10, @types/node-fetch@npm:^2.6.1":
+"@types/node-fetch@npm:^2.5.10":
   version: 2.6.13
   resolution: "@types/node-fetch@npm:2.6.13"
   dependencies:
     "@types/node": "npm:*"
     form-data: "npm:^4.0.4"
   checksum: 10c0/6313c89f62c50bd0513a6839cdff0a06727ac5495ccbb2eeda51bb2bbbc4f3c0a76c0393a491b7610af703d3d2deb6cf60e37e59c81ceeca803ffde745dbf309
+  languageName: node
+  linkType: hard
+
+"@types/node-fetch@npm:^2.6.1":
+  version: 2.6.10
+  resolution: "@types/node-fetch@npm:2.6.10"
+  dependencies:
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/beeadfb31eb097c49a63cb2be21dcb83aa2e988f36b411edfa879a32f0497b509d65eec19d76f869895b3ef87199b21d4e13e9139d3ee38a70b437dc65ba1075
   languageName: node
   linkType: hard
 
@@ -12295,12 +12705,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.8":
+"@types/yargs@npm:^17.0.33":
   version: 17.0.34
   resolution: "@types/yargs@npm:17.0.34"
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10c0/7d4c6a6bc2b8dd4c7deaf507633fe6fd91424873add76b63c8263479223ea7a061bea86e7e0f3ed28cbe897338a934f3c04d802e8f67b7d2d3874924c94468c5
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^17.0.8":
+  version: 17.0.24
+  resolution: "@types/yargs@npm:17.0.24"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10c0/fbebf57e1d04199e5e7eb0c67a402566fa27177ee21140664e63da826408793d203d262b48f8f41d4a7665126393d2e952a463e960e761226def247d9bbcdbd0
   languageName: node
   linkType: hard
 
@@ -13225,6 +13644,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^7.0.0":
   version: 7.0.1
   resolution: "acorn-globals@npm:7.0.1"
@@ -13262,12 +13691,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1, acorn@npm:^8.8.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.0.4, acorn@npm:^8.9.0":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/3ff155f8812e4a746fee8ecff1f227d527c4c45655bb1fad6347c3cb58e46190598217551b1500f18542d2bbe5c87120cb6927f5a074a59166fbdd9468f0a299
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.1.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1, acorn@npm:^8.8.1":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
     acorn: bin/acorn
   checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.0":
+  version: 8.14.0
+  resolution: "acorn@npm:8.14.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/6d4ee461a7734b2f48836ee0fbb752903606e576cc100eb49340295129ca0b452f3ba91ddd4424a1d4406a98adfb2ebb6bd0ff4c49d7a0930c10e462719bbfd7
   languageName: node
   linkType: hard
 
@@ -13358,7 +13805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:~3.0.1":
+"ajv-formats@npm:^3.0.1, ajv-formats@npm:~3.0.1":
   version: 3.0.1
   resolution: "ajv-formats@npm:3.0.1"
   dependencies:
@@ -13392,7 +13839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.18.0, ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.6.3, ajv@npm:^8.9.0, ajv@npm:~8.18.0":
+"ajv@npm:8.18.0, ajv@npm:~8.18.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
   dependencies:
@@ -13413,6 +13860,18 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.11.0, ajv@npm:^8.17.1, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
+  version: 8.17.1
+  resolution: "ajv@npm:8.17.1"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
   languageName: node
   linkType: hard
 
@@ -13766,6 +14225,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arraybuffer.prototype.slice@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "arraybuffer.prototype.slice@npm:1.0.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.22.3"
+    es-errors: "npm:^1.2.1"
+    get-intrinsic: "npm:^1.2.3"
+    is-array-buffer: "npm:^3.0.4"
+    is-shared-array-buffer: "npm:^1.0.2"
+  checksum: 10c0/d32754045bcb2294ade881d45140a5e52bda2321b9e98fa514797b7f0d252c4c5ab0d1edb34112652c62fa6a9398def568da63a4d7544672229afea283358c36
+  languageName: node
+  linkType: hard
+
 "arraybuffer.prototype.slice@npm:^1.0.4":
   version: 1.0.4
   resolution: "arraybuffer.prototype.slice@npm:1.0.4"
@@ -13943,7 +14418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.0, axios@npm:^1.6.0, axios@npm:^1.6.8, axios@npm:^1.7.4":
+"axios@npm:1.16.0":
   version: 1.16.0
   resolution: "axios@npm:1.16.0"
   dependencies:
@@ -13951,6 +14426,17 @@ __metadata:
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.0, axios@npm:^1.6.8, axios@npm:^1.7.4":
+  version: 1.13.6
+  resolution: "axios@npm:1.13.6"
+  dependencies:
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
   languageName: node
   linkType: hard
 
@@ -14284,6 +14770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "body-parser@npm:2.2.2"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.7.0"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.1"
+    raw-body: "npm:^3.0.1"
+    type-is: "npm:^2.0.1"
+  checksum: 10c0/95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:~1.20.3":
   version: 1.20.4
   resolution: "body-parser@npm:1.20.4"
@@ -14582,7 +15085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind-apply-helpers@npm:1.0.2"
   dependencies:
@@ -14601,6 +15104,18 @@ __metadata:
     get-intrinsic: "npm:^1.3.0"
     set-function-length: "npm:^1.2.2"
   checksum: 10c0/a6621f6da1444481919ce3b4983dff725691e0754d3507ae483ce56e54985f2da7d6f1df512c56dbf28660745cf1ca52553f1fc9aef5557f3ce353ef14fab714
+  languageName: node
+  linkType: hard
+
+"call-bind@npm:^1.0.5, call-bind@npm:^1.0.6":
+  version: 1.0.8
+  resolution: "call-bind@npm:1.0.8"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.2.4"
+    set-function-length: "npm:^1.2.2"
+  checksum: 10c0/a13819be0681d915144467741b69875ae5f4eba8961eb0bf322aab63ec87f8250eb6d6b0dcbb2e1349876412a56129ca338592b3829ef4343527f5f18a0752d4
   languageName: node
   linkType: hard
 
@@ -14746,17 +15261,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:^5.4.1":
-  version: 5.6.2
-  resolution: "chalk@npm:5.6.2"
-  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
-  languageName: node
-  linkType: hard
-
-"chalk@npm:~5.3.0":
+"chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:~5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 10c0/8297d436b2c0f95801103ff2ef67268d362021b8210daf8ddbe349695333eb3610a71122172ff3b0272f1ef2cf7cc2c41fdaa4715f52e49ffe04c56340feed09
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.4.1":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
   languageName: node
   linkType: hard
 
@@ -14806,6 +15321,13 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
@@ -15500,6 +16022,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "content-disposition@npm:1.0.1"
+  checksum: 10c0/bd7ff1fe8d2542d3a2b9a29428cc3591f6ac27bb5595bba2c69664408a68f9538b14cbd92479796ea835b317a09a527c8c7209c4200381dedb0c34d3b658849e
+  languageName: node
+  linkType: hard
+
 "content-type@npm:^1.0.4, content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
@@ -15553,7 +16082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:^1.2.2":
+"cookie-signature@npm:^1.2.1, cookie-signature@npm:^1.2.2":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
   checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
@@ -15567,7 +16096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.2, cookie@npm:~0.7.1":
+"cookie@npm:^0.7.1, cookie@npm:^0.7.2, cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -15824,7 +16353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -16018,6 +16547,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-view-buffer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-buffer@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10c0/8984119e59dbed906a11fcfb417d7d861936f16697a0e7216fe2c6c810f6b5e8f4a5281e73f2c28e8e9259027190ac4a33e2a65fdd7fa86ac06b76e838918583
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -16029,6 +16569,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-view-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10c0/b7d9e48a0cf5aefed9ab7d123559917b2d7e0d65531f43b2fd95b9d3a6b46042dd3fca597c42bba384e66b70d7ad66ff23932f8367b241f53d93af42cfe04ec2
+  languageName: node
+  linkType: hard
+
 "data-view-byte-length@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-byte-length@npm:1.0.2"
@@ -16037,6 +16588,17 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-data-view: "npm:^1.0.2"
   checksum: 10c0/f8a4534b5c69384d95ac18137d381f18a5cfae1f0fc1df0ef6feef51ef0d568606d970b69e02ea186c6c0f0eac77fe4e6ad96fec2569cc86c3afcc7475068c55
+  languageName: node
+  linkType: hard
+
+"data-view-byte-offset@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "data-view-byte-offset@npm:1.0.0"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 10c0/21b0d2e53fd6e20cc4257c873bf6d36d77bd6185624b84076c0a1ddaa757b49aaf076254006341d35568e89f52eecd1ccb1a502cfb620f2beca04f48a6a62a8f
   languageName: node
   linkType: hard
 
@@ -16092,15 +16654,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "debug@npm:4.4.3"
+"debug@npm:4, debug@npm:^4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:~4.3.6":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
   languageName: node
   linkType: hard
 
@@ -16125,15 +16687,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:~4.3.6":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
+"debug@npm:^4.0.0":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
   languageName: node
   linkType: hard
 
@@ -16648,14 +17222,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:16.6.1, dotenv@npm:^16.4.5":
+"dotenv@npm:16.6.1":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
   languageName: node
   linkType: hard
 
-"dotenv@npm:~16.4.5":
+"dotenv@npm:^16.4.5, dotenv@npm:~16.4.5":
   version: 16.4.6
   resolution: "dotenv@npm:16.4.6"
   checksum: 10c0/6c0c0c82eaa0ca6cc7193b2550920ec6d2eabfe32498bf454c0a1187c0680c79daa199ba873d33692f055755e5068f862689aca03bc8ff57e7d70302f3152012
@@ -16823,7 +17397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encodeurl@npm:~2.0.0":
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
@@ -16938,7 +17512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.5, es-abstract@npm:^1.20.4, es-abstract@npm:^1.21.2, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0, es-abstract@npm:^1.24.2":
+"es-abstract@npm:^1.17.5, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0, es-abstract@npm:^1.24.2":
   version: 1.24.2
   resolution: "es-abstract@npm:1.24.2"
   dependencies:
@@ -17000,6 +17574,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-abstract@npm:^1.20.4, es-abstract@npm:^1.21.2, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0, es-abstract@npm:^1.23.2":
+  version: 1.23.3
+  resolution: "es-abstract@npm:1.23.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    arraybuffer.prototype.slice: "npm:^1.0.3"
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    data-view-buffer: "npm:^1.0.1"
+    data-view-byte-length: "npm:^1.0.1"
+    data-view-byte-offset: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    es-set-tostringtag: "npm:^2.0.3"
+    es-to-primitive: "npm:^1.2.1"
+    function.prototype.name: "npm:^1.1.6"
+    get-intrinsic: "npm:^1.2.4"
+    get-symbol-description: "npm:^1.0.2"
+    globalthis: "npm:^1.0.3"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+    has-proto: "npm:^1.0.3"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.2"
+    internal-slot: "npm:^1.0.7"
+    is-array-buffer: "npm:^3.0.4"
+    is-callable: "npm:^1.2.7"
+    is-data-view: "npm:^1.0.1"
+    is-negative-zero: "npm:^2.0.3"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.3"
+    is-string: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.13"
+    is-weakref: "npm:^1.0.2"
+    object-inspect: "npm:^1.13.1"
+    object-keys: "npm:^1.1.1"
+    object.assign: "npm:^4.1.5"
+    regexp.prototype.flags: "npm:^1.5.2"
+    safe-array-concat: "npm:^1.1.2"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.trim: "npm:^1.2.9"
+    string.prototype.trimend: "npm:^1.0.8"
+    string.prototype.trimstart: "npm:^1.0.8"
+    typed-array-buffer: "npm:^1.0.2"
+    typed-array-byte-length: "npm:^1.0.1"
+    typed-array-byte-offset: "npm:^1.0.2"
+    typed-array-length: "npm:^1.0.6"
+    unbox-primitive: "npm:^1.0.2"
+    which-typed-array: "npm:^1.1.15"
+  checksum: 10c0/d27e9afafb225c6924bee9971a7f25f20c314f2d6cb93a63cada4ac11dcf42040896a6c22e5fb8f2a10767055ed4ddf400be3b1eb12297d281726de470b75666
+  languageName: node
+  linkType: hard
+
 "es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
   version: 1.0.1
   resolution: "es-define-property@npm:1.0.1"
@@ -17007,7 +17635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-errors@npm:^1.3.0":
+"es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
@@ -17071,6 +17699,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es-set-tostringtag@npm:2.0.3"
+  dependencies:
+    get-intrinsic: "npm:^1.2.4"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.1"
+  checksum: 10c0/f22aff1585eb33569c326323f0b0d175844a1f11618b86e193b386f8be0ea9474cfbe46df39c45d959f7aa8f6c06985dc51dd6bce5401645ec5a74c4ceaa836a
+  languageName: node
+  linkType: hard
+
 "es-set-tostringtag@npm:^2.1.0":
   version: 2.1.0
   resolution: "es-set-tostringtag@npm:2.1.0"
@@ -17089,6 +17728,17 @@ __metadata:
   dependencies:
     hasown: "npm:^2.0.2"
   checksum: 10c0/1b9702c8a1823fc3ef39035a4e958802cf294dd21e917397c561d0b3e195f383b978359816b1732d02b255ccf63e1e4815da0065b95db8d7c992037be3bbbcdb
+  languageName: node
+  linkType: hard
+
+"es-to-primitive@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "es-to-primitive@npm:1.2.1"
+  dependencies:
+    is-callable: "npm:^1.1.4"
+    is-date-object: "npm:^1.0.1"
+    is-symbol: "npm:^1.0.2"
+  checksum: 10c0/0886572b8dc075cb10e50c0af62a03d03a68e1e69c388bd4f10c0649ee41b1fbb24840a1b7e590b393011b5cdbe0144b776da316762653685432df37d6de60f1
   languageName: node
   linkType: hard
 
@@ -18135,7 +18785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
@@ -18156,7 +18806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.5, eventsource-parser@npm:^3.0.6":
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1, eventsource-parser@npm:^3.0.5, eventsource-parser@npm:^3.0.6":
   version: 3.0.6
   resolution: "eventsource-parser@npm:3.0.6"
   checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
@@ -18167,6 +18817,15 @@ __metadata:
   version: 2.0.2
   resolution: "eventsource@npm:2.0.2"
   checksum: 10c0/0b8c70b35e45dd20f22ff64b001be9d530e33b92ca8bdbac9e004d0be00d957ab02ef33c917315f59bf2f20b178c56af85c52029bc8e6cc2d61c31d87d943573
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
   languageName: node
   linkType: hard
 
@@ -18292,6 +18951,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "express-rate-limit@npm:8.2.1"
+  dependencies:
+    ip-address: "npm:10.0.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/54185f211c25655382436b8ad1a2136df0d5dc88f4d9d4438ca7cbc87cef0cd34cb01b8fc62d290445326aa6581470d2ff44502c3f1a34a5ed2c2ce56809fa01
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.21.1":
   version: 4.22.1
   resolution: "express@npm:4.22.1"
@@ -18331,6 +19001,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10c0/45e8c841ad188a41402ddcd1294901e861ee0819f632fb494f2ed344ef9c43315d294d443fb48d594e6586a3b779785120f43321417adaef8567316a55072949
+  languageName: node
+  linkType: hard
+
 "exsolve@npm:^1.0.7":
   version: 1.0.8
   resolution: "exsolve@npm:1.0.8"
@@ -18361,6 +19067,17 @@ __metadata:
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
+  languageName: node
+  linkType: hard
+
+"external-editor@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
   languageName: node
   linkType: hard
 
@@ -18555,7 +19272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:3.2.0":
+"figures@npm:3.2.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
@@ -18653,6 +19370,20 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/6bd664e21b7b2e79efcaace7d1a427169f61cce048fae68eb56290e6934e676b78e55d89f5998c5508871345bc59a61f47002dc505dc7288be68cceac1b701e2
   languageName: node
   linkType: hard
 
@@ -18832,13 +19563,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.2, follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
   checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.2":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
   languageName: node
   linkType: hard
 
@@ -19015,6 +19756,13 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/716addd9fa85dd2c1475ab848e14c4e6d3246ced041de84afc19b1d6534c897256c8f2878864cf057039116e56f5ca1b87a4cbb943f0b1cf37199ef7174c3cf8
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
   languageName: node
   linkType: hard
 
@@ -19221,7 +19969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1, get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -19239,6 +19987,24 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.2.6":
+  version: 1.3.0
+  resolution: "get-intrinsic@npm:1.3.0"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
   languageName: node
   linkType: hard
 
@@ -19343,6 +20109,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-symbol-description@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "get-symbol-description@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 10c0/867be6d63f5e0eb026cb3b0ef695ec9ecf9310febb041072d2e142f260bd91ced9eeb426b3af98791d1064e324e653424afa6fd1af17dee373bea48ae03162bc
+  languageName: node
+  linkType: hard
+
 "get-symbol-description@npm:^1.1.0":
   version: 1.1.0
   resolution: "get-symbol-description@npm:1.1.0"
@@ -19354,12 +20131,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.1, get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.5":
+"get-tsconfig@npm:^4.10.1":
   version: 4.14.0
   resolution: "get-tsconfig@npm:4.14.0"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10c0/abc2b9275468eb589079a0b7a95eb5107c14fdd0ca6dda1bff116fe774ea1f79975421dcb22a0c86b4f820fcc69a7655dddf9b6d6a8a2c06fcb59e19794c0724
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.5":
+  version: 4.13.6
+  resolution: "get-tsconfig@npm:4.13.6"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/bab6937302f542f97217cbe7cbbdfa7e85a56a377bc7a73e69224c1f0b7c9ae8365918e55752ae8648265903f506c1705f63c0de1d4bab1ec2830fef3e539a1a
   languageName: node
   linkType: hard
 
@@ -19574,7 +20360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.2, globalthis@npm:^1.0.4":
+"globalthis@npm:^1.0.2, globalthis@npm:^1.0.3, globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
   dependencies:
@@ -19789,7 +20575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.9, handlebars@npm:^4.7.8":
+"handlebars@npm:4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -19804,6 +20590,24 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.8":
+  version: 4.7.8
+  resolution: "handlebars@npm:4.7.8"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
   languageName: node
   linkType: hard
 
@@ -19854,6 +20658,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-proto@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: 10c0/35a6989f81e9f8022c2f4027f8b48a552de714938765d019dbea6bb547bd49ce5010a3c7c32ec6ddac6e48fc546166a3583b128f5a7add8b058a6d8b4afec205
+  languageName: node
+  linkType: hard
+
 "has-proto@npm:^1.2.0":
   version: 1.2.0
   resolution: "has-proto@npm:1.2.0"
@@ -19863,7 +20674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+"has-symbols@npm:^1.0.2, has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
   checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
@@ -19898,7 +20709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2":
+"hasown@npm:^2.0.0, hasown@npm:^2.0.1, hasown@npm:^2.0.2":
   version: 2.0.2
   resolution: "hasown@npm:2.0.2"
   dependencies:
@@ -20005,6 +20816,13 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10c0/3c099844f94b8b438f124bd5698bdcfef32b2d455115fb8050d7148e7f7b95fc89ba9922586c491f0e1cdebf437b1053c84ecddb8d596e109e9ac69c5b4a9e27
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.11.4":
+  version: 4.11.9
+  resolution: "hono@npm:4.11.9"
+  checksum: 10c0/fe396a8e1a61755adb7afe8ce8e0935a6423a5680ec62f4fd3577c5c5a9236dec390dc28fef6b9742e067b5d9c53ddb3aa511b3359bf87dcc2105dae751f1242
   languageName: node
   linkType: hard
 
@@ -20197,7 +21015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:^2.0.0, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+"http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
   dependencies:
@@ -20340,21 +21158,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0, iconv-lite@npm:^0.7.2":
-  version: 0.7.2
-  resolution: "iconv-lite@npm:0.7.2"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:~0.4.24":
+"iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
+  version: 0.7.1
+  resolution: "iconv-lite@npm:0.7.1"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/f5c9e2bddd7101a71b07a381ace44ebdc65ca76a10be0e9e64d372b511132acc4ee41b830962f438840d492cd6f9e08c237289f760d6a7fed754e61cffcb6757
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -20527,7 +21354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer@npm:9.3.8, inquirer@npm:^9.2.15, inquirer@npm:^9.3.8":
+"inquirer@npm:9.3.8, inquirer@npm:^9.3.8":
   version: 9.3.8
   resolution: "inquirer@npm:9.3.8"
   dependencies:
@@ -20547,12 +21374,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^9.2.15":
+  version: 9.2.16
+  resolution: "inquirer@npm:9.2.16"
+  dependencies:
+    "@ljharb/through": "npm:^2.3.13"
+    ansi-escapes: "npm:^4.3.2"
+    chalk: "npm:^5.3.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^4.1.0"
+    external-editor: "npm:^3.1.0"
+    figures: "npm:^3.2.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:1.0.0"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^3.0.0"
+    rxjs: "npm:^7.8.1"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^6.2.0"
+  checksum: 10c0/85b67a6c035e601f5f72803353ad8400a1eb738762137b092f06bc84fd480cb1faba5161e0b514a00935f73c9b46869af1d4f3cad08138f1c5d37388b01111dd
+  languageName: node
+  linkType: hard
+
 "inspect-with-kind@npm:^1.0.5":
   version: 1.0.5
   resolution: "inspect-with-kind@npm:1.0.5"
   dependencies:
     kind-of: "npm:^6.0.2"
   checksum: 10c0/4a7ca641927d24b5f0fabbad48ed940cffa840d6cfa07b6bc475593f6e0679b4d30ec1714de289cb17b10214a36e6bdccc257262a1163e33741425e5d311e8d1
+  languageName: node
+  linkType: hard
+
+"internal-slot@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "internal-slot@npm:1.0.7"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    hasown: "npm:^2.0.0"
+    side-channel: "npm:^1.0.4"
+  checksum: 10c0/f8b294a4e6ea3855fc59551bbf35f2b832cf01fd5e6e2a97f5c201a071cc09b49048f856e484b67a6c721da5e55736c5b6ddafaf19e2dbeb4a3ff1821680de6c
   languageName: node
   linkType: hard
 
@@ -20619,6 +21480,13 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.0.0"
   checksum: 10c0/5af133a917c0bcf65e84e7f23e779e7abc1cd49cb7fdc62d00d1de74b0d8c1b5ee74ac7766099fb3be1b05b26dfc67bab76a17030d2fe7ea2eef867434362dfc
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:10.0.1":
+  version: 10.0.1
+  resolution: "ip-address@npm:10.0.1"
+  checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843
   languageName: node
   linkType: hard
 
@@ -20744,7 +21612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-callable@npm:^1.2.7":
+"is-callable@npm:^1.1.4, is-callable@npm:^1.2.7":
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
   checksum: 10c0/ceebaeb9d92e8adee604076971dd6000d38d6afc40bb843ea8e45c5579b57671c3f3b50d7f04869618242c6cee08d1b67806a8cb8edaaaf7c0748b3720d6066f
@@ -20775,6 +21643,15 @@ __metadata:
     get-intrinsic: "npm:^1.2.6"
     is-typed-array: "npm:^1.1.13"
   checksum: 10c0/ef3548a99d7e7f1370ce21006baca6d40c73e9f15c941f89f0049c79714c873d03b02dae1c64b3f861f55163ecc16da06506c5b8a1d4f16650b3d9351c380153
+  languageName: node
+  linkType: hard
+
+"is-date-object@npm:^1.0.1":
+  version: 1.0.5
+  resolution: "is-date-object@npm:1.0.5"
+  dependencies:
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10c0/eed21e5dcc619c48ccef804dfc83a739dbb2abee6ca202838ee1bd5f760fe8d8a93444f0d49012ad19bb7c006186e2884a1b92f6e1c056da7fd23d0a9ad5992e
   languageName: node
   linkType: hard
 
@@ -20999,6 +21876,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
+  languageName: node
+  linkType: hard
+
 "is-property@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-property@npm:1.0.2"
@@ -21059,6 +21943,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-shared-array-buffer@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "is-shared-array-buffer@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+  checksum: 10c0/adc11ab0acbc934a7b9e5e9d6c588d4ec6682f6fea8cda5180721704fa32927582ede5b123349e32517fdadd07958973d24716c80e7ab198970c47acc09e59c7
+  languageName: node
+  linkType: hard
+
 "is-ssh@npm:^1.4.0":
   version: 1.4.0
   resolution: "is-ssh@npm:1.4.0"
@@ -21099,6 +21992,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-symbol@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "is-symbol@npm:1.0.4"
+  dependencies:
+    has-symbols: "npm:^1.0.2"
+  checksum: 10c0/9381dd015f7c8906154dbcbf93fad769de16b4b961edc94f88d26eb8c555935caa23af88bda0c93a18e65560f6d7cca0fd5a3f8a8e1df6f1abbb9bead4502ef7
+  languageName: node
+  linkType: hard
+
 "is-symbol@npm:^1.0.4, is-symbol@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-symbol@npm:1.1.1"
@@ -21130,7 +22032,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.13, is-typed-array@npm:^1.1.14, is-typed-array@npm:^1.1.15":
+"is-typed-array@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "is-typed-array@npm:1.1.13"
+  dependencies:
+    which-typed-array: "npm:^1.1.14"
+  checksum: 10c0/fa5cb97d4a80e52c2cc8ed3778e39f175a1a2ae4ddf3adae3187d69586a1fd57cfa0b095db31f66aa90331e9e3da79184cea9c6abdcd1abc722dc3c3edd51cca
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.14, is-typed-array@npm:^1.1.15":
   version: 1.1.15
   resolution: "is-typed-array@npm:1.1.15"
   dependencies:
@@ -21901,6 +22812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "jose@npm:6.1.3"
+  checksum: 10c0/b9577b4a7a5e84131011c23823db9f5951eae3ba796771a6a2401ae5dd50daf71104febc8ded9c38146aa5ebe94a92ac09c725e699e613ef26949b9f5a8bc30f
+  languageName: node
+  linkType: hard
+
 "joycon@npm:^3.1.1":
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
@@ -22104,6 +23022,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -22802,10 +23727,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:^3.1.1, lilconfig@npm:~3.1.2":
+"lilconfig@npm:^3.1.1":
   version: 3.1.3
   resolution: "lilconfig@npm:3.1.3"
   checksum: 10c0/f5604e7240c5c275743561442fbc5abf2a84ad94da0f5adc71d25e31fa8483048de3dcedcb7a44112a942fed305fd75841cdf6c9681c7f640c63f1049e9a5dcc
+  languageName: node
+  linkType: hard
+
+"lilconfig@npm:~3.1.2":
+  version: 3.1.2
+  resolution: "lilconfig@npm:3.1.2"
+  checksum: 10c0/f059630b1a9bddaeba83059db00c672b64dc14074e9f232adce32b38ca1b5686ab737eb665c5ba3c32f147f0002b4bee7311ad0386a9b98547b5623e87071fbe
   languageName: node
   linkType: hard
 
@@ -23300,12 +24232,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21, magic-string@npm:^0.30.3":
+"magic-string@npm:^0.30.17, magic-string@npm:^0.30.21":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.5"
   checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.3":
+  version: 0.30.11
+  resolution: "magic-string@npm:0.30.11"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10c0/b9eb370773d0bd90ca11a848753409d8e5309b1ad56d2a1aa49d6649da710a6d2fe7237ad1a643c5a5d3800de2b9946ed9690acdfc00e6cc1aeafff3ab1752c4
   languageName: node
   linkType: hard
 
@@ -23636,6 +24577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "memfs@npm:4.6.0":
   version: 4.6.0
   resolution: "memfs@npm:4.6.0"
@@ -23689,6 +24637,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10c0/95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
   languageName: node
   linkType: hard
 
@@ -23973,12 +24928,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:^2.1.27, mime-types@npm:^2.1.28, mime-types@npm:^2.1.31, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -24092,7 +25063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.5, minimatch@npm:^10.2.2, minimatch@npm:^10.2.5":
+"minimatch@npm:10.2.5, minimatch@npm:^10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -24116,6 +25087,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.2":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
@@ -24573,7 +25553,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -24584,6 +25564,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/7a4a0e027e509b741bec4172749103f158da23187ff251cb988dd54ea7267519c3fa11838971da0f5f3c54e79da3174e7bd72aa2179c9f69887511ece16c9c0f
   languageName: node
   linkType: hard
 
@@ -24995,7 +25989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
+"object-inspect@npm:^1.13.1, object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
@@ -25030,6 +26024,18 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     object-keys: "npm:^1.1.1"
   checksum: 10c0/3b2732bd860567ea2579d1567525168de925a8d852638612846bd8082b3a1602b7b89b67b09913cbb5b9bd6e95923b2ae73580baa9d99cb4e990564e8cbf5ddc
+  languageName: node
+  linkType: hard
+
+"object.assign@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "object.assign@npm:4.1.5"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    has-symbols: "npm:^1.0.3"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/60108e1fa2706f22554a4648299b0955236c62b3685c52abf4988d14fffb0e7731e00aa8c6448397e3eb63d087dcc124a9f21e1980f36d0b2667f3c18bacd469
   languageName: node
   linkType: hard
 
@@ -25116,7 +26122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.3.0, on-finished@npm:~2.4.1":
+"on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -25288,6 +26294,13 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10c0/196b31eaba32d56780ad42674c7fab22f9cdc811c90bca0e7eb9b016ce76ad8eb4d32dc537e7eea8ca11627b6e2c709ae9a1287d7b265c3b6feb855f87579022
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -25674,7 +26687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:^1.3.2, parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.2, parseurl@npm:^1.3.3, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
@@ -25850,6 +26863,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^8.0.0":
+  version: 8.3.0
+  resolution: "path-to-regexp@npm:8.3.0"
+  checksum: 10c0/ee1544a73a3f294a97a4c663b0ce71bbf1621d732d80c9c9ed201b3e911a86cb628ebad691b9d40f40a3742fe22011e5a059d8eed2cf63ec2cb94f6fb4efe67c
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:~0.1.12":
   version: 0.1.13
   resolution: "path-to-regexp@npm:0.1.13"
@@ -25996,10 +27016,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "picocolors@npm:1.1.0"
+  checksum: 10c0/86946f6032148801ef09c051c6fb13b5cf942eaf147e30ea79edb91dd32d700934edebe782a1078ff859fb2b816792e97ef4dab03d7f0b804f6b01a0df35e023
   languageName: node
   linkType: hard
 
@@ -26065,6 +27092,13 @@ __metadata:
     "@napi-rs/nice":
       optional: true
   checksum: 10c0/ab67830065ff41523cd901db41b11045cb00a0be43bf79323ff7b4ef2fbce5e3a56ad440d99d6c3944ce94451a0a69fd175500e3220b21efe54142e601322189
+  languageName: node
+  linkType: hard
+
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
   languageName: node
   linkType: hard
 
@@ -26272,14 +27306,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.10, postcss@npm:^8.5.3":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+"postcss@npm:^8.3.11, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.3":
+  version: 8.5.8
+  resolution: "postcss@npm:8.5.8"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 
@@ -26528,13 +27573,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7, proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
   checksum: 10c0/c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 
@@ -26695,6 +27747,18 @@ __metadata:
     iconv-lite: "npm:~0.4.24"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/449844344fc90547fb994383a494b83300e4f22199f146a79f68d78a199a8f2a923ea9fd29c3be979bfd50291a3884733619ffc15ba02a32e703b612f8d3f74a
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -27329,6 +28393,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp.prototype.flags@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "regexp.prototype.flags@npm:1.5.2"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    define-properties: "npm:^1.2.1"
+    es-errors: "npm:^1.3.0"
+    set-function-name: "npm:^2.0.1"
+  checksum: 10c0/0f3fc4f580d9c349f8b560b012725eb9c002f36daa0041b3fbf6f4238cb05932191a4d7d5db3b5e2caa336d5150ad0402ed2be81f711f9308fe7e1a9bf9bd552
+  languageName: node
+  linkType: hard
+
 "regexpp@npm:^3.0.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
@@ -27619,7 +28695,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.10, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/07e179f4375e1fd072cfb72ad66d78547f86e6196c4014b31cb0b8bb1db5f7ca871f922d08da0fbc05b94e9fd42206f819648fa3b5b873ebbc8e1dc68fec433a
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.22.10":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -27648,7 +28737,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.13.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10c0/0446f024439cd2e50c6c8fa8ba77eaa8370b4180f401a96abf3d1ebc770ac51c1955e12764cde449fde3fff480a61f84388e3505ecdbab778f4bef5f8212c729
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -27743,7 +28845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:3.0.2, rimraf@npm:^3.0.2":
+"rimraf@npm:3.0.2, rimraf@npm:^3.0.0, rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
   dependencies:
@@ -28024,6 +29126,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10c0/3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^3.0.0":
   version: 3.0.0
   resolution: "run-async@npm:3.0.0"
@@ -28046,6 +29161,18 @@ __metadata:
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: 10c0/3c49c1ecd66170b175c9cacf5cef67f8914dcbc7cd0162855538d365c83fea631167cacb644b3ce533b2ea0e9a4d0b12175186985f89d75abe73dbd8f7f06f68
+  languageName: node
+  linkType: hard
+
+"safe-array-concat@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "safe-array-concat@npm:1.1.2"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    get-intrinsic: "npm:^1.2.4"
+    has-symbols: "npm:^1.0.3"
+    isarray: "npm:^2.0.5"
+  checksum: 10c0/12f9fdb01c8585e199a347eacc3bae7b5164ae805cdc8c6707199dbad5b9e30001a50a43c4ee24dc9ea32dbb7279397850e9208a7e217f4d8b1cf5d90129dec9
   languageName: node
   linkType: hard
 
@@ -28083,6 +29210,17 @@ __metadata:
     es-errors: "npm:^1.3.0"
     isarray: "npm:^2.0.5"
   checksum: 10c0/831f1c9aae7436429e7862c7e46f847dfe490afac20d0ee61bae06108dbf5c745a0de3568ada30ccdd3eeb0864ca8331b2eef703abd69bfea0745b21fd320750
+  languageName: node
+  linkType: hard
+
+"safe-regex-test@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "safe-regex-test@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-regex: "npm:^1.1.4"
+  checksum: 10c0/900bf7c98dc58f08d8523b7012b468e4eb757afa624f198902c0643d7008ba777b0bdc35810ba0b758671ce887617295fb742b3f3968991b178ceca54cb07603
   languageName: node
   linkType: hard
 
@@ -28270,6 +29408,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10c0/fbbbbdc902a913d65605274be23f3d604065cfc3ee3d78bf9fc8af1dc9fc82667c50d3d657f5e601ac657bac9b396b50ee97bd29cd55436320cf1cddebdcec72
+  languageName: node
+  linkType: hard
+
 "send@npm:~0.19.0, send@npm:~0.19.1":
   version: 0.19.2
   resolution: "send@npm:0.19.2"
@@ -28297,6 +29454,18 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: 10c0/8cfd89f43ca93e283c5f1d16178a536bdfac9bc6029f4a9df988610cc399bc4f2478d1f10ce40b9dff66b863a5158a19b438fbec929045c96d92174f6bca1e88
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10c0/37986096e8572e2dfaad35a3925fa8da0c0969f8814fd7788e84d4d388bc068cf0c06d1658509788e55bed942a6b6d040a8a267fa92bb9ffb1179f8bacde5fd7
   languageName: node
   linkType: hard
 
@@ -28333,7 +29502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-function-name@npm:^2.0.2":
+"set-function-name@npm:^2.0.1, set-function-name@npm:^2.0.2":
   version: 2.0.2
   resolution: "set-function-name@npm:2.0.2"
   dependencies:
@@ -28500,10 +29669,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.1":
+"shell-quote@npm:^1.6.1":
   version: 1.8.2
   resolution: "shell-quote@npm:1.8.2"
   checksum: 10c0/85fdd44f2ad76e723d34eb72c753f04d847ab64e9f1f10677e3f518d0e5b0752a176fd805297b30bb8c3a1556ebe6e77d2288dbd7b7b0110c7e941e9e9c20ce1
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "shell-quote@npm:1.8.1"
+  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
   languageName: node
   linkType: hard
 
@@ -29037,7 +30213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:^2.0.2, statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.1, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
@@ -29345,6 +30521,29 @@ __metadata:
     es-object-atoms: "npm:^1.0.0"
     has-property-descriptors: "npm:^1.0.2"
   checksum: 10c0/8a8854241c4b54a948e992eb7dd6b8b3a97185112deb0037a134f5ba57541d8248dd610c966311887b6c2fd1181a3877bffb14d873ce937a344535dabcc648f8
+  languageName: node
+  linkType: hard
+
+"string.prototype.trim@npm:^1.2.9":
+  version: 1.2.9
+  resolution: "string.prototype.trim@npm:1.2.9"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.0"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/dcef1a0fb61d255778155006b372dff8cc6c4394bc39869117e4241f41a2c52899c0d263ffc7738a1f9e61488c490b05c0427faa15151efad721e1a9fb2663c2
+  languageName: node
+  linkType: hard
+
+"string.prototype.trimend@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "string.prototype.trimend@npm:1.0.8"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/0a0b54c17c070551b38e756ae271865ac6cc5f60dabf2e7e343cceae7d9b02e1a1120a824e090e79da1b041a74464e8477e2da43e2775c85392be30a6f60963c
   languageName: node
   linkType: hard
 
@@ -29976,7 +31175,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.10, tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
+"tinyglobby@npm:^0.2.10, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.15":
+  version: 0.2.15
+  resolution: "tinyglobby@npm:0.2.15"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.3"
+  checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.11, tinyglobby@npm:^0.2.16":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
   dependencies:
@@ -30018,10 +31227,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.3, tmp@npm:~0.2.1":
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.3":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
   checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
+  languageName: node
+  linkType: hard
+
+"tmp@npm:~0.2.1":
+  version: 0.2.1
+  resolution: "tmp@npm:0.2.1"
+  dependencies:
+    rimraf: "npm:^3.0.0"
+  checksum: 10c0/67607aa012059c9ce697bee820ee51bc0f39b29a8766def4f92d3f764d67c7cf9205d537d24e0cb1ce9685c40d4c628ead010910118ea18348666b5c46ed9123
   languageName: node
   linkType: hard
 
@@ -30478,7 +31705,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typed-array-buffer@npm:^1.0.3":
+"type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/7f7ec0a060b16880bdad36824ab37c26019454b67d73e8a465ed5a3587440fbe158bc765f0da68344498235c877e7dbbb1600beccc94628ed05599d667951b99
+  languageName: node
+  linkType: hard
+
+"typed-array-buffer@npm:^1.0.2, typed-array-buffer@npm:^1.0.3":
   version: 1.0.3
   resolution: "typed-array-buffer@npm:1.0.3"
   dependencies:
@@ -30486,6 +31724,19 @@ __metadata:
     es-errors: "npm:^1.3.0"
     is-typed-array: "npm:^1.1.14"
   checksum: 10c0/1105071756eb248774bc71646bfe45b682efcad93b55532c6ffa4518969fb6241354e4aa62af679ae83899ec296d69ef88f1f3763657cdb3a4d29321f7b83079
+  languageName: node
+  linkType: hard
+
+"typed-array-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "typed-array-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10c0/fcebeffb2436c9f355e91bd19e2368273b88c11d1acc0948a2a306792f1ab672bce4cfe524ab9f51a0505c9d7cd1c98eff4235c4f6bfef6a198f6cfc4ff3d4f3
   languageName: node
   linkType: hard
 
@@ -30502,6 +31753,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typed-array-byte-offset@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "typed-array-byte-offset@npm:1.0.2"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 10c0/d2628bc739732072e39269389a758025f75339de2ed40c4f91357023c5512d237f255b633e3106c461ced41907c1bf9a533c7e8578066b0163690ca8bc61b22f
+  languageName: node
+  linkType: hard
+
 "typed-array-byte-offset@npm:^1.0.4":
   version: 1.0.4
   resolution: "typed-array-byte-offset@npm:1.0.4"
@@ -30514,6 +31779,20 @@ __metadata:
     is-typed-array: "npm:^1.1.15"
     reflect.getprototypeof: "npm:^1.0.9"
   checksum: 10c0/3d805b050c0c33b51719ee52de17c1cd8e6a571abdf0fffb110e45e8dd87a657e8b56eee94b776b13006d3d347a0c18a730b903cf05293ab6d92e99ff8f77e53
+  languageName: node
+  linkType: hard
+
+"typed-array-length@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "typed-array-length@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 10c0/74253d7dc488eb28b6b2711cf31f5a9dcefc9c41b0681fd1c178ed0a1681b4468581a3626d39cd4df7aee3d3927ab62be06aa9ca74e5baf81827f61641445b77
   languageName: node
   linkType: hard
 
@@ -30717,6 +31996,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unbox-primitive@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "unbox-primitive@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    has-bigints: "npm:^1.0.2"
+    has-symbols: "npm:^1.0.3"
+    which-boxed-primitive: "npm:^1.0.2"
+  checksum: 10c0/81ca2e81134167cc8f75fa79fbcc8a94379d6c61de67090986a2273850989dd3bae8440c163121b77434b68263e34787a675cbdcb34bb2f764c6b9c843a11b66
+  languageName: node
+  linkType: hard
+
 "unbox-primitive@npm:^1.1.0":
   version: 1.1.0
   resolution: "unbox-primitive@npm:1.1.0"
@@ -30767,7 +32058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:6.25.0, undici@npm:^6.19.5":
+"undici@npm:6.25.0":
   version: 6.25.0
   resolution: "undici@npm:6.25.0"
   checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
@@ -30780,6 +32071,13 @@ __metadata:
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
   checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.19.5":
+  version: 6.24.0
+  resolution: "undici@npm:6.24.0"
+  checksum: 10c0/a97d7f1214b34c5b2802558d06cbed97ff96a27ab6548972ba9d07c13951c69e2e9f2f01581f71c86b74755d2bf92e64091cf8f2c6eba4184f10c6d583e60388
   languageName: node
   linkType: hard
 
@@ -31774,6 +33072,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-typed-array@npm:^1.1.14":
+  version: 1.1.15
+  resolution: "which-typed-array@npm:1.1.15"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10c0/4465d5348c044032032251be54d8988270e69c6b7154f8fcb2a47ff706fe36f7624b3a24246b8d9089435a8f4ec48c1c1025c5d6b499456b9e5eff4f48212983
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.15":
+  version: 1.1.19
+  resolution: "which-typed-array@npm:1.1.19"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    for-each: "npm:^0.3.5"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-tostringtag: "npm:^1.0.2"
+  checksum: 10c0/702b5dc878addafe6c6300c3d0af5983b175c75fcb4f2a72dfc3dd38d93cf9e89581e4b29c854b16ea37e50a7d7fca5ae42ece5c273d8060dcd603b2404bbb3f
+  languageName: node
+  linkType: hard
+
 "which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19, which-typed-array@npm:^1.1.9":
   version: 1.1.20
   resolution: "which-typed-array@npm:1.1.20"
@@ -32269,6 +33595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.1
+  resolution: "zod-to-json-schema@npm:3.25.1"
+  peerDependencies:
+    zod: ^3.25 || ^4
+  checksum: 10c0/711b30e34d1f1211f1afe64bf457f0d799234199dc005cca720b236ea808804c03164039c232f5df33c46f462023874015a8a0b3aab1585eca14124c324db7e2
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^2.1.0":
   version: 2.1.0
   resolution: "zod-validation-error@npm:2.1.0"
@@ -32278,10 +33613,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.25.67, zod@npm:^3.19.1, zod@npm:^3.22.4":
+"zod@npm:3.25.67":
   version: 3.25.67
   resolution: "zod@npm:3.25.67"
   checksum: 10c0/80a0cab3033272c4ab9312198081f0c4ea88e9673c059aa36dc32024906363729db54bdb78f3dc9d5529bd1601f74974d5a56c0a23e40c6f04a9270c9ff22336
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.19.1, zod@npm:^3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 10c0/7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.3.5
+  resolution: "zod@npm:4.3.5"
+  checksum: 10c0/5a2db7e59177a3d7e202543f5136cb87b97b047b77c8a3d824098d3fa8b80d3aa40a0a5f296965c3b82dfdccdd05dbbfacce91347f16a39c675680fd7b1ab109
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Introduces `strapi.ai.mcp` — a built-in MCP (Model Context Protocol) server embedded in the Strapi core.

- Adds `McpService` under `strapi.ai.mcp` with `registerTool()`, `registerPrompt()`, `registerResource()`, `start()`, and `stop()` lifecycle methods
- Implements Streamable HTTP transport (`POST /mcp`, `GET /mcp`, `DELETE /mcp`) with JSON-RPC 2.0 compliance
- Session management (`McpSessionManager`) with configurable idle timeout, max sessions, and periodic cleanup
- Capability definition registries (`McpCapabilityDefinitionRegistry`) for tools, prompts, and resources — registration is locked once the server starts
- `McpConfiguration` reads from `server.mcp.*` config keys (enabled, sessionIdleTimeoutMs, maxSessions, cleanupIntervalMs, requestTimeoutMs)
- A built-in `log` tool registered out of the box
- Full TypeScript types published under `@strapi/types` (`Modules.MCP.*`)
- MCP is **dev-mode only** (`autoReload: true`) until auth is implemented

### Why is it needed?

AI coding agents (Cursor, Copilot, Claude, etc.) use the MCP protocol to interact with external services. Exposing a native MCP server in Strapi allows AI tools to introspect and manipulate a running Strapi instance — content types, entries, config — directly from the IDE, without requiring a third-party bridge.

### How to test it?

1. Enable MCP in `config/server.js`:
   ```js
   mcp: { enabled: true }
   ```
2. Start Strapi in dev mode (`yarn develop`)
3. Connect any MCP client (e.g. Cursor, Claude Desktop) to `http://localhost:1337/mcp`
4. Verify the `log` tool is available and callable
5. Register a custom tool from a plugin's `register()` hook via `strapi.ai.mcp.registerTool(...)` and verify it appears in the client

### Related issue(s)/PR(s)

N/A
