### PR TITLE
chore(deps): use workspace:* for private workspace deps

### DIFF
--- a/.github/actions/check-pr-status/package.json
+++ b/.github/actions/check-pr-status/package.json
@@ -14,6 +14,7 @@
     "@actions/github": "6.0.0"
   },
   "devDependencies": {
-    "@vercel/ncc": "0.38.2"
+    "@vercel/ncc": "0.38.2",
+    "eslint-config-custom": "workspace:*"
   }
 }

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -86,10 +86,10 @@
   "devDependencies": {
     "@reduxjs/toolkit": "1.9.7",
     "@testing-library/jest-dom": "6.4.5",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "jest-environment-jsdom": "29.6.1",
     "styled-components": "6.4.1",
-    "tsconfig": "5.46.0"
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.9.7",

--- a/packages/cli/cloud/package.json
+++ b/packages/cli/cloud/package.json
@@ -73,8 +73,8 @@
     "@types/cli-progress": "3.11.5",
     "@types/eventsource": "1.1.15",
     "@types/lodash": "^4.14.191",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -70,8 +70,8 @@
     "@types/async-retry": "^1",
     "@types/fs-extra": "11.0.4",
     "@types/inquirer": "9.0.9",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/admin/package.json
+++ b/packages/core/admin/package.json
@@ -150,7 +150,7 @@
     "zod": "3.25.67"
   },
   "devDependencies": {
-    "@strapi/admin-test-utils": "5.46.0",
+    "@strapi/admin-test-utils": "workspace:*",
     "@strapi/data-transfer": "5.46.0",
     "@types/codemirror5": "npm:@types/codemirror@^5.60.15",
     "@types/fs-extra": "11.0.4",
@@ -169,12 +169,14 @@
     "@types/react-window": "1.8.8",
     "@types/sanitize-html": "2.13.0",
     "@vitejs/plugin-react-swc": "3.6.0",
+    "eslint-config-custom": "workspace:*",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
+    "tsconfig": "workspace:*",
     "vite": "5.4.21",
     "vite-plugin-dts": "^4.3.0"
   },

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -115,12 +115,14 @@
     "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191",
     "@types/prismjs": "1.26.5",
+    "eslint-config-custom": "workspace:*",
     "koa-body": "6.0.1",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -80,12 +80,13 @@
   },
   "devDependencies": {
     "@strapi/admin": "5.46.0",
-    "@strapi/admin-test-utils": "5.46.0",
+    "@strapi/admin-test-utils": "workspace:*",
     "@strapi/content-manager": "5.46.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
     "@types/koa": "2.13.4",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "msw": "2.13.4",
     "react": "18.3.1",
@@ -93,6 +94,7 @@
     "react-query": "3.39.3",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },
   "peerDependencies": {

--- a/packages/core/content-type-builder/package.json
+++ b/packages/core/content-type-builder/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@strapi/admin": "5.46.0",
+    "@strapi/admin-test-utils": "workspace:*",
     "@strapi/types": "5.46.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.0",
@@ -101,13 +102,15 @@
     "@types/fs-extra": "11.0.4",
     "@types/micromatch": "^4.0.9",
     "@types/pluralize": "0.0.32",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-query": "3.39.3",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -133,11 +133,11 @@
     "@types/node": "24.10.0",
     "@types/node-schedule": "2.1.7",
     "@types/statuses": "2.0.1",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "supertest": "7.2.2",
-    "tsconfig": "5.46.0",
+    "tsconfig": "workspace:*",
     "vitest": "catalog:",
-    "vitest-config": "5.46.0"
+    "vitest-config": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -81,9 +81,11 @@
     "@types/stream-json": "1.7.3",
     "@types/tar-stream": "2.2.2",
     "@types/ws": "^8.5.4",
+    "eslint-config-custom": "workspace:*",
     "knex": "3.0.1",
     "koa": "2.16.4",
     "rimraf": "6.1.3",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },
   "engines": {

--- a/packages/core/database/package.json
+++ b/packages/core/database/package.json
@@ -55,8 +55,8 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/email/package.json
+++ b/packages/core/email/package.json
@@ -78,12 +78,14 @@
     "@testing-library/react": "16.3.0",
     "@types/koa": "2.13.4",
     "@types/lodash": "^4.14.191",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/openapi/package.json
+++ b/packages/core/openapi/package.json
@@ -63,6 +63,8 @@
   },
   "devDependencies": {
     "@strapi/types": "5.46.0",
-    "@types/debug": "^4"
+    "@types/debug": "^4",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   }
 }

