### PR TITLE
fix: generate apis in named directories

### DIFF
--- a/packages/generators/generators/src/plops/api.ts
+++ b/packages/generators/generators/src/plops/api.ts
@@ -52,7 +52,7 @@ export default (plop: NodePlopAPI) => {
       }
 
       const filePath = getFilePath(
-        answers.destination || (answers.isPluginApi && answers.plugin ? 'plugin' : 'api')
+        answers.destination || (answers.isPluginApi && answers.plugin ? 'plugin' : 'new')
       );
       const currentDir = process.cwd();
       let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';

--- a/packages/generators/generators/src/plops/utils/__tests__/get-file-path.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/get-file-path.test.ts
@@ -3,6 +3,11 @@ import getFilePath from '../get-file-path';
 describe('Get-File-Path util', () => {
   test('with destination set as api', () => {
     const filePath = getFilePath('api');
+    expect(filePath).toBe(`api/{{ api }}`);
+  });
+
+  test('with destination set as new', () => {
+    const filePath = getFilePath('new');
     expect(filePath).toBe(`api/{{ id }}`);
   });
 

--- a/packages/generators/generators/src/plops/utils/__tests__/get-file-path.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/get-file-path.test.ts
@@ -3,7 +3,7 @@ import getFilePath from '../get-file-path';
 describe('Get-File-Path util', () => {
   test('with destination set as api', () => {
     const filePath = getFilePath('api');
-    expect(filePath).toBe(`api/{{ api }}`);
+    expect(filePath).toBe(`api/{{ id }}`);
   });
 
   test('with destination set as plugin', () => {

--- a/packages/generators/generators/src/plops/utils/get-file-path.ts
+++ b/packages/generators/generators/src/plops/utils/get-file-path.ts
@@ -1,6 +1,6 @@
 export default (destination: string) => {
   if (destination === 'api') {
-    return `api/{{ api }}`;
+    return `api/{{ id }}`;
   }
 
   if (destination === 'plugin') {

--- a/packages/generators/generators/src/plops/utils/get-file-path.ts
+++ b/packages/generators/generators/src/plops/utils/get-file-path.ts
@@ -1,6 +1,6 @@
 export default (destination: string) => {
   if (destination === 'api') {
-    return `api/{{ id }}`;
+    return `api/{{ api }}`;
   }
 
   if (destination === 'plugin') {


### PR DESCRIPTION
### What does it do?

Fixes the API generator destination so generated API files are placed under `api/<api-name>/...` instead of directly under `api/controllers`, `api/services`, and `api/routes`.

Fixes #25179

### Why is it needed?

The `api` destination used `{{ api }}`, but the generator prompt stores the API name in `id`. Because `{{ api }}` is empty, Plop generated files one level too high.

### How to test it?

Run the API generator and choose "No" for plugin API. The generated files should now be created under the named API directory.

### Related issue(s)/PR(s)

- #25179

### Validation

- `corepack yarn workspace @strapi/generators test:unit --runTestsByPath src/plops/utils/__tests__/get-file-path.test.ts`
- `corepack yarn workspace @strapi/utils build && corepack yarn workspace @strapi/generators test:ts`
- `corepack yarn workspace @strapi/generators lint`
- `git diff --check`


---
Fixes CPR-348