### PR TITLE
fix(upload): disable empty asset upload

### DIFF
--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx
@@ -193,7 +193,11 @@ export const PendingAssetStep = ({
         <Button onClick={onClose} variant="tertiary">
           {formatMessage({ id: 'app.components.Button.cancel', defaultMessage: 'cancel' })}
         </Button>
-        <Button onClick={handleSubmit} loading={uploadStatus === Status.Uploading}>
+        <Button
+          onClick={handleSubmit}
+          loading={uploadStatus === Status.Uploading}
+          disabled={assets.length === 0}
+        >
           {formatMessage(
             {
               id: getTrad('modal.upload-list.footer.button'),

--- a/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.tsx
+++ b/packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.tsx
@@ -88,4 +88,31 @@ describe('PendingAssetStep', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('disables the upload button when there are no assets', () => {
+    const { getByRole } = renderTL(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <IntlProvider locale="en">
+            <Modal.Root open>
+              <Modal.Content>
+                <PendingAssetStep
+                  assets={[]}
+                  onClose={jest.fn()}
+                  onAddAsset={jest.fn()}
+                  onEditAsset={jest.fn()}
+                  onClickAddAsset={jest.fn()}
+                  onCancelUpload={jest.fn()}
+                  onRemoveAsset={jest.fn()}
+                  onUploadSucceed={jest.fn()}
+                />
+              </Modal.Content>
+            </Modal.Root>
+          </IntlProvider>
+        </DesignSystemProvider>
+      </QueryClientProvider>
+    );
+
+    expect(getByRole('button', { name: 'Upload 0 assets to the library' })).toBeDisabled();
+  });
 });


### PR DESCRIPTION
### What does it do?

Disables the Media Library pending upload submit button when the pending asset list is empty. Adds regression coverage for the empty-state button so the modal no longer presents an actionable "Upload 0 assets to the library" control.

### Why is it needed?

When users open the upload flow without selecting files, or remove every selected file, the footer button stays enabled even though submitting does nothing. This makes the empty upload state look actionable.

### How to test it?

- `yarn workspace @strapi/admin build:code`
- `yarn workspace @strapi/upload test:front PendingAssetStep.test.tsx --runInBand`
- `yarn prettier --check packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.tsx`
- `yarn eslint packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/PendingAssetStep.tsx packages/core/upload/admin/src/components/UploadAssetDialog/PendingAssetStep/tests/PendingAssetStep.test.tsx`
- `git diff --check`

Note: the full `nx run-many -t lint -p @strapi/upload` pre-commit task currently fails in this local checkout on existing `@strapi/admin/strapi-admin` import resolution errors across the upload package, unrelated to the touched files. The two touched files pass direct ESLint.

### Related issue(s)/PR(s)

Fixes #23466

---
Fixes CPR-351