### PR TITLE
enhancement(strapi): skip primary compile when dist current; defer post-load TS

### DIFF
--- a/packages/core/strapi/src/node/develop.ts
+++ b/packages/core/strapi/src/node/develop.ts
@@ -7,6 +7,7 @@ import cluster from 'node:cluster';
 import { createStrapi } from '@strapi/core';
 
 import type { CLIContext } from '../cli/types';
+import type { TsConfig } from '../cli/utils/tsconfig';
 import { checkRequiredDependencies } from './core/dependencies';
 import { getTimer, prettyTime, type TimeMeasurer } from './core/timer';
 import { createBuildContext } from './create-build-context';
@@ -28,6 +29,42 @@ interface DevelopOptions extends CLIContext {
   watchAdmin?: boolean;
   buildAdmin?: boolean;
 }
+
+// Skip directories that don't carry source: avoids rescanning dist/build/cache trees.
+const NON_SOURCE_DIRS = new Set(['node_modules', 'dist', 'build', '.tmp', '.cache', '.strapi']);
+
+// Highest mtime under cwd, ignoring NON_SOURCE_DIRS and dotfiles.
+const newestSourceMtime = async (dir: string): Promise<number> => {
+  let latest = 0;
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return latest;
+  }
+  for (const entry of entries) {
+    if (NON_SOURCE_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    const mtime = entry.isDirectory()
+      ? await newestSourceMtime(full)
+      : await fs
+          .stat(full)
+          .then((s) => s.mtimeMs)
+          .catch(() => 0);
+    if (mtime > latest) latest = mtime;
+  }
+  return latest;
+};
+
+// True when dist/src/index.js and tsconfig.tsbuildinfo exist and post-date all source.
+const isDistUpToDate = async (cwd: string, tsconfig: TsConfig): Promise<boolean> => {
+  const distDir = tsconfig.config.options.outDir;
+  if (!distDir) return false;
+  const entry = await fs.stat(path.join(distDir, 'src/index.js')).catch(() => null);
+  const info = await fs.stat(path.join(distDir, 'tsconfig.tsbuildinfo')).catch(() => null);
+  if (!entry || !info) return false;
+  return (await newestSourceMtime(cwd)) <= entry.mtimeMs;
+};
 
 // This method removes all non-admin build files from the dist directory
 const cleanupDistDirectory = async ({
@@ -92,7 +129,7 @@ const develop = async ({
       return;
     }
 
-    if (tsconfig?.config) {
+    if (tsconfig?.config && !(await isDistUpToDate(cwd, tsconfig))) {
       // Build without diagnostics in case schemas have changed
       await cleanupDistDirectory({ tsconfig, logger, timer });
       try {
@@ -246,40 +283,56 @@ const develop = async ({
       loadStrapiSpinner.text = `Loading Strapi (${prettyTime(loadStrapiDuration)})`;
       loadStrapiSpinner.succeed();
 
-      // For TS projects, type generation is a requirement for the develop command so that the server can restart
-      // For JS projects, we respect the experimental autogenerate setting
-      if (tsconfig?.config || strapi.config.get('typescript.autogenerate') !== false) {
-        timer.start('generatingTS');
-        generatingTsSpinner.start();
-
-        await tsUtils.generators.generate({
-          strapi: strapiInstance,
-          pwd: cwd,
-          rootDir: undefined,
-          logger: { silent: true, debug: false },
-          artifacts: { contentTypes: true, components: true },
-        });
-
-        const generatingDuration = timer.end('generatingTS');
-        generatingTsSpinner.text = `Generating types (${prettyTime(generatingDuration)})`;
-        generatingTsSpinner.succeed();
-      }
-
-      if (tsconfig?.config) {
-        timer.start('compilingTS');
-        compilingTsSpinner.start();
-
-        await cleanupDistDirectory({ tsconfig, logger, timer });
-        await tsUtils.compile(cwd, { configOptions: { ignoreDiagnostics: false } });
-
-        const compilingDuration = timer.end('compilingTS');
-        compilingTsSpinner.text = `Compiling TS (${prettyTime(compilingDuration)})`;
-        compilingTsSpinner.succeed();
-      }
-
       ensureWatcher();
 
       strapiInstance.start();
+
+      // Type generation (for IDE) and the diagnostic TS pass are not on the
+      // request path. Defer both so they run after `strapiInstance.start()`
+      // resolves; errors surface as deferred log lines instead of blocking.
+      setImmediate(async () => {
+        // For TS projects, type generation is a requirement for the develop command so that the server can restart
+        // For JS projects, we respect the experimental autogenerate setting
+        if (tsconfig?.config || strapi.config.get('typescript.autogenerate') !== false) {
+          timer.start('generatingTS');
+          generatingTsSpinner.start();
+
+          try {
+            await tsUtils.generators.generate({
+              strapi: strapiInstance,
+              pwd: cwd,
+              rootDir: undefined,
+              logger: { silent: true, debug: false },
+              artifacts: { contentTypes: true, components: true },
+            });
+
+            const generatingDuration = timer.end('generatingTS');
+            generatingTsSpinner.text = `Generating types (${prettyTime(generatingDuration)})`;
+            generatingTsSpinner.succeed();
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            generatingTsSpinner.text = `Type generation failed: ${message}`;
+            generatingTsSpinner.fail();
+          }
+        }
+
+        if (tsconfig?.config) {
+          timer.start('compilingTS');
+          compilingTsSpinner.start();
+
+          try {
+            await tsUtils.compile(cwd, { configOptions: { ignoreDiagnostics: false } });
+
+            const compilingDuration = timer.end('compilingTS');
+            compilingTsSpinner.text = `Compiling TS (${prettyTime(compilingDuration)})`;
+            compilingTsSpinner.succeed();
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            compilingTsSpinner.text = `TS diagnostics failed: ${message}`;
+            compilingTsSpinner.fail();
+          }
+        }
+      });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(`Error during development: ${message}`);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Two related changes in `packages/core/strapi/src/node/develop.ts`:

1. **Primary cluster — skip cleanup + compile when dist is current.** Today the primary always runs `cleanupDistDirectory` + `tsUtils.compile(... ignoreDiagnostics: true)` before forking. Add an `isDistUpToDate(cwd, tsconfig)` mtime check that confirms `dist/src/index.js` and `dist/tsconfig.tsbuildinfo` exist and post-date all source under `cwd` (excluding `node_modules`, `dist`, `build`, `.tmp`, `.cache`, `.strapi`, dotfiles). Skip on hit; the full compile remains the fallback.

2. **Worker — defer post-load TS work to `setImmediate`.** After `strapi.load()` resolves, the worker still synchronously runs `tsUtils.generators.generate(...)` (for IDE types) and `tsUtils.compile(... ignoreDiagnostics: false)` (the type-check pass) BEFORE `strapiInstance.start()`. Move both into a `setImmediate` that fires after `start()` so the server is listening sooner. Errors surface as deferred fail-spinners; the diagnostic compile still runs, just off the request path.

### Why is it needed?

Profiling on a fresh quickstart shows ~1.5 s of work between `strapi.load()` resolving and `strapiInstance.start()` being callable, dominated by:

- Worker type-gen (`tsUtils.generators.generate`): ~140 ms
- Worker type-check pass (`tsUtils.compile { ignoreDiagnostics: false }`): ~900 ms
- Primary's cleanup + redundant first compile when nothing changed: ~500 ms

Combined: deferring type-gen + diagnostic TS, plus skipping the redundant primary compile, removes ~1.5 s from perceived "Strapi started" time.

The deferred work still runs and still surfaces failures via `compilingTsSpinner.fail()` — they just don't gate `listen()` anymore.

### Trade-offs

- **mtime resolution.** FAT-formatted volumes and some Docker bind mounts have second-resolution mtimes. A file edited within the same second as the dist build could be missed. Mitigation: `isDistUpToDate` also requires `tsconfig.tsbuildinfo` to exist — `tsc --incremental` regenerates it on every emit, so a missed source change still produces a deferred type-check failure that's visible in the worker output. The cost is a delayed error, not a silent failure.
- **Diagnostic timing.** A TS error that previously blocked startup now surfaces ~1 s after the "Strapi started" banner. The fail-spinner makes it visible, but maintainers may prefer to keep the old behaviour behind an opt-in flag (`--strict-startup`) for CI. Happy to add that in a follow-up if requested.

### Dependencies

- Behaviour relies on `*.tsbuildinfo` being preserved across restarts (#26264). Without that PR, every restart still pays for a full compile, so the `isDistUpToDate` skip rarely fires.
- Both `tsUtils.compile` and `tsUtils.generators.generate` are still eager imports here. PR-5 (#26268) makes them lazy in this same file; this PR ignores that to keep the diff minimal. Cherry-pick conflicts on this file are expected if multiple PRs from the series land — happy to rebase.

Part of the boot-perf series:
- #26264, #26265, #26266, #26267, #26268, #26269, #26270, #26271 (PR-1..7, 9, 10 of the series)

### How to test it?

```bash
# 1. First run does a real compile; second run hits the skip
yarn develop                    # primary compile runs (cold)
# stop, no edits
yarn develop                    # primary compile skipped (mtime <= dist)

# 2. Editing a source file invalidates the skip
touch src/index.ts
yarn develop                    # primary compile runs again

# 3. Type errors still surface (deferred)
# Add a TS error to src/index.ts
yarn develop                    # server starts, then the diagnostic spinner fails

# 4. JS projects still work
mv tsconfig.json tsconfig.json.bak
yarn develop                    # tsconfig?.config falsy; primary block skipped entirely
mv tsconfig.json.bak tsconfig.json
```

### Related issue(s)/PR(s)

- #26264, #26265, #26266, #26267, #26268, #26269, #26270, #26271 — same boot-perf series.