### PR TITLE
fix(database): respect nested sort in populate for join-table relations

### DIFF
--- a/packages/core/database/src/query/helpers/populate/apply.ts
+++ b/packages/core/database/src/query/helpers/populate/apply.ts
@@ -11,6 +11,22 @@ import { ID, RelationalAttribute, Relation } from '../../../types';
 // TODO: ...and completely restrict the strapi_ prefix for an attribute name in the future
 const joinColPrefix = '__strapi' as const;
 
+/**
+ * Join-table `order` preserves connect order when no explicit populate sort is set.
+ * When `populateValue.orderBy` is present, join-table ordering must not take precedence
+ * over the target attribute sort (see query-builder join vs root orderBy ordering).
+ */
+const getJoinTableOrderBy = (
+  populateValue: Record<string, unknown>,
+  joinTable: { orderBy?: Record<string, 'asc' | 'desc'> }
+) => {
+  if (populateValue.orderBy || !joinTable.orderBy) {
+    return undefined;
+  }
+
+  return _.mapValues((v) => populateValue.ordering || v, joinTable.orderBy);
+};
+
 type Context = {
   db: Database;
   qb: QueryBuilder;
@@ -154,7 +170,7 @@ const XtoOne = async (
         rootColumn: joinTable.inverseJoinColumn.referencedColumn,
         rootTable: qb.alias,
         on: joinTable.on,
-        orderBy: joinTable.orderBy,
+        orderBy: getJoinTableOrderBy(populateValue, joinTable),
       })
       .addSelect(joinColSelect)
       .where({ [joinColAlias]: referencedValues })
@@ -281,7 +297,7 @@ const oneToMany = async (input: InputWithTarget<Relation.OneToMany>, ctx: Contex
         rootColumn: joinTable.inverseJoinColumn.referencedColumn,
         rootTable: qb.alias,
         on: joinTable.on,
-        orderBy: _.mapValues((v) => populateValue.ordering || v, joinTable.orderBy),
+        orderBy: getJoinTableOrderBy(populateValue, joinTable),
       })
       .addSelect(joinColSelect)
       .where({ [joinColAlias]: referencedValues })
@@ -370,7 +386,7 @@ const manyToMany = async (input: InputWithTarget<Relation.ManyToMany>, ctx: Cont
       rootColumn: joinTable.inverseJoinColumn.referencedColumn,
       rootTable: populateQb.alias,
       on: joinTable.on,
-      orderBy: _.mapValues((v) => populateValue.ordering || v, joinTable.orderBy),
+      orderBy: getJoinTableOrderBy(populateValue, joinTable),
     })
     .addSelect(joinColSelect)
     .where({ [joinColAlias]: referencedValues })
@@ -464,7 +480,7 @@ const morphX = async (
           ...(joinTable.on || {}),
           field: attributeName,
         },
