### PR TITLE
fix(content-manager): prevent single-type switch crashes and refresh schema after CTB updates

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -520,6 +520,80 @@ describe('useDocumentLayout', () => {
 
     expect(result.current.edit.components).toEqual({});
   });
+
+  it('waits for the active model configuration when switching single types and handles missing component settings safely (regression gh#26206)', async () => {
+    const firstModelUid = 'api::homepage.homepage';
+    const secondModelUid = 'api::address.address';
+
+    server.use(
+      rest.get('/content-manager/init', (req, res, ctx) =>
+        res(
+          ctx.json({
+            data: {
+              components: mockData.contentManager.components,
+              contentTypes: mockData.contentManager.contentTypes,
+            },
+          })
+        )
+      ),
+      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
+        if (req.params.model === firstModelUid) {
+          return res(ctx.json({ data: mockData.contentManager.singleTypeConfiguration }));
+        }
+
+        if (req.params.model === secondModelUid) {
+          return res(
+            ctx.delay(75),
+            ctx.json({
+              data: {
+                contentType: {
+                  uid: secondModelUid,
+                  settings: {
+                    bulkable: true,
+                    filterable: true,
+                    searchable: true,
+                    pageSize: 10,
+                    mainField: 'id',
+                    defaultSortBy: 'id',
+                    defaultSortOrder: 'ASC',
+                  },
+                  metadatas:
+                    mockData.contentManager.collectionTypeConfiguration.contentType.metadatas,
+                  options: {},
+                  layouts: {
+                    edit: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
+                      .edit,
+                    list: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
+                      .list,
+                  },
+                },
+                // Simulate mismatch where component settings map is not ready/available yet.
+                components: {},
+              },
+            })
+          );
+        }
+
+        return res(ctx.json({ data: mockData.contentManager.collectionTypeConfiguration }));
+      })
+    );
+
+    const { result, rerender } = renderHook(({ model }) => useDocumentLayout(model), {
+      initialProps: { model: firstModelUid },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    rerender({ model: secondModelUid });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.edit.layout).toEqual([]);
+    expect(result.current.edit.components).toEqual({});
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.edit.settings.displayName).toBe('Address');
+    expect(result.current.edit.layout.length).toBeGreaterThan(0);
+  });
 });
 
 describe('extractContentTypeComponents', () => {
@@ -528,7 +602,7 @@ describe('extractContentTypeComponents', () => {
       footer: {
         type: 'component' as const,
         repeatable: false,
-        component: 'missing.catalog.component',
+        component: 'missing.catalog.component' as const,
         pluginOptions: {},
         required: false,
       },

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -583,12 +583,12 @@ describe('useDocumentLayout', () => {
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const firstModelLayout = result.current.edit.layout;
 
     rerender({ model: secondModelUid });
 
     expect(result.current.isLoading).toBe(true);
-    expect(result.current.edit.layout).toEqual([]);
-    expect(result.current.edit.components).toEqual({});
+    expect(result.current.edit.layout).toEqual(firstModelLayout);
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.edit.settings.displayName).toBe('Address');

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -583,12 +583,13 @@ describe('useDocumentLayout', () => {
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    const firstModelLayout = result.current.edit.layout;
 
     rerender({ model: secondModelUid });
 
     expect(result.current.isLoading).toBe(true);
-    expect(result.current.edit.layout).toEqual(firstModelLayout);
+    // While switching to a model with no cached layout we surface the
+    // empty default rather than bleeding the previous model's layout.
+    expect(result.current.edit.layout).toEqual([]);
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.edit.settings.displayName).toBe('Address');

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -3,6 +3,7 @@ import { renderHook, screen, server, waitFor } from '@tests/utils';
 import { rest } from 'msw';
 
 import { mockData } from '../../../tests/mockData';
+import { extractContentTypeComponents } from '../useContentTypeSchema';
 import { useDocumentLayout } from '../useDocumentLayout';
 
 describe('useDocumentLayout', () => {
@@ -422,5 +423,117 @@ describe('useDocumentLayout', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     await screen.findByText('Error fetching configuration');
+  });
+
+  it('does not crash when persisted configuration references component layouts without matching `/init` schemas (regression gh#26206)', async () => {
+    const orphanModelUid = 'api::orphan.footer';
+
+    server.use(
+      rest.get('/content-manager/init', (req, res, ctx) =>
+        res(
+          ctx.json({
+            data: {
+              components: mockData.contentManager.components,
+              contentTypes: [
+                ...mockData.contentManager.contentTypes,
+                {
+                  uid: orphanModelUid,
+                  isDisplayed: true,
+                  apiID: 'footer',
+                  kind: 'singleType',
+                  info: {
+                    singularName: 'footer',
+                    pluralName: 'footers',
+                    displayName: 'Footer',
+                    name: 'Footer',
+                    description: '',
+                  },
+                  options: {},
+                  pluginOptions: {},
+                  attributes: {},
+                },
+              ],
+            },
+          })
+        )
+      ),
+      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
+        if (req.params.model !== orphanModelUid) {
+          const configuration =
+            req.params.model === 'api::homepage.homepage'
+              ? mockData.contentManager.singleTypeConfiguration
+              : mockData.contentManager.collectionTypeConfiguration;
+
+          return res(ctx.json({ data: configuration }));
+        }
+
+        return res(
+          ctx.json({
+            data: {
+              contentType: {
+                uid: orphanModelUid,
+                settings: {
+                  bulkable: false,
+                  filterable: false,
+                  searchable: false,
+                  pageSize: 10,
+                  mainField: 'title',
+                  defaultSortBy: '',
+                  defaultSortOrder: 'ASC',
+                },
+                metadatas: {},
+                options: {},
+                layouts: {
+                  edit: [],
+                  list: [],
+                },
+              },
+              components: {
+                'orphan.ghost': {
+                  layouts: {
+                    edit: [[{ name: 'field', size: 12 }]],
+                  },
+                  metadatas: {
+                    field: {
+                      edit: {
+                        label: 'field',
+                        description: '',
+                        placeholder: '',
+                        visible: true,
+                        editable: true,
+                      },
+                    },
+                  },
+                  settings: {},
+                  isComponent: true,
+                },
+              },
+            },
+          })
+        );
+      })
+    );
+
+    const { result } = renderHook(() => useDocumentLayout(orphanModelUid));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.edit.components).toEqual({});
+  });
+});
+
+describe('extractContentTypeComponents', () => {
+  it('omits component UIDs that are referenced but missing from the catalog', () => {
+    const attributes = {
+      footer: {
+        type: 'component' as const,
+        repeatable: false,
+        component: 'missing.catalog.component',
+        pluginOptions: {},
+        required: false,
+      },
+    };
+
+    expect(extractContentTypeComponents(attributes, {})).toEqual({});
   });
 });

--- a/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
+++ b/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
@@ -12,8 +12,6 @@ import type { Schema } from '@strapi/types';
  * useContentTypeSchema
  * -----------------------------------------------------------------------------------------------*/
 type ComponentsDictionary = Record<string, Component>;
-const CONTENT_MANAGER_SCHEMA_VERSION_KEY = 'STRAPI_CONTENT_MANAGER_SCHEMA_VERSION';
-let lastKnownSchemaVersion: string | null = null;
 
 /**
  * @internal
@@ -28,7 +26,7 @@ const useContentTypeSchema = (model?: string) => {
   const { toggleNotification } = useNotification();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
 
-  const { data, error, isLoading, isFetching, refetch } = useGetInitialDataQuery(undefined);
+  const { data, error, isLoading, isFetching } = useGetInitialDataQuery(undefined);
 
   const { components, contentType, contentTypes } = React.useMemo(() => {
     const contentType = data?.contentTypes.find((ct) => ct.uid === model);
@@ -56,19 +54,6 @@ const useContentTypeSchema = (model?: string) => {
       });
     }
   }, [toggleNotification, error, formatAPIError]);
-
-  React.useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const schemaVersion = window.localStorage.getItem(CONTENT_MANAGER_SCHEMA_VERSION_KEY);
-
-    if (schemaVersion && schemaVersion !== lastKnownSchemaVersion) {
-      lastKnownSchemaVersion = schemaVersion;
-      void refetch();
-    }
-  }, [refetch]);
 
   return {
     // This must be memoized to avoid inifiinite re-renders where the empty object is different everytime.

--- a/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
+++ b/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
@@ -113,7 +113,10 @@ const extractContentTypeComponents = (
   const uniqueComponentUids = [...new Set(componentUids)];
 
   const componentsByKey = uniqueComponentUids.reduce<ComponentsDictionary>((acc, uid) => {
-    acc[uid] = allComponents[uid];
+    const component = allComponents[uid];
+    if (component) {
+      acc[uid] = component;
+    }
 
     return acc;
   }, {});

--- a/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
+++ b/packages/core/content-manager/admin/src/hooks/useContentTypeSchema.ts
@@ -12,6 +12,8 @@ import type { Schema } from '@strapi/types';
  * useContentTypeSchema
  * -----------------------------------------------------------------------------------------------*/
 type ComponentsDictionary = Record<string, Component>;
+const CONTENT_MANAGER_SCHEMA_VERSION_KEY = 'STRAPI_CONTENT_MANAGER_SCHEMA_VERSION';
+let lastKnownSchemaVersion: string | null = null;
 
 /**
  * @internal
@@ -26,7 +28,7 @@ const useContentTypeSchema = (model?: string) => {
   const { toggleNotification } = useNotification();
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
 
-  const { data, error, isLoading, isFetching } = useGetInitialDataQuery(undefined);
+  const { data, error, isLoading, isFetching, refetch } = useGetInitialDataQuery(undefined);
 
   const { components, contentType, contentTypes } = React.useMemo(() => {
     const contentType = data?.contentTypes.find((ct) => ct.uid === model);
@@ -54,6 +56,19 @@ const useContentTypeSchema = (model?: string) => {
       });
     }
   }, [toggleNotification, error, formatAPIError]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const schemaVersion = window.localStorage.getItem(CONTENT_MANAGER_SCHEMA_VERSION_KEY);
+
+    if (schemaVersion && schemaVersion !== lastKnownSchemaVersion) {
+      lastKnownSchemaVersion = schemaVersion;
+      void refetch();
+    }
+  }, [refetch]);
 
   return {
     // This must be memoized to avoid inifiinite re-renders where the empty object is different everytime.

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -285,17 +285,24 @@ const formatEditLayout = (
 
   const componentEditAttributes = Object.entries(data.components).reduce<EditLayout['components']>(
     (acc, [uid, configuration]) => {
+      const componentSchema = components[uid];
+
+      // Persisted configuration can reference component UIDs absent from `/init`.
+      if (!componentSchema) {
+        return acc;
+      }
+
       acc[uid] = {
         layout: convertEditLayoutToFieldLayouts(
           configuration.layouts.edit,
-          components[uid].attributes,
+          componentSchema.attributes,
           configuration.metadatas,
           { configurations: data.components, schemas: components }
         ),
         settings: {
           ...configuration.settings,
-          icon: components[uid].info.icon,
-          displayName: components[uid].info.displayName,
+          icon: componentSchema.info.icon,
+          displayName: componentSchema.info.displayName,
         },
       };
       return acc;

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -159,9 +159,14 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { isLoading: isLoadingSchemas, schemas } = useContentTypeSchema();
 
-  const { data, isLoading: isLoadingConfigs, error } = useGetContentTypeConfigurationQuery(model);
+  const {
+    currentData: data,
+    isLoading: isLoadingConfigs,
+    error,
+  } = useGetContentTypeConfigurationQuery(model);
 
-  const isLoading = isLoadingSchemas || isLoadingConfigs;
+  const isConfigResolvedForModel = data?.contentType?.uid === model;
+  const isLoading = isLoadingSchemas || isLoadingConfigs || (!error && !isConfigResolvedForModel);
 
   React.useEffect(() => {
     if (error) {
@@ -369,7 +374,7 @@ const convertEditLayoutToFieldLayouts = (
 
         const settings: Partial<Settings> =
           attribute.type === 'component' && components
-            ? components.configurations[attribute.component].settings
+            ? (components.configurations[attribute.component]?.settings ?? {})
             : {};
 
         return {
@@ -478,7 +483,7 @@ const convertListLayoutToFieldLayouts = (
 
       const settings: Partial<Settings> =
         attribute.type === 'component' && components
-          ? components.configurations[attribute.component].settings
+          ? (components.configurations[attribute.component]?.settings ?? {})
           : {};
 
       return {

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -331,7 +331,7 @@ const formatEditLayout = (
     metadatas: editMetadatas,
     settings: {
       ...data.contentType.settings,
-      displayName: schema?.info.displayName,
+      displayName: schema?.info?.displayName,
     },
     options: {
       ...schema?.options,
@@ -370,7 +370,12 @@ const convertEditLayoutToFieldLayouts = (
           return null;
         }
 
-        const { edit: metadata } = metadatas[field.name];
+        const fieldMetadata = metadatas[field.name];
+        if (!fieldMetadata) {
+          return null;
+        }
+
+        const { edit: metadata } = fieldMetadata;
 
         const settings: Partial<Settings> =
           attribute.type === 'component' && components
@@ -440,7 +445,7 @@ const formatListLayout = (
 
   return {
     layout: listAttributes,
-    settings: { ...data.contentType.settings, displayName: schema?.info.displayName },
+    settings: { ...data.contentType.settings, displayName: schema?.info?.displayName },
     metadatas: listMetadatas,
     options: {
       ...schema?.options,
@@ -480,6 +485,9 @@ const convertListLayoutToFieldLayouts = (
       }
 
       const metadata = metadatas[name];
+      if (!metadata) {
+        return null;
+      }
 
       const settings: Partial<Settings> =
         attribute.type === 'component' && components

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -167,11 +167,16 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
 
   const isConfigResolvedForModel = data?.contentType?.uid === model;
   const isLoading = isLoadingSchemas || isLoadingConfigs || (!error && !isConfigResolvedForModel);
-  const lastStableLayoutRef = React.useRef<{
-    edit: EditLayout;
-    list: ListLayout;
-    listViewConversionContext: ListViewConversionContext | null;
-  } | null>(null);
+  const stableLayoutsByModelRef = React.useRef(
+    new Map<
+      string,
+      {
+        edit: EditLayout;
+        list: ListLayout;
+        listViewConversionContext: ListViewConversionContext | null;
+      }
+    >()
+  );
 
   React.useEffect(() => {
     if (error) {
@@ -200,30 +205,36 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
 
   React.useEffect(() => {
     if (resolvedLayouts) {
-      lastStableLayoutRef.current = resolvedLayouts;
+      stableLayoutsByModelRef.current.set(model, resolvedLayouts);
     }
-  }, [resolvedLayouts]);
+  }, [model, resolvedLayouts]);
 
-  const stableLayouts = resolvedLayouts ?? lastStableLayoutRef.current;
+  const stableLayouts = resolvedLayouts ?? stableLayoutsByModelRef.current.get(model) ?? null;
 
-  const editLayout =
-    stableLayouts?.edit ??
-    ({
-      layout: [],
-      components: {},
-      metadatas: {},
-      options: {},
-      settings: DEFAULT_SETTINGS,
-    } as EditLayout);
+  const editLayout = React.useMemo(
+    () =>
+      stableLayouts?.edit ??
+      ({
+        layout: [],
+        components: {},
+        metadatas: {},
+        options: {},
+        settings: DEFAULT_SETTINGS,
+      } as EditLayout),
+    [stableLayouts]
+  );
 
-  const listLayout =
-    stableLayouts?.list ??
-    ({
-      layout: [],
-      metadatas: {},
-      options: {},
-      settings: DEFAULT_SETTINGS,
-    } as ListLayout);
+  const listLayout = React.useMemo(
+    () =>
+      stableLayouts?.list ??
+      ({
+        layout: [],
+        metadatas: {},
+        options: {},
+        settings: DEFAULT_SETTINGS,
+      } as ListLayout),
+    [stableLayouts]
+  );
 
   const { layout: edit } = React.useMemo(
     () =>

--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -167,6 +167,11 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
 
   const isConfigResolvedForModel = data?.contentType?.uid === model;
   const isLoading = isLoadingSchemas || isLoadingConfigs || (!error && !isConfigResolvedForModel);
+  const lastStableLayoutRef = React.useRef<{
+    edit: EditLayout;
+    list: ListLayout;
+    listViewConversionContext: ListViewConversionContext | null;
+  } | null>(null);
 
   React.useEffect(() => {
     if (error) {
@@ -177,30 +182,48 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
     }
   }, [error, formatAPIError, toggleNotification]);
 
-  const editLayout = React.useMemo(
-    () =>
-      data && !isLoading
-        ? formatEditLayout(data, { schemas, schema, components })
-        : ({
-            layout: [],
-            components: {},
-            metadatas: {},
-            options: {},
-            settings: DEFAULT_SETTINGS,
-          } as EditLayout),
-    [data, isLoading, schemas, schema, components]
-  );
+  const resolvedLayouts = React.useMemo(() => {
+    if (!data || isLoading) {
+      return null;
+    }
 
-  const listLayout = React.useMemo(() => {
-    return data && !isLoading
-      ? formatListLayout(data, { schemas, schema, components })
-      : ({
-          layout: [],
-          metadatas: {},
-          options: {},
-          settings: DEFAULT_SETTINGS,
-        } as ListLayout);
+    const edit = formatEditLayout(data, { schemas, schema, components });
+    const list = formatListLayout(data, { schemas, schema, components });
+    const listViewConversionContext: ListViewConversionContext = {
+      componentConfigurations: data.components,
+      componentSchemas: components,
+      contentTypeSchemas: schemas,
+    };
+
+    return { edit, list, listViewConversionContext };
   }, [data, isLoading, schemas, schema, components]);
+
+  React.useEffect(() => {
+    if (resolvedLayouts) {
+      lastStableLayoutRef.current = resolvedLayouts;
+    }
+  }, [resolvedLayouts]);
+
+  const stableLayouts = resolvedLayouts ?? lastStableLayoutRef.current;
+
+  const editLayout =
+    stableLayouts?.edit ??
+    ({
+      layout: [],
+      components: {},
+      metadatas: {},
+      options: {},
+      settings: DEFAULT_SETTINGS,
+    } as EditLayout);
+
+  const listLayout =
+    stableLayouts?.list ??
+    ({
+      layout: [],
+      metadatas: {},
+      options: {},
+      settings: DEFAULT_SETTINGS,
+    } as ListLayout);
 
   const { layout: edit } = React.useMemo(
     () =>
@@ -211,17 +234,7 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
     [editLayout, query, runHookWaterfall]
   );
 
-  const listViewConversionContext = React.useMemo((): ListViewConversionContext | null => {
-    if (!data || isLoading) {
-      return null;
-    }
-
-    return {
-      componentConfigurations: data.components,
-      componentSchemas: components,
-      contentTypeSchemas: schemas,
-    };
-  }, [data, isLoading, components, schemas]);
+  const listViewConversionContext = stableLayouts?.listViewConversionContext ?? null;
 
   return {
     error,

--- a/packages/core/content-manager/admin/src/pages/ComponentConfigurationPage.tsx
+++ b/packages/core/content-manager/admin/src/pages/ComponentConfigurationPage.tsx
@@ -231,16 +231,21 @@ const formatEditLayout = (
 
   const componentEditAttributes = Object.entries(data.components).reduce<EditLayout['components']>(
     (acc, [uid, configuration]) => {
+      const componentSchema = components[uid];
+      if (!componentSchema) {
+        return acc;
+      }
+
       acc[uid] = {
         layout: convertEditLayoutToFieldLayouts(
           configuration.layouts.edit,
-          components[uid].attributes,
+          componentSchema.attributes,
           configuration.metadatas
         ),
         settings: {
           ...configuration.settings,
-          icon: components[uid].info.icon,
-          displayName: components[uid].info.displayName,
+          icon: componentSchema.info.icon,
+          displayName: componentSchema.info.displayName,
         },
       };
       return acc;

--- a/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
@@ -41,7 +41,24 @@ interface DataManagerProviderProps {
 
 const selectState = (state: Record<string, unknown>) =>
   (state['content-type-builder_dataManagerProvider'] || initialState) as State;
-const CONTENT_MANAGER_SCHEMA_VERSION_KEY = 'STRAPI_CONTENT_MANAGER_SCHEMA_VERSION';
+
+/**
+ * Tag types registered on the shared `adminApi` instance at runtime by
+ * `@strapi/content-manager` via `enhanceEndpoints({ addTagTypes: [...] })`
+ * (see packages/core/content-manager/admin/src/services/api.ts).
+ *
+ * The cast is only required because adminApi's compile-time tag union doesn't see
+ * tags added downstream from this side of the dependency graph.
+ */
+const CONTENT_MANAGER_SCHEMA_CACHE_TAGS = [
+  'InitialData',
+  'ContentTypesConfiguration',
+  'ContentTypeSettings',
+  'ComponentConfiguration',
+] as const;
+
+const invalidateContentManagerSchemaCaches = () =>
+  adminApi.util.invalidateTags(CONTENT_MANAGER_SCHEMA_CACHE_TAGS as never);
 
 const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
   const dispatch = useDispatch();
@@ -220,10 +237,8 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       await getDataRef.current();
       // Update the app's permissions
       await updatePermissions();
-      // Signal other admin areas (e.g. content-manager) to refresh schema caches.
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(CONTENT_MANAGER_SCHEMA_VERSION_KEY, String(Date.now()));
-      }
+      // Refresh content-manager caches that depend on the CT/component schema.
+      dispatch(invalidateContentManagerSchemaCaches());
     } catch (err) {
       console.error({ err });
       toggleNotification({

--- a/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
+++ b/packages/core/content-type-builder/admin/src/components/DataManager/DataManagerProvider.tsx
@@ -41,6 +41,7 @@ interface DataManagerProviderProps {
 
 const selectState = (state: Record<string, unknown>) =>
   (state['content-type-builder_dataManagerProvider'] || initialState) as State;
+const CONTENT_MANAGER_SCHEMA_VERSION_KEY = 'STRAPI_CONTENT_MANAGER_SCHEMA_VERSION';
 
 const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
   const dispatch = useDispatch();
@@ -81,7 +82,7 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
 
   const isInDevelopmentMode = autoReload;
 
-  const getDataRef = React.useRef<any>();
+  const getDataRef = React.useRef<() => Promise<void>>(async () => undefined);
 
   getDataRef.current = async () => {
     try {
@@ -219,6 +220,10 @@ const DataManagerProvider = ({ children }: DataManagerProviderProps) => {
       await getDataRef.current();
       // Update the app's permissions
       await updatePermissions();
+      // Signal other admin areas (e.g. content-manager) to refresh schema caches.
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(CONTENT_MANAGER_SCHEMA_VERSION_KEY, String(Date.now()));
+      }
     } catch (err) {
       console.error({ err });
       toggleNotification({


### PR DESCRIPTION
### What does it do?

- Fixes `useDocumentLayout` model-switch race conditions by relying on active-query data (`currentData`) and waiting only until configuration is resolved for the active model UID.
- Keeps defensive guards for missing component schemas in persisted layout configuration.
- Hardens component settings resolution in layout conversion (`?.settings ?? {}`) to avoid crashes when component configuration is temporarily missing.
- Adds/updates regression tests in `useDocumentLayout.test.ts` to cover:
  - orphan component references in persisted config,
  - switching between models while the next config is in-flight,
  - missing component settings map during conversion.
- Adds a safe CTB -> CM schema refresh signal:
  - after CTB schema save, writes a schema-version marker to localStorage,
  - CM `useContentTypeSchema` conditionally refetches `/content-manager/init` when the marker changes.

### Why is it needed?

Users reported intermittent crashes when navigating between single types after `5.44.0`, including:
- `Cannot read properties of undefined (reading 'attributes')`
- `Cannot read properties of undefined (reading 'settings')`

The previous fix path addressed one symptom, but the root issue involved model-switch timing and stale/mismatched schema/config state.  
This update fixes the race safely while preserving performance improvements from prior query optimizations (no blanket `isFetching` loading rollback).

### How to test it?

From repo root (or package dirs):

1. Content Manager targeted regression tests:

```bash
cd packages/core/content-manager
yarn test:front --testPathPattern=useDocumentLayout
```

2. Content Type Builder related tests:

```bash
cd packages/core/content-type-builder
yarn test:front --testPathPattern=DataManager
```

3. Optional broader CM frontend suite:

```bash
cd packages/core/content-manager
yarn test:front
```

Manual validation:
- Navigate between multiple single types repeatedly (including quick switches).
- Confirm no runtime errors in admin (`attributes`/`settings` crashes).
- Update schema in CTB, save, return to CM, and verify updated shape is reflected.

### Related issue(s)/PR(s)

- Fixes #26206
- Fixes #26228
- Related discussion: #26005
- Related follow-up: #26233