### PR TITLE
fix(core/core): codeBlockValidator uses language instead of syntax

### DIFF
--- a/packages/core/core/src/services/entity-validator/__tests__/blocks-validators.test.ts
+++ b/packages/core/core/src/services/entity-validator/__tests__/blocks-validators.test.ts
@@ -192,7 +192,7 @@ const validLists = [
 const validCodeBlock = [
   {
     type: 'code',
-    syntax: 'javascript',
+    language: 'javascript',
     children: [{ type: 'text', text: 'const test = "whatever"' }],
   },
 ];
@@ -425,7 +425,7 @@ describe('Blocks validator', () => {
         validator([
           {
             type: 'code',
-            syntax: 'javascript',
+            language: 'javascript',
             children: [{ type: 'link', text: 'const test = "whatever"' }],
           },
         ])

--- a/packages/core/core/src/services/entity-validator/blocks-validator.ts
+++ b/packages/core/core/src/services/entity-validator/blocks-validator.ts
@@ -80,7 +80,7 @@ const quoteNodeValidator = yup.object().shape({
 
 const codeBlockValidator = yup.object().shape({
   type: yup.string().equals(['code']).required(),
-  syntax: yup.string().nullable(),
+  language: yup.string().nullable(),
   children: yup
     .array()
     .of(textNodeValidator)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Renames the optional language field on the `codeBlockValidator` Yup shape from `syntax` to `language` in the server-side entity validator (`packages/core/core/src/services/entity-validator/blocks-validator.ts`, line 83). Updates the two corresponding unit test fixtures in `blocks-validators.test.ts` (lines 195 and 428) to use `language: 'javascript'` instead of `syntax: 'javascript'`.

### Why is it needed?

PR [#20469](https://github.com/strapi/strapi/pull/20469) (Jun 2024) renamed the code-block language field from `syntax` to `language` in `@strapi/types` (`CodeBlockNode.language`) and in the admin Blocks editor (`Code.tsx`), but the server-side Yup validator was not updated. This left a split contract:

- Admin and TypeScript types use `language`
- Entity validator (and its tests) documented `syntax`

As a result, API clients reading the TypeScript types would write `language`, which the validator silently ignored (Yup does not reject unknown keys). Conversely, clients sending `syntax` would pass validation but produce blocks that the admin treats as having no language set (falls back to `plaintext` for highlighting).

This change closes the partial rename and makes all layers agree on `language` as the single field name.

### How to test it?

1. Apply the change and run the entity validator unit tests:
   ```bash
   yarn test:unit packages/core/core/src/services/entity-validator/__tests__/blocks-validators.test.ts
   ```
   All 15 tests should pass.

2. Start the dev sandbox and create or edit a content type with a `blocks` field. In the Blocks editor, add a code block, set a language (e.g. `javascript`), save, and reload. Syntax highlighting and the language selector should both reflect the saved value — confirming the `language` key round-trips correctly through the entity validator.

3. Optionally send a `PUT`/`POST` to the content API with a blocks payload using `language`:
   ```json
   [{ "type": "code", "language": "javascript", "children": [{ "type": "text", "text": "const x = 1" }] }]
   ```
   The request should be accepted (HTTP 200/201) and the stored value should contain `language`.

### Related issue(s)/PR(s)

- PR #20469 — *feat: add language selector to the blocks code editor* — introduced the rename in types and admin but missed the entity validator.
- PR #18166 — *Add new Blocks rich text editor (alpha)* — originally introduced `syntax` in the entity validator.
- PR #22332 — *add syntax highlighting in the code block* — added Prism decoration against `node.language`, widening the split further.
- Required for #26371 
