### PR TITLE
POC: scope jest globals to tests in @strapi/database via project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ schema.graphql
 dist
 .nx
 .tsbuildinfo
+*.tsbuildinfo
 .eslintcache
 
 ############################

--- a/docs/package.json
+++ b/docs/package.json
@@ -48,7 +48,7 @@
     "docusaurus-plugin-typedoc": "0.22.0",
     "typedoc": "0.25.10",
     "typedoc-plugin-markdown": "3.17.1",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "unist-util-visit": "5.0.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -671,6 +671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-string-parser@npm:7.25.9"
+  checksum: 10c0/7244b45d8e65f6b4338a6a68a8556f2cb161b782343e97281a5f2b9b93e420cad0d9f5773a59d79f61d0c448913d06f6a2358a87f2e203cf112e3c5b53522ee6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-string-parser@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-string-parser@npm:7.27.1"
@@ -1695,7 +1702,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.21.3, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.10, @babel/types@npm:^7.27.0, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.21.3, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.10, @babel/types@npm:^7.27.0, @babel/types@npm:^7.4.4":
+  version: 7.27.0
+  resolution: "@babel/types@npm:7.27.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+  checksum: 10c0/6f1592eabe243c89a608717b07b72969be9d9d2fce1dee21426238757ea1fa60fdfc09b29de9e48d8104311afc6e6fb1702565a9cc1e09bc1e76f2b2ddb0f6e1
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
   dependencies:
@@ -3198,7 +3215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/react@npm:3.1.1, @mdx-js/react@npm:^3.0.0":
+"@mdx-js/react@npm:3.1.1":
   version: 3.1.1
   resolution: "@mdx-js/react@npm:3.1.1"
   dependencies:
@@ -3207,6 +3224,18 @@ __metadata:
     "@types/react": ">=16"
     react: ">=16"
   checksum: 10c0/34ca98bc2a0f969894ea144dc5c8a5294690505458cd24965cd9be854d779c193ad9192bf9143c4c18438fafd1902e100d99067e045c69319288562d497558c6
+  languageName: node
+  linkType: hard
+
+"@mdx-js/react@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "@mdx-js/react@npm:3.0.1"
+  dependencies:
+    "@types/mdx": "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ">=16"
+    react: ">=16"
+  checksum: 10c0/d210d926ef488d39ad65f04d821936b668eadcdde3b6421e94ec4200ca7ad17f17d24c5cbc543882586af9f08b10e2eea715c728ce6277487945e05c5199f532
   languageName: node
   linkType: hard
 
@@ -5534,10 +5563,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:2.1.1, clsx@npm:^2.0.0":
+"clsx@npm:2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "clsx@npm:2.1.0"
+  checksum: 10c0/c09c00ad14f638366ca814097e6cab533dfa1972a358da5b557be487168acbb25b4c1395e89ffa842a8a61ba87a462d2b4885bc9d4f8410b598f3cb339599cdb
   languageName: node
   linkType: hard
 
@@ -6733,7 +6769,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     typedoc: "npm:0.25.10"
     typedoc-plugin-markdown: "npm:3.17.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     unist-util-visit: "npm:5.0.0"
   languageName: unknown
   linkType: soft
@@ -13545,23 +13581,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
+  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
   languageName: node
   linkType: hard
 

--- a/examples/complex/package.json
+++ b/examples/complex/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "^6.0.2"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/examples/complex/tsconfig.json
+++ b/examples/complex/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "^6.0.2"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/examples/empty/tsconfig.json
+++ b/examples/empty/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,

--- a/examples/kitchensink-ts/tsconfig.json
+++ b/examples/kitchensink-ts/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -15,6 +15,7 @@
     "**/*.test.js",
     "**/*.test.api.js",
     "**/examples/getstarted/*",
-    "**/examples/kitchensink/*"
+    "**/examples/kitchensink/*",
+    "packages/**"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "syncpack": "13.0.4",
     "tar": "7.5.11",
     "ts-jest": "29.1.0",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "vitest": "catalog:",
     "yalc": "1.0.0-pre.53",
     "yargs": "17.7.2"

--- a/packages/admin-test-utils/tsconfig.build.json
+++ b/packages/admin-test-utils/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src", "custom.d.ts"],
   "exclude": ["**/__tests__/**"]

