### PR TITLE
fix(core/admin): admin and content api tokens retro-compatibility

### DIFF
--- a/packages/core/admin/server/src/controllers/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/controllers/__tests__/api-token.test.ts
@@ -425,13 +425,9 @@ describe('API Token Controller', () => {
 
     const superAdmin = { id: 99, roles: [{ code: 'strapi-super-admin' }] };
 
-    test('Retrieve a content API token includes accessKey for any caller', async () => {
+    test('Retrieve a content API token calls getById once with includeDecryptedKey', async () => {
       const tokenWithKey = { ...legacyToken, accessKey: 'plaintext-key' };
-      // first call (no key), second call (with key)
-      const getById = jest
-        .fn()
-        .mockResolvedValueOnce(legacyToken)
-        .mockResolvedValueOnce(tokenWithKey);
+      const getById = jest.fn().mockResolvedValue(tokenWithKey);
       const send = jest.fn();
       const ctx = createContext(
         { params: { id: legacyToken.id } },
@@ -450,11 +446,12 @@ describe('API Token Controller', () => {
 
       await apiTokenController.get(ctx as any);
 
-      expect(getById).toHaveBeenCalledTimes(2);
+      expect(getById).toHaveBeenCalledTimes(1);
+      expect(getById).toHaveBeenCalledWith(legacyToken.id, { includeDecryptedKey: true });
       expect(send).toHaveBeenCalledWith({ data: tokenWithKey });
     });
 
-    test('Fails if the API token does not exist', async () => {
+    test('Returns 404 when the token does not exist', async () => {
       const getById = jest.fn().mockResolvedValue(null);
       const notFound = jest.fn();
       const ctx = createContext(
@@ -474,7 +471,7 @@ describe('API Token Controller', () => {
 
       await apiTokenController.get(ctx as any);
 
-      expect(getById).toHaveBeenCalledWith(legacyToken.id);
+      expect(getById).toHaveBeenCalledTimes(1);
       expect(notFound).toHaveBeenCalledWith('API Token not found');
     });
   });

--- a/packages/core/admin/server/src/controllers/api-token.ts
+++ b/packages/core/admin/server/src/controllers/api-token.ts
@@ -85,14 +85,13 @@ export default {
     const { id } = ctx.params;
     const apiTokenService = getService('api-token-content-api');
 
-    const token = await apiTokenService.getById(id);
+    const token = await apiTokenService.getById(id, { includeDecryptedKey: true });
     if (!token) {
       ctx.notFound('API Token not found');
       return;
     }
 
-    const withKey = await apiTokenService.getById(id, { includeDecryptedKey: true });
-    ctx.send({ data: withKey ?? token } satisfies Get.Response);
+    ctx.send({ data: token } satisfies Get.Response);
   },
 
   // -------------------------------------------------------------------------

--- a/packages/core/admin/server/src/services/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/api-token.test.ts
@@ -800,6 +800,56 @@ describe('API Token', () => {
 
       expect(res[0].adminUserOwner).toEqual(adminTokenOwnerDto);
     });
+
+    test('Does not throw when an admin token has adminUserOwner: null (orphaned row)', async () => {
+      const orphanedToken = {
+        id: 1,
+        kind: 'admin',
+        name: 'orphaned-admin-token',
+        adminPermissions: [],
+        adminUserOwner: null,
+      };
+      const findMany = jest.fn().mockResolvedValue([orphanedToken]);
+      const superAdmin = { id: 1, roles: [{ code: 'strapi-super-admin' }] } as any;
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { findMany };
+          },
+        },
+      });
+
+      const res = await list(superAdmin);
+
+      expect(res).toHaveLength(1);
+      expect((res[0] as any).adminUserOwner).toBeNull();
+    });
+
+    test('Does not throw when an admin token has adminUserOwner: undefined (orphaned row)', async () => {
+      const orphanedToken = {
+        id: 2,
+        kind: 'admin',
+        name: 'orphaned-admin-token-2',
+        adminPermissions: [],
+        adminUserOwner: undefined,
+      };
+      const findMany = jest.fn().mockResolvedValue([orphanedToken]);
+      const superAdmin = { id: 1, roles: [{ code: 'strapi-super-admin' }] } as any;
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { findMany };
+          },
+        },
+      });
+
+      const res = await list(superAdmin);
+
+      expect(res).toHaveLength(1);
+      expect((res[0] as any).adminUserOwner).toBeNull();
+    });
   });
 
   describe('revoke', () => {
@@ -839,7 +889,13 @@ describe('API Token', () => {
         where: { id: token.id },
         populate: ['permissions', 'adminPermissions', 'adminUserOwner'],
       });
-      expect(res).toEqual(token);
+      expect(res).toMatchObject({
+        id: token.id,
+        name: token.name,
+        description: token.description,
+        type: token.type,
+        kind: 'content-api',
+      });
     });
 
     test('It returns `null` if the resource does not exist', async () => {
@@ -931,6 +987,120 @@ describe('API Token', () => {
         throw new Error('Expected admin token response');
       }
       expect(res.adminUserOwner).toEqual(adminTokenOwnerDto);
+    });
+
+    test('Normalises kind: null to content-api in the returned DTO', async () => {
+      const mockedFindOne = jest.fn().mockResolvedValue({ id: 1, adminPermissions: [] });
+      const mockedDelete = jest.fn().mockResolvedValue({
+        id: 1,
+        kind: null,
+        permissions: [{ action: 'api::foo.find' }],
+        adminPermissions: [],
+        adminUserOwner: null,
+      });
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne: mockedFindOne, delete: mockedDelete };
+          },
+        },
+        admin: {
+          services: {
+            permission: { deleteByIds: jest.fn() },
+          },
+        },
+      } as any;
+
+      const res = await revoke(1);
+
+      expect(res).not.toBeNull();
+      expect((res as any).kind).toBe('content-api');
+    });
+
+    test('Returns kind: content-api for a regular content-api token', async () => {
+      const mockedFindOne = jest.fn().mockResolvedValue({ id: 2, adminPermissions: [] });
+      const mockedDelete = jest.fn().mockResolvedValue({
+        id: 2,
+        kind: 'content-api',
+        permissions: [{ action: 'api::foo.find' }],
+        adminPermissions: [],
+        adminUserOwner: null,
+      });
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne: mockedFindOne, delete: mockedDelete };
+          },
+        },
+        admin: {
+          services: {
+            permission: { deleteByIds: jest.fn() },
+          },
+        },
+      } as any;
+
+      const res = await revoke(2);
+
+      expect((res as any).kind).toBe('content-api');
+    });
+
+    test('Content-api revoke response does not include adminPermissions or adminUserOwner', async () => {
+      const mockedFindOne = jest.fn().mockResolvedValue({ id: 3, adminPermissions: [] });
+      const mockedDelete = jest.fn().mockResolvedValue({
+        id: 3,
+        kind: 'content-api',
+        permissions: [{ action: 'api::foo.find' }],
+        adminPermissions: [],
+        adminUserOwner: null,
+      });
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne: mockedFindOne, delete: mockedDelete };
+          },
+        },
+        admin: {
+          services: {
+            permission: { deleteByIds: jest.fn() },
+          },
+        },
+      } as any;
+
+      const res = await revoke(3);
+
+      expect('adminPermissions' in (res as object)).toBe(false);
+      expect('adminUserOwner' in (res as object)).toBe(false);
+    });
+
+    test('Flattens permissions to an array of strings for content-api tokens', async () => {
+      const mockedFindOne = jest.fn().mockResolvedValue({ id: 4, adminPermissions: [] });
+      const mockedDelete = jest.fn().mockResolvedValue({
+        id: 4,
+        kind: 'content-api',
+        permissions: [{ action: 'api::foo.find' }, { action: 'api::foo.create' }],
+        adminPermissions: [],
+        adminUserOwner: null,
+      });
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne: mockedFindOne, delete: mockedDelete };
+          },
+        },
+        admin: {
+          services: {
+            permission: { deleteByIds: jest.fn() },
+          },
+        },
+      } as any;
+
+      const res = await revoke(4);
+
+      expect((res as any).permissions).toEqual(['api::foo.find', 'api::foo.create']);
     });
   });
 
