### PR TITLE
fix(admin): handle null adminUserOwner for admin API tokens

### DIFF
--- a/packages/core/admin/server/src/controllers/admin-token.ts
+++ b/packages/core/admin/server/src/controllers/admin-token.ts
@@ -29,14 +29,24 @@ const { ApplicationError } = errors;
 const isSuperAdmin = (user: AdminUser): boolean =>
   user.roles.some((r) => r.code === constants.SUPER_ADMIN_CODE) === true;
 
-const getOwnerId = (token: AdminApiToken): string => {
+const getOwnerId = (token: AdminApiToken): string | null => {
   const owner = token.adminUserOwner;
+  if (owner === null || owner === undefined) {
+    return null;
+  }
+
   return String(typeof owner === 'object' ? owner.id : owner);
 };
 
 /** Returns true when user is the recorded owner of an admin token. */
-const isTokenOwner = (user: AdminUser, token: AdminApiToken): boolean =>
-  getOwnerId(token) === String(user.id);
+const isTokenOwner = (user: AdminUser, token: AdminApiToken): boolean => {
+  const ownerId = getOwnerId(token);
+  if (ownerId === null) {
+    return false;
+  }
+
+  return ownerId === String(user.id);
+};
 
 /** Owner OR super-admin can manage an admin token (read metadata, update…). */
 const canAccessAdminToken = (user: AdminUser, token: AdminApiToken): boolean =>
@@ -216,6 +226,10 @@ export default {
     }
 
     const ownerId = getOwnerId(token);
+    if (ownerId === null) {
+      return ctx.notFound('owner.notFound');
+    }
+
     const ownerUser = await userService.findOne(ownerId);
     if (!ownerUser) {
       return ctx.notFound('owner.notFound');

--- a/packages/core/admin/server/src/services/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/api-token.test.ts
@@ -800,6 +800,42 @@ describe('API Token', () => {
 
       expect(res[0].adminUserOwner).toEqual(adminTokenOwnerDto);
     });
+
+    /**
+     * Regression: super-admin `list()` maps every admin row through `toAdminTokenOwner`; null owner used to throw.
+     */
+    test('Lists admin tokens with null adminUserOwner without throwing (legacy rows)', async () => {
+      const findMany = jest.fn().mockResolvedValue([
+        {
+          id: 99,
+          kind: 'admin',
+          name: 'legacy-admin-token',
+          description: 'd',
+          adminPermissions: [],
+          adminUserOwner: null,
+        },
+      ]);
+      const superAdmin = { id: 1, roles: [{ code: 'strapi-super-admin' }] } as any;
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { findMany };
+          },
+        },
+        admin: {
+          services: {
+            encryption: encryptionService,
+          },
+        },
+      });
+
+      const res = await list(superAdmin, { filter: { kind: 'admin' } });
+
+      expect(res).toHaveLength(1);
+      expect(res[0].kind).toBe('admin');
+      expect(res[0].adminUserOwner).toBeNull();
+    });
   });
 
   describe('revoke', () => {
@@ -931,6 +967,41 @@ describe('API Token', () => {
         throw new Error('Expected admin token response');
       }
       expect(res.adminUserOwner).toEqual(adminTokenOwnerDto);
+    });
+
+    /**
+     * Regression: revoke returned admin tokens through `toAdminTokenOwner`, which threw on null owner.
+     */
+    test('Revoke admin token with null adminUserOwner returns without throwing', async () => {
+      const adminToken = {
+        id: 5,
+        kind: 'admin',
+        adminPermissions: [],
+        adminUserOwner: null,
+      };
+      const mockedFindOne = jest
+        .fn()
+        .mockResolvedValue({ id: adminToken.id, adminPermissions: [] });
+      const mockedDelete = jest.fn().mockResolvedValue(adminToken);
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { findOne: mockedFindOne, delete: mockedDelete };
+          },
+        },
+        admin: {
+          services: {
+            encryption: encryptionService,
+            permission: { deleteByIds: jest.fn() },
+          },
+        },
+      });
+
+      await expect(revoke(adminToken.id)).resolves.toMatchObject({
+        kind: 'admin',
+        adminUserOwner: null,
+      });
     });
   });
 
