### PR TITLE
fix(database): move document_id secondary indexes to schema sync

### DIFF
--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
@@ -235,7 +235,7 @@ const expectedModels = [
     },
     indexes: [
       {
-        name: 'countries_document_id_index',
+        name: 'countries_documents_index',
         columns: ['document_id'],
       },
     ],
@@ -252,7 +252,7 @@ const expectedModels = [
     },
     indexes: [
       {
-        name: 'categories_document_id_index',
+        name: 'categories_documents_index',
         columns: ['document_id'],
       },
     ],
@@ -343,7 +343,7 @@ describe('transformContentTypesToModels', () => {
       }
     );
 
-    it('adds document_id btree plus full composite when locale and publishedAt are on the model', () => {
+    it('declares a single documents index covering document_id, locale and published_at when present', () => {
       const patched = patchContentTypes('countries', {
         attributes: {
           locale: { type: 'string' },
@@ -353,16 +353,12 @@ describe('transformContentTypesToModels', () => {
       const models = transformContentTypesToModels(patched, identifiers);
       const country = models.find((m) => m.uid === 'api::countries.countries');
 
-      expect(country?.indexes).toEqual(
-        expect.arrayContaining([
-          { name: 'countries_document_id_index', columns: ['document_id'] },
-          {
-            name: 'countries_documents_index',
-            columns: ['document_id', 'locale', 'published_at'],
-          },
-        ])
-      );
-      expect(country?.indexes).toHaveLength(2);
+      expect(country?.indexes).toEqual([
+        {
+          name: 'countries_documents_index',
+          columns: ['document_id', 'locale', 'published_at'],
+        },
+      ]);
     });
   });
 });

--- a/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
+++ b/packages/core/core/src/utils/__tests__/transform-content-types-to-models.vitest.test.ts
@@ -235,7 +235,7 @@ const expectedModels = [
     },
     indexes: [
       {
-        name: 'countries_documents_index',
+        name: 'countries_document_id_index',
         columns: ['document_id'],
       },
     ],
@@ -252,7 +252,7 @@ const expectedModels = [
     },
     indexes: [
       {
-        name: 'categories_documents_index',
+        name: 'categories_document_id_index',
         columns: ['document_id'],
       },
     ],
@@ -342,5 +342,27 @@ describe('transformContentTypesToModels', () => {
         );
       }
     );
+
+    it('adds document_id btree plus full composite when locale and publishedAt are on the model', () => {
+      const patched = patchContentTypes('countries', {
+        attributes: {
+          locale: { type: 'string' },
+          publishedAt: { type: 'datetime' },
+        },
+      });
+      const models = transformContentTypesToModels(patched, identifiers);
+      const country = models.find((m) => m.uid === 'api::countries.countries');
+
+      expect(country?.indexes).toEqual(
+        expect.arrayContaining([
+          { name: 'countries_document_id_index', columns: ['document_id'] },
+          {
+            name: 'countries_documents_index',
+            columns: ['document_id', 'locale', 'published_at'],
+          },
+        ])
+      );
+      expect(country?.indexes).toHaveLength(2);
+    });
   });
 });

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -321,43 +321,22 @@ export const transformContentTypesToModels = (
       lifecycles: contentType?.lifecycles ?? {},
     };
 
