### PR TITLE
fix(core/core): validation uses injected strapi instance

### DIFF
--- a/packages/core/core/src/core-api/routes/validation/attributes.ts
+++ b/packages/core/core/src/core-api/routes/validation/attributes.ts
@@ -5,7 +5,7 @@
  * of incoming data.
  */
 
-import { type Schema, UID } from '@strapi/types';
+import { type Core, type Schema, UID } from '@strapi/types';
 
 import {
   relations,
@@ -75,11 +75,13 @@ export const booleanToSchema = (attribute: Schema.Attribute.Boolean): z.Schema =
  * @returns A Zod schema representing the component field.
  */
 export const componentToSchema = (
+  strapi: Core.Strapi,
   attribute: Schema.Attribute.Component<UID.Component, boolean>
 ): z.Schema => {
   const { writable, required, min, max, component, repeatable } = attribute;
 
   const componentSchema = safeSchemaCreation(
+    strapi,
     component,
     () => new CoreComponentRouteValidator(strapi, component).entry
   ) as z.ZodType;
@@ -267,6 +269,7 @@ export const jsonToSchema = (attribute: Schema.Attribute.JSON): z.Schema => {
  * @returns A Zod schema representing the media field.
  */
 export const mediaToSchema = (
+  strapi: Core.Strapi,
   attribute: Schema.Attribute.Media<Schema.Attribute.MediaKind | undefined, boolean>
 ): z.Schema => {
   const { writable, required, multiple } = attribute;
@@ -277,6 +280,7 @@ export const mediaToSchema = (
   const fileSchema = uploadPlugin.contentTypes.file as Struct.ContentTypeSchema;
 
   const mediaSchema = safeSchemaCreation(
+    strapi,
     fileSchema.uid,
     () => new CoreContentTypeRouteValidator(strapi, fileSchema.uid).document
   ) as z.ZodType;
@@ -293,7 +297,10 @@ export const mediaToSchema = (
  * @param attribute - The Relation attribute object from the Strapi schema.
  * @returns A Zod schema representing the relational field.
  */
-export const relationToSchema = (attribute: Schema.Attribute.Relation): z.Schema => {
+export const relationToSchema = (
+  strapi: Core.Strapi,
+  attribute: Schema.Attribute.Relation
+): z.Schema => {
   if (!('target' in attribute)) {
     return z.any();
   }
@@ -301,6 +308,7 @@ export const relationToSchema = (attribute: Schema.Attribute.Relation): z.Schema
   const { writable, required, target } = attribute as Schema.Attribute.RelationWithTarget;
 
   const targetSchema = safeSchemaCreation(
+    strapi,
     target,
     () => new CoreContentTypeRouteValidator(strapi, target).document
   ) as z.ZodType;

--- a/packages/core/core/src/core-api/routes/validation/component.ts
+++ b/packages/core/core/src/core-api/routes/validation/component.ts
@@ -38,6 +38,6 @@ export class CoreComponentRouteValidator extends AbstractCoreRouteValidator<UID.
 
     const entries = Object.entries({ ..._scalarFields, ..._populatableFields });
 
-    return createAttributesSchema(entries);
+    return createAttributesSchema(this._strapi, entries);
   }
 }

--- a/packages/core/core/src/core-api/routes/validation/content-type.ts
+++ b/packages/core/core/src/core-api/routes/validation/content-type.ts
@@ -74,7 +74,7 @@ export class CoreContentTypeRouteValidator extends AbstractCoreRouteValidator<UI
       .filter(([, attribute]) => !['password'].includes(attribute.type));
 
     // Merge all attributes into a single schema
-    const attributesSchema = createAttributesSchema(sanitizedAttributes);
+    const attributesSchema = createAttributesSchema(this._strapi, sanitizedAttributes);
 
     return z
       .object({
@@ -185,7 +185,7 @@ export class CoreContentTypeRouteValidator extends AbstractCoreRouteValidator<UI
       // Remove non-writable attributes
       .filter(isWritableAttribute);
 
-    return createAttributesInputSchema(sanitizedAttributes);
+    return createAttributesInputSchema(this._strapi, sanitizedAttributes);
   }
 
   get query() {

--- a/packages/core/core/src/core-api/routes/validation/mappers.ts
+++ b/packages/core/core/src/core-api/routes/validation/mappers.ts
@@ -3,7 +3,7 @@
  * This file contains functions responsible for mapping Strapi attribute definitions to Zod schemas.
  */
 
-import type { Schema } from '@strapi/types';
+import type { Core, Schema } from '@strapi/types';
 import * as z from 'zod/v4';
 
 // eslint-disable-next-line import/no-cycle
@@ -38,12 +38,13 @@ const isCustomFieldAttribute = (
  * ```
  */
 export const createAttributesSchema = (
+  strapi: Core.Strapi,
   attributes: [name: string, attribute: Schema.Attribute.AnyAttribute][]
 ) => {
   return attributes.reduce((acc, [name, attribute]) => {
     return acc.extend({
       get [name]() {
-        return mapAttributeToSchema(attribute);
+        return mapAttributeToSchema(strapi, attribute);
       },
     });
   }, z.object({}));
@@ -68,12 +69,13 @@ export const createAttributesSchema = (
  * ```
  */
 export const createAttributesInputSchema = (
+  strapi: Core.Strapi,
   attributes: [name: string, attribute: Schema.Attribute.AnyAttribute][]
 ) => {
   return attributes.reduce((acc, [name, attribute]) => {
     return acc.extend({
       get [name]() {
-        return mapAttributeToInputSchema(attribute);
+        return mapAttributeToInputSchema(strapi, attribute);
       },
     });
   }, z.object({}));
@@ -98,7 +100,10 @@ export const createAttributesInputSchema = (
  * const booleanSchema = mapAttributeToSchema(booleanAttribute); // Returns a Zod boolean schema with a default.
  * ```
  */
-export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): z.ZodTypeAny => {
+export const mapAttributeToSchema = (
+  strapi: Core.Strapi,
+  attribute: Schema.Attribute.AnyAttribute
+): z.ZodTypeAny => {
   switch (attribute.type) {
     case 'biginteger':
       return attributes.bigIntegerToSchema(attribute);
@@ -107,7 +112,7 @@ export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): 
     case 'boolean':
       return attributes.booleanToSchema(attribute);
     case 'component':
-      return attributes.componentToSchema(attribute);
+      return attributes.componentToSchema(strapi, attribute);
     case 'date':
       return attributes.dateToSchema(attribute);
     case 'datetime':
@@ -127,9 +132,9 @@ export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): 
     case 'json':
       return attributes.jsonToSchema(attribute);
     case 'media':
-      return attributes.mediaToSchema(attribute);
+      return attributes.mediaToSchema(strapi, attribute);
     case 'relation':
-      return attributes.relationToSchema(attribute);
+      return attributes.relationToSchema(strapi, attribute);
     case 'password':
     case 'text':
     case 'richtext':
@@ -144,18 +149,13 @@ export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): 
     default: {
       if (isCustomFieldAttribute(attribute)) {
         const attrCF = attribute as { type: 'customField'; customField: string };
-        const strapiInstance = global.strapi;
-        if (!strapiInstance) {
-          throw new Error('Strapi instance not available for custom field conversion');
-        }
-
-        const customField = strapiInstance.get('custom-fields').get(attrCF.customField);
+        const customField = strapi.get('custom-fields').get(attrCF.customField);
         if (!customField) {
           throw new Error(`Custom field '${attrCF.customField}' not found`);
         }
 
         // Re-dispatch with the resolved underlying Strapi kind
-        return mapAttributeToSchema({ ...attrCF, type: customField.type });
+        return mapAttributeToSchema(strapi, { ...attrCF, type: customField.type });
       }
 
       const { type } = attribute as Schema.Attribute.AnyAttribute;
@@ -206,6 +206,7 @@ export const mapAttributeToSchema = (attribute: Schema.Attribute.AnyAttribute): 
  *
  */
 export const mapAttributeToInputSchema = (
+  strapi: Core.Strapi,
   attribute: Schema.Attribute.AnyAttribute
 ): z.ZodTypeAny => {
   switch (attribute.type) {
@@ -253,18 +254,13 @@ export const mapAttributeToInputSchema = (
     default: {
       if (isCustomFieldAttribute(attribute)) {
         const attrCF = attribute as { type: 'customField'; customField: string };
-        const strapiInstance = global.strapi;
-        if (!strapiInstance) {
-          throw new Error('Strapi instance not available for custom field conversion');
-        }
-
-        const customField = strapiInstance.get('custom-fields').get(attrCF.customField);
+        const customField = strapi.get('custom-fields').get(attrCF.customField);
         if (!customField) {
           throw new Error(`Custom field '${attrCF.customField}' not found`);
         }
 
         // Re-dispatch with the resolved underlying Strapi kind
-        return mapAttributeToInputSchema({ ...attrCF, type: customField.type });
+        return mapAttributeToInputSchema(strapi, { ...attrCF, type: customField.type });
       }
 
       const { type } = attribute as Schema.Attribute.AnyAttribute;

--- a/packages/core/core/src/core-api/routes/validation/utils.ts
+++ b/packages/core/core/src/core-api/routes/validation/utils.ts
@@ -1,5 +1,5 @@
 import { transformUidToValidOpenApiName } from '@strapi/utils';
-import type { Internal } from '@strapi/types';
+import type { Core, Internal } from '@strapi/types';
 import * as z from 'zod/v4';
 
 // Schema generation happens on-demand when schemas don't exist in the registry
@@ -18,7 +18,11 @@ import * as z from 'zod/v4';
  * safeGlobalRegistrySet("mySchema", z.object({ name: z.string() }));
  * ```
  */
-export const safeGlobalRegistrySet = (id: Internal.UID.Schema, schema: z.ZodType) => {
+export const safeGlobalRegistrySet = (
+  strapi: Core.Strapi,
+  id: Internal.UID.Schema,
+  schema: z.ZodType
+) => {
   try {
     const { _idmap: idMap } = z.globalRegistry;
 
@@ -31,7 +35,6 @@ export const safeGlobalRegistrySet = (id: Internal.UID.Schema, schema: z.ZodType
       idMap.delete(transformedId);
     }
 
-    // Register the new schema with the transformed ID
     strapi.log.debug(
       `${isReplacing ? 'Replacing' : 'Registering'} schema ${transformedId} in global registry`
     );
@@ -73,7 +76,11 @@ export const safeGlobalRegistrySet = (id: Internal.UID.Schema, schema: z.ZodType
  * );
  * ```
  */
-export const safeSchemaCreation = (id: Internal.UID.Schema, callback: () => z.ZodType) => {
+export const safeSchemaCreation = (
+  strapi: Core.Strapi,
+  id: Internal.UID.Schema,
+  callback: () => z.ZodType
+) => {
   try {
     const { _idmap: idMap } = z.globalRegistry;
 
@@ -92,10 +99,8 @@ export const safeSchemaCreation = (id: Internal.UID.Schema, callback: () => z.Zo
     const isBuiltInSchema = id.startsWith('plugin::') || id.startsWith('admin');
 
     if (isBuiltInSchema) {
-      // Built-in schemas keep at debug level to avoid clutter
       strapi.log.debug(`Initializing validation schema for ${transformedId}`);
     } else {
-      // User content
       const schemaName = transformedId
         .replace('Document', '')
         .replace('Entry', '')
@@ -106,13 +111,13 @@ export const safeSchemaCreation = (id: Internal.UID.Schema, callback: () => z.Zo
 
     // Temporary any placeholder before replacing with the actual schema type
     // Used to prevent infinite loops in cyclical data structures
-    safeGlobalRegistrySet(id, z.any());
+    safeGlobalRegistrySet(strapi, id, z.any());
 
     // Generate the actual schema using the callback
     const schema = callback();
 
     // Replace the placeholder with the real schema
-    safeGlobalRegistrySet(id, schema);
+    safeGlobalRegistrySet(strapi, id, schema);
 
     // Show completion for user content only
     if (!isBuiltInSchema) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Eliminates all `global.strapi` usages in the validation module (`packages/core/core/src/core-api/routes/validation/`) by threading the Strapi instance via explicit function parameters:

- `utils.ts` — `safeGlobalRegistrySet(strapi, id, schema)` and `safeSchemaCreation(strapi, id, callback)` gain `strapi: Core.Strapi` as first param; 8 bare `strapi.log.*` calls now use the injected instance.
- `attributes.ts` — `componentToSchema`, `mediaToSchema`, and `relationToSchema` gain `strapi: Core.Strapi` as first param and forward it into `safeSchemaCreation` and validator constructors.
- `mappers.ts` — All four public functions (`mapAttributeToSchema`, `mapAttributeToInputSchema`, `createAttributesSchema`, `createAttributesInputSchema`) gain `strapi: Core.Strapi` as first param; both `customField` default branches resolve the instance from the injected param instead of `global.strapi`.
- `content-type.ts` and `component.ts` — Call sites updated to pass `this._strapi` (already available from `AbstractCoreRouteValidator`).

### Why is it needed?

Relying on `global.strapi` is an anti-pattern in this codebase: it makes the code harder to test in isolation, bypasses the established DI convention (`strapi` injected via factory/constructor), and creates implicit hidden dependencies. `AbstractCoreRouteValidator` already held `this._strapi` — this change propagates it consistently downward through the call chain.

### How to test it?

No behaviour change is expected. Verify with:

```bash
# Type-check the affected package
yarn nx build @strapi/core --skip-nx-cache

# Unit tests
yarn test:unit

# Start the dev sandbox and exercise content-type routes to confirm validation still works
cd examples/getstarted && yarn develop
# Then create/update a document via the admin or REST API and confirm no validation regressions
```

### Related issue(s)/PR(s)

ø
