### PR TITLE
fix(admin): type addMenuLink with optional Component for menu-only links

### DIFF
--- a/packages/core/admin/admin/src/core/apis/router.tsx
+++ b/packages/core/admin/admin/src/core/apis/router.tsx
@@ -137,7 +137,7 @@ class Router {
 
   public addMenuLink = (
     link: Omit<MenuItem, 'Component'> & {
-      Component: () => Promise<{ default: React.ComponentType }>;
+      Component?: () => Promise<{ default: React.ComponentType }>;
     }
   ) => {
     invariant(link.to, `[${link.intlLabel.defaultMessage}]: link.to should be defined`);


### PR DESCRIPTION
### What does it do?

Updates the `addMenuLink` parameter type in `packages/core/admin/admin/src/core/apis/router.tsx` so `Component` is optional (`Component?: () => Promise<{ default: React.ComponentType }>`), matching how menu-only links are registered at runtime and aligning with `UnloadedSettingsLink`.

### Why is it needed?

The router already supports links without a lazy route (`Component` is only used when present). Requiring `Component` in the type made valid calls invalid and broke frontend typechecking (`@strapi/admin:test:ts:front`), e.g. the “menu-only link” case in `StrapiApp.test.tsx`.

### How to test it?

From the repo root:

```bash
yarn test:ts
```

### Related issue(s)/PR(s)
