### PR TITLE
enhancement(core/core): rounded thin borders for startup banner

### DIFF
--- a/packages/core/core/src/utils/startup-logger.ts
+++ b/packages/core/core/src/utils/startup-logger.ts
@@ -4,6 +4,24 @@ import _ from 'lodash/fp';
 
 import type { Core } from '@strapi/types';
 
+const ROUNDED_CHARS = {
+  top: '─',
+  'top-mid': '┬',
+  'top-left': '╭',
+  'top-right': '╮',
+  bottom: '─',
+  'bottom-mid': '┴',
+  'bottom-left': '╰',
+  'bottom-right': '╯',
+  left: '│',
+  right: '│',
+  middle: '│',
+  mid: '',
+  'left-mid': '',
+  'mid-mid': '',
+  'right-mid': '',
+};
+
 export const createStartupLogger = (app: Core.Strapi) => {
   return {
     logStats() {
@@ -14,7 +32,7 @@ export const createStartupLogger = (app: Core.Strapi) => {
 
       const infoTable = new CLITable({
         colWidths: [20, 50],
-        chars: { mid: '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
+        chars: ROUNDED_CHARS,
       });
 
       const dbInfo = app.db?.getInfo();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Switches the cli-table3 `chars` config in `packages/core/core/src/utils/startup-logger.ts` from the default heavy double-line preset to a rounded thin-line preset (`╭─╮ ╰─╯` + `│ ┬ ┴` seams).

```
Before                                  After
┌────────────────┬───────────────────┐  ╭────────────────┬───────────────────╮
│ Time           │ ...               │  │ Time           │ ...               │
│ ...            │                   │  │ ...            │                   │
└────────────────┴───────────────────┘  ╰────────────────┴───────────────────╯
```

Same rows, same data — only the border glyphs change.

### Why is it needed?

Pure visual polish; the heavier double-line corners stand out against the surrounding banner copy. The rounded thin-line preset is consistent with the visual style commonly used by other modern CLI tools (vite, next, turborepo, vercel).

### Notes

- Field consolidation, the "Project information / Actions available" preamble, and the framed `addressTable` are deliberately untouched. Those are larger UX calls that benefit from a separate, scoped discussion.
- Spinner-related items in the original boot-perf plan (phase-aware load spinner, single bg-tasks spinner) are not part of this PR — they need design-system buy-in and would change the visible output sequence that some user automation greps. Happy to file as separate proposals if there's interest.

Part of the boot-perf series:
- #26264, #26265, #26266, #26267, #26268, #26269, #26270, #26271, #26272 (other PRs in the series)

### How to test it?

```bash
yarn develop  # banner renders with rounded corners
```

### Related issue(s)/PR(s)

- ø