### PR TITLE
fix(upgrade): remove obsolete plugin strapi-admin.js via codemod

### DIFF
--- a/packages/utils/upgrade/resources/codemods/5.0.0/remove-strapi-admin-js.code.ts
+++ b/packages/utils/upgrade/resources/codemods/5.0.0/remove-strapi-admin-js.code.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Transform } from 'jscodeshift';
+
+type RunnerOptions = {
+  dry?: boolean;
+  projectRoot?: string;
+};
+
+/**
+ * Strapi 5 plugins wire admin via package exports (`strapi/admin`); legacy root `strapi-admin.js` should go.
+ * Only unlinks files directly under `options.projectRoot` (matches `--project-path`).
+ */
+const transform: Transform = (file, _api, options: RunnerOptions) => {
+  const projectRoot = options.projectRoot;
+
+  if (!projectRoot) {
+    return file.source;
+  }
+
+  if (
+    path.basename(file.path) !== 'strapi-admin.js' ||
+    path.normalize(path.dirname(file.path)) !== path.normalize(projectRoot)
+  ) {
+    return file.source;
+  }
+
+  if (!options.dry) {
+    fs.unlinkSync(file.path);
+  }
+
+  return undefined;
+};
+
+export default transform;

--- a/packages/utils/upgrade/src/modules/project/project.ts
+++ b/packages/utils/upgrade/src/modules/project/project.ts
@@ -88,6 +88,7 @@ export class Project {
       runInBand: true,
       babel: true,
       extensions: constants.PROJECT_CODE_EXTENSIONS.join(','),
+      projectRoot: this.cwd,
       // Don't output any log coming from the runner
       print: false,
       silent: true,

--- a/packages/utils/upgrade/src/modules/runner/__tests__/remove-strapi-admin-js.test.ts
+++ b/packages/utils/upgrade/src/modules/runner/__tests__/remove-strapi-admin-js.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable import/first */
+
+import path from 'node:path';
+import { vol, fs } from 'memfs';
+
+jest.mock('node:fs', () => fs);
+
+import removeStrapiAdminJsTransform from '../../../../resources/codemods/5.0.0/remove-strapi-admin-js.code';
+
+const cwd = '/__unit_tests__/plugin';
+
+const pluginVolume = {
+  'package.json': JSON.stringify({
+    name: 'test-plugin',
+    version: '1.0.0',
+    strapi: { kind: 'plugin' },
+  }),
+  server: {
+    'index.js': '// server',
+  },
+  admin: {
+    'strapi-admin.js': 'module.exports = () => {};',
+  },
+  'strapi-admin.js': 'module.exports = () => {};',
+};
+
+describe('Runner (code)', () => {
+  describe('remove-strapi-admin-js codemod', () => {
+    beforeEach(() => {
+      vol.reset();
+      vol.fromNestedJSON(pluginVolume, cwd);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('unlinkSync removes root strapi-admin.js only', () => {
+      const rootAdmin = path.join(cwd, 'strapi-admin.js');
+      const nestedAdmin = path.join(cwd, 'admin', 'strapi-admin.js');
+
+      expect(vol.existsSync(rootAdmin)).toBe(true);
+      expect(vol.existsSync(nestedAdmin)).toBe(true);
+
+      removeStrapiAdminJsTransform(
+        { path: rootAdmin, source: 'module.exports = () => {};' },
+        // Transform ignores api for this codemod
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        { projectRoot: cwd, dry: false }
+      );
+
+      expect(vol.existsSync(rootAdmin)).toBe(false);
+      expect(vol.existsSync(nestedAdmin)).toBe(true);
+    });
+
+    test('skips unlink in dry mode', () => {
+      const rootAdmin = path.join(cwd, 'strapi-admin.js');
+
+      removeStrapiAdminJsTransform(
+        { path: rootAdmin, source: 'module.exports = () => {};' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        { projectRoot: cwd, dry: true }
+      );
+
+      expect(vol.existsSync(rootAdmin)).toBe(true);
+    });
+
+    test('does not touch nested strapi-admin.js when transforming that path', () => {
+      const nestedAdmin = path.join(cwd, 'admin', 'strapi-admin.js');
+
+      removeStrapiAdminJsTransform(
+        { path: nestedAdmin, source: 'module.exports = () => {};' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        { projectRoot: cwd, dry: false }
+      );
+
+      expect(vol.existsSync(nestedAdmin)).toBe(true);
+    });
+
+    test('does nothing when projectRoot option is omitted', () => {
+      const rootAdmin = path.join(cwd, 'strapi-admin.js');
+
+      removeStrapiAdminJsTransform(
+        { path: rootAdmin, source: 'x' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        {}
+      );
+
+      expect(vol.existsSync(rootAdmin)).toBe(true);
+    });
+
+    test('passes source through when file is not targeted', () => {
+      const out = removeStrapiAdminJsTransform(
+        { path: path.join(cwd, 'server', 'index.js'), source: '// server' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        { projectRoot: cwd, dry: false }
+      );
+
+      expect(out).toBe('// server');
+    });
+  });
+});

--- a/packages/utils/upgrade/src/modules/runner/code/types.ts
+++ b/packages/utils/upgrade/src/modules/runner/code/types.ts
@@ -7,4 +7,9 @@ export interface CodeRunnerConfiguration {
   print?: boolean;
   silent?: boolean;
   parser?: 'js' | 'ts';
+  /**
+   * Absolute path to the Strapi application or plugin root. Passed to transforms for
+   * path checks that cannot rely on `process.cwd()` (e.g. `--project-path`).
+   */
+  projectRoot?: string;
 }


### PR DESCRIPTION
### What does it do?

Adds a 5.0.0 **`remove-strapi-admin-js`** code codemod that **`unlink`**s `./strapi-admin.js` only when it lives directly under the resolved project directory (supports **`--project-path`**). Threads **`projectRoot: this.cwd`** through **`CodeRunnerConfiguration`** into jscodeshift so transforms never rely on the shell cwd. **`@strapi/upgrade`** unit tests call the transform with **`jest.mock('node:fs')`** and memfs (`vol`), consistent with other upgrade tests.

### Why is it needed?

Plugin upgrades did not drop the legacy Strapi ≤4-style root **`strapi-admin.js`**, unlike the generator, so migrated plugins kept a redundant file (#21090).

Fix #21090

### How to test it?

From the repo root after **`yarn setup`** / **`yarn build`** as needed:

```bash
yarn test:unit packages/utils/upgrade/src/modules/runner/__tests__/remove-strapi-admin-js.test.ts
cd packages/utils/upgrade && yarn test:unit
```

Manual check: **`strapi-upgrade codemods run --project-path <plugin-dir>`** (or **`npx @strapi/upgrade codemods run`** against a built tool) — root **`strapi-admin.js`** disappears when not using **`--dry`**.

### Related issue(s)/PR(s)

Fix https://github.com/strapi/strapi/issues/21090
