### PR TITLE
fix(document-service): pick the right ghost side in component join repair

### DIFF
--- a/packages/core/core/src/services/document-service/utils/clean-component-join-table.ts
+++ b/packages/core/core/src/services/document-service/utils/clean-component-join-table.ts
@@ -3,8 +3,25 @@ import type { Schema } from '@strapi/types';
 import { findComponentParent, getParentSchemasForComponent } from '../components';
 
 /**
- * Cleans ghost relations with publication state mismatches from a join table
- * Uses schema-based draft/publish checking like prevention fix
+ * Cleans ghost relations with publication state mismatches from a join table.
+ *
+ * "Ghost" relations are duplicated join rows where, for a single source instance,
+ * relations exist to both the draft and the published version of the same target
+ * document. Only one of those relations is legitimate: the one whose publication
+ * state matches the source's own publication state. The other is a leftover
+ * from a past write-path bug and must be removed.
+ *
+ * Which side is the ghost is therefore not fixed — it depends on the source:
+ *   - A draft source (or a component instance whose owning entry is a draft)
+ *     should keep the relation pointing to the draft target; the
+ *     published-target row is the ghost.
+ *   - A published source (or a component instance whose owning entry is
+ *     published) should keep the relation pointing to the published target;
+ *     the draft-target row is the ghost.
+ *
+ * If the source's effective publication state cannot be determined (for
+ * example, an orphan component instance with no parent), the row is left
+ * untouched to avoid further data loss.
  */
 export const cleanComponentJoinTable = async (
   db: Database,
@@ -65,6 +82,11 @@ export const cleanComponentJoinTable = async (
   }
 };
 
