### PR TITLE
fix(typescript-utils): emit namespace keyword instead of deprecated module

### DIFF
--- a/packages/core/types/src/index.ts
+++ b/packages/core/types/src/index.ts
@@ -1,4 +1,4 @@
-import { Strapi } from './core';
+import type { Strapi } from './core';
 
 export type * as Core from './core';
 export type * as Data from './data';

--- a/packages/core/types/src/public/registries.ts
+++ b/packages/core/types/src/public/registries.ts
@@ -11,11 +11,9 @@ import type { ComponentSchema, ContentTypeSchema } from '../struct';
  * Example usage of ContentTypeSchemas:
  * ```ts
  * declare module '@strapi/types' {
- *   export module Public {
- *     export module Registries {
- *       export interface ContentTypesSchemas {
- *         'api::foo.foo': { ... }
- *       }
+ *   export namespace Public {
+ *     export interface ContentTypeSchemas {
+ *       'api::foo.foo': { ... }
  *     }
  *   }
  * }
@@ -34,11 +32,9 @@ export interface ContentTypeSchemas {
  * Example usage of ComponentSchemas:
  * ```ts
  * declare module '@strapi/types' {
- *   export module Public {
- *     export module Registries {
- *       export interface ComponentSchemas {
- *         'default.foo': { ... }
- *       }
+ *   export namespace Public {
+ *     export interface ComponentSchemas {
+ *       'default.foo': { ... }
  *     }
  *   }
  * }

--- a/packages/core/types/src/public/shared.ts
+++ b/packages/core/types/src/public/shared.ts
@@ -13,7 +13,7 @@
  * Here's how `DocumentServicePluginParams` can be used to define parameters for a fictional plugin "Internationalization":
  * ```typescript
  * declare module '@strapi/types' {
- *   export module Shared {
+ *   export namespace Public {
  *     export interface DocumentServicePluginParams {
  *       'locale': string;
  *     }
@@ -38,7 +38,7 @@ export interface DocumentServicePluginParams {}
  * Here's how `EntityServicePluginParams` can be used to define parameters for a fictional plugin "Internationalization":
  * ```typescript
  * declare module '@strapi/types' {
- *   export module Shared {
+ *   export namespace Public {
  *     export interface EntityServicePluginParams {
  *       'locale': string;
  *     }

--- a/packages/utils/typescript/lib/__tests__/generators/utils.test.js
+++ b/packages/utils/typescript/lib/__tests__/generators/utils.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const { generateSharedExtensionDefinition, emitDefinitions } = require('../../generators/utils');
+
+const makeDefinition = (uid, name) => ({
+  uid,
+  definition: { name: { escapedText: name } },
+});
+
+describe('generateSharedExtensionDefinition', () => {
+  test('emits ambient module aug with TS-6-compliant `namespace` keyword (not legacy `module`)', () => {
+    const node = generateSharedExtensionDefinition('ContentTypeSchemas', [
+      makeDefinition('api::foo.foo', 'ApiFooFoo'),
+    ]);
+
+    const output = emitDefinitions([node]);
+
+    expect(output).toContain("declare module '@strapi/strapi'");
+    expect(output).toContain('export namespace Public');
+    expect(output).not.toMatch(/export\s+module\s+Public\b/);
+    expect(output).toContain("'api::foo.foo': ApiFooFoo");
+  });
+
+  test('emits empty namespace block when no definitions provided', () => {
+    const node = generateSharedExtensionDefinition('ContentTypeSchemas', []);
+
+    const output = emitDefinitions([node]);
+
+    expect(output).toContain('export namespace Public');
+    expect(output).not.toMatch(/export\s+module\s+Public\b/);
+    expect(output).not.toContain('ContentTypeSchemas');
+  });
+
+  test('passes through registry name to interface declaration', () => {
+    const node = generateSharedExtensionDefinition('ComponentSchemas', [
+      makeDefinition('default.bar', 'DefaultBar'),
+    ]);
+
+    const output = emitDefinitions([node]);
+
+    expect(output).toContain('export interface ComponentSchemas');
+  });
+});

--- a/packages/utils/typescript/lib/generators/utils.js
+++ b/packages/utils/typescript/lib/generators/utils.js
@@ -114,7 +114,8 @@ const generateSharedExtensionDefinition = (registry, definitions) => {
                 ),
               ]
             : []
-        )
+        ),
+        ts.NodeFlags.Namespace
       ),
     ]),
     ts.NodeFlags.ExportContext

