### PR TITLE
chore(database): inject Strapi host instead of using global

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -295,6 +295,7 @@ class Strapi extends Container implements Core.Strapi {
                 dir: path.join(projectDir, 'database/migrations'),
               },
             },
+            strapi: this,
           })
         );
       })

--- a/packages/core/database/src/__tests__/index.test.ts
+++ b/packages/core/database/src/__tests__/index.test.ts
@@ -57,6 +57,11 @@ const models = [
   },
 ];
 
+const strapiStub = {
+  getModel: jest.fn(),
+  store: { get: jest.fn() },
+};
+
 const configConnectionObject: DatabaseConfig = {
   connection: {
     client: 'postgres',
@@ -73,6 +78,7 @@ const configConnectionObject: DatabaseConfig = {
       dir: 'migrations',
     },
   },
+  strapi: strapiStub,
 };
 const configConnectionFunction: DatabaseConfig = {
   connection: {
@@ -92,6 +98,7 @@ const configConnectionFunction: DatabaseConfig = {
       dir: 'migrations',
     },
   },
+  strapi: strapiStub,
 };
 
 describe('Database', () => {

--- a/packages/core/database/src/entity-manager/index.ts
+++ b/packages/core/database/src/entity-manager/index.ts
@@ -180,6 +180,7 @@ const toAssocs = (data: Assocs) => {
 };
 
 const processData = (
+  db: Database,
   metadata: Meta,
   data: Record<string, unknown> = {},
   { withDefaults = false } = {}
@@ -239,7 +240,7 @@ const processData = (
         ) {
           const setIds = attrValue.set;
           if (setIds.length > 1) {
-            strapi?.log?.warn?.(
+            db.logger.warn(
               `Multiple ids provided for xToOne relation "${attributeName}" stored in a single FK column; keeping only the last id. Consider using a join table (useJoinTable: true) to support multiple versions of a Draft-and-Publish target.`
             );
           }
@@ -339,7 +340,7 @@ export const createEntityManager = (db: Database): EntityManager => {
         throw new Error('Create expects a data object');
       }
 
-      const dataToInsert = processData(metadata, data, { withDefaults: true });
+      const dataToInsert = processData(db, metadata, data, { withDefaults: true });
 
       const res = await this.createQueryBuilder(uid)
         .insert(dataToInsert)
@@ -347,7 +348,7 @@ export const createEntityManager = (db: Database): EntityManager => {
 
       const id = isRecord(res[0]) ? res[0].id : res[0];
 
-      const trx = await strapi.db.transaction();
+      const trx = await db.transaction();
       try {
         await this.attachRelations(uid, id, data, { transaction: trx.get() });
 
@@ -384,7 +385,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       }
 
       const dataToInsert = data.map((datum) =>
-        processData(metadata, datum, { withDefaults: true })
+        processData(db, metadata, datum, { withDefaults: true })
       );
 
       if (isEmpty(dataToInsert)) {
@@ -447,13 +448,13 @@ export const createEntityManager = (db: Database): EntityManager => {
 
       const { id } = entity;
 
-      const dataToUpdate = processData(metadata, data);
+      const dataToUpdate = processData(db, metadata, data);
 
       if (!isEmpty(dataToUpdate)) {
         await this.createQueryBuilder(uid).where({ id }).update(dataToUpdate).execute();
       }
 
-      const trx = await strapi.db.transaction();
+      const trx = await db.transaction();
       try {
         await this.updateRelations(uid, id, data, { transaction: trx.get() });
         await trx.commit();
@@ -483,7 +484,7 @@ export const createEntityManager = (db: Database): EntityManager => {
       const metadata = db.metadata.get(uid);
       const { where, data } = params;
 
-      const dataToUpdate = processData(metadata, data);
+      const dataToUpdate = processData(db, metadata, data);
 
       if (isEmpty(dataToUpdate)) {
         throw new Error('Update requires data');
@@ -525,7 +526,7 @@ export const createEntityManager = (db: Database): EntityManager => {
 
       await this.createQueryBuilder(uid).where({ id }).delete().execute();
 
-      const trx = await strapi.db.transaction();
+      const trx = await db.transaction();
       try {
         await this.deleteRelations(uid, id, { transaction: trx.get() });
 

--- a/packages/core/database/src/entity-manager/regular-relations.ts
+++ b/packages/core/database/src/entity-manager/regular-relations.ts
@@ -24,10 +24,10 @@ declare module 'knex' {
 }
 
 //  TODO: This is a short term solution, to not steal relations from the same document.
-const getDocumentSiblingIdsQuery = (tableName: string, id: ID) => {
+const getDocumentSiblingIdsQuery = (tableName: string, id: ID, db: Database) => {
   // Find if the model is a content type or something else (e.g. component)
   // to only get the documentId if it's a content type
-  const models: Model[] = Array.from(strapi.db.metadata.values());
+  const models: Model[] = Array.from(db.metadata.values());
 
   const isContentType = models.find((model) => {
     return model.tableName === tableName && model.attributes.documentId;
@@ -84,7 +84,7 @@ const deletePreviousOneToAnyRelations = async ({
     .delete()
     .from(joinTable.name)
     // Exclude the ids of the current document
-    .whereNotIn(joinColumn.name, getDocumentSiblingIdsQuery(joinColumn.referencedTable!, id))
+    .whereNotIn(joinColumn.name, getDocumentSiblingIdsQuery(joinColumn.referencedTable!, id, db))
     // Include all the ids that are being connected
     .whereIn(inverseJoinColumn.name, relIdsToadd)
     .where(joinTable.on || {})
@@ -125,7 +125,7 @@ const deletePreviousAnyToOneRelations = async ({
       .where(joinColumn.name, id)
       .whereNotIn(
         inverseJoinColumn.name,
-        getDocumentSiblingIdsQuery(inverseJoinColumn.referencedTable!, relIdToadd)
+        getDocumentSiblingIdsQuery(inverseJoinColumn.referencedTable!, relIdToadd, db)
       )
       .where(joinTable.on || {})
       .transacting(trx);
@@ -153,7 +153,7 @@ const deletePreviousAnyToOneRelations = async ({
       // Exclude the ids of the current document
       .whereNotIn(
         inverseJoinColumn.name,
-        getDocumentSiblingIdsQuery(inverseJoinColumn.referencedTable!, relIdToadd)
+        getDocumentSiblingIdsQuery(inverseJoinColumn.referencedTable!, relIdToadd, db)
       )
       .where(joinTable.on || {})
       .transacting(trx);
@@ -284,7 +284,7 @@ const cleanOrderColumns = async ({
         .where(joinColumn.name, id)
         .toSQL();
 
-    switch (strapi.db.dialect.client) {
+    switch (db.dialect.client) {
       case 'mysql': {
         // Here it's MariaDB and MySQL 8
         const select = selectRowsToOrder(joinTable.name);
@@ -342,7 +342,7 @@ const cleanOrderColumns = async ({
         .where(inverseJoinColumn.name, 'in', inverseRelIds)
         .toSQL();
 
-    switch (strapi.db.dialect.client) {
+    switch (db.dialect.client) {
       case 'mysql': {
         // Here it's MariaDB and MySQL 8
         const select = selectRowsToOrder(joinTable.name);

--- a/packages/core/database/src/global.d.ts
+++ b/packages/core/database/src/global.d.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line no-var
-declare var strapi: any;
-
 declare module 'knex/lib/dialects/sqlite3/index';
 declare module 'knex/lib/query/querybuilder';
 declare module 'knex/lib/raw';

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -36,6 +36,13 @@ export interface DatabaseConfig {
   connection: Knex.Config;
   settings: Settings;
   logger?: Logger;
+  /**
+   * Strapi host used by the database layer (e.g. for model lookups and store
+   * access). Optional for backwards compatibility: when omitted, the
+   * constructor falls back to `globalThis.strapi`, which is deprecated and
+   * will be removed in the next major. At that point this field will become
+   * required — always pass the Strapi instance explicitly.
+   */
   strapi?: StrapiHost;
 }
 
@@ -86,10 +93,20 @@ class Database {
 
     this.logger = config.logger ?? console;
 
-    const strapi = config.strapi ?? (globalThis as { strapi?: StrapiHost }).strapi;
+    let strapi = config.strapi;
+    if (!strapi) {
+      strapi = (globalThis as { strapi?: StrapiHost }).strapi;
+      if (strapi) {
+        this.logger.warn(
+          'Database resolved its Strapi host from `globalThis.strapi`. This fallback is deprecated and will be removed in the next major; pass `config.strapi` to the Database constructor explicitly.'
+        );
+      }
+    }
+
     if (!strapi) {
       throw new Error('Database requires a Strapi host. Pass `config.strapi` to the constructor.');
     }
+
     this.strapi = strapi;
 
     this.dialect = getDialect(this);

--- a/packages/core/database/src/index.ts
+++ b/packages/core/database/src/index.ts
@@ -12,7 +12,7 @@ import { createConnection } from './connection';
 import * as errors from './errors';
 import { Callback, transactionCtx, TransactionObject } from './transaction-context';
 import { validateDatabase } from './validations';
-import type { Model, JoinTable } from './types';
+import type { Model, JoinTable, StrapiHost } from './types';
 import type { Identifiers } from './utils/identifiers';
 import { createRepairManager, type RepairManager } from './repairs';
 
@@ -36,6 +36,7 @@ export interface DatabaseConfig {
   connection: Knex.Config;
   settings: Settings;
   logger?: Logger;
+  strapi?: StrapiHost;
 }
 
 const afterCreate =
@@ -71,6 +72,8 @@ class Database {
 
   logger: Logger;
 
+  strapi: StrapiHost;
+
   constructor(config: DatabaseConfig) {
     this.config = {
       ...config,
@@ -82,6 +85,12 @@ class Database {
     };
 
     this.logger = config.logger ?? console;
+
+    const strapi = config.strapi ?? (globalThis as { strapi?: StrapiHost }).strapi;
+    if (!strapi) {
+      throw new Error('Database requires a Strapi host. Pass `config.strapi` to the constructor.');
+    }
+    this.strapi = strapi;
 
     this.dialect = getDialect(this);
 
@@ -264,4 +273,4 @@ class Database {
 }
 
 export { Database, errors };
-export type { Model, JoinTable, Identifiers, Migration };
+export type { Model, JoinTable, Identifiers, Migration, StrapiHost };

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-03-locale.ts
@@ -27,7 +27,7 @@ export const createdLocale: Migration = {
 
       // Ignore non-content types
       const uid = meta.uid;
-      const model = strapi.getModel(uid);
+      const model = db.strapi.getModel(uid);
       if (!model) {
         continue;
       }

--- a/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
+++ b/packages/core/database/src/migrations/internal-migrations/5.0.0-04-published-at.ts
@@ -30,7 +30,7 @@ export const createdPublishedAt: Migration = {
 
       // Ignore non-content types
       const uid = meta.uid;
-      const model = strapi.getModel(uid);
+      const model = db.strapi.getModel(uid);
       if (!model) {
         continue;
       }

--- a/packages/core/database/src/repairs/__tests__/repair.test.ts
+++ b/packages/core/database/src/repairs/__tests__/repair.test.ts
@@ -46,6 +46,10 @@ describe('Database Repair Manager', () => {
         warn: jest.fn(),
         error: jest.fn(),
       },
+      strapi: {
+        getModel: jest.fn(),
+        store: { get: jest.fn() },
+      },
     };
   });
 

--- a/packages/core/database/src/schema/__tests__/schema-diff.test.ts
+++ b/packages/core/database/src/schema/__tests__/schema-diff.test.ts
@@ -4,8 +4,15 @@ import type { Index, Schema, Table } from '..';
 
 describe('diffSchemas', () => {
   let diffSchemas: ReturnType<typeof createSchemaDiff>['diff'];
+  let mockStrapi: { store: { get: (...args: any[]) => any } };
 
   beforeEach(() => {
+    mockStrapi = {
+      store: {
+        get: () => [],
+      },
+    };
+
     const schemaDiff = createSchemaDiff({
       dialect: {
         usesForeignKeys() {
@@ -14,15 +21,10 @@ describe('diffSchemas', () => {
         getSqlType: (type: string) => type, // Mock the getSqlType function to return the type as-is
         supportsUnsigned: () => false,
       },
+      strapi: mockStrapi,
     } as any);
 
     diffSchemas = schemaDiff.diff.bind(schemaDiff);
-
-    global.strapi = {
-      store: {
-        get: () => [],
-      },
-    };
   });
 
   test('New Table', async () => {
@@ -1181,11 +1183,7 @@ describe('diffSchemas', () => {
       foreignKeys: [],
     };
 
-    global.strapi = {
-      store: {
-        get: async () => [testTables[0].name, 'table2'],
-      },
-    } as any;
+    mockStrapi.store.get = async () => [testTables[0].name, 'table2'];
 
     const databaseSchema: Schema = {
       tables: [...testTables, coreStoreTable],

--- a/packages/core/database/src/schema/diff.ts
+++ b/packages/core/database/src/schema/diff.ts
@@ -417,7 +417,7 @@ export default (db: Database) => {
     }
 
     // maintain audit logs table from EE -> CE
-    const parsePersistedTable = (persistedTable: string | Table) => {
+    const parsePersistedTable = (persistedTable: PersistedTable) => {
       if (typeof persistedTable === 'string') {
         return persistedTable;
       }
@@ -426,10 +426,10 @@ export default (db: Database) => {
 
     const persistedTables = helpers.hasTable(databaseSchema, 'strapi_core_store_settings')
       ? // TODO: replace with low level db query instead
-        ((await strapi.store.get({
+        (((await db.strapi.store.get({
           type: 'core',
           key: 'persisted_tables',
-        })) ?? [])
+        })) ?? []) as PersistedTable[])
       : [];
 
     const reservedTables = [...RESERVED_TABLE_NAMES, ...persistedTables.map(parsePersistedTable)];
@@ -463,7 +463,7 @@ export default (db: Database) => {
             );
           })
           // In case the table is not found, filter undefined values
-          .filter((table: PersistedTable) => !_.isNil(table));
+          .filter((table: Table | undefined): table is Table => !_.isNil(table));
 
         removedTables.push(databaseTable, ...dependencies);
       }

--- a/packages/core/database/src/types/host.ts
+++ b/packages/core/database/src/types/host.ts
@@ -1,0 +1,14 @@
+type GetParams = {
+  key: string;
+  type?: string;
+  environment?: string;
+  name?: string;
+  tag?: string;
+};
+
+export interface StrapiHost {
+  getModel(uid: string): unknown;
+  store: {
+    get(params: GetParams): Promise<unknown>;
+  };
+}

--- a/packages/core/database/src/types/index.ts
+++ b/packages/core/database/src/types/index.ts
@@ -1,6 +1,8 @@
 import type { Action, SubscriberFn } from '../lifecycles';
 import type { ForeignKey, Index } from '../schema/types';
 
+export type { StrapiHost } from './host';
+
 export type ID = string | number;
 
 export interface ColumnInfo {


### PR DESCRIPTION
### What does it do?

Replaces the untyped `declare var strapi: any` global in `@strapi/database` with an explicit `StrapiHost` port (just `getModel` and `store.get` — what database actually consumes), defined locally inside the package.

The Strapi instance is now passed into `Database` at construction (`new Database({ ..., strapi: this })`) instead of being read from a global. `Database.strapi` is a non-nullable field; the constructor falls back to `globalThis.strapi` and throws when neither is available, surfacing the dependency at start-up rather than at first use.

The ambient global declaration is removed entirely — the constructor's `globalThis as { strapi?: StrapiHost }` cast is enough.

Three of the six original lookups (`strapi.db.metadata`, `strapi.db.dialect`, `strapi.db.transaction`) were self-references that just needed `this`/`db`. Two needed `getModel`. One needed `store.get`. A stray `strapi?.log?.warn?.(...)` call inside `processData` was rerouted through `db.logger` by threading `db` into that helper.

### Why is it needed?

`@strapi/database` reached the running Strapi via `declare var strapi: any` at six call sites (entity-manager, schema diff, two internal migrations). That created a hidden runtime contract: the package looked self-contained but silently depended on a global being assigned before any DB code ran. Trying to type the global as `Strapi` from `@strapi/types` would have flipped the existing `types → database` dependency and created a cycle.

This change applies the **host port** pattern (the consumer of an abstraction owns it): `@strapi/database` declares the narrow shape it needs, and `Strapi` from `@strapi/types` satisfies it via TypeScript structural typing — no import in either direction. The existing `types → database` dep stays unchanged. Future work could lift the `Database` contract into `@strapi/types` (the second inversion) to fully satisfy DIP, but is intentionally out of scope for this PR.

### How to test it?

- `yarn workspace @strapi/database build` — clean
- `yarn workspace @strapi/database test:unit` — 17/17 suites, 149/149 tests pass
- `yarn workspace @strapi/core build` — clean
- `yarn run -T tsc --noEmit` from `packages/core/core` — 217 errors, **identical to develop baseline** (zero new)
- `rg 'declare var strapi|globalThis\.strapi' packages/core/database/src` — only the controlled fallback in `index.ts`
- No bare `strapi.X` global access remains in `packages/core/database/src`
- Smoke a sample app (`yarn develop`): migrations run, CRUD works, schema diff runs after editing a content type

### Related issue(s)/PR(s)

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)