### PR TITLE
[Upload] Silent data loss when uploading multiple files with duplicate filenames

### DIFF
--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -146,11 +146,21 @@ export default {
       filesArray.length === data.fileInfo.length
     ) {
       // Reorder filesArray to match data.fileInfo order
-      const alignedFilesArray = data.fileInfo
-        .map((info) => {
-          return filesArray.find((file) => file.originalFilename === info.name);
-        })
-        .filter(Boolean) as any[];
+const alignedFilesArray = data.fileInfo.map((info, index) => {
+  const match = filesArray.find((file) => file.originalFilename === info.name);
+  if (!match) {
+    return filesArray[index];
+  }
+  return match;
+});
+
+if (alignedFilesArray.every(Boolean)) {
+  filesArray = alignedFilesArray as any[];
+} else {
+  strapi.log.warn(
+    'Could not align file order by name; using original order'
+  );
+}
 
       filesArray = alignedFilesArray;
     }


### PR DESCRIPTION
### What does it do?
Fixes the file alignment logic in `uploadFiles` controller.
Replaces the find()-only approach with a positional fallback
to prevent silent file loss when multiple uploaded files share
the same filename.

### Why is it needed?
When two files have the same name, Array.find() always returns
the first match. This causes one file to be silently dropped
with no error and no warning — a data loss bug.

### How to test it?
1. Start a Strapi v5 project
2. Upload two files both named photo.jpg via the Media Library
3. Confirm both files are stored as distinct assets
4. Confirm the API response returns two entries with different URLs

### Related issue(s)/PR(s)
Fix #26394

---
Fixes CPR-358