--- a/packages/core/permissions/package.json
+++ b/packages/core/permissions/package.json
@@ -50,8 +50,8 @@
     "sift": "16.0.1"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/core/review-workflows/package.json
+++ b/packages/core/review-workflows/package.json
@@ -78,11 +78,13 @@
     "@strapi/content-manager": "5.46.0",
     "@strapi/types": "5.46.0",
     "@testing-library/react": "16.3.0",
+    "eslint-config-custom": "workspace:*",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -180,11 +180,11 @@
     "@types/node": "24.10.0",
     "@types/webpack-bundle-analyzer": "4.7.0",
     "@types/webpack-hot-middleware": "2.25.9",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "jest": "29.6.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "tsconfig": "5.46.0",
+    "tsconfig": "workspace:*",
     "yalc": "1.0.0-pre.53"
   },
   "peerDependencies": {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -68,9 +68,9 @@
     "@types/koa": "2.13.4",
     "@types/koa__router": "12.0.0",
     "@types/node-schedule": "2.1.7",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "lodash": "4.18.1",
-    "tsconfig": "5.46.0",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5",
     "undici": "6.25.0"
   },

--- a/packages/core/upload/package.json
+++ b/packages/core/upload/package.json
@@ -111,6 +111,7 @@
     "@types/koa": "2.13.4",
     "@types/koa-range": "0.3.5",
     "@types/koa-static": "4.0.2",
+    "eslint-config-custom": "workspace:*",
     "formidable": "3.5.4",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
@@ -118,7 +119,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -62,10 +62,10 @@
     "@types/http-errors": "2.0.4",
     "@types/koa": "2.13.4",
     "@types/node": "24.10.0",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
-    "tsconfig": "5.46.0"
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/generators/generators/package.json
+++ b/packages/generators/generators/package.json
@@ -64,9 +64,9 @@
     "@types/fs-extra": "11.0.4",
     "@types/jscodeshift": "17.3.0",
     "copyfiles": "2.4.1",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "outdent": "^0.8.0",
