### PR TITLE
fix(admin): return empty object for empty json body in fetch client

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -327,7 +327,7 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
       // constructor is not the same identity as the one this module closes over. Name
       // comparison is realm-agnostic.
       if ((error as Error | null)?.name === 'SyntaxError' && response.ok) {
-        return { data: [], status: response.status } as FetchResponse<any>;
+        return { data: {}, status: response.status } as FetchResponse<any>;
       } else {
         throw error;
       }


### PR DESCRIPTION
## Summary

Follow-up to #25416 ([review comment](https://github.com/strapi/strapi/pull/25416#discussion_r3217473264)).

The 204 no-content path returns `{ data: {} }`, but the `SyntaxError` catch fallback (empty body on a 2xx JSON response) still returned `{ data: [] }`. Aligning both so callers get a consistent shape on empty responses.

```diff
-        return { data: [], status: response.status } as FetchResponse<any>;
+        return { data: {}, status: response.status } as FetchResponse<any>;
```

## Test plan

- [x] `yarn test:front src/utils/tests/getFetchClient.test.ts` — 20/20 pass
- [x] No new test added: the `SyntaxError` branch is currently uncovered; existing 204 tests already assert the `{}` shape.