### PR TITLE
fix: validate short text maxLength before DB to prevent 500

### DIFF
--- a/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/string-validators.test.ts
@@ -303,7 +303,28 @@ describe('String validator', () => {
     ({ isDraft }: { isDraft: boolean }) => {
       const options = { ...mockOptions, isDraft };
 
-      test('it does not validates the maxLength constraint if the attribute maxLength is not an integer', async () => {
+      test('uses implicit varchar(255) max when maxLength is missing or not an integer', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string', maxLength: 'not-an-integer' as unknown as number },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'attrStringUnique',
+                value: 'test-data',
+              },
+              entity: { id: 1, attrStringUnique: 'other-data' },
+            },
+            options
+          )
+        );
+
+        expect(await validator('a')).toBe('a');
+
+        await expect(validator('x'.repeat(256))).rejects.toBeInstanceOf(errors.YupValidationError);
+      });
+
+      test('allows strings up to explicit integer maxLength when set', async () => {
         const validator = strapiUtils.validateYupSchema(
           Validators.string(
             {
@@ -364,6 +385,72 @@ describe('String validator', () => {
         );
 
         expect(await validator('a')).toBe('a');
+      });
+    }
+  );
+
+  describe.each([{ isDraft: true }, { isDraft: false }])(
+    'implicit short-text max length — $isDraft',
+    ({ isDraft }: { isDraft: boolean }) => {
+      const options = { ...mockOptions, isDraft };
+
+      test('rejects strings longer than 255 chars when maxLength is omitted', async () => {
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'title',
+                value: 'x'.repeat(256),
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        await expect(validator('x'.repeat(256))).rejects.toBeInstanceOf(errors.YupValidationError);
+      });
+
+      test('accepts strings of exactly 255 chars when maxLength is omitted', async () => {
+        const value = 'x'.repeat(255);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.string(
+            {
+              attr: { type: 'string' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'title',
+                value,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(value)).toBe(value);
+      });
+
+      test('does not apply implicit limit to long text fields', async () => {
+        const value = 'x'.repeat(500);
+        const validator = strapiUtils.validateYupSchema(
+          Validators.text(
+            {
+              attr: { type: 'text' },
+              model: fakeModel,
+              updatedAttribute: {
+                name: 'body',
+                value,
+              },
+              entity: null,
+            },
+            options
+          )
+        );
+
+        expect(await validator(value)).toBe(value);
       });
     }
   );

--- a/packages/core/core/src/services/entity-validator/validators.ts
+++ b/packages/core/core/src/services/entity-validator/validators.ts
@@ -70,6 +70,9 @@ const addMinLengthValidator = (
  * Adds maxLength validator
  * @returns {StringSchema}
  */
+/** Knex defaults `string` columns to varchar(255); match that when the schema omits maxLength. */
+const SHORT_TEXT_DEFAULT_MAX_LENGTH = 255;
+
 const addMaxLengthValidator = (
   validator: yup.StringSchema,
   {
@@ -84,7 +87,12 @@ const addMaxLengthValidator = (
       | Schema.Attribute.UID;
   }
 ) => {
-  return attr.maxLength && _.isInteger(attr.maxLength) ? validator.max(attr.maxLength) : validator;
+  const explicitMax = _.isInteger(attr.maxLength) ? attr.maxLength : undefined;
+  const implicitShortTextMax =
+    attr.type === 'string' && explicitMax === undefined ? SHORT_TEXT_DEFAULT_MAX_LENGTH : undefined;
+  const maxLen = explicitMax ?? implicitShortTextMax;
+
+  return maxLen !== undefined ? validator.max(maxLen) : validator;
 };
 
 /**

--- a/packages/core/utils/src/__tests__/content-types.test.ts
+++ b/packages/core/utils/src/__tests__/content-types.test.ts
@@ -112,8 +112,8 @@ describe('Content types utils', () => {
   });
 
   describe('getDoesAttributeRequireValidation', () => {
-    test('false for field without constraints', () => {
-      expect(getDoesAttributeRequireValidation({ type: 'string' })).toEqual(false);
+    test('true for short text without explicit maxLength (implicit varchar limit)', () => {
+      expect(getDoesAttributeRequireValidation({ type: 'string' })).toEqual(true);
     });
     test('true for required fields', () => {
       expect(getDoesAttributeRequireValidation({ type: 'string', required: true })).toEqual(true);
@@ -133,12 +133,12 @@ describe('Content types utils', () => {
     test('true for fields with a min length', () => {
       expect(getDoesAttributeRequireValidation({ type: 'string', minLength: 10 })).toEqual(true);
     });
-    test('false for non-required fields', () => {
-      expect(getDoesAttributeRequireValidation({ type: 'string', required: false })).toEqual(false);
+    test('true for non-required short text fields (implicit max length still applies)', () => {
+      expect(getDoesAttributeRequireValidation({ type: 'string', required: false })).toEqual(true);
     });
 
-    test('false for non-unique fields', () => {
-      expect(getDoesAttributeRequireValidation({ type: 'string', unique: false })).toEqual(false);
+    test('true for non-unique short text fields (implicit max length still applies)', () => {
+      expect(getDoesAttributeRequireValidation({ type: 'string', unique: false })).toEqual(true);
     });
   });
 

--- a/packages/core/utils/src/content-types.ts
+++ b/packages/core/utils/src/content-types.ts
@@ -185,13 +185,21 @@ const isScalarAttribute = (attribute?: Attribute) => {
 };
 
 const getDoesAttributeRequireValidation = (attribute: Attribute) => {
+  const hasIntegerMaxLength =
+    Object.prototype.hasOwnProperty.call(attribute, 'maxLength') &&
+    _.isInteger(attribute.maxLength);
+
+  const shortTextUsesImplicitMaxLength =
+    attribute.type === 'string' && !hasIntegerMaxLength;
+
   return (
     attribute.required ||
     attribute.unique ||
     Object.prototype.hasOwnProperty.call(attribute, 'max') ||
     Object.prototype.hasOwnProperty.call(attribute, 'min') ||
-    Object.prototype.hasOwnProperty.call(attribute, 'maxLength') ||
-    Object.prototype.hasOwnProperty.call(attribute, 'minLength')
+    hasIntegerMaxLength ||
+    Object.prototype.hasOwnProperty.call(attribute, 'minLength') ||
+    shortTextUsesImplicitMaxLength
   );
 };
 const isMediaAttribute = (attribute?: Attribute) => attribute?.type === 'media';


### PR DESCRIPTION
## Problem
Submitting a short text (string) field with more than 255 characters causes a 500 Internal Server Error from the database layer instead of a proper validation error, since no `maxLength` is enforced at the application level.

## Change
Add implicit `maxLength: 255` validation for short text fields when no explicit `maxLength` is defined in the schema, preventing the database constraint violation.

Fixes #26113.

Made with [Cursor](https://cursor.com)