@@ -1070,6 +1141,43 @@ describe('API Token', () => {
         expect(res).not.toBeNull();
         expect(res?.kind).toBe('admin');
         expect((res as Record<string, any>).adminUserOwner).toEqual(adminTokenOwnerDto);
+      });
+
+      /**
+       * Regression: `kind === 'admin'` with `adminUserOwner: null` used to throw
+       * `adminUserOwner is required` from `toAdminTokenOwner` during serialization (e.g. super-admin list).
+       */
+      test('Admin token with null adminUserOwner: getById returns without throwing and owner is null', async () => {
+        const tokenFromDb = {
+          id: 99,
+          kind: 'admin',
+          name: 'legacy-admin-token',
+          description: 'd',
+          adminUserOwner: null,
+          adminPermissions: [],
+          permissions: [],
+        };
+
+        const findOne = jest.fn().mockResolvedValue(tokenFromDb);
+
+        setupStrapiMock({
+          db: {
+            query() {
+              return { findOne };
+            },
+          },
+          admin: {
+            services: {
+              encryption: encryptionService,
+              user: {},
+            },
+          },
+        });
+
+        await expect(getById(99)).resolves.toMatchObject({
+          kind: 'admin',
+          adminUserOwner: null,
+        });
       });
 
       test('Preserves kind when DB returns explicit kind "content-api"', async () => {
@@ -1615,6 +1723,63 @@ describe('API Token', () => {
       await expect(
         apiTokenUpdate(1, { type: 'read-only', name: 'api-token_tests-name' } as any)
       ).rejects.toThrow('Admin tokens cannot carry a legacy type');
+    });
+
+    test('Rejects admin permission update when persisted token has no owner', async () => {
+      const originalToken = {
+        id: 1,
+        kind: 'admin',
+        name: 'orphan-admin-token',
+        description: '',
+        adminUserOwner: null,
+      };
+
+      const dbFindOne = jest.fn().mockResolvedValue(originalToken);
+      const validActions = ['plugin::content-manager.explorer.read'];
+      const requestedPermissions = [
+        {
+          action: 'plugin::content-manager.explorer.read',
+          subject: 'api::article.article',
+          conditions: [],
+          properties: {},
+        },
+      ];
+
+      const userFindOne = jest.fn();
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne: dbFindOne };
+          },
+        },
+        config: { get: jest.fn(() => '') },
+        admin: {
+          services: {
+            user: { findOne: userFindOne },
+            permission: {
+              findUserPermissions: jest.fn(),
+              actionProvider: {
+                keys: jest.fn().mockReturnValue(validActions),
+                values: jest.fn().mockReturnValue([
+                  {
+                    actionId: 'plugin::content-manager.explorer.read',
+                    section: 'contentTypes',
+                    subjects: ['api::article.article'],
+                  },
+                ]),
+              },
+              findMany: jest.fn().mockResolvedValue([]),
+            },
+          },
+        },
+      } as any;
+
+      await expect(
+        apiTokenUpdate(1, { adminPermissions: requestedPermissions } as any)
+      ).rejects.toThrow('This admin API token has no owner');
+
+      expect(userFindOne).not.toHaveBeenCalled();
     });
 
     test('Enforces owner ceiling when updating admin token permissions', async () => {

--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -61,16 +61,24 @@ const assertOwnerMatchesCallingUser = async (
 const isSuperAdmin = (user: AdminUser | undefined): boolean =>
   user?.roles?.some((r) => r.code === SUPER_ADMIN_CODE) === true;
 
-const getOwnerId = (token: AdminApiToken): string => {
+const getOwnerId = (token: AdminApiToken): string | null => {
   const owner = token.adminUserOwner;
+  if (owner === null || owner === undefined) {
+    return null;
+  }
+
   return String(typeof owner === 'object' ? owner.id : owner);
 };
 
+/**
+ * Maps a persisted owner relation to the API DTO. Null is allowed for legacy rows
+ * (e.g. admin-kind tokens created before owner was enforced) so list/get do not throw.
+ */
 const toAdminTokenOwner = (
   owner: AdminApiToken['adminUserOwner'] | null | undefined
-): Data.ID | AdminTokenOwner => {
+): Data.ID | AdminTokenOwner | null => {
   if (owner === null || owner === undefined) {
-    throw new Error('adminUserOwner is required');
+    return null;
   }
 
   // Bare id
@@ -991,6 +999,11 @@ const update = async (
       // Ceiling is always the owner's permissions, not the calling user's.
       // A super admin editing another user's token must not overflow that user's scope.
       const ownerId = getOwnerId(originalToken as AdminApiToken);
+      if (ownerId === null) {
+        throw new ValidationError(
+          'This admin API token has no owner. Re-create the token or set an owner in the database.'
+        );
+      }
       const resolvedOwner = await getService('user').findOne(ownerId);
       if (resolvedOwner === null || resolvedOwner === undefined) {
         throw new ValidationError('Token owner no longer exists');

--- a/packages/core/admin/shared/contracts/admin-token.ts
+++ b/packages/core/admin/shared/contracts/admin-token.ts
@@ -6,7 +6,8 @@ import type { ApiTokenBase } from './content-api-token';
 export type AdminApiToken = ApiTokenBase & {
   kind: 'admin';
   adminPermissions: Permission[];
-  adminUserOwner: Data.ID | AdminTokenOwner;
+  /** Null only for inconsistent / pre-migration DB rows; new tokens always have an owner. */
+  adminUserOwner: Data.ID | AdminTokenOwner | null;
 };
 
 export type AdminTokenBody = Pick<AdminApiToken, 'name' | 'description'> & {

--- a/packages/core/core/src/migrations/database/5.45.0-backfill-admin-api-token-owners.ts
+++ b/packages/core/core/src/migrations/database/5.45.0-backfill-admin-api-token-owners.ts
@@ -1,0 +1,144 @@
+import type { Database, Migration } from '@strapi/database';
+
+type Knex = Parameters<Migration['up']>[0];
+
+const SUPER_ADMIN_ROLE_CODE = 'strapi-super-admin';
+
+/** Narrow relation attributes enough for join column / join table checks (no admin imports into @strapi/database). */
+type RelationalAttr = {
+  type: 'relation';
+  relation: string;
+  joinColumn?: { name: string };
+  joinTable?: {
+    name: string;
+    joinColumn: { name: string };
+    inverseJoinColumn: { name: string };
+  };
+};
+
+const isRelational = (attr: unknown): attr is RelationalAttr =>
+  typeof attr === 'object' && attr !== null && (attr as { type?: string }).type === 'relation';
+
+const hasManyToOneJoinColumn = (
+  attr: RelationalAttr
+): attr is RelationalAttr & { joinColumn: { name: string } } =>
+  attr.relation === 'manyToOne' &&
+  'joinColumn' in attr &&
+  typeof attr.joinColumn === 'object' &&
+  attr.joinColumn !== null &&
+  'name' in attr.joinColumn;
+
+const hasManyToManyJoinTable = (
+  attr: RelationalAttr
+): attr is RelationalAttr & {
+  joinTable: {
+    name: string;
+    joinColumn: { name: string };
+    inverseJoinColumn: { name: string };
+  };
+} =>
+  attr.relation === 'manyToMany' &&
+  'joinTable' in attr &&
+  typeof attr.joinTable === 'object' &&
+  attr.joinTable !== null &&
+  'name' in attr.joinTable &&
+  'joinColumn' in attr.joinTable &&
+  'inverseJoinColumn' in attr.joinTable;
+
+/**
+ * Assigns `adminUserOwner` on `admin::api-token` rows that are `kind: 'admin'` but have a null owner.
+ * Uses the smallest-id user that has the super-admin role when multiple exist.
+ *
+ * Idempotent. Skips when metadata/tables/columns are missing (e.g. admin plugin not loaded).
+ */
+export const backfillAdminApiTokenOwners = async (knex: Knex, db: Database): Promise<void> => {
+  if (!db.metadata.has('admin::api-token')) {
+    return;
+  }
+
+  const apiTokenMeta = db.metadata.get('admin::api-token');
+  const tokenTable = apiTokenMeta.tableName;
+
+  if (!(await knex.schema.hasTable(tokenTable))) {
+    return;
+  }
+
+  const ownerAttr = apiTokenMeta.attributes.adminUserOwner;
+  if (!isRelational(ownerAttr) || !hasManyToOneJoinColumn(ownerAttr)) {
+    return;
+  }
+
+  const ownerColumn = ownerAttr.joinColumn.name;
+
+  const kindAttr = apiTokenMeta.attributes.kind;
+  const kindColumn =
+    kindAttr && 'columnName' in kindAttr && kindAttr.columnName ? kindAttr.columnName : 'kind';
+
+  if (!(await knex.schema.hasColumn(tokenTable, ownerColumn))) {
+    return;
+  }
+
+  if (!(await knex.schema.hasColumn(tokenTable, kindColumn))) {
+    return;
+  }
+
+  if (!db.metadata.has('admin::user') || !db.metadata.has('admin::role')) {
+    return;
+  }
+
+  const userMeta = db.metadata.get('admin::user');
+  const roleMeta = db.metadata.get('admin::role');
+  const rolesAttr = userMeta.attributes.roles;
+
+  if (!isRelational(rolesAttr) || !hasManyToManyJoinTable(rolesAttr)) {
+    return;
+  }
+
+  const { name: joinTable, joinColumn, inverseJoinColumn } = rolesAttr.joinTable;
+  const userLinkColumn = joinColumn.name;
+  const roleLinkColumn = inverseJoinColumn.name;
+  const roleTable = roleMeta.tableName;
+  const roleCodeAttr = roleMeta.attributes.code;
+  const roleCodeColumn =
+    roleCodeAttr && 'columnName' in roleCodeAttr && roleCodeAttr.columnName
+      ? roleCodeAttr.columnName
+      : 'code';
+
+  if (!(await knex.schema.hasTable(joinTable)) || !(await knex.schema.hasTable(roleTable))) {
+    return;
+  }
+
+  const ownerRow = await knex(joinTable)
+    .select(`${joinTable}.${userLinkColumn} as owner_id`)
+    .innerJoin(roleTable, `${joinTable}.${roleLinkColumn}`, `${roleTable}.id`)
+    .where(`${roleTable}.${roleCodeColumn}`, SUPER_ADMIN_ROLE_CODE)
+    .orderBy(`${joinTable}.${userLinkColumn}`, 'asc')
+    .first();
+
+  const ownerId = ownerRow?.owner_id;
+
+  if (ownerId === undefined || ownerId === null) {
+    return;
+  }
+
+  await knex(tokenTable)
+    .where(kindColumn, 'admin')
+    .whereNull(ownerColumn)
+    .update({
+      [ownerColumn]: ownerId,
+    });
+};
+
+/**
+ * Registered from `providers/registries.ts` (same pattern as `discardDocumentDrafts`), not in
+ * `@strapi/database` internal-migrations, so admin-domain policy stays in core.
+ */
+export const backfillAdminApiTokenOwnersMigration: Migration = {
+  name: 'core::5.45.0-backfill-admin-api-token-owners',
+  async up(knex, db) {
+    await backfillAdminApiTokenOwners(knex, db);
+  },
+  async down() {
+    throw new Error('Down migration not supported');
+  },
+};

--- a/packages/core/core/src/migrations/database/__tests__/5.45.0-backfill-admin-api-token-owners.test.ts
+++ b/packages/core/core/src/migrations/database/__tests__/5.45.0-backfill-admin-api-token-owners.test.ts
@@ -1,0 +1,138 @@
+import {
+  backfillAdminApiTokenOwners,
+  backfillAdminApiTokenOwnersMigration,
+} from '../5.45.0-backfill-admin-api-token-owners';
+
+const buildKnexMock = (options: { ownerId: number | null; updateMock: jest.Mock }) => {
+  const { ownerId, updateMock } = options;
+
+  const knex = jest.fn((table: string) => {
+    if (table === 'strapi_users_roles') {
+      return {
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(ownerId === null ? undefined : { owner_id: ownerId }),
+      };
+    }
+    if (table === 'strapi_api_tokens') {
+      return {
+        where: jest.fn().mockReturnThis(),
+        whereNull: jest.fn().mockReturnThis(),
+        update: updateMock,
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  }) as any;
+
+  knex.schema = {
+    hasTable: jest.fn().mockResolvedValue(true),
+    hasColumn: jest.fn().mockResolvedValue(true),
+  };
+
+  return knex;
+};
+
+const buildMetadataMock = () => {
+  const apiTokenMeta = {
+    tableName: 'strapi_api_tokens',
+    attributes: {
+      adminUserOwner: {
+        type: 'relation',
+        relation: 'manyToOne',
+        joinColumn: { name: 'admin_user_owner_id' },
+      },
+      kind: { type: 'enumeration', columnName: 'kind' },
+    },
+  };
+
+  const userMeta = {
+    attributes: {
+      roles: {
+        type: 'relation',
+        relation: 'manyToMany',
+        joinTable: {
+          name: 'strapi_users_roles',
+          joinColumn: { name: 'user_id' },
+          inverseJoinColumn: { name: 'role_id' },
+        },
+      },
+    },
+  };
+
+  const roleMeta = {
+    tableName: 'admin_roles',
+    attributes: {
+      code: { type: 'string', columnName: 'code' },
+    },
+  };
+
+  return {
+    has: jest.fn((uid: string) => ['admin::api-token', 'admin::user', 'admin::role'].includes(uid)),
+    get: jest.fn((uid: string) => {
+      if (uid === 'admin::api-token') {
+        return apiTokenMeta;
+      }
+      if (uid === 'admin::user') {
+        return userMeta;
+      }
+      if (uid === 'admin::role') {
+        return roleMeta;
+      }
+      return undefined;
+    }),
+  };
+};
+
+describe('5.45.0-backfill-admin-api-token-owners', () => {
+  describe('backfillAdminApiTokenOwners', () => {
+    test('sets admin_user_owner_id from the first super-admin user link', async () => {
+      const updateMock = jest.fn().mockResolvedValue(1);
+      const knex = buildKnexMock({ ownerId: 7, updateMock });
+      const db = { metadata: buildMetadataMock() } as any;
+
+      await backfillAdminApiTokenOwners(knex, db);
+
+      expect(updateMock).toHaveBeenCalledWith({ admin_user_owner_id: 7 });
+    });
+
+    test('does not update when no super-admin user exists in the link table', async () => {
+      const updateMock = jest.fn().mockResolvedValue(0);
+      const knex = buildKnexMock({ ownerId: null, updateMock });
+      const db = { metadata: buildMetadataMock() } as any;
+
+      await backfillAdminApiTokenOwners(knex, db);
+
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    test('no-ops when admin API token model is absent from metadata', async () => {
+      const updateMock = jest.fn();
+      const knex = buildKnexMock({ ownerId: 7, updateMock });
+      const db = {
+        metadata: {
+          has: jest.fn(() => false),
+          get: jest.fn(),
+        },
+      } as any;
+
+      await backfillAdminApiTokenOwners(knex, db);
+
+      expect(knex).not.toHaveBeenCalled();
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backfillAdminApiTokenOwnersMigration', () => {
+    test('up delegates to backfillAdminApiTokenOwners', async () => {
+      const updateMock = jest.fn().mockResolvedValue(1);
+      const knex = buildKnexMock({ ownerId: 2, updateMock });
+      const db = { metadata: buildMetadataMock() } as any;
+
+      await backfillAdminApiTokenOwnersMigration.up(knex, db);
+
+      expect(updateMock).toHaveBeenCalledWith({ admin_user_owner_id: 2 });
+    });
+  });
+});

--- a/packages/core/core/src/providers/registries.ts
+++ b/packages/core/core/src/providers/registries.ts
@@ -4,6 +4,10 @@ import { defineProvider } from './provider';
 import * as registries from '../registries';
 import { loadApplicationContext } from '../loaders';
 import * as syncMigrations from '../migrations';
+import {
+  backfillAdminApiTokenOwners,
+  backfillAdminApiTokenOwnersMigration,
+} from '../migrations/database/5.45.0-backfill-admin-api-token-owners';
 import { discardDocumentDrafts } from '../migrations/database/5.0.0-discard-drafts';
 
 export default defineProvider({
@@ -34,7 +38,12 @@ export default defineProvider({
     strapi.hook('strapi::content-types.beforeSync').register(syncMigrations.disable);
     strapi.hook('strapi::content-types.afterSync').register(syncMigrations.enable);
 
-    // Database migrations
+    strapi.hook('strapi::content-types.afterSync').register(async () => {
+      await strapi.db.transaction(({ trx }) => backfillAdminApiTokenOwners(trx, strapi.db));
+    });
+
+    // Database migrations (core-owned domain migrations, not in @strapi/database internal list)
     strapi.db.migrations.providers.internal.register(discardDocumentDrafts);
+    strapi.db.migrations.providers.internal.register(backfillAdminApiTokenOwnersMigration);
   },
 });


### PR DESCRIPTION
### What does it do?

- **Admin API tokens (`@strapi/admin`)**  
  - Treats `adminUserOwner` as nullable on `AdminApiToken` when serializing legacy/inconsistent rows: `toAdminTokenOwner` returns `null` instead of throwing; `getOwnerId` handles null/undefined safely.  
  - `update()` throws a clear `ValidationError` if someone tries to change **admin permissions** while the persisted token has no owner.  
  - **Controller** (`admin-token.ts`): null-safe `getOwnerId` / `isTokenOwner`; `getOwnerPermissions` returns 404 when there is no owner.  
  - **Tests**: regression coverage for `list`, `getById`, `revoke` with `kind: 'admin'` and `adminUserOwner: null`, plus permission update rejection without owner.

- **Data repair (`@strapi/core`)**  
  - Adds `packages/core/core/src/migrations/database/5.45.0-backfill-admin-api-token-owners.ts`: idempotent SQL backfill that sets `admin_user_owner_id` on `kind = 'admin'` rows with a null owner, using metadata for table/column names and the lowest-id user linked to the super-admin role.  
  - Registers **`core::5.45.0-backfill-admin-api-token-owners`** via `strapi.db.migrations.providers.internal.register` (same pattern as discard-drafts), keeping admin-domain policy out of `@strapi/database`.  
  - Registers **`strapi::content-types.afterSync`** to run the same helper in a transaction so rows are still fixed when the owner FK column appears in the same boot as migrations (ordering after `syncSchema`).

- **Tests (`@strapi/core`)**  
  - Unit tests for `backfillAdminApiTokenOwners` and the migration `up` path with mocked Knex + metadata.

### Why is it needed?

Some databases can contain **`kind = 'admin'`** API token rows with a **null** `adminUserOwner` FK (legacy or inconsistent data). Super admins load all tokens; serialization previously threw **`adminUserOwner is required`**, which could break unrelated admin flows. This change restores safe behavior, repairs data where a super-admin exists, and guards unsafe permission updates on ownerless tokens.

### How to test it?

1. **Unit tests**  
   - From repo root:  
     `yarn nx run @strapi/admin:test:unit --testPathPattern=server/src/services/__tests__/api-token.test.ts`  
   - `yarn nx run @strapi/core:test:unit --testPathPattern=5.45.0-backfill-admin-api-token-owners`

2. **Manual (optional)**  
   - On a dev DB, ensure an `admin::api-token` row has `kind = 'admin'` and null owner (or rely on upgrade from a state that had orphans). Start Strapi as super admin: admin should load; after boot, confirm the row has an owner if a super-admin user exists.  
   - Try **Settings → Admin API tokens** (or flows that list tokens) before/after.

3. **Types / build**  
   - `yarn nx run @strapi/database:build:types` and `yarn nx run @strapi/admin:build:types` / `yarn nx run @strapi/core:build:types` as appropriate for touched packages.

### Related issue(s)/PR(s)

a [report from StackOverflow](https://stackoverflow.com/questions/79939777/strapi-v5-45-1-error-adminuserowner-is-required) but it is a legitimate issue