### PR TITLE
fix(upgrade): align scoped @strapi packages in devDependencies

### DIFF
--- a/packages/utils/upgrade/src/modules/upgrader/__tests__/upgrader.test.ts
+++ b/packages/utils/upgrade/src/modules/upgrader/__tests__/upgrader.test.ts
@@ -1,0 +1,96 @@
+import path from 'node:path';
+
+import { vol, fs } from 'memfs';
+
+import { assertAppProject, projectFactory } from '../../project';
+import { semVerFactory } from '../../version';
+import { upgraderFactory } from '../upgrader';
+
+import type { NPM } from '../../npm/types';
+
+jest.mock('fs', () => fs);
+
+jest.mock('../../codemod-runner', () => ({
+  codemodRunnerFactory: jest.fn(() => ({
+    dry: jest.fn().mockReturnThis(),
+    setLogger: jest.fn().mockReturnThis(),
+    run: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('@strapi/utils', () => ({
+  packageManager: {
+    getPreferred: jest.fn().mockResolvedValue('yarn'),
+    installDependencies: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe('Upgrader', () => {
+  const cwd = '/__upgrader_tests__';
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('updates scoped @strapi packages in dependencies and devDependencies (issue #22768)', async () => {
+    const projectVersion = '5.8.1';
+    const targetVersion = '5.9.0';
+
+    vol.fromNestedJSON(
+      {
+        package: {
+          'package.json': JSON.stringify(
+            {
+              name: 'strapi-upgrade-test-app',
+              version: '1.0.0',
+              dependencies: {
+                '@strapi/strapi': projectVersion,
+              },
+              devDependencies: {
+                '@strapi/types': projectVersion,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      },
+      cwd
+    );
+
+    const packageRoot = path.join(cwd, 'package');
+    const project = projectFactory(packageRoot);
+
+    assertAppProject(project);
+
+    const npmPackageStub: NPM.Package = {
+      name: '@strapi/strapi',
+      get isLoaded() {
+        return true;
+      },
+      refresh: jest.fn().mockResolvedValue(undefined),
+      versionExists: jest.fn(),
+      getVersionsDict: jest.fn(() => ({})),
+      getVersionsAsList: jest.fn(() => []),
+      findVersion: jest.fn((semverTarget) => ({
+        version: semverTarget.raw,
+      })),
+      findVersionsInRange: jest.fn(),
+    } as unknown as NPM.Package;
+
+    const nextTarget = semVerFactory(targetVersion);
+    const upgrader = upgraderFactory(project, nextTarget, npmPackageStub);
+
+    await upgrader.upgrade();
+
+    const packageJsonRaw = vol.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(packageJsonRaw.toString());
+
+    expect(pkg.dependencies['@strapi/strapi']).toBe(targetVersion);
+    expect(pkg.devDependencies['@strapi/types']).toBe(targetVersion);
+  });
+});

--- a/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
+++ b/packages/utils/upgrade/src/modules/upgrader/upgrader.ts
@@ -249,20 +249,36 @@ export class Upgrader implements UpgraderInterface {
     const json = createJSONTransformAPI(packageJSON);
 
     const dependencies = json.get<Record<string, string>>('dependencies', {});
-    const strapiDependencies = this.getScopedStrapiDependencies(dependencies);
+    const devDependencies = json.get<Record<string, string>>('devDependencies', {});
+
+    const strapiProductionDependencies = this.getScopedStrapiDependencies(dependencies);
+    const strapiDevelopmentDependencies = this.getScopedStrapiDependencies(devDependencies);
+
+    const strapiPackagesToUpgradeCount =
+      strapiProductionDependencies.length + strapiDevelopmentDependencies.length;
 
     this.logger?.debug?.(
-      `Found ${f.highlight(strapiDependencies.length)} dependency(ies) to update`
+      `Found ${f.highlight(strapiPackagesToUpgradeCount)} dependency(ies) to update`
     );
-    strapiDependencies.forEach((dependency) =>
+    strapiProductionDependencies.forEach((dependency) =>
       this.logger?.debug?.(`- ${dependency[0]} (${dependency[1]} -> ${this.target})`)
     );
+    strapiDevelopmentDependencies.forEach((dependency) =>
+      this.logger?.debug?.(
+        `- ${dependency[0]} (devDependencies) (${dependency[1]} -> ${this.target})`
+      )
+    );
 
-    if (strapiDependencies.length === 0) {
+    if (strapiPackagesToUpgradeCount === 0) {
       return;
     }
 
-    strapiDependencies.forEach(([name]) => json.set(`dependencies.${name}`, this.target.raw));
+    strapiProductionDependencies.forEach(([name]) =>
+      json.set(`dependencies.${name}`, this.target.raw)
+    );
+    strapiDevelopmentDependencies.forEach(([name]) =>
+      json.set(`devDependencies.${name}`, this.target.raw)
+    );
 
     const updatedPackageJSON = json.root();
 


### PR DESCRIPTION
### What does it do?

Extends **`updateDependencies()`** in **`packages/utils/upgrade`** so that **`@strapi/*`** packages listed under **`devDependencies`** (when their version matches the project Strapi version, same rules as **`dependencies`**) are bumped to the upgrade target. Adds a unit test that runs **`Upgrader.upgrade()`** against a memfs app with **`@strapi/strapi`** and **`@strapi/types`** pinned together.

### Why is it needed?

**`npx @strapi/upgrade minor`** (and other upgrade flows) only rewrote **`dependencies`**, so **`@strapi/types`** and similar dev-only Strapi packages could stay on an old version while **`@strapi/strapi`** advanced, causing version skew (#22768).

Fix #22768

### How to test it?

```bash
cd packages/utils/upgrade && yarn test:unit src/modules/upgrader/__tests__/upgrader.test.ts
```

From repo root (optional): **`yarn build`** then **`yarn test:unit`** scoped to **`@strapi/upgrade`** if you prefer the full package suite.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/22768