+/**
+ * Walks up the component containment chain for a component instance until it
+ * reaches the owning content-type entry. Returns the content-type uid, table
+ * name and id of that entry, or null if the chain breaks (orphan component).
+ */
 const findContentTypeParentForComponentInstance = async (
   componentSchema: Schema.Component,
   componentId: number | string
@@ -98,8 +120,78 @@ const findContentTypeParentForComponentInstance = async (
 };
 
 /**
- * Finds join table entries with publication state mismatches
- * Uses existing component parent detection from document service
+ * Returns the effective publication state of a join-row's source:
+ *   - 'published' if the source row (or its owning content-type entry for
+ *     a component source) has `published_at IS NOT NULL`
+ *   - 'draft' if `published_at IS NULL`
+ *   - null if the state can't be determined (e.g., orphan component, or the
+ *     owning content type doesn't support D&P — in which case the source
+ *     keeps both states and we must not touch it)
+ */
+const resolveSourcePublicationState = async (
+  db: Database,
+  sourceModel: any,
+  sourceId: number | string
+): Promise<'draft' | 'published' | null> => {
+  const isComponentModel =
+    !sourceModel.uid?.startsWith('api::') &&
+    !sourceModel.uid?.startsWith('plugin::') &&
+    sourceModel.uid?.includes('.');
+
+  // Component source: walk up the component chain to the owning content-type entry
+  if (isComponentModel) {
+    const componentSchema = strapi.components[sourceModel.uid as keyof typeof strapi.components] as
+      | Schema.Component
+      | undefined;
+    if (!componentSchema) {
+      return null;
+    }
+
+    const parent = await findContentTypeParentForComponentInstance(componentSchema, sourceId);
+    if (!parent) {
+      return null;
+    }
+
+    const parentContentType = strapi.contentTypes[parent.uid as keyof typeof strapi.contentTypes];
+
+    // If the owning content type doesn't support D&P its entries hold both
+    // states inline; touching the join rows could destroy legitimate links.
+    if (!parentContentType?.options?.draftAndPublish) {
+      return null;
+    }
+
+    const parentRow = await db
+      .connection(parent.table)
+      .select('published_at')
+      .where('id', parent.parentId)
+      .first();
+
+    if (!parentRow) {
+      return null;
+    }
+    return parentRow.published_at === null ? 'draft' : 'published';
+  }
+
+  // Non-component source: read publication state directly from the source row
+  const sourceRow = await db
+    .connection(sourceModel.tableName)
+    .select('published_at')
+    .where('id', sourceId)
+    .first();
+
+  if (!sourceRow) {
+    return null;
+  }
+  return sourceRow.published_at === null ? 'draft' : 'published';
+};
+
+/**
+ * Finds join table entries with publication state mismatches.
+ *
+ * For every (source_id, target_document_id) pair where both a draft-target row
+ * and a published-target row exist, exactly one of them is a ghost. The one
+ * to drop is the one whose target publication state does NOT match the
+ * source's own publication state.
  */
 const findPublicationStateMismatches = async (
   db: Database,
@@ -113,22 +205,23 @@ const findPublicationStateMismatches = async (
     const sourceColumn = relation.joinTable.joinColumn.name;
     const targetColumn = relation.joinTable.inverseJoinColumn.name;
 
-    // Get all join entries with their target entities
-    const query = db
+    // Get all join entries with their target entities. We also fetch
+    // `document_id` so we can group by target document and apply the mismatch
+    // rule per-document rather than across the whole source.
+    const joinEntries = await db
       .connection(joinTableName)
       .select(
         `${joinTableName}.id as join_id`,
         `${joinTableName}.${sourceColumn} as source_id`,
         `${joinTableName}.${targetColumn} as target_id`,
-        `${targetModel.tableName}.published_at as target_published_at`
+        `${targetModel.tableName}.published_at as target_published_at`,
+        `${targetModel.tableName}.document_id as target_document_id`
       )
       .leftJoin(
         targetModel.tableName,
         `${joinTableName}.${targetColumn}`,
         `${targetModel.tableName}.id`
       );
-
-    const joinEntries = await query;
 
     // Group by source_id to find duplicates pointing to draft/published versions of same entity
     const entriesBySource: { [key: string]: any[] } = {};
@@ -142,13 +235,6 @@ const findPublicationStateMismatches = async (
 
     const ghostEntries: number[] = [];
 
-    // Check if this is a join table (ends with _lnk)
-    const isRelationJoinTable = joinTableName.endsWith('_lnk');
-    const isComponentModel =
-      !sourceModel.uid?.startsWith('api::') &&
-      !sourceModel.uid?.startsWith('plugin::') &&
-      sourceModel.uid?.includes('.');
-
     // Check for draft/publish inconsistencies
     for (const [sourceId, entries] of Object.entries(entriesBySource)) {
       // Skip entries with single relations
@@ -157,64 +243,63 @@ const findPublicationStateMismatches = async (
         continue;
       }
 
-      // For component join tables, check if THIS specific component instance's parent supports D&P
-      if (isRelationJoinTable && isComponentModel) {
-        try {
-          const componentSchema = strapi.components[sourceModel.uid] as Schema.Component;
-          if (!componentSchema) {
-            // eslint-disable-next-line no-continue
-            continue;
-          }
+      // Resolve the source's effective publication state. We need this to
+      // know which side of the duplicate pair is the ghost: the row whose
+      // target state disagrees with the source state.
+      let sourceState: 'draft' | 'published' | null;
+      try {
+        sourceState = await resolveSourcePublicationState(db, sourceModel, sourceId);
+      } catch (error) {
+        // Skip on error — better to leave data alone than to delete the wrong row
+        // eslint-disable-next-line no-continue
+        continue;
+      }
 
-          const parent = await findContentTypeParentForComponentInstance(componentSchema, sourceId);
-          if (!parent) {
-            continue;
-          }
+      if (sourceState === null) {
+        // Unknown source state — skip to avoid destroying legitimate links
+        // eslint-disable-next-line no-continue
+        continue;
+      }
 
-          // Check if THIS component instance's parent supports draft/publish
-          const parentContentType =
-            strapi.contentTypes[parent.uid as keyof typeof strapi.contentTypes];
-          if (!parentContentType?.options?.draftAndPublish) {
-            // This component instance's parent does NOT support D&P - skip cleanup
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-
-          // If we reach here, this component instance's parent DOES support D&P
-          // Continue to process this component instance for ghost relations
-        } catch (error) {
-          // Skip this component instance on error
+      // Group this source's rows by target document. The mismatch rule
+      // applies per-document: a single source may legitimately link to many
+      // different documents, mixed-state across documents is fine; what is
+      // never legitimate is the same source linking to BOTH versions of the
+      // SAME document.
+      const entriesByDocument: { [docId: string]: any[] } = {};
+      for (const entry of entries) {
+        const docId = String(entry.target_document_id ?? '');
+        if (!docId) {
           // eslint-disable-next-line no-continue
           continue;
         }
+        if (!entriesByDocument[docId]) {
+          entriesByDocument[docId] = [];
+        }
+        entriesByDocument[docId].push(entry);
       }
 
-      // Find ghost relations (same logic as original but with improved parent checking)
-      for (const entry of entries) {
-        if (entry.target_published_at === null) {
-          // This is a draft target - find its published version
-          const draftTarget = await db
-            .connection(targetModel.tableName)
-            .select('document_id')
-            .where('id', entry.target_id)
-            .first();
+      for (const documentEntries of Object.values(entriesByDocument)) {
+        if (documentEntries.length <= 1) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
 
-          if (draftTarget) {
-            const publishedVersion = await db
-              .connection(targetModel.tableName)
-              .select('id', 'document_id')
-              .where('document_id', draftTarget.document_id)
-              .whereNotNull('published_at')
-              .first();
+        const draftRows = documentEntries.filter((e) => e.target_published_at === null);
+        const publishedRows = documentEntries.filter((e) => e.target_published_at !== null);
 
-            if (publishedVersion) {
-              // Check if we also have a relation to the published version
-              const publishedRelation = entries.find((e) => e.target_id === publishedVersion.id);
-              if (publishedRelation) {
-                ghostEntries.push(publishedRelation.join_id);
-              }
-            }
-          }
+        // Only act when both states are present for the same document
+        if (draftRows.length === 0 || publishedRows.length === 0) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        // Delete the rows whose target state disagrees with the source state.
+        // A draft source keeps draft-target rows; a published source keeps
+        // published-target rows.
+        const ghostRows = sourceState === 'draft' ? publishedRows : draftRows;
+        for (const row of ghostRows) {
+          ghostEntries.push(row.join_id);
         }
       }
     }

--- a/tests/api/core/strapi/repairs/unidirectional-join-table-repair.test.api.ts
+++ b/tests/api/core/strapi/repairs/unidirectional-join-table-repair.test.api.ts
@@ -16,7 +16,10 @@ import type { Core } from '@strapi/types';
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
 
-// Local cleaner used for tests to have full control and avoid coupling to core internals
+// Local cleaner used for tests. Mirrors the parent-state-aware logic of the
+// production `cleanComponentJoinTable`: for each (source, target-document)
+// pair where both draft and published target rows exist, drop the row whose
+// target state disagrees with the source's own publication state.
 const testCleaner = async (
   db: any,
   joinTableName: string,
@@ -64,47 +67,76 @@ const testCleaner = async (
       bySource[key].push(r);
     }
 
-    // Resolve table names for our parents to detect D&P support
+    // Resolve cmps tables so we can find the owning entity for each component
+    // instance and read its publication state.
     const productMd = db.metadata.get(PRODUCT_UID);
     const boxMd = db.metadata.get(BOX_UID);
-    const productCmpsTable = productMd?.tableName ? `${productMd.tableName}_cmps` : undefined;
+    const articleMd = db.metadata.get(ARTICLE_UID);
+    const productTable = productMd?.tableName;
+    const productCmpsTable = productTable ? `${productTable}_cmps` : undefined;
     const boxCmpsTable = boxMd?.tableName ? `${boxMd.tableName}_cmps` : undefined;
+    const articleTable = articleMd?.tableName;
+
+    const isComponentSource =
+      !sourceModel.uid?.startsWith('api::') && !sourceModel.uid?.startsWith('plugin::');
 
     const toDelete: number[] = [];
 
     for (const [sourceId, entries] of Object.entries(bySource)) {
       if (entries.length <= 1) continue;
 
-      // Parent D&P check: find component row to get entity_id
-      let parentSupportsDP = true;
+      // Resolve source's effective publication state:
+      //   - component source: walk to owning entity, use its published_at
+      //   - direct content-type source: use the source row's published_at
+      //   - non-D&P parent / unknown: skip safely (do not delete)
+      let sourceState: 'draft' | 'published' | null = null;
       try {
-        // Prefer mapping tables to detect parent type reliably
-        let productParent = null;
-        let boxParent = null;
-        if (productCmpsTable) {
-          productParent = await db
-            .connection(productCmpsTable)
-            .select('entity_id')
-            .where('cmp_id', Number(sourceId))
+        if (isComponentSource) {
+          if (productCmpsTable) {
+            const productParent = await db
+              .connection(productCmpsTable)
+              .select('entity_id')
+              .where('cmp_id', Number(sourceId))
+              .first();
+            if (productParent) {
+              const parentRow = await db
+                .connection(productTable as string)
+                .select('published_at')
+                .where('id', productParent.entity_id)
+                .first();
+              sourceState = parentRow?.published_at === null ? 'draft' : 'published';
+            }
+          }
+          if (sourceState === null && boxCmpsTable) {
+            const boxParent = await db
+              .connection(boxCmpsTable)
+              .select('entity_id')
+              .where('cmp_id', Number(sourceId))
+              .first();
+            if (boxParent) {
+              // Box has no D&P; do not act on these.
+              sourceState = null;
+            }
+          }
+        } else if (sourceModel.uid === ARTICLE_UID && articleTable) {
+          const sourceRow = await db
+            .connection(articleTable)
+            .select('published_at')
+            .where('id', Number(sourceId))
             .first();
+          if (sourceRow) {
+            sourceState = sourceRow.published_at === null ? 'draft' : 'published';
+          }
         }
-        if (!productParent && boxCmpsTable) {
-          boxParent = await db
-            .connection(boxCmpsTable)
-            .select('entity_id')
-            .where('cmp_id', Number(sourceId))
-            .first();
-        }
-        if (boxParent) parentSupportsDP = false;
       } catch (e) {
-        // If any error, default to safe side: do not delete
-        parentSupportsDP = false;
+        sourceState = null;
       }
-      if (!parentSupportsDP) {
+
+      if (sourceState === null) {
         continue;
       }
 
-      // For each document, if both draft and published relations exist, delete the published one(s)
+      // Per-document mismatch rule
       const byDoc: Record<string, any[]> = {};
       for (const e of entries) {
         const key = String(e.target_document_id ?? '');
@@ -115,9 +147,10 @@ const testCleaner = async (
         if (!docId || docEntries.length <= 1) continue;
         const publishedEntries = docEntries.filter((e) => e.target_published_at !== null);
         const draftEntries = docEntries.filter((e) => e.target_published_at === null);
-        if (publishedEntries.length > 0 && draftEntries.length > 0) {
-          for (const pub of publishedEntries) toDelete.push(pub.join_id);
-        }
+        if (publishedEntries.length === 0 || draftEntries.length === 0) continue;
+
+        const ghostRows = sourceState === 'draft' ? publishedEntries : draftEntries;
+        for (const row of ghostRows) toDelete.push(row.join_id);
       }
     }
 
@@ -720,6 +753,126 @@ describe('Unidirectional join-table repair (components)', () => {
     expect(rows[0][targetColumn]).toBe(draftTag.id);
 
     // Cleanup article
+    await strapi.documents(ARTICLE_UID).delete({ documentId: article.documentId });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression coverage for the published-parent case: when the source is the
+  // PUBLISHED side, the row pointing to the DRAFT target is the ghost — not
+  // the other way round. The previous implementation always deleted the
+  // published-pointing row, which corrupted published parents.
+  // ---------------------------------------------------------------------------
+
+  it('Removes draft-target row when both exist under a PUBLISHED component parent', async () => {
+    const { joinTableName, sourceColumn, targetColumn } = getCompoTagsRelationInfo();
+
+    const tagVersions = await strapi.db.query(TAG_UID).findMany({ where: { documentId: 'GTagR' } });
+    const draftTag = tagVersions.find((t: any) => t.publishedAt === null)!;
+    const publishedTag = tagVersions.find((t: any) => t.publishedAt !== null)!;
+
+    // Create + publish a product so its component instance is the PUBLISHED-side one
+    const product = await strapi.documents(PRODUCT_UID).create({
+      data: {
+        name: 'Published-parent-ghost',
+        rcompo: { rtags: [{ id: publishedTag.id }] },
+      },
+      status: 'draft',
+    });
+    await strapi.documents(PRODUCT_UID).publish({ documentId: product.documentId });
+
+    // Find the published parent's component-instance row in the join table by
+    // walking through the published product entry's _cmps row.
+    const productMd: any = (strapi as any).db.metadata.get(PRODUCT_UID);
+    const productCmpsTable = `${productMd.tableName}_cmps`;
+
+    const publishedProductRow = await strapi.db
+      .connection(productMd.tableName)
+      .select('id')
+      .where('document_id', product.documentId)
+      .whereNotNull('published_at')
+      .first();
+    expect(publishedProductRow).toBeDefined();
+
+    const publishedCmpsRow = await strapi.db
+      .connection(productCmpsTable)
+      .select('cmp_id')
+      .where('entity_id', publishedProductRow.id)
+      .first();
+    expect(publishedCmpsRow).toBeDefined();
+    const publishedSourceId = publishedCmpsRow.cmp_id;
+
+    // Confirm the published parent's component currently has exactly one row,
+    // pointing to the PUBLISHED tag (the legitimate state).
+    let rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(1);
+    expect(rows[0][targetColumn]).toBe(publishedTag.id);
+
+    // Inject the corrupt state: a stray draft-target row under the same
+    // published parent.
+    const ghost = { ...rows[0] } as any;
+    delete ghost.id;
+    ghost[targetColumn] = draftTag.id;
+    await strapi.db.connection(joinTableName).insert(ghost);
+
+    rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(2);
+
+    const removed = await strapi.db.repair.processUnidirectionalJoinTables(testCleaner);
+    expect(removed).toBeGreaterThanOrEqual(1);
+
+    // The legitimate published-target row must remain; the draft-target row
+    // must be removed.
+    rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(1);
+    expect(rows[0][targetColumn]).toBe(publishedTag.id);
+
+    await strapi.documents(PRODUCT_UID).delete({ documentId: product.documentId });
+  });
+
+  it('Removes draft-target row when both exist under a PUBLISHED content-type source', async () => {
+    const { joinTableName, sourceColumn, targetColumn } = getArticleTagsRelationInfo();
+
+    const tagVersions = await strapi.db.query(TAG_UID).findMany({ where: { documentId: 'GTagR' } });
+    const draftTag = tagVersions.find((t: any) => t.publishedAt === null)!;
+    const publishedTag = tagVersions.find((t: any) => t.publishedAt !== null)!;
+
+    // Create + publish an article so we have a published-side source row
+    const article = await strapi.documents(ARTICLE_UID).create({
+      data: { title: 'Article-published', tags: [{ id: publishedTag.id }] },
+      status: 'draft',
+    });
+    await strapi.documents(ARTICLE_UID).publish({ documentId: article.documentId });
+
+    const articleMd: any = (strapi as any).db.metadata.get(ARTICLE_UID);
+    const publishedArticle = await strapi.db
+      .connection(articleMd.tableName)
+      .select('id')
+      .where('document_id', article.documentId)
+      .whereNotNull('published_at')
+      .first();
+    expect(publishedArticle).toBeDefined();
+
+    const publishedSourceId = publishedArticle.id;
+    let rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(1);
+    expect(rows[0][targetColumn]).toBe(publishedTag.id);
+
+    // Inject a draft-target ghost row under the published article
+    const ghost = { ...rows[0] } as any;
+    delete ghost.id;
+    ghost[targetColumn] = draftTag.id;
+    await strapi.db.connection(joinTableName).insert(ghost);
+
+    rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(2);
+
+    const removed = await strapi.db.repair.processUnidirectionalJoinTables(testCleaner);
+    expect(removed).toBeGreaterThanOrEqual(1);
+
+    rows = await selectBySource(joinTableName, sourceColumn, publishedSourceId);
+    expect(rows.length).toBe(1);
+    expect(rows[0][targetColumn]).toBe(publishedTag.id);
+
     await strapi.documents(ARTICLE_UID).delete({ documentId: article.documentId });
   });
 });


### PR DESCRIPTION
### What does it do?

Fixes the unidirectional join-table repair (`cleanComponentJoinTable`, introduced in #24316) so that it picks the correct row to delete when both a draft-target and a published-target row exist for the same source/document pair.

Previously the repair *always* marked the published-pointing row as the ghost. That assumption only holds for a draft source. For a **published** component instance — or a published content-type source — it is the *draft-pointing* row that is the ghost, and the previous logic was wiping the legitimately-correct published-target row on every published parent. The corruption only surfaces at read time, because the public REST API propagates the root-level `publishedAt IS NOT NULL` filter into every nested populate (#23673), so any deep populate going through one of those join rows now returns empty arrays for the affected relations.

### Why is it needed?

The repair runs once per installation at boot time (gated by the core-store flag `unidirectional-join-table-repair-ran`). On any project where a published parent legitimately had both draft- and published-target rows for the same source — for example, after a v4→v5 migration that produced both — the run silently deletes the correct row and leaves the ghost. The next deep-populate REST call returns `null`/empty for those relations even though the data is still in the database, and there's no log line to suggest something was changed.

The fix:

- Resolves the source's effective publication state:
  - For a **component source**, walk up the `*_cmps` chain via `findComponentParent` until we reach the owning content-type entry; read its `published_at`.
  - For a **direct content-type source**, read `published_at` on the source row.
- Removes the row whose target publication state disagrees with the source's state.
- If the source's state cannot be determined (orphan component instance, owning content type has no D&P), leaves all rows alone.

The conservative “only act when *both* draft and published target rows exist for the same document” rule from #24316 is preserved — this PR does not expand the cleanup scope, only inverts the choice when the source is on the published side.

### Caveats

- This does not recover data that the previous (broken) run already deleted. Installations where the buggy repair has already executed (i.e. `unidirectional-join-table-repair-ran = true`) will not see their lost published-target rows re-created — there is nothing to re-create them from. Those projects still need an out-of-band repair (SQL remap from draft → published id, or a republish of the affected entries via the admin) before this fix becomes visible at the API layer. Open question for the reviewers: do we want to version-bump the flag (e.g. `unidirectional-join-table-repair-ran-v2`) so the corrected repair re-runs on every install, or leave it as-is to avoid churn on projects that have been manually patched?
- The known follow-up issue raised in the original PR discussion — “draft source with *only* a stranded published-target row after clearing the relation in the admin” — is still out of scope here. That requires expanding the cleanup beyond duplicate pairs and should be a separate PR.

### How to test it?

#### Automated

\`\`\`
yarn test:api --db=postgres -- tests/api/core/strapi/repairs/unidirectional-join-table-repair.test.api.ts
\`\`\`

Two new assertions cover the regression:
- *Removes draft-target row when both exist under a PUBLISHED component parent*
- *Removes draft-target row when both exist under a PUBLISHED content-type source*

The local `testCleaner` is updated to mirror the production rule, so all existing cases still pass.

#### Manual

1. On a fresh project, create a content type with D&P and a component containing a `oneToMany` relation also with D&P.
2. Create an entry, populate the component relation, publish the entry.
3. Manually `INSERT` a draft-target row into the join table for the published parent's component instance (simulating the corrupt state).
4. Clear the `strapi_unidirectional-join-table-repair-ran` row from `strapi_core_store_settings` so the repair re-runs.
5. Restart Strapi.
6. Confirm the draft-target row is removed and the published-target row remains. Before this PR the opposite happened.

### Related issue(s)/PR(s)

- Original repair PR: #24316
- Adjacent fixes already merged: #24227 (stop creating new ghosts), #24467 (skip non-D&P source content types), #24470 / #24652 (auto-run toggle history)
- Remaining ghost shape still unaddressed: see https://github.com/strapi/strapi/pull/24316#issuecomment-3338115028

cc @markkaylor @Bassel17 @innerdvations @jhoward1994 @laurenskling — original authors / reviewers.