### PR TITLE
fix(upload): accept single-file arrays on replacement

### DIFF
--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -136,6 +136,93 @@ describe('Admin Upload Controller - AI Service Connection', () => {
     } as any;
   });
 
+  describe('replaceFile', () => {
+    it('accepts a single replacement file received as an array', async () => {
+      const replacementFile = {
+        filepath: '/tmp/replacement.pdf',
+        originalFilename: 'replacement.pdf',
+        mimetype: 'application/pdf',
+      };
+
+      mockContext.query = { id: '1' } as any;
+      mockContext.request!.body = {
+        fileInfo: ['{"name":"replacement.pdf","folder":null}'],
+      };
+      mockContext.request!.files = { files: [replacementFile] } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        errors: [],
+      });
+      mockValidateUploadBody.mockResolvedValue({
+        fileInfo: {
+          name: 'replacement.pdf',
+          folder: null,
+          alternativeText: '',
+          caption: '',
+          focalPoint: null,
+        },
+      });
+
+      uploadService.replace.mockResolvedValue({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+
+      await adminUploadController.replaceFile(mockContext as Context);
+
+      expect(mockPrepareUploadRequest).toHaveBeenCalledWith(
+        replacementFile,
+        mockContext.request!.body,
+        strapi
+      );
+      expect(uploadService.replace).toHaveBeenCalledWith(
+        '1',
+        {
+          data: {
+            fileInfo: {
+              name: 'replacement.pdf',
+              folder: null,
+              alternativeText: '',
+              caption: '',
+              focalPoint: null,
+            },
+          },
+          file: replacementFile,
+        },
+        { user: { id: 1 } }
+      );
+      expect(mockContext.body).toEqual({
+        id: 1,
+        name: 'replacement.pdf',
+        cleaned: true,
+      });
+    });
+
+    it('rejects multiple replacement files', async () => {
+      mockContext.query = { id: '1' } as any;
+      mockContext.request!.files = {
+        files: [
+          { filepath: '/tmp/first.jpg', originalFilename: 'first.jpg', mimetype: 'image/jpeg' },
+          { filepath: '/tmp/second.jpg', originalFilename: 'second.jpg', mimetype: 'image/jpeg' },
+        ],
+      } as any;
+
+      await expect(adminUploadController.replaceFile(mockContext as Context)).rejects.toThrow(
+        'Cannot replace a file with multiple ones'
+      );
+
+      expect(mockPrepareUploadRequest).not.toHaveBeenCalled();
+      expect(uploadService.replace).not.toHaveBeenCalled();
+    });
+  });
+
   describe('uploadFiles - Security Filtering', () => {
     it('should call enforceUploadSecurity with uploaded files', async () => {
       const files = [

--- a/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts
@@ -142,6 +142,94 @@ describe('Admin Upload Controller - AI Service Connection', () => {
     } as any;
   });
 
+  describe('replaceFile', () => {
+    it('accepts a single replacement file received as an array', async () => {
+      const replacementFile = {
+        filepath: '/tmp/replacement.pdf',
+        originalFilename: 'replacement.pdf',
+        mimetype: 'application/pdf',
+      };
+
+      mockContext.query = { id: '1' } as any;
+      mockContext.request!.body = {
+        fileInfo: ['{"name":"replacement.pdf","folder":null}'],
+      };
+      mockContext.request!.files = { files: [replacementFile] } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        errors: [],
+      });
+      mockValidateUploadBody.mockResolvedValue({
+        fileInfo: {
+          name: 'replacement.pdf',
+          folder: null,
+          alternativeText: '',
+          caption: '',
+          focalPoint: null,
+        },
+      });
+
+      uploadService.replace.mockResolvedValue({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+
+      await adminUploadController.replaceFile(mockContext as Context);
+
+      expect(mockPrepareUploadRequest).toHaveBeenCalledWith(
+        replacementFile,
+        mockContext.request!.body,
+        strapi
+      );
+      expect(uploadService.replace).toHaveBeenCalledWith(
+        '1',
+        {
+          data: {
+            fileInfo: {
+              name: 'replacement.pdf',
+              folder: null,
+              alternativeText: '',
+              caption: '',
+              focalPoint: null,
+            },
+          },
+          file: replacementFile,
+        },
+        { user: { id: 1 } }
+      );
+      expect(mockContext.body).toEqual({
+        id: 1,
+        name: 'replacement.pdf',
+        cleaned: true,
+        isUrlSigned: true,
+      });
+    });
+
+    it('rejects multiple replacement files', async () => {
+      mockContext.query = { id: '1' } as any;
+      mockContext.request!.files = {
+        files: [
+          { filepath: '/tmp/first.jpg', originalFilename: 'first.jpg', mimetype: 'image/jpeg' },
+          { filepath: '/tmp/second.jpg', originalFilename: 'second.jpg', mimetype: 'image/jpeg' },
+        ],
+      } as any;
+
+      await expect(adminUploadController.replaceFile(mockContext as Context)).rejects.toThrow(
+        'Cannot replace a file with multiple ones'
+      );
+
+      expect(mockPrepareUploadRequest).not.toHaveBeenCalled();
+      expect(uploadService.replace).not.toHaveBeenCalled();
+    });
+  });
+
   describe('uploadFiles - Security Filtering', () => {
     it('should call enforceUploadSecurity with uploaded files', async () => {
       const files = [

--- a/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
@@ -1,0 +1,147 @@
+import type { Context } from 'koa';
+
+import createContentApiController from '../content-api';
+import { getService } from '../../utils';
+import { validateUploadBody } from '../validation/content-api/upload';
+import { prepareUploadRequest } from '../../utils/mime-validation';
+
+jest.mock('../../utils');
+jest.mock('../validation/content-api/upload');
+jest.mock('../../utils/mime-validation', () => ({
+  prepareUploadRequest: jest.fn(),
+}));
+
+const mockGetService = getService as jest.MockedFunction<typeof getService>;
+const mockValidateUploadBody = validateUploadBody as jest.MockedFunction<typeof validateUploadBody>;
+const mockPrepareUploadRequest = jest.mocked(prepareUploadRequest);
+
+describe('Content API Upload Controller', () => {
+  const strapiMock = {
+    getModel: jest.fn(() => ({})),
+    contentAPI: {
+      sanitize: {
+        output: jest.fn((data) => Promise.resolve(data)),
+        query: jest.fn((data) => Promise.resolve(data)),
+      },
+      validate: {
+        query: jest.fn(() => Promise.resolve()),
+      },
+    },
+  } as any;
+
+  let controller: ReturnType<typeof createContentApiController>;
+  let uploadService: {
+    replace: jest.Mock;
+  };
+  let fileService: {
+    signFileUrls: jest.Mock;
+  };
+  let ctx: Partial<Context>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    controller = createContentApiController({ strapi: strapiMock });
+    uploadService = {
+      replace: jest.fn(),
+    };
+    fileService = {
+      signFileUrls: jest.fn((file) => Promise.resolve(file)),
+    };
+
+    mockGetService.mockImplementation(((serviceName: string) => {
+      if (serviceName === 'upload') {
+        return uploadService;
+      }
+      if (serviceName === 'file') {
+        return fileService;
+      }
+
+      return {};
+    }) as any);
+
+    mockValidateUploadBody.mockResolvedValue({
+      fileInfo: {
+        name: 'replacement.pdf',
+        folder: null,
+      },
+    } as any);
+
+    ctx = {
+      query: { id: '1' },
+      state: { auth: {}, route: {} },
+      request: {
+        body: {},
+        files: {},
+      } as any,
+    } as any;
+  });
+
+  describe('replaceFile', () => {
+    it('accepts a single replacement file received as an array', async () => {
+      const replacementFile = {
+        filepath: '/tmp/replacement.pdf',
+        originalFilename: 'replacement.pdf',
+        mimetype: 'application/pdf',
+      };
+
+      ctx.request!.body = {
+        fileInfo: ['{"name":"replacement.pdf","folder":null}'],
+      };
+      ctx.request!.files = { files: [replacementFile] } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        errors: [],
+      });
+
+      uploadService.replace.mockResolvedValue({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+
+      await controller.replaceFile(ctx as Context);
+
+      expect(mockPrepareUploadRequest).toHaveBeenCalledWith(
+        replacementFile,
+        ctx.request!.body,
+        strapiMock
+      );
+      expect(uploadService.replace).toHaveBeenCalledWith('1', {
+        data: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        file: replacementFile,
+      });
+      expect(ctx.body).toEqual({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+    });
+
+    it('rejects multiple replacement files', async () => {
+      ctx.request!.files = {
+        files: [
+          { filepath: '/tmp/first.jpg', originalFilename: 'first.jpg', mimetype: 'image/jpeg' },
+          { filepath: '/tmp/second.jpg', originalFilename: 'second.jpg', mimetype: 'image/jpeg' },
+        ],
+      } as any;
+
+      await expect(controller.replaceFile(ctx as Context)).rejects.toThrow(
+        'Cannot replace a file with multiple ones'
+      );
+
+      expect(mockPrepareUploadRequest).not.toHaveBeenCalled();
+      expect(uploadService.replace).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
@@ -2,10 +2,18 @@ import type { Context } from 'koa';
 
 import contentApiController from '../content-api';
 import { getService } from '../../utils';
+import { validateUploadBody } from '../validation/content-api/upload';
+import { prepareUploadRequest } from '../../utils/mime-validation';
 
 jest.mock('../../utils');
+jest.mock('../validation/content-api/upload');
+jest.mock('../../utils/mime-validation', () => ({
+  prepareUploadRequest: jest.fn(),
+}));
 
 const mockGetService = getService as jest.MockedFunction<typeof getService>;
+const mockValidateUploadBody = validateUploadBody as jest.MockedFunction<typeof validateUploadBody>;
+const mockPrepareUploadRequest = jest.mocked(prepareUploadRequest);
 
 describe('Content API Controller - find / findPage', () => {
   let mockContext: Context;
@@ -26,6 +34,7 @@ describe('Content API Controller - find / findPage', () => {
       findAndCountPage: jest.fn(),
       findOne: jest.fn(),
       remove: jest.fn(),
+      replace: jest.fn(),
     };
 
     mockFileService = {
@@ -41,6 +50,12 @@ describe('Content API Controller - find / findPage', () => {
     mockValidateQuery = jest.fn().mockResolvedValue(undefined);
     mockSanitizeQuery = jest.fn((query) => Promise.resolve(query));
     mockSanitizeOutput = jest.fn((data) => Promise.resolve(data));
+    mockValidateUploadBody.mockResolvedValue({
+      fileInfo: {
+        name: 'replacement.pdf',
+        folder: null,
+      },
+    } as any);
 
     globalThis.strapi = {
       getModel: jest.fn().mockReturnValue({ uid: 'plugin::upload.file' }),
@@ -276,6 +291,87 @@ describe('Content API Controller - find / findPage', () => {
 
       expect(mockValidateQuery).toHaveBeenCalled();
       expect(mockSanitizeQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe('replaceFile', () => {
+    it('accepts a single replacement file received as an array', async () => {
+      const replacementFile = {
+        filepath: '/tmp/replacement.pdf',
+        originalFilename: 'replacement.pdf',
+        mimetype: 'application/pdf',
+      };
+
+      mockContext.query = { id: '1' } as any;
+      mockContext.request = {
+        body: {
+          fileInfo: ['{"name":"replacement.pdf","folder":null}'],
+        },
+        files: {
+          files: [replacementFile],
+        },
+      } as any;
+
+      mockPrepareUploadRequest.mockResolvedValue({
+        validFiles: [replacementFile],
+        filteredBody: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        errors: [],
+      });
+
+      mockUploadService.replace.mockResolvedValue({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+
+      await buildController().replaceFile(mockContext);
+
+      expect(mockPrepareUploadRequest).toHaveBeenCalledWith(
+        replacementFile,
+        mockContext.request!.body,
+        globalThis.strapi
+      );
+      expect(mockUploadService.replace).toHaveBeenCalledWith('1', {
+        data: {
+          fileInfo: {
+            name: 'replacement.pdf',
+            folder: null,
+          },
+        },
+        file: replacementFile,
+      });
+      expect(mockContext.body).toEqual({
+        id: 1,
+        name: 'replacement.pdf',
+      });
+    });
+
+    it('rejects multiple replacement files', async () => {
+      mockContext.query = { id: '1' } as any;
+      mockContext.request = {
+        body: {},
+        files: {
+          files: [
+            { filepath: '/tmp/first.jpg', originalFilename: 'first.jpg', mimetype: 'image/jpeg' },
+            {
+              filepath: '/tmp/second.jpg',
+              originalFilename: 'second.jpg',
+              mimetype: 'image/jpeg',
+            },
+          ],
+        },
+      } as any;
+
+      await expect(buildController().replaceFile(mockContext)).rejects.toThrow(
+        'Cannot replace a file with multiple ones'
+      );
+
+      expect(mockPrepareUploadRequest).not.toHaveBeenCalled();
+      expect(mockUploadService.replace).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -72,7 +72,7 @@ export default {
     const {
       state: { userAbility, user },
       query: { id },
-      request: { body, files: { files } = {} },
+      request: { body, files: { files: filesInput } = {} },
     } = ctx;
 
     if (typeof id !== 'string') {
@@ -87,9 +87,11 @@ export default {
       id
     );
 
-    if (Array.isArray(files)) {
+    if (Array.isArray(filesInput) && filesInput.length > 1) {
       throw new errors.ApplicationError('Cannot replace a file with multiple ones');
     }
+
+    const files = Array.isArray(filesInput) ? filesInput[0] : filesInput;
 
     const {
       validFiles,

--- a/packages/core/upload/server/src/controllers/admin-upload.ts
+++ b/packages/core/upload/server/src/controllers/admin-upload.ts
@@ -79,7 +79,7 @@ export default {
     const {
       state: { userAbility, user },
       query: { id },
-      request: { body, files: { files } = {} },
+      request: { body, files: { files: filesInput } = {} },
     } = ctx;
 
     if (typeof id !== 'string') {
@@ -94,9 +94,11 @@ export default {
       id
     );
 
-    if (Array.isArray(files)) {
+    if (Array.isArray(filesInput) && filesInput.length > 1) {
       throw new errors.ApplicationError('Cannot replace a file with multiple ones');
     }
+
+    const files = Array.isArray(filesInput) ? filesInput[0] : filesInput;
 
     const {
       validFiles,

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -107,18 +107,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         request: { body, files: { files: filesInput } = {} },
       } = ctx;
 
+      // cannot replace with more than one file
+      if (Array.isArray(filesInput) && filesInput.length > 1) {
+        throw new ValidationError('Cannot replace a file with multiple ones');
+      }
+
+      const files = Array.isArray(filesInput) ? filesInput[0] : filesInput;
+
       const {
         validFiles,
         filteredBody,
         errors: validationErrors,
-      } = await prepareUploadRequest(filesInput, body, strapi);
+      } = await prepareUploadRequest(files, body, strapi);
       if (validFiles.length === 0) {
         throw new errors.ValidationError(validationErrors[0].message);
-      }
-
-      // cannot replace with more than one file
-      if (Array.isArray(filesInput)) {
-        throw new ValidationError('Cannot replace a file with multiple ones');
       }
 
       if (!id || (typeof id !== 'string' && typeof id !== 'number')) {

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -118,18 +118,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         request: { body, files: { files: filesInput } = {} },
       } = ctx;
 
+      // cannot replace with more than one file
+      if (Array.isArray(filesInput) && filesInput.length > 1) {
+        throw new ValidationError('Cannot replace a file with multiple ones');
+      }
+
+      const files = Array.isArray(filesInput) ? filesInput[0] : filesInput;
+
       const {
         validFiles,
         filteredBody,
         errors: validationErrors,
-      } = await prepareUploadRequest(filesInput, body, strapi);
+      } = await prepareUploadRequest(files, body, strapi);
       if (validFiles.length === 0) {
         throw new errors.ValidationError(validationErrors[0].message);
-      }
-
-      // cannot replace with more than one file
-      if (Array.isArray(filesInput)) {
-        throw new ValidationError('Cannot replace a file with multiple ones');
       }
 
       if (!id || (typeof id !== 'string' && typeof id !== 'number')) {

--- a/packages/utils/api-tests/agent.js
+++ b/packages/utils/api-tests/agent.js
@@ -28,6 +28,41 @@ const applyHeadersToRequest = (rq, headers) => {
   }
 };
 
+const isFileDescriptor = (value) =>
+  value && typeof value === 'object' && 'filename' in value && !Array.isArray(value);
+
+const isReadableFile = (value) =>
+  value && typeof value === 'object' && typeof value.pipe === 'function';
+
+const applyFormDataValue = (rq, field, value) => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => applyFormDataValue(rq, field, item));
+    return;
+  }
+
+  // File attachment: { path, filename } or { value, filename }; optional contentType for multipart part
+  if (isFileDescriptor(value)) {
+    const opts = { filename: value.filename };
+    if (value.contentType !== undefined) {
+      opts.contentType = value.contentType;
+    }
+    if ('path' in value) {
+      rq.attach(field, value.path, opts);
+    } else if ('value' in value) {
+      rq.attach(field, value.value, opts);
+    }
+    return;
+  }
+
+  if (isReadableFile(value)) {
+    rq.attach(field, value);
+    return;
+  }
+
+  // Regular form field (string, number, etc.)
+  rq.field(field, value);
+};
+
 const createAgent = (strapi, initialState = {}) => {
   const state = clone(initialState);
   const utils = createUtils(strapi);
@@ -60,22 +95,7 @@ const createAgent = (strapi, initialState = {}) => {
 
     if (formData) {
       Object.keys(formData).forEach((field) => {
-        const value = formData[field];
-        // File attachment: { path, filename } or { value, filename }; optional contentType for multipart part
-        if (value && typeof value === 'object' && 'filename' in value && !Array.isArray(value)) {
-          const opts = { filename: value.filename };
-          if (value.contentType !== undefined) {
-            opts.contentType = value.contentType;
-          }
-          if ('path' in value) {
-            rq.attach(field, value.path, opts);
-          } else if ('value' in value) {
-            rq.attach(field, value.value, opts);
-          }
-        } else {
-          // Regular form field (string, number, etc.)
-          rq.field(field, value);
-        }
+        applyFormDataValue(rq, field, formData[field]);
       });
     }
 

--- a/tests/api/core/upload/admin/file.test.api.js
+++ b/tests/api/core/upload/admin/file.test.api.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const request = require('supertest');
 
 const { createTestBuilder } = require('api-tests/builder');
 const { createStrapiInstance } = require('api-tests/strapi');
@@ -37,6 +38,13 @@ const uploadFile = async (request, filePath = path.join(__dirname, '../utils/rec
 const getFiles = async (request) => {
   const res = await request({ method: 'GET', url: '/upload/files' });
   return res;
+};
+
+const parseBinaryResponse = (res, callback) => {
+  const chunks = [];
+
+  res.on('data', (chunk) => chunks.push(chunk));
+  res.on('end', () => callback(null, Buffer.concat(chunks)));
 };
 
 describe('Upload', () => {
@@ -290,6 +298,53 @@ describe('Upload', () => {
 
         expect(res.statusCode).toBe(200);
         expect(res.body.mime).toBe('image/jpeg');
+      });
+
+      test('Accepts replacement file submitted as a single-element files array', async () => {
+        const replacementPath = path.join(__dirname, '../utils/rec.pdf');
+
+        const res = await rq({
+          method: 'POST',
+          url: `/upload?id=${fileToReplace.id}`,
+          formData: {
+            files: [
+              {
+                path: replacementPath,
+                filename: 'rec.pdf',
+                contentType: 'application/pdf',
+              },
+            ],
+            fileInfo: JSON.stringify({ name: 'rec.pdf' }),
+          },
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toMatchObject({
+          id: fileToReplace.id,
+          name: 'rec.pdf',
+          mime: 'application/pdf',
+        });
+
+        const { body: file } = await rq({
+          method: 'GET',
+          url: `/upload/files/${fileToReplace.id}`,
+        });
+
+        expect(file).toMatchObject({
+          id: fileToReplace.id,
+          name: 'rec.pdf',
+          mime: 'application/pdf',
+          provider: 'local',
+          url: expect.any(String),
+        });
+
+        const downloadRes = await request(strapi.server.httpServer)
+          .get(file.url)
+          .buffer(true)
+          .parse(parseBinaryResponse);
+
+        expect(downloadRes.statusCode).toBe(200);
+        expect(downloadRes.body).toEqual(fs.readFileSync(replacementPath));
       });
     });
   });


### PR DESCRIPTION
### What does it do?

Normalizes single-file multipart arrays before replacing upload assets from the admin and content API controllers. True multi-file replacement requests (more than one file) continue to be rejected.

Fixes #26207.
Refs #26387 (related, intentionally not closed by this PR — see below).

### Why is it needed?

Some multipart clients submit a replacement upload as a one-item `files` array. The replace controllers rejected any array before upload validation with `Cannot replace a file with multiple ones`, even when the array contained exactly one file. This keeps replacement requests on the file replacement path when exactly one file is provided.

### Scope note on #26387

This PR fixes the hard-error failure mode (`Cannot replace a file with multiple ones`). The silent failure mode described in #26387 — metadata updates but the served asset appears unchanged, with no error — is not addressed here. At the server/API level the replace does overwrite the stored bytes; because replacement intentionally keeps the same hash/extension, the URL never changes, so a CDN or browser cache can keep serving the old content at the unchanged URL. That investigation should stay open separately, which is why #26387 is referenced rather than closed.

### Notes

This intentionally preserves the existing upload service behavior that keeps the stored hash and extension stable when replacing media, so the PR does not change media URL semantics.

### How to test it?

- API-level integration test covering the single-element-array replace path end to end (real multipart parsing, real local provider, byte-level check of the served file): `node .yarn/releases/yarn-4.12.0.cjs test:api tests/api/core/upload/admin/file.test.api.js`
- `node .yarn/releases/yarn-4.12.0.cjs workspace @strapi/upload test:unit`
- `node .yarn/releases/yarn-4.12.0.cjs prettier --check packages/core/upload/server/src/controllers/admin-upload.ts packages/core/upload/server/src/controllers/content-api.ts packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts packages/core/upload/server/src/controllers/__tests__/content-api.test.ts packages/utils/api-tests/agent.js tests/api/core/upload/admin/file.test.api.js`
- `node .yarn/releases/yarn-4.12.0.cjs eslint packages/core/upload/server/src/controllers/admin-upload.ts packages/core/upload/server/src/controllers/content-api.ts packages/core/upload/server/src/controllers/__tests__/admin-upload.test.ts packages/core/upload/server/src/controllers/__tests__/content-api.test.ts packages/utils/api-tests/agent.js tests/api/core/upload/admin/file.test.api.js`

---
Fixes CPR-359