-        orderBy: _.mapValues((v) => populateValue.ordering || v, joinTable.orderBy),
+        orderBy: getJoinTableOrderBy(populateValue, joinTable),
       })
       .addSelect([`${alias}.${idColumn.name}`, `${alias}.${typeColumn.name}`])
       .where({

--- a/tests/api/core/strapi/document-service/relations/basic.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/basic.test.api.ts
@@ -103,6 +103,27 @@ describe('Document Service relations', () => {
     );
   });
 
+  describe('Populate sort', () => {
+    // https://github.com/strapi/strapi/issues/26359
+    testInTransaction.each([
+      ['object', { sort: { name: 'asc' } }],
+      ['string', { sort: 'name' }],
+    ])('sorts manyToMany populated relations (%s sort)', async (_label, populateCategories) => {
+      const article = await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title: 'Populate sort test',
+          categories: ['Cat2', 'Cat1'],
+        },
+        populate: {
+          categories: populateCategories,
+        },
+      });
+
+      expect(article.categories.map((category) => category.name)).toEqual(['Cat1-EN', 'Cat2-EN']);
+    });
+  });
+
   describe('Discard', () => {
     testInTransaction(
       'Discarding draft brings back relations from the published version',

--- a/tests/api/core/strapi/document-service/relations/basic.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/basic.test.api.ts
@@ -105,6 +105,10 @@ describe('Document Service relations', () => {
 
   describe('Populate sort', () => {
     // https://github.com/strapi/strapi/issues/26359
+
+    const categoryNames = (article: { categories: Array<{ name: string }> }) =>
+      article.categories.map((category) => category.name);
+
     testInTransaction.each([
       ['object', { sort: { name: 'asc' } }],
       ['string', { sort: 'name' }],
@@ -120,8 +124,183 @@ describe('Document Service relations', () => {
         },
       });
 
-      expect(article.categories.map((category) => category.name)).toEqual(['Cat1-EN', 'Cat2-EN']);
+      expect(categoryNames(article)).toEqual(['Cat1-EN', 'Cat2-EN']);
     });
+
+    testInTransaction('sorts manyToMany populated relations on findMany', async () => {
+      await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title: 'Populate sort findMany test',
+          categories: ['Cat2', 'Cat1'],
+        },
+      });
+
+      const [article] = await strapi.documents(ARTICLE_UID).findMany({
+        locale: 'en',
+        filters: { title: 'Populate sort findMany test' },
+        populate: { categories: { sort: 'name' } },
+      });
+
+      expect(categoryNames(article)).toEqual(['Cat1-EN', 'Cat2-EN']);
+    });
+
+    testInTransaction('sorts manyToMany populated relations via db.query orderBy', async () => {
+      await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title: 'Populate sort db query test',
+          categories: ['Cat2', 'Cat1'],
+        },
+      });
+
+      const article = await strapi.db.query(ARTICLE_UID).findOne({
+        where: { title: 'Populate sort db query test', locale: 'en' },
+        populate: { categories: { orderBy: { name: 'asc' } } },
+      });
+
+      expect(categoryNames(article)).toEqual(['Cat1-EN', 'Cat2-EN']);
+    });
+
+    testInTransaction('sorts manyToMany populated relations in descending order', async () => {
+      const article = await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title: 'Populate sort desc test',
+          categories: ['Cat2', 'Cat1'],
+        },
+        populate: {
+          categories: { sort: { name: 'desc' } },
+        },
+      });
+
+      expect(categoryNames(article)).toEqual(['Cat2-EN', 'Cat1-EN']);
+    });
+
+    testInTransaction(
+      'preserves manyToMany connect order when nested sort is omitted',
+      async () => {
+        const article = await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title: 'Populate sort connect order test',
+            categories: ['Cat2', 'Cat1'],
+          },
+          populate: { categories: true },
+        });
+
+        expect(categoryNames(article)).toEqual(['Cat2-EN', 'Cat1-EN']);
+      }
+    );
+
+    testInTransaction(
+      'reverses manyToMany connect order with ordering via db.query when sort is omitted',
+      async () => {
+        await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title: 'Populate sort ordering test',
+            categories: ['Cat2', 'Cat1'],
+          },
+        });
+
+        const article = await strapi.db.query(ARTICLE_UID).findOne({
+          where: { title: 'Populate sort ordering test', locale: 'en' },
+          populate: { categories: { ordering: 'desc' } },
+        });
+
+        expect(categoryNames(article)).toEqual(['Cat1-EN', 'Cat2-EN']);
+      }
+    );
+
+    testInTransaction('sorts oneToMany joinColumn populated relations', async () => {
+      const parent = await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'Parent-EN' },
+      });
+
+      await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'SubB-EN', parentCategory: parent.documentId },
+      });
+
+      await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'SubA-EN', parentCategory: parent.documentId },
+      });
+
+      const loaded = await strapi.documents(CATEGORY_UID).findOne({
+        documentId: parent.documentId,
+        locale: 'en',
+        populate: { subcategories: { sort: 'name' } },
+      });
+
+      expect(loaded.subcategories.map((category) => category.name)).toEqual(['SubA-EN', 'SubB-EN']);
+    });
+
+    testInTransaction('sorts nested populate at multiple levels', async () => {
+      const parent = await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'Parent-EN' },
+      });
+
+      await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'SubB-EN', parentCategory: parent.documentId },
+      });
+
+      await strapi.documents(CATEGORY_UID).create({
+        locale: 'en',
+        data: { name: 'SubA-EN', parentCategory: parent.documentId },
+      });
+
+      const article = await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title: 'Populate sort nested populate test',
+          categories: [parent.documentId],
+        },
+        populate: {
+          categories: {
+            sort: 'name',
+            populate: {
+              subcategories: { sort: 'name' },
+            },
+          },
+        },
+      });
+
+      expect(categoryNames(article)).toEqual(['Parent-EN']);
+      expect(article.categories[0].subcategories.map((category) => category.name)).toEqual([
+        'SubA-EN',
+        'SubB-EN',
+      ]);
+    });
+
+    testInTransaction(
+      'applies nested sort before limit on populated relations via db.query',
+      async () => {
+        await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title: 'Populate sort limit test',
+            categories: ['Cat2', 'Cat1'],
+          },
+        });
+
+        const article = await strapi.db.query(ARTICLE_UID).findOne({
+          where: { title: 'Populate sort limit test', locale: 'en' },
+          populate: {
+            categories: {
+              orderBy: { name: 'asc' },
+              limit: 1,
+            },
+          },
+        });
+
+        expect(categoryNames(article)).toEqual(['Cat1-EN']);
+      }
+    );
   });
 
   describe('Discard', () => {

--- a/tests/api/core/strapi/document-service/resources/schemas/category.js
+++ b/tests/api/core/strapi/document-service/resources/schemas/category.js
@@ -23,5 +23,17 @@ module.exports = {
         },
       },
     },