--- a/templates/website/types/generated/components.d.ts
+++ b/templates/website/types/generated/components.d.ts
@@ -336,7 +336,7 @@ export interface ElementsFeatureColumn extends Struct.ComponentSchema {
 }
 
 declare module '@strapi/strapi' {
-  export module Public {
+  export namespace Public {
     export interface ComponentSchemas {
       'meta.metadata': MetaMetadata;
       'sections.testimonials-group': SectionsTestimonialsGroup;

--- a/templates/website/types/generated/contentTypes.d.ts
+++ b/templates/website/types/generated/contentTypes.d.ts
@@ -862,7 +862,7 @@ export interface AdminTransferTokenPermission extends Struct.CollectionTypeSchem
 }
 
 declare module '@strapi/strapi' {
-  export module Public {
+  export namespace Public {
     export interface ContentTypeSchemas {
       'plugin::upload.file': PluginUploadFile;
       'plugin::upload.folder': PluginUploadFolder;

--- a/tests/api/core/strapi/document-service/resources/types/components.d.ts
+++ b/tests/api/core/strapi/document-service/resources/types/components.d.ts
@@ -82,8 +82,8 @@ export interface MixedContentNestedMediaWrapper extends Schema.Component {
 }
 
 declare module '@strapi/types' {
-  export module Shared {
-    export interface Components {
+  export namespace Public {
+    export interface ComponentSchemas {
       'article.comp': ArticleComp;
       'article.dz-comp': ArticleDzComp;
       'article.dz-other-comp': ArticleDzOtherComp;

--- a/tests/api/core/strapi/document-service/resources/types/contentTypes.d.ts
+++ b/tests/api/core/strapi/document-service/resources/types/contentTypes.d.ts
@@ -817,27 +817,25 @@ export interface ApiMixedContentMixedContent extends Struct.CollectionTypeSchema
 }
 
 declare module '@strapi/types' {
-  export module Public {
-    export module Registries {
-      export interface ContentTypesSchemas {
-        'admin::permission': AdminPermission;
-        'admin::user': AdminUser;
-        'admin::role': AdminRole;
-        'admin::api-token': AdminApiToken;
-        'admin::api-token-permission': AdminApiTokenPermission;
-        'admin::transfer-token': AdminTransferToken;
-        'admin::transfer-token-permission': AdminTransferTokenPermission;
-        'plugin::upload.file': PluginUploadFile;
-        'plugin::upload.folder': PluginUploadFolder;
-        'plugin::i18n.locale': PluginI18NLocale;
-        'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
-        'plugin::users-permissions.role': PluginUsersPermissionsRole;
-        'plugin::users-permissions.user': PluginUsersPermissionsUser;
-        'api::article.article': ApiArticleArticle;
-        'api::author.author': ApiAuthorAuthor;
-        'api::category.category': ApiCategoryCategory;
-        'api::mixed-content.mixed-content': ApiMixedContentMixedContent;
-      }
+  export namespace Public {
+    export interface ContentTypeSchemas {
+      'admin::permission': AdminPermission;
+      'admin::user': AdminUser;
+      'admin::role': AdminRole;
+      'admin::api-token': AdminApiToken;
+      'admin::api-token-permission': AdminApiTokenPermission;
+      'admin::transfer-token': AdminTransferToken;
+      'admin::transfer-token-permission': AdminTransferTokenPermission;
+      'plugin::upload.file': PluginUploadFile;
+      'plugin::upload.folder': PluginUploadFolder;
+      'plugin::i18n.locale': PluginI18NLocale;
+      'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
+      'plugin::users-permissions.role': PluginUsersPermissionsRole;
+      'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::article.article': ApiArticleArticle;
+      'api::author.author': ApiAuthorAuthor;
+      'api::category.category': ApiCategoryCategory;
+      'api::mixed-content.mixed-content': ApiMixedContentMixedContent;
     }
   }
 }


### PR DESCRIPTION
### What does it do?

Aligns Strapi's TypeScript type emission and public-type documentation with TypeScript 6 semantics.

#### 1. Generator emits `namespace` instead of legacy `module` keyword

Fixes the typegen output (`strapi ts:generate-types`) so it emits the modern `namespace` keyword instead of the deprecated `module` keyword for internal namespace declarations.

Before:
```ts
declare module '@strapi/strapi' {
  export module Public {
    export interface ContentTypeSchemas { /* ... */ }
  }
}
```

After:
```ts
declare module '@strapi/strapi' {
  export namespace Public {
    export interface ContentTypeSchemas { /* ... */ }
  }
}
```

Root cause is in `packages/utils/typescript/lib/generators/utils.js` — `ts.factory.createModuleDeclaration` only emits the modern `namespace` keyword when the name is an `Identifier` **and** `ts.NodeFlags.Namespace` is passed in the flags argument. Without the flag, the printer falls back to the deprecated `module` form. The fix adds the flag to the inner declaration. The outer ambient module augmentation (`declare module '@strapi/strapi' { ... }`) uses a `StringLiteral` name, so it correctly stays as `module 'name' { ... }`.

A regression test is added (`packages/utils/typescript/lib/__tests__/generators/utils.test.js`) covering `generateSharedExtensionDefinition` — it asserts `export namespace Public` is emitted and `export module Public` is not.

The committed `.d.ts` fixtures in `templates/website/types/generated/*` are updated to match what the fixed generator now emits.

#### 2. Correct JSDoc augmentation paths in `@strapi/types`

The JSDoc `@example` blocks on the public registries pointed users at namespace paths that don't exist in the type surface:

| File / interface | JSDoc said | Real path |
|---|---|---|
| `public/registries.ts` → `ContentTypeSchemas` | `Public.Registries.ContentTypesSchemas` (extra nesting + `ContentTypes`/`ContentType` typo) | `Public.ContentTypeSchemas` |
| `public/registries.ts` → `ComponentSchemas` | `Public.Registries.ComponentSchemas` (extra nesting) | `Public.ComponentSchemas` |
| `public/shared.ts` → `*PluginParams` | `Shared.DocumentServicePluginParams` / `Shared.EntityServicePluginParams` (no `Shared` namespace exists) | `Public.DocumentServicePluginParams` / `Public.EntityServicePluginParams` |

Tracing `packages/core/types/src/index.ts`, the only public namespace exposed by `@strapi/types` is `Public` (`export type * as Public from './public'`), and everything declared in `./public/{registries,shared}.ts` is re-exported flat into it. The JSDoc examples are updated to match, so users copy-pasting them actually augment the right registry.

#### 3. Fix phantom augmentation paths in document-service test fixtures

The `.d.ts` fixtures under `tests/api/core/strapi/document-service/resources/types/` declared `@strapi/types` augmentations on the same non-existent namespaces:

- `Shared.Components` → no top-level `Shared` namespace exists
- `Public.Registries.ContentTypesSchemas` → no `Registries` nesting (plus the `ContentTypes`/`ContentType` typo)

These were dead augmentations: they declared standalone phantom namespaces that nothing in the codebase consumed. Re-targeted to the real registries (`Public.ComponentSchemas`, `Public.ContentTypeSchemas`) so the fixture content actually augments `@strapi/types`, mirroring what `strapi ts:generate-types` emits for real Strapi projects.

#### 4. Minor cleanup: `import type` for `Strapi` in `@strapi/types` entry

`packages/core/types/src/index.ts` imports the `Strapi` type only to use it in type positions (`var strapi: Strapi;` and the ambient `NodeJS.Global` augmentation). Switched to `import type` so the import doesn't contribute to the runtime module graph. Surfaced while auditing the entry file for the namespace tracing in fix #2.

### Why is it needed?

TypeScript 6 fully deprecates the legacy `module Foo { ... }` syntax for namespace declarations (release notes: ["Deprecated: legacy `module` Syntax for namespaces"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated-legacy-module-syntax-for-namespaces)). User projects that consume Strapi's generated types will fail to compile under TS 6 until the generator emits the `namespace` keyword.

Ambient module augmentation (`declare module '<string>' { ... }`) is **not** affected by the deprecation and is intentionally left as-is.

The JSDoc and fixture corrections were surfaced while auditing the same files for the namespace migration: they document/augment paths that never existed in the real public type surface, which is misleading to users and produces silently dead augmentations in tests.

### How to test it?

```bash
yarn workspace @strapi/typescript-utils test
yarn workspace @strapi/types build
```

To verify the generated output by hand:

```bash
node -e "
const { generateSharedExtensionDefinition, emitDefinitions } = require('./packages/utils/typescript/lib/generators/utils.js'); const node = generateSharedExtensionDefinition('ContentTypeSchemas', [
  { uid: 'api::foo.foo', definition: { name: { escapedText: 'ApiFooFoo' } } },
]); console.log(emitDefinitions([node])); "
```

Expected output now contains `export namespace Public`, not `export module Public`.

In a Strapi project, running `yarn strapi ts:generate-types` and inspecting `types/generated/{components,contentTypes}.d.ts` shows the same.

### Related issue(s)/PR(s)

None linked. Surfaced while preparing the codebase for TypeScript 6 compatibility.
