### PR TITLE
fix: revert loading state logic

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts
@@ -159,9 +159,14 @@ const useDocumentLayout: UseDocumentLayout = (model) => {
   const { _unstableFormatAPIError: formatAPIError } = useAPIErrorHandler();
   const { isLoading: isLoadingSchemas, schemas } = useContentTypeSchema();
 
-  const { data, isLoading: isLoadingConfigs, error } = useGetContentTypeConfigurationQuery(model);
+  const {
+    data,
+    isLoading: isLoadingConfigs,
+    error,
+    isFetching: isFetchingConfigs,
+  } = useGetContentTypeConfigurationQuery(model);
 
-  const isLoading = isLoadingSchemas || isLoadingConfigs;
+  const isLoading = isLoadingSchemas || isFetchingConfigs || isLoadingConfigs;
 
   React.useEffect(() => {
     if (error) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Reverts changes made in https://github.com/strapi/strapi/pull/26005 to `packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts`

This seems to be the root cause of bug when navigating between single types in the content manager

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/26206
https://github.com/strapi/strapi/issues/26228
