### PR TITLE
fix(admin): preserve auth context for injected components

### DIFF
--- a/packages/core/admin/admin/src/core/apis/Plugin.ts
+++ b/packages/core/admin/admin/src/core/apis/Plugin.ts
@@ -3,11 +3,34 @@ import * as React from 'react';
 
 import { immerable } from 'immer';
 
+import { AuthProvider, useAuth } from '../../features/Auth';
+
 export interface PluginConfig
   extends Partial<Pick<Plugin, 'apis' | 'initializer' | 'injectionZones' | 'isReady'>> {
   name: string;
   id: string;
 }
+
+const InjectionZoneAuthBoundary = ({ children }: { children: React.ReactNode }) => {
+  const hasAuthProvider = useAuth('InjectionZoneAuthBoundary', () => true, false);
+
+  if (hasAuthProvider) {
+    return React.createElement(React.Fragment, null, children);
+  }
+
+  return React.createElement(AuthProvider, null, children);
+};
+
+const withInjectionZoneAuth = (Component: React.ComponentType) => {
+  const ComponentWithAuth = (props: Record<string, unknown>) =>
+    React.createElement(InjectionZoneAuthBoundary, null, React.createElement(Component, props));
+
+  ComponentWithAuth.displayName = `InjectionZoneAuthBoundary(${
+    Component.displayName ?? Component.name ?? 'Component'
+  })`;
+
+  return ComponentWithAuth as React.ComponentType;
+};
 
 export class Plugin {
   [immerable] = true;
@@ -47,7 +70,10 @@ export class Plugin {
     component: { name: string; Component: React.ComponentType }
   ) {
     try {
-      this.injectionZones[containerName][blockName].push(component);
+      this.injectionZones[containerName][blockName].push({
+        ...component,
+        Component: withInjectionZoneAuth(component.Component),
+      });
     } catch (err) {
       console.error('Cannot inject component', err);
     }

--- a/packages/core/admin/admin/src/core/apis/tests/Plugin.test.tsx
+++ b/packages/core/admin/admin/src/core/apis/tests/Plugin.test.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { useAuth } from '../../../features/Auth';
+import { Plugin } from '../Plugin';
+
+jest.mock('../../../features/Auth', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="auth-provider">{children}</div>
+  ),
+  useAuth: jest.fn(),
+}));
+
+describe('Plugin.injectComponent', () => {
+  let plugin: Plugin;
+  const mockedUseAuth = jest.mocked(useAuth);
+
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue(true);
+
+    plugin = new Plugin({
+      id: 'test-plugin',
+      name: 'Test Plugin',
+      injectionZones: { editView: { informations: [], 'right-links': [] } },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('wraps the stored component in an auth boundary HOC', () => {
+    const Dummy = () => null;
+    Dummy.displayName = 'Dummy';
+
+    plugin.injectComponent('editView', 'right-links', {
+      name: 'dummy',
+      Component: Dummy,
+    });
+
+    const [stored] = plugin.getInjectedComponents('editView', 'right-links');
+    expect(stored.Component).not.toBe(Dummy);
+    expect(stored.Component.displayName).toBe('InjectionZoneAuthBoundary(Dummy)');
+  });
+
+  it('derives the HOC displayName from Component.name when displayName is absent', () => {
+    plugin.injectComponent('editView', 'right-links', {
+      name: 'named-fn',
+      // eslint-disable-next-line prefer-arrow-callback
+      Component: function NamedComponent() {
+        return null;
+      },
+    });
+
+    const [stored] = plugin.getInjectedComponents('editView', 'right-links');
+    expect(stored.Component.displayName).toBe('InjectionZoneAuthBoundary(NamedComponent)');
+  });
+
+  it('wraps the injected component in AuthProvider when the auth context is missing', () => {
+    mockedUseAuth.mockReturnValue(undefined);
+    plugin.injectComponent('editView', 'right-links', {
+      name: 'auth-aware',
+      Component: () => <span>injected component</span>,
+    });
+
+    const [stored] = plugin.getInjectedComponents('editView', 'right-links');
+
+    render(React.createElement(stored.Component));
+
+    expect(mockedUseAuth).toHaveBeenCalledWith(
+      'InjectionZoneAuthBoundary',
+      expect.any(Function),
+      false
+    );
+    expect(screen.getByTestId('auth-provider')).toContainElement(
+      screen.getByText('injected component')
+    );
+  });
+
+  it('does not nest AuthProvider when the auth context is already present', () => {
+    plugin.injectComponent('editView', 'right-links', {
+      name: 'auth-aware',
+      Component: () => <span>injected component</span>,
+    });
+
+    const [stored] = plugin.getInjectedComponents('editView', 'right-links');
+
+    render(React.createElement(stored.Component));
+
+    expect(screen.queryByTestId('auth-provider')).not.toBeInTheDocument();
+    expect(screen.getByText('injected component')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### What does it do?

Wraps plugin components registered through injection zones in a small auth boundary. If the component is already rendered under the admin Auth context, it renders unchanged. If the context is missing, the boundary supplies AuthProvider so injected components can safely call admin APIs such as useAuth, useRBAC, and Page.Protect.

Adds unit coverage for both cases:
- injected components are wrapped in an auth boundary
- the boundary supplies AuthProvider only when auth context is missing

### Why is it needed?

Custom plugin components injected into admin/content-manager views can fail in production builds with errors like `useRBAC` must be used within `Auth` or `useAuth` must be used within `Auth`.

### How to test it?

Using Node 20:

```bash
yarn install
yarn nx build @strapi/admin-test-utils
yarn test:front packages/core/admin/admin/src/core/apis/tests/Plugin.test.tsx --runInBand
yarn prettier --check packages/core/admin/admin/src/core/apis/Plugin.ts packages/core/admin/admin/src/core/apis/tests/Plugin.test.tsx
yarn eslint packages/core/admin/admin/src/core/apis/Plugin.ts packages/core/admin/admin/src/core/apis/tests/Plugin.test.tsx
yarn nx test:ts @strapi/admin
```

Note: full `@strapi/admin` lint currently reports unrelated existing import resolution errors in this local checkout; the targeted files lint with no errors.

### Related issue(s)/PR(s)

Fix #23203

---
Fixes CPR-347