--- a/packages/cli/cloud/tsconfig.build.json
+++ b/packages/cli/cloud/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules", "**/__tests__/**", "**/tests/**"]
 }

--- a/packages/cli/create-strapi-app/src/index.ts
+++ b/packages/cli/create-strapi-app/src/index.ts
@@ -203,7 +203,7 @@ async function run(args: string[]): Promise<void> {
   if (scope.useTypescript) {
     scope.devDependencies = {
       ...scope.devDependencies,
-      typescript: '^5',
+      typescript: '^6',
       '@types/node': '^20',
       '@types/react': '^18',
       '@types/react-dom': '^18',

--- a/packages/cli/create-strapi-app/src/utils/template.ts
+++ b/packages/cli/create-strapi-app/src/utils/template.ts
@@ -158,7 +158,6 @@ async function downloadGithubRepo(rootPath: string, { owner, repo, branch, subPa
   }
 
   await pipeline(
-    // @ts-expect-error - Readable is not a valid source
     Readable.fromWeb(res.body),
     tar.x({
       cwd: rootPath,

--- a/packages/cli/create-strapi-app/templates/example/tsconfig.json
+++ b/packages/cli/create-strapi-app/templates/example/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,

--- a/packages/cli/create-strapi-app/templates/vanilla/tsconfig.json
+++ b/packages/cli/create-strapi-app/templates/vanilla/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,

--- a/packages/core/admin/admin/tsconfig.build.json
+++ b/packages/core/admin/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/admin/admin/tsconfig.json
+++ b/packages/core/admin/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "paths": {
       "@tests/*": ["./tests/*"]
     }

--- a/packages/core/admin/ee/admin/tsconfig.json
+++ b/packages/core/admin/ee/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../../",
-    "baseUrl": ".",
     "paths": {
       "@tests/*": ["../../admin/tests/*"]
     }

--- a/packages/core/admin/ee/server/tsconfig.build.json
+++ b/packages/core/admin/ee/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "../../",
-    "baseUrl": ".",
     "outDir": "./dist"
   },
   "include": ["src"],

--- a/packages/core/admin/ee/server/tsconfig.json
+++ b/packages/core/admin/ee/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
-    "rootDir": "../../",
-    "baseUrl": "."
+    "rootDir": "../../"
   }
 }

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -144,7 +144,7 @@
     "semver": "7.7.4",
     "sift": "16.0.1",
     "sonner": "2.0.7",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "use-context-selector": "1.4.1",
     "yup": "0.32.9",
     "zod": "3.25.67"

--- a/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
+++ b/packages/core/admin/server/src/services/permission/permissions-manager/sanitize.ts
@@ -201,9 +201,8 @@ export default ({ action, ability, model }: any) => {
   const wrapSanitize = (createSanitizeFunction: any) => {
     const { getPermissionFields } = createPermissionFieldsCache(ability);
 
-    // TODO
-    // @ts-expect-error define the correct return type
-    const wrappedSanitize = async (data: unknown, options = {} as any) => {
+    // TODO @Nico - define the correct return type for wrappedSanitize
+    const wrappedSanitize = async (data: unknown, options = {} as any): Promise<any> => {
       if (isArray(data)) {
         return Promise.all(data.map((entity: unknown) => wrappedSanitize(entity, options)));
       }

--- a/packages/core/admin/server/tsconfig.build.json
+++ b/packages/core/admin/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/admin/server/tsconfig.json
+++ b/packages/core/admin/server/tsconfig.json
@@ -3,8 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
-    "types": ["lodash", "jest"],
+    "types": ["node", "lodash", "jest"],
     "esModuleInterop": true
   }
 }

--- a/packages/core/admin/tsconfig.build.json
+++ b/packages/core/admin/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": ".",
     "noEmit": false
   },
   "include": ["_internal"]

--- a/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/TableCells/CellContent.tsx
@@ -21,8 +21,10 @@ const CellContent = ({ content, mainField, attribute, rowId, name }: CellContent
     return (
       <Typography
         textColor="neutral800"
-        paddingLeft={attribute.type === ('relation' || 'component') ? '1.6rem' : 0}
-        paddingRight={attribute.type === ('relation' || 'component') ? '1.6rem' : 0}
+        paddingLeft={attribute.type === 'relation' || attribute.type === 'component' ? '1.6rem' : 0}
+        paddingRight={
+          attribute.type === 'relation' || attribute.type === 'component' ? '1.6rem' : 0
+        }
       >
         -
       </Typography>

--- a/packages/core/content-manager/admin/tsconfig.build.json
+++ b/packages/core/content-manager/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/content-manager/admin/tsconfig.json
+++ b/packages/core/content-manager/admin/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "paths": {
-      "@tests/*": ["./tests/*"]
+      "@tests/*": ["./tests/*"],
+      "msw": ["../../admin/node_modules/msw"],
+      "msw/*": ["../../admin/node_modules/msw/*"]
     }
   },
   "include": ["./src", "../shared", "./tests", "./custom.d.ts"]

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -737,7 +737,7 @@ export default {
       }
     }
 
-    const entitiesIds = entities.map((document) => document.documentId);
+    const entitiesIds = entities.map((document: any) => document.documentId);
 
     const { count } = await documentManager.unpublishMany(entitiesIds, model, { locale });
 
@@ -879,7 +879,7 @@ export default {
     }
 
     // We filter out documentsIds that maybe doesn't exist in a specific locale
-    const localeDocumentsIds = documentLocales.map((document) => document.documentId);
+    const localeDocumentsIds = documentLocales.map((document: any) => document.documentId);
 
     const { count } = await documentManager.deleteMany(localeDocumentsIds, model, { locale });
 

--- a/packages/core/content-manager/server/src/services/utils/configuration/layouts.ts
+++ b/packages/core/content-manager/server/src/services/utils/configuration/layouts.ts
@@ -72,24 +72,23 @@ function syncLayouts(configuration: any, schema: any) {
     const newRow: unknown[] = [];
 
     for (const el of row) {
-      if (!hasEditableAttribute(schema, el.name)) continue;
+      if (hasEditableAttribute(schema, el.name)) {
+        // Check if the field is a custom field with a custom size.
+        // If so, use the custom size instead of the type size
+        const { hasFieldSize } = getService('field-sizes');
+        const fieldType = hasFieldSize(schema.attributes[el.name].customField)
+          ? schema.attributes[el.name].customField
+          : schema.attributes[el.name].type;
 
-      // Check if the field is a custom field with a custom size.
-      // If so, use the custom size instead of the type size
-      const { hasFieldSize } = getService('field-sizes');
-      const fieldType = hasFieldSize(schema.attributes[el.name].customField)
-        ? schema.attributes[el.name].customField
-        : schema.attributes[el.name].type;
-
-      /* if the type of a field was changed (ex: string -> json) or a new field was added in the schema
-         and the new type doesn't allow the size of the previous type, append the field at the end of layouts
-      */
-      if (!isAllowedFieldSize(fieldType, el.size)) {
-        elementsToReAppend.push(el.name);
-        continue;
+        /* if the type of a field was changed (ex: string -> json) or a new field was added in the schema
+           and the new type doesn't allow the size of the previous type, append the field at the end of layouts
+        */
+        if (!isAllowedFieldSize(fieldType, el.size)) {
+          elementsToReAppend.push(el.name);
+        } else {
+          newRow.push(el);
+        }
       }
