### PR TITLE
chore(ai): ignore .agents/local-skills and .agents/local-state for local only harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@ tests/cli/.env
 ############################
 CLAUDE.local.md
 .claude
+.agents/local-skills
+.agents/local-state
 
 ############################
 # Strapi


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds `.agents/local-skills` and `.agents/local-state` to `.gitignore`

### Why is it needed?

Some agent harness files under `.agents/` are meant to stay on each machine (local skills, local state) to help the contributors iterate on tooling.
Without ignore rules, they show up as untracked or accidental changes in `git status` and can be committed by mistake. This keeps the repo clean while still allowing a local-only agent setup.
The ultimate goal of those directories is to produce skills and agents architecture to be promoted for anyone to use.

### How to test it?

From the repo root on a branch that includes this commit:

1. Create local harness paths, for example:
   - `mkdir -p .agents/local-skills .agents/local-state`
   - `touch .agents/local-skills/example.md .agents/local-state/example.md`
2. Run `git status` and confirm those paths are not listed.
3. Run `git check-ignore -v .agents/local-skills/example.md .agents/local-state/example.json` and confirm both match the new `.gitignore` entries.

No app build, tests, or runtime verification are required; this is a Git ignore-only change.

### Related issue(s)/PR(s)

- ø
