### PR TITLE
Improve schema sync performance

### DIFF
--- a/packages/core/database/src/dialects/mysql/schema-inspector.ts
+++ b/packages/core/database/src/dialects/mysql/schema-inspector.ts
@@ -7,6 +7,7 @@ interface RawTable {
 }
 
 interface RawColumn {
+  table_name: string;
   data_type: string;
   column_name: string;
   character_maximum_length: number;
@@ -17,13 +18,20 @@ interface RawColumn {
 }
 
 interface RawIndex {
-  Key_name: string;
-  Column_name: string;
-  Non_unique: boolean | string;
+  table_name: string;
+  key_name: string;
+  column_name: string;
+  non_unique: number | string;
 }
 
 interface RawForeignKey {
+  table_name: string;
   constraint_name: string;
+  column_name: string;
+  referenced_table_name: string | null;
+  referenced_column_name: string | null;
+  on_update: string;
+  on_delete: string;
 }
 
 const SQL_QUERIES = {
@@ -34,8 +42,9 @@ const SQL_QUERIES = {
     WHERE table_type = 'BASE TABLE'
     AND table_schema = schema();
   `,
-  LIST_COLUMNS: /* sql */ `
+  BULK_COLUMNS: /* sql */ `
     SELECT
+      c.table_name as table_name,
       c.data_type as data_type,
       c.column_name as column_name,
       c.character_maximum_length as character_maximum_length,
@@ -45,39 +54,41 @@ const SQL_QUERIES = {
       c.column_key as column_key
     FROM information_schema.columns c
     WHERE table_schema = database()
-    AND table_name = ?;
+    AND table_name in (:tables);
   `,
-  INDEX_LIST: /* sql */ `
-    show index from ??;
-  `,
-  FOREIGN_KEY_LIST: /* sql */ `
+  BULK_INDEXES: /* sql */ `
     SELECT
-      tc.constraint_name as constraint_name
-    FROM information_schema.table_constraints tc
-    WHERE tc.constraint_type = 'FOREIGN KEY'
-    AND tc.table_schema = database()
-    AND tc.table_name = ?;
+      s.table_name as table_name,
+      s.index_name as key_name,
+      s.column_name as column_name,
+      s.non_unique as non_unique
+    FROM information_schema.statistics s
+    WHERE s.table_schema = database()
+    AND s.table_name in (:tables)
+    ORDER BY s.table_name, s.index_name, s.seq_in_index;
   `,
-  FOREIGN_KEY_REFERENCES: /* sql */ `
+  BULK_FOREIGN_KEYS: /* sql */ `
     SELECT
-      kcu.constraint_name as constraint_name,
+      tc.table_name as table_name,
+      tc.constraint_name as constraint_name,
       kcu.column_name as column_name,
       kcu.referenced_table_name as referenced_table_name,
-      kcu.referenced_column_name as referenced_column_name
-    FROM information_schema.key_column_usage kcu
-    WHERE kcu.constraint_name in (?)
-    AND kcu.table_schema = database()
-    AND kcu.table_name = ?;
-  `,
-  FOREIGN_KEY_REFERENTIALS_CONSTRAINTS: /* sql */ `
-    SELECT
-      rc.constraint_name as constraint_name,
+      kcu.referenced_column_name as referenced_column_name,
       rc.update_rule as on_update,
       rc.delete_rule as on_delete
-    FROM information_schema.referential_constraints AS rc
-    WHERE rc.constraint_name in (?)
-    AND rc.constraint_schema = database()
-    AND rc.table_name = ?;
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+      AND tc.table_name = kcu.table_name
+    JOIN information_schema.referential_constraints rc
+      ON tc.constraint_name = rc.constraint_name
+      AND tc.table_schema = rc.constraint_schema
+      AND tc.table_name = rc.table_name
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema = database()
+    AND tc.table_name in (:tables)
+    ORDER BY tc.table_name, tc.constraint_name, kcu.ordinal_position;
   `,
 };
 
@@ -146,20 +157,23 @@ export default class MysqlSchemaInspector implements SchemaInspector {
 
     const tables = await this.getTables();
 
-    schema.tables = await Promise.all(
-      tables.map(async (tableName) => {
-        const columns = await this.getColumns(tableName);
-        const indexes = await this.getIndexes(tableName);
-        const foreignKeys = await this.getForeignKeys(tableName);
+    if (tables.length === 0) {
+      return schema;
+    }
 
-        return {
-          name: tableName,
-          columns,
-          indexes,
-          foreignKeys,
-        };
-      })
-    );
+    // Run 3 bulk queries in parallel instead of N+1 per-table queries
+    const [allColumns, allIndexes, allForeignKeys] = await Promise.all([
+      this.getBulkColumns(tables),
+      this.getBulkIndexes(tables),
+      this.getBulkForeignKeys(tables),
+    ]);
+
+    schema.tables = tables.map((tableName) => ({
+      name: tableName,
+      columns: allColumns.get(tableName) ?? [],
+      indexes: allIndexes.get(tableName) ?? [],
+      foreignKeys: allForeignKeys.get(tableName) ?? [],
+    }));
 
     return schema;
   }
@@ -170,15 +184,21 @@ export default class MysqlSchemaInspector implements SchemaInspector {
     return rows.map((row) => row.table_name);
   }
 
-  async getColumns(tableName: string): Promise<Column[]> {
-    const [rows] = await this.db.connection.raw<[RawColumn[]]>(SQL_QUERIES.LIST_COLUMNS, [
-      tableName,
-    ]);
+  async getBulkColumns(tableNames: string[]): Promise<Map<string, Column[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
 
-    return rows.map((row) => {
+    const [rows] = await this.db.connection.raw<[RawColumn[]]>(SQL_QUERIES.BULK_COLUMNS, {
+      tables: this.db.connection.raw(tableNames.map(() => '?').join(', '), tableNames),
+    });
+
+    const result = new Map<string, Column[]>();
+
+    for (const row of rows) {
       const { type, args = [], ...rest } = toStrapiType(row);
 
-      return {
+      const column: Column = {
         type,
         args,
         defaultTo: row.column_default,
@@ -187,82 +207,127 @@ export default class MysqlSchemaInspector implements SchemaInspector {
         unsigned: row.column_type.endsWith(' unsigned'),
         ...rest,
       };
-    });
+
+      const existing = result.get(row.table_name);
+      if (existing) {
+        existing.push(column);
+      } else {
+        result.set(row.table_name, [column]);
+      }
+    }
+
+    return result;
   }
 
-  async getIndexes(tableName: string): Promise<Index[]> {
-    const [rows] = await this.db.connection.raw<[RawIndex[]]>(SQL_QUERIES.INDEX_LIST, [tableName]);
+  async getColumns(tableName: string): Promise<Column[]> {
+    const result = await this.getBulkColumns([tableName]);
+    return result.get(tableName) ?? [];
+  }
 
-    const ret: Record<RawIndex['Key_name'], Index> = {};
+  async getBulkIndexes(tableNames: string[]): Promise<Map<string, Index[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
+
+    const [rows] = await this.db.connection.raw<[RawIndex[]]>(SQL_QUERIES.BULK_INDEXES, {
+      tables: this.db.connection.raw(tableNames.map(() => '?').join(', '), tableNames),
+    });
+
+    // Group by table, then by key_name
+    const byTable = new Map<string, Map<string, Index>>();
 
     for (const index of rows) {
-      if (index.Column_name === 'id') {
+      if (index.column_name === 'id') {
         continue;
       }
 
-      if (!ret[index.Key_name]) {
+      let tableIndexes = byTable.get(index.table_name);
+      if (!tableIndexes) {
+        tableIndexes = new Map();
+        byTable.set(index.table_name, tableIndexes);
+      }
+
+      const existing = tableIndexes.get(index.key_name);
+      if (existing) {
+        existing.columns.push(index.column_name);
+      } else {
         const indexInfo: Index = {
-          columns: [index.Column_name],
-          name: index.Key_name,
+          columns: [index.column_name],
+          name: index.key_name,
         };
-        if (!index.Non_unique || index.Non_unique === '0') {
+        if (!index.non_unique || index.non_unique === '0') {
           indexInfo.type = 'unique';
         }
-
-        ret[index.Key_name] = indexInfo;
-      } else {
-        ret[index.Key_name].columns.push(index.Column_name);
+        tableIndexes.set(index.key_name, indexInfo);
       }
     }
 
-    return Object.values(ret);
+    const result = new Map<string, Index[]>();
+    for (const [tableName, tableIndexes] of byTable) {
+      result.set(tableName, Array.from(tableIndexes.values()));
+    }
+
+    return result;
+  }
+
+  async getIndexes(tableName: string): Promise<Index[]> {
+    const result = await this.getBulkIndexes([tableName]);
+    return result.get(tableName) ?? [];
+  }
+
+  async getBulkForeignKeys(tableNames: string[]): Promise<Map<string, ForeignKey[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
+
+    const [rows] = await this.db.connection.raw<[RawForeignKey[]]>(SQL_QUERIES.BULK_FOREIGN_KEYS, {
+      tables: this.db.connection.raw(tableNames.map(() => '?').join(', '), tableNames),
+    });
+
+    // Group by table_name, then by constraint_name
+    const byTable = new Map<string, Map<string, ForeignKey>>();
+
+    for (const row of rows) {
+      let tableFKs = byTable.get(row.table_name);
+      if (!tableFKs) {
+        tableFKs = new Map();
+        byTable.set(row.table_name, tableFKs);
+      }
+
+      let fk = tableFKs.get(row.constraint_name);
+      if (!fk) {
+        fk = {
+          name: row.constraint_name,
+          columns: [row.column_name],
+          referencedColumns: row.referenced_column_name ? [row.referenced_column_name] : [],
+          referencedTable: row.referenced_table_name,
+          onUpdate: row.on_update?.toUpperCase() ?? null,
+          onDelete: row.on_delete?.toUpperCase() ?? null,
+        } as unknown as ForeignKey;
+        tableFKs.set(row.constraint_name, fk);
+      } else {
+        if (!fk.columns.includes(row.column_name)) {
+          fk.columns.push(row.column_name);
+        }
+        if (
+          row.referenced_column_name &&
+          !fk.referencedColumns.includes(row.referenced_column_name)
+        ) {
+          fk.referencedColumns.push(row.referenced_column_name);
+        }
+      }
+    }
+
+    const result = new Map<string, ForeignKey[]>();
+    for (const [tableName, tableFKs] of byTable) {
+      result.set(tableName, Array.from(tableFKs.values()));
+    }
+
+    return result;
   }
 
   async getForeignKeys(tableName: string): Promise<ForeignKey[]> {
-    const [rows] = await this.db.connection.raw<[RawForeignKey[]]>(SQL_QUERIES.FOREIGN_KEY_LIST, [
-      tableName,
-    ]);
-
-    const ret: Record<RawForeignKey['constraint_name'], ForeignKey> = {};
-
-    for (const fk of rows) {
-      ret[fk.constraint_name] = {
-        name: fk.constraint_name,
-        columns: [],
-        referencedColumns: [],
-        referencedTable: null,
-        onUpdate: null,
-        onDelete: null,
-      } as unknown as ForeignKey;
-    }
-
-    const contraintNames = Object.keys(ret);
-
-    if (contraintNames.length > 0) {
-      const [fkReferences] = await this.db.connection.raw(SQL_QUERIES.FOREIGN_KEY_REFERENCES, [
-        contraintNames,
-        tableName,
-      ]);
-
-      for (const fkReference of fkReferences) {
-        ret[fkReference.constraint_name].referencedTable = fkReference.referenced_table_name;
-        ret[fkReference.constraint_name].columns.push(fkReference.column_name);
-        ret[fkReference.constraint_name].referencedColumns.push(fkReference.referenced_column_name);
-      }
-
-      const [fkReferentialConstraints] = await this.db.connection.raw(
-        SQL_QUERIES.FOREIGN_KEY_REFERENTIALS_CONSTRAINTS,
-        [contraintNames, tableName]
-      );
-
-      for (const fkReferentialConstraint of fkReferentialConstraints) {
-        ret[fkReferentialConstraint.constraint_name].onUpdate =
-          fkReferentialConstraint.on_update.toUpperCase();
-        ret[fkReferentialConstraint.constraint_name].onDelete =
-          fkReferentialConstraint.on_delete.toUpperCase();
-      }
-    }
-
-    return Object.values(ret);
+    const result = await this.getBulkForeignKeys([tableName]);
+    return result.get(tableName) ?? [];
   }
 }

--- a/packages/core/database/src/dialects/postgresql/schema-inspector.ts
+++ b/packages/core/database/src/dialects/postgresql/schema-inspector.ts
@@ -2,11 +2,8 @@ import type { Database } from '../..';
 import type { Schema, Column, Index, ForeignKey } from '../../schema/types';
 import type { SchemaInspector } from '../dialect';
 
-interface RawTable {
-  table_name: string;
-}
-
 interface RawColumn {
+  table_name: string;
   data_type: string;
   column_name: string;
   character_maximum_length: number;
@@ -15,6 +12,7 @@ interface RawColumn {
 }
 
 interface RawIndex {
+  table_name: string;
   indexrelid: string;
   index_name: string;
   column_name: string;
@@ -22,8 +20,8 @@ interface RawIndex {
   is_primary: boolean;
 }
 
-interface RawForeignKey {
-  constraint_name: string;
+interface RawTable {
+  table_name: string;
 }
 
 const SQL_QUERIES = {
@@ -36,13 +34,14 @@ const SQL_QUERIES = {
       AND table_name != 'geometry_columns'
       AND table_name != 'spatial_ref_sys';
   `,
-  LIST_COLUMNS: /* sql */ `
-    SELECT data_type, column_name, character_maximum_length, column_default, is_nullable
+  BULK_COLUMNS: /* sql */ `
+    SELECT table_name, data_type, column_name, character_maximum_length, column_default, is_nullable
     FROM information_schema.columns
-    WHERE table_schema = ? AND table_name = ?;
+    WHERE table_schema = ? AND table_name = ANY(?);
   `,
-  INDEX_LIST: /* sql */ `
+  BULK_INDEXES: /* sql */ `
     SELECT
+      t.relname as table_name,
       ix.indexrelid,
       i.relname as index_name,
       a.attname as column_name,
@@ -62,45 +61,32 @@ const SQL_QUERIES = {
       AND t.relkind = 'r'
       AND t.relnamespace = s.oid
       AND s.nspname = ?
-      AND t.relname = ?;
+      AND t.relname = ANY(?);
   `,
-  FOREIGN_KEY_LIST: /* sql */ `
+  BULK_FOREIGN_KEYS: /* sql */ `
     SELECT
-      tco."constraint_name" as constraint_name
+      tco.table_name,
+      tco.constraint_name,
+      kcu.column_name,
+      rco.update_rule as on_update,
+      rco.delete_rule as on_delete,
+      rel_kcu.table_name as foreign_table,
+      rel_kcu.column_name as fk_column_name
     FROM information_schema.table_constraints tco
-    WHERE
-      tco.constraint_type = 'FOREIGN KEY'
+    JOIN information_schema.key_column_usage kcu
+      ON tco.constraint_name = kcu.constraint_name
+      AND tco.constraint_schema = kcu.constraint_schema
+      AND tco.table_name = kcu.table_name
+    JOIN information_schema.referential_constraints rco
+      ON tco.constraint_name = rco.constraint_name
+      AND tco.constraint_schema = rco.constraint_schema
+    JOIN information_schema.key_column_usage rel_kcu
+      ON rco.unique_constraint_name = rel_kcu.constraint_name
+      AND rco.unique_constraint_schema = rel_kcu.constraint_schema
+    WHERE tco.constraint_type = 'FOREIGN KEY'
       AND tco.constraint_schema = ?
-      AND tco.table_name = ?
+      AND tco.table_name = ANY(?);
   `,
-  FOREIGN_KEY_REFERENCES: /* sql */ `
-    SELECT
-      kcu."constraint_name" as constraint_name,
-      kcu."column_name" as column_name
-
-    FROM information_schema.key_column_usage kcu
-    WHERE kcu.constraint_name=ANY(?)
-    AND kcu.table_schema = ?
-    AND kcu.table_name = ?;
-  `,
-
-  FOREIGN_KEY_REFERENCES_CONSTRAIN: /* sql */ `
-  SELECT
-  rco.update_rule as on_update,
-  rco.delete_rule as on_delete,
-  rco."unique_constraint_name" as unique_constraint_name
-  FROM information_schema.referential_constraints rco
-  WHERE rco.constraint_name=ANY(?)
-  AND rco.constraint_schema = ?
-`,
-  FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE: /* sql */ `
-  SELECT
-  rel_kcu."table_name" as foreign_table,
-  rel_kcu."column_name" as fk_column_name
-    FROM information_schema.key_column_usage rel_kcu
-    WHERE rel_kcu.constraint_name=?
-    AND rel_kcu.table_schema = ?
-`,
 };
 
 const toStrapiType = (column: RawColumn) => {
@@ -167,23 +153,27 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
 
   async getSchema() {
     const schema: Schema = { tables: [] };
+    const dbSchema = this.getDatabaseSchema();
 
     const tables = await this.getTables();
 
-    schema.tables = await Promise.all(
-      tables.map(async (tableName) => {
-        const columns = await this.getColumns(tableName);
-        const indexes = await this.getIndexes(tableName);
-        const foreignKeys = await this.getForeignKeys(tableName);
+    if (tables.length === 0) {
+      return schema;
+    }
 
-        return {
-          name: tableName,
-          columns,
-          indexes,
-          foreignKeys,
-        };
-      })
-    );
+    // Run 3 bulk queries in parallel instead of N+1 per-table queries
+    const [allColumns, allIndexes, allForeignKeys] = await Promise.all([
+      this.getBulkColumns(dbSchema, tables),
+      this.getBulkIndexes(dbSchema, tables),
+      this.getBulkForeignKeys(dbSchema, tables),
+    ]);
+
+    schema.tables = tables.map((tableName) => ({
+      name: tableName,
+      columns: allColumns.get(tableName) ?? [],
+      indexes: allIndexes.get(tableName) ?? [],
+      foreignKeys: allForeignKeys.get(tableName) ?? [],
+    }));
 
     return schema;
   }
@@ -200,19 +190,20 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
     return rows.map((row) => row.table_name);
   }
 
-  async getColumns(tableName: string): Promise<Column[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.LIST_COLUMNS, [
-      this.getDatabaseSchema(),
-      tableName,
+  async getBulkColumns(dbSchema: string, tableNames: string[]): Promise<Map<string, Column[]>> {
+    const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.BULK_COLUMNS, [
+      dbSchema,
+      tableNames,
     ]);
 
-    return rows.map((row) => {
-      const { type, args = [], ...rest } = toStrapiType(row);
+    const result = new Map<string, Column[]>();
 
+    for (const row of rows) {
+      const { type, args = [], ...rest } = toStrapiType(row);
       const defaultTo =
         row.column_default && row.column_default.includes('nextval(') ? null : row.column_default;
 
-      return {
+      const column: Column = {
         type,
         args,
         defaultTo,
@@ -221,88 +212,122 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
         unsigned: false,
         ...rest,
       };
-    });
+
+      const existing = result.get(row.table_name);
+      if (existing) {
+        existing.push(column);
+      } else {
+        result.set(row.table_name, [column]);
+      }
+    }
+
+    return result;
   }
 
-  async getIndexes(tableName: string): Promise<Index[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.INDEX_LIST, [
-      this.getDatabaseSchema(),
-      tableName,
+  async getBulkIndexes(dbSchema: string, tableNames: string[]): Promise<Map<string, Index[]>> {
+    const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.BULK_INDEXES, [
+      dbSchema,
+      tableNames,
     ]);
 
-    const ret: Record<RawIndex['indexrelid'], Index> = {};
+    // Group by table, then by indexrelid
+    const byTable = new Map<string, Map<string, Index>>();
 
     for (const index of rows) {
       if (index.column_name === 'id') {
         continue;
       }
 
-      if (!ret[index.indexrelid]) {
-        ret[index.indexrelid] = {
+      let tableIndexes = byTable.get(index.table_name);
+      if (!tableIndexes) {
+        tableIndexes = new Map();
+        byTable.set(index.table_name, tableIndexes);
+      }
+
+      const existing = tableIndexes.get(index.indexrelid);
+      if (existing) {
+        existing.columns.push(index.column_name);
+      } else {
+        tableIndexes.set(index.indexrelid, {
           columns: [index.column_name],
           name: index.index_name,
           type: getIndexType(index),
-        };
-      } else {
-        ret[index.indexrelid].columns.push(index.column_name);
+        });
       }
     }
 
-    return Object.values(ret);
+    const result = new Map<string, Index[]>();
+    for (const [tableName, tableIndexes] of byTable) {
+      result.set(tableName, Array.from(tableIndexes.values()));
+    }
+
+    return result;
+  }
+
+  async getIndexes(tableName: string): Promise<Index[]> {
+    const dbSchema = this.getDatabaseSchema();
+    const result = await this.getBulkIndexes(dbSchema, [tableName]);
+    return result.get(tableName) ?? [];
   }
 
   async getForeignKeys(tableName: string): Promise<ForeignKey[]> {
-    const { rows } = await this.db.connection.raw<{ rows: RawForeignKey[] }>(
-      SQL_QUERIES.FOREIGN_KEY_LIST,
-      [this.getDatabaseSchema(), tableName]
-    );
-
-    const ret: Record<RawForeignKey['constraint_name'], ForeignKey> = {};
-
-    for (const fk of rows) {
-      ret[fk.constraint_name] = {
-        name: fk.constraint_name,
-        columns: [],
-        referencedColumns: [],
-        referencedTable: null,
-        onUpdate: null,
-        onDelete: null,
-      } as unknown as ForeignKey;
-    }
-
-    const constraintNames = Object.keys(ret);
     const dbSchema = this.getDatabaseSchema();
-    if (constraintNames.length > 0) {
-      const { rows: fkReferences } = await this.db.connection.raw(
-        SQL_QUERIES.FOREIGN_KEY_REFERENCES,
-        [[constraintNames], dbSchema, tableName]
-      );
+    const result = await this.getBulkForeignKeys(dbSchema, [tableName]);
+    return result.get(tableName) ?? [];
+  }
 
-      for (const fkReference of fkReferences) {
-        ret[fkReference.constraint_name].columns.push(fkReference.column_name);
+  async getBulkForeignKeys(
+    dbSchema: string,
+    tableNames: string[]
+  ): Promise<Map<string, ForeignKey[]>> {
+    const { rows } = await this.db.connection.raw<{
+      rows: Array<{
+        table_name: string;
+        constraint_name: string;
+        column_name: string;
+        on_update: string;
+        on_delete: string;
+        foreign_table: string;
+        fk_column_name: string;
+      }>;
+    }>(SQL_QUERIES.BULK_FOREIGN_KEYS, [dbSchema, tableNames]);
 
-        const { rows: fkReferencesConstraint } = await this.db.connection.raw(
-          SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN,
-          [[fkReference.constraint_name], dbSchema]
-        );
+    // Group by table_name, then by constraint_name
+    const byTable = new Map<string, Map<string, ForeignKey>>();
 
-        for (const fkReferenceC of fkReferencesConstraint) {
-          const { rows: fkReferencesConstraintReferece } = await this.db.connection.raw(
-            SQL_QUERIES.FOREIGN_KEY_REFERENCES_CONSTRAIN_RFERENCE,
-            [fkReferenceC.unique_constraint_name, dbSchema]
-          );
-          for (const fkReferenceConst of fkReferencesConstraintReferece) {
-            ret[fkReference.constraint_name].referencedTable = fkReferenceConst.foreign_table;
-            ret[fkReference.constraint_name].referencedColumns.push(
-              fkReferenceConst.fk_column_name
-            );
-          }
-          ret[fkReference.constraint_name].onUpdate = fkReferenceC.on_update.toUpperCase();
-          ret[fkReference.constraint_name].onDelete = fkReferenceC.on_delete.toUpperCase();
+    for (const row of rows) {
+      let tableFKs = byTable.get(row.table_name);
+      if (!tableFKs) {
+        tableFKs = new Map();
+        byTable.set(row.table_name, tableFKs);
+      }
+
+      let fk = tableFKs.get(row.constraint_name);
+      if (!fk) {
+        fk = {
+          name: row.constraint_name,
+          columns: [row.column_name],
+          referencedColumns: [row.fk_column_name],
+          referencedTable: row.foreign_table,
+          onUpdate: row.on_update?.toUpperCase() ?? null,
+          onDelete: row.on_delete?.toUpperCase() ?? null,
+        };
+        tableFKs.set(row.constraint_name, fk);
+      } else {
+        if (!fk.columns.includes(row.column_name)) {
+          fk.columns.push(row.column_name);
+        }
+        if (!fk.referencedColumns.includes(row.fk_column_name)) {
+          fk.referencedColumns.push(row.fk_column_name);
         }
       }
     }
 
-    return Object.values(ret);
+    const result = new Map<string, ForeignKey[]>();
+    for (const [tableName, tableFKs] of byTable) {
+      result.set(tableName, Array.from(tableFKs.values()));
+    }
+
+    return result;
   }
 }

--- a/packages/core/database/src/dialects/postgresql/schema-inspector.ts
+++ b/packages/core/database/src/dialects/postgresql/schema-inspector.ts
@@ -65,27 +65,37 @@ const SQL_QUERIES = {
   `,
   BULK_FOREIGN_KEYS: /* sql */ `
     SELECT
-      tco.table_name,
-      tco.constraint_name,
-      kcu.column_name,
-      rco.update_rule as on_update,
-      rco.delete_rule as on_delete,
-      rel_kcu.table_name as foreign_table,
-      rel_kcu.column_name as fk_column_name
-    FROM information_schema.table_constraints tco
-    JOIN information_schema.key_column_usage kcu
-      ON tco.constraint_name = kcu.constraint_name
-      AND tco.constraint_schema = kcu.constraint_schema
-      AND tco.table_name = kcu.table_name
-    JOIN information_schema.referential_constraints rco
-      ON tco.constraint_name = rco.constraint_name
-      AND tco.constraint_schema = rco.constraint_schema
-    JOIN information_schema.key_column_usage rel_kcu
-      ON rco.unique_constraint_name = rel_kcu.constraint_name
-      AND rco.unique_constraint_schema = rel_kcu.constraint_schema
-    WHERE tco.constraint_type = 'FOREIGN KEY'
-      AND tco.constraint_schema = ?
-      AND tco.table_name = ANY(?);
+      cl.relname AS table_name,
+      c.conname AS constraint_name,
+      att.attname AS column_name,
+      fcl.relname AS foreign_table,
+      fatt.attname AS fk_column_name,
+      CASE c.confupdtype
+        WHEN 'a' THEN 'NO ACTION'
+        WHEN 'r' THEN 'RESTRICT'
+        WHEN 'c' THEN 'CASCADE'
+        WHEN 'n' THEN 'SET NULL'
+        WHEN 'd' THEN 'SET DEFAULT'
+      END AS on_update,
+      CASE c.confdeltype
+        WHEN 'a' THEN 'NO ACTION'
+        WHEN 'r' THEN 'RESTRICT'
+        WHEN 'c' THEN 'CASCADE'
+        WHEN 'n' THEN 'SET NULL'
+        WHEN 'd' THEN 'SET DEFAULT'
+      END AS on_delete
+    FROM pg_constraint c
+    JOIN pg_class cl ON cl.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    JOIN pg_class fcl ON fcl.oid = c.confrelid
+    JOIN LATERAL unnest(c.conkey, c.confkey) AS cols(conkey, confkey) ON true
+    JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = cols.conkey
+    JOIN pg_attribute fatt ON fatt.attrelid = c.confrelid AND fatt.attnum = cols.confkey
+    WHERE c.contype = 'f'
+      AND n.nspname = ?
+      AND cl.relname = ANY(?)
+      AND fcl.relnamespace = cl.relnamespace
+    ORDER BY cl.relname, c.conname, cols.conkey;
   `,
 };
 
@@ -191,6 +201,10 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
   }
 
   async getBulkColumns(dbSchema: string, tableNames: string[]): Promise<Map<string, Column[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
+
     const { rows } = await this.db.connection.raw<{ rows: RawColumn[] }>(SQL_QUERIES.BULK_COLUMNS, [
       dbSchema,
       tableNames,
@@ -225,6 +239,10 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
   }
 
   async getBulkIndexes(dbSchema: string, tableNames: string[]): Promise<Map<string, Index[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
+
     const { rows } = await this.db.connection.raw<{ rows: RawIndex[] }>(SQL_QUERIES.BULK_INDEXES, [
       dbSchema,
       tableNames,
@@ -280,6 +298,10 @@ export default class PostgresqlSchemaInspector implements SchemaInspector {
     dbSchema: string,
     tableNames: string[]
   ): Promise<Map<string, ForeignKey[]>> {
+    if (tableNames.length === 0) {
+      return new Map();
+    }
+
     const { rows } = await this.db.connection.raw<{
       rows: Array<{
         table_name: string;

--- a/tests/api/core/database/schema-inspector.test.api.js
+++ b/tests/api/core/database/schema-inspector.test.api.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createTestBuilder } = require('api-tests/builder');
+
+const categoryCT = {
+  displayName: 'inspector_category',
+  singularName: 'inspector-category',
+  pluralName: 'inspector-categories',
+  kind: 'collectionType',
+  attributes: {
+    title: { type: 'string' },
+  },
+};
+
+const articleCT = {
+  displayName: 'inspector_article',
+  singularName: 'inspector-article',
+  pluralName: 'inspector-articles',
+  kind: 'collectionType',
+  attributes: {
+    slug: { type: 'string', unique: true },
+    body: { type: 'text' },
+    published: { type: 'boolean' },
+    category: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'api::inspector-category.inspector-category',
+    },
+  },
+};
+
+const builder = createTestBuilder();
+/** @type {import('@strapi/types').Core.Strapi} */
+let strapi;
+/** @type {import('@strapi/types').Core.Strapi['db']['dialect']['schemaInspector']} */
+let schemaInspector;
+
+describe('SchemaInspector (integration)', () => {
+  beforeAll(async () => {
+    await builder.addContentTypes([categoryCT, articleCT]).build();
+    strapi = await createStrapiInstance();
+    schemaInspector = strapi.db.dialect.schemaInspector;
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('getSchema returns every known content-type table with columns', async () => {
+    const schema = await schemaInspector.getSchema();
+
+    const articleTable = strapi.db.metadata.get(
+      'api::inspector-article.inspector-article'
+    ).tableName;
+    const categoryTable = strapi.db.metadata.get(
+      'api::inspector-category.inspector-category'
+    ).tableName;
+
+    const tableNames = schema.tables.map((t) => t.name);
+    expect(tableNames).toEqual(expect.arrayContaining([articleTable, categoryTable]));
+
+    const article = schema.tables.find((t) => t.name === articleTable);
+    const columnNames = article.columns.map((c) => c.name);
+    expect(columnNames).toEqual(expect.arrayContaining(['id', 'slug', 'body', 'published']));
+
+    // id column: NOT NULL across all dialects
+    const idCol = article.columns.find((c) => c.name === 'id');
+    expect(idCol.notNullable).toBe(true);
+
+    // boolean / text columns map to the same Strapi types across all dialects
+    const publishedCol = article.columns.find((c) => c.name === 'published');
+    expect(publishedCol.type).toBe('boolean');
+
+    const bodyCol = article.columns.find((c) => c.name === 'body');
+    expect(bodyCol.type).toBe('text');
+    expect(bodyCol.args).toEqual(['longtext']);
+  });
+
+  test('foreign keys from the article<->category link table are reported', async () => {
+    // Strapi v5 stores manyToOne relations in a join/link table, not as a
+    // direct FK on the source table — assert against that link table.
+    const articleMeta = strapi.db.metadata.get('api::inspector-article.inspector-article');
+    const articleTable = articleMeta.tableName;
+    const categoryTable = strapi.db.metadata.get(
+      'api::inspector-category.inspector-category'
+    ).tableName;
+    const linkTable = articleMeta.attributes.category.joinTable.name;
+
+    const fks = await schemaInspector.getForeignKeys(linkTable);
+
+    const articleFk = fks.find((fk) => fk.referencedTable === articleTable);
+    const categoryFk = fks.find((fk) => fk.referencedTable === categoryTable);
+
+    expect(articleFk).toBeDefined();
+    expect(categoryFk).toBeDefined();
+    expect(categoryFk.columns.length).toBeGreaterThan(0);
+    expect(categoryFk.referencedColumns).toContain('id');
+    // on_update / on_delete come back uppercased by the inspector
+    if (categoryFk.onUpdate !== null) {
+      expect(categoryFk.onUpdate).toBe(categoryFk.onUpdate.toUpperCase());
+    }
+    if (categoryFk.onDelete !== null) {
+      expect(categoryFk.onDelete).toBe(categoryFk.onDelete.toUpperCase());
+    }
+  });
+
+  test('getSchema and getIndexes return consistent index data for the same table', async () => {
+    const articleTable = strapi.db.metadata.get(
+      'api::inspector-article.inspector-article'
+    ).tableName;
+
+    const schema = await schemaInspector.getSchema();
+    const fromSchema = schema.tables.find((t) => t.name === articleTable).indexes;
+    const fromSingle = await schemaInspector.getIndexes(articleTable);
+
+    const normalize = (indexes) =>
+      indexes
+        .map((i) => ({ name: i.name, columns: [...i.columns].sort(), type: i.type }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    expect(normalize(fromSchema)).toEqual(normalize(fromSingle));
+  });
+});

--- a/tests/api/core/database/schema-inspector.test.api.js
+++ b/tests/api/core/database/schema-inspector.test.api.js
@@ -122,4 +122,63 @@ describe('SchemaInspector (integration)', () => {
 
     expect(normalize(fromSchema)).toEqual(normalize(fromSingle));
   });
+
+  test('getSchema groups columns per-table without leaking across tables', async () => {
+    // Covers the per-table grouping logic that the bulk inspector implementations
+    // rely on: `slug` lives only on article, `title` lives only on category, so
+    // a grouping bug would surface them on the wrong table.
+    const schema = await schemaInspector.getSchema();
+
+    const articleTable = strapi.db.metadata.get(
+      'api::inspector-article.inspector-article'
+    ).tableName;
+    const categoryTable = strapi.db.metadata.get(
+      'api::inspector-category.inspector-category'
+    ).tableName;
+
+    const article = schema.tables.find((t) => t.name === articleTable);
+    const category = schema.tables.find((t) => t.name === categoryTable);
+
+    const articleColNames = new Set(article.columns.map((c) => c.name));
+    const categoryColNames = new Set(category.columns.map((c) => c.name));
+
+    expect(articleColNames.has('slug')).toBe(true);
+    expect(articleColNames.has('title')).toBe(false);
+    expect(categoryColNames.has('title')).toBe(true);
+    expect(categoryColNames.has('slug')).toBe(false);
+  });
+
+  test('composite foreign keys are reported with every column in the constraint', async () => {
+    const knex = strapi.db.connection;
+    const parent = 'inspector_composite_parent';
+    const child = 'inspector_composite_child';
+
+    await knex.schema.dropTableIfExists(child);
+    await knex.schema.dropTableIfExists(parent);
+
+    try {
+      await knex.schema.createTable(parent, (t) => {
+        t.integer('a').notNullable();
+        t.integer('b').notNullable();
+        t.primary(['a', 'b']);
+      });
+      await knex.schema.createTable(child, (t) => {
+        t.integer('pa').notNullable();
+        t.integer('pb').notNullable();
+        t.foreign(['pa', 'pb']).references(['a', 'b']).inTable(parent);
+      });
+
+      const fks = await schemaInspector.getForeignKeys(child);
+      const compositeFk = fks.find((fk) => fk.referencedTable === parent);
+
+      expect(compositeFk).toBeDefined();
+      expect(compositeFk.columns).toEqual(expect.arrayContaining(['pa', 'pb']));
+      expect(compositeFk.referencedColumns).toEqual(expect.arrayContaining(['a', 'b']));
+      expect(compositeFk.columns).toHaveLength(2);
+      expect(compositeFk.referencedColumns).toHaveLength(2);
+    } finally {
+      await knex.schema.dropTableIfExists(child);
+      await knex.schema.dropTableIfExists(parent);
+    }
+  });
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update schema inspector to replace per-table N+1 queries (`getColumns`, `getIndexes`, `getForeignKeys` called individually for each table) with bulk queries using `ANY()` operator. 

This fetches columns, indexes, and foreign keys for all tables in 3 parallel queries instead of 3*N sequential ones.

### Why is it needed?

Improve bootstrap performance when syncing DB schema for large schemas.

On a remote Postgres, with the `getstarted` example, `strapi.db.schema.sync()` goes from ~7s to ~1s

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
