### PR TITLE
ci: remove build steps from community-label workflow

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -78,21 +78,6 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
-      - uses: actions/setup-node@v4
-        if: steps.check-label.outputs.labeled == 'true'
-        with:
-          node-version: '24'
-
-      - name: Install action dependencies
-        if: steps.check-label.outputs.labeled == 'true'
-        run: npm ci
-        working-directory: .github/actions/community-pr-triage
-
-      - name: Build action
-        if: steps.check-label.outputs.labeled == 'true'
-        run: npm run build
-        working-directory: .github/actions/community-pr-triage
-
       - name: Sync PR to Linear
         if: steps.check-label.outputs.labeled == 'true'
         uses: ./.github/actions/community-pr-triage
@@ -123,18 +108,6 @@ jobs:
         # SECURITY: always checkout the base branch (default_branch), never the PR head.
         with:
           ref: ${{ github.event.repository.default_branch }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install action dependencies
-        run: npm ci
-        working-directory: .github/actions/community-pr-triage
-
-      - name: Build action
-        run: npm run build
-        working-directory: .github/actions/community-pr-triage
 
       - name: Sync PR to Linear
         uses: ./.github/actions/community-pr-triage


### PR DESCRIPTION
## Summary

- `dist/index.cjs` is pre-built and committed to the repo, so the `setup-node` / `npm ci` / `npm run build` steps in the workflow are unnecessary
- They were causing all `community-label` runs to fail with `npm error: The npm ci command can only install with an existing package-lock.json` (no `package-lock.json` is committed)
- Removing these 3 steps from both the `label` and `triage` jobs fixes the failures

## Test plan

- [ ] Open a community PR (author with `NONE` association) targeting `develop` and verify the `label` job succeeds and creates a Linear ticket
- [ ] Manually add the `community` label to a PR and verify the `triage` job succeeds
