### PR TITLE
fix(review-workflows): keep stages visible for unsaved locales

### DIFF
--- a/packages/core/review-workflows/server/src/controllers/__tests__/stages.test.ts
+++ b/packages/core/review-workflows/server/src/controllers/__tests__/stages.test.ts
@@ -1,0 +1,132 @@
+jest.mock(
+  '@strapi/utils',
+  () => {
+    const chain = {
+      shape: jest.fn(() => chain),
+      integer: jest.fn(() => chain),
+      min: jest.fn(() => chain),
+      max: jest.fn(() => chain),
+      required: jest.fn(() => chain),
+      nullable: jest.fn(() => chain),
+      oneOf: jest.fn(() => chain),
+      matches: jest.fn(() => chain),
+      of: jest.fn(() => chain),
+      test: jest.fn(() => chain),
+      uniqueProperty: jest.fn(() => chain),
+    };
+
+    const yup = {
+      object: jest.fn(() => chain),
+      number: jest.fn(() => chain),
+      string: jest.fn(() => chain),
+      array: jest.fn(() => chain),
+    };
+
+    return {
+      async: {
+        map: async (items: unknown[], mapper: (item: unknown) => unknown) =>
+          Promise.all(items.map(mapper)),
+      },
+      yup,
+      validateYupSchema: jest.fn(() => async (value: unknown) => value),
+    };
+  },
+  { virtual: true }
+);
+
+import stagesController from '../stages';
+import { getService } from '../../utils';
+
+jest.mock('../../utils', () => ({
+  getService: jest.fn(),
+}));
+
+const mockedGetService = getService as jest.Mock;
+
+describe('review-workflows stages controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listAvailableStages', () => {
+    test('returns workflow metadata instead of 404 when the localized entity does not exist yet', async () => {
+      const workflowStages = [
+        { id: 1, name: 'Draft' },
+        { id: 2, name: 'Review' },
+      ];
+
+      const stagePermissions = {
+        can: jest.fn(),
+      };
+      const workflowService = {
+        count: jest.fn().mockResolvedValue(1),
+        getAssignedWorkflow: jest.fn().mockResolvedValue({ stages: workflowStages }),
+      };
+
+      mockedGetService.mockImplementation((name: string) => {
+        if (name === 'stage-permissions') {
+          return stagePermissions;
+        }
+
+        if (name === 'workflows') {
+          return workflowService;
+        }
+
+        throw new Error(`Unexpected service: ${name}`);
+      });
+
+      (global as any).strapi = {
+        plugins: {
+          'content-manager': {
+            services: {
+              'permission-checker': {
+                create: jest.fn(() => ({
+                  cannot: {
+                    read: jest.fn(() => false),
+                  },
+                })),
+              },
+            },
+          },
+        },
+        apis: {},
+        admin: { services: {} },
+        documents: jest.fn(() => ({
+          findOne: jest.fn().mockResolvedValue(null),
+        })),
+      } as any;
+
+      const ctx = {
+        params: {
+          model_uid: 'api::article.article',
+          id: 'document-id',
+        },
+        request: {
+          query: {
+            locale: 'pt-BR',
+          },
+        },
+        state: {
+          userAbility: {},
+        },
+        forbidden: jest.fn(),
+        throw: jest.fn((status, message) => {
+          throw new Error(`${status}: ${message}`);
+        }),
+      } as any;
+
+      await stagesController.listAvailableStages(ctx);
+
+      expect(ctx.throw).not.toHaveBeenCalled();
+      expect(stagePermissions.can).not.toHaveBeenCalled();
+      expect(ctx.body).toEqual({
+        data: [],
+        meta: {
+          stageCount: workflowStages.length,
+          workflowCount: 1,
+          canTransition: false,
+        },
+      });
+    });
+  });
+});

--- a/packages/core/review-workflows/server/src/controllers/stages.ts
+++ b/packages/core/review-workflows/server/src/controllers/stages.ts
@@ -158,14 +158,7 @@ export default {
       return ctx.forbidden();
     }
 
-    // Load entity
-    const locale = (await validateLocale(query?.locale)) ?? undefined;
-    const [entity, workflowCount, workflowResult] = await Promise.all([
-      strapi.documents(modelUID).findOne({
-        documentId,
-        locale,
-        populate: [ENTITY_STAGE_ATTRIBUTE],
-      }),
+    const [workflowCount, workflowResult] = await Promise.all([
       workflowService.count(),
       workflowService.getAssignedWorkflow(modelUID, {
         populate: { stages: { populate: { permissions: { populate: ['role'] } } } },
@@ -173,8 +166,19 @@ export default {
     ]);
 
     const workflowStages = workflowResult ? workflowResult.stages : [];
+
+    // Load entity
+    const locale = (await validateLocale(query?.locale)) ?? undefined;
+    const entity = await strapi.documents(modelUID).findOne({
+      documentId,
+      locale,
+      populate: [ENTITY_STAGE_ATTRIBUTE],
+    });
+
     const entityStageId = entity?.[ENTITY_STAGE_ATTRIBUTE]?.id;
-    const canTransition = stagePermissions.can(STAGE_TRANSITION_UID, entityStageId);
+    const canTransition = entity
+      ? stagePermissions.can(STAGE_TRANSITION_UID, entityStageId)
+      : false;
 
     const meta = {
       stageCount: workflowStages.length,


### PR DESCRIPTION
### What does it do?

Keeps the Review Workflows stage endpoint from returning 404 when a localized document variant does not exist yet. The endpoint now returns workflow metadata with no available transitions, so the admin panel can keep the stage UI mounted in a disabled state.

Fixes #26115.

### Why is it needed?

Review Workflow stages belong to the workflow, not to each localized entry. When switching to a locale that has not been created yet, the admin still needs the workflow stage count and transition state instead of a hard 404.

### How to test it?

- `yarn test:unit packages/core/review-workflows/server/src/controllers/__tests__/stages.test.ts --runInBand`
- `yarn prettier:code --check packages/core/review-workflows/server/src/controllers/stages.ts packages/core/review-workflows/server/src/controllers/__tests__/stages.test.ts`

Note: package lint via the pre-commit hook currently fails in this local checkout on unrelated admin import resolution errors for existing files under `packages/core/review-workflows/admin/src/*`.

---
Fixes CPR-343