### PR TITLE
fix(upgrade): use pnpm install when project prefers pnpm

### DIFF
--- a/packages/core/utils/src/__tests__/package-manager.test.ts
+++ b/packages/core/utils/src/__tests__/package-manager.test.ts
@@ -1,0 +1,52 @@
+import preferredPM from 'preferred-pm';
+import execa from 'execa';
+import * as pkg from '../package-manager';
+
+jest.mock('preferred-pm');
+jest.mock('execa');
+
+const mockedPreferredPM = preferredPM as jest.MockedFunction<typeof preferredPM>;
+const mockedExeca = execa as jest.MockedFunction<typeof execa>;
+
+describe('package-manager', () => {
+  describe('getPreferred', () => {
+    it('returns pnpm when preferred-pm detects pnpm', async () => {
+      mockedPreferredPM.mockResolvedValue({ name: 'pnpm', version: '10.12.1' });
+
+      await expect(pkg.getPreferred('/some/project')).resolves.toBe('pnpm');
+      expect(mockedPreferredPM).toHaveBeenCalledWith('/some/project');
+    });
+
+    it('defaults to npm with a warning when the detected package manager is not supported', async () => {
+      const warnSpy = jest.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      mockedPreferredPM.mockResolvedValue({ name: 'bun', version: '1.2.0' });
+
+      await expect(pkg.getPreferred('/some/project')).resolves.toBe('npm');
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('throws when preferred-pm cannot detect a package manager', async () => {
+      mockedPreferredPM.mockResolvedValue(undefined);
+
+      await expect(pkg.getPreferred('/some/project')).rejects.toThrow(
+        `Couldn't find a package manager in your project.`
+      );
+    });
+  });
+
+  describe('installDependencies', () => {
+    it('runs pnpm install in the given directory', async () => {
+      mockedExeca.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 } as Awaited<
+        ReturnType<typeof execa>
+      >);
+
+      await pkg.installDependencies('/project/root', 'pnpm');
+
+      expect(mockedExeca).toHaveBeenCalledWith('pnpm', ['install'], {
+        cwd: '/project/root',
+        stdin: 'ignore',
+      });
+    });
+  });
+});

--- a/packages/core/utils/src/package-manager.ts
+++ b/packages/core/utils/src/package-manager.ts
@@ -3,10 +3,10 @@ import preferredPM from 'preferred-pm';
 
 import type { Options as ProcessOptions } from 'execa';
 
-const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn'];
+const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'];
 const DEFAULT_PACKAGE_MANAGER = 'npm' as const;
 
-type SupportedPackageManagerName = 'npm' | 'yarn';
+type SupportedPackageManagerName = 'npm' | 'yarn' | 'pnpm';
 
 export const getPreferred = async (pkgPath: string): Promise<SupportedPackageManagerName> => {
   const pm = await preferredPM(pkgPath);
@@ -16,7 +16,9 @@ export const getPreferred = async (pkgPath: string): Promise<SupportedPackageMan
     throw new Error(`Couldn't find a package manager in your project.`);
   }
 
-  const isPackageManagerSupported = SUPPORTED_PACKAGE_MANAGERS.includes(pm.name);
+  const isPackageManagerSupported = (SUPPORTED_PACKAGE_MANAGERS as readonly string[]).includes(
+    pm.name
+  );
   if (!isPackageManagerSupported) {
     process.emitWarning(
       `We detected your package manager (${pm.name} v${pm.version}), but it's not officially supported by Strapi yet. Defaulting to npm instead.`

--- a/packages/core/utils/src/package-manager.ts
+++ b/packages/core/utils/src/package-manager.ts
@@ -3,10 +3,10 @@ import preferredPM from 'preferred-pm';
 
 import type { Options as ProcessOptions } from 'execa';
 
-const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'];
+const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'] as const;
 const DEFAULT_PACKAGE_MANAGER = 'npm' as const;
 
-type SupportedPackageManagerName = 'npm' | 'yarn' | 'pnpm';
+type SupportedPackageManagerName = (typeof SUPPORTED_PACKAGE_MANAGERS)[number];
 
 export const getPreferred = async (pkgPath: string): Promise<SupportedPackageManagerName> => {
   const pm = await preferredPM(pkgPath);

--- a/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
+++ b/packages/utils/upgrade/src/modules/npm/__tests__/package.test.ts
@@ -250,6 +250,24 @@ describe('Package registry URL determination', () => {
     );
   });
 
+  it('should use pnpm registry when pnpm is the preferred package manager', async () => {
+    const pnpmRegistry = 'https://pnpm-registry.example.com/';
+    mockGetPreferred.mockResolvedValue('pnpm');
+    mockExeca.mockResolvedValue({ stdout: pnpmRegistry } as ExecaReturnValue);
+
+    const pkg = new Package('@test/package', mockCwd, mockLogger);
+    await pkg.refresh();
+
+    expect(mockGetPreferred).toHaveBeenCalledWith(mockCwd);
+    expect(mockExeca).toHaveBeenCalledWith('pnpm', ['config', 'get', 'registry'], {
+      timeout: 10_000,
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://pnpm-registry.example.com/@test/package',
+      expect.anything()
+    );
+  });
+
   it('should fallback to default registry when no other registry is available', async () => {
     delete process.env.NPM_REGISTRY_URL;
     mockGetPreferred.mockResolvedValue(null);

--- a/packages/utils/upgrade/src/modules/npm/package.ts
+++ b/packages/utils/upgrade/src/modules/npm/package.ts
@@ -72,6 +72,7 @@ export class Package implements PackageInterface {
       const registryCommands = {
         yarn: ['config', 'get', 'npmRegistryServer'],
         npm: ['config', 'get', 'registry'],
+        pnpm: ['config', 'get', 'registry'],
       } as const;
 
       const command = registryCommands[packageManagerName as keyof typeof registryCommands];


### PR DESCRIPTION
### What does it do?

- **`@strapi/utils`**: `packageManager.getPreferred()` and `installDependencies()` now treat **pnpm** as supported (alongside npm and yarn), instead of warning and falling back to npm.
- **`@strapi/upgrade`**: when resolving the NPM registry for metadata fetches, **pnpm** uses `pnpm config get registry` like npm.
- Adds unit tests under **`@strapi/utils`** and extends **`@strapi/upgrade`** package tests for the pnpm registry path.

### Why is it needed?

`npx @strapi/upgrade` on a **pnpm** project detected pnpm but ran **`npm install`**, which breaks on typical pnpm layouts and produced errors such as npm’s `Cannot read properties of null (reading 'matches')`. Fix #23927.

### How to test it?

- **`cd packages/core/utils && yarn test:unit --testPathPattern=package-manager`**
- **`cd packages/utils/upgrade && yarn test:unit --testPathPattern='package\.test'`**
- On a **backed-up** Strapi app managed with pnpm, run the upgrade command and confirm the install step runs **pnpm** without the previous “defaulting to npm” warning.

### Related issue(s)/PR(s)

- Fix https://github.com/strapi/strapi/issues/23927
