### PR TITLE
fix(content-manager): skip locale resolution for non-i18n content types in delete

### DIFF
--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -603,7 +603,20 @@ export default {
 
     const { locale } = await getDocumentLocaleAndStatus(ctx.query, model);
 
-    // Find locales to delete
+    // Check if the content type is i18n-enabled
+    const i18nPlugin = strapi.plugin('i18n');
+    const isLocalized = i18nPlugin
+      ? i18nPlugin.service('content-types').isLocalizedContentType(model)
+      : false;
+
+    // For non-i18n content types, skip locale resolution and delete directly
+    if (!isLocalized) {
+      const result = await documentManager.delete(id, model);
+      ctx.body = await permissionChecker.sanitizeOutput(result);
+      return;
+    }
+
+    // For i18n content types, find locales to delete
     const documentLocales = await documentManager.findLocales(id, model, { populate, locale });
 
     if (documentLocales.length === 0) {


### PR DESCRIPTION
Hey! 👋

This PR fixes the single-row delete 404 error for non-i18n content types in the Content Manager.

## The Problem

When deleting a single row in the Content Manager for non-i18n collection types with Draft & Publish enabled, the API returns 404 Not Found. This happens because:

1. The delete handler passes `locale=*` to `findLocales`
2. For non-i18n content types, there's no locale field in the database
3. `findLocales` returns an empty array
4. The code returns `ctx.notFound()` on line 609-611

## The Solution

Check if the content type is i18n-enabled before calling `findLocales`. For non-i18n types, skip locale resolution and delete directly using the Document Service API.

## What Changed

- Added check for `isLocalizedContentType` before locale resolution
- For non-i18n types, skip `findLocales` and delete directly
- For i18n types, keep existing behavior

## Testing

- All existing tests pass
- Verified fix resolves the 404 error for non-i18n content types

Fixes #26238

---
Fixes CPR-334