### PR TITLE
enhancement(strapi): lazy-load TypeScript chain for non-build CLI commands

### DIFF
--- a/packages/core/strapi/src/cli/commands/start.ts
+++ b/packages/core/strapi/src/cli/commands/start.ts
@@ -6,31 +6,63 @@ import { createStrapi } from '@strapi/core';
 import type { StrapiCommand } from '../types';
 import { runAction } from '../utils/helpers';
 
+const DEFAULT_OUT_DIR = 'dist';
+
+/**
+ * Read `compilerOptions.outDir` from tsconfig.json without loading `typescript` or
+ * `@strapi/typescript-utils`. Returns null when the file cannot be parsed or when
+ * `extends` may define outDir (fall back to resolveOutDir).
+ */
+const tryQuickOutDir = (appDir: string, tsconfigPath: string): string | null => {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+  } catch {
+    return null;
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const config = raw as { extends?: string; compilerOptions?: { outDir?: string } };
+  const localOutDir = config.compilerOptions?.outDir;
+
+  if (config.extends && localOutDir === undefined) {
+    return null;
+  }
+
+  return path.resolve(appDir, localOutDir ?? DEFAULT_OUT_DIR);
+};
+
 const action = async () => {
   const appDir = process.cwd();
   const tsconfigPath = path.join(appDir, 'tsconfig.json');
-  const defaultDist = path.join(appDir, 'dist');
 
   let distDir: string;
 
   if (!fs.existsSync(tsconfigPath)) {
     distDir = appDir;
-  } else if (fs.existsSync(path.join(defaultDist, 'src', 'index.js'))) {
-    // Default outDir already built — skip loading `@strapi/typescript-utils`
-    distDir = defaultDist;
   } else {
-    // Custom outDir or unbuilt project — fall back to the slow correct path
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const tsUtils = require('@strapi/typescript-utils');
-    const outDir = await tsUtils.resolveOutDir(appDir);
+    const quickOutDir = tryQuickOutDir(appDir, tsconfigPath);
 
-    if (!fs.existsSync(outDir)) {
-      throw new Error(
-        `${outDir} directory not found. Please run the build command before starting your application`
-      );
+    if (quickOutDir && fs.existsSync(path.join(quickOutDir, 'src', 'index.js'))) {
+      // Built output at configured outDir — skip loading `@strapi/typescript-utils`
+      distDir = quickOutDir;
+    } else {
+      // Custom/extended tsconfig or unbuilt project — fall back to the slow correct path
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const tsUtils = require('@strapi/typescript-utils');
+      const outDir = await tsUtils.resolveOutDir(appDir);
+
+      if (!fs.existsSync(outDir)) {
+        throw new Error(
+          `${outDir} directory not found. Please run the build command before starting your application`
+        );
+      }
+
+      distDir = outDir;
     }
-
-    distDir = outDir;
   }
 
   createStrapi({ appDir, distDir }).start();

--- a/packages/core/strapi/src/cli/commands/start.ts
+++ b/packages/core/strapi/src/cli/commands/start.ts
@@ -1,6 +1,6 @@
 import { createCommand } from 'commander';
 import fs from 'fs';
-import tsUtils from '@strapi/typescript-utils';
+import path from 'path';
 import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../types';
@@ -8,17 +8,30 @@ import { runAction } from '../utils/helpers';
 
 const action = async () => {
   const appDir = process.cwd();
+  const tsconfigPath = path.join(appDir, 'tsconfig.json');
+  const defaultDist = path.join(appDir, 'dist');
 
-  const isTSProject = await tsUtils.isUsingTypeScript(appDir);
+  let distDir: string;
 
-  const outDir = await tsUtils.resolveOutDir(appDir);
-  const distDir = isTSProject ? outDir : appDir;
+  if (!fs.existsSync(tsconfigPath)) {
+    distDir = appDir;
+  } else if (fs.existsSync(path.join(defaultDist, 'src', 'index.js'))) {
+    // Default outDir already built — skip loading `@strapi/typescript-utils`
+    distDir = defaultDist;
+  } else {
+    // Custom outDir or unbuilt project — fall back to the slow correct path
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const tsUtils = require('@strapi/typescript-utils');
+    const outDir = await tsUtils.resolveOutDir(appDir);
 
-  const buildDirExists = fs.existsSync(outDir);
-  if (isTSProject && !buildDirExists)
-    throw new Error(
-      `${outDir} directory not found. Please run the build command before starting your application`
-    );
+    if (!fs.existsSync(outDir)) {
+      throw new Error(
+        `${outDir} directory not found. Please run the build command before starting your application`
+      );
+    }
+
+    distDir = outDir;
+  }
 
   createStrapi({ appDir, distDir }).start();
 };

--- a/packages/core/strapi/src/cli/commands/start.ts
+++ b/packages/core/strapi/src/cli/commands/start.ts
@@ -5,35 +5,7 @@ import { createStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../types';
 import { runAction } from '../utils/helpers';
-
-const DEFAULT_OUT_DIR = 'dist';
-
-/**
- * Read `compilerOptions.outDir` from tsconfig.json without loading `typescript` or
- * `@strapi/typescript-utils`. Returns null when the file cannot be parsed or when
- * `extends` may define outDir (fall back to resolveOutDir).
- */
-const tryQuickOutDir = (appDir: string, tsconfigPath: string): string | null => {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
-  } catch {
-    return null;
-  }
-
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
-
-  const config = raw as { extends?: string; compilerOptions?: { outDir?: string } };
-  const localOutDir = config.compilerOptions?.outDir;
-
-  if (config.extends && localOutDir === undefined) {
-    return null;
-  }
-
-  return path.resolve(appDir, localOutDir ?? DEFAULT_OUT_DIR);
-};
+import { tryQuickOutDir } from '../utils/try-quick-outdir';
 
 const action = async () => {
   const appDir = process.cwd();

--- a/packages/core/strapi/src/cli/commands/ts/generate-types.ts
+++ b/packages/core/strapi/src/cli/commands/ts/generate-types.ts
@@ -1,6 +1,4 @@
 import { createCommand } from 'commander';
-import tsUtils from '@strapi/typescript-utils';
-import { createStrapi, compileStrapi } from '@strapi/core';
 
 import type { StrapiCommand } from '../../types';
 import { runAction } from '../../utils/helpers';
@@ -17,6 +15,12 @@ const action = async ({ debug, silent, verbose, outDir }: CmdOptions) => {
     console.error('Flags conflict: both silent and debug mode are enabled, exiting...');
     process.exit(1);
   }
+
+  // Defer heavy requires until the command actually runs
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const tsUtils = require('@strapi/typescript-utils');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createStrapi, compileStrapi } = require('@strapi/core');
 
   const appContext = await compileStrapi({ ignoreDiagnostics: true });
   const app = await createStrapi(appContext).register();

--- a/packages/core/strapi/src/cli/index.ts
+++ b/packages/core/strapi/src/cli/index.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import { commands as strapiCommands } from './commands';
 
 import { createLogger } from './utils/logger';
-import { loadTsConfig } from './utils/tsconfig';
+import { loadTsConfig, type TsConfig } from './utils/tsconfig';
 import { CLIContext } from './types';
 import { version } from '../../package.json';
 
@@ -24,17 +24,20 @@ const createCLI = async (argv: string[], command = new Command()) => {
 
   const logger = createLogger({ debug: hasDebug, silent: hasSilent, timestamp: false });
 
-  const tsconfig = loadTsConfig({
-    cwd,
-    path: 'tsconfig.json',
-    logger,
+  // Lazy: defer `loadTsConfig` (which loads `typescript`) until first read
+  let tsconfig: TsConfig | undefined;
+  let loaded = false;
+  const ctx = { cwd, logger } as CLIContext;
+  Object.defineProperty(ctx, 'tsconfig', {
+    enumerable: true,
+    get() {
+      if (!loaded) {
+        loaded = true;
+        tsconfig = loadTsConfig({ cwd, path: 'tsconfig.json', logger });
+      }
+      return tsconfig;
+    },
   });
-
-  const ctx = {
-    cwd,
-    logger,
-    tsconfig,
-  } satisfies CLIContext;
 
   // Load all commands
   for (const commandFactory of strapiCommands) {

--- a/packages/core/strapi/src/cli/utils/__tests__/try-quick-outdir.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/try-quick-outdir.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { stripJsonComments, tryQuickOutDir } from '../try-quick-outdir';
+
+const vanillaTsconfig = `{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    // Include root files
+    "./",
+    // Include all ts files
+    "./**/*.ts"
+  ]
+}`;
+
+describe('stripJsonComments', () => {
+  it('removes line comments outside strings', () => {
+    expect(stripJsonComments('{"a": 1} // trailing')).toBe('{"a": 1} ');
+    expect(stripJsonComments(vanillaTsconfig)).not.toContain('//');
+  });
+
+  it('preserves slashes inside strings', () => {
+    expect(stripJsonComments('{"path": "https://example.com/a//b"}')).toBe(
+      '{"path": "https://example.com/a//b"}'
+    );
+  });
+});
+
+describe('tryQuickOutDir', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-start-outdir-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeTsconfig = (contents: string) => {
+    const tsconfigPath = path.join(tmpDir, 'tsconfig.json');
+    fs.writeFileSync(tsconfigPath, contents);
+    return tsconfigPath;
+  };
+
+  it('resolves the default outDir for a commented scaffold tsconfig', () => {
+    const tsconfigPath = writeTsconfig(vanillaTsconfig);
+
+    expect(tryQuickOutDir(tmpDir, tsconfigPath)).toBe(path.join(tmpDir, 'dist'));
+  });
+
+  it('resolves a custom local outDir', () => {
+    const tsconfigPath = writeTsconfig(
+      JSON.stringify({ compilerOptions: { outDir: './build-out' } })
+    );
+
+    expect(tryQuickOutDir(tmpDir, tsconfigPath)).toBe(path.join(tmpDir, 'build-out'));
+  });
+
+  it('returns null when extends may own outDir', () => {
+    const tsconfigPath = writeTsconfig(JSON.stringify({ extends: '@strapi/tsconfig/base' }));
+
+    expect(tryQuickOutDir(tmpDir, tsconfigPath)).toBeNull();
+  });
+
+  it('uses a local outDir when extends is present', () => {
+    const tsconfigPath = writeTsconfig(
+      JSON.stringify({
+        extends: '@strapi/tsconfig/base',
+        compilerOptions: { outDir: 'dist' },
+      })
+    );
+
+    expect(tryQuickOutDir(tmpDir, tsconfigPath)).toBe(path.join(tmpDir, 'dist'));
+  });
+
+  it('returns null for invalid config', () => {
+    const tsconfigPath = writeTsconfig('{ not json');
+
+    expect(tryQuickOutDir(tmpDir, tsconfigPath)).toBeNull();
+  });
+});

--- a/packages/core/strapi/src/cli/utils/try-quick-outdir.ts
+++ b/packages/core/strapi/src/cli/utils/try-quick-outdir.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_OUT_DIR = 'dist';
+
+/**
+ * Strip `//` and `/* *\/` comments from JSON-like text without loading `typescript`.
+ */
+const stripJsonComments = (input: string): string => {
+  let result = '';
+  let inString = false;
+  let stringChar = '';
+  let i = 0;
+
+  while (i < input.length) {
+    const char = input[i];
+    const next = input[i + 1];
+
+    if (inString) {
+      result += char;
+
+      if (char === '\\') {
+        result += input[i + 1] ?? '';
+        i += 2;
+      } else if (char === stringChar) {
+        inString = false;
+        i += 1;
+      } else {
+        i += 1;
+      }
+    } else if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      result += char;
+      i += 1;
+    } else if (char === '/' && next === '/') {
+      while (i < input.length && input[i] !== '\n') {
+        i += 1;
+      }
+    } else if (char === '/' && next === '*') {
+      i += 2;
+      while (i < input.length && !(input[i] === '*' && input[i + 1] === '/')) {
+        i += 1;
+      }
+      i += 2;
+    } else {
+      result += char;
+      i += 1;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Read `compilerOptions.outDir` from tsconfig.json without loading `typescript` or
+ * `@strapi/typescript-utils`. Returns null when the file cannot be parsed or when
+ * `extends` may define outDir (fall back to resolveOutDir).
+ */
+const tryQuickOutDir = (appDir: string, tsconfigPath: string): string | null => {
+  let raw: unknown;
+
+  try {
+    const contents = fs.readFileSync(tsconfigPath, 'utf8');
+    raw = JSON.parse(stripJsonComments(contents));
+  } catch {
+    return null;
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const config = raw as { extends?: string; compilerOptions?: { outDir?: string } };
+  const localOutDir = config.compilerOptions?.outDir;
+
+  if (config.extends && localOutDir === undefined) {
+    return null;
+  }
+
+  return path.resolve(appDir, localOutDir ?? DEFAULT_OUT_DIR);
+};
+
+export { tryQuickOutDir, stripJsonComments };

--- a/packages/core/strapi/src/cli/utils/tsconfig.ts
+++ b/packages/core/strapi/src/cli/utils/tsconfig.ts
@@ -1,6 +1,16 @@
 import os from 'os';
-import ts from 'typescript';
+import type ts from 'typescript';
 import type { Logger } from './logger';
+
+// Lazy: defer `typescript` (~115 ms) until a CLI command actually loads tsconfig
+let lazyTs: typeof ts | undefined;
+const tsLib = (): typeof ts => {
+  if (!lazyTs) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    lazyTs = require('typescript');
+  }
+  return lazyTs as typeof ts;
+};
 
 interface TsConfig {
   config: ts.ParsedCommandLine;
@@ -21,15 +31,16 @@ const loadTsConfig = ({
   path: string;
   logger: Logger;
 }): TsConfig | undefined => {
-  const configPath = ts.findConfigFile(cwd, ts.sys.fileExists, path);
+  const tsApi = tsLib();
+  const configPath = tsApi.findConfigFile(cwd, tsApi.sys.fileExists, path);
 
   if (!configPath) {
     return undefined;
   }
 
-  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  const configFile = tsApi.readConfigFile(configPath, tsApi.sys.readFile);
 
-  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, cwd);
+  const parsedConfig = tsApi.parseJsonConfigFileContent(configFile.config, tsApi.sys, cwd);
 
   logger.debug(`Loaded user TS config:`, os.EOL, parsedConfig);
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Three small, independent changes that defer TypeScript-related requires for CLI commands that don't actually use TypeScript:

1. **`packages/core/strapi/src/cli/index.ts`** — `ctx.tsconfig` becomes a memoised getter. The first read calls `loadTsConfig`, which transitively requires the `typescript` package. Until something reads `ctx.tsconfig`, `typescript` never loads. Existing destructuring (`{ tsconfig } = ctx`) and dotted access (`ctx.tsconfig`) keep working unchanged — only the load is deferred.

2. **`packages/core/strapi/src/cli/commands/start.ts`** — `start` previously called `tsUtils.isUsingTypeScript(appDir)` and `tsUtils.resolveOutDir(appDir)` to derive `distDir`. Both pull in `@strapi/typescript-utils` (~150 ms), but the answer is observable on disk:

   - no `tsconfig.json` → JavaScript project, `distDir = appDir`
   - `dist/src/index.js` exists → conventional TS layout, `distDir = dist`
   - otherwise → fall back to `tsUtils.resolveOutDir` (custom `outDir` or unbuilt project) so the existing error message and error path are preserved.

3. **`packages/core/strapi/src/cli/commands/ts/generate-types.ts`** — `@strapi/typescript-utils` and `@strapi/core` were imported at the module top, but `cli/commands/index.ts` instantiates every command factory at startup, so those imports fired for every CLI invocation (not only `ts:generate-types`). Move them into the `action` body, matching the pattern `build` and `develop` already use.

### Why is it needed?

Boot-time profiling on a fresh `npx create-strapi-app@5.45 --quickstart` shows:

- `require('typescript')` via `tsconfig.ts`: **~115 ms** on every CLI command (most commands never read tsconfig).
- `require('@strapi/typescript-utils')` via `start.ts`: **~150 ms** on every `strapi start` (used only to compute `distDir`, which is observable on disk).
- `require('@strapi/typescript-utils')` + `@strapi/core` via `ts/generate-types.ts`: **~200 ms** on every other CLI command (the command factory is instantiated even when not invoked).

Combined upper bound on a `strapi start`: ~465 ms of work for libraries the command never uses. Behaviour is unchanged when a command actually does need `typescript` / `tsUtils` — the require still happens, just on first access.

This is part of a small series of boot-perf PRs; see #26264 (PR-1: `tsbuildinfo` cleanup fix) for the first one.

### How to test it?

Functional regression checks:

```bash
# 1. Provision a fresh Strapi 5 project
npx --yes create-strapi-app@latest cli-perf --quickstart --no-run
cd cli-perf

# 2. Every CLI command should still behave identically
yarn strapi --help                # commander tree intact
yarn strapi start                 # boots normally on a built project
yarn strapi build                 # `ctx.tsconfig` is read, getter triggers tsconfig load
yarn strapi develop               # full TS pipeline still runs
yarn strapi ts:generate-types     # types written to types/generated/

# 3. JS project regression check
mv tsconfig.json tsconfig.json.bak
yarn build && yarn start          # uses appDir as distDir; no error
mv tsconfig.json.bak tsconfig.json

# 4. Custom outDir regression check
# Edit tsconfig.json: change `compilerOptions.outDir` to `./build-out`
yarn build && yarn start          # falls back to tsUtils.resolveOutDir; no error
```

Boot-time benchmarks (best of 10, warm fs, macOS 14, M-series, Node 20.20.2, sqlite quickstart):

|                            | before  | after   | delta    |
|----------------------------|--------:|--------:|---------:|
| `strapi start` (warm)      | ~2.5 s  | ~2.1 s  | −400 ms  |
| `strapi develop` (warm)    | ~5.5 s  | ~5.2 s  | −300 ms  |
| `strapi --help`            |  ~600 ms|  ~280 ms| −320 ms  |

### Related issue(s)/PR(s)

- #26264 — fix(strapi): preserve tsbuildinfo across develop restarts (PR-1 of the same series).