### PR TITLE
chore(deps): bump ws from 8.17.1 to 8.20.1 in @strapi/data-transfer

### DIFF
--- a/packages/core/data-transfer/package.json
+++ b/packages/core/data-transfer/package.json
@@ -67,7 +67,7 @@
     "stream-json": "1.8.0",
     "tar": "7.5.11",
     "tar-stream": "2.2.0",
-    "ws": "8.17.1"
+    "ws": "8.20.1"
   },
   "devDependencies": {
     "@strapi/database": "5.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9382,7 +9382,7 @@ __metadata:
     tar: "npm:7.5.11"
     tar-stream: "npm:2.2.0"
     typescript: "npm:5.4.5"
-    ws: "npm:8.17.1"
+    ws: "npm:8.20.1"
   languageName: unknown
   linkType: soft
 
@@ -31684,9 +31684,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.17.1, ws@npm:^8.8.0":
-  version: 8.17.1
-  resolution: "ws@npm:8.17.1"
+"ws@npm:8.20.1, ws@npm:^8.8.0":
+  version: 8.20.1
+  resolution: "ws@npm:8.20.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -31695,13 +31695,13 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
+  checksum: 10c0/ce162433218399cdedeb76fd33363d4d86a7d910058d4e3c679dce08cea65d6da6b39f11baa4d7808d024cf46ed88f6a05c17611621aaad8fc5e62edacc30c5d
   languageName: node
   linkType: hard
 
 "ws@npm:^7.3.1":
-  version: 7.5.9
-  resolution: "ws@npm:7.5.9"
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -31710,7 +31710,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/aec4ef4eb65821a7dde7b44790f8699cfafb7978c9b080f6d7a98a7f8fc0ce674c027073a78574c94786ba7112cc90fa2cc94fc224ceba4d4b1030cff9662494
+  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does it do?

Bumps the pinned `ws` dependency in `@strapi/data-transfer` from `8.17.1` to `8.20.1` and refreshes `yarn.lock` (including transitive `ws@7.5.10` resolution).

### Why is it needed?

`ws@8.20.1` fixes a memory-disclosure bug in `websocket.close()` when a non-string/non-Buffer value (e.g. a `TypedArray`) is passed as the close reason. `@strapi/data-transfer` uses `ws` for remote transfer WebSocket connections.

### How to test it?

- `yarn install`
- `yarn nx test @strapi/data-transfer` (remote transfer / WebSocket unit tests)
- Optional: run a remote data transfer between two Strapi instances and confirm push/pull completes

### Related issue(s)/PR(s)

N/A — proactive dependency maintenance.

Made with [Cursor](https://cursor.com)