### PR TITLE
chore(.github): bump CI runners to node 24

### DIFF
--- a/.github/actions/check-pr-status/action.yml
+++ b/.github/actions/check-pr-status/action.yml
@@ -1,5 +1,5 @@
 name: 'PR Checker'
 description: 'Check PR status for mergeability'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - uses: ./.github/actions/security/lockfile
         with:
           allowedHosts: 'yarn'
@@ -42,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Install dependencies
         uses: ./.github/actions/yarn-nm-install
       - name: Check package versions

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - uses: nrwl/nx-set-shas@v4
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install

--- a/.github/workflows/contributor-doc.yml
+++ b/.github/workflows/contributor-doc.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: yarn install  --immutable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn
       - run: ./scripts/pre-publish.sh --yes
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: yarn
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn
       - run: ./scripts/pre-publish.sh
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn
       - run: ./scripts/publish.sh
         env:

--- a/.github/workflows/remove-dist-tag.yml
+++ b/.github/workflows/remove-dist-tag.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn
       - run: ./scripts/remove-dist-tag.sh
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false # remove once tests aren't flaky
       matrix:
-        node: [20]
+        node: [24]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -253,7 +253,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
       - name: Install Playwright Browsers
@@ -302,7 +302,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

- Bump the composite action `.github/actions/check-pr-status` from `node20` to `node24` as the JavaScript action runtime.
- Set `node-version: 24` (or `node-version: '24'`) in GitHub Actions workflows that previously used Node 20: `adminBundleSize.yml`, `commitlint.yml`, `contributor-doc.yml`, `nightly.yml`, `publish-npm.yml`, `publish-prerelease.yml`, `publish-release.yml`, `remove-dist-tag.yml`.
- In `checks.yml`, pin Node 24 for the jobs that call `actions/setup-node@v6` without relying on the runner default.
- In `tests.yml`, run the Node matrix on **24** instead of **20**, align the E2E setup job from **22** to **24**, and bump the remaining test workflow Node setup from **20** to **24**.

### Why is it needed?

CI should run on a current LTS-aligned Node version so builds and tests match the project’s supported Node range (see repo guidance: Node ≥20 ≤24) and benefit from runtime updates on GitHub-hosted runners. Pinning Node 24 keeps workflows explicit and consistent instead of depending on whatever default `setup-node` applies when no version is set.

### How to test it?

- **Environment:** Push the branch and open a PR (or run workflows manually where `workflow_dispatch` exists).
- **Verify:** Confirm GitHub Actions jobs complete successfully—especially **Tests** (`tests.yml`: unit/front/API/CLI/E2E as applicable), **Checks** (`checks.yml`), **Commitlint** (`commitlint.yml`), and any workflow you normally rely on (e.g. **Admin bundle size**, **Contributor docs**).
- **Spot-check:** In a failing job’s logs, confirm `Setup Node` reports **v24** and the matrix job lists **node: 24** where expected.

### Related issue(s)/PR(s)

ø
