### PR TITLE
fix(graphql): isolate root query args per root field

### DIFF
--- a/packages/plugins/graphql/server/src/bootstrap.ts
+++ b/packages/plugins/graphql/server/src/bootstrap.ts
@@ -22,7 +22,7 @@ const merge = mergeWith((a, b) => {
 });
 
 type StrapiGraphQLContext = BaseContext & {
-  rootQueryArgs?: Record<string, unknown>;
+  rootQueryArgsByPath?: Map<string | number, Record<string, unknown>>;
 };
 
 export const determineLandingPage = (
@@ -138,13 +138,14 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
           return {
             willResolveField({ source, args, contextValue, info }) {
               if (!source && info.operation.operation === 'query') {
-                // Track which query field set the rootQueryArgs
-                const fieldName = info.fieldName;
-                // Set rootQueryArgs with the field name that originated it
-                contextValue.rootQueryArgs = {
+                // Key args per root field (alias)
+                if (!contextValue.rootQueryArgsByPath) {
+                  contextValue.rootQueryArgsByPath = new Map();
+                }
+                contextValue.rootQueryArgsByPath.set(info.path.key, {
                   ...args,
-                  _originField: fieldName, // Track which field set this
-                };
+                  _originField: info.fieldName,
+                });
               }
             },
           };

--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -38,7 +38,7 @@ export default ({ strapi }: Context) => {
 
       const targetContentType = strapi.getModel(targetUID);
 
-      return async (parent: any, args: any = {}, context: any = {}) => {
+      return async (parent: any, args: any, context: any, info: any) => {
         const { auth } = context.state;
 
         const transformedArgs = transformArgs(args, {
@@ -69,12 +69,19 @@ export default ({ strapi }: Context) => {
           return graphqlService.isBuiltInQueryField(fieldName);
         };
 
+        // Walk back to the root of info.path so we pick up the args of *our* query branch
+        let rootPath = info?.path;
+        while (rootPath?.prev) {
+          rootPath = rootPath.prev;
+        }
+        const rootQueryArgs = rootPath ? context.rootQueryArgsByPath?.get(rootPath.key) : undefined;
+
         // Only inherit status from built-in queries to avoid conflicts with custom resolvers
         const inheritedStatus =
-          context.rootQueryArgs?.status &&
-          context.rootQueryArgs?._originField &&
-          isBuiltInQueryField(context.rootQueryArgs._originField)
-            ? context.rootQueryArgs.status
+          rootQueryArgs?.status &&
+          rootQueryArgs?._originField &&
+          isBuiltInQueryField(rootQueryArgs._originField)
+            ? rootQueryArgs.status
             : null;
 
         const statusToApply = args.status || inheritedStatus;
@@ -90,10 +97,10 @@ export default ({ strapi }: Context) => {
 
         // Inherit hasPublishedVersion from root query (same pattern as status)
         const inheritedHasPublishedVersion =
-          context.rootQueryArgs?.hasPublishedVersion !== undefined &&
-          context.rootQueryArgs?._originField &&
-          isBuiltInQueryField(context.rootQueryArgs._originField)
-            ? context.rootQueryArgs.hasPublishedVersion
+          rootQueryArgs?.hasPublishedVersion !== undefined &&
+          rootQueryArgs?._originField &&
+          isBuiltInQueryField(rootQueryArgs._originField)
+            ? rootQueryArgs.hasPublishedVersion
             : undefined;
 
         // Build hasPublishedVersion condition for this relation's model

--- a/packages/plugins/graphql/server/src/services/builders/utils.ts
+++ b/packages/plugins/graphql/server/src/services/builders/utils.ts
@@ -38,8 +38,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
 
       // On non–D&P roots (e.g. User) these args do not version the parent document, but they
       // are required: association resolvers inherit them into nested D&P relations (see
-      // builders/resolvers/association.ts + rootQueryArgs). Omitting them broke draft/published
-      // control for populated relations (e.g. github.com/strapi/strapi/issues/25746).
+      // builders/resolvers/association.ts + rootQueryArgsByPath). Omitting them broke
+      // draft/published control for populated relations (e.g. github.com/strapi/strapi/issues/25746).
       //
       // Future direction: add `status` / `hasPublishedVersion` to GraphQL args on nested
       // to-many (and to-one) relation fields when the *target* content type has D&P, instead

--- a/tests/api/plugins/graphql/dp-relations.test.api.js
+++ b/tests/api/plugins/graphql/dp-relations.test.api.js
@@ -432,5 +432,100 @@ describe('Test Graphql Relations with Draft and Publish enabled', () => {
         )
       ).toBe(false);
     });
+
+    // Regression test: combined root queries with different status args must not
+    // cross-contaminate each other's nested relations. Previously a single
+    // `context.rootQueryArgs` was overwritten by the last root field's args, so
+    // the draft branch would inherit `PUBLISHED` and yield empty/null relations.
+    test('Aliased draft + published root queries keep status isolated per branch', async () => {
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          {
+            draft: labels_connection(status: DRAFT) {
+              data {
+                documentId
+                attributes {
+                  publishedAt
+                  articles_connection {
+                    data {
+                      documentId
+                      attributes {
+                        publishedAt
+                      }
+                    }
+                  }
+                  one_to_many_articles_connection {
+                    data {
+                      documentId
+                      attributes {
+                        publishedAt
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            published: labels_connection(status: PUBLISHED) {
+              data {
+                documentId
+                attributes {
+                  publishedAt
+                  articles_connection {
+                    data {
+                      documentId
+                      attributes {
+                        publishedAt
+                      }
+                    }
+                  }
+                  one_to_many_articles_connection {
+                    data {
+                      documentId
+                      attributes {
+                        publishedAt
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `,
+      });
+
+      const { body } = res;
+      expect(res.statusCode).toBe(200);
+
+      const draftLabels = body.data.draft.data;
+      const publishedLabels = body.data.published.data;
+
+      expect(draftLabels.length).toBeGreaterThan(0);
+      expect(publishedLabels.length).toBeGreaterThan(0);
+
+      // Parent rows themselves carry the status from their own args, so they
+      // remain correct even with the bug — we still assert it as a sanity check.
+      expect(draftLabels.every((l) => l.attributes.publishedAt === null)).toBe(true);
+      expect(publishedLabels.every((l) => l.attributes.publishedAt !== null)).toBe(true);
+
+      const flatten = (labels, key) => labels.flatMap((l) => l.attributes[key].data);
+
+      const draftM2M = flatten(draftLabels, 'articles_connection');
+      const draftO2M = flatten(draftLabels, 'one_to_many_articles_connection');
+      const publishedM2M = flatten(publishedLabels, 'articles_connection');
+      const publishedO2M = flatten(publishedLabels, 'one_to_many_articles_connection');
+
+      // Sanity: relations actually populated, otherwise `every` would pass vacuously.
+      expect(draftM2M.length).toBeGreaterThan(0);
+      expect(draftO2M.length).toBeGreaterThan(0);
+      expect(publishedM2M.length).toBeGreaterThan(0);
+      expect(publishedO2M.length).toBeGreaterThan(0);
+
+      // The actual regression assertion: nested relations must not pick up the
+      // sibling root's status.
+      expect(draftM2M.every((a) => a.attributes.publishedAt === null)).toBe(true);
+      expect(draftO2M.every((a) => a.attributes.publishedAt === null)).toBe(true);
+      expect(publishedM2M.every((a) => a.attributes.publishedAt !== null)).toBe(true);
+      expect(publishedO2M.every((a) => a.attributes.publishedAt !== null)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
### What does it do?

Stores root-query args per root field (keyed by `info.path.key`, i.e. the alias) instead of a single shared `context.rootQueryArgs` property. 

The association resolver walks `info.path` back to its root and looks up the args of *its own* query branch.

### How to test it?

test project https://github.com/cdreier/strapi-gql-draft-bug and my local test query 

```gql
query compareCars {
	draft: cars(status: DRAFT) {
		name
		passengers {
			name
		}
		driver {
			name
		}
		motor {
			manufacturer
		}
	}
	published: cars(status: PUBLISHED) {
		name
		passengers {
			name
		}
		driver {
			name
		}
		motor {
			manufacturer
		}
	}
}
```

also added a regression test :robot: 

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/23799