-    "tsconfig": "5.46.0"
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/plugins/cloud/package.json
+++ b/packages/plugins/cloud/package.json
@@ -56,12 +56,12 @@
   "devDependencies": {
     "@strapi/admin": "5.46.0",
     "@strapi/strapi": "5.46.0",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
-    "tsconfig": "5.46.0",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },
   "peerDependencies": {

--- a/packages/plugins/color-picker/package.json
+++ b/packages/plugins/color-picker/package.json
@@ -70,10 +70,12 @@
     "@strapi/strapi": "5.46.0",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
+    "eslint-config-custom": "workspace:*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },
   "peerDependencies": {

--- a/packages/plugins/documentation/package.json
+++ b/packages/plugins/documentation/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
-    "@strapi/admin-test-utils": "5.46.0",
+    "@strapi/admin-test-utils": "workspace:*",
     "@strapi/strapi": "5.46.0",
     "@strapi/types": "5.46.0",
     "@testing-library/react": "16.3.0",
@@ -91,6 +91,7 @@
     "@types/koa": "2.13.4",
     "@types/koa-session": "6.4.1",
     "@types/swagger-ui-dist": "3.30.4",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "koa-body": "6.0.1",
     "koa-session": "6.4.0",
@@ -99,7 +100,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -83,13 +83,13 @@
     "@types/koa-bodyparser": "4.3.12",
     "@types/koa__cors": "5.0.0",
     "cross-env": "^7.0.3",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
     "styled-components": "6.4.1",
-    "tsconfig": "5.46.0",
+    "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },
   "peerDependencies": {

--- a/packages/plugins/i18n/package.json
+++ b/packages/plugins/i18n/package.json
@@ -73,19 +73,21 @@
   },
   "devDependencies": {
     "@strapi/admin": "5.46.0",
-    "@strapi/admin-test-utils": "5.46.0",
+    "@strapi/admin-test-utils": "workspace:*",
     "@strapi/content-manager": "5.46.0",
     "@strapi/database": "5.46.0",
     "@strapi/types": "5.46.0",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
+    "eslint-config-custom": "workspace:*",
     "koa": "2.16.4",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-query": "3.39.3",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/admin": "^5.0.0",

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -63,10 +63,12 @@
   },
   "devDependencies": {
     "@strapi/strapi": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "styled-components": "6.4.1"
+    "styled-components": "6.4.1",
+    "tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "@strapi/strapi": "^5.0.0",

--- a/packages/plugins/users-permissions/package.json
+++ b/packages/plugins/users-permissions/package.json
@@ -79,6 +79,7 @@
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
+    "eslint-config-custom": "workspace:*",
     "msw": "2.13.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/providers/email-amazon-ses/package.json
+++ b/packages/providers/email-amazon-ses/package.json
@@ -49,8 +49,8 @@
     "node-ses": "^3.0.3"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/email-mailgun/package.json
+++ b/packages/providers/email-mailgun/package.json
@@ -52,8 +52,8 @@
     "mailgun.js": "10.2.1"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/email-nodemailer/package.json
+++ b/packages/providers/email-nodemailer/package.json
@@ -76,8 +76,8 @@
   },
   "devDependencies": {
     "@types/nodemailer": "7.0.11",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/email-sendgrid/package.json
+++ b/packages/providers/email-sendgrid/package.json
@@ -49,8 +49,8 @@
     "@strapi/utils": "5.46.0"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/email-sendmail/package.json
+++ b/packages/providers/email-sendmail/package.json
@@ -49,8 +49,8 @@
   },
   "devDependencies": {
     "@types/nodemailer": "7.0.11",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/upload-aws-s3/package.json
+++ b/packages/providers/upload-aws-s3/package.json
@@ -56,8 +56,8 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.2",
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/upload-cloudinary/package.json
+++ b/packages/providers/upload-cloudinary/package.json
@@ -50,8 +50,8 @@
     "into-stream": "^5.1.0"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/providers/upload-local/package.json
+++ b/packages/providers/upload-local/package.json
@@ -53,9 +53,9 @@
     "@strapi/types": "5.46.0",
     "@types/fs-extra": "11.0.4",
     "@types/jest": "29.5.2",
-    "eslint-config-custom": "5.46.0",
+    "eslint-config-custom": "workspace:*",
     "memfs": "4.6.0",
-    "tsconfig": "5.46.0"
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/utils/logger/package.json
+++ b/packages/utils/logger/package.json
@@ -45,8 +45,8 @@
     "winston": "3.10.0"
   },
   "devDependencies": {
-    "eslint-config-custom": "5.46.0",
-    "tsconfig": "5.46.0"
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/utils/typescript/package.json
+++ b/packages/utils/typescript/package.json
@@ -47,7 +47,8 @@
     "typescript": "5.4.5"
   },
   "devDependencies": {
-    "@types/fs-extra": "11.0.4"
+    "@types/fs-extra": "11.0.4",
+    "eslint-config-custom": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/packages/utils/upgrade/package.json
+++ b/packages/utils/upgrade/package.json
@@ -86,8 +86,9 @@
     "@strapi/types": "5.46.0",
     "@types/fs-extra": "11.0.4",
     "@types/jscodeshift": "17.3.0",
-    "eslint-config-custom": "5.46.0",
-    "rimraf": "6.1.3"
+    "eslint-config-custom": "workspace:*",
+    "rimraf": "6.1.3",
+    "tsconfig": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0 <=24.x.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9270,7 +9270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/admin-test-utils@npm:5.46.0, @strapi/admin-test-utils@workspace:*, @strapi/admin-test-utils@workspace:packages/admin-test-utils":
+"@strapi/admin-test-utils@workspace:*, @strapi/admin-test-utils@workspace:packages/admin-test-utils":
   version: 0.0.0-use.local
   resolution: "@strapi/admin-test-utils@workspace:packages/admin-test-utils"
   dependencies:
@@ -9278,12 +9278,12 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@testing-library/jest-dom": "npm:6.4.5"
     "@testing-library/react": "npm:16.3.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     jest-environment-jsdom: "npm:29.6.1"
     jest-styled-components: "npm:7.1.1"
     react-query: "npm:3.39.3"
     styled-components: "npm:6.4.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     whatwg-fetch: "npm:3.6.2"
   peerDependencies:
     "@reduxjs/toolkit": ^1.9.7
@@ -9302,7 +9302,7 @@ __metadata:
     "@radix-ui/react-context": "npm:1.0.1"
     "@radix-ui/react-toolbar": "npm:1.0.4"
     "@reduxjs/toolkit": "npm:1.9.7"
-    "@strapi/admin-test-utils": "npm:5.46.0"
+    "@strapi/admin-test-utils": "workspace:*"
     "@strapi/data-transfer": "npm:5.46.0"
     "@strapi/design-system": "npm:2.2.0"
     "@strapi/icons": "npm:2.2.0"
@@ -9337,6 +9337,7 @@ __metadata:
     codemirror5: "npm:codemirror@^5.65.11"
     cross-env: "npm:^7.0.3"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     fast-deep-equal: "npm:3.1.3"
     formik: "npm:2.4.5"
@@ -9382,6 +9383,7 @@ __metadata:
     sift: "npm:16.0.1"
     sonner: "npm:2.0.7"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
     use-context-selector: "npm:1.4.1"
     vite: "npm:5.4.21"
@@ -9420,7 +9422,7 @@ __metadata:
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
     commander: "npm:8.3.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     eventsource: "npm:2.0.2"
     fast-safe-stringify: "npm:2.1.1"
     fs-extra: "npm:11.3.4"
@@ -9433,7 +9435,7 @@ __metadata:
     ora: "npm:5.4.1"
     pkg-up: "npm:3.1.0"
     tar: "npm:7.5.11"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     xdg-app-paths: "npm:8.3.0"
     yup: "npm:0.32.9"
   bin:
@@ -9463,6 +9465,7 @@ __metadata:
     "@types/prismjs": "npm:1.26.5"
     codemirror5: "npm:codemirror@^5.65.11"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "workspace:*"
     fractional-indexing: "npm:3.2.0"
     highlight.js: "npm:^10.4.1"
     immer: "npm:9.0.21"
@@ -9497,6 +9500,7 @@ __metadata:
     slate-history: "npm:0.93.0"
     slate-react: "npm:0.98.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -9513,7 +9517,7 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/admin": "npm:5.46.0"
-    "@strapi/admin-test-utils": "npm:5.46.0"
+    "@strapi/admin-test-utils": "workspace:*"
     "@strapi/content-manager": "npm:5.46.0"
     "@strapi/database": "npm:5.46.0"
     "@strapi/design-system": "npm:2.2.0"
@@ -9526,6 +9530,7 @@ __metadata:
     "@types/koa": "npm:2.13.4"
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:2.0.1"
+    eslint-config-custom: "workspace:*"
     formik: "npm:2.4.5"
     koa: "npm:2.16.4"
     lodash: "npm:4.18.1"
@@ -9538,6 +9543,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -9562,6 +9568,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@sindresorhus/slugify": "npm:1.1.0"
     "@strapi/admin": "npm:5.46.0"
+    "@strapi/admin-test-utils": "workspace:*"
     "@strapi/design-system": "npm:2.2.0"
     "@strapi/generators": "npm:5.46.0"
     "@strapi/icons": "npm:2.2.0"
@@ -9575,6 +9582,7 @@ __metadata:
     "@types/pluralize": "npm:0.0.32"
     ai: "npm:5.0.52"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
     jszip: "npm:^3.10.1"
@@ -9593,6 +9601,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   peerDependencies:
@@ -9650,7 +9659,7 @@ __metadata:
     debug: "npm:4.3.4"
     delegates: "npm:1.0.0"
     dotenv: "npm:16.6.1"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.3.4"
     glob: "npm:13.0.6"
@@ -9681,11 +9690,11 @@ __metadata:
     semver: "npm:7.7.4"
     statuses: "npm:2.0.1"
     supertest: "npm:7.2.2"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
     undici: "npm:6.25.0"
     vitest: "catalog:"
-    vitest-config: "npm:5.46.0"
+    vitest-config: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   languageName: unknown
@@ -9712,6 +9721,7 @@ __metadata:
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
     knex: "npm:3.0.1"
@@ -9725,6 +9735,7 @@ __metadata:
     stream-json: "npm:1.8.0"
     tar: "npm:7.5.11"
     tar-stream: "npm:2.2.0"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
     ws: "npm:8.17.1"
   languageName: unknown
@@ -9740,12 +9751,12 @@ __metadata:
     ajv: "npm:8.18.0"
     date-fns: "npm:2.30.0"
     debug: "npm:4.3.4"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     knex: "npm:3.0.1"
     lodash: "npm:4.18.1"
     semver: "npm:7.7.4"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     umzug: "npm:3.8.1"
   languageName: unknown
   linkType: soft
@@ -9801,6 +9812,7 @@ __metadata:
     "@testing-library/react": "npm:16.3.0"
     "@types/koa": "npm:2.13.4"
     "@types/lodash": "npm:^4.14.191"
+    eslint-config-custom: "workspace:*"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
     koa2-ratelimit: "npm:^1.1.3"
@@ -9811,6 +9823,7 @@ __metadata:
     react-query: "npm:3.39.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   peerDependencies:
@@ -9865,7 +9878,7 @@ __metadata:
     "@types/jscodeshift": "npm:17.3.0"
     chalk: "npm:4.1.2"
     copyfiles: "npm:2.4.1"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     handlebars: "npm:4.7.9"
     jscodeshift: "npm:17.3.0"
@@ -9873,7 +9886,7 @@ __metadata:
     outdent: "npm:^0.8.0"
     plop: "npm:4.0.5"
     pluralize: "npm:8.0.0"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -9883,7 +9896,7 @@ __metadata:
   dependencies:
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/admin": "npm:5.46.0"
-    "@strapi/admin-test-utils": "npm:5.46.0"
+    "@strapi/admin-test-utils": "workspace:*"
     "@strapi/content-manager": "npm:5.46.0"
     "@strapi/database": "npm:5.46.0"
     "@strapi/design-system": "npm:2.2.0"
@@ -9892,6 +9905,7 @@ __metadata:
     "@strapi/utils": "npm:5.46.0"
     "@testing-library/react": "npm:16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
+    eslint-config-custom: "workspace:*"
     koa: "npm:2.16.4"
     lodash: "npm:4.18.1"
     msw: "npm:2.13.4"
@@ -9903,6 +9917,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   peerDependencies:
@@ -9930,9 +9945,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@strapi/logger@workspace:packages/utils/logger"
   dependencies:
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     lodash: "npm:4.18.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     winston: "npm:3.10.0"
   languageName: unknown
   linkType: soft
@@ -9944,7 +9959,9 @@ __metadata:
     "@strapi/types": "npm:5.46.0"
     "@types/debug": "npm:^4"
     debug: "npm:4.3.4"
+    eslint-config-custom: "workspace:*"
     openapi-types: "npm:12.1.3"
+    tsconfig: "workspace:*"
     zod: "npm:3.25.67"
   languageName: unknown
   linkType: soft
@@ -9955,11 +9972,11 @@ __metadata:
   dependencies:
     "@casl/ability": "npm:6.7.5"
     "@strapi/utils": "npm:5.46.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     lodash: "npm:4.18.1"
     qs: "npm:6.15.0"
     sift: "npm:16.0.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -9971,13 +9988,13 @@ __metadata:
     "@strapi/design-system": "npm:2.2.0"
     "@strapi/icons": "npm:2.2.0"
     "@strapi/strapi": "npm:5.46.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -9998,12 +10015,14 @@ __metadata:
     "@strapi/strapi": "npm:5.46.0"
     "@testing-library/react": "npm:16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
+    eslint-config-custom: "workspace:*"
     react: "npm:18.3.1"
     react-colorful: "npm:5.6.1"
     react-dom: "npm:18.3.1"
     react-intl: "npm:6.6.2"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
@@ -10021,7 +10040,7 @@ __metadata:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
     "@reduxjs/toolkit": "npm:1.9.7"
     "@strapi/admin": "npm:5.46.0"
-    "@strapi/admin-test-utils": "npm:5.46.0"
+    "@strapi/admin-test-utils": "workspace:*"
     "@strapi/design-system": "npm:2.2.0"
     "@strapi/icons": "npm:2.2.0"
     "@strapi/strapi": "npm:5.46.0"
@@ -10035,6 +10054,7 @@ __metadata:
     "@types/swagger-ui-dist": "npm:3.30.4"
     bcryptjs: "npm:2.4.3"
     cheerio: "npm:^1.0.0"
+    eslint-config-custom: "workspace:*"
     formik: "npm:2.4.5"
     fs-extra: "npm:11.3.4"
     immer: "npm:9.0.21"
@@ -10052,6 +10072,7 @@ __metadata:
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
     swagger-ui-dist: "npm:4.19.0"
+    tsconfig: "workspace:*"
     yaml: "npm:1.10.3"
     yup: "npm:0.32.9"
   peerDependencies:
@@ -10081,7 +10102,7 @@ __metadata:
     "@types/koa-bodyparser": "npm:4.3.12"
     "@types/koa__cors": "npm:5.0.0"
     cross-env: "npm:^7.0.3"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     graphql: "npm:^16.8.1"
     graphql-depth-limit: "npm:^1.1.0"
     graphql-playground-middleware-koa: "npm:^1.6.21"
@@ -10096,7 +10117,7 @@ __metadata:
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
@@ -10115,10 +10136,12 @@ __metadata:
     "@strapi/design-system": "npm:2.2.0"
     "@strapi/icons": "npm:2.2.0"
     "@strapi/strapi": "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
   peerDependencies:
     "@strapi/strapi": ^5.0.0
     react: ^17.0.0 || ^18.0.0
@@ -10140,6 +10163,7 @@ __metadata:
     "@testing-library/react": "npm:16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
     bcryptjs: "npm:2.4.3"
+    eslint-config-custom: "workspace:*"
     formik: "npm:2.4.5"
     grant: "npm:5.4.24"
     immer: "npm:9.0.21"
@@ -10175,9 +10199,9 @@ __metadata:
   resolution: "@strapi/provider-email-amazon-ses@workspace:packages/providers/email-amazon-ses"
   dependencies:
     "@strapi/utils": "npm:5.46.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     node-ses: "npm:^3.0.3"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10186,10 +10210,10 @@ __metadata:
   resolution: "@strapi/provider-email-mailgun@workspace:packages/providers/email-mailgun"
   dependencies:
     "@strapi/utils": "npm:5.46.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     form-data: "npm:4.0.4"
     mailgun.js: "npm:10.2.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10198,9 +10222,9 @@ __metadata:
   resolution: "@strapi/provider-email-nodemailer@workspace:packages/providers/email-nodemailer"
   dependencies:
     "@types/nodemailer": "npm:7.0.11"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     nodemailer: "npm:8.0.5"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10210,8 +10234,8 @@ __metadata:
   dependencies:
     "@sendgrid/mail": "npm:8.1.3"
     "@strapi/utils": "npm:5.46.0"
-    eslint-config-custom: "npm:5.46.0"
-    tsconfig: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10220,9 +10244,9 @@ __metadata:
   resolution: "@strapi/provider-email-sendmail@workspace:packages/providers/email-sendmail"
   dependencies:
     "@types/nodemailer": "npm:7.0.11"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     nodemailer: "npm:8.0.5"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10235,9 +10259,9 @@ __metadata:
     "@aws-sdk/s3-request-presigner": "npm:3.1023.0"
     "@aws-sdk/types": "npm:3.973.6"
     "@types/jest": "npm:29.5.2"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     lodash: "npm:4.18.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10247,9 +10271,9 @@ __metadata:
   dependencies:
     "@strapi/utils": "npm:5.46.0"
     cloudinary: "npm:^2.7.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     into-stream: "npm:^5.1.0"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10261,10 +10285,10 @@ __metadata:
     "@strapi/utils": "npm:5.46.0"
     "@types/fs-extra": "npm:11.0.4"
     "@types/jest": "npm:29.5.2"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     memfs: "npm:4.6.0"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10280,6 +10304,7 @@ __metadata:
     "@strapi/types": "npm:5.46.0"
     "@strapi/utils": "npm:5.46.0"
     "@testing-library/react": "npm:16.3.0"
+    eslint-config-custom: "workspace:*"
     fractional-indexing: "npm:3.2.0"
     msw: "npm:2.13.4"
     react: "npm:18.3.1"
@@ -10291,6 +10316,7 @@ __metadata:
     react-redux: "npm:8.1.3"
     react-router-dom: "npm:6.30.3"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
   peerDependencies:
     "@strapi/admin": ^5.0.0
@@ -10380,7 +10406,7 @@ __metadata:
     dotenv: "npm:16.6.1"
     esbuild-loader: "npm:4.4.3"
     esbuild-register: "npm:3.6.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     fork-ts-checker-webpack-plugin: "npm:8.0.0"
     fs-extra: "npm:11.3.4"
@@ -10403,7 +10429,7 @@ __metadata:
     resolve-from: "npm:5.0.0"
     semver: "npm:7.7.4"
     style-loader: "npm:3.3.4"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     typescript: "npm:5.4.5"
     vite: "npm:5.4.21"
     webpack: "npm:^5.90.3"
@@ -10450,13 +10476,13 @@ __metadata:
     "@types/koa__router": "npm:12.0.0"
     "@types/node-schedule": "npm:2.1.7"
     commander: "npm:8.3.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     json-logic-js: "npm:2.0.5"
     koa: "npm:2.16.4"
     koa-body: "npm:6.0.1"
     lodash: "npm:4.18.1"
     node-schedule: "npm:2.1.1"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     typedoc: "npm:0.28.19"
     typedoc-github-wiki-theme: "npm:2.1.0"
     typedoc-plugin-markdown: "npm:4.11.0"
@@ -10473,6 +10499,7 @@ __metadata:
     "@types/fs-extra": "npm:11.0.4"
     chalk: "npm:4.1.2"
     cli-table3: "npm:0.6.5"
+    eslint-config-custom: "workspace:*"
     fs-extra: "npm:11.3.4"
     lodash: "npm:4.18.1"
     prettier: "npm:3.3.3"
@@ -10524,7 +10551,7 @@ __metadata:
     cli-table3: "npm:0.6.5"
     commander: "npm:8.3.0"
     esbuild-register: "npm:3.6.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     fast-glob: "npm:3.3.2"
     fs-extra: "npm:11.3.4"
@@ -10536,6 +10563,7 @@ __metadata:
     rimraf: "npm:6.1.3"
     semver: "npm:7.7.4"
     simple-git: "npm:3.36.0"
+    tsconfig: "workspace:*"
     undici: "npm:6.25.0"
   bin:
     upgrade: ./bin/upgrade.js
@@ -10568,6 +10596,7 @@ __metadata:
     byte-size: "npm:8.1.1"
     cropperjs: "npm:1.6.1"
     date-fns: "npm:2.30.0"
+    eslint-config-custom: "workspace:*"
     file-type: "npm:21.3.4"
     formidable: "npm:3.5.4"
     formik: "npm:2.4.5"
@@ -10592,6 +10621,7 @@ __metadata:
     react-select: "npm:5.8.0"
     sharp: "npm:0.33.5"
     styled-components: "npm:6.4.1"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   peerDependencies:
@@ -10612,7 +10642,7 @@ __metadata:
     "@types/koa": "npm:2.13.4"
     "@types/node": "npm:24.10.0"
     date-fns: "npm:2.30.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     http-errors: "npm:2.0.0"
     koa: "npm:2.16.4"
@@ -10621,7 +10651,7 @@ __metadata:
     node-machine-id: "npm:1.1.12"
     p-map: "npm:4.0.0"
     preferred-pm: "npm:3.1.3"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
     yup: "npm:0.32.9"
     zod: "npm:3.25.67"
   languageName: unknown
@@ -14823,6 +14853,7 @@ __metadata:
     "@actions/core": "npm:1.11.1"
     "@actions/github": "npm:6.0.0"
     "@vercel/ncc": "npm:0.38.2"
+    eslint-config-custom: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -15740,7 +15771,7 @@ __metadata:
     async-retry: "npm:1.3.3"
     chalk: "npm:4.1.2"
     commander: "npm:8.3.0"
-    eslint-config-custom: "npm:5.46.0"
+    eslint-config-custom: "workspace:*"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.3.4"
     inquirer: "npm:9.3.8"
@@ -15751,7 +15782,7 @@ __metadata:
     semver: "npm:7.7.4"
     sort-package-json: "npm:2.10.0"
     tar: "npm:7.5.11"
-    tsconfig: "npm:5.46.0"
+    tsconfig: "workspace:*"
   bin:
     create-strapi-app: ./bin/index.js
   languageName: unknown
@@ -17571,7 +17602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-custom@npm:5.46.0, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
+"eslint-config-custom@workspace:*, eslint-config-custom@workspace:packages/utils/eslint-config-custom":
   version: 0.0.0-use.local
   resolution: "eslint-config-custom@workspace:packages/utils/eslint-config-custom"
   languageName: unknown
@@ -30296,7 +30327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig@npm:5.46.0, tsconfig@workspace:packages/utils/tsconfig":
+"tsconfig@workspace:*, tsconfig@workspace:packages/utils/tsconfig":
   version: 0.0.0-use.local
   resolution: "tsconfig@workspace:packages/utils/tsconfig"
   dependencies:
@@ -31420,7 +31451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest-config@npm:5.46.0, vitest-config@workspace:packages/utils/vitest-config":
+"vitest-config@workspace:*, vitest-config@workspace:packages/utils/vitest-config":
   version: 0.0.0-use.local
   resolution: "vitest-config@workspace:packages/utils/vitest-config"
   dependencies:


### PR DESCRIPTION
### What does it do?

- Replaces pinned versions (e.g. `"5.46.0"`) with `"workspace:*"` for every place a **private** workspace is consumed by another workspace: `tsconfig`, `eslint-config-custom`, `vitest-config`, `@strapi/admin-test-utils`.
- Adds missing `devDependencies` entries for private workspaces that were referenced from config files but never declared in `package.json`. References scanned:
  - `tsconfig*.json` → `"extends": "tsconfig/..."`
  - `.eslintrc.cjs` → `extends: ['eslint-config-custom/...']`
  - `jest.config.*` → `testEnvironment: '@strapi/admin-test-utils/environment'`
  - `vitest.config.*` → `import ... from 'vitest-config/...'`

Scope:
- 26 `package.json` files: pinned version → `workspace:*`
- 19 `package.json` files: 31 missing devDependency entries added (all `workspace:*`)

After the change, every reference to a private workspace from another workspace is declared in `package.json` with the workspace protocol.

### Why is it needed?

Two reasons:

1. **Precursor to introducing [`knip`](https://knip.dev/)** (see #26293). Knip walks declared `package.json` deps to map usage.

2. **Fewer release-time merge conflicts.** Pinning private workspace deps to a concrete version (e.g. `"5.46.0"`) means every release bumps those numbers across many `package.json` files. Open PRs that touch lines near those version fields then surface as merge conflicts (especially on rebase) purely because the version string changed — even when the PR has nothing to do with the dep. `workspace:*` keeps the consumer line stable across releases; the version bump only touches the workspace's own `version` field.

### How to test it?

Environment: monorepo root, Yarn 4.

- [x] `yarn install` completes without errors
- [x] `yarn build` succeeds across the monorepo
- [x] `yarn lint` succeeds (ESLint resolves `eslint-config-custom`)
- [x] TypeScript project builds succeed (tsconfig `extends` resolves)

### Related issue(s)/PR(s)

- #26293 — chore: add knip for dead-code and unused-dependency detection (this PR is a precursor)


---
Fixes CPR-398