### PR TITLE
ci: create new Linear tickets in Triage status

### DIFF
--- a/.github/actions/community-pr-triage/dist/index.cjs
+++ b/.github/actions/community-pr-triage/dist/index.cjs
@@ -40800,7 +40800,7 @@ function buildLinearUpdateBody(stats, viewUrl) {
   const quickWinLines = stats.quickWins.map((a2) => prLine(a2, `${a2.pr.additions + a2.pr.deletions} LOC`)).join("\n");
   const newThisWeekLines = stats.newThisWeek.map((a2) => prLine(a2)).join("\n");
   return [
-    `\u{1F4CA} Weekly Community PR Report \u2014 ${date}`,
+    `## \u{1F4CA} Weekly Community PR Report \u2014 ${date}`,
     "",
     `\u{1F4C1} Total open PRs: ${stats.totalOpen}`,
     `\u{1F195} New this week: ${stats.newThisWeek.length}`,

--- a/.github/actions/community-pr-triage/dist/index.cjs
+++ b/.github/actions/community-pr-triage/dist/index.cjs
@@ -40365,16 +40365,23 @@ async function fetchAllTicketsByPRNumber(teamId) {
   }
   return map;
 }
+async function findTriageStateId(teamId) {
+  const team = await linearClient.team(teamId);
+  const states = await team.states({ filter: { type: { eq: "triage" } }, first: 1 });
+  return states.nodes[0]?.id;
+}
 async function createTicket(pr2, analysis, teamId, projectId, labelMap) {
   const title = `PR #${pr2.number}: ${pr2.title}`;
   const description = buildDescription(pr2, analysis);
   const labelIds = await buildLabelIds(analysis, labelMap, teamId);
+  const stateId = await findTriageStateId(teamId);
   const result = await linearClient.createIssue({
     teamId,
     projectId,
     title,
     description,
-    labelIds
+    labelIds,
+    stateId
   });
   const issue = await result.issue;
   if (!issue) throw new Error(`Failed to create Linear issue for PR #${pr2.number}`);

--- a/.github/actions/community-pr-triage/src/lib/linear.ts
+++ b/.github/actions/community-pr-triage/src/lib/linear.ts
@@ -166,6 +166,12 @@ export async function fetchAllTicketsByPRNumber(
   return map;
 }
 
+async function findTriageStateId(teamId: string): Promise<string | undefined> {
+  const team = await linearClient.team(teamId);
+  const states = await team.states({ filter: { type: { eq: 'triage' } }, first: 1 });
+  return states.nodes[0]?.id;
+}
+
 export async function createTicket(
   pr: CommunityPR,
   analysis: PRAnalysis,
@@ -176,6 +182,7 @@ export async function createTicket(
   const title = `PR #${pr.number}: ${pr.title}`;
   const description = buildDescription(pr, analysis);
   const labelIds = await buildLabelIds(analysis, labelMap, teamId);
+  const stateId = await findTriageStateId(teamId);
 
   const result = await linearClient.createIssue({
     teamId,
@@ -183,6 +190,7 @@ export async function createTicket(
     title,
     description,
     labelIds,
+    stateId,
   });
 
   const issue = await result.issue;

--- a/.github/actions/community-pr-triage/src/modes/weekly-report.ts
+++ b/.github/actions/community-pr-triage/src/modes/weekly-report.ts
@@ -22,7 +22,7 @@ function buildLinearUpdateBody(stats: WeeklyStats, viewUrl: string): string {
   const newThisWeekLines = stats.newThisWeek.map((a) => prLine(a)).join('\n');
 
   return [
-    `📊 Weekly Community PR Report — ${date}`,
+    `## 📊 Weekly Community PR Report — ${date}`,
     '',
     `📁 Total open PRs: ${stats.totalOpen}`,
     `🆕 New this week: ${stats.newThisWeek.length}`,

--- a/.github/workflows/community-pr-report.yml
+++ b/.github/workflows/community-pr-report.yml
@@ -29,18 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install action dependencies
-        run: npm ci
-        working-directory: .github/actions/community-pr-triage
-
-      - name: Build action
-        run: npm run build
-        working-directory: .github/actions/community-pr-triage
-
       - name: Run report
         uses: ./.github/actions/community-pr-triage
         with:


### PR DESCRIPTION
## What does it do?

Sets the status of newly created Linear tickets to **Triage** by looking up the team's triage workflow state at creation time and passing it as `stateId` to `createIssue`.

## Why is it needed?

New community PR tickets were being created in **In Progress** (the team's default state) instead of **Triage**, requiring manual correction after each sync.

## How to test it?

Open a community PR (or re-trigger the community-label workflow on an existing one) and verify the resulting Linear ticket lands in Triage.

## Related issue(s)/PR(s)

- #26283