### PR TITLE
fix(content-manager): local-storage was not updated if filters were r…

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/usePersistentQueryParams.test.ts
@@ -142,6 +142,34 @@ describe('usePersistentPartialQueryParams', () => {
     expect(saved).toBeNull();
   });
 
+  it('should remove persisted params from localStorage when persisted keys are cleared', async () => {
+    window.localStorage.setItem(key, JSON.stringify({ page: 1, pageSize: 10, sort: 'name:asc' }));
+
+    type Props = { query: Record<string, unknown> };
+
+    const { rerender } = renderHook(
+      ({ query }: Props) => {
+        (useQueryParams as jest.Mock).mockReturnValue([{ query }, mockSetQuery]);
+        return usePersistentPartialQueryParams({
+          [key]: { paths: keysToPersist },
+        });
+      },
+      { initialProps: { query: { page: 1, pageSize: 10, sort: 'name:asc' } } as Props }
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(key)).toBe(
+        JSON.stringify({ page: 1, pageSize: 10, sort: 'name:asc' })
+      );
+    });
+
+    rerender({ query: {} } as Props);
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(key)).toBeNull();
+    });
+  });
+
   it('should handle invalid JSON in localStorage gracefully', () => {
     window.localStorage.setItem(key, 'invalid-json');
 

--- a/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
+++ b/packages/core/content-manager/admin/src/hooks/usePersistentQueryParams.ts
@@ -82,7 +82,11 @@ export const usePersistentPartialQueryParams = (config: PersistentQueryConfig) =
       const { key, paths } = normalizeConfigEntry(keyPrefix, entry, scope);
 
       const paramsToPersist = filterObjectKeys(query, paths);
-      if (Object.keys(paramsToPersist).length === 0) continue;
+      if (Object.keys(paramsToPersist).length === 0) {
+        window.localStorage.removeItem(key);
+        continue;
+      }
+
       window.localStorage.setItem(key, JSON.stringify(paramsToPersist));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
…emoved

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Updates `usePersistentPartialQueryParams` to delete the persisted localStorage entry when there are no persisted query keys left (instead of leaving stale data behind).
* Adds a unit test to `usePersistentQueryParams.test.ts `covering the “clear persisted keys → localStorage key removed” behavior.

### Why is it needed?
Clearing the last list-view filter could leave stale `STRAPI_LIST_VIEW_SETTINGS:*` values in localStorage. On revisiting the List View, the hydration logic would re-apply the old persisted filters, making it look like filters “come back” after being removed.

### How to test it?
Test: 
* Run `yarn test:front packages/core/contentmanager/admin/src/hooks/tests/usePersistentQueryParams.test.ts`

Manual: 
* Go to Content Manager → your Restaurant collection type List View.
* Apply a filter (verify list is filtered).
* Navigate away, then return to the Restaurant List View -> _the filter should still be applied._
* Remove the applied filter using the “X” on the filter chip (verify list refetches unfiltered).
* Navigate away, then return to the Restaurant List View -> _the filter is not re-applied automatically._

### Related PR
Partially fixes https://github.com/strapi/strapi/issues/26024 
Partially fixes CG-1266