### PR TITLE
fix(content-manager): capitalize component category names in dynamic zone (closes #24426)

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/ComponentCategory.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Accordion, Box, Flex, FlexComponent, Tooltip, Typography } from '@strapi/design-system';
+import upperFirst from 'lodash/upperFirst';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
 
@@ -31,7 +32,7 @@ const ComponentCategory = ({
     <Accordion.Item value={category}>
       <Accordion.Header variant={variant}>
         <Accordion.Trigger>
-          {formatMessage({ id: category, defaultMessage: category })}
+          {formatMessage({ id: category, defaultMessage: upperFirst(category) })}
         </Accordion.Trigger>
       </Accordion.Header>
       <ResponsiveAccordionContent>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/DynamicComponent.tsx
@@ -12,6 +12,7 @@ import {
   BoxComponent,
 } from '@strapi/design-system';
 import { Drag, More, Trash, ArrowUp, ArrowDown } from '@strapi/icons';
+import upperFirst from 'lodash/upperFirst';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -271,7 +272,7 @@ const DynamicComponent = ({
               {Object.entries(dynamicComponentsByCategory).map(([category, components]) => (
                 <React.Fragment key={category}>
                   <Menu.Label>
-                    {formatMessage({ id: category, defaultMessage: category })}
+                    {formatMessage({ id: category, defaultMessage: upperFirst(category) })}
                   </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index)}>
@@ -293,7 +294,7 @@ const DynamicComponent = ({
               {Object.entries(dynamicComponentsByCategory).map(([category, components]) => (
                 <React.Fragment key={category}>
                   <Menu.Label>
-                    {formatMessage({ id: category, defaultMessage: category })}
+                    {formatMessage({ id: category, defaultMessage: upperFirst(category) })}
                   </Menu.Label>
                   {components.map(({ displayName, uid }) => (
                     <Menu.Item key={uid} onSelect={() => onAddComponent(uid, index + 1)}>

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/ComponentCategory.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/ComponentCategory.test.tsx
@@ -23,7 +23,7 @@ describe('ComponentCategory', () => {
       ],
     });
 
-    await user.click(getByRole('button', { name: /testing/ }));
+    await user.click(getByRole('button', { name: /testing/i }));
 
     expect(getByRole('button', { name: /myComponent/ })).toBeInTheDocument();
   });
@@ -33,7 +33,7 @@ describe('ComponentCategory', () => {
       category: 'myCategory',
     });
 
-    expect(getByText(/myCategory/)).toBeInTheDocument();
+    expect(getByText(/myCategory/i)).toBeInTheDocument();
   });
 
   it('should call onAddComponent with the componentUid when a ComponentCard is clicked', async () => {
@@ -49,7 +49,7 @@ describe('ComponentCategory', () => {
       ],
     });
 
-    await user.click(getByRole('button', { name: /testing/ }));
+    await user.click(getByRole('button', { name: /testing/i }));
 
     await user.click(getByRole('button', { name: /myComponent/ }));
 

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/ComponentPicker.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/ComponentPicker.test.tsx
@@ -31,7 +31,7 @@ describe('ComponentPicker', () => {
   it('should render the category names by default', () => {
     render();
 
-    expect(screen.getByText('blog')).toBeInTheDocument();
+    expect(screen.getByText('Blog')).toBeInTheDocument();
   });
 
   it('should open the first category of components when isOpen changes to true from false', () => {
@@ -55,8 +55,8 @@ describe('ComponentPicker', () => {
 
     rerender(<Component isOpen />);
 
-    expect(screen.getByRole('button', { name: /blog/ })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /seo/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Blog/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Seo/ })).not.toBeInTheDocument();
   });
 
   it('should call onClickAddComponent with the componentUid when a Component is clicked', async () => {

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/DynamicComponent.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/DynamicZone/tests/DynamicComponent.test.tsx
@@ -204,16 +204,16 @@ describe('DynamicComponent', () => {
 
       await user.click(screen.getByRole('menuitem', { name: 'Add component above' }));
 
-      expect(screen.getByText('blog')).toBeInTheDocument();
-      expect(screen.getByText('seo')).toBeInTheDocument();
+      expect(screen.getByText('Blog')).toBeInTheDocument();
+      expect(screen.getByText('Seo')).toBeInTheDocument();
 
       expect(screen.getByRole('menuitem', { name: 'component' })).toBeInTheDocument();
       expect(screen.getByRole('menuitem', { name: 'metadata' })).toBeInTheDocument();
 
       await user.click(screen.getByRole('menuitem', { name: 'Add component below' }));
 
-      expect(screen.getByText('blog')).toBeInTheDocument();
-      expect(screen.getByText('seo')).toBeInTheDocument();
+      expect(screen.getByText('Blog')).toBeInTheDocument();
+      expect(screen.getByText('Seo')).toBeInTheDocument();
 
       expect(screen.getByRole('menuitem', { name: 'component' })).toBeInTheDocument();
       expect(screen.getByRole('menuitem', { name: 'metadata' })).toBeInTheDocument();


### PR DESCRIPTION
### What does it do?

Capitalizes the component category labels rendered in the dynamic zone (component picker accordion and the "Add component above / below" menus) so they match the Content-Type Builder sidebar, which already uses `upperFirst` on the category.

Files changed:
- `ComponentCategory.tsx` — accordion trigger label
- `DynamicComponent.tsx` — `Menu.Label`s for "Add component above" and "Add component below"
- Updated three test files to match the new capitalized output.

### Why is it needed?

The CTB sidebar displays category names with `upperFirst` (e.g. `Shared`) while the dynamic zone shows the raw slug (`shared`). Reported in #24426 as inconsistent UX. The category slug is the canonical lowercase storage; both surfaces should capitalize it for display.

Closes #24426

### How to test it?

1. Create a content-type with a Dynamic Zone field that accepts components from a category named e.g. `Shared`.
2. In the Content Manager, open an entry with that dynamic zone field.
3. Click "Add a component" — the category label in the picker accordion now shows `Shared` (was `shared`).
4. With an existing component, click "More actions" → "Add component above" / "Add component below" — the category label in the submenu now shows `Shared`.
5. Check the CTB sidebar — already showed `Shared`. Both surfaces now match.

### Related issue(s)/PR(s)

Closes #24426

---
Fixes CPR-400