### PR TITLE
feat(mcp): bind admin tokens authentication

### DIFF
--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -15,6 +15,7 @@ import {
 } from 'lodash/fp';
 import type { Core, Data } from '@strapi/types';
 import { errors } from '@strapi/utils';
+import type { Ability } from '@casl/ability';
 import type {
   Update,
   ContentApiApiToken,
@@ -26,12 +27,17 @@ import constants from './constants';
 import { getService } from '../utils';
 import permissionDomain from '../domain/permission';
 import { validatePermissionsExist } from '../validation/permission';
+import { checkExpiry, updateLastUsedAt } from '../strategies/api-token-utils';
 
 type AnyApiToken = ContentApiApiToken | AdminApiToken;
 
 const { SUPER_ADMIN_CODE } = constants;
 
-const { ValidationError, NotFoundError } = errors;
+const { ValidationError, NotFoundError, UnauthorizedError } = errors;
+
+export type AdminTokenAuthenticationResult =
+  | { authenticated: false; error?: InstanceType<typeof UnauthorizedError> }
+  | { authenticated: true; credentials: AdminApiToken; user: AdminUser; ability: Ability };
 
 const assertOwnerMatchesCallingUser = async (
   adminUserOwner: Data.ID,
@@ -64,6 +70,20 @@ const isSuperAdmin = (user: AdminUser | undefined): boolean =>
 const getOwnerId = (token: AdminApiToken): string => {
   const owner = token.adminUserOwner;
   return String(typeof owner === 'object' ? owner.id : owner);
+};
+
+const resolveAdminTokenOwnerId = (token: AdminApiToken): Data.ID | null => {
+  const owner = token.adminUserOwner;
+
+  if (owner === null || owner === undefined) {
+    return null;
+  }
+
+  if (typeof owner === 'object') {
+    return owner.id;
+  }
+
+  return owner;
 };
 
 const toAdminTokenOwner = (
@@ -662,6 +682,55 @@ const hash = (accessKey: string) => {
   return crypto.createHmac('sha512', salt).update(accessKey).digest('hex');
 };
 
+const authenticateAdminToken = async (
+  accessToken: string
+): Promise<AdminTokenAuthenticationResult> => {
+  if (strapi.features.future.isEnabled('adminTokens') !== true) {
+    return { authenticated: false };
+  }
+
+  const apiToken = (await getBy({ accessKey: hash(accessToken) })) as AdminApiToken | null;
+
+  if (apiToken === null || apiToken === undefined) {
+    return { authenticated: false };
+  }
+
+  if (apiToken.kind !== 'admin') {
+    return { authenticated: false };
+  }
+
+  const expiryError = checkExpiry(apiToken);
+  if (expiryError !== null) {
+    return { authenticated: false, error: expiryError };
+  }
+
+  await updateLastUsedAt(apiToken);
+
+  const ownerId = resolveAdminTokenOwnerId(apiToken);
+  if (ownerId === null) {
+    return { authenticated: false, error: new UnauthorizedError('Token owner not found') };
+  }
+
+  const user = await strapi.db
+    .query('admin::user')
+    .findOne({ where: { id: ownerId }, populate: ['roles'] });
+
+  if (user === null || user === undefined) {
+    return { authenticated: false, error: new UnauthorizedError('Token owner not found') };
+  }
+
+  if (user.isActive !== true || user.blocked === true) {
+    return { authenticated: false, error: new UnauthorizedError('Token owner is deactivated') };
+  }
+
+  const ability = await getService('permission').engine.generateTokenAbility(
+    apiToken.adminPermissions ?? [],
+    user
+  );
+
+  return { authenticated: true, credentials: apiToken, user, ability };
+};
+
 const getExpirationFields = (lifespan: AnyApiToken['lifespan']) => {
   // it must be nil or a finite number >= 0
   const isValidNumber = isNumber(lifespan) && Number.isFinite(lifespan) && lifespan > 0;
@@ -1184,6 +1253,7 @@ export interface ContentApiTokenService extends SharedTokenMethods {
 }
 
 export interface AdminTokenService extends SharedTokenMethods {
+  authenticateAdminToken(accessToken: string): Promise<AdminTokenAuthenticationResult>;
   create(attributes: AdminTokenBody, callingUser: AdminUser): Promise<AdminApiToken>;
   list(callingUser: AdminUser): Promise<AdminApiToken[]>;
   getById(id: string | number, options?: GetByOptions): Promise<AdminApiToken | null>;
@@ -1253,6 +1323,7 @@ function createTokenService(
 
   const svc: AdminTokenService = {
     ...shared,
+    authenticateAdminToken,
     create: (attributes: AdminTokenBody, callingUser: AdminUser) =>
       create({ ...attributes, kind: 'admin' }, callingUser) as Promise<AdminApiToken>,
     list: (callingUser: AdminUser) =>
@@ -1291,6 +1362,7 @@ export {
   update,
   getByName,
   getBy,
+  authenticateAdminToken,
   assignAdminPermissionsToToken,
   enforceAdminPermissionsCeiling,
   reconcileTokenPermissionsToUserCeiling,

--- a/packages/core/admin/server/src/strategies/__tests__/admin-token.test.ts
+++ b/packages/core/admin/server/src/strategies/__tests__/admin-token.test.ts
@@ -34,29 +34,79 @@ describe('Admin Token Auth Strategy', () => {
     getByAccessKey: jest.Mock,
     findOneUser: jest.Mock = jest.fn(() => activeUserWithRoles),
     adminTokensEnabled = true
-  ) => ({
-    features: {
-      future: {
-        isEnabled: jest.fn((featureName: string) => {
-          return featureName === 'adminTokens' ? adminTokensEnabled : false;
-        }),
+  ) => {
+    const authenticateAdminToken = jest.fn(async () => {
+      if (global.strapi.features.future.isEnabled('adminTokens') !== true) {
+        return { authenticated: false };
+      }
+
+      const apiToken = await getByAccessKey(hash());
+      if (apiToken === null || apiToken === undefined || apiToken.kind !== 'admin') {
+        return { authenticated: false };
+      }
+
+      const expiresAt = apiToken.expiresAt;
+      if (expiresAt !== null && expiresAt !== undefined && new Date(expiresAt) < new Date()) {
+        return { authenticated: false, error: new errors.UnauthorizedError('Token expired') };
+      }
+
+      await update(apiToken);
+
+      const owner = apiToken.adminUserOwner;
+      const ownerId =
+        // eslint-disable-next-line no-nested-ternary
+        owner === null || owner === undefined ? null : typeof owner === 'object' ? owner.id : owner;
+
+      if (ownerId === null) {
+        return {
+          authenticated: false,
+          error: new errors.UnauthorizedError('Token owner not found'),
+        };
+      }
+
+      const user = await findOneUser({ where: { id: ownerId }, populate: ['roles'] });
+      if (user === null || user === undefined) {
+        return {
+          authenticated: false,
+          error: new errors.UnauthorizedError('Token owner not found'),
+        };
+      }
+
+      if (user.isActive !== true || user.blocked === true) {
+        return {
+          authenticated: false,
+          error: new errors.UnauthorizedError('Token owner is deactivated'),
+        };
+      }
+
+      const ability = await generateTokenAbility();
+      return { authenticated: true, credentials: apiToken, user, ability };
+    });
+
+    return {
+      features: {
+        future: {
+          isEnabled: jest.fn((featureName: string) => {
+            return featureName === 'adminTokens' ? adminTokensEnabled : false;
+          }),
+        },
       },
-    },
-    admin: {
-      services: {
-        'api-token-admin': { getByAccessKey, hash },
-        permission: { engine: { generateTokenAbility } },
+      admin: {
+        services: {
+          'api-token-admin': { getByAccessKey, hash, authenticateAdminToken },
+          permission: { engine: { generateTokenAbility } },
+        },
       },
-    },
-    db: {
-      query(uid: string) {
-        if (uid === 'admin::user') {
-          return { findOne: findOneUser };
-        }
-        return { update };
+      db: {
+        query(uid: string) {
+          if (uid === 'admin::user') {
+            return { findOne: findOneUser };
+          }
+          return { update };
+        },
       },
-    },
-  });
+    };
+  };
 
   const adminRouteCtx = (authorization = 'Bearer test-token') =>
     createContext(

--- a/packages/core/admin/server/src/strategies/admin-token.ts
+++ b/packages/core/admin/server/src/strategies/admin-token.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'koa';
 import { errors } from '@strapi/utils';
 import { getService } from '../utils';
-import { extractToken, checkExpiry, updateLastUsedAt } from './api-token-utils';
+import { extractToken, checkExpiry } from './api-token-utils';
 import '@strapi/types';
 
 const { UnauthorizedError } = errors;
@@ -10,10 +10,6 @@ const { UnauthorizedError } = errors;
  * Authenticate an admin token. Rejects tokens with kind !== 'admin'.
  */
 export const authenticate = async (ctx: Context) => {
-  if (strapi.features.future.isEnabled('adminTokens') !== true) {
-    return { authenticated: false };
-  }
-
   const apiTokenService = getService('api-token-admin');
   const token = extractToken(ctx);
 
@@ -21,56 +17,14 @@ export const authenticate = async (ctx: Context) => {
     return { authenticated: false };
   }
 
-  const apiToken = await apiTokenService.getByAccessKey(apiTokenService.hash(token));
+  const authResult = await apiTokenService.authenticateAdminToken(token);
 
-  if (apiToken === null || apiToken === undefined) {
-    return { authenticated: false };
+  if (authResult.authenticated === true) {
+    ctx.state.userAbility = authResult.ability;
+    ctx.state.user = authResult.user;
   }
 
-  // Defensive kind check — only handle admin tokens
-  if (apiToken.kind !== 'admin') {
-    return { authenticated: false };
-  }
-
-  const expiryError = checkExpiry(apiToken);
-  if (expiryError !== null) {
-    return { authenticated: false, error: expiryError };
-  }
-
-  await updateLastUsedAt(apiToken);
-
-  const owner = apiToken.adminUserOwner;
-  const ownerId =
-    // eslint-disable-next-line no-nested-ternary
-    owner === null || owner === undefined ? null : typeof owner === 'object' ? owner.id : owner;
-
-  if (ownerId === null) {
-    return { authenticated: false, error: new UnauthorizedError('Token owner not found') };
-  }
-
-  // Token populate does not load `roles`; reload the user like session auth (`admin` strategy)
-  // so `isSuperAdmin` and permission ceiling logic see the full admin user.
-  const user = await strapi.db
-    .query('admin::user')
-    .findOne({ where: { id: ownerId }, populate: ['roles'] });
-
-  if (user === null || user === undefined) {
-    return { authenticated: false, error: new UnauthorizedError('Token owner not found') };
-  }
-
-  if (user.isActive !== true || user.blocked === true) {
-    return { authenticated: false, error: new UnauthorizedError('Token owner is deactivated') };
-  }
-
-  const ability = await getService('permission').engine.generateTokenAbility(
-    apiToken.adminPermissions ?? [],
-    user
-  );
-
-  ctx.state.userAbility = ability;
-  ctx.state.user = user;
-
-  return { authenticated: true, credentials: apiToken, ability };
+  return authResult;
 };
 
 /**

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -32,9 +32,6 @@ describe('MCP Service Integration', () => {
           if (key === 'server.mcp.enabled') {
             return true;
           }
-          if (key === 'autoReload') {
-            return true; // Required for isEnabled() to return true
-          }
           if (key === 'server.url') {
             return 'http://localhost:1337';
           }
@@ -123,9 +120,6 @@ describe('MCP Service Integration', () => {
             if (key === 'server.mcp.enabled') {
               return false;
             }
-            if (key === 'autoReload') {
-              return false; // Disabled will also require autoReload to be false
-            }
             return defaultValue;
           }),
         } as any,
@@ -186,7 +180,7 @@ describe('MCP Service Integration', () => {
           title: 'Test Tool',
           description: 'Test tool',
           outputSchema: {} as any,
-          devModeOnly: false,
+          auth: { action: 'test.action' },
           createHandler: jest.fn(),
         });
       }).not.toThrow();
@@ -203,7 +197,7 @@ describe('MCP Service Integration', () => {
           title: 'Test Tool',
           description: 'Test tool',
           outputSchema: {} as any,
-          devModeOnly: false,
+          auth: { action: 'test.action' },
           createHandler: jest.fn(),
         });
       }).toThrow('[MCP] Tools must be registered before MCP server starts');

--- a/packages/core/core/src/services/mcp/authentication.ts
+++ b/packages/core/core/src/services/mcp/authentication.ts
@@ -1,0 +1,54 @@
+import type { Core, Data } from '@strapi/types';
+import type { Context } from 'koa';
+
+export type McpAdminTokenAbility = {
+  can(action: string, subject?: string): boolean;
+};
+
+export type McpAdminTokenAuthResult =
+  | { authenticated: false; error?: Error }
+  | {
+      authenticated: true;
+      credentials: { id: Data.ID };
+      ability: McpAdminTokenAbility;
+    };
+
+const extractBearerToken = (ctx: Context): string | null => {
+  const authorization = ctx.request.header.authorization;
+
+  if (authorization === undefined) {
+    return null;
+  }
+
+  const parts = authorization.split(/\s+/);
+
+  if (parts[0].toLowerCase() !== 'bearer' || parts.length !== 2) {
+    return null;
+  }
+
+  return parts[1];
+};
+
+export const createMcpAdminTokenAuthenticator = (strapi: Core.Strapi) => ({
+  async authenticate(ctx: Context): Promise<McpAdminTokenAuthResult> {
+    const token = extractBearerToken(ctx);
+
+    if (token === null) {
+      return { authenticated: false };
+    }
+
+    const authResult = (await strapi.admin.services['api-token-admin'].authenticateAdminToken(
+      token
+    )) as McpAdminTokenAuthResult;
+
+    if (authResult.authenticated === false) {
+      return authResult;
+    }
+
+    return {
+      authenticated: true,
+      credentials: { id: authResult.credentials.id },
+      ability: authResult.ability,
+    };
+  },
+});

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleDelete.test.ts
@@ -2,8 +2,9 @@ import type { Core } from '@strapi/types';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { McpConfiguration } from '../../internal/McpConfiguration';
 import { McpSessionManager } from '../../internal/McpSessionManager';
-import { McpSession } from '../../session';
+import { McpSession } from '../../internal/McpSession';
 import { JSON_RPC_ERRORS } from '../../utils/jsonRpcErrors';
+import { syncMcpSessionCapabilities } from '../../internal/syncMcpSessionCapabilities';
 import { createDeleteHandler } from '../handleDelete';
 import type { McpHandlerDependencies } from '../types';
 
@@ -11,10 +12,15 @@ jest.mock('../../utils/withTimeout', () => ({
   withTimeout: jest.fn((promise) => promise),
 }));
 
+jest.mock('../../internal/syncMcpSessionCapabilities', () => ({
+  syncMcpSessionCapabilities: jest.fn(),
+}));
+
 describe('handleDelete', () => {
   let mockStrapi: Partial<Core.Strapi>;
   let mockConfig: McpConfiguration;
   let mockSessionManager: McpSessionManager;
+  let mockAuthenticationStrategy: McpHandlerDependencies['authenticationStrategy'];
   let logErrorSpy: jest.Mock;
 
   beforeEach(() => {
@@ -29,11 +35,20 @@ describe('handleDelete', () => {
     };
     mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
     mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+    mockAuthenticationStrategy = {
+      authenticate: jest.fn().mockResolvedValue({
+        authenticated: true,
+        credentials: { id: 1 },
+        ability: { can: jest.fn(() => true) },
+      }),
+    };
+    jest.mocked(syncMcpSessionCapabilities).mockClear();
   });
 
   test('should return error when session ID is missing', async () => {
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -61,7 +76,7 @@ describe('handleDelete', () => {
 
     await handler(ctx, () => Promise.resolve());
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
@@ -74,9 +89,17 @@ describe('handleDelete', () => {
     );
   });
 
-  test('should return error when session is invalid', async () => {
+  test('should return error when authentication fails', async () => {
+    mockAuthenticationStrategy.authenticate = jest.fn().mockResolvedValue({
+      authenticated: false,
+      credentials: null,
+      ability: null,
+      error: null,
+    });
+
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -106,7 +129,110 @@ describe('handleDelete', () => {
 
     await handler(ctx, () => Promise.resolve());
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.SESSION_REQUIRED.code,
+          message: JSON_RPC_ERRORS.SESSION_REQUIRED.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+          message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session admin token does not match credentials', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const mockSession = {
+      lastActivity: Date.now(),
+      adminTokenId: 999,
+      transport: {
+        handleRequest: jest.fn(),
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createDeleteHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
@@ -125,6 +251,7 @@ describe('handleDelete', () => {
 
     const mockSession = {
       lastActivity: Date.now(),
+      adminTokenId: 1,
       transport: {
         handleRequest: handleRequestSpy,
       },
@@ -134,6 +261,7 @@ describe('handleDelete', () => {
 
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -159,6 +287,15 @@ describe('handleDelete', () => {
 
     await handler(ctx, () => Promise.resolve());
 
+    expect(syncMcpSessionCapabilities).toHaveBeenCalledWith({
+      session: mockSession,
+      definitions: deps.capabilityDefinitions,
+      ability: expect.objectContaining({ can: expect.any(Function) }),
+      isDevMode: mockConfig.isDevMode(),
+    });
+    expect(jest.mocked(syncMcpSessionCapabilities).mock.invocationCallOrder[0]).toBeLessThan(
+      handleRequestSpy.mock.invocationCallOrder[0]
+    );
     expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
   });
 
@@ -169,6 +306,7 @@ describe('handleDelete', () => {
 
     const mockSession = {
       lastActivity: Date.now(),
+      adminTokenId: 1,
       transport: {
         handleRequest: handleRequestSpy,
       },
@@ -178,6 +316,7 @@ describe('handleDelete', () => {
 
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handleGet.test.ts
@@ -2,15 +2,21 @@ import type { Core } from '@strapi/types';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { McpConfiguration } from '../../internal/McpConfiguration';
 import { McpSessionManager } from '../../internal/McpSessionManager';
-import { McpSession } from '../../session';
+import { McpSession } from '../../internal/McpSession';
 import { JSON_RPC_ERRORS } from '../../utils/jsonRpcErrors';
+import { syncMcpSessionCapabilities } from '../../internal/syncMcpSessionCapabilities';
 import { createGetHandler } from '../handleGet';
 import type { McpHandlerDependencies } from '../types';
+
+jest.mock('../../internal/syncMcpSessionCapabilities', () => ({
+  syncMcpSessionCapabilities: jest.fn(),
+}));
 
 describe('handleGet', () => {
   let mockStrapi: Partial<Core.Strapi>;
   let mockConfig: McpConfiguration;
   let mockSessionManager: McpSessionManager;
+  let mockAuthenticationStrategy: McpHandlerDependencies['authenticationStrategy'];
   let logErrorSpy: jest.Mock;
 
   beforeEach(() => {
@@ -25,11 +31,20 @@ describe('handleGet', () => {
     };
     mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
     mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+    mockAuthenticationStrategy = {
+      authenticate: jest.fn().mockResolvedValue({
+        authenticated: true,
+        credentials: { id: 1 },
+        ability: { can: jest.fn(() => true) },
+      }),
+    };
+    jest.mocked(syncMcpSessionCapabilities).mockClear();
   });
 
   test('should return error when session ID is missing', async () => {
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -57,7 +72,9 @@ describe('handleGet', () => {
 
     await handler(ctx, () => Promise.resolve());
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(JSON_RPC_ERRORS.SESSION_REQUIRED.httpStatus, {
+      'Content-Type': 'application/json',
+    });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
@@ -70,9 +87,17 @@ describe('handleGet', () => {
     );
   });
 
-  test('should return error when session is invalid', async () => {
+  test('should return error when authentication fails', async () => {
+    mockAuthenticationStrategy.authenticate = jest.fn().mockResolvedValue({
+      authenticated: false,
+      credentials: null,
+      ability: null,
+      error: null,
+    });
+
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -102,7 +127,117 @@ describe('handleGet', () => {
 
     await handler(ctx, () => Promise.resolve());
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(JSON_RPC_ERRORS.SESSION_REQUIRED.httpStatus, {
+      'Content-Type': 'application/json',
+    });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.SESSION_REQUIRED.code,
+          message: JSON_RPC_ERRORS.SESSION_REQUIRED.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session is invalid', async () => {
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': '12345678-1234-1234-1234-123456789abc',
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(JSON_RPC_ERRORS.INVALID_SESSION.httpStatus, {
+      'Content-Type': 'application/json',
+    });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+          message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+        },
+        id: null,
+      })
+    );
+  });
+
+  test('should return error when session admin token does not match credentials', async () => {
+    const sessionId = '12345678-1234-1234-1234-123456789abc';
+    const mockSession = {
+      lastActivity: Date.now(),
+      updateActivity: jest.fn(),
+      adminTokenId: 999,
+      transport: {
+        handleRequest: jest.fn(),
+      },
+    } as unknown as McpSession;
+
+    mockSessionManager.set(sessionId, mockSession);
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createGetHandler(deps);
+
+    const req = {
+      headers: {
+        'mcp-session-id': sessionId,
+      },
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(JSON_RPC_ERRORS.INVALID_SESSION.httpStatus, {
+      'Content-Type': 'application/json',
+    });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
@@ -123,6 +258,7 @@ describe('handleGet', () => {
     const mockSession = {
       lastActivity: Date.now(),
       updateActivity: updateActivitySpy,
+      adminTokenId: 1,
       transport: {
         handleRequest: handleRequestSpy,
       },
@@ -132,6 +268,7 @@ describe('handleGet', () => {
 
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -158,6 +295,15 @@ describe('handleGet', () => {
     await handler(ctx, () => Promise.resolve());
 
     expect(updateActivitySpy).toHaveBeenCalled();
+    expect(syncMcpSessionCapabilities).toHaveBeenCalledWith({
+      session: mockSession,
+      definitions: deps.capabilityDefinitions,
+      ability: expect.objectContaining({ can: expect.any(Function) }),
+      isDevMode: mockConfig.isDevMode(),
+    });
+    expect(jest.mocked(syncMcpSessionCapabilities).mock.invocationCallOrder[0]).toBeLessThan(
+      handleRequestSpy.mock.invocationCallOrder[0]
+    );
     expect(handleRequestSpy).toHaveBeenCalledWith(req, res, null);
   });
 
@@ -169,6 +315,7 @@ describe('handleGet', () => {
     const mockSession = {
       lastActivity: Date.now(),
       updateActivity: jest.fn(),
+      adminTokenId: 1,
       transport: {
         handleRequest: handleRequestSpy,
       },
@@ -178,6 +325,7 @@ describe('handleGet', () => {
 
     const deps: McpHandlerDependencies = {
       strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
       sessionManager: mockSessionManager,
       config: mockConfig,
       createServerWithRegistries: jest.fn(),
@@ -213,6 +361,18 @@ describe('handleGet', () => {
         error: 'Request failed',
       })
     );
-    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(JSON_RPC_ERRORS.INTERNAL_ERROR.httpStatus, {
+      'Content-Type': 'application/json',
+    });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.INTERNAL_ERROR.code,
+          message: JSON_RPC_ERRORS.INTERNAL_ERROR.message,
+        },
+        id: null,
+      })
+    );
   });
 });

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -2,12 +2,18 @@ import type { Core } from '@strapi/types';
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { McpConfiguration } from '../../internal/McpConfiguration';
 import { McpSessionManager } from '../../internal/McpSessionManager';
-import { McpSession } from '../../session';
+import { McpSession } from '../../internal/McpSession';
+import { JSON_RPC_ERRORS } from '../../utils/jsonRpcErrors';
+import { syncMcpSessionCapabilities } from '../../internal/syncMcpSessionCapabilities';
 import { createPostHandler } from '../handlePost';
 import type { McpHandlerDependencies } from '../types';
 
 jest.mock('../../utils/withTimeout', () => ({
   withTimeout: jest.fn((promise) => promise),
+}));
+
+jest.mock('../../internal/syncMcpSessionCapabilities', () => ({
+  syncMcpSessionCapabilities: jest.fn(),
 }));
 
 jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
@@ -18,6 +24,7 @@ describe('handlePost', () => {
   let mockStrapi: Partial<Core.Strapi>;
   let mockConfig: McpConfiguration;
   let mockSessionManager: McpSessionManager;
+  let mockAuthenticationStrategy: McpHandlerDependencies['authenticationStrategy'];
   let logErrorSpy: jest.Mock;
   let logInfoSpy: jest.Mock;
 
@@ -35,6 +42,66 @@ describe('handlePost', () => {
     };
     mockConfig = new McpConfiguration(mockStrapi as Core.Strapi);
     mockSessionManager = new McpSessionManager(mockConfig, mockStrapi as Core.Strapi);
+    mockAuthenticationStrategy = {
+      authenticate: jest.fn().mockResolvedValue({
+        authenticated: true,
+        credentials: { id: 1 },
+        ability: { can: jest.fn(() => true) },
+      }),
+    };
+    jest.mocked(syncMcpSessionCapabilities).mockClear();
+  });
+
+  test('should return error when authentication fails', async () => {
+    mockAuthenticationStrategy.authenticate = jest.fn().mockResolvedValue({
+      authenticated: false,
+      credentials: null,
+      ability: null,
+      error: null,
+    });
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      sessionManager: mockSessionManager,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createPostHandler(deps);
+
+    const req = {
+      headers: {},
+    } as unknown as IncomingMessage;
+
+    const writeHeadSpy = jest.fn();
+    const endSpy = jest.fn();
+    const res = {
+      headersSent: false,
+      writeHead: writeHeadSpy,
+      end: endSpy,
+    } as unknown as ServerResponse;
+
+    const ctx = {
+      req,
+      res,
+      request: {},
+    } as any;
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(endSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: JSON_RPC_ERRORS.SESSION_REQUIRED.code,
+          message: JSON_RPC_ERRORS.SESSION_REQUIRED.message,
+        },
+        id: null,
+      })
+    );
   });
 
   describe('existing session', () => {
@@ -46,6 +113,7 @@ describe('handlePost', () => {
       const mockSession = {
         lastActivity: Date.now(),
         updateActivity: updateActivitySpy,
+        adminTokenId: 1,
         transport: {
           handleRequest: handleRequestSpy,
         },
@@ -55,6 +123,7 @@ describe('handlePost', () => {
 
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries: jest.fn(),
@@ -85,12 +154,22 @@ describe('handlePost', () => {
       await handler(ctx, () => Promise.resolve());
 
       expect(updateActivitySpy).toHaveBeenCalled();
+      expect(syncMcpSessionCapabilities).toHaveBeenCalledWith({
+        session: mockSession,
+        definitions: deps.capabilityDefinitions,
+        ability: expect.objectContaining({ can: expect.any(Function) }),
+        isDevMode: mockConfig.isDevMode(),
+      });
+      expect(jest.mocked(syncMcpSessionCapabilities).mock.invocationCallOrder[0]).toBeLessThan(
+        handleRequestSpy.mock.invocationCallOrder[0]
+      );
       expect(handleRequestSpy).toHaveBeenCalledWith(req, res, requestBody);
     });
 
     test('should return error when session is invalid', async () => {
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries: jest.fn(),
@@ -121,8 +200,76 @@ describe('handlePost', () => {
 
       await handler(ctx, () => Promise.resolve());
 
-      expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
-      expect(endSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid session'));
+      expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+            message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+          },
+          id: null,
+        })
+      );
+    });
+
+    test('should return error when session admin token does not match credentials', async () => {
+      const sessionId = '12345678-1234-1234-1234-123456789abc';
+      const mockSession = {
+        lastActivity: Date.now(),
+        updateActivity: jest.fn(),
+        adminTokenId: 999,
+        transport: {
+          handleRequest: jest.fn(),
+        },
+      } as unknown as McpSession;
+
+      mockSessionManager.set(sessionId, mockSession);
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
+        sessionManager: mockSessionManager,
+        config: mockConfig,
+        createServerWithRegistries: jest.fn(),
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+
+      const req = {
+        headers: {
+          'mcp-session-id': sessionId,
+        },
+      } as unknown as IncomingMessage;
+
+      const writeHeadSpy = jest.fn();
+      const endSpy = jest.fn();
+      const res = {
+        headersSent: false,
+        writeHead: writeHeadSpy,
+        end: endSpy,
+      } as unknown as ServerResponse;
+
+      const ctx = {
+        req,
+        res,
+        request: {},
+      } as any;
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+      expect(endSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: JSON_RPC_ERRORS.INVALID_SESSION.code,
+            message: JSON_RPC_ERRORS.INVALID_SESSION.message,
+          },
+          id: null,
+        })
+      );
     });
   });
 
@@ -163,6 +310,7 @@ describe('handlePost', () => {
 
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries,
@@ -198,6 +346,7 @@ describe('handlePost', () => {
         strapi: mockStrapi,
         definitions: deps.capabilityDefinitions,
         isDevMode: mockConfig.isDevMode(),
+        ability: expect.objectContaining({ can: expect.any(Function) }),
       });
       expect(mockMcpServer.connect).toHaveBeenCalledWith(mockTransport);
       expect(mockTransport.handleRequest).toHaveBeenCalledWith(req, res, requestBody);
@@ -214,6 +363,7 @@ describe('handlePost', () => {
 
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries: jest.fn(),
@@ -244,7 +394,14 @@ describe('handlePost', () => {
 
       expect(writeHeadSpy).toHaveBeenCalledWith(503, { 'Content-Type': 'application/json' });
       expect(endSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Maximum number of sessions reached')
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: {
+            code: JSON_RPC_ERRORS.MAX_SESSIONS_REACHED.code,
+            message: JSON_RPC_ERRORS.MAX_SESSIONS_REACHED.message,
+          },
+          id: null,
+        })
       );
     });
   });
@@ -258,6 +415,7 @@ describe('handlePost', () => {
       const mockSession = {
         lastActivity: Date.now(),
         updateActivity: jest.fn(),
+        adminTokenId: 1,
         transport: {
           handleRequest: handleRequestSpy,
         },
@@ -267,6 +425,7 @@ describe('handlePost', () => {
 
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries: jest.fn(),
@@ -313,6 +472,7 @@ describe('handlePost', () => {
       const mockSession = {
         lastActivity: Date.now(),
         updateActivity: jest.fn(),
+        adminTokenId: 1,
         transport: {
           handleRequest: handleRequestSpy,
         },
@@ -322,6 +482,7 @@ describe('handlePost', () => {
 
       const deps: McpHandlerDependencies = {
         strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
         sessionManager: mockSessionManager,
         config: mockConfig,
         createServerWithRegistries: jest.fn(),

--- a/packages/core/core/src/services/mcp/handlers/handleDelete.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleDelete.ts
@@ -1,16 +1,23 @@
 import type { Core } from '@strapi/types';
 import { extractSessionId } from '../internal/extractSessionId';
+import { syncMcpSessionCapabilities } from '../internal/syncMcpSessionCapabilities';
 import { sendJsonRpcError } from '../utils/sendJsonRpcError';
 import { withTimeout } from '../utils/withTimeout';
 import type { McpHandlerDependencies } from './types';
 
 export const createDeleteHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
-  const { strapi, sessionManager, config } = deps;
+  const { strapi, authenticationStrategy, sessionManager, config, capabilityDefinitions } = deps;
 
   return async (ctx) => {
     const req = ctx.req;
     const res = ctx.res;
     const sessionId = extractSessionId(req);
+
+    const authResult = await authenticationStrategy.authenticate(ctx);
+    if (authResult.authenticated === false) {
+      sendJsonRpcError(res, 'SESSION_REQUIRED');
+      return;
+    }
 
     if (sessionId === undefined) {
       sendJsonRpcError(res, 'SESSION_REQUIRED');
@@ -22,8 +29,19 @@ export const createDeleteHandler = (deps: McpHandlerDependencies): Core.Middlewa
       sendJsonRpcError(res, 'INVALID_SESSION');
       return;
     }
+    if (String(session.adminTokenId) !== String(authResult.credentials.id)) {
+      sendJsonRpcError(res, 'INVALID_SESSION');
+      return;
+    }
 
     try {
+      syncMcpSessionCapabilities({
+        session,
+        definitions: capabilityDefinitions,
+        ability: authResult.ability,
+        isDevMode: config.isDevMode(),
+      });
+
       await withTimeout(
         session.transport.handleRequest(req, res, null),
         config.requestTimeoutMs,

--- a/packages/core/core/src/services/mcp/handlers/handleGet.ts
+++ b/packages/core/core/src/services/mcp/handlers/handleGet.ts
@@ -1,15 +1,22 @@
 import type { Core } from '@strapi/types';
 import { extractSessionId } from '../internal/extractSessionId';
+import { syncMcpSessionCapabilities } from '../internal/syncMcpSessionCapabilities';
 import { sendJsonRpcError } from '../utils/sendJsonRpcError';
 import type { McpHandlerDependencies } from './types';
 
 export const createGetHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
-  const { strapi, sessionManager } = deps;
+  const { strapi, authenticationStrategy, sessionManager, capabilityDefinitions, config } = deps;
 
   return async (ctx) => {
     const req = ctx.req;
     const res = ctx.res;
     const sessionId = extractSessionId(req);
+
+    const authResult = await authenticationStrategy.authenticate(ctx);
+    if (authResult.authenticated === false) {
+      sendJsonRpcError(res, 'SESSION_REQUIRED');
+      return;
+    }
 
     if (sessionId === undefined) {
       sendJsonRpcError(res, 'SESSION_REQUIRED');
@@ -21,11 +28,22 @@ export const createGetHandler = (deps: McpHandlerDependencies): Core.MiddlewareH
       sendJsonRpcError(res, 'INVALID_SESSION');
       return;
     }
+    if (String(session.adminTokenId) !== String(authResult.credentials.id)) {
+      sendJsonRpcError(res, 'INVALID_SESSION');
+      return;
+    }
 
     // GET requests establish long-lived SSE streams; transport manages their lifecycle.
     session.updateActivity();
 
     try {
+      syncMcpSessionCapabilities({
+        session,
+        definitions: capabilityDefinitions,
+        ability: authResult.ability,
+        isDevMode: config.isDevMode(),
+      });
+
       await session.transport.handleRequest(req, res, null);
     } catch (error) {
       strapi.log.error('[MCP] Error handling GET request', {

--- a/packages/core/core/src/services/mcp/handlers/handlePost.ts
+++ b/packages/core/core/src/services/mcp/handlers/handlePost.ts
@@ -3,14 +3,21 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { Core } from '@strapi/types';
 import { randomUUID } from 'node:crypto';
 import { extractSessionId } from '../internal/extractSessionId';
-import { McpSession } from '../session';
+import { McpSession } from '../internal/McpSession';
+import { syncMcpSessionCapabilities } from '../internal/syncMcpSessionCapabilities';
 import { sendJsonRpcError } from '../utils/sendJsonRpcError';
 import { withTimeout } from '../utils/withTimeout';
 import type { McpHandlerDependencies } from './types';
 
 export const createPostHandler = (deps: McpHandlerDependencies): Core.MiddlewareHandler => {
-  const { strapi, sessionManager, config, createServerWithRegistries, capabilityDefinitions } =
-    deps;
+  const {
+    strapi,
+    authenticationStrategy,
+    sessionManager,
+    config,
+    createServerWithRegistries,
+    capabilityDefinitions,
+  } = deps;
 
   return async (ctx) => {
     const req = ctx.req;
@@ -18,6 +25,12 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
     const sessionId = extractSessionId(req);
 
     try {
+      const authResult = await authenticationStrategy.authenticate(ctx);
+      if (authResult.authenticated === false) {
+        sendJsonRpcError(res, 'SESSION_REQUIRED');
+        return;
+      }
+
       let transport: StreamableHTTPServerTransport;
 
       // Existing session handling
@@ -27,7 +40,17 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
           sendJsonRpcError(res, 'INVALID_SESSION');
           return;
         }
+        if (String(existingSession.adminTokenId) !== String(authResult.credentials.id)) {
+          sendJsonRpcError(res, 'INVALID_SESSION');
+          return;
+        }
         existingSession.updateActivity();
+        syncMcpSessionCapabilities({
+          session: existingSession,
+          definitions: capabilityDefinitions,
+          ability: authResult.ability,
+          isDevMode: config.isDevMode(),
+        });
         transport = existingSession.transport;
 
         // Handle request with existing session
@@ -50,6 +73,7 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
           strapi,
           definitions: capabilityDefinitions,
           isDevMode: config.isDevMode(),
+          ability: authResult.ability,
         });
 
         transport = new StreamableHTTPServerTransport({
@@ -63,6 +87,7 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
                 toolRegistry: registries.toolRegistry,
                 promptRegistry: registries.promptRegistry,
                 resourceRegistry: registries.resourceRegistry,
+                adminTokenId: authResult.credentials.id,
               })
             );
             strapi.log.info('[MCP] Session initialized', { sessionId: id });

--- a/packages/core/core/src/services/mcp/handlers/types.ts
+++ b/packages/core/core/src/services/mcp/handlers/types.ts
@@ -5,9 +5,11 @@ import type {
   createMcpServerWithRegistries,
 } from '../internal/McpServerFactory';
 import type { McpSessionManager } from '../internal/McpSessionManager';
+import type { createMcpAdminTokenAuthenticator } from '../authentication';
 
 export type McpHandlerDependencies = {
   strapi: Core.Strapi;
+  authenticationStrategy: ReturnType<typeof createMcpAdminTokenAuthenticator>;
   sessionManager: McpSessionManager;
   config: McpConfiguration;
   createServerWithRegistries: typeof createMcpServerWithRegistries;

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -1,4 +1,5 @@
 import type { Core, Modules } from '@strapi/types';
+import { createMcpAdminTokenAuthenticator } from './authentication';
 import { createDeleteHandler } from './handlers/handleDelete';
 import { createGetHandler } from './handlers/handleGet';
 import { createPostHandler } from './handlers/handlePost';
@@ -20,6 +21,8 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
 
   // Initialize session manager
   const sessionManager = new McpSessionManager(config, strapi);
+
+  const authenticationStrategy = createMcpAdminTokenAuthenticator(strapi);
 
   // Status tracking
   let serverStatus: Modules.MCP.McpServiceStatus = 'idle';
@@ -46,6 +49,7 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
   // Prepare handler dependencies
   const handlerDependencies: McpHandlerDependencies = {
     strapi,
+    authenticationStrategy,
     sessionManager,
     config,
     createServerWithRegistries: createMcpServerWithRegistries,
@@ -89,11 +93,7 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
           '[MCP] Prompts must be registered before MCP server starts. Register during plugin register().'
         );
       }
-      const { argsSchema, ...rest } = prompt;
-      promptDefinitions.define({
-        ...rest,
-        argsSchema,
-      });
+      promptDefinitions.define(prompt);
     },
 
     registerResource(resource) {

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
@@ -12,6 +12,10 @@ export class McpCapabilityDefinitionRegistry<
     this.capability = capability;
   }
 
+  get size(): number {
+    return this.#definitions.size;
+  }
+
   define(definition: Definition) {
     const existing = this.#definitions.get(definition.name);
     if (existing !== undefined) {
@@ -19,6 +23,15 @@ export class McpCapabilityDefinitionRegistry<
         `[MCP] ${this.capability} with name "${definition.name}" is already registered. Names must be unique.`
       );
     }
+
+    if (definition.devModeOnly !== true) {
+      if (definition.auth === undefined || definition.auth.action === '') {
+        throw new Error(
+          `[MCP] ${this.capability} with name "${definition.name}" must declare auth action or be devModeOnly.`
+        );
+      }
+    }
+
     this.#definitions.set(definition.name, definition);
   }
 
@@ -34,7 +47,7 @@ export class McpCapabilityDefinitionRegistry<
     return Array.from(this.#definitions.values());
   }
 
-  get size(): number {
-    return this.#definitions.size;
+  forEach(callback: (definition: Definition) => void) {
+    this.#definitions.forEach(callback);
   }
 }

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityRegistry.ts
@@ -30,7 +30,7 @@ export class McpCapabilityRegistryBase<
   protected register<LocallyRegistered extends Registered>(
     registerFn: (definition: Definition) => LocallyRegistered
   ) {
-    for (const definition of this.#definitions.getAll()) {
+    this.#definitions.forEach((definition) => {
       const existing = this.#registered.get(definition.name);
       if (existing !== undefined) {
         throw new Error(
@@ -44,7 +44,7 @@ export class McpCapabilityRegistryBase<
       registered.disable();
 
       this.#registered.set(definition.name, registered);
-    }
+    });
   }
 
   list(ctx?: {
@@ -58,13 +58,14 @@ export class McpCapabilityRegistryBase<
         name: string;
         status: 'enabled' | 'disabled' | 'defined' | 'undefined';
         devModeOnly: boolean;
+        auth: Definition['auth'] | undefined;
       }[]
     >((acc, curr) => {
       const status = this.status(curr.name);
       if (filter?.status !== undefined && !filter.status.includes(status)) {
         return acc;
       }
-      acc.push({ name: curr.name, status, devModeOnly: curr.devModeOnly });
+      acc.push({ name: curr.name, status, devModeOnly: !!curr.devModeOnly, auth: curr.auth });
       return acc;
     }, []);
   }

--- a/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
+++ b/packages/core/core/src/services/mcp/internal/McpConfiguration.ts
@@ -26,11 +26,7 @@ export class McpConfiguration {
   }
 
   isEnabled(): boolean {
-    return (
-      this.#strapi.config.get('server.mcp.enabled', false) &&
-      // Only enabled in development mode until Auth is implemented
-      this.#strapi.config.get('autoReload') === true
-    );
+    return this.#strapi.config.get<boolean>('server.mcp.enabled', false) === true;
   }
 
   isDevMode(): boolean {

--- a/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
+++ b/packages/core/core/src/services/mcp/internal/McpServerFactory.ts
@@ -4,7 +4,9 @@ import type { Core, Modules } from '@strapi/types';
 import { McpPromptRegistry } from '../prompt-registry';
 import { McpResourceRegistry } from '../resource-registry';
 import { McpToolRegistry } from '../tool-registry';
+import type { McpAdminTokenAbility } from '../authentication';
 import { McpCapabilityDefinitionRegistry } from './McpCapabilityDefinitionRegistry';
+import { syncMcpSessionCapabilities } from './syncMcpSessionCapabilities';
 
 export type McpCapabilityDefinitions = {
   tools: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
@@ -27,12 +29,14 @@ export type CreateMcpServerWithRegistriesParams = {
   strapi: Core.Strapi;
   definitions: McpCapabilityDefinitions;
   isDevMode: boolean;
+  ability: McpAdminTokenAbility;
 };
 
 export const createMcpServerWithRegistries = ({
   strapi,
   definitions,
   isDevMode,
+  ability,
 }: CreateMcpServerWithRegistriesParams): McpServerWithRegistries => {
   const capabilities: {
     logging?: Record<string, unknown>;
@@ -81,26 +85,16 @@ export const createMcpServerWithRegistries = ({
   promptRegistry.bind(mcpServer);
   resourceRegistry.bind(mcpServer);
 
-  // TODO @Nico: Manage Permissions from Auth
-
-  // Enable devModeOnly capabilities when running in dev mode
-  if (isDevMode === true) {
-    toolRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
-      if (cap.devModeOnly === true) {
-        toolRegistry.enable(cap.name);
-      }
-    });
-    promptRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
-      if (cap.devModeOnly === true) {
-        promptRegistry.enable(cap.name);
-      }
-    });
-    resourceRegistry.list({ filter: { status: ['disabled'] } }).forEach((cap) => {
-      if (cap.devModeOnly === true) {
-        resourceRegistry.enable(cap.name);
-      }
-    });
-  }
+  syncMcpSessionCapabilities({
+    session: {
+      toolRegistry,
+      promptRegistry,
+      resourceRegistry,
+    },
+    definitions,
+    ability,
+    isDevMode,
+  });
 
   return {
     mcpServer,

--- a/packages/core/core/src/services/mcp/internal/McpSession.ts
+++ b/packages/core/core/src/services/mcp/internal/McpSession.ts
@@ -2,9 +2,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 // eslint-disable-next-line import/extensions
 import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { McpPromptRegistry } from './prompt-registry';
-import { McpResourceRegistry } from './resource-registry';
-import { McpToolRegistry } from './tool-registry';
+import type { Data } from '@strapi/types';
+import { McpPromptRegistry } from '../prompt-registry';
+import { McpResourceRegistry } from '../resource-registry';
+import { McpToolRegistry } from '../tool-registry';
 
 export class McpSession {
   server: McpServer;
@@ -19,18 +20,22 @@ export class McpSession {
 
   lastActivity: number;
 
+  adminTokenId: Data.ID;
+
   constructor(params: {
     server: McpServer;
     transport: StreamableHTTPServerTransport;
     toolRegistry: McpToolRegistry;
     promptRegistry: McpPromptRegistry;
     resourceRegistry: McpResourceRegistry;
+    adminTokenId: Data.ID;
   }) {
     this.server = params.server;
     this.transport = params.transport;
     this.toolRegistry = params.toolRegistry;
     this.promptRegistry = params.promptRegistry;
     this.resourceRegistry = params.resourceRegistry;
+    this.adminTokenId = params.adminTokenId;
     this.lastActivity = Date.now();
   }
 

--- a/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
+++ b/packages/core/core/src/services/mcp/internal/McpSessionManager.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import { McpSession } from '../session';
+import { McpSession } from './McpSession';
 import { McpConfiguration } from './McpConfiguration';
 
 export class McpSessionManager {

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
@@ -20,7 +20,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
 
     const definition: Modules.MCP.McpCapabilityDefinition = {
       name: 'my-capability',
-      devModeOnly: false,
+      auth: { action: 'test.action' },
     };
 
     registry.define(definition);
@@ -43,7 +43,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
     };
     const definitionB: Modules.MCP.McpCapabilityDefinition = {
       name: 'duplicate',
-      devModeOnly: false,
+      auth: { action: 'test.action' },
     };
 
     registry.define(definitionA);
@@ -56,6 +56,34 @@ describe('McpCapabilityDefinitionRegistry', () => {
     expect(registry.size).toBe(1);
   });
 
+  test('define() throws when a non-dev capability does not declare auth action', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    expect(() =>
+      registry.define({
+        name: 'missing-auth',
+        devModeOnly: false,
+      } as Modules.MCP.McpCapabilityDefinition)
+    ).toThrow('[MCP] tool with name "missing-auth" must declare auth action or be devModeOnly.');
+  });
+
+  test('define() throws when a non-dev capability declares an empty auth action', () => {
+    const registry = new McpCapabilityDefinitionRegistry<
+      'tool',
+      Modules.MCP.McpCapabilityDefinition
+    >('tool');
+
+    expect(() =>
+      registry.define({
+        name: 'empty-action',
+        auth: { action: '' },
+      })
+    ).toThrow('[MCP] tool with name "empty-action" must declare auth action or be devModeOnly.');
+  });
+
   test('delete() removes definitions and reports success', () => {
     const registry = new McpCapabilityDefinitionRegistry<
       'resource',
@@ -64,7 +92,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
 
     const definitionA: Modules.MCP.McpCapabilityDefinition = {
       name: 'a',
-      devModeOnly: false,
+      auth: { action: 'test.action' },
     };
     const definitionB: Modules.MCP.McpCapabilityDefinition = {
       name: 'b',

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
@@ -49,7 +49,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -71,7 +71,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
 
       registry.registerDefinitions();
@@ -84,7 +84,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'duplicate-tool',
         title: 'Tool',
         description: 'Tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
 
       registry.registerDefinitions();
@@ -104,7 +104,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -116,7 +116,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-3',
         title: 'Tool 3',
         description: 'Third tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
     });
 
@@ -127,9 +127,19 @@ describe('McpCapabilityRegistryBase', () => {
 
       expect(list).toHaveLength(3);
       expect(list).toEqual([
-        { name: 'tool-1', status: 'disabled', devModeOnly: false },
-        { name: 'tool-2', status: 'disabled', devModeOnly: true },
-        { name: 'tool-3', status: 'disabled', devModeOnly: false },
+        {
+          name: 'tool-1',
+          status: 'disabled',
+          devModeOnly: false,
+          auth: { action: 'test.action' },
+        },
+        { name: 'tool-2', status: 'disabled', devModeOnly: true, auth: undefined },
+        {
+          name: 'tool-3',
+          status: 'disabled',
+          devModeOnly: false,
+          auth: { action: 'test.action' },
+        },
       ]);
     });
 
@@ -142,7 +152,12 @@ describe('McpCapabilityRegistryBase', () => {
       });
 
       expect(list).toHaveLength(1);
-      expect(list[0]).toEqual({ name: 'tool-1', status: 'enabled', devModeOnly: false });
+      expect(list[0]).toEqual({
+        name: 'tool-1',
+        status: 'enabled',
+        devModeOnly: false,
+        auth: { action: 'test.action' },
+      });
     });
 
     test('should list capabilities filtered by disabled status', () => {
@@ -165,9 +180,24 @@ describe('McpCapabilityRegistryBase', () => {
       });
 
       expect(list).toHaveLength(3);
-      expect(list[0]).toEqual({ name: 'tool-1', status: 'defined', devModeOnly: false });
-      expect(list[1]).toEqual({ name: 'tool-2', status: 'defined', devModeOnly: true });
-      expect(list[2]).toEqual({ name: 'tool-3', status: 'defined', devModeOnly: false });
+      expect(list[0]).toEqual({
+        name: 'tool-1',
+        status: 'defined',
+        devModeOnly: false,
+        auth: { action: 'test.action' },
+      });
+      expect(list[1]).toEqual({
+        name: 'tool-2',
+        status: 'defined',
+        devModeOnly: true,
+        auth: undefined,
+      });
+      expect(list[2]).toEqual({
+        name: 'tool-3',
+        status: 'defined',
+        devModeOnly: false,
+        auth: { action: 'test.action' },
+      });
     });
 
     test('should list capabilities filtered by multiple statuses', () => {
@@ -208,7 +238,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
     });
 
@@ -241,7 +271,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       registry.registerDefinitions();
     });
@@ -272,7 +302,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -307,7 +337,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       registry.registerDefinitions();
     });
@@ -343,7 +373,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -382,7 +412,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       registry.registerDefinitions();
     });
@@ -424,7 +454,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -478,7 +508,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       registry.registerDefinitions();
 
@@ -497,7 +527,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -519,7 +549,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -543,7 +573,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        devModeOnly: false,
+        auth: { action: 'test.action' },
       });
       definitionRegistry.define({
         name: 'tool-2',

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpConfiguration.test.ts
@@ -46,10 +46,9 @@ describe('McpConfiguration', () => {
   });
 
   describe('isEnabled', () => {
-    test('should return true when both mcp.enabled and autoReload are true', () => {
+    test('should return true when mcp.enabled is true', () => {
       configGetSpy.mockImplementation((key, defaultValue) => {
         if (key === 'server.mcp.enabled') return true;
-        if (key === 'autoReload') return true;
         return defaultValue;
       });
 
@@ -61,7 +60,6 @@ describe('McpConfiguration', () => {
     test('should return false when mcp.enabled is false', () => {
       configGetSpy.mockImplementation((key, defaultValue) => {
         if (key === 'server.mcp.enabled') return false;
-        if (key === 'autoReload') return true;
         return defaultValue;
       });
 
@@ -70,24 +68,8 @@ describe('McpConfiguration', () => {
       expect(config.isEnabled()).toBe(false);
     });
 
-    test('should return false when autoReload is false', () => {
-      configGetSpy.mockImplementation((key, defaultValue) => {
-        if (key === 'server.mcp.enabled') return true;
-        if (key === 'autoReload') return false;
-        return defaultValue;
-      });
-
-      const config = new McpConfiguration(mockStrapi as Core.Strapi);
-
-      expect(config.isEnabled()).toBe(false);
-    });
-
-    test('should return false when both are false', () => {
-      configGetSpy.mockImplementation((key, defaultValue) => {
-        if (key === 'server.mcp.enabled') return false;
-        if (key === 'autoReload') return false;
-        return defaultValue;
-      });
+    test('should return false when mcp.enabled is not set', () => {
+      configGetSpy.mockImplementation((key, defaultValue) => defaultValue);
 
       const config = new McpConfiguration(mockStrapi as Core.Strapi);
 

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
@@ -36,6 +36,7 @@ jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
 
 describe('createMcpServerWithRegistries', () => {
   let mockStrapi: Partial<Core.Strapi>;
+  let mockAbility: { can: jest.Mock };
   let toolDefinitions: McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>;
   let promptDefinitions: McpCapabilityDefinitionRegistry<'prompt', Modules.MCP.McpPromptDefinition>;
   let resourceDefinitions: McpCapabilityDefinitionRegistry<
@@ -45,6 +46,7 @@ describe('createMcpServerWithRegistries', () => {
 
   beforeEach(() => {
     mockStrapi = {} as Core.Strapi;
+    mockAbility = { can: jest.fn(() => false) };
     toolDefinitions = new McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>(
       'tool'
     );
@@ -67,6 +69,7 @@ describe('createMcpServerWithRegistries', () => {
         resources: resourceDefinitions,
       },
       isDevMode: false,
+      ability: mockAbility,
     });
 
     expect(result.mcpServer).toBeDefined();
@@ -95,6 +98,7 @@ describe('createMcpServerWithRegistries', () => {
         resources: resourceDefinitions,
       },
       isDevMode: true,
+      ability: mockAbility,
     });
 
     // The tool should be enabled
@@ -122,6 +126,7 @@ describe('createMcpServerWithRegistries', () => {
         resources: resourceDefinitions,
       },
       isDevMode: false,
+      ability: mockAbility,
     });
 
     // The tool should remain disabled
@@ -140,10 +145,88 @@ describe('createMcpServerWithRegistries', () => {
         resources: resourceDefinitions,
       },
       isDevMode: false,
+      ability: mockAbility,
     });
 
     expect(result.registries.toolRegistry.list().length).toBe(0);
     expect(result.registries.promptRegistry.list().length).toBe(0);
     expect(result.registries.resourceRegistry.list().length).toBe(0);
+  });
+
+  test('should enable auth-gated capabilities when action is allowed', () => {
+    mockAbility.can.mockReturnValue(true);
+    toolDefinitions.define({
+      name: 'authorized-tool',
+      title: 'Authorized Tool',
+      description: 'An authorized tool',
+      auth: { action: 'admin::read' },
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+      ability: mockAbility,
+    });
+
+    expect(result.registries.toolRegistry.status('authorized-tool')).toBe('enabled');
+    expect(mockAbility.can).toHaveBeenCalledWith('admin::read');
+  });
+
+  test('should keep auth-gated capabilities disabled when action is denied', () => {
+    mockAbility.can.mockReturnValue(false);
+    toolDefinitions.define({
+      name: 'unauthorized-tool',
+      title: 'Unauthorized Tool',
+      description: 'An unauthorized tool',
+      auth: { action: 'admin::read' },
+      inputSchema: undefined,
+      outputSchema: z.object({}),
+      createHandler: () => async () => ({ content: [], structuredContent: {} }),
+    });
+
+    const result = createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+      ability: mockAbility,
+    });
+
+    expect(result.registries.toolRegistry.status('unauthorized-tool')).toBe('disabled');
+  });
+
+  test('should pass auth subject when checking capabilities', () => {
+    mockAbility.can.mockReturnValue(true);
+    resourceDefinitions.define({
+      name: 'authorized-resource',
+      uri: 'strapi://authorized-resource',
+      metadata: {},
+      auth: { action: 'admin::read', subject: 'api::article.article' },
+      createHandler: () => async () => ({ contents: [] }),
+    });
+
+    createMcpServerWithRegistries({
+      strapi: mockStrapi as Core.Strapi,
+      definitions: {
+        tools: toolDefinitions,
+        prompts: promptDefinitions,
+        resources: resourceDefinitions,
+      },
+      isDevMode: false,
+      ability: mockAbility,
+    });
+
+    expect(mockAbility.can).toHaveBeenCalledWith('admin::read', 'api::article.article');
   });
 });

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpSessionManager.test.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import { McpSession } from '../../session';
+import { McpSession } from '../McpSession';
 import { McpConfiguration } from '../McpConfiguration';
 import { McpSessionManager } from '../McpSessionManager';
 

--- a/packages/core/core/src/services/mcp/internal/__tests__/syncMcpSessionCapabilities.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/syncMcpSessionCapabilities.test.ts
@@ -1,0 +1,221 @@
+import type { Modules } from '@strapi/types';
+import type { McpCapabilityDefinitions } from '../McpServerFactory';
+import type { McpAdminTokenAbility } from '../../authentication';
+import type { McpSession } from '../McpSession';
+import { McpCapabilityDefinitionRegistry } from '../McpCapabilityDefinitionRegistry';
+import { canUseMcpCapability, syncMcpSessionCapabilities } from '../syncMcpSessionCapabilities';
+
+type RegistryStatus = 'enabled' | 'disabled' | 'defined' | 'undefined';
+
+const createDefinitions = ({
+  tools = [],
+  prompts = [],
+  resources = [],
+}: {
+  tools?: Modules.MCP.McpToolDefinition[];
+  prompts?: Modules.MCP.McpPromptDefinition[];
+  resources?: Modules.MCP.McpResourceDefinition[];
+}): McpCapabilityDefinitions => {
+  const toolDefinitions = new McpCapabilityDefinitionRegistry<
+    'tool',
+    Modules.MCP.McpToolDefinition
+  >('tool');
+  tools.forEach((definition) => {
+    toolDefinitions.define(definition);
+  });
+
+  const promptDefinitions = new McpCapabilityDefinitionRegistry<
+    'prompt',
+    Modules.MCP.McpPromptDefinition
+  >('prompt');
+  prompts.forEach((definition) => {
+    promptDefinitions.define(definition);
+  });
+
+  const resourceDefinitions = new McpCapabilityDefinitionRegistry<
+    'resource',
+    Modules.MCP.McpResourceDefinition
+  >('resource');
+  resources.forEach((definition) => {
+    resourceDefinitions.define(definition);
+  });
+
+  return {
+    tools: toolDefinitions,
+    prompts: promptDefinitions,
+    resources: resourceDefinitions,
+  };
+};
+
+const createRegistry = (initialStatus: Record<string, RegistryStatus>) => {
+  const statuses = new Map<string, RegistryStatus>(Object.entries(initialStatus));
+
+  return {
+    status: jest.fn((name: string) => statuses.get(name) ?? 'undefined'),
+    enable: jest.fn((name: string) => {
+      statuses.set(name, 'enabled');
+    }),
+    disable: jest.fn((name: string) => {
+      statuses.set(name, 'disabled');
+    }),
+  };
+};
+
+const createSession = ({
+  toolStatus = {},
+  promptStatus = {},
+  resourceStatus = {},
+}: {
+  toolStatus?: Record<string, RegistryStatus>;
+  promptStatus?: Record<string, RegistryStatus>;
+  resourceStatus?: Record<string, RegistryStatus>;
+}): Pick<McpSession, 'toolRegistry' | 'promptRegistry' | 'resourceRegistry'> =>
+  ({
+    toolRegistry: createRegistry(toolStatus),
+    promptRegistry: createRegistry(promptStatus),
+    resourceRegistry: createRegistry(resourceStatus),
+  }) as unknown as Pick<McpSession, 'toolRegistry' | 'promptRegistry' | 'resourceRegistry'>;
+
+const createAbility = (can: McpAdminTokenAbility['can']): McpAdminTokenAbility => ({
+  can,
+  cannot: jest.fn(
+    (action: string, subject?: unknown, field?: string) => !can(action, subject, field)
+  ),
+});
+
+const createToolDefinition = (
+  params: Pick<Modules.MCP.McpToolDefinition, 'name'> &
+    Partial<Pick<Modules.MCP.McpToolDefinition, 'auth' | 'devModeOnly'>>
+): Modules.MCP.McpToolDefinition =>
+  ({
+    name: params.name,
+    auth: params.auth,
+    devModeOnly: params.devModeOnly,
+  }) as Modules.MCP.McpToolDefinition;
+
+describe('syncMcpSessionCapabilities', () => {
+  test('disables an enabled capability when fresh ability denies it', () => {
+    const ability = createAbility(jest.fn(() => false));
+    const session = createSession({ toolStatus: { denied: 'enabled' } });
+    const definitions = createDefinitions({
+      tools: [createToolDefinition({ name: 'denied', auth: { action: 'admin::read' } })],
+    });
+
+    const summary = syncMcpSessionCapabilities({
+      session,
+      definitions,
+      ability,
+      isDevMode: false,
+    });
+
+    expect(session.toolRegistry.disable).toHaveBeenCalledWith('denied');
+    expect(session.toolRegistry.enable).not.toHaveBeenCalled();
+    expect(summary).toStrictEqual({ enabled: [], disabled: ['denied'] });
+  });
+
+  test('enables a disabled capability when fresh ability allows it', () => {
+    const ability = createAbility(jest.fn(() => true));
+    const session = createSession({ promptStatus: { allowed: 'disabled' } });
+    const definitions = createDefinitions({
+      prompts: [
+        {
+          name: 'allowed',
+          auth: { action: 'admin::read' },
+        } as Modules.MCP.McpPromptDefinition,
+      ],
+    });
+
+    const summary = syncMcpSessionCapabilities({
+      session,
+      definitions,
+      ability,
+      isDevMode: false,
+    });
+
+    expect(session.promptRegistry.enable).toHaveBeenCalledWith('allowed');
+    expect(session.promptRegistry.disable).not.toHaveBeenCalled();
+    expect(summary).toStrictEqual({ enabled: ['allowed'], disabled: [] });
+  });
+
+  test('does not mutate registries when current status already matches desired state', () => {
+    const ability = createAbility(jest.fn((action: string) => action === 'admin::read'));
+    const session = createSession({
+      toolStatus: { allowed: 'enabled', denied: 'disabled' },
+    });
+    const definitions = createDefinitions({
+      tools: [
+        createToolDefinition({ name: 'allowed', auth: { action: 'admin::read' } }),
+        createToolDefinition({ name: 'denied', auth: { action: 'admin::delete' } }),
+      ],
+    });
+
+    const summary = syncMcpSessionCapabilities({
+      session,
+      definitions,
+      ability,
+      isDevMode: false,
+    });
+
+    expect(session.toolRegistry.enable).not.toHaveBeenCalled();
+    expect(session.toolRegistry.disable).not.toHaveBeenCalled();
+    expect(summary).toStrictEqual({ enabled: [], disabled: [] });
+  });
+
+  test('passes auth subject through the centralized availability adapter', () => {
+    const ability = createAbility(jest.fn(() => true));
+
+    canUseMcpCapability({
+      ability,
+      definition: createToolDefinition({
+        name: 'subject-tool',
+        auth: { action: 'admin::read', subject: 'api::article.article' },
+      }),
+      isDevMode: false,
+    });
+
+    expect(ability.can).toHaveBeenCalledWith('admin::read', 'api::article.article');
+  });
+
+  test('does not model field-level availability at the session capability layer', () => {
+    const ability = createAbility(jest.fn(() => true));
+
+    canUseMcpCapability({
+      ability,
+      definition: createToolDefinition({
+        name: 'field-restricted-tool',
+        auth: { action: 'admin::read', subject: 'api::article.article' },
+      }),
+      isDevMode: false,
+    });
+
+    expect(ability.can).toHaveBeenCalledWith('admin::read', 'api::article.article');
+  });
+
+  test('keeps devModeOnly availability governed by dev mode only', () => {
+    const ability = createAbility(jest.fn(() => false));
+
+    expect(
+      canUseMcpCapability({
+        ability,
+        definition: createToolDefinition({ name: 'dev-tool', devModeOnly: true }),
+        isDevMode: true,
+      })
+    ).toBe(true);
+    expect(ability.can).not.toHaveBeenCalled();
+  });
+
+  test('does not evaluate entity conditions during coarse session availability', () => {
+    const ability = createAbility(jest.fn(() => true));
+
+    canUseMcpCapability({
+      ability,
+      definition: createToolDefinition({
+        name: 'conditioned-tool',
+        auth: { action: 'admin::read', subject: 'api::article.article' },
+      }),
+      isDevMode: false,
+    });
+
+    expect(ability.can).toHaveBeenCalledWith('admin::read', 'api::article.article');
+  });
+});

--- a/packages/core/core/src/services/mcp/internal/syncMcpSessionCapabilities.ts
+++ b/packages/core/core/src/services/mcp/internal/syncMcpSessionCapabilities.ts
@@ -1,0 +1,115 @@
+import type { Modules } from '@strapi/types';
+import type { McpAdminTokenAbility } from '../authentication';
+import type { McpSession } from './McpSession';
+import type { McpCapabilityDefinitions } from './McpServerFactory';
+
+type CanUseAuthorizedCapabilityParams = {
+  ability: McpAdminTokenAbility;
+  auth: Modules.MCP.McpCapabilityAuth;
+};
+
+export type CanUseMcpCapabilityParams = {
+  ability: McpAdminTokenAbility;
+  definition: Modules.MCP.McpCapabilityDefinition;
+  isDevMode: boolean;
+};
+
+export type SyncMcpSessionCapabilitiesParams = {
+  session: Pick<McpSession, 'toolRegistry' | 'promptRegistry' | 'resourceRegistry'>;
+  definitions: McpCapabilityDefinitions;
+  ability: McpAdminTokenAbility;
+  isDevMode: boolean;
+};
+
+export type SyncMcpSessionCapabilitiesSummary = {
+  enabled: string[];
+  disabled: string[];
+};
+
+const canUseAuthorizedCapability = ({
+  ability,
+  auth,
+}: CanUseAuthorizedCapabilityParams): boolean => {
+  if (auth.subject !== undefined) {
+    return ability.can(auth.action, auth.subject);
+  }
+
+  return ability.can(auth.action);
+};
+
+export const canUseMcpCapability = ({
+  ability,
+  definition,
+  isDevMode,
+}: CanUseMcpCapabilityParams): boolean => {
+  if (definition.devModeOnly === true) {
+    return isDevMode === true;
+  }
+
+  if (definition.auth === undefined) {
+    return false;
+  }
+
+  // Session capability availability is a coarse allowlist. Field/entity conditions must be
+  // enforced by capability handlers with request-specific context.
+  return canUseAuthorizedCapability({ ability, auth: definition.auth });
+};
+
+export const syncMcpSessionCapabilities = ({
+  session,
+  definitions,
+  ability,
+  isDevMode,
+}: SyncMcpSessionCapabilitiesParams): SyncMcpSessionCapabilitiesSummary => {
+  const summary: SyncMcpSessionCapabilitiesSummary = {
+    enabled: [],
+    disabled: [],
+  };
+
+  definitions.tools.forEach((definition) => {
+    const allowed = canUseMcpCapability({ ability, definition, isDevMode });
+    const status = session.toolRegistry.status(definition.name);
+
+    if (status === 'disabled' && allowed === true) {
+      session.toolRegistry.enable(definition.name);
+      summary.enabled.push(definition.name);
+    }
+
+    if (status === 'enabled' && allowed === false) {
+      session.toolRegistry.disable(definition.name);
+      summary.disabled.push(definition.name);
+    }
+  });
+
+  definitions.prompts.forEach((definition) => {
+    const allowed = canUseMcpCapability({ ability, definition, isDevMode });
+    const status = session.promptRegistry.status(definition.name);
+
+    if (status === 'disabled' && allowed === true) {
+      session.promptRegistry.enable(definition.name);
+      summary.enabled.push(definition.name);
+    }
+
+    if (status === 'enabled' && allowed === false) {
+      session.promptRegistry.disable(definition.name);
+      summary.disabled.push(definition.name);
+    }
+  });
+
+  definitions.resources.forEach((definition) => {
+    const allowed = canUseMcpCapability({ ability, definition, isDevMode });
+    const status = session.resourceRegistry.status(definition.name);
+
+    if (status === 'disabled' && allowed === true) {
+      session.resourceRegistry.enable(definition.name);
+      summary.enabled.push(definition.name);
+    }
+
+    if (status === 'enabled' && allowed === false) {
+      session.resourceRegistry.disable(definition.name);
+      summary.disabled.push(definition.name);
+    }
+  });
+
+  return summary;
+};

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/extensions
 import type { McpServer, RegisteredPrompt } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Core, Modules } from '@strapi/types';
-import { z } from '@strapi/utils';
+
 import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
 import {
   type McpCapabilityRegistry,
@@ -9,20 +9,9 @@ import {
 } from './internal/McpCapabilityRegistry';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 
-export const makeMcpPromptDefinition = <
-  Name extends string,
-  Title extends string,
-  Description extends string,
-  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
->(prompt: {
-  name: Name;
-  title: Title;
-  description: Description;
-  argsSchema?: ArgsSchema;
-  devModeOnly: boolean;
-  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpPromptCallback<ArgsSchema>;
-}): Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description> =>
-  prompt as Modules.MCP.McpPromptDefinition<Name, ArgsSchema, Title, Description>;
+export const makeMcpPromptDefinition = <Definition extends Modules.MCP.McpPromptDefinition>(
+  prompt: Definition
+): Definition => prompt;
 
 export class McpPromptRegistry
   extends McpCapabilityRegistryBase<'prompt', Modules.MCP.McpPromptDefinition, RegisteredPrompt>

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -1,7 +1,6 @@
 import type {
   McpServer,
   RegisteredResource,
-  ResourceMetadata,
   // eslint-disable-next-line import/extensions
 } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Core, Modules } from '@strapi/types';
@@ -12,13 +11,9 @@ import {
 } from './internal/McpCapabilityRegistry';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 
-export const makeMcpResourceDefinition = <Name extends string>(resource: {
-  name: Name;
-  uri: string;
-  metadata: ResourceMetadata;
-  devModeOnly: boolean;
-  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpResourceCallback;
-}): Modules.MCP.McpResourceDefinition<Name> => resource as Modules.MCP.McpResourceDefinition<Name>;
+export const makeMcpResourceDefinition = <Definition extends Modules.MCP.McpResourceDefinition>(
+  resource: Definition
+): Definition => resource;
 
 export class McpResourceRegistry
   extends McpCapabilityRegistryBase<

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -9,22 +9,42 @@ import {
 } from './internal/McpCapabilityRegistry';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 
-export const makeMcpToolDefinition = <
+export function makeMcpToolDefinition<
   Name extends string,
   Title extends string,
   Description extends string,
   OutputSchema extends z.ZodObject<z.ZodRawShape>,
-  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
->(tool: {
-  name: Name;
-  title: Title;
-  description: Description;
-  inputSchema?: InputSchema;
-  outputSchema: OutputSchema;
-  devModeOnly: boolean;
-  createHandler: (strapi: Core.Strapi) => Modules.MCP.McpToolCallback<InputSchema, OutputSchema>;
-}): Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description> =>
-  tool as Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description>;
+  InputSchema extends z.ZodObject<z.ZodRawShape>,
+  Access extends Modules.MCP.McpCapabilityAccess,
+>(
+  tool: {
+    name: Name;
+    title: Title;
+    description: Description;
+    inputSchema: InputSchema;
+    outputSchema: OutputSchema;
+    createHandler: (strapi: Core.Strapi) => Modules.MCP.McpToolCallback<InputSchema, OutputSchema>;
+  } & Access
+): Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description> & Access;
+export function makeMcpToolDefinition<
+  Name extends string,
+  Title extends string,
+  Description extends string,
+  OutputSchema extends z.ZodObject<z.ZodRawShape>,
+  Access extends Modules.MCP.McpCapabilityAccess,
+>(
+  tool: {
+    name: Name;
+    title: Title;
+    description: Description;
+    inputSchema?: undefined;
+    outputSchema: OutputSchema;
+    createHandler: (strapi: Core.Strapi) => Modules.MCP.McpToolCallback<undefined, OutputSchema>;
+  } & Access
+): Modules.MCP.McpToolDefinition<Name, undefined, OutputSchema, Title, Description> & Access;
+export function makeMcpToolDefinition(tool: Modules.MCP.McpToolDefinition) {
+  return tool;
+}
 
 export class McpToolRegistry
   extends McpCapabilityRegistryBase<'tool', Modules.MCP.McpToolDefinition, RegisteredTool>

--- a/packages/core/core/src/services/mcp/tools/log.ts
+++ b/packages/core/core/src/services/mcp/tools/log.ts
@@ -2,23 +2,27 @@ import { z } from '@strapi/utils';
 
 import { makeMcpToolDefinition } from '../tool-registry';
 
+const inputSchema = z.object({
+  message: z.string().describe('Message to log'),
+  level: z
+    .enum(['info', 'http', 'warn', 'error', 'log'])
+    .optional()
+    .describe('Log level (default: info)'),
+});
+
+const outputSchema = z.object({
+  status: z.string(),
+  message: z.string(),
+  level: z.string(),
+  timestamp: z.string(),
+});
+
 export const logToolDefinition = makeMcpToolDefinition({
   name: 'log',
   title: 'Strapi Log',
   description: 'Logs a message to the Strapi logger with specified level',
-  inputSchema: z.object({
-    message: z.string().describe('Message to log'),
-    level: z
-      .enum(['info', 'http', 'warn', 'error', 'log'])
-      .optional()
-      .describe('Log level (default: info)'),
-  }),
-  outputSchema: z.object({
-    status: z.string(),
-    message: z.string(),
-    level: z.string(),
-    timestamp: z.string(),
-  }),
+  inputSchema,
+  outputSchema,
   devModeOnly: true,
   createHandler: (strapi) => async (params) => {
     const { message, level = 'info' } = params;

--- a/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
+++ b/packages/core/core/src/services/mcp/utils/__tests__/sendJsonRpcError.test.ts
@@ -20,7 +20,7 @@ describe('sendJsonRpcError', () => {
   test('should send JSON-RPC error response with correct format', () => {
     sendJsonRpcError(mockResponse as ServerResponse, 'INVALID_SESSION', 'Invalid request');
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',
@@ -59,7 +59,7 @@ describe('sendJsonRpcError', () => {
   test('should override catalog message when custom message is provided', () => {
     sendJsonRpcError(mockResponse as ServerResponse, 'SESSION_REQUIRED', 'Session ID required');
 
-    expect(writeHeadSpy).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
+    expect(writeHeadSpy).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     expect(endSpy).toHaveBeenCalledWith(
       JSON.stringify({
         jsonrpc: '2.0',

--- a/packages/core/core/src/services/mcp/utils/jsonRpcErrors.ts
+++ b/packages/core/core/src/services/mcp/utils/jsonRpcErrors.ts
@@ -11,17 +11,17 @@ export const JSON_RPC_ERRORS = {
   INVALID_SESSION: {
     code: -32003, // Session expired
     message: 'Invalid session',
-    httpStatus: 400,
+    httpStatus: 401,
+  },
+  SESSION_REQUIRED: {
+    code: -32000, // Server error
+    message: 'Session required',
+    httpStatus: 401,
   },
   MAX_SESSIONS_REACHED: {
     code: -32001, // Server overloaded
     message: 'Maximum number of sessions reached',
     httpStatus: 503,
-  },
-  SESSION_REQUIRED: {
-    code: -32000, // Server error
-    message: 'Session required',
-    httpStatus: 400,
   },
   METHOD_NOT_ALLOWED: {
     code: -32601, // Method not found

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -14,12 +14,29 @@ import type { ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type * as Core from '../core';
 
 /**
+ * Admin permission requirement for non-dev MCP capabilities.
+ */
+export type McpCapabilityAuth = {
+  action: string;
+  subject?: string;
+};
+
+export type McpCapabilityAccess =
+  | {
+      devModeOnly: true;
+      auth?: never;
+    }
+  | {
+      devModeOnly?: never;
+      auth: McpCapabilityAuth;
+    };
+
+/**
  * Base definition for Strapi MCP capabilities
  */
-export interface McpCapabilityDefinition<Name extends string = string> {
+export type McpCapabilityDefinition<Name extends string = string> = {
   name: Name;
-  devModeOnly: boolean;
-}
+} & McpCapabilityAccess;
 
 /**
  * Callback function for Strapi MCP tools
@@ -45,7 +62,7 @@ export type McpToolCallback<
 /**
  * Definition for Strapi MCP tools
  */
-export interface McpToolDefinition<
+export type McpToolDefinition<
   Name extends string = string,
   InputSchema extends z.ZodObject<z.ZodRawShape> | undefined =
     | z.ZodObject<z.ZodRawShape>
@@ -53,13 +70,13 @@ export interface McpToolDefinition<
   OutputSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
   Title extends string = string,
   Description extends string = string,
-> extends McpCapabilityDefinition<Name> {
+> = McpCapabilityDefinition<Name> & {
   title: Title;
   description: Description;
   inputSchema: InputSchema;
   outputSchema: OutputSchema;
   createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
-}
+};
 
 /**
  * Callback function for Strapi MCP prompts
@@ -75,19 +92,19 @@ export type McpPromptCallback<ArgsSchema extends z.ZodObject<z.ZodRawShape> | un
 /**
  * Definition for Strapi MCP prompts
  */
-export interface McpPromptDefinition<
+export type McpPromptDefinition<
   Name extends string = string,
   ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined =
     | z.ZodObject<z.ZodRawShape>
     | undefined,
   Title extends string = string,
   Description extends string = string,
-> extends McpCapabilityDefinition<Name> {
+> = McpCapabilityDefinition<Name> & {
   title: Title;
   description: Description;
   argsSchema?: ArgsSchema;
   createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
-}
+};
 
 /**
  * Callback function for Strapi MCP resources
@@ -100,12 +117,11 @@ export type McpResourceCallback = (
 /**
  * Definition for Strapi MCP resources
  */
-export interface McpResourceDefinition<Name extends string = string>
-  extends McpCapabilityDefinition<Name> {
+export type McpResourceDefinition<Name extends string = string> = McpCapabilityDefinition<Name> & {
   uri: string;
   metadata: ResourceMetadata;
   createHandler: (strapi: Core.Strapi) => McpResourceCallback;
-}
+};
 
 export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
 
@@ -141,7 +157,24 @@ export interface McpService {
     description: Description;
     inputSchema?: InputSchema;
     outputSchema: OutputSchema;
-    devModeOnly: boolean;
+    devModeOnly: true;
+    auth?: never;
+    createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
+  }): void;
+  registerTool<
+    Name extends string,
+    OutputSchema extends z.ZodObject<z.ZodRawShape>,
+    Title extends string,
+    Description extends string,
+    InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+  >(tool: {
+    name: Name;
+    title: Title;
+    description: Description;
+    inputSchema?: InputSchema;
+    outputSchema: OutputSchema;
+    devModeOnly?: never;
+    auth: McpCapabilityAuth;
     createHandler: (strapi: Core.Strapi) => McpToolCallback<InputSchema, OutputSchema>;
   }): void;
 
@@ -160,7 +193,22 @@ export interface McpService {
     title: Title;
     description: Description;
     argsSchema?: ArgsSchema;
-    devModeOnly: boolean;
+    devModeOnly: true;
+    auth?: never;
+    createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+  }): void;
+  registerPrompt<
+    Name extends string,
+    ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+    Title extends string,
+    Description extends string,
+  >(prompt: {
+    name: Name;
+    title: Title;
+    description: Description;
+    argsSchema?: ArgsSchema;
+    devModeOnly?: never;
+    auth: McpCapabilityAuth;
     createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
   }): void;
 
@@ -173,7 +221,16 @@ export interface McpService {
     name: Name;
     uri: string;
     metadata: ResourceMetadata;
-    devModeOnly: boolean;
+    devModeOnly: true;
+    auth?: never;
+    createHandler: (strapi: Core.Strapi) => McpResourceCallback;
+  }): void;
+  registerResource<Name extends string>(resource: {
+    name: Name;
+    uri: string;
+    metadata: ResourceMetadata;
+    devModeOnly?: never;
+    auth: McpCapabilityAuth;
     createHandler: (strapi: Core.Strapi) => McpResourceCallback;
   }): void;
 

--- a/tests/api/core/mcp/mcp-auth.test.api.ts
+++ b/tests/api/core/mcp/mcp-auth.test.api.ts
@@ -1,0 +1,355 @@
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAgent } from 'api-tests/agent';
+import { createAuthRequest } from 'api-tests/request';
+import type { Core } from '@strapi/types';
+import * as z from 'zod';
+import { JSON_RPC_ERRORS } from '../../../../packages/core/core/src/services/mcp/utils/jsonRpcErrors';
+
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+const TEST_TOOL_NAME = 'mcp-refresh-test-tool';
+const AUTHORIZED_ACTION = 'admin::webhooks.read';
+
+type AdminToken = {
+  id: number;
+  name: string;
+  accessKey: string;
+};
+
+type JsonRpcResponse = {
+  jsonrpc?: '2.0';
+  id?: number | string | null;
+  result?: {
+    tools?: Array<{ name: string }>;
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+describe('MCP admin token authentication (api)', () => {
+  let strapi: Core.Strapi;
+  let rq: Awaited<ReturnType<typeof createAuthRequest>>;
+  let tokenCount = 0;
+  let rpcId = 0;
+
+  const deleteAllAdminTokens = async () => {
+    await strapi.db.query('admin::api-token').deleteMany({ where: { kind: 'admin' } });
+  };
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      register({ strapi: instance }) {
+        instance.config.set('features.future.adminTokens', true);
+        instance.config.set('server.mcp.enabled', true);
+      },
+      bootstrap({ strapi: instance }) {
+        instance.ai.mcp.registerTool({
+          name: TEST_TOOL_NAME,
+          title: 'MCP Refresh Test Tool',
+          description: 'Only used by MCP API integration tests',
+          auth: { action: AUTHORIZED_ACTION },
+          inputSchema: z.object({}),
+          outputSchema: z.object({ ok: z.boolean() }),
+          createHandler: () => async () => ({ structuredContent: { ok: true }, content: [] }),
+        });
+      },
+    });
+    strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key');
+
+    rq = await createAuthRequest({ strapi });
+    await deleteAllAdminTokens();
+  });
+
+  afterAll(async () => {
+    await deleteAllAdminTokens();
+    await strapi.destroy();
+  });
+
+  afterEach(async () => {
+    await deleteAllAdminTokens();
+  });
+
+  const createAdminToken = async (
+    overrides: Partial<{
+      name: string;
+      lifespan: number | null;
+      adminPermissions: Array<{
+        action: string;
+        subject: null;
+        conditions: string[];
+        properties: Record<string, unknown>;
+      }>;
+    }> = {}
+  ): Promise<AdminToken> => {
+    tokenCount += 1;
+
+    const res = await rq({
+      url: '/admin/admin-tokens',
+      method: 'POST',
+      body: {
+        name: `mcp-auth-token-${tokenCount}`,
+        ...overrides,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    return res.body.data;
+  };
+
+  const parseMcpResponse = (res: { body?: unknown; text?: string }): JsonRpcResponse => {
+    if (res.body !== undefined && Object.keys(res.body as Record<string, unknown>).length > 0) {
+      return res.body as JsonRpcResponse;
+    }
+
+    if (typeof res.text === 'string' && res.text.length > 0) {
+      const dataLines = res.text
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length).trim())
+        .filter((line) => line.length > 0 && line !== '[DONE]');
+
+      if (dataLines.length > 0) {
+        return JSON.parse(dataLines[dataLines.length - 1]);
+      }
+
+      return JSON.parse(res.text);
+    }
+
+    return {};
+  };
+
+  const mcpRequest = async (
+    method: 'GET' | 'POST' | 'DELETE',
+    accessKey?: string,
+    sessionId?: string | string[],
+    body?: Record<string, unknown>
+  ) => {
+    const headers: Record<string, string | string[]> = {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+    };
+
+    if (accessKey !== undefined) {
+      headers.Authorization = `Bearer ${accessKey}`;
+    }
+    if (sessionId !== undefined) {
+      headers['mcp-session-id'] = sessionId;
+      headers['Mcp-Protocol-Version'] = MCP_PROTOCOL_VERSION;
+    }
+
+    return createAgent(strapi)({
+      url: '/mcp',
+      method,
+      headers,
+      body,
+    });
+  };
+
+  const expectJsonRpcError = (
+    res: Awaited<ReturnType<typeof mcpRequest>>,
+    errorKey: keyof typeof JSON_RPC_ERRORS,
+    customMessage?: string
+  ) => {
+    const expectedError = JSON_RPC_ERRORS[errorKey];
+    expect(res.statusCode).toBe(expectedError.httpStatus);
+
+    expect(parseMcpResponse(res)).toMatchObject({
+      jsonrpc: '2.0',
+      error: {
+        code: expectedError.code,
+        message: customMessage ?? expectedError.message,
+      },
+      id: null,
+    });
+  };
+
+  const mcpRpc = async (
+    accessKey: string,
+    sessionId: string,
+    method: string,
+    params?: Record<string, unknown>
+  ) => {
+    rpcId += 1;
+
+    return mcpRequest('POST', accessKey, sessionId, {
+      jsonrpc: '2.0',
+      id: rpcId,
+      method,
+      params,
+    });
+  };
+
+  const sendInitializedNotification = async (accessKey: string, sessionId: string) => {
+    const res = await mcpRequest('POST', accessKey, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+
+    expect([200, 202]).toContain(res.statusCode);
+  };
+
+  const initializeMcpSession = async (accessKey: string): Promise<string> => {
+    rpcId += 1;
+
+    const res = await mcpRequest('POST', accessKey, undefined, {
+      jsonrpc: '2.0',
+      id: rpcId,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: {
+          name: 'strapi-mcp-api-test',
+          version: '1.0.0',
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(parseMcpResponse(res)).toMatchObject({
+      jsonrpc: '2.0',
+      result: expect.any(Object),
+    });
+    expect(res.headers['mcp-session-id']).toEqual(expect.any(String));
+
+    const sessionId = res.headers['mcp-session-id'] as string;
+    await sendInitializedNotification(accessKey, sessionId);
+
+    return sessionId;
+  };
+
+  const listTools = async (accessKey: string, sessionId: string): Promise<string[]> => {
+    const res = await mcpRpc(accessKey, sessionId, 'tools/list');
+
+    expect(res.statusCode).toBe(200);
+    const rpcResponse = parseMcpResponse(res);
+    expect(rpcResponse.error).toBeUndefined();
+    expect(rpcResponse.result?.tools).toEqual(expect.any(Array));
+
+    return rpcResponse.result?.tools?.map((tool) => tool.name) ?? [];
+  };
+
+  const setAdminTokenPermissions = async (
+    token: AdminToken,
+    adminPermissions: Array<{
+      action: string;
+      subject: null;
+      conditions: string[];
+      properties: Record<string, unknown>;
+    }>
+  ) => {
+    const res = await rq({
+      url: `/admin/admin-tokens/${token.id}`,
+      method: 'PUT',
+      body: {
+        name: token.name,
+        adminPermissions,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+  };
+
+  describe('unauthorized requests', () => {
+    test.each(['POST', 'GET', 'DELETE'] as const)(
+      '%s /mcp returns session-required JSON-RPC error without a bearer token',
+      async (method) => {
+        const res = await mcpRequest(method, undefined, undefined, {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+        });
+
+        expectJsonRpcError(res, 'SESSION_REQUIRED');
+      }
+    );
+  });
+
+  describe('session ownership', () => {
+    test.each(['POST', 'GET', 'DELETE'] as const)(
+      '%s /mcp rejects a different token for an existing session',
+      async (method) => {
+        const tokenA = await createAdminToken();
+        const tokenB = await createAdminToken();
+        const sessionId = await initializeMcpSession(tokenA.accessKey);
+
+        const res = await mcpRequest(method, tokenB.accessKey, sessionId, {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+        });
+
+        expectJsonRpcError(res, 'INVALID_SESSION');
+      }
+    );
+  });
+
+  test('revoked token is rejected for an existing session', async () => {
+    const token = await createAdminToken();
+    const sessionId = await initializeMcpSession(token.accessKey);
+
+    const revokeRes = await rq({
+      url: `/admin/admin-tokens/${token.id}`,
+      method: 'DELETE',
+    });
+    expect(revokeRes.statusCode).toBe(200);
+
+    const res = await mcpRpc(token.accessKey, sessionId, 'tools/list');
+
+    expectJsonRpcError(res, 'SESSION_REQUIRED');
+  });
+
+  test('expired token is rejected for an existing session', async () => {
+    const token = await createAdminToken();
+    const sessionId = await initializeMcpSession(token.accessKey);
+
+    await strapi.db.query('admin::api-token').update({
+      where: { id: token.id },
+      data: { expiresAt: new Date(Date.now() - 1000) },
+    });
+
+    const res = await mcpRpc(token.accessKey, sessionId, 'tools/list');
+
+    expectJsonRpcError(res, 'SESSION_REQUIRED');
+  });
+
+  test('same-session tools/list reflects admin token permission changes', async () => {
+    const token = await createAdminToken({
+      adminPermissions: [
+        { action: AUTHORIZED_ACTION, subject: null, conditions: [], properties: {} },
+      ],
+    });
+    const sessionId = await initializeMcpSession(token.accessKey);
+
+    await expect(listTools(token.accessKey, sessionId)).resolves.toContain(TEST_TOOL_NAME);
+
+    await setAdminTokenPermissions(token, []);
+
+    await expect(listTools(token.accessKey, sessionId)).resolves.not.toContain(TEST_TOOL_NAME);
+  });
+
+  test('authenticated GET and DELETE reject malformed session ids', async () => {
+    const token = await createAdminToken();
+
+    const getRes = await mcpRequest('GET', token.accessKey, 'not-a-uuid');
+    expectJsonRpcError(getRes, 'SESSION_REQUIRED');
+
+    const deleteRes = await mcpRequest('DELETE', token.accessKey, 'not-a-uuid');
+    expectJsonRpcError(deleteRes, 'SESSION_REQUIRED');
+  });
+
+  test('authenticated GET and DELETE reject multiple session headers', async () => {
+    const token = await createAdminToken();
+    const sessionIds = [
+      '12345678-1234-1234-1234-123456789abc',
+      '12345678-1234-1234-1234-123456789abd',
+    ];
+
+    const getRes = await mcpRequest('GET', token.accessKey, sessionIds);
+    expectJsonRpcError(getRes, 'SESSION_REQUIRED');
+
+    const deleteRes = await mcpRequest('DELETE', token.accessKey, sessionIds);
+    expectJsonRpcError(deleteRes, 'SESSION_REQUIRED');
+  });
+});


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Binds admin token authentication to the MCP HTTP transport layer.

- Adds `authentication.ts` in the MCP service — a `createMcpAdminTokenAuthenticator` that extracts the `Bearer` token from the `Authorization` header, delegates to `admin::api-token-admin.authenticateAdminToken`, and returns a typed `McpAdminTokenAuthResult` with credentials and a CASL `ability`.
- Adds `authenticateAdminToken` to the admin `api-token` service: validates the token (existence, kind = `admin`, expiry, owner activeness), updates `lastUsedAt`, and generates a permission `ability` from the token's `adminPermissions` + owning user roles.
- Wires authentication into all three MCP HTTP handlers (`POST`, `GET`, `DELETE`): each handler now calls `authenticationStrategy.authenticate(ctx)` first and returns `401` on failure; for existing sessions it additionally verifies that `session.adminTokenId` matches the token's id, returning `403` on mismatch.
- Stores `adminTokenId` on `McpSession` at creation time (POST → new session path).
- Replaces the static dev-mode-only capability toggle in `McpServerFactory` with a per-request `canUseCapability` check that evaluates either `devModeOnly` (requires dev mode) or `auth.action` / `auth.subject` against the token ability.
- Restructures `McpCapabilityDefinition` (and derived tool/prompt/resource types) from `interface` to `type` and replaces the plain `devModeOnly: boolean` flag with the discriminated union `McpCapabilityAccess` (`devModeOnly: true` | `auth: McpCapabilityAuth`), enforced at both definition and `registerTool` / `registerPrompt` / `registerResource` call sites via overloads.

### Why is it needed?

The MCP server was previously unauthenticated — any client that could reach the endpoint could connect, initialize a session, and invoke capabilities regardless of permissions. Admin tokens (gated behind the `adminTokens` future flag) need to be the authentication mechanism for MCP so that:

1. Only callers with a valid, non-expired admin token owned by an active admin user can establish or resume a session.
2. Per-capability RBAC is enforced at session creation: the token's ability gates which tools/prompts/resources are enabled for that session, instead of blanket-enabling everything in dev mode.

### How to test it?

**Prerequisites**
- Strapi running with `adminTokens` future flag enabled (set in `config/features.ts` or env).
- An existing admin token created via **Settings → Admin API Tokens** with some permissions.

**Steps**

1. Start Strapi in development mode (`yarn develop`).
2. Attempt to connect to the MCP endpoint **without** an `Authorization` header → expect `401 Unauthorized`.
3. Connect with a valid `Authorization: Bearer <token>` → expect a successful MCP initialize handshake.
4. Connect with an expired or revoked token → expect `401`.
5. Connect successfully, obtain a `sessionId`, then attempt a follow-up `GET` or `DELETE` request using a **different** valid token → expect `403 Token mismatch for session`.
6. Verify that capabilities marked `devModeOnly: true` are only visible when the server runs in dev mode.
7. Verify that capabilities declared with `auth: { action, subject }` are enabled/disabled according to the token's assigned permissions.

### Related issue(s)/PR(s)

<!-- Add links to related issues or PRs here -->
