### PR TITLE
fix(migrations): guard inverseJoinColumn access in discard-drafts migration

### DIFF
--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -1551,6 +1551,10 @@ async function cloneComponentRelationJoinTables(
 
     const joinTable = attribute.joinTable;
     const sourceColumnName = joinTable.joinColumn.name;
+    // Morph join tables use morphColumn instead of inverseJoinColumn — skip them
+    if (!joinTable.inverseJoinColumn) {
+      continue;
+    }
     const targetColumnName = joinTable.inverseJoinColumn.name;
 
     if (!componentMeta.relationsLogPrinted) {
@@ -2004,6 +2008,10 @@ async function copyRelationsForContentType({
     }
 
     const { name: sourceColumnName } = joinTable.joinColumn;
+    // Morph join tables use morphColumn instead of inverseJoinColumn — skip them
+    if (!joinTable.inverseJoinColumn) {
+      continue;
+    }
     const { name: targetColumnName } = joinTable.inverseJoinColumn;
 
     // Process in batches to avoid MySQL query size limits and SQLite expression tree limits
@@ -2148,6 +2156,9 @@ async function copyRelationsFromOtherContentTypes({
       }
 
       const { name: sourceColumnName } = joinTable.joinColumn;
+      if (!joinTable.inverseJoinColumn) {
+        continue;
+      }
       const { name: targetColumnName } = joinTable.inverseJoinColumn;
 
       // Query existing relations by target IDs to avoid duplicates
@@ -2252,6 +2263,9 @@ async function copyRelationsToOtherContentTypes({
     }
 
     const { name: sourceColumnName } = joinTable.joinColumn;
+    if (!joinTable.inverseJoinColumn) {
+      continue;
+    }
     const { name: targetColumnName } = joinTable.inverseJoinColumn;
 
     // Get target content type's publishedToDraftMap if it has draft/publish (cached)
@@ -2554,6 +2568,9 @@ async function fixExistingDraftRelations({ trx, uid }: { trx: Knex; uid: string 
     }
 
     const { name: sourceColumnName } = joinTable.joinColumn;
+    if (!joinTable.inverseJoinColumn) {
+      continue;
+    }
     const { name: targetColumnName } = joinTable.inverseJoinColumn;
 
     // Get draft map for target to convert published targets to draft targets
@@ -2746,6 +2763,9 @@ async function fixExistingDraftComponentRelations({ trx, uid }: { trx: Knex; uid
 
         const relationJoinTable = attr.joinTable.name;
         const sourceColumn = attr.joinTable.joinColumn.name;
+        if (!attr.joinTable.inverseJoinColumn) {
+          continue;
+        }
         const targetColumn = attr.joinTable.inverseJoinColumn.name;
 
         const hasRelationTable = await trx.schema.hasTable(relationJoinTable);
@@ -2965,6 +2985,9 @@ async function fixPublishedComponentRelationTargets({ trx, uid }: { trx: Knex; u
 
       const relationJoinTable = attr.joinTable.name;
       const sourceColumn = attr.joinTable.joinColumn.name;
+      if (!attr.joinTable.inverseJoinColumn) {
+        continue;
+      }
       const targetColumn = attr.joinTable.inverseJoinColumn.name;
       if (!(await ensureTableExists(trx, relationJoinTable))) continue;
 


### PR DESCRIPTION
## Summary

The `5.0.0-discard-drafts` migration crashes when processing `morphToMany` relations because it accesses `joinTable.inverseJoinColumn.name` in 7 locations without checking if `inverseJoinColumn` exists.

Morph join tables (polymorphic relations) use `morphColumn` instead of `inverseJoinColumn`. Accessing `.name` on `undefined` throws:

```
TypeError: Cannot read properties of undefined (reading 'name')
```

## Root Cause

The migration iterates all relation attributes and their join tables, but assumes every join table has `inverseJoinColumn`. Morph tables (`_mph` suffix) have `morphColumn` instead.

## Fix

Added a null guard (`if (!joinTable.inverseJoinColumn) continue;`) before each of the 7 accesses. Morph tables are correctly skipped — they don't need the draft/published copy logic because morph data is handled by separate morph-specific functions (`copyMorphRowsByIdMap`, `copyMorphRowsByPairs`, etc.).

## Reproduction

1. Have a Strapi v4 project with any `morphToMany` relation
2. Upgrade to Strapi v5 (tested on v5.42.1 and v5.46.0)
3. Boot — the `discard-drafts` migration crashes

## Related

- Fixes #25542
- Related PR #25543 (added validation tests but did not fix the migration code itself)
- Fixes #26330

## Testing

Tested on a production v4→v5 migration with morph tables: `*_mph`, all morph tables correctly skipped, migration completes successfully, all data intact.

---
Fixes CPR-341