### PR TITLE
docs(openapi): add contributor documentation

### DIFF
--- a/docs/docs/docs/01-core/openapi/00-intro.md
+++ b/docs/docs/docs/01-core/openapi/00-intro.md
@@ -45,17 +45,15 @@ It's within this context that we've developed this new package, designed to offe
 This package provides APIs and tools to:
 
 - Programmatically generate OpenAPI documents **specifically** tailored for Strapi applications
-- Validate generated documents for compliance and accuracy
-- Customize the document generation process to suit your needs
+- Customize the document generation process through providers, matchers, assemblers, and processors
 
 **What it's not intended to be ❌**
 
 - A direct replacement for the documentation plugin (including Swagger UI)
 - A generic OpenAPI specification generator for non-Strapi applications
-- A tool for generating OpenAPI documents as static files
-- A command-line interface (CLI)
+- A standalone file writer (generation returns an in-memory document; see [Usage](./03-usage.md) for the experimental CLI wrapper)
 
 ### Limitations
 
-- Currently unable to represent cyclical references (awaiting zod v4), which are temporarily represented as simple "any" objects
+- Cyclical references between models (_relations, components, dynamic zones, media_) are not fully represented in component schemas yet
 - Limited customization capabilities in the current version; these will be expanded in future releases (our priority is making it ready for client use before iterating further)

--- a/docs/docs/docs/01-core/openapi/01-technologies.md
+++ b/docs/docs/docs/01-core/openapi/01-technologies.md
@@ -9,7 +9,7 @@ tags:
 
 # OpenAPI
 
-This section provides an overview of the technologies used in the OpenAPI package
+This section provides an overview of the technologies used in the OpenAPI package.
 
 ---
 
@@ -30,29 +30,17 @@ The package focuses on using a limited set of external dependencies to keep a li
 
 ---
 
-### [Zod to OpenAPI](https://github.com/asteasolutions/zod-to-openapi)
+### [Zod](https://github.com/colinhacks/zod)
 