@@ -1214,15 +1384,16 @@ describe('API Token', () => {
 
       expect(update).toHaveBeenCalledWith({
         where: { id },
-        select: ['id', 'accessKey'],
+        select: ['id', 'accessKey', 'kind'],
         data: {
           accessKey: hash(mockedApiToken.hexedString),
           encryptedKey: expect.any(String),
         },
       });
-      expect(res).toEqual({
+      expect(res).toMatchObject({
         accessKey: mockedApiToken.hexedString,
         encryptedKey: expect.any(String),
+        kind: 'content-api',
       });
     });
 
@@ -1244,12 +1415,48 @@ describe('API Token', () => {
 
       expect(update).toHaveBeenCalledWith({
         where: { id },
-        select: ['id', 'accessKey'],
+        select: ['id', 'accessKey', 'kind'],
         data: {
           accessKey: hash(mockedApiToken.hexedString),
           encryptedKey: expect.any(String),
         },
       });
+    });
+
+    test('Return value includes kind from the DB row', async () => {
+      const update = jest.fn().mockResolvedValue({ id: 1, accessKey: 'hash', kind: 'content-api' });
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { update };
+          },
+        },
+      });
+
+      const res = await regenerate(1);
+
+      expect((res as any).kind).toBe('content-api');
+    });
+
+    test('Selects kind in the DB query', async () => {
+      const update = jest.fn().mockResolvedValue({ id: 1, accessKey: 'hash', kind: 'content-api' });
+
+      setupStrapiMock({
+        db: {
+          query() {
+            return { update };
+          },
+        },
+      });
+
+      await regenerate(1);
+
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          select: expect.arrayContaining(['kind']),
+        })
+      );
     });
   });
 
@@ -1567,6 +1774,35 @@ describe('API Token', () => {
       ).rejects.toThrow('kind is immutable after creation');
     });
 
