### PR TITLE
fix(graphql): inherit publicationFilter into populated relations

### DIFF
--- a/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
+++ b/packages/plugins/graphql/server/src/services/builders/resolvers/association.ts
@@ -104,10 +104,10 @@ export default ({ strapi }: Context) => {
             : {};
 
         const inheritedPublicationFilter =
-          context.rootQueryArgs?.publicationFilter !== undefined &&
-          context.rootQueryArgs?._originField &&
-          isBuiltInQueryField(context.rootQueryArgs._originField)
-            ? context.rootQueryArgs.publicationFilter
+          rootQueryArgs?.publicationFilter !== undefined &&
+          rootQueryArgs?._originField &&
+          isBuiltInQueryField(rootQueryArgs._originField)
+            ? rootQueryArgs.publicationFilter
             : undefined;
 
         const inheritedHasPublishedVersion =


### PR DESCRIPTION
### What does it do?

Fixes GraphQL association resolvers so `publicationFilter` from a root query is inherited when loading nested draft-and-publish relations.

The inheritance path now reads from `rootQueryArgsByPath` (via `rootQueryArgs`), matching how `status` and `hasPublishedVersion` were already resolved after #26178.

### Why is it needed?

#25793 added `publicationFilter` support but still read from the removed `context.rootQueryArgs` API. As a result, top-level queries filtered correctly while populated relations returned unfiltered results — breaking the cascade tests on `develop`.

### How to test it?

```bash
yarn test:api -- tests/api/plugins/graphql/publication-filter.test.api.js
```

Or manually query articles with `publicationFilter: HAS_PUBLISHED_VERSION` / `NEVER_PUBLISHED`, populate `categories`, and confirm only categories matching the filter are returned.

### Related issue(s)/PR(s)

Regression from #25793 (publicationFilter) interacting with #26178 (rootQueryArgsByPath).