-> A library that uses [zod schemas](https://github.com/colinhacks/zod) to generate OpenAPI Swagger documentation.
-
-This library is used to transform `zod` schema obtained from Strapi routes objects into valid OpenAPI Schema.
+Route objects carry Zod schemas on `route.request` and `route.response`. Assemblers convert those schemas into OpenAPI parameters, request bodies, and response objects via `z.toJSONSchema` (see `src/utils/zod.ts` and the `ComponentsWriter` post-processor).
 
 :::info
-It is particularly useful to avoid leaking the OpenAPI domain logic into the Strapi core logic.
+Keeping schemas on routes avoids leaking OpenAPI domain logic into Strapi core.
 :::
 
 :::warning
-The main pain point of using this library is **not being able to infer, represent, and transform cyclic dependencies between models** (_relations, components, dynamic zones, media_) **in the final schema** without leaking the OpenAPI domain to the Strapi core.
-
-Luckily, `zod` v4 will [soon go stable](https://v4.zod.dev/v4#wrapping-up) and offer the possibility to transform `zod` schema into JSON object natively **and** with cycles’ support.
-
-It would represent a huge opportunity to migrate away from this dependency and use `zod` only.
-
-For more information, see
-
-- https://v4.zod.dev/
-- https://v4.zod.dev/json-schema
-- https://v4.zod.dev/metadata
-  :::
+Cyclic dependencies between models (_relations, components, dynamic zones, media_) remain difficult to represent accurately in the final component schemas.
+:::
 
 ### [Debug](https://github.com/debug-js/debug)
 
@@ -64,6 +52,8 @@ The root namespace for the package is `strapi:core:openapi` and each component a
 
 :::tip
 A small wrapper that automatically binds the correct default namespace can be found in the package utils: `src/utils/debug.ts`
+
+Enable debug output with `DEBUG=strapi:core:openapi:*`.
 :::
 
 ### Types

--- a/docs/docs/docs/01-core/openapi/02-architecture.md
+++ b/docs/docs/docs/01-core/openapi/02-architecture.md
@@ -31,19 +31,21 @@ This domain could potentially be moved to the Strapi core or Strapi utils in the
 
 This domain contains all the components necessary to generate a valid OpenAPI document from a Strapi application:
 
-| Component         | Path                                       |
-| ----------------- | ------------------------------------------ |
-| OpenAPI Generator | `src/generator`                            |
-| Assemblers        | `src/assemblers`                           |
-| Contexts          | `src/context`                              |
-| Registries        | `src/registries`                           |
-| Processors        | `src/pre-processor`, `src/post-processors` |
+| Component         | Path                                      |
+| ----------------- | ----------------------------------------- |
+| OpenAPI Generator | `src/generator`                           |
+| Assemblers        | `src/assemblers`                          |
+| Contexts          | `src/context`                             |
+| Registries        | `src/registries`                          |
+| Processors        | `src/pre-processor`, `src/post-processor` |
 
 ---
 
 Additionally, the package centralizes all exports for the public API in an `src/exports.ts` file.
 
 This approach decouples the package root exports from the public programmatic API it exposes.
+
+For step-by-step extension guides, see the [Contributing](./contributing/overview) section.
 
 ## Design Pattern
 
@@ -137,7 +139,7 @@ Generates valid OpenAPI documents from a Strapi application:
   - Holds information and instances for assembly processes
   - Maintains reference to the final built object in `context.output.data`
   - **Registries**
-    - Data structures for storing/retrieving configurations and common objects
+    - Reserved for shared assembly state (`RegistriesFactory` currently returns an empty object)
 
 ```mermaid
 erDiagram

--- a/docs/docs/docs/01-core/openapi/03-usage.md
+++ b/docs/docs/docs/01-core/openapi/03-usage.md
@@ -10,7 +10,7 @@ toc_max_heading_level: 4
 
 # OpenAPI
 
-This section explores the Strapi OpenAPI toolset
+This section explores the Strapi OpenAPI toolset.
 
 ---
 
@@ -23,17 +23,41 @@ By default, it collects content API routes registered in the application, transf
 ### Signature
 
 ```typescript
-function generate(strapi: Core.Strapi, options?: GeneratorOptions): GeneratorOutput;
+function generate(strapi: Core.Strapi, options?: GenerationOptions): GeneratorOutput;
 ```
 
 ### Parameters
 
-- `strapi`, the Strapi application to generate an OpenAPI specification for
-- `options`, optional configuration for the generation process
+- `strapi` — the Strapi application to generate an OpenAPI specification for
+- `options.type` — optional route set to document: `'content-api'` (default) or `'admin'`
 
-### Return Value
+### Return value
 
-A generation output object, containing:
+A generation output object containing:
 
-- `document`, the generated OpenAPI specification, as JSON.
-- `stats`, statistics about the generation process
+- `document` — the generated OpenAPI specification as JSON
+- `durationMs` — elapsed generation time in milliseconds
+
+### Example
+
+```typescript
+import { generate } from '@strapi/openapi';
+
+const { document, durationMs } = generate(strapi, { type: 'content-api' });
+```
+
+---
+
+## CLI
+
+An experimental CLI wrapper is available in `@strapi/strapi`:
+
+```bash
+strapi openapi generate [-o, --output <path>]
+```
+
+The command loads the current application, calls `generate()`, and writes the result to a JSON file (default: `specification.json` in the project root).
+
+:::warning
+The OpenAPI generation feature is experimental. Its behavior and output may change without following semver.
+:::

--- a/docs/docs/docs/01-core/openapi/contributing/00-overview.md
+++ b/docs/docs/docs/01-core/openapi/contributing/00-overview.md
@@ -1,0 +1,34 @@
+---
+title: Overview
+slug: /openapi/contributing/overview
+tags:
+  - openapi
+  - contributing
+toc_max_heading_level: 4
+---
+
+# OpenAPI
+
+Guides for extending `@strapi/openapi`. Start with [Architecture](../architecture) if you need the overall pipeline.
+
+---
+
+## Extension points
+
+| Guide                                        | Use when you need to…                         |
+| -------------------------------------------- | --------------------------------------------- |
+| [Routes provider](./routes-provider)         | Collect routes from a new Strapi source       |
+| [Routes matcher rule](./routes-matcher-rule) | Filter which routes are documented            |
+| [Assemblers](./assemblers)                   | Build or extend OpenAPI document sections     |
+| [Context factory](./context-factory)         | Add a new assembly level with its own context |
+| [Processors](./processors)                   | Run logic before or after assembly            |
+| [Testing](./testing)                         | Write or debug unit tests                     |
+
+Most changes touch **assemblers** (especially operation-level leaf assemblers) or **route collection**. Context factories and processors are needed less often.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+import { useCurrentSidebarCategory } from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items} />
+```

--- a/docs/docs/docs/01-core/openapi/contributing/01-routes-provider.md
+++ b/docs/docs/docs/01-core/openapi/contributing/01-routes-provider.md
@@ -1,0 +1,89 @@
+---
+title: Routes Provider
+slug: /openapi/contributing/routes-provider
+tags:
+  - openapi
+  - contributing
+  - routes
+  - provider
+---
+
+# OpenAPI
+
+Learn how to create a new routes provider
+
+---
+
+## Adding a Routes Provider
+
+Considering you want to add a new provider called `xxx`.
+
+#### 1. Add a new `xxx.ts` file in `src/routes/providers` and paste the following snippet:
+
+```typescript
+import type { Core } from '@strapi/types';
+
+import { createDebugger } from '../../utils';
+
+import { AbstractRoutesProvider } from './abstract';
+
+const debug = createDebugger('routes:provider:xxx');
+
+export class XXXRoutesProvider extends AbstractRoutesProvider {
+  public get routes(): Core.Route[] {
+    const routes = [];
+    // ^ The routes collection logic goes here
+    //   Access to this._strapi to interact with the Strapi application
+
+    debug('found %o routes in xxx', routes.length);
+
+    return routes;
+  }
+}
+```
+
+#### 2. Export the provider from `src/routes/providers/index.ts`
+
+```typescript
+// ...
+
+export { XXXRoutesProvider } from './xxx';
+// ^ export the provider from here
+```
+
+#### 3. Re-export the provider from `src/routes/index.ts`
+
+```typescript
+export {
+  // ... other providers
+  XXXRoutesProvider,
+  // ^ re-export the provider from here
+} from './providers';
+```
+
+#### 4. Finally, modify the `generate` function in `src/exports.ts` to use the newly created provider
+
+```typescript
+// ...
+
+import {
+  // ...
+  XXXRoutesProvider,
+  // ^  import the newly created provider
+} from './routes';
+
+export const generate = (strapi: Core.Strapi, options?: GenerationOptions): GeneratorOutput => {
+  // ...
+
+  const routeCollector = new RouteCollector(
+    [
+      // ... other providers
+      new XXXRoutesProvider(strapi),
+      // ^ instantiate the new provider here
+    ]
+    // ...
+  );
+
+  // ...
+};
+```

--- a/docs/docs/docs/01-core/openapi/contributing/02-routes-matcher-rule.md
+++ b/docs/docs/docs/01-core/openapi/contributing/02-routes-matcher-rule.md
@@ -1,0 +1,63 @@
+---
+title: Routes Matcher Rule
+slug: /openapi/contributing/routes-matcher-rule
+tags:
+  - openapi
+  - contributing
+  - routes
+  - matcher
+  - rule
+---
+
+# OpenAPI
+
+Learn how to create a new routes' matcher rule
+
+---
+
+## Adding a Routes Matcher Rule
+
+Considering you want to add a new route matcher rule to only select routes with certain methods.
+
+#### 1. Add a new file named `is-method-in.ts` in `src/routes/rules` and paste the following snippet:
+
+```typescript
+import type { MatcherRule } from '../types';
+
+export const isMethodIn = (methods: string[]): MatcherRule => {
+  return (route) => methods.includes(route.method);
+};
+```
+
+#### 2. Next, export the rule from `src/routes/rules/index.ts`
+
+```typescript
+// ... other exports
+
+export { isMethodIn } from './is-method-in';
+// ^ export the rule from here
+```
+
+#### 3. Finally, pass the new rule to the route collector instance created in the `generate` process in `src/exports.ts`
+
+```typescript
+// ...
+
+export const generate = (strapi: Core.Strapi, options?: GenerationOptions): GeneratorOutput => {
+  // ...
+
+  const routeCollector = new RouteCollector(
+    [
+      /* ... */
+    ],
+
+    new RouteMatcher([
+      // ... other rules
+      rules.isMethodIn(['POST', 'PUT']),
+      // ^ pass the new rule to the matcher instance
+    ])
+  );
+
+  // ...
+};
+```

--- a/docs/docs/docs/01-core/openapi/contributing/03-assemblers.md
+++ b/docs/docs/docs/01-core/openapi/contributing/03-assemblers.md
@@ -1,0 +1,129 @@
+---
+title: Assemblers
+slug: /openapi/contributing/assemblers
+tags:
+  - openapi
+  - contributing
+  - assemblers
+---
+
+# OpenAPI
+
+Learn how to add assemblers to the document generation pipeline.
+
+---
+
+## Assembler levels
+
+Assemblers build the OpenAPI document in layers. Each level has a matching context type (see [Context factory](./context-factory)).
+
+| Level     | Interface             | Example                        | Factory                     |
+| --------- | --------------------- | ------------------------------ | --------------------------- |
+| Document  | `Assembler.Document`  | `DocumentInfoAssembler`        | `DocumentAssemblerFactory`  |
+| Path      | `Assembler.Path`      | `PathItemAssembler`            | `PathAssemblerFactory`      |
+| Path item | `Assembler.PathItem`  | `OperationAssembler`           | `PathItemAssemblerFactory`  |
+| Operation | `Assembler.Operation` | `OperationParametersAssembler` | `OperationAssemblerFactory` |
+
+Most day-to-day changes are **operation-level leaf assemblers** (parameters, body, responses, etc.). Add a **composite assembler** when you need to orchestrate a new nested structure.
+
+---
+
+## Adding a leaf assembler
+
+Consider adding an operation assembler called `OperationSummaryAssembler` that sets `summary` from route metadata.
+
+#### 1. Create `summary.ts` in `src/assemblers/document/path/path-item/operation`
+
+```typescript
+import type { Core } from '@strapi/types';
+
+import type { OperationContext } from '../../../../../types';
+import { createDebugger } from '../../../../../utils';
+import type { Assembler } from '../../../..';
+
+const debug = createDebugger('assembler:summary');
+
+export class OperationSummaryAssembler implements Assembler.Operation {
+  assemble(context: OperationContext, route: Core.Route): void {
+    const summary = route.info.apiName ?? route.handler;
+
+    debug('assembling summary for %o %o: %o', route.method, route.path, summary);
+
+    context.output.data.summary = summary;
+  }
+}
+```
+
+Leaf assemblers receive the context for their level plus any extra arguments defined on the interface (operation assemblers also receive the `route`).
+
+Write results into `context.output.data`. That object is merged into the parent output by the composite assembler that invoked yours.
+
+#### 2. Export from `src/assemblers/document/path/path-item/operation/index.ts`
+
+```typescript
+export { OperationSummaryAssembler } from './summary';
+```
+
+#### 3. Register in `OperationAssemblerFactory.createAll()`
+
+```typescript
+import { OperationSummaryAssembler } from './summary';
+
+export class OperationAssemblerFactory {
+  createAll(): Assembler.Operation[] {
+    return [
+      // ... existing assemblers
+      new OperationSummaryAssembler(),
+    ];
+  }
+}
+```
+
+For a **document-level** leaf assembler (e.g. a new top-level OpenAPI field), follow the same pattern under `src/assemblers/document/` and register it in `DocumentAssemblerFactory`.
+
+---
+
+## Adding a composite assembler
+
+Composite assemblers create a child context, run sub-assemblers, then merge the result into the parent output. `OperationAssembler` (`src/assemblers/document/path/path-item/operation/operation.ts`) is the reference implementation.
+
+Use this pattern when you introduce a new nested document section that needs its own context and multiple sub-assemblers.
+
+#### 1. Implement the composite class
+
+```typescript
+import type { Core } from '@strapi/types';
+
+import { OperationContextFactory } from '../../../../../context';
+import type { PathItemContext } from '../../../../../types';
+import type { Assembler } from '../../../..';
+
+export class OperationAssembler implements Assembler.PathItem {
+  constructor(
+    private readonly _assemblers: Assembler.Operation[],
+    private readonly _contextFactory: OperationContextFactory = new OperationContextFactory()
+  ) {}
+
+  assemble(context: PathItemContext, path: string, routes: Core.Route[]): void {
+    const { output, ...sharedProps } = context;
+
+    for (const route of routes) {
+      const operationContext = this._contextFactory.create(sharedProps);
+
+      for (const assembler of this._assemblers) {
+        assembler.assemble(operationContext, route);
+      }
+
+      Object.assign(output.data, { [route.method.toLowerCase()]: operationContext.output.data });
+    }
+  }
+}
+```
+
+#### 2. Wire it through a factory
+
+Create or extend a factory (e.g. `PathItemAssemblerFactory`) that instantiates your composite assembler with its sub-assemblers and context factory, then register that factory in the parent level (`PathAssemblerFactory` or `DocumentAssemblerFactory`).
+
+:::tip
+Reuse `timer` and `registries` from the parent context when creating child contexts so timing and shared state stay consistent. Pass them via `PartialContext` (see [Context factory](./context-factory)).
+:::

--- a/docs/docs/docs/01-core/openapi/contributing/04-context-factory.md
+++ b/docs/docs/docs/01-core/openapi/contributing/04-context-factory.md
@@ -1,0 +1,90 @@
+---
+title: Context Factory
+slug: /openapi/contributing/context-factory
+tags:
+  - openapi
+  - contributing
+  - context
+---
+
+# OpenAPI
+
+Learn how to add a context factory for a new assembly level.
+
+---
+
+## When to add one
+
+Each assembler level operates on a typed context (`DocumentContext`, `OperationContext`, etc.) created by a matching factory. Add a new factory when you introduce a **new assembly level** with its own output shape.
+
+If you only add leaf assemblers at an existing level, reuse the existing factory (e.g. `OperationContextFactory`).
+
+---
+
+## Adding a context factory
+
+Suppose you need a new assembly level with its own output shape. Follow the pattern used by `OperationContextFactory`.
+
+#### 1. Define the context data type in `src/types.ts`
+
+```typescript
+import type { Context } from './context';
+
+export type WidgetContextData = Partial<{ widgets: Record<string, unknown> }>;
+export type WidgetContext = Context<WidgetContextData>;
+```
+
+#### 2. Create `src/context/factories/widget.ts`
+
+```typescript
+import { RegistriesFactory } from '../../registries';
+import type { WidgetContext, WidgetContextData } from '../../types';
+import { TimerFactory } from '../../utils';
+import type { PartialContext } from '../types';
+
+import { AbstractContextFactory } from './abstract';
+
+export class WidgetContextFactory extends AbstractContextFactory<WidgetContextData> {
+  constructor(
+    registriesFactory: RegistriesFactory = new RegistriesFactory(),
+    timerFactory: TimerFactory = new TimerFactory()
+  ) {
+    super(registriesFactory, timerFactory);
+  }
+
+  create(context: PartialContext<WidgetContextData>): WidgetContext {
+    return super.create(context, {});
+  }
+}
+```
+
+`AbstractContextFactory.create()` builds a context with:
+
+- `strapi` and `routes` (required)
+- `timer` and `registries` (reused from the parent when provided, otherwise created fresh)
+- `output.data` initialized to the `defaultValue` passed to `super.create()`
+
+#### 3. Export from `src/context/factories/index.ts`
+
+```typescript
+export { WidgetContextFactory } from './widget';
+```
+
+#### 4. Use in your composite assembler
+
+Pass shared props from the parent context so sub-assemblers share the same timer and registries:
+
+```typescript
+const childContext = this._contextFactory.create({
+  strapi: context.strapi,
+  routes: context.routes,
+  timer: context.timer,
+  registries: context.registries,
+});
+```
+
+---
+
+## Registries
+
+`RegistriesFactory.createAll()` currently returns an empty object and `ContextRegistries` is an empty interface. Registries are reserved for future shared assembly state (deduplicated schemas, cross-assembler caches, etc.). No separate setup is required today.

--- a/docs/docs/docs/01-core/openapi/contributing/05-processors.md
+++ b/docs/docs/docs/01-core/openapi/contributing/05-processors.md
@@ -1,0 +1,62 @@
+---
+title: Processors
+slug: /openapi/contributing/processors
+tags:
+  - openapi
+  - contributing
+  - processors
+---
+
+# OpenAPI
+
+Learn how to add pre- and post-processors to the generation lifecycle.
+
+---
+
+## Overview
+
+The generator runs components in this order:
+
+1. **Pre-processors** — prepare the document context before assembly
+2. **Assemblers** — build the OpenAPI document
+3. **Post-processors** — finalize the document after assembly
+
+Both processor types receive the full `DocumentContext`. Register instances in `PreProcessorFactory` or `PostProcessorsFactory`; those factories are wired in `src/exports.ts`.
+
+---
+
+## Adding a post-processor
+
+`ComponentsWriter` is the current post-processor: it writes `components.schemas` from `z.globalRegistry` after assembly.
+
+#### 1. Create a processor class
+
+```typescript
+import type { DocumentContext } from '../types';
+import type { PostProcessor } from './types';
+
+export class ExamplePostProcessor implements PostProcessor {
+  postProcess(context: DocumentContext): void {
+    // mutate context.output.data
+  }
+}
+```
+
+#### 2. Register it in `PostProcessorsFactory`
+
+```typescript
+import { ComponentsWriter } from './component-writer';
+import { ExamplePostProcessor } from './example';
+
+export class PostProcessorsFactory {
+  createAll(): PostProcessor[] {
+    return [new ComponentsWriter(), new ExamplePostProcessor()];
+  }
+}
+```
+
+Pre-processors implement `PreProcessor` with a `preProcess(context: DocumentContext)` method and are registered the same way in `PreProcessorFactory`.
+
+:::tip
+Prefer assemblers for building document sections. Use processors only for cross-cutting work that must run before or after the full assembly pass.
+:::

--- a/docs/docs/docs/01-core/openapi/contributing/06-testing.md
+++ b/docs/docs/docs/01-core/openapi/contributing/06-testing.md
@@ -1,0 +1,113 @@
+---
+title: Testing
+slug: /openapi/contributing/testing
+tags:
+  - openapi
+  - contributing
+  - testing
+---
+
+# OpenAPI
+
+How to test changes in `@strapi/openapi`.
+
+---
+
+## Location and tooling
+
+Unit tests live in `packages/core/openapi/__tests__/`. Run them from the package directory:
+
+```bash
+cd packages/core/openapi && yarn test:unit
+```
+
+Shared helpers are in `__tests__/fixtures/` and `__tests__/mocks/`.
+
+---
+
+## Testing route providers
+
+Mock the Strapi instance with only the properties your provider reads. `StrapiMock` in `__tests__/mocks/strapi.mock.ts` covers common `apis` and `plugins` shapes.
+
+```typescript
+import type { Core } from '@strapi/types';
+
+import { ApiRoutesProvider } from '../../src/routes';
+import { StrapiMock } from '../mocks';
+
+it('returns registered API routes', () => {
+  const strapi = new StrapiMock() as unknown as Core.Strapi;
+  const provider = new ApiRoutesProvider(strapi);
+
+  expect(provider.routes.length).toBeGreaterThan(0);
+});
+```
+
+---
+
+## Testing matcher rules
+
+Build a minimal `Core.Route` and pass it to `RouteMatcher`:
+
+```typescript
+import type { Core } from '@strapi/types';
+
+import { RouteMatcher } from '../../src/routes';
+
+const route: Core.Route = {
+  method: 'GET',
+  path: '/api/articles',
+  handler: '',
+  info: { type: 'content-api' },
+};
+
+expect(new RouteMatcher([(r) => r.method === 'GET']).match(route)).toBe(true);
+```
+
+---
+
+## Testing assemblers
+
+Create a context through the matching factory, run the assembler, and assert on `context.output.data`:
+
+```typescript
+import type { Core } from '@strapi/types';
+import * as z from 'zod/v4';
+
+import { OperationParametersAssembler } from '../../src/assemblers/document/path/path-item/operation';
+import { OperationContextFactory } from '../../src/context';
+
+const context = new OperationContextFactory().create({ strapi: {} as Core.Strapi, routes: [] }, {});
+
+new OperationParametersAssembler().assemble(context, {
+  method: 'GET',
+  path: '/api/articles/:id',
+  handler: '',
+  info: { type: 'content-api' },
+  request: {
+    params: { id: z.string() },
+    query: { locale: z.string().optional() },
+  },
+});
+
+expect(context.output.data.parameters).toEqual(
+  expect.arrayContaining([
+    expect.objectContaining({ name: 'id', in: 'path' }),
+    expect.objectContaining({ name: 'locale', in: 'query' }),
+  ])
+);
+```
+
+Route `request` and `response` Zod schemas are the primary inputs to operation assemblers. See `__tests__/operation-assemblers.test.ts` for examples that mirror content API `addQueryParams` / `addInputParams` behaviour.
+
+---
+
+## Debugging failing tests
+
+Enable package debug output from the package directory:
+
+```bash
+cd packages/core/openapi && DEBUG=strapi:core:openapi:* yarn test:unit
+```
+
+See [Technologies](../technologies) for the debug namespace conventions.

--- a/docs/docs/docs/01-core/openapi/contributing/_category_.json
+++ b/docs/docs/docs/01-core/openapi/contributing/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Contributing",
+  "collapsible": true,
+  "collapsed": true
+}


### PR DESCRIPTION
### What does it do?

Adds contributor documentation for the `@strapi/openapi` package in the core docs, including extension guides for routes providers, matcher rules, assemblers, context factories, processors, and testing. Also updates the existing intro, technologies, architecture, and usage pages to match the current package API and behaviour.

### Why is it needed?

The OpenAPI package had partial contributor documentation on develop but no practical guides for extending it. This completes the work started in https://github.com/strapi/strapi/pull/23445, which was closed without merging so the content could be brought up to date against the current codebase.

### How to test it?

1. From the repo root, build or serve the contributor docs site (see `docs/` README).
2. Navigate to **Core → OpenAPI** and confirm the updated intro, usage, and architecture pages render correctly.
3. Open the **Contributing** subsection and verify all guides appear in the sidebar and link to each other.
4. Spot-check code snippets against `packages/core/openapi/src/` (paths, types, and factory registration patterns).

### Related issue(s)/PR(s)

- Supersedes https://github.com/strapi/strapi/pull/23445