### PR TITLE
fix(test): check button attribute differently

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/Field.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/Field.test.tsx
@@ -15,12 +15,57 @@ jest.mock('../../../InputRenderer', () => ({
   InputRenderer: () => 'INPUTS',
 }));
 
+const useDocMock = jest.fn();
+const useDocumentMock = jest.fn();
+
+jest.mock('../../../../../../hooks/useDocument', () => ({
+  useDoc: (...args: unknown[]) => useDocMock(...args),
+  useDocument: (...args: unknown[]) => useDocumentMock(...args),
+}));
+
+jest.mock('../../../../../../hooks/useDocumentLayout', () => ({
+  useDocumentLayout: () => ({
+    edit: {
+      components: {
+        'blog.test-como': { settings: { mainField: 'name' } },
+      },
+    },
+  }),
+}));
+
 jest.mock('@strapi/admin/strapi-admin', () => ({
   ...jest.requireActual('@strapi/admin/strapi-admin'),
   useIsDesktop: jest.fn().mockReturnValue(true),
 }));
 
 describe('DynamicZone', () => {
+  beforeEach(() => {
+    // Keep DocumentContext deterministic by avoiding RTK-query / schema fetch timing.
+    useDocMock.mockReturnValue({
+      collectionType: 'collectionType',
+      model: 'api::address.address',
+      id: 'create',
+    });
+
+    useDocumentMock.mockReturnValue({
+      isLoading: false,
+      components: {
+        'blog.test-como': {
+          category: 'blog',
+          info: { displayName: 'test comp' },
+          attributes: {
+            name: { type: 'string', default: 'toto' },
+          },
+        },
+        'seo.metadata': {
+          category: 'seo',
+          info: { displayName: 'metadata' },
+          attributes: {},
+        },
+      },
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -61,9 +106,9 @@ describe('DynamicZone', () => {
   });
 
   const waitForQueryToFinish = async () => {
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: /Add a component to/i })).toBeEnabled()
-    );
+    // Wait for the button to be rendered (DocumentContext is mocked to be "ready").
+    const addComponentButton = await screen.findByRole('button', { name: /Add a component to/i });
+    expect(addComponentButton).toBeEnabled();
   };
 
   describe('rendering', () => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
Update the `Field.test.tsx` to avoid flakiness. Made the test not depend on RTK-query timing by mocking `useDoc` + `useDocument` (from `hooks/useDocument`) so `useDocumentContext()` always gets a `currentDocument` with:
* `isLoading: false` (so “Add a component to…” is enabled immediately)
* a minimal `components` dictionary for the UIDs used in the test
* `blog.test-como` includes a name attribute defaulting to 'toto' so the existing assertions still pass.

I also mocked `useDocumentLayout` so `DynamicComponent` uses `mainField: 'name'`, keeping the `test comp - test` label stable, and finally updated `waitForQueryToFinish()` to simply wait for the button to exist and then assert it’s enabled (no timeouts, no polling on async queries).

### Why is it needed?
The CI-only flake is due to the button staying disabled because document/schema queries are slow.

### How to test it?
The flake only happened on the CI, the test passes locally. 