-
-      newRow.push(el);
     }
 
     if (newRow.length > 0) {

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -1,7 +1,6 @@
 import { merge, isEmpty, set, propEq } from 'lodash/fp';
 import strapiUtils from '@strapi/utils';
 import type { UID, Schema, Modules } from '@strapi/types';
-import { getService } from '../../utils';
 
 const {
   isVisibleAttribute,
@@ -423,7 +422,7 @@ const buildDeepPopulate = async (uid: UID.CollectionType) => {
     return cached;
   }
 
-  const result = await getService('populate-builder')(uid)
+  const result = await (strapi.plugin('content-manager').service('populate-builder') as any)(uid)
     .populateDeep(Infinity)
     .countRelations()
     .build();

--- a/packages/core/content-manager/server/src/utils/index.ts
+++ b/packages/core/content-manager/server/src/utils/index.ts
@@ -1,7 +1,7 @@
 import '@strapi/types';
 
-import { DocumentManagerService } from 'src/services/document-manager';
-import DocumentMetadata from 'src/services/document-metadata';
+import { DocumentManagerService } from '../services/document-manager';
+import DocumentMetadata from '../services/document-metadata';
 
 type Services = {
   'document-manager': DocumentManagerService;

--- a/packages/core/content-manager/server/tsconfig.build.json
+++ b/packages/core/content-manager/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/content-manager/server/tsconfig.json
+++ b/packages/core/content-manager/server/tsconfig.json
@@ -3,8 +3,7 @@
   "include": ["./src"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
-    "types": ["lodash", "jest"],
+    "types": ["node", "lodash", "jest"],
     "esModuleInterop": true
   }
 }

--- a/packages/core/content-releases/admin/tsconfig.build.json
+++ b/packages/core/content-releases/admin/tsconfig.build.json
@@ -4,7 +4,6 @@
   "exclude": ["node_modules", "tests", "**/*.test.*"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   }

--- a/packages/core/content-releases/admin/tsconfig.json
+++ b/packages/core/content-releases/admin/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "tsconfig/client.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "../",
     "paths": {
       "@tests/*": ["./tests/*"]

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -93,7 +93,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.3",
     "styled-components": "6.1.8",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/content-releases/server/tsconfig.build.json
+++ b/packages/core/content-releases/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/content-releases/server/tsconfig.json
+++ b/packages/core/content-releases/server/tsconfig.json
@@ -4,7 +4,6 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "esModuleInterop": true
   }
 }

--- a/packages/core/content-type-builder/admin/tsconfig.build.json
+++ b/packages/core/content-type-builder/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/content-type-builder/admin/tsconfig.json
+++ b/packages/core/content-type-builder/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["src", "./custom.d.ts"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -41,7 +41,6 @@
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.ts",
   "files": [
     "dist/",
     "strapi-server.js"

--- a/packages/core/content-type-builder/server/tsconfig.build.json
+++ b/packages/core/content-type-builder/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/content-type-builder/server/tsconfig.json
+++ b/packages/core/content-type-builder/server/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": ["lodash", "jest"],
+    "types": ["node", "lodash", "jest"],
     "esModuleInterop": true,
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/core/content-type-builder/tsconfig.build.json
+++ b/packages/core/content-type-builder/tsconfig.build.json
@@ -3,6 +3,7 @@
   "include": ["./shared", "./server", "./admin"],
   "compilerOptions": {
     "declarationDir": "./dist",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "."
   }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -107,7 +107,7 @@
     "resolve.exports": "2.0.2",
     "semver": "7.7.4",
     "statuses": "2.0.1",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "undici": "6.25.0",
     "yup": "0.32.9",
     "zod": "3.25.67"

--- a/packages/core/core/src/ee/index.ts
+++ b/packages/core/core/src/ee/index.ts
@@ -256,7 +256,7 @@ const getTrialEndDate = async ({
     );
   });
 
-  const data = await res.json();
+  const data = (await res.json()) as { trialEndsAt: string } | null;
 
   return data;
 };

--- a/packages/core/core/src/ee/license.ts
+++ b/packages/core/core/src/ee/license.ts
@@ -114,7 +114,10 @@ const fetchLicense = async (
   const contentType = response.headers.get('Content-Type');
 
   if (contentType?.includes('application/json')) {
-    const { data, error } = await response.json();
+    const { data, error } = (await response.json()) as {
+      data: { license: string };
+      error: { message: string };
+    };
 
     switch (response.status) {
       case 200:

--- a/packages/core/core/src/utils/fetch.ts
+++ b/packages/core/core/src/utils/fetch.ts
@@ -14,7 +14,7 @@ export const createStrapiFetch = (
 ): Modules.Fetch.Fetch => {
   const { logs = true } = options ?? {};
 
-  function strapiFetch(url: RequestInfo | URL, options?: RequestInit) {
+  function strapiFetch(url: string | URL | Request, options?: RequestInit) {
     const fetchOptions = {
       ...(strapiFetch.dispatcher ? { dispatcher: strapiFetch.dispatcher } : {}),
       ...options,
@@ -24,7 +24,7 @@ export const createStrapiFetch = (
       strapi.log.debug(`Making request for ${url}`);
     }
 
-    return fetch(url, fetchOptions);
+    return fetch(url, fetchOptions as RequestInit);
   }
 
   const proxy =

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -36,7 +36,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/src/index.d.ts",
   "files": [
     "dist/"
   ],
@@ -84,7 +84,7 @@
     "knex": "3.0.1",
     "koa": "2.16.4",
     "rimraf": "6.1.3",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/data-transfer/src/engine/index.ts
+++ b/packages/core/data-transfer/src/engine/index.ts
@@ -881,7 +881,9 @@ class TransferEngine<
           this.panic(error);
         } else {
           this.panic(
-            new Error(`Unknwon error when executing "beforeTransfer" on the ${origin} provider`)
+            new Error(
+              `Unknown error when executing "beforeTransfer" on the ${provider.name} provider`
+            )
           );
         }
       }
@@ -1071,6 +1073,9 @@ export type {
   ErrorHandlerContext,
   SchemaDiffHandlerContext,
   ITransferResults,
+  ILink,
+  IEntity,
+  Diff,
 };
 
 export * as errors from './errors';

--- a/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-source/assets.ts
@@ -21,7 +21,7 @@ function getFileStream(
   // fetch the image from remote url and stream it
   strapi
     .fetch(filepath)
-    .then((res: Response) => {
+    .then((res) => {
       if (res.status !== 200) {
         readableStream.emit('error', new Error(`Request failed with status code ${res.status}`));
         return;
@@ -52,7 +52,7 @@ export function getFileStatsForTransfer(
   return new Promise((resolve, reject) => {
     strapi
       .fetch(filepath)
-      .then((res: Response) => {
+      .then((res) => {
         if (res.status !== 200) {
           reject(new Error(`Request failed with status code ${res.status}`));
           return;

--- a/packages/core/data-transfer/tsconfig.build.json
+++ b/packages/core/data-transfer/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "."
   },
   "include": ["types", "src"],
   "exclude": ["node_modules", "**/__tests__/**"]

--- a/packages/core/database/.eslintrc.js
+++ b/packages/core/database/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
   root: true,
   extends: ['custom/back/typescript'],
+  parserOptions: {
+    project: ['./tsconfig.eslint.json'],
+    tsconfigRootDir: __dirname,
+  },
 };

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
+    "@types/jest": "29.5.2",
     "eslint-config-custom": "5.44.0",
     "tsconfig": "5.44.0"
   },

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "run -T npm-run-all clean --parallel build:code build:types",
-    "build:code": "run -T  rollup -c",
+    "build:code": "run -T rollup -c",
     "build:types": "run -T tsc -p tsconfig.build.json --emitDeclarationOnly",
     "clean": "run -T rimraf ./dist",
     "lint": "run -T tsc --noEmit && run -T eslint .",

--- a/packages/core/database/tsconfig.build.json
+++ b/packages/core/database/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/**"]

--- a/packages/core/database/tsconfig.build.json
+++ b/packages/core/database/tsconfig.build.json
@@ -1,10 +1,12 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "tsconfig/base.json",
   "compilerOptions": {
+    "composite": true,
+    "types": ["node"],
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules", "**/__tests__/**", "src/**/*.test.ts"]
 }

--- a/packages/core/database/tsconfig.build.json
+++ b/packages/core/database/tsconfig.build.json
@@ -8,5 +8,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "**/__tests__/", "**/*.test.ts"]
 }

--- a/packages/core/database/tsconfig.eslint.json
+++ b/packages/core/database/tsconfig.eslint.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "tsconfig/base.json",
   "compilerOptions": {
+    "types": ["jest", "node"],
+    "allowJs": true,
     "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src", ".eslintrc.js"],
   "exclude": ["node_modules"]
 }

--- a/packages/core/database/tsconfig.json
+++ b/packages/core/database/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node", "jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/packages/core/database/tsconfig.json
+++ b/packages/core/database/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "extends": "tsconfig/base.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "types": ["node", "jest"]
-  },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "files": [],
+  "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/packages/core/database/tsconfig.test.json
+++ b/packages/core/database/tsconfig.test.json
@@ -5,6 +5,6 @@
     "types": ["jest", "node"],
     "noEmit": true
   },
-  "include": ["src/global.d.ts", "src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "include": ["src/global.d.ts", "src/**/__tests__/", "src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/core/database/tsconfig.test.json
+++ b/packages/core/database/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "references": [{ "path": "./tsconfig.build.json" }]
+}

--- a/packages/core/database/tsconfig.test.json
+++ b/packages/core/database/tsconfig.test.json
@@ -5,6 +5,6 @@
     "types": ["jest", "node"],
     "noEmit": true
   },
-  "include": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "include": ["src/global.d.ts", "src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
   "references": [{ "path": "./tsconfig.build.json" }]
 }

--- a/packages/core/email/admin/tsconfig.build.json
+++ b/packages/core/email/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/email/admin/tsconfig.json
+++ b/packages/core/email/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["./src", "../shared"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/core/email/server/tsconfig.build.json
+++ b/packages/core/email/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/email/server/tsconfig.json
+++ b/packages/core/email/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src", "../shared"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/core/review-workflows/admin/tsconfig.build.json
+++ b/packages/core/review-workflows/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/review-workflows/admin/tsconfig.json
+++ b/packages/core/review-workflows/admin/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "paths": {
-      "@tests/*": ["./tests/*"]
+      "@tests/*": ["./tests/*"],
+      "msw": ["../../admin/node_modules/msw"],
+      "msw/*": ["../../admin/node_modules/msw/*"]
     }
   },
   "include": ["../package.json", "./src", "../shared", "./tests", "./custom.d.ts"]

--- a/packages/core/review-workflows/server/tsconfig.build.json
+++ b/packages/core/review-workflows/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/review-workflows/server/tsconfig.json
+++ b/packages/core/review-workflows/server/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src", "custom.d.ts", "../shared"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node", "jest"]
   }
 }

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -163,7 +163,7 @@
     "resolve-from": "5.0.0",
     "semver": "7.7.4",
     "style-loader": "3.3.4",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "vite": "5.4.21",
     "webpack": "^5.90.3",
     "webpack-bundle-analyzer": "^4.10.1",

--- a/packages/core/strapi/src/cli/commands/export/action.ts
+++ b/packages/core/strapi/src/cli/commands/export/action.ts
@@ -82,14 +82,14 @@ export default async (opts: CmdOptions) => {
     transforms: {
       links: [
         {
-          filter(link) {
+          filter(link: engineDataTransfer.ILink) {
             return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
-          filter(entity) {
+          filter(entity: engineDataTransfer.IEntity) {
             return !isIgnoredContentType(entity.type);
           },
         },

--- a/packages/core/strapi/src/cli/commands/import/action.ts
+++ b/packages/core/strapi/src/cli/commands/import/action.ts
@@ -89,14 +89,14 @@ export default async (opts: CmdOptions) => {
     transforms: {
       links: [
         {
-          filter(link) {
+          filter(link: engineDataTransfer.ILink) {
             return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
-          filter: (entity) => !isIgnoredContentType(entity.type),
+          filter: (entity: engineDataTransfer.IEntity) => !isIgnoredContentType(entity.type),
         },
       ],
     },

--- a/packages/core/strapi/src/cli/commands/transfer/action.ts
+++ b/packages/core/strapi/src/cli/commands/transfer/action.ts
@@ -156,14 +156,14 @@ export default async (opts: CmdOptions) => {
     transforms: {
       links: [
         {
-          filter(link) {
+          filter(link: engineDataTransfer.ILink) {
             return !isIgnoredContentType(link.left.type) && !isIgnoredContentType(link.right.type);
           },
         },
       ],
       entities: [
         {
-          filter(entity) {
+          filter(entity: engineDataTransfer.IEntity) {
             return !isIgnoredContentType(entity.type);
           },
         },

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -416,33 +416,38 @@ const getDiffHandler = (
     let workflowsStatus;
     const source = 'Schema Integrity';
 
-    Object.entries(context.diffs).forEach(([uid, diffs]) => {
-      for (const diff of diffs) {
-        const path = [uid].concat(diff.path).join('.');
-        const endPath = diff.path[diff.path.length - 1];
+    (Object.entries(context.diffs) as Array<[string, engineDataTransfer.Diff[]]>).forEach(
+      ([uid, diffs]) => {
+        for (const diff of diffs) {
+          const path = [uid].concat(diff.path).join('.');
+          const endPath = diff.path[diff.path.length - 1];
 
-        // Catch known features
-        if (
-          uid === 'plugin::review-workflows.workflow' ||
-          uid === 'plugin::review-workflows.workflow-stage' ||
-          endPath?.startsWith('strapi_stage') ||
-          endPath?.startsWith('strapi_assignee')
-        ) {
-          workflowsStatus = diff.kind;
-        }
-        // handle generic cases
-        else if (diff.kind === 'added') {
-          engine.reportWarning(chalk.red(`${chalk.bold(path)} does not exist on source`), source);
-        } else if (diff.kind === 'deleted') {
-          engine.reportWarning(
-            chalk.red(`${chalk.bold(path)} does not exist on destination`),
-            source
-          );
-        } else if (diff.kind === 'modified') {
-          engine.reportWarning(chalk.red(`${chalk.bold(path)} has a different data type`), source);
+          // Catch known features
+          if (
+            uid === 'plugin::review-workflows.workflow' ||
+            uid === 'plugin::review-workflows.workflow-stage' ||
+            endPath?.startsWith('strapi_stage') ||
+            endPath?.startsWith('strapi_assignee')
+          ) {
+            workflowsStatus = diff.kind;
+          }
+          // handle generic cases
+          else if (diff.kind === 'added') {
+            engine.reportWarning(chalk.red(`${chalk.bold(path)} does not exist on source`), source);
+          } else if (diff.kind === 'deleted') {
+            engine.reportWarning(
+              chalk.red(`${chalk.bold(path)} does not exist on destination`),
+              source
+            );
+          } else if (diff.kind === 'modified') {
+            engine.reportWarning(
+              chalk.red(`${chalk.bold(path)} has a different data type`),
+              source
+            );
+          }
         }
       }
-    });
+    );
 
     // output the known feature warnings
     if (workflowsStatus === 'added') {

--- a/packages/core/strapi/tsconfig.build.json
+++ b/packages/core/strapi/tsconfig.build.json
@@ -2,8 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "noEmit": false
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules", "**/__tests__/**", "src/test/**"]
 }

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -71,7 +71,7 @@
     "eslint-config-custom": "5.44.0",
     "lodash": "4.18.1",
     "tsconfig": "5.44.0",
-    "typescript": "5.4.5",
+    "typescript": "6.0.2",
     "undici": "6.25.0"
   },
   "engines": {

--- a/packages/core/types/src/modules/fetch.ts
+++ b/packages/core/types/src/modules/fetch.ts
@@ -7,6 +7,6 @@ import type { ProxyAgent } from 'undici';
  * */
 
 export interface Fetch {
-  (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>;
+  (input: string | URL | Request, init?: RequestInit): Promise<Response>;
   dispatcher?: ProxyAgent;
 }

--- a/packages/core/types/tsconfig.build.json
+++ b/packages/core/types/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "noEmit": false,
     "allowJs": false
   },

--- a/packages/core/types/tsconfig.json
+++ b/packages/core/types/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "node",
     "noEmit": true
   },
   "include": ["src"],

--- a/packages/core/upload/admin/src/components/EditAssetDialog/EditAssetContent.tsx
+++ b/packages/core/upload/admin/src/components/EditAssetDialog/EditAssetContent.tsx
@@ -172,18 +172,20 @@ export const EditAssetContent = ({
   };
 
   const activeFolderId = asset?.folder?.id;
-  const initialFormData = !folderStructureIsLoading && {
-    name: asset?.name,
-    alternativeText: asset?.alternativeText ?? undefined,
-    caption: asset?.caption ?? undefined,
-    focalPoint: asset?.focalPoint ?? null,
-    parent: {
-      value: activeFolderId ?? undefined,
-      label:
-        findRecursiveFolderByValue(folderStructure!, activeFolderId!)?.label ??
-        folderStructure![0].label,
-    },
-  };
+  const initialFormData: FormInitialData = !folderStructureIsLoading
+    ? {
+        name: asset?.name,
+        alternativeText: asset?.alternativeText ?? undefined,
+        caption: asset?.caption ?? undefined,
+        focalPoint: asset?.focalPoint ?? null,
+        parent: {
+          value: activeFolderId ?? undefined,
+          label:
+            findRecursiveFolderByValue(folderStructure!, activeFolderId!)?.label ??
+            folderStructure![0].label,
+        },
+      }
+    : {};
 
   const handleClose = (values?: { [key: string]: unknown }) => {
     if (!isEqual(initialFormData, values)) {

--- a/packages/core/upload/admin/tsconfig.build.json
+++ b/packages/core/upload/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/upload/admin/tsconfig.json
+++ b/packages/core/upload/admin/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "paths": {
-      "@tests/*": ["./tests/*"]
+      "@tests/*": ["./tests/*"],
+      "msw": ["../../admin/node_modules/msw"],
+      "msw/*": ["../../admin/node_modules/msw/*"]
     }
   },
   "include": ["../package.json", "./src", "../shared", "./tests", "./custom.d.ts"]

--- a/packages/core/upload/server/tsconfig.build.json
+++ b/packages/core/upload/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/core/upload/server/tsconfig.json
+++ b/packages/core/upload/server/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["./src"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": "."
+    "types": ["node", "jest"]
   }
 }

--- a/packages/generators/generators/tsconfig.build.json
+++ b/packages/generators/generators/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "exclude": ["node_modules", "**/__tests__/**", "src/files", "src/templates"]
 }

--- a/packages/generators/generators/tsconfig.json
+++ b/packages/generators/generators/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
   "include": ["src"],
   "exclude": ["node_modules", "src/files", "src/templates"]
 }

--- a/packages/plugins/cloud/admin/tsconfig.build.json
+++ b/packages/plugins/cloud/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/cloud/admin/tsconfig.json
+++ b/packages/plugins/cloud/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["./src", "*.d.ts"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -62,7 +62,7 @@
     "react-router-dom": "6.30.3",
     "styled-components": "6.1.8",
     "tsconfig": "5.44.0",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/color-picker/admin/tsconfig.build.json
+++ b/packages/plugins/color-picker/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/color-picker/admin/tsconfig.json
+++ b/packages/plugins/color-picker/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -74,7 +74,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.1.8",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/color-picker/server/tsconfig.build.json
+++ b/packages/plugins/color-picker/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/color-picker/server/tsconfig.json
+++ b/packages/plugins/color-picker/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/documentation/admin/tsconfig.build.json
+++ b/packages/plugins/documentation/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/documentation/admin/tsconfig.json
+++ b/packages/plugins/documentation/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/documentation/server/tsconfig.build.json
+++ b/packages/plugins/documentation/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/documentation/server/tsconfig.json
+++ b/packages/plugins/documentation/server/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["./src"],
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": "."
+    "types": ["node", "jest"]
   }
 }

--- a/packages/plugins/graphql/admin/tsconfig.build.json
+++ b/packages/plugins/graphql/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/graphql/admin/tsconfig.json
+++ b/packages/plugins/graphql/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -90,7 +90,7 @@
     "react-router-dom": "6.30.3",
     "styled-components": "6.1.8",
     "tsconfig": "5.44.0",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/graphql/server/tsconfig.build.json
+++ b/packages/plugins/graphql/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/graphql/server/tsconfig.json
+++ b/packages/plugins/graphql/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/i18n/admin/tsconfig.build.json
+++ b/packages/plugins/i18n/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/i18n/admin/tsconfig.json
+++ b/packages/plugins/i18n/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "paths": {
       "@tests/*": ["./tests/*"]
     }

--- a/packages/plugins/i18n/server/src/services/ai-localizations.ts
+++ b/packages/plugins/i18n/server/src/services/ai-localizations.ts
@@ -331,7 +331,9 @@ const createAILocalizationsService = ({ strapi }: { strapi: Core.Strapi }) => {
         throw new Error(`AI Localizations request failed: ${response.statusText}`);
       }
 
-      const aiResult = await response.json();
+      const aiResult = (await response.json()) as {
+        localizations: Array<{ content: Record<string, unknown>; locale: string }>;
+      };
 
       // Use populate-builder service for deep populate to fetch all nested fields
       const populateBuilderService = strapi.plugin('content-manager').service('populate-builder');

--- a/packages/plugins/i18n/server/tsconfig.build.json
+++ b/packages/plugins/i18n/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/i18n/server/tsconfig.json
+++ b/packages/plugins/i18n/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/sentry/admin/tsconfig.build.json
+++ b/packages/plugins/sentry/admin/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/sentry/admin/tsconfig.json
+++ b/packages/plugins/sentry/admin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/client.json",
   "include": ["src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/plugins/sentry/server/src/services/sentry.ts
+++ b/packages/plugins/sentry/server/src/services/sentry.ts
@@ -1,6 +1,6 @@
 import type { Core } from '@strapi/strapi';
-import type { Config } from 'src/config';
 import * as Sentry from '@sentry/node';
+import type { Config } from '../config';
 
 const createSentryService = (strapi: Core.Strapi) => {
   let isReady = false;

--- a/packages/plugins/sentry/server/tsconfig.build.json
+++ b/packages/plugins/sentry/server/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "../",
-    "baseUrl": ".",
     "outDir": "../dist",
     "noEmit": false
   },

--- a/packages/plugins/sentry/server/tsconfig.json
+++ b/packages/plugins/sentry/server/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "tsconfig/base.json",
   "include": ["./src"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "rootDir": "../"
   }
 }

--- a/packages/providers/email-amazon-ses/tsconfig.build.json
+++ b/packages/providers/email-amazon-ses/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/email-mailgun/tsconfig.build.json
+++ b/packages/providers/email-mailgun/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/email-nodemailer/tsconfig.build.json
+++ b/packages/providers/email-nodemailer/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/email-sendgrid/tsconfig.build.json
+++ b/packages/providers/email-sendgrid/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/email-sendmail/tsconfig.build.json
+++ b/packages/providers/email-sendmail/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/upload-aws-s3/tsconfig.build.json
+++ b/packages/providers/upload-aws-s3/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/upload-cloudinary/tsconfig.build.json
+++ b/packages/providers/upload-cloudinary/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/providers/upload-local/tsconfig.build.json
+++ b/packages/providers/upload-local/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**"]

--- a/packages/utils/logger/tsconfig.build.json
+++ b/packages/utils/logger/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "tsconfig/base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__tests__/**"]

--- a/packages/utils/tsconfig/base.json
+++ b/packages/utils/tsconfig/base.json
@@ -11,6 +11,7 @@
     "noImplicitAny": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   }
 }

--- a/packages/utils/tsconfig/client.json
+++ b/packages/utils/tsconfig/client.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "11.3.4",
     "lodash": "4.18.1",
     "prettier": "3.3.3",
-    "typescript": "5.4.5"
+    "typescript": "6.0.2"
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4"

--- a/packages/utils/typescript/tsconfigs/admin.json
+++ b/packages/utils/typescript/tsconfigs/admin.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/packages/utils/typescript/tsconfigs/server.json
+++ b/packages/utils/typescript/tsconfigs/server.json
@@ -3,7 +3,7 @@
 
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
 

--- a/templates/website/tsconfig.json
+++ b/templates/website/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "target": "ES2019",
     "strict": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8658,7 +8658,7 @@ __metadata:
     sift: "npm:16.0.1"
     sonner: "npm:2.0.7"
     styled-components: "npm:6.1.8"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     use-context-selector: "npm:1.4.1"
     vite: "npm:5.4.21"
     vite-plugin-dts: "npm:^4.3.0"
@@ -8814,7 +8814,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -8958,7 +8958,7 @@ __metadata:
     statuses: "npm:2.0.1"
     supertest: "npm:7.2.2"
     tsconfig: "npm:5.44.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     undici: "npm:6.25.0"
     vitest: "catalog:"
     vitest-config: "npm:5.44.0"
@@ -9001,7 +9001,7 @@ __metadata:
     stream-json: "npm:1.8.0"
     tar: "npm:7.5.11"
     tar-stream: "npm:2.2.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     ws: "npm:8.17.1"
   languageName: unknown
   linkType: soft
@@ -9013,6 +9013,7 @@ __metadata:
     "@paralleldrive/cuid2": "npm:2.2.2"
     "@strapi/utils": "npm:5.44.0"
     "@types/fs-extra": "npm:11.0.4"
+    "@types/jest": "npm:29.5.2"
     ajv: "npm:8.18.0"
     date-fns: "npm:2.30.0"
     debug: "npm:4.3.4"
@@ -9255,7 +9256,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
     tsconfig: "npm:5.44.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
   peerDependencies:
     "@strapi/admin": ^5.0.0
     "@strapi/strapi": ^5.0.0
@@ -9281,7 +9282,7 @@ __metadata:
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9374,7 +9375,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
     tsconfig: "npm:5.44.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -9682,7 +9683,7 @@ __metadata:
     semver: "npm:7.7.4"
     style-loader: "npm:3.3.4"
     tsconfig: "npm:5.44.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     vite: "npm:5.4.21"
     webpack: "npm:^5.90.3"
     webpack-bundle-analyzer: "npm:^4.10.1"
@@ -9738,7 +9739,7 @@ __metadata:
     typedoc: "npm:0.25.10"
     typedoc-github-wiki-theme: "npm:1.1.0"
     typedoc-plugin-markdown: "npm:3.17.1"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     undici: "npm:6.25.0"
     zod: "npm:3.25.67"
   languageName: unknown
@@ -9754,7 +9755,7 @@ __metadata:
     fs-extra: "npm:11.3.4"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
   languageName: unknown
   linkType: soft
 
@@ -14720,7 +14721,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
-    typescript: "npm:^5"
+    typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft
 
@@ -15985,14 +15986,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:16.6.1, dotenv@npm:^16.4.5":
+"dotenv@npm:16.6.1":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
   languageName: node
   linkType: hard
 
-"dotenv@npm:~16.4.5":
+"dotenv@npm:^16.4.5, dotenv@npm:~16.4.5":
   version: 16.4.6
   resolution: "dotenv@npm:16.4.6"
   checksum: 10c0/6c0c0c82eaa0ca6cc7193b2550920ec6d2eabfe32498bf454c0a1187c0680c79daa199ba873d33692f055755e5068f862689aca03bc8ff57e7d70302f3152012
@@ -16142,7 +16143,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.1.8"
-    typescript: "npm:^5"
+    typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft
 
@@ -18632,12 +18633,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.1, get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.5":
+"get-tsconfig@npm:^4.10.1":
   version: 4.14.0
   resolution: "get-tsconfig@npm:4.14.0"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10c0/abc2b9275468eb589079a0b7a95eb5107c14fdd0ca6dda1bff116fe774ea1f79975421dcb22a0c86b4f820fcc69a7655dddf9b6d6a8a2c06fcb59e19794c0724
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.5.0, get-tsconfig@npm:^4.7.5":
+  version: 4.13.6
+  resolution: "get-tsconfig@npm:4.13.6"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/bab6937302f542f97217cbe7cbbdfa7e85a56a377bc7a73e69224c1f0b7c9ae8365918e55752ae8648265903f506c1705f63c0de1d4bab1ec2830fef3e539a1a
   languageName: node
   linkType: hard
 
@@ -19060,7 +19070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:4.7.9, handlebars@npm:^4.7.7, handlebars@npm:^4.7.8":
+"handlebars@npm:4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:
@@ -19075,6 +19085,24 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
+"handlebars@npm:^4.7.7, handlebars@npm:^4.7.8":
+  version: 4.7.8
+  resolution: "handlebars@npm:4.7.8"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
   languageName: node
   linkType: hard
 
@@ -23426,7 +23454,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:10.2.5, minimatch@npm:^10.2.2":
+"minimatch@npm:10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -23450,6 +23478,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.2":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
@@ -28416,7 +28453,7 @@ __metadata:
     syncpack: "npm:13.0.4"
     tar: "npm:7.5.11"
     ts-jest: "npm:29.1.0"
-    typescript: "npm:5.4.5"
+    typescript: "npm:6.0.2"
     vitest: "catalog:"
     yalc: "npm:1.0.0-pre.53"
     yargs: "npm:17.7.2"
@@ -29744,16 +29781,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
-  languageName: node
-  linkType: hard
-
 "typescript@npm:5.8.2":
   version: 5.8.2
   resolution: "typescript@npm:5.8.2"
@@ -29764,13 +29791,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:6.0.2, typescript@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/4b860b0bf87cc0fee0f66d8ef2640b5a8a8a8c74d1129adb82e389e5f97124383823c47946bef8a73ede371461143a3aa8544399d2133c7b2e4f07e81860af7f
   languageName: node
   linkType: hard
 
@@ -29784,16 +29811,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
   version: 5.8.2
   resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
@@ -29804,13 +29821,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
+  checksum: 10c0/49f0b84fc6ca55653e77752b8a61beabc09ee3dae5d965c31596225aa6ef213c5727b1d2e895b900416dc603854ba0872ac4a812c2a4ed6793a601f9c675de02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

POC on top of `chore/typescript-6` (#25873) addressing a regression that PR introduces in `@strapi/database` typing.

On `develop`, `packages/core/database/tsconfig.json` does **not** declare a `types` field and `@types/jest` is **not** a dependency, so jest ambient globals (`describe`/`it`/`expect`/`global.*` augmentations) are simply not in the TS program for this package — tests compile via `ts-jest`, src never sees them.

PR #25873 adds `@types/jest` to `packages/core/database/package.json` and sets `compilerOptions.types: ["node", "jest"]` in the package's `tsconfig.json` to make jest globals type-check under the new toolchain. Side effect: those globals are now resolvable inside production `src/` code as well — anyone can call `describe(...)` in a non-test file and it will compile.

This PR replaces the flat config with a tsconfig solution file plus two referenced projects:

- `tsconfig.build.json` — `types: ["node"]`, builds `src/`
- `tsconfig.test.json` — `types: ["jest", "node"]`, includes test files plus `src/global.d.ts`, references the build project

Build code can no longer reference jest globals; tests still type-check normally via project references and pick up the package's ambient augmentations (`declare var strapi`, custom knex module declarations) through the explicit `src/global.d.ts` entry.

The structural change itself is independent of the TS 6 upgrade. It targets `chore/typescript-6` because the `@types/jest` addition that creates the leak lives there.

## Other changes

- `.gitignore`: ignore `*.tsbuildinfo` emitted by composite projects.
- `jsconfig.json`: exclude `packages/**` so the JS language service does not crawl TS workspaces.
- `packages/core/database/.eslintrc.js`: set `parserOptions.tsconfigRootDir` as a vscode-eslint workaround. Can be reverted once #26216 lands.
- `packages/core/database/package.json`: cosmetic whitespace fix in `build:code`.

## Test plan

- [ ] `npx tsc -b packages/core/database/tsconfig.json --force` — clean build, both `build` and `test` projects compile.
- [ ] `npx tsc -p packages/core/database/tsconfig.eslint.json --noEmit` — passes.
- [ ] Confirm that introducing `describe('x', () => {})` in `src/connection.ts` (or any non-test src file) is now rejected by the build project.

## Notes

POC scope only. `database` is the only package restructured here; the same pattern can be rolled out to other packages as a follow-up if the approach is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)