### PR TITLE
chore(ci): improve dependabot security grouping and version update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,58 +1,212 @@
+# Dependabot policy for the Strapi monorepo:
+# - Security advisories: open immediately; npm families grouped, others individual.
+# - Version updates: max 10 open npm PRs / 3 actions PRs, weekly on Sundays.
+# - Cooldown: 30d patch / 60d minor before version-update PRs (security unaffected).
+# - Majors: manual only (except security advisories that require a major bump).
 version: 2
 updates:
   - package-ecosystem: npm
     directory: /
     groups:
       babel:
+        applies-to: version-updates
         patterns:
           - '@babel/*'
           - 'babel-*'
 
       eslint:
+        applies-to: version-updates
         patterns:
           - 'eslint'
           - 'eslint-*'
           - '@typescript-eslint/*'
 
       jest:
+        applies-to: version-updates
         patterns:
           - 'jest'
           - 'jest-*'
 
+      nx:
+        applies-to: version-updates
+        patterns:
+          - 'nx'
+          - '@nx/*'
+
+      prettier:
+        applies-to: version-updates
+        patterns:
+          - 'prettier'
+
       react:
+        applies-to: version-updates
         patterns:
           - 'react'
           - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+          - '@types/react-*'
 
       react-dnd:
+        applies-to: version-updates
         patterns:
           - 'react-dnd'
           - 'react-dnd-*'
 
       redux:
+        applies-to: version-updates
         patterns:
           - '@reduxjs/toolkit'
           - 'react-redux'
 
       richtext-editor:
+        applies-to: version-updates
         patterns:
           - 'markdown-it'
           - 'markdown-it-*'
 
+      rollup:
+        applies-to: version-updates
+        patterns:
+          - 'rollup'
+          - '@rollup/*'
+          - 'rollup-plugin-*'
+
       storybook:
+        applies-to: version-updates
         patterns:
           - 'storybook'
           - '@storybook/*'
 
       testing-library:
+        applies-to: version-updates
         patterns:
           - '@testing-library/*'
 
+      typescript:
+        applies-to: version-updates
+        patterns:
+          - 'typescript'
+
+      vite:
+        applies-to: version-updates
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - 'vitest'
+
       webpack:
+        applies-to: version-updates
         patterns:
           - 'webpack'
-          - 'webpack-cli'
-          - 'webpack-dev-server'
+          - 'webpack-*'
+          - 'html-webpack-plugin'
+          - 'mini-css-extract-plugin'
+
+      # Security update groups override GitHub's default npm_and_yarn mega-PR.
+      # Related families stay grouped; all other advisories open one PR per dependency.
+      babel-security:
+        applies-to: security-updates
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+
+      eslint-security:
+        applies-to: security-updates
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@typescript-eslint/*'
+
+      jest-security:
+        applies-to: security-updates
+        patterns:
+          - 'jest'
+          - 'jest-*'
+
+      nx-security:
+        applies-to: security-updates
+        patterns:
+          - 'nx'
+          - '@nx/*'
+
+      prettier-security:
+        applies-to: security-updates
+        patterns:
+          - 'prettier'
+
+      react-security:
+        applies-to: security-updates
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+          - '@types/react-*'
+
+      react-dnd-security:
+        applies-to: security-updates
+        patterns:
+          - 'react-dnd'
+          - 'react-dnd-*'
+
+      redux-security:
+        applies-to: security-updates
+        patterns:
+          - '@reduxjs/toolkit'
+          - 'react-redux'
+
+      richtext-editor-security:
+        applies-to: security-updates
+        patterns:
+          - 'markdown-it'
+          - 'markdown-it-*'
+
+      rollup-security:
+        applies-to: security-updates
+        patterns:
+          - 'rollup'
+          - '@rollup/*'
+          - 'rollup-plugin-*'
+
+      storybook-security:
+        applies-to: security-updates
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+
+      testing-library-security:
+        applies-to: security-updates
+        patterns:
+          - '@testing-library/*'
+
+      typescript-security:
+        applies-to: security-updates
+        patterns:
+          - 'typescript'
+
+      vite-security:
+        applies-to: security-updates
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+
+      vitest-security:
+        applies-to: security-updates
+        patterns:
+          - 'vitest'
+
+      webpack-security:
+        applies-to: security-updates
+        patterns:
+          - 'webpack'
+          - 'webpack-*'
+          - 'html-webpack-plugin'
+          - 'mini-css-extract-plugin'
 
     commit-message:
       prefix: 'chore'
@@ -61,7 +215,14 @@ updates:
       interval: weekly
       day: sunday
       time: '22:00'
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
+    # Wait for releases to stabilise before opening version-update PRs.
+    # Security advisories are not affected by cooldown.
+    cooldown:
+      default-days: 30
+      semver-patch-days: 30
+      semver-minor-days: 60
+      semver-major-days: 90
     versioning-strategy: increase
     ignore:
       # Only allow patch as minor babel versions need to be upgraded all together
@@ -72,7 +233,6 @@ updates:
 
       - dependency-name: '*'
         update-types:
-          - 'version-update:semver-patch'
           - 'version-update:semver-major'
 
     labels:
@@ -80,8 +240,17 @@ updates:
       - 'pr: chore'
 
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 3
     directory: /
+    groups:
+      # Override org-level grouped security updates; each action gets its own PR.
+      security-individual:
+        applies-to: security-updates
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '*'
+
     commit-message:
       prefix: 'chore'
       include: 'scope'
@@ -89,6 +258,11 @@ updates:
       interval: weekly
       day: sunday
       time: '22:00'
+    cooldown:
+      default-days: 30
+      semver-patch-days: 30
+      semver-minor-days: 60
+      semver-major-days: 90
     labels:
       - 'source: dependencies'
       - 'pr: chore'


### PR DESCRIPTION
### What does it do?

- Adds `applies-to: security-updates` family groups to override GitHub's default `npm_and_yarn` mega-PR (unrelated advisories like vite + `@apollo/server` get separate PRs; webpack, babel, etc. stay grouped).
- Adds a github-actions security group so each action gets its own security PR instead of org-level bundling.
- Re-enables throttled version updates: 10 open npm PRs / 3 actions PRs, with 30d patch / 60d minor cooldowns (security advisories unaffected).
- Allows patch and minor version updates again; majors remain manual (babel still patch-only for version updates).
- Expands version/security families: nx, prettier, rollup, vite, vitest, broader webpack/react patterns.

### Why is it needed?

Dependabot was opening broken grouped security PRs (e.g. #26403) bundling unrelated major bumps. Version updates were fully disabled (`open-pull-requests-limit: 0`), so routine dependency maintenance never happened. This config separates security grouping from version-update policy and throttles non-security bumps to reduce noise and supply-chain risk.

### How to test it?

1. Merge to `develop` and close any stale grouped Dependabot PRs (e.g. #26403).
2. On the next security scan, confirm new advisories open as separate PRs per dependency (or per family for webpack/babel/etc.), not a single `npm_and_yarn` PR.
3. After cooldown elapses, confirm version-update PRs respect the 10-PR cap and family grouping on the weekly Sunday schedule.

### Related issue(s)/PR(s)

- Related PR: #26403 (broken grouped security update that motivated this change)