### PR TITLE
fix(content-manager): content history crash on deleted relations

### DIFF
--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -12,7 +12,6 @@ import { useIntl } from 'react-intl';
 import { NavLink } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { HistoryVersionDataResponse } from '../../../../shared/contracts/history-versions';
 import { COLLECTION_TYPES } from '../../constants/collections';
 import { useDocumentRBAC } from '../../features/DocumentRBAC';
 import { useDoc } from '../../hooks/useDocument';
@@ -79,9 +78,24 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
       : field.value;
   }
 
+  // Be defensive about the shape: admin-user relations are sanitized to a
+  // plain user object on the server, and historical version data can carry
+  // shapes that pre-date the `{ results, meta }` contract. Treat anything
+  // without an array `results` as "no relations".
+  const hasResultsShape =
+    !!formattedFieldValue &&
+    typeof formattedFieldValue === 'object' &&
+    Array.isArray((formattedFieldValue as { results?: unknown }).results);
+  const missingCount =
+    hasResultsShape &&
+    typeof (formattedFieldValue as { meta?: { missingCount?: number } }).meta?.missingCount ===
+      'number'
+      ? (formattedFieldValue as { meta: { missingCount: number } }).meta.missingCount
+      : 0;
+
   if (
-    !formattedFieldValue ||
-    (formattedFieldValue.results.length === 0 && formattedFieldValue.meta.missingCount === 0)
+    !hasResultsShape ||
+    ((formattedFieldValue as { results: unknown[] }).results.length === 0 && missingCount === 0)
   ) {
     return (
       <>
@@ -98,7 +112,10 @@ const CustomRelationInput = (props: RelationsFieldProps) => {
     );
   }
 
-  const { results, meta } = formattedFieldValue;
+  const { results, meta } = formattedFieldValue as {
+    results: RelationResult[];
+    meta: { missingCount: number };
+  };
 
   return (
     <Box>
@@ -548,4 +565,4 @@ const attributeHasCustomFieldProperty = (
   'customField' in attribute && typeof attribute.customField === 'string';
 
 export type { VersionInputRendererProps };
-export { VersionInputRenderer };
+export { VersionInputRenderer, CustomRelationInput };

--- a/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
+++ b/packages/core/content-manager/admin/src/history/components/VersionInputRenderer.tsx
@@ -311,6 +311,34 @@ const getLabelAction = (labelAction: VersionInputRendererProps['labelAction']) =
 };
 
 /**
+ * Resolve the layout, configuration metadata and schema attributes needed to
+ * render a component field on the history page. Returns `null` when any of
+ * those are missing — happens when the component schema referenced by the
+ * version was deleted via the Content-Type Builder, in which case the caller
+ * should render a fallback instead of crashing on the destructuring.
+ */
+const resolveComponentRenderResources = (
+  componentUID: string,
+  componentsLayout: { [uid: string]: { layout: unknown } | undefined },
+  configurationComponents: { [uid: string]: { metadatas: unknown } | undefined },
+  components: { [uid: string]: { attributes: unknown } | undefined }
+) => {
+  const componentLayout = componentsLayout[componentUID];
+  const componentConfiguration = configurationComponents[componentUID];
+  const componentSchema = components[componentUID];
+
+  if (!componentLayout || !componentConfiguration || !componentSchema) {
+    return null;
+  }
+
+  return {
+    layout: componentLayout.layout,
+    metadatas: componentConfiguration.metadatas,
+    schemaAttributes: componentSchema.attributes,
+  };
+};
+
+/**
  * @internal
  *
  * @description An abstraction around the regular form input renderer designed specifically
@@ -467,14 +495,33 @@ const VersionInputRenderer = ({
   switch (props.type) {
     case 'blocks':
       return <BlocksInput {...props} hint={hint} type={props.type} disabled={fieldIsDisabled} />;
-    case 'component':
-      const { layout } = componentsLayout[props.attribute.component];
+    case 'component': {
+      const renderResources = resolveComponentRenderResources(
+        props.attribute.component,
+        componentsLayout,
+        configuration.components,
+        components
+      );
+
+      // The component schema referenced by this version is no longer present
+      // (deleted via the Content-Type Builder). Render the label only so the
+      // rest of the page still loads instead of crashing on the lookups below.
+      if (!renderResources) {
+        return <Field.Label>{props.label}</Field.Label>;
+      }
+
+      const { layout, metadatas, schemaAttributes } = renderResources as {
+        layout: Array<EditFieldLayout[]>;
+        metadatas: Parameters<typeof getRemaingFieldsLayout>[0]['metadatas'];
+        schemaAttributes: Parameters<typeof getRemaingFieldsLayout>[0]['schemaAttributes'];
+      };
+
       // Components can only have one panel, so only save the first layout item
       const [remainingFieldsLayout] = getRemaingFieldsLayout({
         layout: [layout],
-        metadatas: configuration.components[props.attribute.component].metadatas,
+        metadatas,
         fieldSizes,
-        schemaAttributes: components[props.attribute.component].attributes,
+        schemaAttributes,
       });
 
       return (
@@ -488,6 +535,7 @@ const VersionInputRenderer = ({
           {(inputProps) => <VersionInputRenderer {...inputProps} shouldIgnoreRBAC={true} />}
         </ComponentInput>
       );
+    }
     case 'dynamiczone':
       return (
         <DynamicZone
@@ -565,4 +613,4 @@ const attributeHasCustomFieldProperty = (
   'customField' in attribute && typeof attribute.customField === 'string';
 
 export type { VersionInputRendererProps };
-export { VersionInputRenderer, CustomRelationInput };
+export { VersionInputRenderer, CustomRelationInput, resolveComponentRenderResources };

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
@@ -14,7 +14,7 @@
 import { Form } from '@strapi/admin/strapi-admin';
 import { render as renderRTL, screen } from '@tests/utils';
 
-import { CustomRelationInput } from '../VersionInputRenderer';
+import { CustomRelationInput, resolveComponentRenderResources } from '../VersionInputRenderer';
 
 import type { RelationsFieldProps } from '../../../pages/EditView/components/FormInputs/Relations/Relations';
 
@@ -98,5 +98,65 @@ describe('CustomRelationInput (history)', () => {
     });
     // Renders the relation label rather than the empty-state copy.
     expect(screen.queryByText(/No relations/i)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Regression tests for the helper that resolves a component's render resources
+ * on the history page. When a component schema is deleted via the Content-Type
+ * Builder while a historical version still references it, the destructure
+ * `const { layout } = componentsLayout[uid]` used to crash. The helper now
+ * returns `null` so the caller can fall back to a label-only render.
+ */
+describe('resolveComponentRenderResources', () => {
+  const componentsLayout = {
+    'default.kept': { layout: [[{ name: 'title' }]] },
+  };
+  const configurationComponents = {
+    'default.kept': { metadatas: { title: { edit: { label: 'Title', visible: true } } } },
+  };
+  const components = {
+    'default.kept': { attributes: { title: { type: 'string' } } },
+  };
+
+  it('returns layout/metadatas/schemaAttributes when the component is fully present', () => {
+    const result = resolveComponentRenderResources(
+      'default.kept',
+      componentsLayout,
+      configurationComponents,
+      components
+    );
+    expect(result).toEqual({
+      layout: componentsLayout['default.kept'].layout,
+      metadatas: configurationComponents['default.kept'].metadatas,
+      schemaAttributes: components['default.kept'].attributes,
+    });
+  });
+
+  it('returns null when the component is missing from the layout dict (deleted via CTB)', () => {
+    expect(
+      resolveComponentRenderResources(
+        'default.gone',
+        componentsLayout,
+        configurationComponents,
+        components
+      )
+    ).toBeNull();
+  });
+
+  it('returns null when the component is missing from the configuration dict', () => {
+    expect(
+      resolveComponentRenderResources('default.kept', componentsLayout, {}, components)
+    ).toBeNull();
+  });
+
+  it('returns null when the component is missing from the schemas dict', () => {
+    expect(
+      resolveComponentRenderResources('default.kept', componentsLayout, configurationComponents, {})
+    ).toBeNull();
+  });
+
+  it('returns null when all three dicts are empty', () => {
+    expect(resolveComponentRenderResources('default.kept', {}, {}, {})).toBeNull();
   });
 });

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Regression tests for the history-page CustomRelationInput.
+ *
+ * The component renders a relation field's value using a `{ results, meta }`
+ * shape produced by the server's populate path. Some scenarios deliver the
+ * field value in a different shape and used to crash with
+ * `Cannot read properties of undefined (reading 'length')`:
+ *
+ *   - one-to-one relation persisted as a single object (no `.results`)
+ *   - admin-user relation sanitized server-side to a plain user object
+ *   - a relation attribute removed from the schema, whose stored historical
+ *     value is the raw payload (server's populate skipped it)
+ */
+import { Form } from '@strapi/admin/strapi-admin';
+import { render as renderRTL, screen } from '@tests/utils';
+
+import { CustomRelationInput } from '../VersionInputRenderer';
+
+import type { RelationsFieldProps } from '../../../pages/EditView/components/FormInputs/Relations/Relations';
+
+const baseAttribute = {
+  type: 'relation' as const,
+  relation: 'oneToMany' as const,
+  targetModel: 'api::category.category',
+  target: 'api::category.category',
+};
+
+const renderField = (
+  initialFormValues: Record<string, unknown>,
+  attributeOverrides: Partial<RelationsFieldProps['attribute']> = {}
+) =>
+  renderRTL(
+    <CustomRelationInput
+      // @ts-expect-error - test setup uses minimal attribute shape
+      attribute={{ ...baseAttribute, ...attributeOverrides }}
+      label="Categories"
+      name="categories"
+      type="relation"
+      mainField={{ name: 'name', type: 'string' }}
+    />,
+    {
+      renderOptions: {
+        wrapper: ({ children }) => (
+          <Form method="POST" initialValues={initialFormValues} onSubmit={jest.fn()}>
+            {children}
+          </Form>
+        ),
+      },
+    }
+  );
+
+describe('CustomRelationInput (history)', () => {
+  it('renders "No relations" when the field value is the expected `{ results, meta }` shape with an empty list', async () => {
+    renderField({ categories: { results: [], meta: { missingCount: 0 } } });
+    expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
+  });
+
+  it('does not crash when the historical field value is a single relation object (no `results` key)', async () => {
+    // Shape that triggered the crash before the fix: a one-to-one relation
+    // persisted as a single object, or any relation whose attribute was
+    // removed from the schema so the server's populate skipped it.
+    renderField({ categories: { id: 1, documentId: 'abc', name: 'Whatever' } });
+    expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
+  });
+
+  it('does not crash when the historical field value is a sanitized admin-user object', async () => {
+    // Admin-user relations are sanitized server-side to a plain user object,
+    // not the `{ results, meta }` shape — same crash class as above.
+    renderField(
+      {
+        manager: { id: 7, firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.test' },
+      },
+      // @ts-expect-error - test override
+      { targetModel: 'admin::user', target: 'admin::user' }
+    );
+    // Field with name="categories" is still rendered (we don't pass "manager"
+    // here), so the empty-state path runs because the field value at "categories"
+    // is undefined. The point is that the render completes without throwing.
+    expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
+  });
+
+  it('does not crash when the field value is null', async () => {
+    renderField({ categories: null });
+    expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
+  });
+
+  it('does not crash when the field value is undefined', async () => {
+    renderField({});
+    expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
+  });
+
+  it('renders the populated relation cards when the value carries results', async () => {
+    renderField({
+      categories: {
+        results: [{ id: 1, documentId: 'doc-1', name: 'A', status: 'draft' }],
+        meta: { missingCount: 0 },
+      },
+    });
+    // Renders the relation label rather than the empty-state copy.
+    expect(screen.queryByText(/No relations/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
@@ -25,16 +25,25 @@ const baseAttribute = {
   target: 'api::category.category',
 };
 
+type RenderFieldOptions = {
+  /** Form field path; must match a key in `initialFormValues` */
+  name?: string;
+  label?: string;
+};
+
 const renderField = (
   initialFormValues: Record<string, unknown>,
-  attributeOverrides: Partial<RelationsFieldProps['attribute']> = {}
-) =>
-  renderRTL(
+  attributeOverrides: Partial<RelationsFieldProps['attribute']> = {},
+  options: RenderFieldOptions = {}
+) => {
+  const name = options.name ?? 'categories';
+  const label = options.label ?? 'Categories';
+  return renderRTL(
     <CustomRelationInput
       // @ts-expect-error - test setup uses minimal attribute shape
       attribute={{ ...baseAttribute, ...attributeOverrides }}
-      label="Categories"
-      name="categories"
+      label={label}
+      name={name}
       type="relation"
       mainField={{ name: 'name', type: 'string' }}
     />,
@@ -48,6 +57,7 @@ const renderField = (
       },
     }
   );
+};
 
 describe('CustomRelationInput (history)', () => {
   it('renders "No relations" when the field value is the expected `{ results, meta }` shape with an empty list', async () => {

--- a/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
+++ b/packages/core/content-manager/admin/src/history/components/tests/VersionInputRenderer.test.tsx
@@ -76,16 +76,15 @@ describe('CustomRelationInput (history)', () => {
   it('does not crash when the historical field value is a sanitized admin-user object', async () => {
     // Admin-user relations are sanitized server-side to a plain user object,
     // not the `{ results, meta }` shape — same crash class as above.
+    // `name` must match the key in `initialValues` so useField reads the value.
     renderField(
       {
         manager: { id: 7, firstname: 'Ada', lastname: 'Lovelace', email: 'ada@example.test' },
       },
       // @ts-expect-error - test override
-      { targetModel: 'admin::user', target: 'admin::user' }
+      { targetModel: 'admin::user', target: 'admin::user' },
+      { name: 'manager', label: 'Manager' }
     );
-    // Field with name="categories" is still rendered (we don't pass "manager"
-    // here), so the empty-state path runs because the field value at "categories"
-    // is undefined. The point is that the render completes without throwing.
     expect(await screen.findByText(/No relations/i)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
### What does it do?

When you delete a relation from a content type and try to access an existing entry that used to have this relation configured, the content history page throws an error:

https://github.com/user-attachments/assets/a203c383-4242-47e4-aa3a-87db1e334298

We also had an error deleting a component or a dynamic zone:

https://github.com/user-attachments/assets/b33f29a6-a96d-40f1-842b-1b8646a7848f


This PR fixes those two issues.

### Why is it needed?

If a field is removed from a content type, we should still be able to access the content history of all impacted entries.

### How to test it?

- Go to the content manager and select a content type that has a relation
- Create an entry and fill the relation
- Save + Publish
- Go to the content type builder and remove the relation field from the content type
- Save
- Go back to the content manager and select your previously created entry
- Go to the content history
-> You should be able to correctly see the page and versions without any error

Repeat the operation for components and dynamic zones.

🚀