-    // Document lookups: secondary btree indexes declared here so syncSchema creates them safely
-    // (instead of DDL in internal migration `5.0.0-06-add-document-id-indexes`, which is a no-op).
-    // Matches former migration branching: standalone document_id plus one composite when applicable.
+    // Document lookups: secondary btree index declared here so syncSchema owns it
+    // (instead of DDL in internal migration `5.0.0-06-add-document-id-indexes`, now a no-op).
+    // Keep the exact same name/columns schema sync already produced so existing databases
+    // see no index diff on upgrade (a rename would orphan the old index, since the schema
+    // builder's dropIndex is a silent no-op unless forceMigration is enabled).
     if (contentType.modelType === 'contentType') {
-      const documentIdColumn = identifiers.getColumnName(_.snakeCase('documentId'));
-      const secondaryIndexes = [
+      model.indexes = [
+        ...(model.indexes || []),
         {
-          name: identifiers.getIndexName([contentType.collectionName, 'document_id']),
-          columns: [documentIdColumn],
+          name: identifiers.getIndexName([contentType.collectionName, 'documents']),
+          // Filter attributes that are not in the schema
+          columns: ['documentId', 'locale', 'publishedAt']
+            .filter((n) => model.attributes[n])
+            .map((name) => identifiers.getColumnName(_.snakeCase(name))),
         },
       ];
-
-      const hasLocale = Boolean(model.attributes.locale);
-      const hasPublishedAt = Boolean(model.attributes.publishedAt);
-
-      if (hasLocale && hasPublishedAt) {
-        secondaryIndexes.push({
-          name: identifiers.getIndexName([contentType.collectionName, 'documents']),
-          columns: ['documentId', 'locale', 'publishedAt'].map((n) =>
-            identifiers.getColumnName(_.snakeCase(n))
-          ),
-        });
-      } else if (hasLocale) {
-        secondaryIndexes.push({
-          name: identifiers.getIndexName([contentType.collectionName, 'documents_locale']),
-          columns: ['documentId', 'locale'].map((n) => identifiers.getColumnName(_.snakeCase(n))),
-        });
-      } else if (hasPublishedAt) {
-        secondaryIndexes.push({
-          name: identifiers.getIndexName([contentType.collectionName, 'documents_published']),
-          columns: ['documentId', 'publishedAt'].map((n) =>
-            identifiers.getColumnName(_.snakeCase(n))
-          ),
-        });
-      }
-
-      model.indexes = [...(model.indexes || []), ...secondaryIndexes];
     }
 
     models.push(model);

--- a/packages/core/core/src/utils/transform-content-types-to-models.ts
+++ b/packages/core/core/src/utils/transform-content-types-to-models.ts
@@ -321,18 +321,43 @@ export const transformContentTypesToModels = (
       lifecycles: contentType?.lifecycles ?? {},
     };
 
-    // Add indexes to model
+    // Document lookups: secondary btree indexes declared here so syncSchema creates them safely
+    // (instead of DDL in internal migration `5.0.0-06-add-document-id-indexes`, which is a no-op).
+    // Matches former migration branching: standalone document_id plus one composite when applicable.
     if (contentType.modelType === 'contentType') {
-      model.indexes = [
-        ...(model.indexes || []),
+      const documentIdColumn = identifiers.getColumnName(_.snakeCase('documentId'));
+      const secondaryIndexes = [
         {
-          name: identifiers.getIndexName([contentType.collectionName, 'documents']),
-          // Filter attributes that are not in the schema
-          columns: ['documentId', 'locale', 'publishedAt']
-            .filter((n) => model.attributes[n])
-            .map((name) => identifiers.getColumnName(_.snakeCase(name))),
+          name: identifiers.getIndexName([contentType.collectionName, 'document_id']),
+          columns: [documentIdColumn],
         },
       ];
+
+      const hasLocale = Boolean(model.attributes.locale);
+      const hasPublishedAt = Boolean(model.attributes.publishedAt);
+
+      if (hasLocale && hasPublishedAt) {
+        secondaryIndexes.push({
+          name: identifiers.getIndexName([contentType.collectionName, 'documents']),
+          columns: ['documentId', 'locale', 'publishedAt'].map((n) =>
+            identifiers.getColumnName(_.snakeCase(n))
+          ),
+        });
+      } else if (hasLocale) {
+        secondaryIndexes.push({
+          name: identifiers.getIndexName([contentType.collectionName, 'documents_locale']),
+          columns: ['documentId', 'locale'].map((n) => identifiers.getColumnName(_.snakeCase(n))),
+        });
+      } else if (hasPublishedAt) {
+        secondaryIndexes.push({
+          name: identifiers.getIndexName([contentType.collectionName, 'documents_published']),
+          columns: ['documentId', 'publishedAt'].map((n) =>
+            identifiers.getColumnName(_.snakeCase(n))
+          ),
+        });
+      }
+
+      model.indexes = [...(model.indexes || []), ...secondaryIndexes];
     }
 
     models.push(model);

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
@@ -1,80 +1,20 @@
 import type { Knex } from 'knex';
 
 import type { Migration } from '../common';
+import type { Database } from '../..';
 
-// Add an index if it does not already exist
-const createIndex = async (knex: Knex, tableName: string, columns: string[], indexName: string) => {
-  try {
-    // If the database can check for indexes, avoid duplicates
-    const hasIndex = (
-      knex.schema as unknown as {
-        hasIndex?: (tableName: string, indexName: string) => Promise<boolean>;
-      }
-    ).hasIndex;
-    if (hasIndex) {
-      const exists = await hasIndex.call(knex.schema, tableName, indexName);
-      if (exists) {
-        return;
-      }
-    }
-
-    await knex.schema.alterTable(tableName, (table) => {
-      table.index(columns, indexName);
-    });
-  } catch (error) {
-    // If the index exists (or cannot be created), move on
-  }
-};
-
-const addIndexesForTable = async (knex: Knex, tableName: string) => {
-  // Only add indexes when the column is present
-  const hasDocumentId = await knex.schema.hasColumn(tableName, 'document_id');
-  if (!hasDocumentId) {
-    return;
-  }
-
-  const hasLocale = await knex.schema.hasColumn(tableName, 'locale');
-  const hasPublishedAt = await knex.schema.hasColumn(tableName, 'published_at');
-
-  // Single column index for basic lookups
-  await createIndex(knex, tableName, ['document_id'], `${tableName}_document_id_idx`);
-
-  if (hasLocale && hasPublishedAt) {
-    // Composite index for common filters
-    await createIndex(
-      knex,
-      tableName,
-      ['document_id', 'locale', 'published_at'],
-      `${tableName}_document_id_locale_published_at_idx`
-    );
-  } else if (hasLocale) {
-    await createIndex(
-      knex,
-      tableName,
-      ['document_id', 'locale'],
-      `${tableName}_document_id_locale_idx`
-    );
-  } else if (hasPublishedAt) {
-    await createIndex(
-      knex,
-      tableName,
-      ['document_id', 'published_at'],
-      `${tableName}_document_id_published_at_idx`
-    );
-  }
-};
+/**
+ * Previously created secondary indexes on `document_id` (and composites) via raw DDL.
+ * Those indexes are now owned by schema sync from model metadata (see transform-content-types-to-models).
+ * Keep this migration as a stable no-op so Umzug / `strapi_migrations_internal` stay consistent.
+ */
 
 export const addDocumentIdIndexes: Migration = {
   name: '5.0.0-06-add-document-id-indexes',
-  async up(knex, db) {
-    for (const meta of db.metadata.values()) {
-      const hasTable = await knex.schema.hasTable(meta.tableName);
-      if (!hasTable) {
-        continue;
-      }
-
-      await addIndexesForTable(knex, meta.tableName);
-    }
+  // Keeping the Umzug signature without doing any DDL; callers pass knex/db for other migrations only.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by MigrationFn
+  async up(_knex: Knex.Transaction, _db: Database) {
+    await Promise.resolve();
   },
   async down() {
     throw new Error('not implemented');

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-06-add-document-id-indexes.ts
@@ -1,7 +1,4 @@
-import type { Knex } from 'knex';
-
 import type { Migration } from '../common';
-import type { Database } from '../..';
 
 /**
  * Previously created secondary indexes on `document_id` (and composites) via raw DDL.
@@ -11,10 +8,8 @@ import type { Database } from '../..';
 
 export const addDocumentIdIndexes: Migration = {
   name: '5.0.0-06-add-document-id-indexes',
-  // Keeping the Umzug signature without doing any DDL; callers pass knex/db for other migrations only.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by MigrationFn
-  async up(_knex: Knex.Transaction, _db: Database) {
-    await Promise.resolve();
+  async up() {
+    // No-op: the document_id indexes are now created by schema sync (see transform-content-types-to-models).
   },
   async down() {
     throw new Error('not implemented');

--- a/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-06-add-document-id-indexes.test.ts
+++ b/packages/core/database/src/migrations/internal-migrations/__tests__/5.0.0-06-add-document-id-indexes.test.ts
@@ -3,42 +3,10 @@ import type { Knex } from 'knex';
 import { addDocumentIdIndexes } from '../5.0.0-06-add-document-id-indexes';
 
 describe('addDocumentIdIndexes migration', () => {
-  it('adds document_id and composite indexes when columns exist', async () => {
-    const indexCalls: Array<{ columns: string[]; name: string }> = [];
+  it('is a no-op (indexes are owned by schema sync / model metadata)', async () => {
+    const knex = {} as unknown as Knex.Transaction;
+    const db = {} as any;
 
-    const knex = {
-      schema: {
-        hasTable: jest.fn().mockResolvedValue(true),
-        hasColumn: jest.fn().mockImplementation((_table: string, column: string) => {
-          return ['document_id', 'locale', 'published_at'].includes(column);
-        }),
-        alterTable: jest.fn(async (_table: string, tableBuilder: (table: any) => void) => {
-          const table = {
-            index(columns: string[], name: string) {
-              indexCalls.push({ columns, name });
-            },
-          };
-          tableBuilder(table);
-        }),
-      },
-    } as unknown as Knex.Transaction;
-
-    const db = {
-      metadata: {
-        values: () => [{ tableName: 'articles', attributes: {} }],
-      },
-    } as any;
-
-    await addDocumentIdIndexes.up(knex, db);
-
-    expect(indexCalls).toEqual(
-      expect.arrayContaining([
-        { columns: ['document_id'], name: 'articles_document_id_idx' },
-        {
-          columns: ['document_id', 'locale', 'published_at'],
-          name: 'articles_document_id_locale_published_at_idx',
-        },
-      ])
-    );
+    await expect(addDocumentIdIndexes.up(knex, db)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
### What does it do?

Moves document-id secondary index creation out of internal migration `5.0.0-06-add-document-id-indexes` and into model metadata so indexes are created by schema sync.  
Keeps migration `5.0.0-06-add-document-id-indexes` as a stable no-op (same migration name, no DDL).  
Updates tests to cover the new sync-owned index declarations and the migration no-op behavior.

### Why is it needed?

Fixes the fragility reported in #25697 where one-shot migration DDL could fail on duplicate/index-name edge cases and block bootstrap.  
These indexes are schema-level expectations and should be owned by sync, not by a migration that only runs once.

### How to test it?

1. Run targeted tests:
   - `yarn workspace @strapi/database test:unit --testPathPattern='5\\.0\\.0-06-add-document-id-indexes'`
   - `yarn workspace @strapi/core test:unit:vitest -- src/utils/__tests__/transform-content-types-to-models.vitest.test.ts`
2. Verify migration behavior:
   - Confirm `5.0.0-06-add-document-id-indexes` is now a no-op and does not execute index DDL.
3. Verify sync-owned indexes:
   - In `transform-content-types-to-models`, confirm content types declare:
     - single-column `document_id` secondary index
     - one composite index branch based on `locale` / `publishedAt` presence
4. Optional manual bootstrap check:
   - Start Strapi on an upgraded project DB and confirm bootstrap no longer depends on migration 06 DDL for these indexes.

### Related issue(s)/PR(s)

- Fixes #25697
- Fixes CMS-690