+    test('Does not throw when a client echoes back kind: content-api for a null-kind legacy token', async () => {
+      const originalToken = {
+        id: 1,
+        kind: null,
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+      };
+
+      const findOne = jest.fn().mockResolvedValue(originalToken);
+      const update = jest.fn(({ data }) => Promise.resolve({ ...originalToken, ...data }));
+      const deleteFn = jest.fn(() => Promise.resolve());
+      const load = jest.fn().mockResolvedValueOnce([]);
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne, update, delete: deleteFn, load };
+          },
+        },
+        config: { get: jest.fn(() => '') },
+      } as any;
+
+      // Client read the token via GET (received kind: 'content-api') and PUTs it back as-is
+      await expect(
+        apiTokenUpdate(1, { kind: 'content-api', name: 'api-token_tests-name' } as any)
+      ).resolves.not.toThrow();
+    });
+
     test('Throws when setting admin fields on a content API token update', async () => {
       const originalToken = {
         id: 1,
@@ -1752,6 +1988,51 @@ describe('API Token', () => {
         throw new Error('Expected admin token response');
       }
       expect(res.adminUserOwner).toEqual(adminTokenOwnerDto);
+    });
+
+    test('Updates a legacy token with null kind without throwing', async () => {
+      const id = 1;
+
+      const originalToken = {
+        id,
+        kind: null,
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+      };
+
+      const updatedAttributes = {
+        name: 'api-token_tests-updated-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+      } as any;
+
+      const findOne = jest.fn().mockResolvedValue(originalToken);
+      const update = jest.fn(({ data }) => Promise.resolve({ ...originalToken, ...data }));
+      const deleteFn = jest.fn(() => Promise.resolve());
+      const load = jest.fn().mockResolvedValueOnce([]);
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne, update, delete: deleteFn, load };
+          },
+        },
+        config: { get: jest.fn(() => '') },
+      } as any;
+
+      const res = await apiTokenUpdate(id, updatedAttributes);
+
+      expect(update).toHaveBeenCalled();
+      expect(res).toMatchObject({
+        name: 'api-token_tests-updated-name',
+        type: 'read-only',
+        // null kind must be normalized to 'content-api' in the returned DTO
+        kind: 'content-api',
+        permissions: [],
+      });
+      // Must NOT contain adminUserOwner — this is a content-api shape
+      expect((res as any).adminUserOwner).toBeUndefined();
     });
   });
 

--- a/packages/core/admin/server/src/services/__tests__/api-token.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/api-token.test.ts
@@ -1508,7 +1508,11 @@ describe('API Token', () => {
       expect(update).toHaveBeenCalledWith({
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
-        data: attributes,
+        data: {
+          name: attributes.name,
+          description: attributes.description,
+          type: attributes.type,
+        },
       });
       expect(res).toEqual(attributes);
     });
