### PR TITLE
fix(content-manager): remove outdated FIXME — deleteMany already handles relations via Document Service

### DIFF
--- a/packages/core/content-manager/server/src/services/document-manager.ts
+++ b/packages/core/content-manager/server/src/services/document-manager.ts
@@ -152,7 +152,12 @@ const documentManager = ({ strapi }: { strapi: Core.Strapi }) => {
       return {};
     },
 
-    // FIXME: handle relations
+    /**
+     * Bulk delete documents — relations are handled by the underlying
+     * Document Service's delete() which cleans up join tables, components
+     * and dynamic zones. Each document is deleted within a single transaction
+     * to ensure atomicity.
+     */
     async deleteMany(
       documentIds: Modules.Documents.ID[],
       uid: UID.CollectionType,


### PR DESCRIPTION
## Summary

Resolves #25640 by removing the misleading `// FIXME: handle relations` comment in `deleteMany`.

## Analysis

The `deleteMany` method delegates to `delete()` which calls `strapi.documents(uid).delete()`. The Document Service's `delete()` already handles:
- Relation cleanup (join tables)
- Component removal
- Dynamic zone cleanup

All deletes run within `strapi.db.transaction()` ensuring atomicity.

## Changes

- Replaced `// FIXME: handle relations` with a descriptive JSDoc block explaining that relations are handled by the Document Service
- No behavioral changes — only documentation improvement

## Testing

The existing behavior is preserved since the call chain `deleteMany → delete → strapi.documents(uid).delete()` remains unchanged. The Document Service's delete path already has its own test coverage.

Closes #25640

---
Fixes CPR-327