### PR TITLE
chore(commitlint): disable body-max-line-length rule

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -21,6 +21,7 @@ const config: UserConfig = {
         'future',
       ],
     ],
+    'body-max-line-length': [RuleConfigSeverity.Disabled],
   },
   ignores: [
     (commitMessage) => {


### PR DESCRIPTION
### What does it do?

Disables the `body-max-line-length` rule in the commitlint configuration.

### Why is it needed?

The default 100-character line length limit on commit message bodies is too restrictive, particularly for AI generated content that follows this very PR template.

### How to test it?

Create a commit with a body line exceeding 100 characters — commitlint should no longer reject it.

### Related issue(s)/PR(s)

- ø
