### PR TITLE
fix(create-strapi-app): keep sqlite driver out of production installs

### DIFF
--- a/packages/cli/create-strapi-app/jest.config.js
+++ b/packages/cli/create-strapi-app/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: '../../../jest-preset.unit.js',
+  displayName: 'Create Strapi App',
+};

--- a/packages/cli/create-strapi-app/package.json
+++ b/packages/cli/create-strapi-app/package.json
@@ -48,6 +48,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "test:ts": "run -T tsc --noEmit",
+    "test:unit": "run -T jest",
     "watch": "run -T rollup -c -w"
   },
   "dependencies": {

--- a/packages/cli/create-strapi-app/src/utils/__tests__/database.test.ts
+++ b/packages/cli/create-strapi-app/src/utils/__tests__/database.test.ts
@@ -1,0 +1,62 @@
+import { addDatabaseDependencies } from '../database';
+
+import type { Scope } from '../../types';
+
+const createScope = (client: Scope['database']['client']): Scope =>
+  ({
+    database: { client },
+    dependencies: {
+      '@strapi/strapi': '5.46.0',
+    },
+    devDependencies: {
+      typescript: '^5',
+    },
+  }) as unknown as Scope;
+
+describe('addDatabaseDependencies', () => {
+  test('keeps better-sqlite3 in dependencies when sqlite is the selected database', () => {
+    const scope = createScope('sqlite');
+
+    addDatabaseDependencies(scope);
+
+    expect(scope.dependencies).toMatchObject({
+      '@strapi/strapi': '5.46.0',
+      'better-sqlite3': '12.8.0',
+    });
+    expect(scope.devDependencies).toEqual({
+      typescript: '^5',
+    });
+  });
+
+  test('keeps postgres in dependencies and adds sqlite only as a development dependency', () => {
+    const scope = createScope('postgres');
+
+    addDatabaseDependencies(scope);
+
+    expect(scope.dependencies).toMatchObject({
+      '@strapi/strapi': '5.46.0',
+      pg: '8.20.0',
+    });
+    expect(scope.dependencies).not.toHaveProperty('better-sqlite3');
+    expect(scope.devDependencies).toMatchObject({
+      typescript: '^5',
+      'better-sqlite3': '12.8.0',
+    });
+  });
+
+  test('keeps mysql in dependencies and adds sqlite only as a development dependency', () => {
+    const scope = createScope('mysql');
+
+    addDatabaseDependencies(scope);
+
+    expect(scope.dependencies).toMatchObject({
+      '@strapi/strapi': '5.46.0',
+      mysql2: '3.20.0',
+    });
+    expect(scope.dependencies).not.toHaveProperty('better-sqlite3');
+    expect(scope.devDependencies).toMatchObject({
+      typescript: '^5',
+      'better-sqlite3': '12.8.0',
+    });
+  });
+});

--- a/packages/cli/create-strapi-app/src/utils/database.ts
+++ b/packages/cli/create-strapi-app/src/utils/database.ts
@@ -110,11 +110,22 @@ const sqlClientModule = {
   sqlite: { 'better-sqlite3': '12.8.0' },
 };
 
+const sqliteDevelopmentModule = sqlClientModule.sqlite;
+
 export function addDatabaseDependencies(scope: Scope) {
+  const { client } = scope.database;
+
   scope.dependencies = {
     ...scope.dependencies,
-    ...sqlClientModule[scope.database.client],
+    ...sqlClientModule[client],
   };
+
+  if (client !== 'sqlite') {
+    scope.devDependencies = {
+      ...scope.devDependencies,
+      ...sqliteDevelopmentModule,
+    };
+  }
 }
 
 interface QuestionFactory {

--- a/packages/cli/create-strapi-app/tsconfig.eslint.json
+++ b/packages/cli/create-strapi-app/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "package.json"],
+  "include": ["src", "package.json", "jest.config.js"],
   "exclude": ["node_modules"]
 }

--- a/packages/utils/upgrade/resources/codemods/5.1.0/__tests__/dependency-better-sqlite3.test.ts
+++ b/packages/utils/upgrade/resources/codemods/5.1.0/__tests__/dependency-better-sqlite3.test.ts
@@ -1,0 +1,95 @@
+import path from 'node:path';
+
+import { cloneDeep, get, has, omit, set } from 'lodash/fp';
+import transform from '../dependency-better-sqlite3.json';
+
+const cwd = '/tmp/project';
+const packageJsonPath = path.join(cwd, 'package.json');
+
+const json = (object: Record<string, unknown>) => {
+  let current = cloneDeep(object);
+
+  return {
+    get: (jsonPath: string) => cloneDeep(get(jsonPath, current)),
+    has: (jsonPath: string) => has(jsonPath, current),
+    remove(jsonPath: string) {
+      current = omit(jsonPath, current);
+      return json(object);
+    },
+    root: () => cloneDeep(current),
+    set(jsonPath: string, value: unknown) {
+      current = set(jsonPath, value, current);
+      return json(object);
+    },
+  };
+};
+
+const runTransform = (packageJson: Record<string, unknown>) =>
+  transform(
+    {
+      path: packageJsonPath,
+      json: packageJson,
+    },
+    {
+      cwd,
+      json,
+    }
+  );
+
+describe('dependency-better-sqlite3 codemod', () => {
+  test('moves better-sqlite3 to devDependencies for postgres projects', () => {
+    const result = runTransform({
+      dependencies: {
+        'better-sqlite3': '12.6.2',
+        pg: '8.20.0',
+      },
+      devDependencies: {
+        typescript: '^5',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        pg: '8.20.0',
+      },
+      devDependencies: {
+        'better-sqlite3': '12.8.0',
+        typescript: '^5',
+      },
+    });
+  });
+
+  test('keeps better-sqlite3 in dependencies for sqlite projects', () => {
+    const result = runTransform({
+      dependencies: {
+        'better-sqlite3': '12.6.2',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        'better-sqlite3': '12.6.2',
+      },
+    });
+  });
+
+  test('updates better-sqlite3 in devDependencies for mysql projects', () => {
+    const result = runTransform({
+      dependencies: {
+        mysql2: '3.20.0',
+      },
+      devDependencies: {
+        'better-sqlite3': '12.6.2',
+      },
+    });
+
+    expect(result).toStrictEqual({
+      dependencies: {
+        mysql2: '3.20.0',
+      },
+      devDependencies: {
+        'better-sqlite3': '12.8.0',
+      },
+    });
+  });
+});

