### PR TITLE
fix(upload): refresh media url on replacement

### DIFF
--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -395,6 +395,79 @@ describe('Admin Upload Controller - AI Service Connection', () => {
     });
   });
 
+  describe('replaceFile', () => {
+    it('normalizes single-file arrays before replacing media', async () => {
+      const replacementFile = { filepath: '/tmp/replacement.pdf', originalFilename: 'file-2.pdf' };
+      const replacedFile = { id: 1, name: 'file-2.pdf', url: '/uploads/file-2.pdf' };
+
+      mockContext.query = { id: '1' };
+      mockContext.request = {
+        body: {
+          fileInfo: ['{"name":"file-2.pdf","folder":null}'],
+        },
+        files: {
+          files: [replacementFile],
+        },
+      } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {
+          fileInfo: {
+            name: 'file-2.pdf',
+            folder: null,
+          },
+        },
+        errors: [],
+      });
+      mockValidateUploadBody.mockResolvedValue({
+        fileInfo: {
+          name: 'file-2.pdf',
+          folder: null,
+          alternativeText: '',
+          caption: '',
+          focalPoint: null,
+        },
+      });
+      uploadService.replace.mockResolvedValue(replacedFile);
+
+      await adminUploadController.replaceFile(mockContext as Context);
+
+      expect(mockPrepareUploadRequest).toHaveBeenCalledWith(
+        replacementFile,
+        mockContext.request!.body,
+        strapi
+      );
+      expect(uploadService.replace).toHaveBeenCalledWith(
+        '1',
+        {
+          data: expect.objectContaining({
+            fileInfo: expect.objectContaining({ name: 'file-2.pdf' }),
+          }),
+          file: replacementFile,
+        },
+        { user: { id: 1 } }
+      );
+      expect(mockContext.body).toEqual({ ...replacedFile, cleaned: true });
+    });
+
+    it('rejects multiple files when replacing media', async () => {
+      mockContext.query = { id: '1' };
+      mockContext.request = {
+        body: {},
+        files: {
+          files: [{ filepath: '/tmp/one.pdf' }, { filepath: '/tmp/two.pdf' }],
+        },
+      } as any;
+
+      await expect(adminUploadController.replaceFile(mockContext as Context)).rejects.toThrow(
+        'Cannot replace a file with multiple ones'
+      );
+      expect(mockPrepareUploadRequest).not.toHaveBeenCalled();
+      expect(uploadService.replace).not.toHaveBeenCalled();
+    });
+  });
+
   describe('uploadFiles - AI Service Connection', () => {
     it('should call AI processFiles when service is enabled', async () => {
       mockAiMetadataService.isEnabled.mockReturnValue(true);

--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -72,7 +72,7 @@ export default {
     const {
       state: { userAbility, user },
       query: { id },
-      request: { body, files: { files } = {} },
+      request: { body, files: { files: filesInput } = {} },
     } = ctx;
 
     if (typeof id !== 'string') {
@@ -87,15 +87,17 @@ export default {
       id
     );
 
-    if (Array.isArray(files)) {
+    if (Array.isArray(filesInput) && filesInput.length > 1) {
       throw new errors.ApplicationError('Cannot replace a file with multiple ones');
     }
+
+    const file = Array.isArray(filesInput) ? filesInput[0] : filesInput;
 
     const {
       validFiles,
       filteredBody,
       errors: validationErrors,
-    } = await prepareUploadRequest(files, body, strapi);
+    } = await prepareUploadRequest(file, body, strapi);
     if (validFiles.length === 0) {
       throw new errors.ValidationError(validationErrors[0].message);
     }

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -107,18 +107,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         request: { body, files: { files: filesInput } = {} },
       } = ctx;
 
+      // cannot replace with more than one file
+      if (Array.isArray(filesInput) && filesInput.length > 1) {
+        throw new ValidationError('Cannot replace a file with multiple ones');
+      }
+
+      const file = Array.isArray(filesInput) ? filesInput[0] : filesInput;
+
       const {
         validFiles,
         filteredBody,
         errors: validationErrors,
-      } = await prepareUploadRequest(filesInput, body, strapi);
+      } = await prepareUploadRequest(file, body, strapi);
       if (validFiles.length === 0) {
         throw new errors.ValidationError(validationErrors[0].message);
-      }
-
-      // cannot replace with more than one file
-      if (Array.isArray(filesInput)) {
-        throw new ValidationError('Cannot replace a file with multiple ones');
       }
 
       if (!id || (typeof id !== 'string' && typeof id !== 'number')) {

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -412,12 +412,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const { fileInfo } = data;
       fileData = await enhanceAndValidateFile(file, fileInfo);
 
-      // keep a constant hash and extension so the file url doesn't change when the file is replaced
-      _.assign(fileData, {
-        hash: dbFile.hash,
-        ext: dbFile.ext,
-      });
-
       // execute delete function of the provider
       if (dbFile.provider === config.provider) {
         await strapi.plugin('upload').provider.delete(dbFile);

--- a/tests/api/core/upload/admin/file-folder.test.api.js
+++ b/tests/api/core/upload/admin/file-folder.test.api.js
@@ -141,9 +141,10 @@ describe('File', () => {
   describe('Update info', () => {
     describe('Move a file from a folder to another folder', () => {
       test('when replacing the file', async () => {
+        const previousFile = data.files[1];
         const res = await rq({
           method: 'POST',
-          url: `/upload?id=${data.files[1].id}`,
+          url: `/upload?id=${previousFile.id}`,
           formData: {
             files: fs.createReadStream(path.join(__dirname, '../utils/rec.pdf')),
             fileInfo: JSON.stringify({ folder: data.folders[1].id }),
@@ -151,7 +152,7 @@ describe('File', () => {
         });
 
         expect(res.statusCode).toBe(200);
-        expect(res.body).toMatchObject({ id: data.files[1].id });
+        expect(res.body).toMatchObject({ id: previousFile.id });
 
         const { body: file } = await rq({
           method: 'GET',
@@ -161,7 +162,7 @@ describe('File', () => {
         expect(file).toMatchObject({
           id: expect.anything(),
           name: 'rec.pdf',
-          ext: '.jpg',
+          ext: '.pdf',
           mime: 'application/pdf',
           hash: expect.any(String),
           size: expect.any(Number),
@@ -172,6 +173,8 @@ describe('File', () => {
           folder: { id: data.folders[1].id },
           folderPath: data.folders[1].path,
         });
+        expect(file.hash).not.toBe(previousFile.hash);
+        expect(file.url).not.toBe(previousFile.url);
         data.files[1] = file;
       });
 
@@ -195,7 +198,7 @@ describe('File', () => {
         expect(file).toMatchObject({
           id: expect.anything(),
           name: 'rec.pdf',
-          ext: '.jpg',
+          ext: '.pdf',
           mime: 'application/pdf',
           hash: expect.any(String),
           size: expect.any(Number),
@@ -232,7 +235,7 @@ describe('File', () => {
         expect(file).toMatchObject({
           id: expect.anything(),
           name: 'rec.pdf',
-          ext: '.jpg',
+          ext: '.pdf',
           mime: 'application/pdf',
           hash: expect.any(String),
           size: expect.any(Number),
@@ -266,7 +269,7 @@ describe('File', () => {
         expect(file).toMatchObject({
           id: expect.anything(),
           name: 'rec.pdf',
-          ext: '.jpg',
+          ext: '.pdf',
           mime: 'application/pdf',
           hash: expect.any(String),
           size: expect.any(Number),
@@ -337,7 +340,7 @@ describe('File', () => {
         expect(file).toMatchObject({
           id: expect.anything(),
           name: 'rec.pdf',
-          ext: '.jpg',
+          ext: '.pdf',
           mime: 'application/pdf',
           hash: expect.any(String),
           size: expect.any(Number),


### PR DESCRIPTION
### What does it do?

Refreshes the media hash and extension when a file is replaced, while still deleting the previous provider object and generated formats. It also accepts single-file multipart arrays for replacement uploads while continuing to reject multi-file replacements.

Fixes #26207.
Fixes #26387.

### Why is it needed?

When the previous hash and extension are reused, S3/CDN/browser caches can continue serving the old asset even though the database metadata has changed. A replacement upload should produce a new cache key so consumers receive the new file content.

Some multipart clients also submit a single replacement file as a one-item array, which should be normalized before validation.

### How to test it?

- `yarn workspace @strapi/upload test:unit server/src/controllers/__tests__/admin-upload.test.ts --runInBand`
- `yarn test:api --no-generate-app tests/api/core/upload/admin/file-folder.test.api.js`

Note: package lint via the pre-commit hook currently fails in this local checkout on unrelated admin import resolution errors for existing files under `packages/core/upload/admin/src/*`. The backend typecheck also hits existing unrelated upload package TS errors.

---
Fixes CPR-344