### PR TITLE
chore(zod): migrate to zod 4 via catalog and bare 'zod' imports

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,4 +8,4 @@ yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
 catalog:
   vitest: ^4.0.18
-  zod: 3.25.76
+  zod: 4.4.2

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,3 +8,4 @@ yarnPath: .yarn/releases/yarn-4.12.0.cjs
 
 catalog:
   vitest: ^4.0.18
+  zod: 3.25.76

--- a/packages/core/admin/admin/src/utils/rulesEngine.ts
+++ b/packages/core/admin/admin/src/utils/rulesEngine.ts
@@ -1,5 +1,5 @@
 import jsonLogic from 'json-logic-js';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 export const ConditionSchema = z.object({
   dependsOn: z.string().min(1),

--- a/packages/core/admin/admin/src/utils/rulesEngine.ts
+++ b/packages/core/admin/admin/src/utils/rulesEngine.ts
@@ -1,5 +1,5 @@
 import jsonLogic from 'json-logic-js';
-import { z } from 'zod';
+import * as z from 'zod/v4';
 
 export const ConditionSchema = z.object({
   dependsOn: z.string().min(1),

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -147,7 +147,7 @@
     "typescript": "5.4.5",
     "use-context-selector": "1.4.1",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/admin-test-utils": "5.44.0",

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // widths must be one of 4, 6, 8, 12
 export const WidthSchema = z.union([z.literal(4), z.literal(6), z.literal(8), z.literal(12)]);

--- a/packages/core/admin/server/src/controllers/validation/schema.ts
+++ b/packages/core/admin/server/src/controllers/validation/schema.ts
@@ -1,31 +1,25 @@
-import { z } from 'zod';
+import * as z from 'zod/v4';
 
 // widths must be one of 4, 6, 8, 12
 export const WidthSchema = z.union([z.literal(4), z.literal(6), z.literal(8), z.literal(12)]);
 
-const WidgetEntrySchema = z
-  .object({
-    uid: z.string().nonempty(),
-    width: WidthSchema,
-  })
-  .strict();
+const WidgetEntrySchema = z.strictObject({
+  uid: z.string().nonempty(),
+  width: WidthSchema,
+});
 
-export const HomepageLayoutSchema = z
-  .object({
-    version: z.number().int().min(1),
-    widgets: z.array(WidgetEntrySchema).max(100),
-    updatedAt: z.string().datetime(),
-  })
-  .strict();
+export const HomepageLayoutSchema = z.strictObject({
+  version: z.number().int().min(1),
+  widgets: z.array(WidgetEntrySchema).max(100),
+  updatedAt: z.string().datetime(),
+});
 
 export type HomepageLayout = z.infer<typeof HomepageLayoutSchema>;
 
-export const HomepageLayoutWriteSchema = z
-  .object({
-    version: z.number().int().min(1).optional(),
-    widgets: z.array(WidgetEntrySchema).max(100),
-    updatedAt: z.string().datetime().optional(),
-  })
-  .strict();
+export const HomepageLayoutWriteSchema = z.strictObject({
+  version: z.number().int().min(1).optional(),
+  widgets: z.array(WidgetEntrySchema).max(100),
+  updatedAt: z.string().datetime().optional(),
+});
 
 export type HomepageLayoutWrite = z.infer<typeof HomepageLayoutWriteSchema>;

--- a/packages/core/admin/server/src/validation/project-settings.ts
+++ b/packages/core/admin/server/src/validation/project-settings.ts
@@ -4,12 +4,10 @@ const MAX_IMAGE_WIDTH = 750;
 const MAX_IMAGE_HEIGHT = MAX_IMAGE_WIDTH;
 const MAX_IMAGE_FILE_SIZE = 1024 * 1024; // 1Mo
 
-const updateProjectSettings = z
-  .object({
-    menuLogo: z.string().nullish(),
-    authLogo: z.string().nullish(),
-  })
-  .strict();
+const updateProjectSettings = z.strictObject({
+  menuLogo: z.string().nullish(),
+  authLogo: z.string().nullish(),
+});
 
 const updateProjectSettingsLogo = z.object({
   originalFilename: z.string().nullish(),
@@ -17,24 +15,20 @@ const updateProjectSettingsLogo = z.object({
   size: z.number().max(MAX_IMAGE_FILE_SIZE).nullish(),
 });
 
-const updateProjectSettingsFiles = z
-  .object({
-    menuLogo: updateProjectSettingsLogo.nullish(),
-    authLogo: updateProjectSettingsLogo.nullish(),
-  })
-  .strict();
+const updateProjectSettingsFiles = z.strictObject({
+  menuLogo: updateProjectSettingsLogo.nullish(),
+  authLogo: updateProjectSettingsLogo.nullish(),
+});
 
 const logoDimensions = z.object({
   width: z.number().max(MAX_IMAGE_WIDTH).nullish(),
   height: z.number().max(MAX_IMAGE_HEIGHT).nullish(),
 });
 
-const updateProjectSettingsImagesDimensions = z
-  .object({
-    menuLogo: logoDimensions.nullish(),
-    authLogo: logoDimensions.nullish(),
-  })
-  .strict();
+const updateProjectSettingsImagesDimensions = z.strictObject({
+  menuLogo: logoDimensions.nullish(),
+  authLogo: logoDimensions.nullish(),
+});
 
 export const validateUpdateProjectSettings = validateZodSchema(updateProjectSettings);
 export const validateUpdateProjectSettingsFiles = validateZodSchema(updateProjectSettingsFiles);

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -90,7 +90,7 @@
     "react-markdown": "9.1.0",
     "react-redux": "8.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/admin": "5.44.0",

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { maxGreaterThanMin, maxLengthGreaterThanMinLength } from '../schema';
 
 describe('Schema', () => {

--- a/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/__tests__/schema.test.ts
@@ -1,14 +1,16 @@
-import { z } from 'zod';
+import * as z from 'zod/v4';
 import { maxGreaterThanMin, maxLengthGreaterThanMinLength } from '../schema';
 
 describe('Schema', () => {
-  let ctx: z.RefinementCtx & { addIssue: jest.Mock };
+  let ctx: z.RefinementCtx<Record<string, unknown>> & { addIssue: jest.Mock };
   let expectAddIssue: (shouldAddIssue: boolean) => void;
 
   beforeEach(() => {
     ctx = {
       addIssue: jest.fn(),
-    } as unknown as z.RefinementCtx & { addIssue: jest.Mock };
+      issues: [],
+      value: {},
+    } as unknown as z.RefinementCtx<Record<string, unknown>> & { addIssue: jest.Mock };
 
     expectAddIssue = (shouldAddIssue: boolean) => {
       if (shouldAddIssue) {

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -210,7 +210,7 @@ const basePropertiesSchema = z.object({
   ]),
   configurable: z.boolean().nullish(),
   private: z.boolean().nullish(),
-  pluginOptions: z.record(z.unknown()).optional(),
+  pluginOptions: z.record(z.string(), z.unknown()).optional(),
   conditions: z.preprocess((val) => {
     return val;
   }, conditionSchema.optional()),
@@ -238,7 +238,7 @@ const baseRelationSchema = z.object({
   ]),
   configurable: z.boolean().nullish(),
   private: z.boolean().nullish(),
-  pluginOptions: z.record(z.unknown()).optional(),
+  pluginOptions: z.record(z.string(), z.unknown()).optional(),
   conditions: z.preprocess((val) => {
     return val;
   }, conditionSchema.optional()),
@@ -675,8 +675,8 @@ const baseContentTypeSchema = z.object({
   displayName: z.string().min(1),
   description: z.string().optional(),
   draftAndPublish: z.boolean(),
-  options: z.record(z.unknown()).optional().default({}),
-  pluginOptions: z.record(z.unknown()).optional().default({}),
+  options: z.record(z.string(), z.unknown()).optional().default({}),
+  pluginOptions: z.record(z.string(), z.unknown()).optional().default({}),
   kind: z.enum([typeKinds.SINGLE_TYPE, typeKinds.COLLECTION_TYPE]).optional(),
 });
 

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod/v4';
 import { strings, validateZodSchema } from '@strapi/utils';
 import type { Struct, UID } from '@strapi/types';
 import { isArray, isNil, isNull, isNumber, isObject, isUndefined, snakeCase } from 'lodash/fp';
@@ -23,17 +23,19 @@ type SchemaMeta =
       modelType: 'component';
     };
 
-const uniqueAttributeName: z.SuperRefinement<{ name: string }[]> = (attributes, ctx) => {
+type SuperRefinement<T> = (value: T, ctx: z.RefinementCtx<T>) => void;
+
+const uniqueAttributeName: SuperRefinement<{ name: string }[]> = (attributes, ctx) => {
   const names = new Set(attributes.map((attribute) => snakeCase(attribute.name)));
   if (names.size !== attributes.length) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: 'custom',
       message: 'Attributes must have unique names',
     });
   }
 };
 
-const verifyUidTargetField: z.SuperRefinement<
+const verifyUidTargetField: SuperRefinement<
   {
     action: 'create' | 'update' | 'delete';
     name: string;
@@ -57,7 +59,7 @@ const verifyUidTargetField: z.SuperRefinement<
         // NOTE: on update we are setting it to undefined later in the process instead to handle renames
         if (action === 'create') {
           ctx.addIssue({
-            code: z.ZodIssueCode.custom,
+            code: 'custom',
             message: 'Target does not exist',
           });
         }
@@ -65,7 +67,7 @@ const verifyUidTargetField: z.SuperRefinement<
         !VALID_UID_TARGETS.some((validUIdTarget) => validUIdTarget === targetAttr.properties?.type)
       ) {
         ctx.addIssue({
-          code: z.ZodIssueCode.custom,
+          code: 'custom',
           message: 'Invalid target type',
         });
       }
@@ -73,7 +75,7 @@ const verifyUidTargetField: z.SuperRefinement<
   });
 };
 
-const verifySingularAndPluralNames: z.SuperRefinement<Record<string, unknown>> = (obj, ctx) => {
+const verifySingularAndPluralNames: SuperRefinement<Record<string, unknown>> = (obj, ctx) => {
   // singular and plural can only be provided on creation
   if (obj.action !== 'create') {
     return;
@@ -81,14 +83,14 @@ const verifySingularAndPluralNames: z.SuperRefinement<Record<string, unknown>> =
 
   if (obj.singularName === obj.pluralName) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: 'custom',
       message: 'Singular and plural names must be different',
       path: ['singularName'],
     });
   }
 };
 
-export const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unknown>> = (
+export const maxLengthGreaterThanMinLength: SuperRefinement<Record<string, unknown>> = (
   value,
   ctx
 ) => {
@@ -100,7 +102,7 @@ export const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unk
   ) {
     if (value.maxLength < value.minLength) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         message: 'maxLength must be greater or equal to minLength',
         path: ['maxLength'],
       });
@@ -108,11 +110,11 @@ export const maxLengthGreaterThanMinLength: z.SuperRefinement<Record<string, unk
   }
 };
 
-export const maxGreaterThanMin: z.SuperRefinement<Record<string, unknown>> = (value, ctx) => {
+export const maxGreaterThanMin: SuperRefinement<Record<string, unknown>> = (value, ctx) => {
   if (!isNil(value.max) && !isNil(value.min) && isNumber(value.max) && isNumber(value.min)) {
     if (value.max < value.min) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         message: 'max must be greater or equal to min',
         path: ['max'],
       });
@@ -120,7 +122,7 @@ export const maxGreaterThanMin: z.SuperRefinement<Record<string, unknown>> = (va
   }
 };
 
-const checkUserTarget: z.SuperRefinement<{
+const checkUserTarget: SuperRefinement<{
   type: string;
   target?: string;
   relation?: string;
@@ -141,28 +143,28 @@ const checkUserTarget: z.SuperRefinement<{
     (!STRAPI_USER_RELATIONS.includes(relation) || !isUndefined(targetAttribute))
   ) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: 'custom',
       path: ['relation'],
       message: `Relations to ${coreUids.STRAPI_USER} must be one of the following values: ${STRAPI_USER_RELATIONS.join(', ')} without targetAttribute`,
     });
   }
 };
 
-const uidRefinement: z.SuperRefinement<{
+const uidRefinement: SuperRefinement<{
   type: string;
   default?: unknown;
   targetField?: string | null;
 }> = (value, ctx) => {
   if (!isNil(value.targetField) && !isNil(value.default)) {
     ctx.addIssue({
-      code: z.ZodIssueCode.custom,
+      code: 'custom',
       message: 'Cannot define a default UID if the targetField is set',
       path: ['default'],
     });
   }
 };
 
-const enumRefinement: z.SuperRefinement<{
+const enumRefinement: SuperRefinement<{
   type: string;
   default?: unknown;
   enum?: string[];
@@ -170,7 +172,7 @@ const enumRefinement: z.SuperRefinement<{
   if (value.type === 'enumeration' && !isNil(value.default) && !isNil(value.enum)) {
     if (value.default === '' || !value.enum.some((v) => v === value.default)) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: 'custom',
         message: 'Default value must be one of the enum values',
         path: ['default'],
       });
@@ -818,14 +820,11 @@ const updateSchemaInput = z.object(
     data: schemaSchema,
   },
   {
-    invalid_type_error: 'Invalid schema, expected an object with a data property',
-    required_error: 'Schema is required',
+    error: (issue) =>
+      issue.input === undefined
+        ? 'Schema is required'
+        : 'Invalid schema, expected an object with a data property',
   }
 );
 
-// TODO: Remove cast when content-type-builder migrates to Zod 4
-export const validateUpdateSchema = validateZodSchema(
-  updateSchemaInput as unknown as import('@strapi/utils').z.ZodType<
-    z.infer<typeof updateSchemaInput>
-  >
-);
+export const validateUpdateSchema = validateZodSchema(updateSchemaInput);

--- a/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
+++ b/packages/core/content-type-builder/server/src/controllers/validation/schema.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { strings, validateZodSchema } from '@strapi/utils';
 import type { Struct, UID } from '@strapi/types';
 import { isArray, isNil, isNull, isNumber, isObject, isUndefined, snakeCase } from 'lodash/fp';

--- a/packages/core/content-type-builder/server/src/routes/content-api.ts
+++ b/packages/core/content-type-builder/server/src/routes/content-api.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import { createContentApiRoutesFactory } from '@strapi/utils';
 

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -110,7 +110,7 @@
     "typescript": "5.4.5",
     "undici": "6.25.0",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/ts-zen": "^0.2.0",

--- a/packages/core/core/src/core-api/routes/index.ts
+++ b/packages/core/core/src/core-api/routes/index.ts
@@ -1,7 +1,7 @@
 import type { Core, Schema } from '@strapi/types';
 
 import { contentTypes, contentTypes as contentTypeUtils } from '@strapi/utils';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import type { QueryParam } from './validation/content-type';
 
 import { CoreContentTypeRouteValidator } from './validation';

--- a/packages/core/core/src/core-api/routes/validation/attributes.ts
+++ b/packages/core/core/src/core-api/routes/validation/attributes.ts
@@ -15,7 +15,7 @@ import {
   maybeWithMinMax,
   augmentSchema,
 } from '@strapi/utils';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 import { BOOLEAN_LITERAL_VALUES } from './constants';
 

--- a/packages/core/core/src/core-api/routes/validation/common.ts
+++ b/packages/core/core/src/core-api/routes/validation/common.ts
@@ -1,7 +1,7 @@
 import type { Core, UID } from '@strapi/types';
 
 import { contentTypes, AbstractRouteValidator } from '@strapi/utils';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * AbstractCoreRouteValidator provides the foundation for validating and managing core routes within a Strapi context for a specific model.

--- a/packages/core/core/src/core-api/routes/validation/content-type.ts
+++ b/packages/core/core/src/core-api/routes/validation/content-type.ts
@@ -1,7 +1,7 @@
 import type { Schema, UID } from '@strapi/types';
 
 import { contentTypes } from '@strapi/utils';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // eslint-disable-next-line import/no-cycle
 import { createAttributesInputSchema, createAttributesSchema } from './mappers';

--- a/packages/core/core/src/core-api/routes/validation/mappers.ts
+++ b/packages/core/core/src/core-api/routes/validation/mappers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Schema } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // eslint-disable-next-line import/no-cycle
 import * as attributes from './attributes';

--- a/packages/core/core/src/core-api/routes/validation/utils.ts
+++ b/packages/core/core/src/core-api/routes/validation/utils.ts
@@ -1,6 +1,6 @@
 import { transformUidToValidOpenApiName } from '@strapi/utils';
 import type { Internal } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // Schema generation happens on-demand when schemas don't exist in the registry
 

--- a/packages/core/core/src/services/__tests__/content-api-permissions.test.ts
+++ b/packages/core/core/src/services/__tests__/content-api-permissions.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import createContentAPI from '../content-api';
 

--- a/packages/core/core/src/services/content-api/index.ts
+++ b/packages/core/core/src/services/content-api/index.ts
@@ -6,7 +6,7 @@ import {
   ALLOWED_QUERY_PARAM_KEYS,
   RESERVED_INPUT_PARAM_KEYS,
 } from '@strapi/utils';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import type { Core, Modules, UID } from '@strapi/types';
 
@@ -30,9 +30,9 @@ const filterContentAPI = (route: Core.Route) => route.info.type === 'content-api
  * any, or schema from another Zod instance); (2) it gives a clear, immediate error at registration
  * time instead of a later failure in validate/sanitize. This list is intentionally tied to Zod v4
  * constructor names; if Zod changes internals, this may need updating.
- * Compatibility: Zod 3 and Zod 4 Classic (zod/v4) both use these constructor names and
- * expose ._def with .innerType / .element for Optional/Default/Array. Zod 4 Core/Mini use
- * ._zod.def instead; we only accept schemas from the same zod/v4 instance used here.
+ * Compatibility: Zod 4 Classic uses these constructor names and exposes
+ * ._def with .innerType / .element for Optional/Default/Array. Zod 4 Core/Mini use
+ * ._zod.def instead; we only accept schemas from the same zod instance used here.
  */
 const ALLOWED_QUERY_SCHEMA_NAMES = new Set([
   'ZodString',

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -70,7 +70,7 @@
     "react-intl": "6.6.2",
     "react-query": "3.39.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/admin": "5.44.0",

--- a/packages/core/email/server/src/routes/validation/email.ts
+++ b/packages/core/email/server/src/routes/validation/email.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 export class EmailRouteValidator {
   protected readonly _strapi: Core.Strapi;

--- a/packages/core/openapi/__tests__/operation-assemblers.test.ts
+++ b/packages/core/openapi/__tests__/operation-assemblers.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import type { Core, Modules } from '@strapi/types';
 

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "debug": "4.3.4",
     "openapi-types": "12.1.3",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/types": "5.44.0",

--- a/packages/core/openapi/src/post-processor/component-writer.ts
+++ b/packages/core/openapi/src/post-processor/component-writer.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3_1 } from 'openapi-types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import type { DocumentContext } from '../types';
 import { toComponentsPath } from '../utils/zod';
 import type { PostProcessor } from './types';

--- a/packages/core/openapi/src/utils/zod.ts
+++ b/packages/core/openapi/src/utils/zod.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import type { OpenAPIV3_1 } from 'openapi-types';
 
@@ -18,7 +18,7 @@ import type { OpenAPIV3_1 } from 'openapi-types';
  *
  * @example
  * ```typescript
- * import * as z from 'zod/v4';
+ * import * as z from 'zod';
  *
  * // Create a Zod schema
  * const userSchema = z.object({

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -59,7 +59,7 @@
     "typedoc": "0.25.10",
     "typedoc-github-wiki-theme": "1.1.0",
     "typedoc-plugin-markdown": "3.17.1",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/ts-zen": "^0.2.0",

--- a/packages/core/types/src/core/route.ts
+++ b/packages/core/types/src/core/route.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod/v4';
+import type { z } from 'zod';
 import type { LiteralUnion } from '../utils/string';
 import type { MiddlewareHandler } from './middleware';
 

--- a/packages/core/types/src/modules/content-api.ts
+++ b/packages/core/types/src/modules/content-api.ts
@@ -1,6 +1,6 @@
 import permissions from '@strapi/permissions';
 import { providerFactory, sanitize, validate } from '@strapi/utils';
-import type { z } from 'zod/v4';
+import type { z } from 'zod';
 
 import type { Route } from '../core';
 
@@ -17,7 +17,7 @@ export type ZodQueryParamSchema =
   | z.ZodDefault<ZodScalarSchema | z.ZodArray<ZodScalarSchema>>
   | z.ZodArray<ZodScalarSchema>;
 
-/** Zod namespace type (e.g. from `import * as z from 'zod/v4'`) passed to schema factory. */
+/** Zod namespace type (e.g. from `import * as z from 'zod'`) passed to schema factory. */
 export type ZodSchemaFactory = typeof z;
 
 /** Schema + optional matchRoute for one query param. Keys in addQueryParams are the param names. */
@@ -82,7 +82,7 @@ export interface ContentApi {
   /**
    * Register extra query params to be merged into content-api route schemas.
    * Query params accept only Zod scalar or array-of-scalar schemas (no nested objects); enforced at runtime. Use {@link ContentApi.addInputParams} for nested structures.
-   * Use `z` from `@strapi/utils` or `zod/v4` for compatibility.
+   * Use `z` from `@strapi/utils` or `zod` for compatibility.
    *
    * @param options - {@link AddQueryParamsOptions}: record of param name → {@link QueryParamEntry}. Each entry has:
    * @param options.[paramName] - {@link QueryParamEntry} (key is the param name, e.g. `"search"`).

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -98,7 +98,7 @@
     "react-select": "5.8.0",
     "sharp": "0.33.5",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/admin": "5.44.0",

--- a/packages/core/upload/server/src/routes/content-api.ts
+++ b/packages/core/upload/server/src/routes/content-api.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { createContentApiRoutesFactory } from '@strapi/utils';
 import { UploadRouteValidator } from './validation';
 

--- a/packages/core/upload/server/src/routes/validation/upload.ts
+++ b/packages/core/upload/server/src/routes/validation/upload.ts
@@ -1,6 +1,6 @@
 import type { Core } from '@strapi/types';
 import { AbstractRouteValidator, type QueryParam } from '@strapi/utils';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 export type FileQueryParam = QueryParam;
 

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import { z } from 'zod';
+import * as z from 'zod/v4';
 import { InputFile, File } from '../types';
 import { Settings } from '../controllers/validation/admin/settings';
 import { getService } from '../utils';

--- a/packages/core/upload/server/src/services/ai-metadata.ts
+++ b/packages/core/upload/server/src/services/ai-metadata.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { InputFile, File } from '../types';
 import { Settings } from '../controllers/validation/admin/settings';
 import { getService } from '../utils';

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -56,7 +56,7 @@
     "p-map": "4.0.0",
     "preferred-pm": "3.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/http-errors": "2.0.4",

--- a/packages/core/utils/src/__tests__/sanitize-input.test.ts
+++ b/packages/core/utils/src/__tests__/sanitize-input.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { createAPISanitizers } from '../sanitize';
 import { articleModel, getModel } from './test-fixtures';
 

--- a/packages/core/utils/src/__tests__/sanitize-query.test.ts
+++ b/packages/core/utils/src/__tests__/sanitize-query.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { createAPISanitizers } from '../sanitize';
 import { articleModel, getModel } from './test-fixtures';
 

--- a/packages/core/utils/src/__tests__/validate-input.test.ts
+++ b/packages/core/utils/src/__tests__/validate-input.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { createAPIValidators } from '../validate';
 import { ValidationError } from '../errors';
 import { articleModel, getModel } from './test-fixtures';

--- a/packages/core/utils/src/__tests__/validate-query.test.ts
+++ b/packages/core/utils/src/__tests__/validate-query.test.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { createAPIValidators } from '../validate';
 import { ValidationError } from '../errors';
 import { articleModel, getModel } from './test-fixtures';

--- a/packages/core/utils/src/content-api-route-params.ts
+++ b/packages/core/utils/src/content-api-route-params.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod/v4';
+import type { z } from 'zod';
 
 import { ALLOWED_QUERY_PARAM_KEYS } from './content-api-constants';
 

--- a/packages/core/utils/src/sanitize/index.ts
+++ b/packages/core/utils/src/sanitize/index.ts
@@ -1,6 +1,6 @@
 import { CurriedFunction1 } from 'lodash';
 import { isArray, cloneDeep, omit, pick } from 'lodash/fp';
-import type { z } from 'zod/v4';
+import type { z } from 'zod';
 
 import { constants, getNonWritableAttributes } from '../content-types';
 import { ALLOWED_QUERY_PARAM_KEYS } from '../content-api-constants';

--- a/packages/core/utils/src/validate/index.ts
+++ b/packages/core/utils/src/validate/index.ts
@@ -1,6 +1,6 @@
 import { CurriedFunction1 } from 'lodash';
 import { isArray, isObject } from 'lodash/fp';
-import type { z } from 'zod/v4';
+import type { z } from 'zod';
 
 import { getNonWritableAttributes, constants } from '../content-types';
 import { ALLOWED_QUERY_PARAM_KEYS } from '../content-api-constants';

--- a/packages/core/utils/src/validation/route-validators/base.ts
+++ b/packages/core/utils/src/validation/route-validators/base.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import { queryParameterSchemas, type QueryParam } from './query-params';
 
 /**

--- a/packages/core/utils/src/validation/route-validators/index.ts
+++ b/packages/core/utils/src/validation/route-validators/index.ts
@@ -10,7 +10,7 @@
  * @example
  * ```typescript
  * import { AbstractRouteValidator, type QueryParam } from '@strapi/utils';
- * import * as z from 'zod/v4';
+ * import * as z from 'zod';
  *
  * export class MyPluginRouteValidator extends AbstractRouteValidator {
  *   constructor(strapi: Core.Strapi) {

--- a/packages/core/utils/src/validation/route-validators/query-params.ts
+++ b/packages/core/utils/src/validation/route-validators/query-params.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * Standard query parameter validators that can be reused across different route validators

--- a/packages/core/utils/src/validation/utilities.ts
+++ b/packages/core/utils/src/validation/utilities.ts
@@ -4,7 +4,7 @@
  * and to safely register and create schemas within Zod's global registry.
  */
 
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * Transforms a Strapi UID into an OpenAPI-compliant component name.

--- a/packages/core/utils/src/zod.ts
+++ b/packages/core/utils/src/zod.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import { ValidationError } from './errors';
 

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -69,7 +69,7 @@
     "react-intl": "6.6.2",
     "react-redux": "8.1.3",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/admin": "5.44.0",

--- a/packages/plugins/i18n/server/src/routes/validation/locale.ts
+++ b/packages/plugins/i18n/server/src/routes/validation/locale.ts
@@ -1,5 +1,5 @@
 import type { Core } from '@strapi/types';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * A validator for i18n locale routes.

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -72,7 +72,7 @@
     "react-redux": "8.1.3",
     "url-join": "4.0.1",
     "yup": "0.32.9",
-    "zod": "3.25.67"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@strapi/strapi": "5.44.0",

--- a/tests/api/core/strapi/api/openapi-extra-params.test.api.ts
+++ b/tests/api/core/strapi/api/openapi-extra-params.test.api.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 import { createStrapiInstance } from 'api-tests/strapi';
 import { generate } from '@strapi/openapi';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8663,7 +8663,7 @@ __metadata:
     vite: "npm:5.4.21"
     vite-plugin-dts: "npm:^4.3.0"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/data-transfer": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -8870,7 +8870,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -8963,7 +8963,7 @@ __metadata:
     vitest: "catalog:"
     vitest-config: "npm:5.44.0"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -9089,7 +9089,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     koa: ^2.15.2
@@ -9181,7 +9181,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
@@ -9222,7 +9222,7 @@ __metadata:
     "@types/debug": "npm:^4"
     debug: "npm:4.3.4"
     openapi-types: "npm:12.1.3"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -9437,7 +9437,7 @@ __metadata:
     styled-components: "npm:6.1.8"
     url-join: "npm:4.0.1"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9740,7 +9740,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:3.17.1"
     typescript: "npm:5.4.5"
     undici: "npm:6.25.0"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -9871,7 +9871,7 @@ __metadata:
     sharp: "npm:0.33.5"
     styled-components: "npm:6.1.8"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9901,7 +9901,7 @@ __metadata:
     preferred-pm: "npm:3.1.3"
     tsconfig: "npm:5.44.0"
     yup: "npm:0.32.9"
-    zod: "npm:3.25.67"
+    zod: "catalog:"
   languageName: unknown
   linkType: soft
 
@@ -31439,7 +31439,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.25.67, zod@npm:^3.19.1, zod@npm:^3.22.4":
+"zod@npm:3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.19.1, zod@npm:^3.22.4":
   version: 3.25.67
   resolution: "zod@npm:3.25.67"
   checksum: 10c0/80a0cab3033272c4ab9312198081f0c4ea88e9673c059aa36dc32024906363729db54bdb78f3dc9d5529bd1601f74974d5a56c0a23e40c6f04a9270c9ff22336

--- a/yarn.lock
+++ b/yarn.lock
@@ -31439,10 +31439,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.25.76":
-  version: 3.25.76
-  resolution: "zod@npm:3.25.76"
-  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+"zod@npm:4.4.2":
+  version: 4.4.2
+  resolution: "zod@npm:4.4.2"
+  checksum: 10c0/aa5097464c41cf22d715cbc29873ae6feaaf56e687b81d140458d7c01201e7b9de1ee46c8567b5458ee3c0068b8a82b2652535b5d39589fcb5562d861c83ded3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Centralize zod via the new yarn `catalog:` entry in `.yarnrc.yml`, then bump it from `3.25.67` to `4.4.2` (one source of truth, ten `package.json` consumers).
- Finish the in-flight zod 4 migration: every remaining `import { z } from 'zod'` site is moved to the v4 surface, and once the bump lands all imports become bare `'zod'` (no more `'zod/v4'` subpath anywhere).
- Drop the `as unknown as @strapi/utils.z.ZodType<...>` cast bridge and TODO in `content-type-builder` now that it is on the same zod instance as the rest of the repo.

The work is split into three commits so each step can be reverted independently:

1. `chore(zod): bump to 3.25.76 via yarn catalog and migrate 3 files to zod/v4`
   - Catalog setup + `3.25.67 -> 3.25.76`.
   - `.object().strict()` -> `z.strictObject({...})` in admin schema and project-settings.
   - Migrate `admin/server/src/controllers/validation/schema.ts`, `admin/admin/src/utils/rulesEngine.ts`, `upload/server/src/services/ai-metadata.ts` to `import * as z from 'zod/v4'`.
2. `chore(content-type-builder): migrate validation schema to zod/v4`
   - `invalid_type_error` / `required_error` -> unified `error: (issue) => ...` callback.
   - Replace removed `z.SuperRefinement<T>` with a local alias backed by `z.RefinementCtx<T>`.
   - `z.ZodIssueCode.custom` -> `'custom'` literal.
   - Drop the consumer cast bridge; update the test ctx mock to the v4 `RefinementCtx` shape.
3. `chore(zod): bump catalog to 4.4.2 and switch all imports to bare 'zod'`
   - `.yarnrc.yml` catalog: `3.25.76 -> 4.4.2` (major).
   - `from 'zod/v4'` -> `from 'zod'` across all source and tests.
   - Two stale doc comments mentioning the `zod/v4` subpath updated.

Net diff vs `develop`: 49 files, +129 / -132.

## Test plan

- [x] `yarn nx run-many --target=test:ts --projects=@strapi/admin,@strapi/utils,@strapi/types`
- [x] `yarn nx run-many --target=test:ts:back --projects=@strapi/upload,@strapi/content-type-builder`
- [x] `yarn nx run-many --target=test:ts:front --projects=@strapi/upload,@strapi/content-type-builder,@strapi/email,@strapi/i18n`
- [x] Targeted unit suites: admin `rulesEngine` (11/11), admin `homepage` (4/4), upload `ai-metadata` (19/19), CTB validation (93/93).
- [x] Broad unit run across affected packages: 1295 tests / 92 suites pass after the 4.x bump.
- [ ] CI must re-run the same matrix against the resolved zod 4.4.2 in `yarn.lock`.

## Notes / known limits

- A pre-existing failure in `@strapi/admin:test:ts:front` (`StrapiApp.test.tsx:479`, lazy `Component` cast) lives on `develop` already and is unrelated to this change.
- `z.string().datetime()` and `z.string().nonempty()` (used by the admin homepage layout schema) are deprecated in zod 4 but still work; intentionally left as-is to keep this PR purely mechanical. Happy to fold a follow-up swap to `z.iso.datetime()` / `.min(1)` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)