+    parentCategory: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'api::category.category',
+      inversedBy: 'subcategories',
+    },
+    subcategories: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::category.category',
+      mappedBy: 'parentCategory',
+    },
   },
 };


### PR DESCRIPTION
### What does it do?

- Adds `getJoinTableOrderBy()` in `packages/core/database/src/query/helpers/populate/apply.ts`.
- When a populate object includes an explicit sort (`populateValue.orderBy`, converted from nested `sort`), join-table `order` ordering is **not** applied on the populate query.
- When no nested sort is provided, join-table connect order is unchanged (including `ordering` to flip direction).
- Adds API regression tests in `tests/api/core/strapi/document-service/relations/basic.test.api.ts` (`Populate sort` describe block).

### Why is it needed?

Fixes #26359.

Nested `sort` inside `populate` (e.g. `populate: { product_tags: { sort: 'Position' } } }`) stopped ordering related records for many-to-many and other join-table relations. Top-level `sort` still worked.

**Regression:** Introduced by #26032 (`fix(database): append primary key to ORDER BY for paginated selects`, merged 2026-05-11). That PR correctly moved join-table `ORDER BY` before root `orderBy` so pagination `id` tie-breakers do not break manual connect order. The side effect was that join-table `order` always ran **before** nested attribute sorts, so connect/insertion order dominated and nested `sort` had no visible effect.

This change is compatible with #26032: default connect ordering is preserved when nested `sort` is omitted; when nested `sort` is present, attribute sort is used instead of join-table `order`.

### How to test it?

**API integration test:**

```bash
yarn nx build @strapi/database
yarn test:api -- tests/api/core/strapi/document-service/relations/basic.test.api.ts
```

**Manual check (document service):**

1. Create a content type with a many-to-many relation and an integer/string field on the target (e.g. `position` or `name`).
2. Link related entries in a non-sorted connect order.
3. Query with nested sort:

```js
await strapi.documents('api::article.article').findOne({
  documentId: '…',
  populate: {
    categories: { sort: { name: 'asc' } }, // or sort: 'name'
  },
});
```

4. Confirm populated relations are ordered by the attribute, not connect order.
5. Confirm connect order is still respected when `sort` is omitted on the populate object.

### Related issue(s)/PR(s)

- Fixes #26359
- Regression from #26032 / #26030 (pagination stable `ORDER BY`)