### PR TITLE
fix(admin): gate expiresIn deprecation on user auth options

### DIFF
--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -2,7 +2,11 @@ import { merge, map, difference, uniq } from 'lodash/fp';
 import type { Core } from '@strapi/types';
 import { async } from '@strapi/utils';
 import { getService } from './utils';
-import { getTokenOptions, expiresInToSeconds, hasUserConfiguredAuthOptionsExpiresIn } from './services/token';
+import {
+  getTokenOptions,
+  expiresInToSeconds,
+  hasUserConfiguredAuthOptionsExpiresIn,
+} from './services/token';
 import adminActions from './config/admin-actions';
 import adminConditions from './config/admin-conditions';
 import constants from './services/constants';

--- a/packages/core/admin/server/src/bootstrap.ts
+++ b/packages/core/admin/server/src/bootstrap.ts
@@ -2,7 +2,7 @@ import { merge, map, difference, uniq } from 'lodash/fp';
 import type { Core } from '@strapi/types';
 import { async } from '@strapi/utils';
 import { getService } from './utils';
-import { getTokenOptions, expiresInToSeconds } from './services/token';
+import { getTokenOptions, expiresInToSeconds, hasUserConfiguredAuthOptionsExpiresIn } from './services/token';
 import adminActions from './config/admin-actions';
 import adminConditions from './config/admin-conditions';
 import constants from './services/constants';
@@ -135,8 +135,11 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   const legacyMaxSessionFallback =
     expiresInToSeconds(options?.expiresIn) ?? DEFAULT_MAX_SESSION_LIFESPAN;
 
-  // Warn if using deprecated legacy expiresIn for new session settings
-  const hasLegacyExpires = options?.expiresIn != null;
+  // Warn only when the user set legacy admin.auth.options.expiresIn. Merged JWT options always
+  // include the default expiresIn ('30d'), so reading merged options alone is a false positive.
+  const hasLegacyExpires = hasUserConfiguredAuthOptionsExpiresIn(
+    strapi.config.get('admin.auth.options')
+  );
   const hasNewMaxRefresh = strapi.config.get('admin.auth.sessions.maxRefreshTokenLifespan') != null;
   const hasNewMaxSession = strapi.config.get('admin.auth.sessions.maxSessionLifespan') != null;
 

--- a/packages/core/admin/server/src/services/__tests__/token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/token.test.ts
@@ -1,4 +1,9 @@
-import { getTokenOptions, createToken, expiresInToSeconds, hasUserConfiguredAuthOptionsExpiresIn } from '../token';
+import {
+  getTokenOptions,
+  createToken,
+  expiresInToSeconds,
+  hasUserConfiguredAuthOptionsExpiresIn,
+} from '../token';
 
 describe('expiresInToSeconds', () => {
   test('returns undefined for null/undefined', () => {

--- a/packages/core/admin/server/src/services/__tests__/token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/token.test.ts
@@ -1,4 +1,4 @@
-import { getTokenOptions, createToken, expiresInToSeconds } from '../token';
+import { getTokenOptions, createToken, expiresInToSeconds, hasUserConfiguredAuthOptionsExpiresIn } from '../token';
 
 describe('expiresInToSeconds', () => {
   test('returns undefined for null/undefined', () => {
@@ -269,6 +269,34 @@ describe('Token', () => {
           publicKey: '-----BEGIN PUBLIC KEY-----\ntest-public-key\n-----END PUBLIC KEY-----',
         },
       });
+    });
+  });
+
+  describe('hasUserConfiguredAuthOptionsExpiresIn', () => {
+    test('returns false when options are undefined', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn(undefined)).toBe(false);
+    });
+
+    test('returns false when options are null', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn(null)).toBe(false);
+    });
+
+    test('returns false when options omit expiresIn', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn({ algorithm: 'HS256' })).toBe(false);
+    });
+
+    test('returns false for non-object values', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn('string')).toBe(false);
+      expect(hasUserConfiguredAuthOptionsExpiresIn(42)).toBe(false);
+    });
+
+    test('returns true when expiresIn is set', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn({ expiresIn: '7d' })).toBe(true);
+      expect(hasUserConfiguredAuthOptionsExpiresIn({ expiresIn: 3600 })).toBe(true);
+    });
+
+    test('returns false when expiresIn is explicitly null', () => {
+      expect(hasUserConfiguredAuthOptionsExpiresIn({ expiresIn: null })).toBe(false);
     });
   });
 

--- a/packages/core/admin/server/src/services/token.ts
+++ b/packages/core/admin/server/src/services/token.ts
@@ -23,6 +23,18 @@ const getTokenOptions = () => {
 };
 
 /**
+ * True when the project set `admin.auth.options.expiresIn`.
+ * Do not use merged options from {@link getTokenOptions}: defaults always inject `expiresIn: '30d'`,
+ * which would make every install look like a legacy config (see GitHub #25989).
+ */
+const hasUserConfiguredAuthOptionsExpiresIn = (adminAuthOptions: unknown): boolean => {
+  if (adminAuthOptions == null || typeof adminAuthOptions !== 'object') {
+    return false;
+  }
+  return (adminAuthOptions as { expiresIn?: unknown }).expiresIn != null;
+};
+
+/**
  * Create a random token
  */
 const createToken = (): string => {
@@ -38,7 +50,7 @@ For security reasons, prefer storing the secret in an environment variable and r
   }
 };
 
-export { createToken, getTokenOptions, checkSecretIsDefined };
+export { createToken, getTokenOptions, checkSecretIsDefined, hasUserConfiguredAuthOptionsExpiresIn };
 
 /**
  * Convert an expiresIn value (string or number) into seconds.

--- a/packages/core/admin/server/src/services/token.ts
+++ b/packages/core/admin/server/src/services/token.ts
@@ -50,7 +50,12 @@ For security reasons, prefer storing the secret in an environment variable and r
   }
 };
 
-export { createToken, getTokenOptions, checkSecretIsDefined, hasUserConfiguredAuthOptionsExpiresIn };
+export {
+  createToken,
+  getTokenOptions,
+  checkSecretIsDefined,
+  hasUserConfiguredAuthOptionsExpiresIn,
+};
 
 /**
  * Convert an expiresIn value (string or number) into seconds.


### PR DESCRIPTION
#25989: `getTokenOptions()` merges `defaultJwtOptions` with a built-in `expiresIn: "30d"`, so the bootstrap check used merged `options.expiresIn` and treated every install as if it opted into the legacy field. The warning fired on a clean project.

I added `hasUserConfiguredAuthOptionsExpiresIn` next to the token helpers (it only inspects `admin.auth.options` from config) and wired bootstrap to use it. Unit tests cover the edge cases called out on the issue.

Closes https://github.com/strapi/strapi/issues/25989

---
Fixes CPR-331