### PR TITLE
fix(admin): scroll to or reposition guided tour tooltip when anchor is out of viewport

### DIFF
--- a/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
+++ b/packages/core/admin/admin/src/components/GuidedTour/Tours.tsx
@@ -84,6 +84,22 @@ const GuidedTourTooltipImpl = ({
     isCurrentStep &&
     isStepConditionMet;
 
+  // Ref to the anchor wrapper for scrolling into view.
+  const anchorRef = React.useRef<HTMLSpanElement>(null);
+
+  // Scroll the anchor element into view when the popover opens,
+  // so the tooltip is not rendered outside the viewport.
+  React.useEffect(() => {
+    if (!isPopoverOpen) return;
+
+    // Use requestAnimationFrame to ensure DOM is painted before scrolling.
+    const raf = requestAnimationFrame(() => {
+      anchorRef.current?.scrollIntoView({ behavior: 'auto', block: 'center' });
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [isPopoverOpen]);
+
   // Lock the scroll
   React.useEffect(() => {
     if (!isPopoverOpen) return;
@@ -132,7 +148,9 @@ const GuidedTourTooltipImpl = ({
         </Portal>
       )}
       <Popover.Root open={isPopoverOpen}>
-        <Popover.Anchor>{children}</Popover.Anchor>
+        <Popover.Anchor asChild>
+          <span ref={anchorRef}>{children}</span>
+        </Popover.Anchor>
         {content({ Step, state, dispatch })}
       </Popover.Root>
     </>


### PR DESCRIPTION
## Problem

When the guided tour anchor element is outside the viewport (e.g., the "single types" section in the content type builder when many collection types are present), the popover tooltip is also rendered outside the viewport and becomes unclickable while the rest of the app is greyed out.

## Solution

When the guided tour popover opens, scroll the anchor element into view so the tooltip is always visible and interactive. This is done by:

1. Wrapping the `Popover.Anchor` children in a `<span>` with a ref
2. Adding a `useEffect` that calls `scrollIntoView({ behavior: 'auto', block: 'center' })` when the popover opens, using `requestAnimationFrame` to ensure the DOM is painted first

## Changes

- `packages/core/admin/admin/src/components/GuidedTour/Tours.tsx` — Added scroll-to-anchor logic in `GuidedTourTooltipImpl`

## Related

Fixes #26301


---
Fixes CPR-345