### PR TITLE
feat: add export audit logs feature

### DIFF
--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -170,6 +170,7 @@
   "Settings.permissions.auditLogs.content-type.delete": "Delete content type",
   "Settings.permissions.auditLogs.content-type.update": "Update content type",
   "Settings.permissions.auditLogs.date": "Date",
+  "Settings.permissions.auditLogs.export": "Export",
   "Settings.permissions.auditLogs.details": "Log Details",
   "Settings.permissions.auditLogs.entry.create": "Create entry{model, select, undefined {} other { ({model})}}",
   "Settings.permissions.auditLogs.entry.delete": "Delete entry{model, select, undefined {} other { ({model})}}",

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/ListPage.tsx
@@ -1,5 +1,5 @@
-import { Flex, IconButton, Typography } from '@strapi/design-system';
-import { Eye } from '@strapi/icons';
+import { Button, Flex, IconButton, Typography } from '@strapi/design-system';
+import { Download, Eye } from '@strapi/icons';
 import { useIntl } from 'react-intl';
 
 import { Filters } from '../../../../../../../admin/src/components/Filters';
@@ -17,6 +17,13 @@ import { useAuditLogsData } from './hooks/useAuditLogsData';
 import { useFormatTimeStamp } from './hooks/useFormatTimeStamp';
 import { getDefaultMessage } from './utils/getActionTypesDefaultMessages';
 import { getDisplayedFilters } from './utils/getDisplayedFilters';
+
+const escapeCsvCell = (value: string) => {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+};
 
 const ListPage = () => {
   const { formatMessage } = useIntl();
@@ -82,6 +89,47 @@ const ListPage = () => {
 
   const { results = [] } = auditLogs ?? {};
 
+  const handleExport = () => {
+    const actionHeader = formatMessage({
+      id: 'Settings.permissions.auditLogs.action',
+      defaultMessage: 'Action',
+    });
+    const dateHeader = formatMessage({
+      id: 'Settings.permissions.auditLogs.date',
+      defaultMessage: 'Date',
+    });
+    const userHeader = formatMessage({
+      id: 'Settings.permissions.auditLogs.user',
+      defaultMessage: 'User',
+    });
+
+    const headerRow = [actionHeader, dateHeader, userHeader].map(escapeCsvCell).join(',');
+
+    const dataRows = results.map((log) => {
+      const actionLabel = formatMessage(
+        {
+          id: `Settings.permissions.auditLogs.${log.action}`,
+          // @ts-expect-error – same pattern as table cells
+          defaultMessage: getDefaultMessage(log.action),
+        },
+        { model: (log.payload?.model as string) ?? '' }
+      );
+      const dateLabel = formatTimeStamp(log.date);
+      const userLabel = log.user?.displayName ?? '';
+
+      return [actionLabel, dateLabel, userLabel].map(escapeCsvCell).join(',');
+    });
+
+    const csv = `\uFEFF${[headerRow, ...dataRows].join('\n')}`;
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `audit-logs-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <Page.Main aria-busy={isLoading}>
       <Page.Title>
@@ -112,6 +160,22 @@ const ListPage = () => {
             <Filters.Popover zIndex={499} />
             <Filters.List />
           </Filters.Root>
+        }
+        endActions={
+          canReadAuditLogs ? (
+            <Button
+              variant="secondary"
+              size="S"
+              startIcon={<Download />}
+              onClick={handleExport}
+              disabled={isLoading || results.length === 0}
+            >
+              {formatMessage({
+                id: 'Settings.permissions.auditLogs.export',
+                defaultMessage: 'Export',
+              })}
+            </Button>
+          ) : null
         }
       />
       <Layouts.Content>

--- a/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
+++ b/packages/core/admin/ee/admin/src/pages/SettingsPage/pages/AuditLogs/tests/ListPage.test.tsx
@@ -22,6 +22,8 @@ describe('ADMIN | Pages | AUDIT LOGS | ListPage', () => {
 
     expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
 
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
+
     expect(screen.getByRole('grid')).toBeInTheDocument();
 
     [


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add the ability to export audit logs.

### Why is it needed?

Request by a lot of customers.

### How to test it?

 - Create and/or update entries in the Content Manager
 - Visit http://localhost:1337/admin/settings/audit-logs
 - Click on the "Export" button

Please note that this exports the list of logs displayed in the current view. Exporting the entirety of the audit logs would require a function on the server side (to handle authentication). However, we are not sure this is needed, so I'd recommend pushing this first version and iterate only if customers ask for this capability.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
