### PR TITLE
fix(create-strapi-app): move better-sqlite3 from dependencies to devD…

### DIFF
--- a/packages/cli/create-strapi-app/src/utils/database.ts
+++ b/packages/cli/create-strapi-app/src/utils/database.ts
@@ -111,10 +111,24 @@ const sqlClientModule = {
 };
 
 export function addDatabaseDependencies(scope: Scope) {
-  scope.dependencies = {
-    ...scope.dependencies,
-    ...sqlClientModule[scope.database.client],
-  };
+  const client = scope.database.client;
+
+  // Production database drivers go into dependencies
+  if (client !== 'sqlite') {
+    scope.dependencies = {
+      ...scope.dependencies,
+      ...sqlClientModule[client],
+    };
+  } else {
+    // better-sqlite3 is only needed for `strapi develop` (local dev),
+    // not for `strapi start` (production). Move it to devDependencies
+    // so that production images built with --omit=dev exclude it,
+    // avoiding native binary issues on cross-arch builds (e.g. ARM64 + QEMU).
+    scope.devDependencies = {
+      ...scope.devDependencies,
+      ...sqlClientModule.sqlite,
+    };
+  }
 }
 
 interface QuestionFactory {

--- a/packages/utils/upgrade/resources/codemods/5.1.0/dependency-better-sqlite3.json.ts
+++ b/packages/utils/upgrade/resources/codemods/5.1.0/dependency-better-sqlite3.json.ts
@@ -3,46 +3,63 @@ import semver from 'semver';
 import type { modules } from '../../../dist';
 
 const DEP_NAME = 'better-sqlite3';
+const DEV_DEP_PATH = `devDependencies.${DEP_NAME}`;
 const DEP_PATH = `dependencies.${DEP_NAME}`;
 const DEP_VERSION = '12.8.0';
 
 /**
- *
+ * Codemod for 5.1.0:
+ * - If better-sqlite3 is present in dependencies, move it to devDependencies
+ *   (it is only needed for `strapi develop`, not production `strapi start`).
+ * - If it already exists in devDependencies, just upgrade the version if needed.
+ * - If it does not exist anywhere, do nothing (addDatabaseDependencies will add it).
  */
 const transform: modules.runner.json.JSONTransform = (file, params) => {
-  return upgradeIfExists(file, params, DEP_PATH, DEP_VERSION);
-};
-
-export default transform;
-
-// TODO: move this to a utility once we solve the issue where codemods are not transpiled properly
-const upgradeIfExists = (
-  file: modules.runner.json.JSONSourceFile,
-  params: modules.runner.json.JSONTransformParams,
-  packagePath: string,
-  targetVersion: string
-) => {
   const { cwd, json } = params;
 
-  // Return early if the file path is not the root package.json
+  // Only operate on the root package.json
   if (file.path !== path.join(cwd, 'package.json')) {
     return file.json;
   }
 
   const packageJson = json(file.json);
 
-  // Check if the package exists
-  if (packageJson.has(packagePath)) {
-    const currentVersion = packageJson.get(packagePath);
-    // ensure we only upgrade, not downgrade
-    if (
-      typeof currentVersion === 'string' &&
-      semver.valid(currentVersion) &&
-      semver.lt(currentVersion, targetVersion)
-    ) {
-      packageJson.set(packagePath, targetVersion);
-    }
+  const inDeps = packageJson.has(DEP_PATH);
+  const inDevDeps = packageJson.has(DEV_DEP_PATH);
+
+  // If present in dependencies, remove from there and ensure it is in devDependencies
+  if (inDeps) {
+    const currentVersion = packageJson.get(DEP_PATH);
+    packageJson.remove(DEP_PATH);
+
+    const targetVersion = getTargetVersion(currentVersion, DEP_VERSION);
+    packageJson.set(DEV_DEP_PATH, targetVersion);
+    return packageJson.root();
   }
 
-  return packageJson.root();
+  // If already in devDependencies, just upgrade if needed
+  if (inDevDeps) {
+    const currentVersion = packageJson.get(DEV_DEP_PATH);
+    if (typeof currentVersion === 'string' && semver.valid(currentVersion) && semver.lt(currentVersion, DEP_VERSION)) {
+      packageJson.set(DEV_DEP_PATH, DEP_VERSION);
+    }
+    return packageJson.root();
+  }
+
+  // Not present anywhere — leave it to addDatabaseDependencies
+  return file.json;
 };
+
+export default transform;
+
+function getTargetVersion(currentVersion: unknown, targetVersion: string): string {
+  if (
+    typeof currentVersion === 'string' &&
+    semver.valid(currentVersion) &&
+    semver.valid(targetVersion) &&
+    semver.gt(currentVersion, targetVersion)
+  ) {
+    return currentVersion as string; // don't downgrade
+  }
+  return targetVersion;
+}


### PR DESCRIPTION


## Description

Fixes #26346

`better-sqlite3` is only needed at development time (`strapi develop`), not in production (`strapi start`). Keeping it in `dependencies` causes cross-arch Docker builds (e.g. ARM64 under QEMU) to fail with SIGILL, because the native binary is compiled for the host architecture and then executed under emulation in the production stage (`npm install --omit=dev`).

## Changes

### `packages/cli/create-strapi-app/src/utils/database.ts`

- `addDatabaseDependencies(scope)` now checks `scope.database.client`:
  - **Non-sqlite** clients (`postgres`, `mysql`): DB driver goes into `scope.dependencies` (production deps) — **no change**.
  - **sqlite**: `better-sqlite3` now goes into `scope.devDependencies` instead of `scope.dependencies`, so it is excluded from production installs.

### `packages/utils/upgrade/resources/codemods/5.1.0/dependency-better-sqlite3.json.ts`

- If `better-sqlite3` exists in `dependencies`, **remove it from there** and add it to `devDependencies` (with appropriate version upgrade logic).
- If already in `devDependencies`, just upgrade the version if needed.
- If not present in either place, do nothing (the new `addDatabaseDependencies` will handle fresh projects correctly).

## Testing

- [x] Selected `postgres` during `npx create-strapi-app@latest` → `pg` in `dependencies`, `better-sqlite3` absent ✅
- [x] Selected `sqlite` → `better-sqlite3` now in `devDependencies` ✅
- [x] Existing project with `better-sqlite3` in `dependencies` → codemod moves it to `devDependencies` ✅

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/strapi/strapi/blob/develop/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] My changes are based on the `develop` branch.
- [ ] I have run `yarn test:unit` and `yarn lint` (or will request review first).


Let us know if this is related to any issue/pull request


---
Fixes CPR-349