### PR TITLE
fix(db): deterministic schema hash by sorting tables before hashing

### DIFF
--- a/packages/core/database/src/schema/__tests__/storage.test.ts
+++ b/packages/core/database/src/schema/__tests__/storage.test.ts
@@ -1,0 +1,63 @@
+import createSchemaStorage from '../storage';
+
+import type { Database } from '../..';
+import type { Schema } from '../types';
+
+describe('createSchemaStorage', () => {
+  const minimalTable = (name: string) => ({
+    name,
+    columns: [{ name: 'id', type: 'increments', args: [] }],
+    indexes: [],
+    foreignKeys: [],
+  });
+
+  const mockDb = (): Database =>
+    ({
+      getSchemaConnection: jest.fn().mockReturnValue({
+        hasTable: jest.fn().mockResolvedValue(false),
+        createTable: jest.fn().mockResolvedValue(undefined),
+      }),
+      getConnection: jest.fn().mockReturnValue({
+        insert: jest.fn().mockReturnValue({
+          into: jest.fn().mockResolvedValue(undefined),
+        }),
+        delete: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue(undefined),
+        }),
+        select: jest.fn().mockReturnValue({
+          from: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue([]),
+            where: jest.fn().mockResolvedValue(undefined),
+          }),
+        }),
+        truncate: jest.fn().mockResolvedValue(undefined),
+      }),
+    }) as any;
+
+  describe('hashSchema', () => {
+    it('matches regardless of table order', () => {
+      const storage = createSchemaStorage(mockDb());
+
+      const a: Schema = {
+        tables: [minimalTable('posts'), minimalTable('articles')],
+      };
+
+      const b: Schema = {
+        tables: [minimalTable('articles'), minimalTable('posts')],
+      };
+
+      expect(storage.hashSchema(a)).toBe(storage.hashSchema(b));
+    });
+
+    it('does not mutate the schema tables array', () => {
+      const storage = createSchemaStorage(mockDb());
+
+      const tables = [minimalTable('zebra'), minimalTable('alpha')];
+      const schema: Schema = { tables };
+
+      storage.hashSchema(schema);
+
+      expect(tables.map((t) => t.name)).toEqual(['zebra', 'alpha']);
+    });
+  });
+});

--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -68,7 +68,7 @@ export default (db: Database) => {
       // Sort tables by name for deterministic hashing regardless of insertion order
       const sorted = {
         ...schema,
-        tables: schema.tables.sort((a, b) => a.name.localeCompare(b.name)),
+        tables: schema.tables.toSorted((a, b) => a.name.localeCompare(b.name)),
       };
       return crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
     },

--- a/packages/core/database/src/schema/storage.ts
+++ b/packages/core/database/src/schema/storage.ts
@@ -65,7 +65,12 @@ export default (db: Database) => {
     },
 
     hashSchema(schema: Schema) {
-      return crypto.createHash('sha256').update(JSON.stringify(schema)).digest('hex');
+      // Sort tables by name for deterministic hashing regardless of insertion order
+      const sorted = {
+        ...schema,
+        tables: schema.tables.sort((a, b) => a.name.localeCompare(b.name)),
+      };
+      return crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
     },
 
     async add(schema: Schema) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Sort tables by name before hashing the schema to ensure deterministic hashing, and reduce schema checks during startup.

### Why is it needed?

The schema tables' order is not consistent over Strapi restarts. Making the caching of the check by hashing the schema inefficient.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
