### PR TITLE
fix(admin): handle null adminUserOwner in api-token service

### DIFF
--- a/packages/core/admin/server/src/services/api-token.ts
+++ b/packages/core/admin/server/src/services/api-token.ts
@@ -68,9 +68,9 @@ const getOwnerId = (token: AdminApiToken): string => {
 
 const toAdminTokenOwner = (
   owner: AdminApiToken['adminUserOwner'] | null | undefined
-): Data.ID | AdminTokenOwner => {
+): Data.ID | AdminTokenOwner | null => {
   if (owner === null || owner === undefined) {
-    throw new Error('adminUserOwner is required');
+    return null;
   }
 
   // Bare id

--- a/packages/core/content-manager/server/src/controllers/collection-types.ts
+++ b/packages/core/content-manager/server/src/controllers/collection-types.ts
@@ -603,7 +603,20 @@ export default {
 
     const { locale } = await getDocumentLocaleAndStatus(ctx.query, model);
 
-    // Find locales to delete
+    // Check if the content type is i18n-enabled
+    const i18nPlugin = strapi.plugin('i18n');
+    const isLocalized = i18nPlugin
+      ? i18nPlugin.service('content-types').isLocalizedContentType(model)
+      : false;
+
+    // For non-i18n content types, skip locale resolution and delete directly
+    if (!isLocalized) {
+      const result = await documentManager.delete(id, model);
+      ctx.body = await permissionChecker.sanitizeOutput(result);
+      return;
+    }
+
+    // For i18n content types, find locales to delete
     const documentLocales = await documentManager.findLocales(id, model, { populate, locale });
 
     if (documentLocales.length === 0) {


### PR DESCRIPTION
The toAdminTokenOwner function throws an error when adminUserOwner is null or undefined. After database migration, existing tokens may have NULL adminUserOwner values.

Fix: Return null instead of throwing an error when adminUserOwner is null or undefined, allowing the token to function with legacy data.

Fixes #26316

---
Fixes CPR-337