### PR TITLE
chore(deps): drop React 17 from peer dependency ranges

### DIFF
--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -179,8 +179,8 @@
   },
   "peerDependencies": {
     "@strapi/data-transfer": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -180,8 +180,8 @@
   },
   "peerDependencies": {
     "@strapi/data-transfer": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -130,8 +130,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -124,8 +124,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -98,8 +98,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -102,8 +102,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -111,8 +111,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -119,8 +119,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -94,8 +94,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "koa": "^2.15.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -89,8 +89,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "koa": "^2.15.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -87,8 +87,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -98,8 +98,8 @@
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
     "@strapi/types": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -188,8 +188,8 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -186,8 +186,8 @@
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -122,8 +122,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -127,8 +127,8 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -67,8 +67,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -87,8 +87,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -78,8 +78,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -103,8 +103,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -107,8 +107,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -94,8 +94,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -99,8 +99,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -101,8 +101,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -95,8 +95,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -90,8 +90,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/content-manager": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -75,8 +75,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -70,8 +70,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -77,8 +77,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -87,8 +87,8 @@
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -89,8 +89,8 @@
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
     "@strapi/strapi": "^5.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8666,8 +8666,8 @@ __metadata:
     zod: "npm:3.25.67"
   peerDependencies:
     "@strapi/data-transfer": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -8776,8 +8776,8 @@ __metadata:
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -8819,8 +8819,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -8873,8 +8873,8 @@ __metadata:
     zod: "npm:3.25.67"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9093,8 +9093,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     koa: ^2.15.2
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9185,8 +9185,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9259,8 +9259,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9284,8 +9284,8 @@ __metadata:
     typescript: "npm:5.4.5"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9333,8 +9333,8 @@ __metadata:
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9377,8 +9377,8 @@ __metadata:
     typescript: "npm:5.4.5"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9398,8 +9398,8 @@ __metadata:
     styled-components: "npm:6.1.8"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9440,8 +9440,8 @@ __metadata:
     zod: "npm:3.25.67"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9573,8 +9573,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9691,8 +9691,8 @@ __metadata:
     yalc: "npm:1.0.0-pre.53"
     yup: "npm:0.32.9"
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   bin:
@@ -9874,8 +9874,8 @@ __metadata:
     zod: "npm:3.25.67"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -9058,8 +9058,8 @@ __metadata:
     zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/data-transfer": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9177,8 +9177,8 @@ __metadata:
     zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9224,8 +9224,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9285,8 +9285,8 @@ __metadata:
     zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9523,8 +9523,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     koa: ^2.15.2
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9623,8 +9623,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9706,8 +9706,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9738,8 +9738,8 @@ __metadata:
     vitest-config: "npm:5.50.2"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9791,8 +9791,8 @@ __metadata:
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9838,8 +9838,8 @@ __metadata:
     typescript: "npm:5.9.3"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9862,8 +9862,8 @@ __metadata:
     styled-components: "npm:6.4.1"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9904,8 +9904,8 @@ __metadata:
     zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -10065,8 +10065,8 @@ __metadata:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
     "@strapi/types": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -10152,8 +10152,8 @@ __metadata:
     yalc: "npm:1.0.0-pre.53"
     yup: "npm:0.32.9"
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   bin:
@@ -10339,8 +10339,8 @@ __metadata:
     zod: "npm:3.25.76"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -8958,8 +8958,8 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/data-transfer": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9077,8 +9077,8 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9124,8 +9124,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9185,8 +9185,8 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9426,8 +9426,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     koa: ^2.15.2
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9526,8 +9526,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9607,8 +9607,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9639,8 +9639,8 @@ __metadata:
     vitest-config: "npm:5.52.3"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9692,8 +9692,8 @@ __metadata:
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9741,8 +9741,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9767,8 +9767,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9811,8 +9811,8 @@ __metadata:
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -9971,8 +9971,8 @@ __metadata:
     "@strapi/admin": ^5.0.0
     "@strapi/content-manager": ^5.0.0
     "@strapi/types": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown
@@ -10056,8 +10056,8 @@ __metadata:
     yalc: "npm:1.0.0-pre.53"
     yup: "npm:0.32.9"
   peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   bin:
@@ -10242,8 +10242,8 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
   languageName: unknown


### PR DESCRIPTION
### What does it do?

Tightens the `react` and `react-dom` peer dependency ranges from
`^17.0.0 || ^18.0.0` to `^18.0.0` across 15 admin/plugin workspaces.
**Effectively drops React 17 from the supported matrix** — server-only
packages (no React in `peerDependencies`) are unaffected.

Affected workspaces:

- `@strapi/admin`, `@strapi/content-manager`, `@strapi/content-releases`,
  `@strapi/content-type-builder`, `@strapi/email`, `@strapi/review-workflows`,
  `@strapi/strapi`, `@strapi/upload`
- `@strapi/plugin-cloud`, `@strapi/plugin-color-picker`,
  `@strapi/plugin-documentation`, `@strapi/plugin-graphql`,
  `@strapi/i18n`, `@strapi/plugin-sentry`, `@strapi/plugin-users-permissions`

`yarn.lock` is regenerated; only the peer-range metadata changes — no
resolution or transitive dependency shifts.

#### Semver / release-notes impact

Tightening a peer range is technically a breaking change for any host
that satisfied the old union but not the new one (i.e. a React 17
host). In practice Strapi v5 already requires React 18 in the official
docs, the engine matrix, and the templates — so this is a
metadata/documentation correction that brings the published manifests
in line with the *de facto* support matrix, rather than a behavioural
break for any currently-working consumer. Worth a line in the next
release notes regardless, so React-17-on-Strapi-5 users (if they exist)
get a clear signal to upgrade React rather than a silent
`yarn install` followed by a runtime crash.

### Why is it needed?

The advertised `^17.0.0 || ^18.0.0` range was out of date:

- `devDependencies` pin `react@18.3.1` — nothing has been built or
  tested against React 17 since the React 18 upgrade.
- The admin runtime uses React 18-only APIs (`createRoot`,
  automatic batching, `useId`, `useSyncExternalStore`).
- Installing into a React 17 host would `yarn install` clean and then
  break at runtime, with no CI signal.
- `@types/react` 17 vs 18 diverge (`ReactNode`, implicit `children` on
  `FC`), so type errors leak to consumers.
- Risk of two React copies via dedupe ("Invalid hook call") when a host
  app stays on 17 while a Strapi plugin pulls 18 transitively.

Narrowing the range to `^18.0.0` makes the advertised contract match
reality.

<details>
<summary><b>Why <code>^18.0.0</code> and not <code>^18.3.0</code> / <code>~18.3.1</code>?</b></summary>

`devDependencies` pin `react@18.3.1`, so a stricter range would be more
"honest" in principle. In practice it isn't necessary — checked the
React CHANGELOG for what landed in each 18.x minor:

| Version | New public APIs |
|---|---|
| **18.0.0** | All the major ones: `createRoot`, `useId`, `useTransition`, `useSyncExternalStore`, automatic batching, etc. |
| **18.1.0** | None. Bug fixes only. |
| **18.2.0** | One: second `componentStack` arg to `onRecoverableError`. |
| **18.3.0** | None. Identical to 18.2 but adds deprecation warnings for React 19. |
| **18.3.1** | One: `act` exported from `'react'` (previously only `react-dom/test-utils`). |

Verified that no code in this repo imports `act` from `'react'` or
relies on the second arg of `onRecoverableError`, so every React API
the admin actually uses ships in 18.0.0. `^18.0.0` is therefore honest
in practice and matches the npm convention for caret ranges on a major.

</details>

### How to test it?

1. Verify the published peer range is tightened:

   ```sh
   jq '.peerDependencies' packages/core/admin/package.json
   # → { "react": "^18.0.0", "react-dom": "^18.0.0", ... }
   ```

   Repeat for any of the other 14 affected `package.json` files.

2. Confirm `yarn install` still resolves cleanly inside this monorepo —
   no new peer-dependency warnings are introduced. (Pre-existing
   warnings about `react@19.0.0-rc` from `examples/experimental-dev` and
   the unrelated `zod`/`typescript`/`msw` warnings are untouched and
   out of scope here.)

3. (Optional) Simulate a React 17 consumer by packing a workspace and
   installing it into a scratch project alongside React 17:

   ```sh
   # Pack a small affected plugin from this branch
   (cd packages/plugins/sentry && npm pack --pack-destination /tmp)

   # Try to install it into a React 17 project
   mkdir /tmp/r17-test && cd /tmp/r17-test
   npm init -y
   npm install react@17 react-dom@17 /tmp/strapi-plugin-sentry-5.44.0.tgz
   ```

#### Verified behaviour change

Running the simulation above against this branch vs. `develop`:

| | Result |
|---|---|
| **`develop` (`^17.0.0 \|\| ^18.0.0`)** | `npm install` **succeeds** (1367 packages added, no React peer error). Runtime would break later via `createRoot` etc. |
| **This branch (`^18.0.0`)** | `npm install` **fails** at install time with a clear `ERESOLVE`: `peer react@"^18.0.0" from @strapi/plugin-sentry@5.44.0 ... Could not resolve dependency` |

That is the exact contract change this PR is intended to deliver:
silent runtime breakage → loud install-time failure for unsupported
React versions.

Note: a full network-wide effect requires a coordinated release of all
15 affected packages, since transitive peers from already-published
versions still advertise the old range.

### Related issue(s)/PR(s)

None.
