### PR TITLE
fix(content-manager): guard component config lookup in convertEditLayoutToFieldLayouts

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -360,9 +360,13 @@ const convertEditLayoutToFieldLayouts = (
 
         const { edit: metadata } = metadatas[field.name];
 
+        // Defensive: a component attribute can reference a configuration that is not present in
+        // `components.configurations` (for example after a partial schema upgrade or when a referenced
+        // component has been renamed/removed). Optional-chain so the layout still renders instead of
+        // throwing `Cannot read properties of undefined (reading 'settings')`.
         const settings: Partial<Settings> =
           attribute.type === 'component' && components
-            ? components.configurations[attribute.component].settings
+            ? (components.configurations[attribute.component]?.settings ?? {})
             : {};
 
         return {


### PR DESCRIPTION
### What does it do?

Fixes #26183.

`convertEditLayoutToFieldLayouts` in `useDocumentLayout.ts` reads:

```ts
const settings: Partial<Settings> =
  attribute.type === 'component' && components
    ? components.configurations[attribute.component].settings
    : {};
```

When a content-type schema references a component whose entry in `components.configurations` is missing (the user reproduced this on plain Single Types after upgrading from `5.42.1` to `5.44.0`), the lookup returns `undefined`, the follow-on `.settings` access throws

```
TypeError: Cannot read properties of undefined (reading 'settings')
    at convertEditLayoutToFieldLayouts (chunk-UHVPD4QV.js:1626:116)
```

and the entire content-manager edit page for that type fails to render. The reporter saw it on Single Types named `Header` and `Homepage`; the same shape would also break Collection Types whose schema points at a component that has been renamed or removed without a configuration migration.

### Why is it needed?

The page becomes unusable with no actionable in-app error: the user has to look at the browser console, find a minified Vite chunk frame, and trace it back to source. There is no admin-side recovery path.

### How to test it?

The failing repro from #26183:

1. `pnpm create strapi-app@5.42.1`, scaffold a Single Type that includes a component field, and seed at least one component configuration entry.
2. Upgrade to `5.44.0` (or later).
3. Manually delete the corresponding `components.configurations[<componentUid>]` row in the configuration store (or rename the component on disk so the schema reference goes stale).
4. Open `/admin/content-manager/single-types/<uid>`.

Before this PR, the page crashes with the stack trace above. With the fix applied, the page renders and the component field falls back to the schema default for `mainField` (the same behaviour you see when a component has no `mainField` override at all).

### Related issue(s) / PR(s)

Closes #26183.