@@ -1619,7 +1623,10 @@ describe('API Token', () => {
       expect(update).toHaveBeenCalledWith({
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
-        data: omit(['permissions'], updatedAttributes),
+        data: {
+          name: updatedAttributes.name,
+          type: updatedAttributes.type,
+        },
       });
 
       expect(res).toEqual({
@@ -1743,7 +1750,11 @@ describe('API Token', () => {
       expect(update).toHaveBeenCalledWith({
         select: expect.arrayContaining([expect.any(String)]),
         where: { id },
-        data: omit(['permissions'], updatedAttributes),
+        data: {
+          name: updatedAttributes.name,
+          description: updatedAttributes.description,
+          type: updatedAttributes.type,
+        },
       });
 
       expect(res).toEqual(updatedAttributes);
@@ -2023,7 +2034,17 @@ describe('API Token', () => {
 
       const res = await apiTokenUpdate(id, updatedAttributes);
 
-      expect(update).toHaveBeenCalled();
+      expect(update).toHaveBeenCalledWith({
+        select: expect.arrayContaining([expect.any(String)]),
+        where: { id },
+        data: {
+          name: updatedAttributes.name,
+          description: updatedAttributes.description,
+          type: updatedAttributes.type,
+          // null kind migrated to 'content-api' on first write
+          kind: 'content-api',
+        },
+      });
       expect(res).toMatchObject({
         name: 'api-token_tests-updated-name',
         type: 'read-only',
@@ -2033,6 +2054,46 @@ describe('API Token', () => {
       });
       // Must NOT contain adminUserOwner — this is a content-api shape
       expect((res as any).adminUserOwner).toBeUndefined();
+    });
+
+    test('Drops lifespan and expiresAt from the DB write — both are immutable after creation', async () => {
+      const id = 1;
+
+      const originalToken = {
+        id,
+        kind: 'content-api',
+        name: 'api-token_tests-name',
+        description: 'api-token_tests-description',
+        type: 'read-only',
+        lifespan: null,
+        expiresAt: null,
+      };
+
+      const findOne = jest.fn().mockResolvedValue(originalToken);
+      const update = jest.fn(({ data }) => Promise.resolve({ ...originalToken, ...data }));
+      const deleteFn = jest.fn(() => Promise.resolve());
+      const load = jest.fn().mockResolvedValueOnce([]);
+
+      global.strapi = {
+        db: {
+          query() {
+            return { findOne, update, delete: deleteFn, load };
+          },
+        },
+        config: { get: jest.fn(() => '') },
+      } as any;
+
+      await apiTokenUpdate(id, {
+        name: 'api-token_tests-updated-name',
+        lifespan: constants.API_TOKEN_LIFESPANS.DAYS_7,
+        expiresAt: Date.now() + 999999,
+      } as any);
+
+      const [[{ data }]] = update.mock.calls;
+
+      expect(data.name).toBe('api-token_tests-updated-name');
+      expect('lifespan' in data).toBe(false);
+      expect('expiresAt' in data).toBe(false);
     });
   });
 

--- a/packages/core/admin/server/src/services/__tests__/services-api-token-alias.test.ts
+++ b/packages/core/admin/server/src/services/__tests__/services-api-token-alias.test.ts
@@ -1,0 +1,15 @@
+import services from '../index';
+
+/**
+ * Guards the backward-compatible `api-token` service key (same instance as
+ * `api-token-content-api`) introduced after the admin/content token split so
+ * `strapi.service('admin::api-token')` keeps working for plugins and scripts.
+ * Remove this file in Strapi 6 once the `api-token` alias is dropped entirely.
+ */
+describe('Admin services — deprecated api-token alias', () => {
+  test('exposes the same service instance as api-token-content-api (backward compatibility)', () => {
+    expect(services['api-token']).toBeDefined();
+    expect(services['api-token-content-api']).toBeDefined();
+    expect(services['api-token']).toBe(services['api-token-content-api']);
+  });
+});

--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -101,6 +101,7 @@ const SELECT_FIELDS = [
 ];
 
 const POPULATE_FIELDS = ['permissions', 'adminPermissions', 'adminUserOwner'];
+const UPDATABLE_FIELDS = ['name', 'description', 'type'] as const;
 
 // TODO: we need to ensure the permissions are actually valid registered permissions!
 
@@ -975,8 +976,6 @@ const update = async (
     throw new ValidationError('kind is immutable after creation');
   }
 
-  assertValidLifespan(attributes.lifespan);
-
   let clampedAdminPermissions: PermissionInput[] | undefined;
   let tokenOwnerUser: AdminUser | undefined;
 
@@ -1035,10 +1034,7 @@ const update = async (
     }
   }
 
-  const baseData = omit(
-    ['kind', 'permissions', 'adminPermissions', 'adminUserOwner'],
-    attributes
-  ) as Record<string, unknown>;
+  const baseData = pick(UPDATABLE_FIELDS, attributes) as Record<string, unknown>;
 
   // Migrate legacy null-kind rows to the explicit value on first write
   if (originalToken.kind === null) {

--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -801,7 +801,7 @@ const regenerate = async (id: string | number): Promise<ContentApiApiToken | Adm
   const encryptedKey = encryptionService.encrypt(accessKey);
 
   const apiToken: AnyApiToken = await strapi.db.query('admin::api-token').update({
-    select: ['id', 'accessKey'],
+    select: ['id', 'accessKey', 'kind'],
     where: { id },
     data: {
       accessKey: hash(accessKey),
@@ -815,8 +815,9 @@ const regenerate = async (id: string | number): Promise<ContentApiApiToken | Adm
 
   return {
     ...apiToken,
+    kind: (apiToken.kind ?? 'content-api') as AnyApiToken['kind'],
     accessKey,
-  };
+  } as any;
 };
 
 const checkSaltIsDefined = () => {
@@ -884,7 +885,10 @@ const list = async <K extends AnyApiToken['kind']>(
         })
       : ({
           ...(omit(['permissions'], token) as object),
-          adminUserOwner: toAdminTokenOwner(token.adminUserOwner),
+          adminUserOwner:
+            token.adminUserOwner !== null && token.adminUserOwner !== undefined
+              ? toAdminTokenOwner(token.adminUserOwner)
+              : null,
         } as any)
   );
 };
@@ -913,14 +917,23 @@ const revoke = async (id: string | number): Promise<AnyApiToken> => {
     .query('admin::api-token')
     .delete({ select: SELECT_FIELDS, populate: POPULATE_FIELDS, where: { id } });
 
-  if (deletedToken === null || deletedToken === undefined || deletedToken.kind !== 'admin') {
+  if (deletedToken === null || deletedToken === undefined) {
     return deletedToken;
   }
 
-  return {
+  if (deletedToken.kind === 'admin') {
+    return {
+      ...deletedToken,
+      adminUserOwner: toAdminTokenOwner(deletedToken.adminUserOwner),
+    };
+  }
+
+  // content-api tokens (including legacy null-kind rows): normalise shape
+  return omit(['adminPermissions', 'adminUserOwner'], {
     ...deletedToken,
-    adminUserOwner: toAdminTokenOwner(deletedToken.adminUserOwner),
-  };
+    kind: 'content-api' as const,
+    permissions: flattenTokenPermissions(deletedToken.permissions),
+  }) as ContentApiApiToken;
 };
 
 /**
@@ -954,8 +967,11 @@ const update = async (
 
   const raw = attributes as Record<string, unknown>;
 
-  // kind is immutable after creation
-  if (raw.kind !== undefined && raw.kind !== null && raw.kind !== originalToken.kind) {
+  // kind is immutable after creation.
+  // Null-kind rows are legacy content-api tokens — treat null and 'content-api' as the same
+  // effective value so that clients echoing back the normalised kind from a GET don't get rejected.
+  const effectiveStoredKind = originalToken.kind ?? 'content-api';
+  if (raw.kind !== undefined && raw.kind !== null && raw.kind !== effectiveStoredKind) {
     throw new ValidationError('kind is immutable after creation');
   }
 
@@ -964,7 +980,7 @@ const update = async (
   let clampedAdminPermissions: PermissionInput[] | undefined;
   let tokenOwnerUser: AdminUser | undefined;
 
-  if (originalToken.kind === 'content-api') {
+  if (originalToken.kind === null || originalToken.kind === 'content-api') {
     assertLegacyKindFields(attributes as ContentApiApiTokenBody);
 
     const incomingType = raw.type as ContentApiApiToken['type'] | undefined;
@@ -1019,14 +1035,23 @@ const update = async (
     }
   }
 
+  const baseData = omit(
+    ['kind', 'permissions', 'adminPermissions', 'adminUserOwner'],
+    attributes
+  ) as Record<string, unknown>;
+
+  // Migrate legacy null-kind rows to the explicit value on first write
+  if (originalToken.kind === null) {
+    baseData.kind = 'content-api';
+  }
+
   const updatedToken = await strapi.db.query('admin::api-token').update({
     select: SELECT_FIELDS,
     where: { id },
-    // kind is immutable — strip it along with relation fields so the DB write is clean
-    data: omit(['kind', 'permissions', 'adminPermissions', 'adminUserOwner'], attributes) as object,
+    data: baseData,
   });
 
-  if (originalToken.kind === 'content-api') {
+  if (originalToken.kind === null || originalToken.kind === 'content-api') {
     const incomingPermissions = raw.permissions as string[] | null | undefined;
 
     // custom tokens need to have their permissions updated as well

--- a/packages/core/admin/server/src/services/index.ts
+++ b/packages/core/admin/server/src/services/index.ts
@@ -16,6 +16,9 @@ import * as transfer from './transfer';
 import * as projectSettings from './project-settings';
 import { homepageService } from './homepage';
 
+const contentApiTokenService = createTokenService('content-api');
+const adminTokenService = createTokenService('admin');
+
 // TODO: TS - Export services one by one as this export is cjs
 export default {
   auth,
@@ -29,8 +32,10 @@ export default {
   constants,
   condition,
   action,
-  'api-token-content-api': createTokenService('content-api'),
-  'api-token-admin': createTokenService('admin'),
+  /** @deprecated Use 'api-token-content-api' instead */
+  'api-token': contentApiTokenService,
+  'api-token-content-api': contentApiTokenService,
+  'api-token-admin': adminTokenService,
   transfer,
   'project-settings': projectSettings,
   encryption,

--- a/packages/core/admin/server/src/strategies/__tests__/content-api-token.test.ts
+++ b/packages/core/admin/server/src/strategies/__tests__/content-api-token.test.ts
@@ -32,7 +32,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': {
+            'api-token-content-api': {
               getByAccessKey,
               hash,
             },
@@ -62,7 +62,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': {
+            'api-token-content-api': {
               getByAccessKey,
               hash,
             },
@@ -93,7 +93,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': {
+            'api-token-content-api': {
               getByAccessKey,
               hash,
             },
@@ -136,7 +136,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': {
+            'api-token-content-api': {
               getByAccessKey,
               hash,
             },
@@ -163,7 +163,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': {
+            'api-token-content-api': {
               getByAccessKey,
               hash,
               update,
@@ -195,7 +195,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': { getByAccessKey, hash },
+            'api-token-content-api': { getByAccessKey, hash },
           },
           db: {
             query() {
@@ -219,7 +219,7 @@ describe('Content-API Token Auth Strategy', () => {
       global.strapi = {
         admin: {
           services: {
-            'api-token-admin': { getByAccessKey, hash },
+            'api-token-content-api': { getByAccessKey, hash },
           },
         },
         db: {

--- a/packages/core/admin/server/src/strategies/content-api-token.ts
+++ b/packages/core/admin/server/src/strategies/content-api-token.ts
@@ -14,7 +14,7 @@ const isReadScope = (scope: string) => scope.endsWith('find') || scope.endsWith(
  * Authenticate a content-api token. Rejects tokens with kind !== 'content-api'.
  */
 export const authenticate = async (ctx: Context) => {
-  const apiTokenService = getService('api-token-admin');
+  const apiTokenService = getService('api-token-content-api');
   const token = extractToken(ctx);
 
   if (token === null) {

--- a/packages/core/admin/server/src/utils/index.d.ts
+++ b/packages/core/admin/server/src/utils/index.d.ts
@@ -21,6 +21,8 @@ type S = {
   token: typeof token;
   auth: typeof auth;
   metrics: typeof metrics;
+  /** @deprecated Use 'api-token-content-api' instead */
+  'api-token': ContentApiTokenService;
   'api-token-content-api': ContentApiTokenService;
   'api-token-admin': AdminTokenService;
   'project-settings': typeof projectSettings;

--- a/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocumentLayout.test.ts
@@ -1,6 +1,6 @@
 import { errors } from '@strapi/utils';
 import { renderHook, screen, server, waitFor } from '@tests/utils';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 
 import { mockData } from '../../../tests/mockData';
 import { extractContentTypeComponents } from '../useContentTypeSchema';
@@ -429,88 +429,84 @@ describe('useDocumentLayout', () => {
     const orphanModelUid = 'api::orphan.footer';
 
     server.use(
-      rest.get('/content-manager/init', (req, res, ctx) =>
-        res(
-          ctx.json({
-            data: {
-              components: mockData.contentManager.components,
-              contentTypes: [
-                ...mockData.contentManager.contentTypes,
-                {
-                  uid: orphanModelUid,
-                  isDisplayed: true,
-                  apiID: 'footer',
-                  kind: 'singleType',
-                  info: {
-                    singularName: 'footer',
-                    pluralName: 'footers',
-                    displayName: 'Footer',
-                    name: 'Footer',
-                    description: '',
-                  },
-                  options: {},
-                  pluginOptions: {},
-                  attributes: {},
+      http.get('/content-manager/init', () => {
+        return HttpResponse.json({
+          data: {
+            components: mockData.contentManager.components,
+            contentTypes: [
+              ...mockData.contentManager.contentTypes,
+              {
+                uid: orphanModelUid,
+                isDisplayed: true,
+                apiID: 'footer',
+                kind: 'singleType',
+                info: {
+                  singularName: 'footer',
+                  pluralName: 'footers',
+                  displayName: 'Footer',
+                  name: 'Footer',
+                  description: '',
                 },
-              ],
-            },
-          })
-        )
-      ),
-      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
-        if (req.params.model !== orphanModelUid) {
+                options: {},
+                pluginOptions: {},
+                attributes: {},
+              },
+            ],
+          },
+        });
+      }),
+      http.get('/content-manager/content-types/:model/configuration', ({ params }) => {
+        if (params.model !== orphanModelUid) {
           const configuration =
-            req.params.model === 'api::homepage.homepage'
+            params.model === 'api::homepage.homepage'
               ? mockData.contentManager.singleTypeConfiguration
               : mockData.contentManager.collectionTypeConfiguration;
 
-          return res(ctx.json({ data: configuration }));
+          return HttpResponse.json({ data: configuration });
         }
 
-        return res(
-          ctx.json({
-            data: {
-              contentType: {
-                uid: orphanModelUid,
-                settings: {
-                  bulkable: false,
-                  filterable: false,
-                  searchable: false,
-                  pageSize: 10,
-                  mainField: 'title',
-                  defaultSortBy: '',
-                  defaultSortOrder: 'ASC',
-                },
-                metadatas: {},
-                options: {},
-                layouts: {
-                  edit: [],
-                  list: [],
-                },
+        return HttpResponse.json({
+          data: {
+            contentType: {
+              uid: orphanModelUid,
+              settings: {
+                bulkable: false,
+                filterable: false,
+                searchable: false,
+                pageSize: 10,
+                mainField: 'title',
+                defaultSortBy: '',
+                defaultSortOrder: 'ASC',
               },
-              components: {
-                'orphan.ghost': {
-                  layouts: {
-                    edit: [[{ name: 'field', size: 12 }]],
-                  },
-                  metadatas: {
-                    field: {
-                      edit: {
-                        label: 'field',
-                        description: '',
-                        placeholder: '',
-                        visible: true,
-                        editable: true,
-                      },
-                    },
-                  },
-                  settings: {},
-                  isComponent: true,
-                },
+              metadatas: {},
+              options: {},
+              layouts: {
+                edit: [],
+                list: [],
               },
             },
-          })
-        );
+            components: {
+              'orphan.ghost': {
+                layouts: {
+                  edit: [[{ name: 'field', size: 12 }]],
+                },
+                metadatas: {
+                  field: {
+                    edit: {
+                      label: 'field',
+                      description: '',
+                      placeholder: '',
+                      visible: true,
+                      editable: true,
+                    },
+                  },
+                },
+                settings: {},
+                isComponent: true,
+              },
+            },
+          },
+        });
       })
     );
 
@@ -526,55 +522,51 @@ describe('useDocumentLayout', () => {
     const secondModelUid = 'api::address.address';
 
     server.use(
-      rest.get('/content-manager/init', (req, res, ctx) =>
-        res(
-          ctx.json({
+      http.get('/content-manager/init', () => {
+        return HttpResponse.json({
+          data: {
+            components: mockData.contentManager.components,
+            contentTypes: mockData.contentManager.contentTypes,
+          },
+        });
+      }),
+      http.get('/content-manager/content-types/:model/configuration', async ({ params }) => {
+        if (params.model === firstModelUid) {
+          return HttpResponse.json({ data: mockData.contentManager.singleTypeConfiguration });
+        }
+
+        if (params.model === secondModelUid) {
+          await delay(75);
+          return HttpResponse.json({
             data: {
-              components: mockData.contentManager.components,
-              contentTypes: mockData.contentManager.contentTypes,
-            },
-          })
-        )
-      ),
-      rest.get('/content-manager/content-types/:model/configuration', (req, res, ctx) => {
-        if (req.params.model === firstModelUid) {
-          return res(ctx.json({ data: mockData.contentManager.singleTypeConfiguration }));
-        }
-
-        if (req.params.model === secondModelUid) {
-          return res(
-            ctx.delay(75),
-            ctx.json({
-              data: {
-                contentType: {
-                  uid: secondModelUid,
-                  settings: {
-                    bulkable: true,
-                    filterable: true,
-                    searchable: true,
-                    pageSize: 10,
-                    mainField: 'id',
-                    defaultSortBy: 'id',
-                    defaultSortOrder: 'ASC',
-                  },
-                  metadatas:
-                    mockData.contentManager.collectionTypeConfiguration.contentType.metadatas,
-                  options: {},
-                  layouts: {
-                    edit: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
-                      .edit,
-                    list: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
-                      .list,
-                  },
+              contentType: {
+                uid: secondModelUid,
+                settings: {
+                  bulkable: true,
+                  filterable: true,
+                  searchable: true,
+                  pageSize: 10,
+                  mainField: 'id',
+                  defaultSortBy: 'id',
+                  defaultSortOrder: 'ASC',
                 },
-                // Simulate mismatch where component settings map is not ready/available yet.
-                components: {},
+                metadatas:
+                  mockData.contentManager.collectionTypeConfiguration.contentType.metadatas,
+                options: {},
+                layouts: {
+                  edit: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
+                    .edit,
+                  list: mockData.contentManager.collectionTypeConfiguration.contentType.layouts
+                    .list,
+                },
               },
-            })
-          );
+              // Simulate mismatch where component settings map is not ready/available yet.
+              components: {},
+            },
+          });
         }
 
-        return res(ctx.json({ data: mockData.contentManager.collectionTypeConfiguration }));
+        return HttpResponse.json({ data: mockData.contentManager.collectionTypeConfiguration });
       })
     );
 

--- a/tests/api/core/admin/admin-api-token-crud.test.api.ts
+++ b/tests/api/core/admin/admin-api-token-crud.test.api.ts
@@ -698,6 +698,39 @@ describe('Admin Content API Token CRUD (api)', () => {
     });
   });
 
+  test('Updates a legacy content-api token with null kind (db-backed)', async () => {
+    const token = await createValidToken({
+      type: 'read-only',
+    });
+
+    // Simulate a legacy row created before kind was persisted.
+    const updatedRows = await strapi.db
+      .connection('strapi_api_tokens')
+      .where({ id: token.id })
+      .update({
+        kind: null,
+      });
+
+    expect(updatedRows).toBe(1);
+
+    const res = await rq({
+      url: `/admin/api-tokens/${token.id}`,
+      method: 'PUT',
+      body: {
+        name: token.name,
+        description: 'updated description',
+        type: token.type,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: token.id,
+      description: 'updated description',
+      kind: 'content-api',
+    });
+  });
+
   test('Retrieves a custom token (successfully)', async () => {
     const token = await createValidToken({
       type: 'custom',
@@ -1032,5 +1065,58 @@ describe('Admin Content API Token CRUD (api)', () => {
     expect(getRes.statusCode).toBe(200);
     expect(getRes.body.data.accessKey).toBe(decryptedKey);
     expect(getRes.body.data.accessKey).toBe(createRes.body.data.accessKey);
+  });
+
+  test('Revokes a legacy content-api token with null kind and returns kind: content-api (db-backed)', async () => {
+    const token = await createValidToken({ type: 'read-only' });
+
+    await strapi.db.connection('strapi_api_tokens').where({ id: token.id }).update({ kind: null });
+
+    const res = await rq({
+      url: `/admin/api-tokens/${token.id}`,
+      method: 'DELETE',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.kind).toBe('content-api');
+  });
+
+  test('Revoke response for a content-api token does not include adminPermissions or adminUserOwner', async () => {
+    const token = await createValidToken({ type: 'read-only' });
+
+    const res = await rq({
+      url: `/admin/api-tokens/${token.id}`,
+      method: 'DELETE',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect('adminPermissions' in res.body.data).toBe(false);
+    expect('adminUserOwner' in res.body.data).toBe(false);
+  });
+
+  test('Regenerated api token response includes kind: content-api', async () => {
+    const token = await createValidToken({ type: 'read-only' });
+
+    const res = await rq({
+      url: `/admin/api-tokens/${token.id}/regenerate`,
+      method: 'POST',
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.kind).toBe('content-api');
+  });
+
+  test('Regenerates a legacy content-api token with null kind and returns kind: content-api (db-backed)', async () => {
+    const token = await createValidToken({ type: 'read-only' });
+
+    await strapi.db.connection('strapi_api_tokens').where({ id: token.id }).update({ kind: null });
+
+    const res = await rq({
+      url: `/admin/api-tokens/${token.id}/regenerate`,
+      method: 'POST',
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.data.kind).toBe('content-api');
   });
 });

--- a/tests/cli/tests/strapi/strapi/__snapshots__/services-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/services-list.test.cli.js.snap
@@ -89,6 +89,7 @@ exports[`services:list should output list of services 1`] = `
 │ admin::constants                                     │
 │ admin::condition                                     │
 │ admin::action                                        │
+│ admin::api-token                                     │
 │ admin::api-token-content-api                         │
 │ admin::api-token-admin                               │
 │ admin::transfer                                      │


### PR DESCRIPTION
### What does it do?

#### `fix(core/admin): api-token service treats kind.null as content-api`

- Normalises legacy `admin::api-token` rows with `kind: null` through the content-api service paths.
- `update()`, `revoke()`, and `regenerate()` treat null as content-api and migrate null to explicit `kind: 'content-api'` on write.
- Revoke returns content-api DTOs, including flattened `permissions`.
- `list()` maps missing admin owners to `null` instead of throwing.
- The content-api token GET handler loads the decrypted key in a single `getById` call.
- Unit and API integration tests cover null-kind update/revoke/regenerate, revoke response shape, and orphaned admin token listing.

#### `fix(core/admin): services expose backward compatible 'api-token' shim`

- Restores a deprecated `api-token` admin service entry that delegates to the content-api token service.
- Reuses the same service instance as `api-token-content-api`.
- Types the legacy `api-token` key in `getService`.

#### `enhancement(core/admin): api-token service uses pick instead of omit`

- Introduces `UPDATABLE_FIELDS` (`name`, `description`, `type`) and uses `pick` in `update()` instead of an `omit` negative list.
- Stops forwarding `lifespan` and `expiresAt` on update; removes `assertValidLifespan` from the update path because those fields are immutable after creation.
- Tightens update unit tests to assert the exact DB update payload, including null-kind migration writing `kind: 'content-api'`.
- Adds a unit test that request-body `lifespan` and `expiresAt` are dropped before the DB write.

#### `fix(core/admin): strategies content-api-token uses api-token-content-api service`

- Points the `content-api-token` auth strategy at the content-api token service for `getByAccessKey` and `hash`.
- Stops resolving the admin token service during Content API bearer authentication.

### Why is it needed?

#### `fix(core/admin): api-token service treats kind.null as content-api`

- Pre-migration content API tokens keep `kind: null` after the admin-token migration.
- Those rows were routed through admin-token logic (for example `update()` requiring `adminUserOwner`) or returned inconsistent shapes on revoke/regenerate.
- That broke editing existing tokens and produced wrong responses for legacy rows.

#### `fix(core/admin): services expose backward compatible 'api-token' shim`

- The admin-token split removed the `api-token` service name.
- Plugins, scripts, and custom code that still resolve that key failed at runtime.

#### `enhancement(core/admin): api-token service uses pick instead of omit`

- `omit` is a negative contract: new request-body fields can reach the DB UPDATE unless each one is explicitly excluded.
- `pick` with an explicit allowlist is safe-by-default; unknown or future fields are dropped automatically.
- `lifespan` and `expiresAt` must not be mutable through `update()` after token creation.

#### `fix(core/admin): strategies content-api-token uses api-token-content-api service`

- After the admin-token split, the strategy still called `getService('api-token-admin')`, so Content API routes looked up bearer tokens in the wrong service.
- Valid content-api tokens could fail authentication or hit admin-only lookup paths.

### How to test it?

**Reported user scenarios** (each must pass after the fix):

- [#26309](https://github.com/strapi/strapi/issues/26309) — Open Settings → API Tokens with at least one pre-existing token. Page must load without `TypeError: Cannot read properties of undefined (reading 'toString')`.
- [#25657 comment](https://github.com/strapi/strapi/pull/25657#issuecomment-4428091114) / [SO](https://stackoverflow.com/questions/79939777/strapi-v5-45-1-error-adminuserowner-is-required) — Edit an API token's permissions (e.g. change type or description) on an instance upgraded from <5.45.0. Must succeed without `adminUserOwner is required`.
- Seed scripts / plugins calling `strapi.service('admin::api-token')` must resolve (not `undefined`).

**Automated tests:**

#### `fix(core/admin): api-token service treats kind.null as content-api`

This is the core regression fix. Run:

```bash
# Unit tests — service + controller
yarn test:unit api-token

# Integration tests — full HTTP round-trip against a real DB
yarn test:api admin-api-token-crud
```

Covers every user-reported scenario with DB-backed tokens whose `kind` column is forced to `NULL` (simulating a pre-5.45.0 upgrade):

| Test | Scenario reproduced |
|---|---|
| `Updates a legacy content-api token with null kind (db-backed)` | SO / #25657: editing an existing token throws `adminUserOwner is required` |
| `Retrieves a legacy content-api token with null kind (db-backed)` | #26309: loading the API Tokens page fails to render token data |
| `Revokes a legacy content-api token with null kind` | Revoke returns `kind: 'content-api'` with flattened `permissions`, no admin-only fields |
| `Regenerates a legacy content-api token with null kind` | Regenerate returns `kind: 'content-api'` |
| `Lists tokens even when an admin token has a null owner` | Orphaned `kind: 'admin'` row with no owner doesn't crash the list endpoint |
| `Revoke response does not include adminPermissions or adminUserOwner` | Content-api DTOs never leak admin-only fields |

#### `fix(core/admin): services expose backward compatible 'api-token' shim`

No dedicated unit test in this branch. Confirm at runtime that `strapi.service('admin::api-token')` and `strapi.service('admin::api-token-content-api')` resolve to the same object (see manual smoke test below).

#### `enhancement(core/admin): api-token service uses pick instead of omit`

```bash
yarn test:unit packages/core/admin/server/src/services/__tests__/api-token.test.ts
```

Update tests assert the exact keys written to the DB update mock:
- Only `name`, `description`, `type` (+ `kind: 'content-api'` for null-kind migration) reach the DB.
- `lifespan` and `expiresAt` in the request body are dropped — they're immutable after creation.

#### `fix(core/admin): strategies content-api-token uses api-token-content-api service`

Strategy unit tests in this branch still mock `api-token-admin`; they are not updated here. Verify manually: call a Content API route with a valid content-api bearer token and confirm authentication succeeds.

**Manual smoke test (optional but recommended):**

1. Start a Strapi instance with at least one API token created on a version before 5.45.0 (or create one and force `kind: null` in the DB).
2. Open Settings → API Tokens → confirm the list renders.
3. Click an existing token → edit description → Save → confirm no error.
4. Regenerate the token → confirm success.
5. Delete the token → confirm success.
6. Call a Content API endpoint with a content-api token bearer header → confirm `200` (not `401`).
7. In a bootstrap script or REPL, `strapi.service('admin::api-token')` resolves and matches `strapi.service('admin::api-token-content-api')`.

### Related issue(s)/PR(s)

 - Fixes #26309
 - Patches #25657
 - Replaces #26310
