### PR TITLE
fix: added guard against missing component schema in formatEditLayout

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -405,6 +405,54 @@ describe('useDocumentLayout', () => {
     expect(result.current.list.layout).toEqual(expectedListLayout);
   });
 
+  it('should skip components in the configuration that are missing from the schema dictionary', async () => {
+    // Simulates the nested relation modal bug (issue #26190): the configuration
+    // endpoint can return component UIDs that are not present in the components
+    // dictionary built from the init response (e.g. when a deeply nested relation
+    // modal is opened and the inner schema's component set diverges from what the
+    // config API returns). Without the guard, components[uid].attributes throws.
+    server.use(
+      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
+        return res(
+          ctx.json({
+            data: {
+              ...mockData.contentManager.collectionTypeConfiguration,
+              components: {
+                ...mockData.contentManager.collectionTypeConfiguration.components,
+                'page-blocks.orphan': {
+                  uid: 'page-blocks.orphan',
+                  category: 'page-blocks',
+                  settings: {
+                    bulkable: true,
+                    filterable: true,
+                    searchable: true,
+                    pageSize: 10,
+                    mainField: 'id',
+                    defaultSortBy: 'id',
+                    defaultSortOrder: 'ASC',
+                  },
+                  metadatas: {},
+                  layouts: { list: [], edit: [] },
+                  isComponent: true,
+                },
+              },
+            },
+          })
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useDocumentLayout(mockData.contentManager.contentType));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The orphan component (present in config but absent from schema dict) must be
+    // silently skipped — not throw and not appear in the output.
+    expect(result.current.edit.components['page-blocks.orphan']).toBeUndefined();
+    // Known components must still be resolved normally.
+    expect(result.current.edit.components['blog.test-como']).toBeDefined();
+  });
+
   it('should display an error should the configuration fail to fetch', async () => {
     server.use(
       rest.get('/content-manager/:collectionType/:model/configuration', (req, res, ctx) => {

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -285,17 +285,23 @@ const formatEditLayout = (
 
   const componentEditAttributes = Object.entries(data.components).reduce<EditLayout['components']>(
     (acc, [uid, configuration]) => {
+      const component = components[uid];
+
+      if (!component) {
+        return acc;
+      }
+
       acc[uid] = {
         layout: convertEditLayoutToFieldLayouts(
           configuration.layouts.edit,
-          components[uid].attributes,
+          component.attributes,
           configuration.metadatas,
           { configurations: data.components, schemas: components }
         ),
         settings: {
           ...configuration.settings,
-          icon: components[uid].info.icon,
-          displayName: components[uid].info.displayName,
+          icon: component.info.icon,
+          displayName: component.info.displayName,
         },
       };
       return acc;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Adds a null guard in `formatEditLayout` (`useDocumentLayout.ts`) before accessing `components[uid].attributes`. When iterating over `data.components` from the configuration API, any UID that is absent from the local `components` dictionary is now silently skipped instead of being processed. 

[26190-fix.webm](https://github.com/user-attachments/assets/c9b8038d-6c11-45a2-9a58-9d699dbf0ecd)

### Why is it needed?

When a second-level nested relation modal is opened (e.g. `Page -> relation -> Outer -> repeatable component -> relation -> Inner`), the configuration API returns `data.components` entries for the target content type that are not present in the `components` dictionary built by `extractContentTypeComponents`. Without the guard, `components[uid]` is `undefined` and accessing `.attributes` on it throws `TypeError: Cannot read properties of undefined (reading 'attributes')`, crashing the modal entirely.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #26190 
Fixes #26228
Fixes #26237
