### PR TITLE
fix(admin): surface server error body when responseType is not json

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -297,7 +297,7 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
         } catch {
           parsedError = {
             error: {
-              name: 'Error',
+              name: 'ApplicationError',
               message: text,
               status: response.status,
             },

--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -281,7 +281,29 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
   ): Promise<FetchResponse<TData>> => {
     if (responseType !== 'json') {
       if (!response.ok && !validateStatus?.(response.status)) {
-        const fetchError = new FetchError('Server Error');
+        // Strapi servers return a JSON error envelope (`{ error: { message, ... } }`)
+        // for failures regardless of the requested success responseType. Read the body
+        // and try to parse it so callers can surface the actual server-side message
+        // and payload via `error.response.data` instead of seeing only `'Server Error'`.
+        const text = await response.text();
+        let parsedError: ErrorResponse['data'] | undefined;
+        let message = 'Server Error';
+        try {
+          const parsed = text ? JSON.parse(text) : undefined;
+          if (parsed?.error?.message && typeof parsed.error.message === 'string') {
+            message = parsed.error.message;
+          }
+          parsedError = parsed;
+        } catch {
+          parsedError = {
+            error: {
+              name: 'Error',
+              message: text,
+              status: response.status,
+            },
+          };
+        }
+        const fetchError = new FetchError(message, parsedError ? { data: parsedError } : undefined);
         fetchError.status = response.status;
         throw fetchError;
       }

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -218,7 +218,7 @@ describe('getFetchClient', () => {
         name: 'FetchError',
         status: 502,
         message: 'Server Error',
-        response: { data: { error: { name: 'Error', message: 'Bad Gateway', status: 502 } } },
+        response: { data: { error: { name: 'ApplicationError', message: 'Bad Gateway', status: 502 } } },
       });
     });
 

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -162,6 +162,7 @@ describe('getFetchClient', () => {
         Promise.resolve({
           status: 404,
           ok: false,
+          text: () => Promise.resolve(''),
         })
       );
 
@@ -170,6 +171,54 @@ describe('getFetchClient', () => {
       await expect(fetchClient.get('/api/export', { responseType: 'blob' })).rejects.toMatchObject({
         name: 'FetchError',
         status: 404,
+      });
+    });
+
+    it('should surface a JSON server error envelope when responseType is non-json', async () => {
+      const errorBody = {
+        data: null,
+        error: {
+          status: 400,
+          name: 'BadRequestError',
+          message: 'Type is required',
+          details: {},
+        },
+      };
+
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 400,
+          ok: false,
+          text: () => Promise.resolve(JSON.stringify(errorBody)),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+
+      await expect(fetchClient.get('/lms/reports/download', { responseType: 'text' })).rejects.toMatchObject({
+        name: 'FetchError',
+        status: 400,
+        message: 'Type is required',
+        response: { data: errorBody },
+      });
+    });
+
+    it('should surface a plain-text server error body when responseType is non-json and body is not JSON', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 502,
+          ok: false,
+          text: () => Promise.resolve('Bad Gateway'),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+
+      await expect(fetchClient.get('/api/export', { responseType: 'blob' })).rejects.toMatchObject({
+        name: 'FetchError',
+        status: 502,
+        message: 'Server Error',
+        response: { data: { error: { name: 'Error', message: 'Bad Gateway', status: 502 } } },
       });
     });
 


### PR DESCRIPTION
Fixes #26199.

When `responseType` is `text`, `blob`, or `arrayBuffer`, the response interceptor used to throw `FetchError('Server Error')` without ever reading the response body, so callers had no way to see the actual error from the server. The Strapi API still serialises errors as JSON (`{ error: { message, ... } }`) regardless of the success `responseType`, so this PR reads the body, parses it as JSON when possible, and attaches it to the `FetchError` the same way the json branch does. When the body is not JSON the raw text is wrapped in the same envelope shape so `error.response.data.error.message` is always populated.

Verified the fix against the reproduction in the issue (a 400 from `/lms/reports/download` with `responseType: 'text'` now exposes the original `BadRequestError` message instead of `'Server Error'`). Added two tests in `getFetchClient.test.ts` covering the JSON-envelope and plain-text body cases, and updated the existing 404 blob test to mock `text()` so it keeps passing after the change.
