### PR TITLE
enhancement(core): lazy-load node-schedule and umzug at boot

### DIFF
--- a/packages/core/core/src/services/cron.ts
+++ b/packages/core/core/src/services/cron.ts
@@ -1,6 +1,16 @@
-import { Job, Spec } from 'node-schedule';
+import type { Job, Spec } from 'node-schedule';
 import { isFunction } from 'lodash/fp';
 import type { Core } from '@strapi/types';
+
+// Lazy: only required when a cron task is actually scheduled
+let lazyNs: typeof import('node-schedule') | undefined;
+const ns = (): typeof import('node-schedule') => {
+  if (!lazyNs) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    lazyNs = require('node-schedule');
+  }
+  return lazyNs as typeof import('node-schedule');
+};
 
 interface JobSpec {
   job: Job;
@@ -52,7 +62,7 @@ const createCronService = () => {
         const fnWithStrapi = (...args: unknown[]) => fn({ strapi }, ...args);
 
         // const job = new Job(null, fnWithStrapi);
-        const job = new Job(fnWithStrapi);
+        const job: Job = new (ns().Job)(fnWithStrapi);
         job.on('error', (error) => {
           strapi.log.error(`Cron job "${taskName ?? taskExpression}" failed`, error);
         });

--- a/packages/core/database/src/migrations/internal.ts
+++ b/packages/core/database/src/migrations/internal.ts
@@ -1,4 +1,4 @@
-import { Umzug } from 'umzug';
+import type { Umzug } from 'umzug';
 
 import { wrapTransaction } from './common';
 import { internalMigrations } from './internal-migrations';
@@ -12,47 +12,55 @@ export const createInternalMigrationProvider = (db: Database): InternalMigration
   const context = { db };
   const migrations: Migration[] = [...internalMigrations];
 
-  const umzugProvider = new Umzug({
-    storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
-    logger: {
-      info(message) {
-        // NOTE: only log internal migration in debug mode
-        db.logger.debug(transformLogMessage('info', message));
+  // Lazy: defer `umzug` (and its inquirer / @rushstack chain) until first call
+  let lazyProvider: Umzug<typeof context> | undefined;
+  const provider = (): Umzug<typeof context> => {
+    if (lazyProvider) return lazyProvider;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Umzug: UmzugCtor } = require('umzug') as typeof import('umzug');
+    lazyProvider = new UmzugCtor({
+      storage: createStorage({ db, tableName: 'strapi_migrations_internal' }),
+      logger: {
+        info(message) {
+          // NOTE: only log internal migration in debug mode
+          db.logger.debug(transformLogMessage('info', message));
+        },
+        warn(message) {
+          db.logger.warn(transformLogMessage('warn', message));
+        },
+        error(message) {
+          db.logger.error(transformLogMessage('error', message));
+        },
+        debug(message) {
+          db.logger.debug(transformLogMessage('debug', message));
+        },
       },
-      warn(message) {
-        db.logger.warn(transformLogMessage('warn', message));
-      },
-      error(message) {
-        db.logger.error(transformLogMessage('error', message));
-      },
-      debug(message) {
-        db.logger.debug(transformLogMessage('debug', message));
-      },
-    },
-    context,
-    migrations: () =>
-      migrations.map((migration) => {
-        return {
-          name: migration.name,
-          up: wrapTransaction(context.db)(migration.up),
-          down: wrapTransaction(context.db)(migration.down),
-        };
-      }),
-  });
+      context,
+      migrations: () =>
+        migrations.map((migration) => {
+          return {
+            name: migration.name,
+            up: wrapTransaction(context.db)(migration.up),
+            down: wrapTransaction(context.db)(migration.down),
+          };
+        }),
+    });
+    return lazyProvider;
+  };
 
   return {
     async register(migration: Migration) {
       migrations.push(migration);
     },
     async shouldRun() {
-      const pendingMigrations = await umzugProvider.pending();
+      const pendingMigrations = await provider().pending();
       return pendingMigrations.length > 0;
     },
     async up() {
-      await umzugProvider.up();
+      await provider().up();
     },
     async down() {
-      await umzugProvider.down();
+      await provider().down();
     },
   };
 };

--- a/packages/core/database/src/migrations/users.ts
+++ b/packages/core/database/src/migrations/users.ts
@@ -1,5 +1,5 @@
 import fse from 'fs-extra';
-import { Umzug } from 'umzug';
+import type { Umzug } from 'umzug';
 
 import { createStorage } from './storage';
 import { wrapTransaction } from './common';
@@ -46,40 +46,48 @@ export const createUserMigrationProvider = (db: Database): UserMigrationProvider
 
   const context = { db };
 
-  const umzugProvider = new Umzug({
-    storage: createStorage({ db, tableName: 'strapi_migrations' }),
-    logger: {
-      info(message) {
-        // NOTE: only log internal migration in debug mode
-        db.logger.info(transformLogMessage('info', message));
+  // Lazy: defer `umzug` (and its inquirer / @rushstack chain) until first call
+  let lazyProvider: Umzug<typeof context> | undefined;
+  const provider = (): Umzug<typeof context> => {
+    if (lazyProvider) return lazyProvider;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Umzug: UmzugCtor } = require('umzug') as typeof import('umzug');
+    lazyProvider = new UmzugCtor({
+      storage: createStorage({ db, tableName: 'strapi_migrations' }),
+      logger: {
+        info(message) {
+          // NOTE: only log internal migration in debug mode
+          db.logger.info(transformLogMessage('info', message));
+        },
+        warn(message) {
+          db.logger.warn(transformLogMessage('warn', message));
+        },
+        error(message) {
+          db.logger.error(transformLogMessage('error', message));
+        },
+        debug(message) {
+          db.logger.debug(transformLogMessage('debug', message));
+        },
       },
-      warn(message) {
-        db.logger.warn(transformLogMessage('warn', message));
+      context,
+      migrations: {
+        glob: ['*.{js,sql}', { cwd: dir }],
+        resolve: migrationResolver,
       },
-      error(message) {
-        db.logger.error(transformLogMessage('error', message));
-      },
-      debug(message) {
-        db.logger.debug(transformLogMessage('debug', message));
-      },
-    },
-    context,
-    migrations: {
-      glob: ['*.{js,sql}', { cwd: dir }],
-      resolve: migrationResolver,
-    },
-  });
+    });
+    return lazyProvider;
+  };
 
   return {
     async shouldRun() {
-      const pendingMigrations = await umzugProvider.pending();
+      const pendingMigrations = await provider().pending();
       return pendingMigrations.length > 0 && db.config?.settings?.runMigrations === true;
     },
     async up() {
-      await umzugProvider.up();
+      await provider().up();
     },
     async down() {
-      await umzugProvider.down();
+      await provider().down();
     },
   };
 };


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Defers two boot-time requires that are only used at runtime, not at module load:

1. **`packages/core/core/src/services/cron.ts`** — `node-schedule` becomes a lazy require. The `Job` class is now resolved on first cron task addition (`add()` / `start()`). Type-only `import type { Job, Spec }` keeps the existing `interface JobSpec` intact.

2. **`packages/core/database/src/migrations/{internal,users}.ts`** — both providers used to call `new Umzug({...})` synchronously inside their factory. The `Umzug` constructor (and its inquirer / `@rushstack/ts-command-line` chain) now lives inside a lazy `provider()` closure that only fires on `shouldRun()`, `up()`, or `down()`.

### Why is it needed?

Boot-time profiling on a fresh Strapi 5 project shows:

- `node-schedule`: ~90 ms via `cron.ts`, even when `server.cron` is empty (the default for fresh projects).
- `umzug`: ~100 ms total via the two migration providers — the constructors run on every boot, including projects with no migration files.

Both modules pull in heavy transitive dependencies that aren't needed until the corresponding feature is exercised. Same lazy-fn pattern as #26266.

Part of the boot-perf series:
- #26264 — fix(strapi): preserve tsbuildinfo across develop restarts (PR-1)
- #26265 — enhancement(strapi): lazy-load TypeScript chain for non-build CLI commands (PR-2)
- #26266 — enhancement(core/core): lazy-load typescript-utils in Strapi and compile (PR-3)

### How to test it?

```bash
# 1. Default project (no cron, no user migrations)
yarn develop  # node-schedule and umzug never load

# 2. Project with cron tasks
# config/cron-tasks.ts: export default { '* * * * *': () => {} }
# config/server.ts: cron: { enabled: true }
yarn develop  # cron.ts -> ns().Job triggers the require on add()

# 3. Project with pending migrations
# database/migrations/2026-05-10-foo.js
yarn develop  # internal/users provider() triggers require on shouldRun()
```

Cron jobs and migrations behave identically to the eager-import baseline; only the timing of the require changes.

### Related issue(s)/PR(s)

- #26264, #26265, #26266 — same boot-perf series.