### PR TITLE
feat(upload, email): support provider modules as strapi factories

### DIFF
--- a/packages/core/email/server/src/bootstrap.ts
+++ b/packages/core/email/server/src/bootstrap.ts
@@ -19,9 +19,17 @@ interface EmailProviderModule {
   provider?: string;
 }
 
-const createProvider = (emailConfig: EmailConfig) => {
+const createProvider = async ({
+  strapi,
+  emailConfig,
+}: {
+  strapi: Core.Strapi;
+  emailConfig: EmailConfig;
+}) => {
   const providerName = emailConfig.provider.toLowerCase();
-  let provider: EmailProviderModule;
+  let providerModule:
+    | EmailProviderModule
+    | ((params: { strapi: Core.Strapi }) => Promise<EmailProviderModule>);
 
   let modulePath: string;
   try {
@@ -40,7 +48,7 @@ const createProvider = (emailConfig: EmailConfig) => {
   }
 
   try {
-    provider = require(modulePath);
+    providerModule = require(modulePath);
   } catch (err) {
     const newError = new Error(`Could not load email provider "${providerName}".`);
     if (err instanceof Error) {
@@ -48,6 +56,9 @@ const createProvider = (emailConfig: EmailConfig) => {
     }
     throw newError;
   }
+
+  const provider =
+    typeof providerModule === 'function' ? await providerModule({ strapi }) : providerModule;
 
   return provider.init(emailConfig.providerOptions, emailConfig.settings);
 };
@@ -63,7 +74,7 @@ export const bootstrap = async ({ strapi }: { strapi: Core.Strapi }) => {
     );
   }
 
-  strapi.plugin('email').provider = createProvider(emailConfig);
+  strapi.plugin('email').provider = await createProvider({ strapi, emailConfig });
 
   // Add permissions
   const actions = [

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -81,7 +81,7 @@
     "@types/koa__router": "12.0.0",
     "@types/node": "20.19.41",
     "@types/node-schedule": "2.1.7",
-    "eslint-config-custom": "workspace:*",
+    "eslint-config-custom": "5.52.2",
     "lodash": "4.18.1",
     "tsconfig": "5.52.2",
     "typescript": "5.9.3",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -81,7 +81,7 @@
     "@types/koa__router": "12.0.0",
     "@types/node": "20.19.41",
     "@types/node-schedule": "2.1.7",
-    "eslint-config-custom": "5.52.2",
+    "eslint-config-custom": "workspace:*",
     "lodash": "4.18.1",
     "tsconfig": "5.52.2",
     "typescript": "5.9.3",

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -127,10 +127,16 @@
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",
+    "@strapi/types": "^5.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.30.3",
     "styled-components": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@strapi/types": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",

--- a/packages/core/upload/server/src/index.ts
+++ b/packages/core/upload/server/src/index.ts
@@ -1,6 +1,3 @@
-import type {} from 'koa-body';
-import type {} from '@strapi/types';
-
 import { register } from './register';
 import { bootstrap } from './bootstrap';
 import { contentTypes } from './content-types';

--- a/packages/core/upload/server/src/register.ts
+++ b/packages/core/upload/server/src/register.ts
@@ -33,7 +33,7 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   sharp.cache(cache);
   sharp.concurrency(concurrency);
 
-  strapi.plugin('upload').provider = createProvider(uploadConfig);
+  strapi.plugin('upload').provider = await createProvider({ strapi, config: uploadConfig });
 
   await registerUploadMiddleware({ strapi });
 
@@ -53,11 +53,17 @@ export async function register({ strapi }: { strapi: Core.Strapi }) {
   }
 }
 
-const createProvider = (config: Config) => {
+type UploadProvider = {
+  init: (config: Record<string, unknown>) => Record<string, any>;
+};
+
+const createProvider = async ({ strapi, config }: { strapi: Core.Strapi; config: Config }) => {
   const { providerOptions, actionOptions = {} } = config;
 
   const providerName = _.toLower(config.provider);
-  let provider;
+  let providerModule:
+    | UploadProvider
+    | ((params: { strapi: Core.Strapi }) => Promise<UploadProvider>);
 
   let modulePath;
   try {
@@ -76,7 +82,7 @@ const createProvider = (config: Config) => {
   }
 
   try {
-    provider = require(modulePath);
+    providerModule = require(modulePath);
   } catch (err) {
     const newError = new Error(`Could not load upload provider "${providerName}".`);
 
@@ -86,6 +92,9 @@ const createProvider = (config: Config) => {
 
     throw newError;
   }
+
+  const provider =
+    typeof providerModule === 'function' ? await providerModule({ strapi }) : providerModule;
 
   const providerInstance = provider.init(providerOptions);
 

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -59,6 +59,14 @@
     "vitest": "catalog:",
     "vitest-config": "5.52.2"
   },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@strapi/types": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",
     "npm": ">=6.0.0"

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -59,6 +59,14 @@
     "vitest": "catalog:",
     "vitest-config": "5.52.3"
   },
+  "peerDependencies": {
+    "@strapi/types": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@strapi/types": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=20.0.0 <=26.x.x",
     "npm": ">=6.0.0"

--- a/packages/providers/upload-local/src/index.ts
+++ b/packages/providers/upload-local/src/index.ts
@@ -4,9 +4,6 @@ import path from 'path';
 import fse from 'fs-extra';
 import * as utils from '@strapi/utils';
 
-// Needed to load global.strapi without having to put @strapi/types in the regular dependencies
-import type {} from '@strapi/types';
-
 interface File {
   name: string;
   alternativeText?: string;

--- a/packages/providers/upload-local/tsconfig.json
+++ b/packages/providers/upload-local/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["src", "vitest.config.ts"],
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "@strapi/types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10066,7 +10066,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     "@types/node-schedule": "npm:2.1.7"
     commander: "npm:8.3.0"
-    eslint-config-custom: "npm:5.52.2"
+    eslint-config-custom: "workspace:*"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
@@ -16994,7 +16994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-custom@npm:5.52.2, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
+"eslint-config-custom@npm:5.52.2, eslint-config-custom@workspace:*, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
   version: 0.0.0-use.local
   resolution: "eslint-config-custom@workspace:packages/utils/eslint-config-custom"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -9910,6 +9910,11 @@ __metadata:
     tsconfig: "npm:5.52.2"
     vitest: "catalog:"
     vitest-config: "npm:5.52.2"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
+  peerDependenciesMeta:
+    "@strapi/types":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -10066,7 +10071,7 @@ __metadata:
     "@types/node": "npm:20.19.41"
     "@types/node-schedule": "npm:2.1.7"
     commander: "npm:8.3.0"
-    eslint-config-custom: "workspace:*"
+    eslint-config-custom: "npm:5.52.2"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
@@ -10225,10 +10230,14 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
+    "@strapi/types": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
+  peerDependenciesMeta:
+    "@strapi/types":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -16994,7 +17003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-custom@npm:5.52.2, eslint-config-custom@workspace:*, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
+"eslint-config-custom@npm:5.52.2, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
   version: 0.0.0-use.local
   resolution: "eslint-config-custom@workspace:packages/utils/eslint-config-custom"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -9930,6 +9930,11 @@ __metadata:
     tsconfig: "npm:5.52.3"
     vitest: "catalog:"
     vitest-config: "npm:5.52.3"
+  peerDependencies:
+    "@strapi/types": ^5.0.0
+  peerDependenciesMeta:
+    "@strapi/types":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -10242,10 +10247,14 @@ __metadata:
     zod: "npm:4.4.3"
   peerDependencies:
     "@strapi/admin": ^5.0.0
+    "@strapi/types": ^5.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.30.3
     styled-components: ^6.0.0
+  peerDependenciesMeta:
+    "@strapi/types":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### What does it do?

Lets upload and email provider modules export a **factory** — a function `({ strapi }) => provider` — instead of only a plain object. Plain-object provider modules keep working exactly as before; the factory form is detected at load time.

- `packages/core/upload/server/src/register.ts`: `createProvider` becomes `async` and takes `{ strapi, config }`. After `require(modulePath)`, if the module is a function it is awaited with `{ strapi }` before `init(providerOptions)` is called. A local `UploadProvider` type replaces the previously untyped `provider` variable.
- `packages/core/email/server/src/bootstrap.ts`: same change for email — `createProvider({ strapi, emailConfig })` is now `async` and awaits the factory form before calling `init(...)`. `bootstrap` awaits it.
- `@strapi/upload` and `@strapi/provider-upload-local` declare `@strapi/types` as an **optional** peer dependency (`peerDependenciesMeta.optional: true`), so the ambient `strapi` global typing is available to consumers without adding a runtime dependency.
- `packages/providers/upload-local/tsconfig.json` picks those types up via `types: ["node", "@strapi/types"]` instead of the `import type {} from '@strapi/types'` side-effect import in `src/index.ts`.
- `packages/core/upload/server/src/index.ts` drops its unused `koa-body` and `@strapi/types` side-effect type imports (nothing in that package references `ctx.request.files`).

Scope note: this PR only adds the *consumer* side. No bundled provider is converted to a factory here, so `@strapi/provider-upload-local` still reads the `strapi` global; converting first-party providers is follow-up work.

### Why is it needed?

Provider modules currently have no way to receive the `strapi` instance. The only way to reach it is the `global.strapi` global, which forces providers to depend on `@strapi/types` purely for the ambient global augmentation, and makes them untestable without setting up that global. Supporting the factory form gives providers dependency injection — the same pattern already used for controllers, services, and `core/factories.ts` — and is the prerequisite for removing `global.strapi` usage from first-party providers.

### How to test it?

Verified locally:

- [x] `yarn workspace @strapi/upload test:ts:back`
- [x] `yarn workspace @strapi/provider-upload-local test:ts`
- [x] `yarn workspace @strapi/provider-upload-local test:unit:vitest` (3 passed)

Manual check in `examples/getstarted` — set `config/plugins.js` upload provider to a local module exporting `({ strapi }) => ({ init: () => ({ upload, uploadStream, delete: ... }) })` and confirm it boots and uploads; then switch the same module back to a plain object export and confirm it still boots.

### Related issue(s)/PR(s)

Related: #26544 (centralising the `koa-body` / `@strapi/types` module-augmentation imports).