--- a/packages/utils/upgrade/resources/codemods/5.1.0/dependency-better-sqlite3.json.ts
+++ b/packages/utils/upgrade/resources/codemods/5.1.0/dependency-better-sqlite3.json.ts
@@ -3,24 +3,24 @@ import semver from 'semver';
 import type { modules } from '../../../dist';
 
 const DEP_NAME = 'better-sqlite3';
+const DEV_DEP_PATH = `devDependencies.${DEP_NAME}`;
 const DEP_PATH = `dependencies.${DEP_NAME}`;
 const DEP_VERSION = '12.8.0';
+const NON_SQLITE_DRIVERS = ['pg', 'mysql2'];
 
 /**
  *
  */
 const transform: modules.runner.json.JSONTransform = (file, params) => {
-  return upgradeIfExists(file, params, DEP_PATH, DEP_VERSION);
+  return moveToDevDependenciesForNonSqliteProjects(file, params);
 };
 
 export default transform;
 
 // TODO: move this to a utility once we solve the issue where codemods are not transpiled properly
-const upgradeIfExists = (
+const moveToDevDependenciesForNonSqliteProjects = (
   file: modules.runner.json.JSONSourceFile,
-  params: modules.runner.json.JSONTransformParams,
-  packagePath: string,
-  targetVersion: string
+  params: modules.runner.json.JSONTransformParams
 ) => {
   const { cwd, json } = params;
 
@@ -31,18 +31,34 @@ const upgradeIfExists = (
 
   const packageJson = json(file.json);
 
-  // Check if the package exists
-  if (packageJson.has(packagePath)) {
-    const currentVersion = packageJson.get(packagePath);
-    // ensure we only upgrade, not downgrade
-    if (
-      typeof currentVersion === 'string' &&
-      semver.valid(currentVersion) &&
-      semver.lt(currentVersion, targetVersion)
-    ) {
-      packageJson.set(packagePath, targetVersion);
-    }
+  const hasNonSqliteDriver = NON_SQLITE_DRIVERS.some((driver) =>
+    packageJson.has(`dependencies.${driver}`)
+  );
+
+  if (!hasNonSqliteDriver) {
+    return packageJson.root();
+  }
+
+  if (packageJson.has(DEP_PATH)) {
+    const currentVersion = packageJson.get(DEP_PATH);
+    packageJson.remove(DEP_PATH);
+    packageJson.set(DEV_DEP_PATH, resolveTargetVersion(currentVersion, DEP_VERSION));
+  } else if (packageJson.has(DEV_DEP_PATH)) {
+    const currentVersion = packageJson.get(DEV_DEP_PATH);
+    packageJson.set(DEV_DEP_PATH, resolveTargetVersion(currentVersion, DEP_VERSION));
   }
 
   return packageJson.root();
+};
+
+const resolveTargetVersion = (currentVersion: unknown, targetVersion: string) => {
+  if (
+    typeof currentVersion === 'string' &&
+    semver.valid(currentVersion) &&
+    semver.gt(currentVersion, targetVersion)
+  ) {
+    return currentVersion;
+  }
+
+  return targetVersion;
 };


### PR DESCRIPTION
### What does it do?

Fixes the database dependency classification used by `create-strapi-app`:

- SQLite projects keep `better-sqlite3` in `dependencies`, because it is the selected runtime database driver.
- PostgreSQL/MySQL projects keep their production driver (`pg`/`mysql2`) in `dependencies` and place `better-sqlite3` in `devDependencies` for local development fallback only.
- The 5.1.0 `better-sqlite3` codemod now only moves `better-sqlite3` to `devDependencies` when a non-SQLite production driver is present, so existing SQLite projects are not broken by production installs with `--omit=dev`.

### Why is it needed?

For non-SQLite projects, installing `better-sqlite3` during production image builds can break ARM64 builds under QEMU with SIGILL during `npm install --omit=dev`. Keeping it out of production dependencies avoids compiling/loading that native module in runtime Docker stages, while still preserving local development behavior.

This keeps the SQLite case conservative: if the project actually selected SQLite, `better-sqlite3` remains available for `strapi start` after a production install.

Fixes #26346.

### How to test it?

- `corepack yarn workspace create-strapi-app test:unit`
- `corepack yarn jest --config packages/utils/upgrade/jest.config.js --runInBand --runTestsByPath packages/utils/upgrade/resources/codemods/5.1.0/__tests__/dependency-better-sqlite3.test.ts`
- `PATH="/tmp/strapi-yarn-shim:$PATH" corepack yarn nx run-many -t lint -p create-strapi-app,@strapi/upgrade`

Note: `corepack yarn workspace create-strapi-app test:ts` currently fails in this local checkout because `@strapi/cloud-cli` workspace types are not built/resolved before the package-level typecheck.


---
Fixes CPR-355