### PR TITLE
docs: add CLAUDE.md alias and link PR template from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,11 +220,7 @@ yarn prettier:check # check only
 - Branch from `develop`, target `develop` — never `main`.
 - Link the issue you're fixing in the description.
 - All tests must pass before merging.
-- PR description must use this template:
-  - **What does it do?** — technical changes made
-  - **Why is it needed?** — problem being solved
-  - **How to test it?** — steps to reproduce and verify
-  - **Related issue(s)/PR(s)** — links
+- PR description must follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### What does it do?

Two small docs touch-ups so agent setup matches repo conventions:

1. Adds a one-line `CLAUDE.md` at the repo root that imports `AGENTS.md`:

   ```
   @AGENTS.md
   ```

   Companion to #26018. Claude Code reads `CLAUDE.md`, not `AGENTS.md`. The `@AGENTS.md` syntax is Claude Code's [native import directive](https://code.claude.com/docs/en/memory#agents-md), so the agent guide stays in one file (`AGENTS.md`) and `CLAUDE.md` is just a discoverability shim.

2. Replaces the inline PR-description checklist in `AGENTS.md` with a link to [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md), so the template file remains the single source of truth and can't drift.

### Why is it needed?

- Without `CLAUDE.md`, Claude Code users don't get the AGENTS.md guidance loaded into context — they hit the same monorepo gotchas (`develop` not `main`, Yarn 4, commitlint scopes, etc.) that #26018 was meant to solve.
- The duplicated PR template list inside `AGENTS.md` could drift from the canonical `.github/PULL_REQUEST_TEMPLATE.md`. Linking the file avoids that.

Using an `@AGENTS.md` import (rather than a duplicate file or a symlink) means:
- Single source of truth — edits to `AGENTS.md` propagate automatically.
- Cross-platform safe — no symlink-on-Windows quirks.
- Tiny diff.

### How to test it?

- Open the repo in Claude Code; the AGENTS.md content appears in the loaded memory list.
- Open `AGENTS.md` → PR Guidelines section now links to `.github/PULL_REQUEST_TEMPLATE.md` instead of inlining its sections.

### Related issue(s)/PR(s)

Follow-up to #26018.