### PR TITLE
fix(admin): add missing TooltipProvider wrapper in admin root

### DIFF
--- a/packages/core/admin/admin/src/components/Providers.tsx
+++ b/packages/core/admin/admin/src/components/Providers.tsx
@@ -13,6 +13,7 @@ import { TrackingProvider } from '../features/Tracking';
 import { GuidedTourProvider } from './GuidedTour/GuidedTourProvider';
 import { LanguageProvider } from './LanguageProvider';
 import { Theme } from './Theme';
+import { TooltipProvider } from '@strapi/design-system';
 
 import type { Store } from '../core/store/configure';
 import type { StrapiApp } from '../StrapiApp';
@@ -57,6 +58,7 @@ const Providers = ({ children, strapi, store }: ProvidersProps) => {
                   <NotificationsProvider>
                     <TrackingProvider>
                       <GuidedTourProvider>
+                        <TooltipProvider>
                         <ConfigurationProvider
                           defaultAuthLogo={strapi.configurations.authLogo}
                           defaultMenuLogo={strapi.configurations.menuLogo}
@@ -64,6 +66,7 @@ const Providers = ({ children, strapi, store }: ProvidersProps) => {
                         >
                           {children}
                         </ConfigurationProvider>
+                        </TooltipProvider>
                       </GuidedTourProvider>
                     </TrackingProvider>
                   </NotificationsProvider>


### PR DESCRIPTION
The Tooltip component from @strapi/design-system internally uses @radix-ui/react-tooltip, which requires a TooltipProvider at the root level. Without it, renders crash with:

  Error: Tooltip must be used within TooltipProvider

Add <TooltipProvider> from @strapi/design-system wrapping around <ConfigurationProvider> so all Tooltip usages in the admin UI are properly contextualized.

Fixes #26404, #26398

## Description

### Problem

The `Tooltip` component from `@strapi/design-system` internally uses `@radix-ui/react-tooltip`, which **requires a `TooltipProvider` at the root level**. Without it, any page that renders a `Tooltip` crashes with:

```
Error: Tooltip must be used within TooltipProvider
    at http://localhost:1337/admin/...
```

This happens reliably when navigating to **Content Manager > Relations modal** or any page that uses `<Tooltip>`, because the admin root component (`Providers.tsx`) does not provide a `TooltipProvider`.

### Solution

Add `<TooltipProvider>` from `@strapi/design-system` wrapping `<ConfigurationProvider>` in the admin root `Providers` component:

```tsx
<GuidedTourProvider>
  <TooltipProvider>          {/* ← added */}
    <ConfigurationProvider ...>
      {children}
    </ConfigurationProvider>
  </TooltipProvider>
</GuidedTourProvider>
```

`TooltipProvider` is imported from `@strapi/design-system` (the same package that exports `Tooltip`).

### Impact

- ✅ All `Tooltip` usages in the admin UI now have a proper React context
- ✅ No more runtime crashes when opening relation modals, edit views, etc.
- ✅ No behavior change for non-Tooltip components
- ✅ Follows the same provider pattern already used for `GuidedTourProvider`, `Theme`, etc.

### Verification

```bash
# Start strapi in dev mode
cd packages/core/strapi
pnpm develop

# Open admin at http://localhost:1337/admin
# Navigate to Content Manager > any collection > open a relation field
# Previously: crashes with "Tooltip must be used within TooltipProvider"
# Now: modal opens normally, tooltip on hover works
```

Fixes #26404, #26398



---
Fixes CPR-360