### PR TITLE
fix(content-manager): guard getMainField when component schema is missing

### DIFF
--- a/packages/core/content-manager/admin/src/utils/attributes.ts
+++ b/packages/core/content-manager/admin/src/utils/attributes.ts
@@ -31,12 +31,15 @@ const getMainField = (
     return undefined;
   }
 
-  const mainFieldType =
-    attribute.type === 'component'
-      ? components[attribute.component].attributes[mainFieldName].type
-      : // @ts-expect-error – `targetModel` does exist on the attribute for a relation.
-        schemas.find((schema) => schema.uid === attribute.targetModel)?.attributes[mainFieldName]
-          .type;
+  let mainFieldType: SchemaUtils.Attribute.Kind | undefined;
+
+  if (attribute.type === 'component') {
+    mainFieldType = components[attribute.component]?.attributes?.[mainFieldName]?.type;
+  } else if (attribute.type === 'relation') {
+    mainFieldType = schemas
+      .find((schemaItem) => schemaItem.uid === attribute.targetModel)
+      ?.attributes?.[mainFieldName]?.type;
+  }
 
   return {
     name: mainFieldName,

--- a/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
@@ -1,4 +1,4 @@
-import { checkIfAttributeIsDisplayable } from '../attributes';
+import { checkIfAttributeIsDisplayable, getMainField } from '../attributes';
 
 describe('attributes', () => {
   describe('checkIfAttributeIsDisplayable', () => {
@@ -36,6 +36,52 @@ describe('attributes', () => {
       } as const;
 
       expect(checkIfAttributeIsDisplayable(attribute)).toBeTruthy();
+    });
+  });
+
+  describe('getMainField', () => {
+    it('falls back to string when the component schema is not in the dictionary yet', () => {
+      const attribute = {
+        type: 'component' as const,
+        component: 'shared.missing',
+        repeatable: false,
+      };
+
+      const result = getMainField(attribute, 'title', { schemas: [], components: {} });
+
+      expect(result).toEqual({ name: 'title', type: 'string' });
+    });
+
+    it('reads the component sub-field type when the component schema is present', () => {
+      const attribute = {
+        type: 'component' as const,
+        component: 'shared.seo',
+        repeatable: false,
+      };
+
+      const result = getMainField(attribute, 'title', {
+        schemas: [],
+        components: {
+          'shared.seo': {
+            uid: 'shared.seo',
+            attributes: { title: { type: 'string' } },
+          } as any,
+        },
+      });
+
+      expect(result).toEqual({ name: 'title', type: 'string' });
+    });
+
+    it('falls back to string when the relation target schema or sub-field is missing', () => {
+      const attribute = {
+        type: 'relation' as const,
+        relation: 'manyToOne',
+        targetModel: 'api::missing.missing',
+      } as any;
+
+      const result = getMainField(attribute, 'name', { schemas: [], components: {} });
+
+      expect(result).toEqual({ name: 'name', type: 'string' });
     });
   });
 });


### PR DESCRIPTION
#26275 describes client-side navigation between single types where `formatEditLayout` sometimes ran while `components[uid]` was still missing from the dictionary, so `getMainField` dereferenced `undefined.attributes`.

I narrowed the relation branch to `attribute.type === "relation"` and used optional chaining for both branches so we fall back to the existing `string` default instead of throwing.

Added unit coverage in `attributes.test.ts` for the missing-component-catalog case and a happy-path component case.

Closes https://github.com/strapi/strapi/issues/26275

---
Fixes CPR-329