### PR TITLE
feat(admin): add documentation helper link in HeaderLayout (revival of #23328)

### DIFF
--- a/examples/complex/config/admin.ts
+++ b/examples/complex/config/admin.ts
@@ -16,6 +16,7 @@ const adminConfig = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/examples/empty/config/admin.ts
+++ b/examples/empty/config/admin.ts
@@ -18,6 +18,7 @@ const adminConfig = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admi
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/examples/experimental-dev/config/admin.ts
+++ b/examples/experimental-dev/config/admin.ts
@@ -15,6 +15,7 @@ const adminConfig = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admi
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/examples/getstarted/config/admin.js
+++ b/examples/getstarted/config/admin.js
@@ -32,6 +32,7 @@ module.exports = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
   preview: {
     enabled: env.bool('PREVIEW_ENABLED', true),

--- a/examples/kitchensink-ts/config/admin.ts
+++ b/examples/kitchensink-ts/config/admin.ts
@@ -15,6 +15,7 @@ const adminConfig = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admi
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/examples/kitchensink/config/admin.js
+++ b/examples/kitchensink/config/admin.js
@@ -14,5 +14,6 @@ module.exports = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });

--- a/packages/cli/create-strapi-app/templates/example-js/config/admin.js
+++ b/packages/cli/create-strapi-app/templates/example-js/config/admin.js
@@ -16,5 +16,6 @@ module.exports = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });

--- a/packages/cli/create-strapi-app/templates/example/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/example/config/admin.ts
@@ -18,6 +18,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => 
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
+++ b/packages/cli/create-strapi-app/templates/vanilla-js/config/admin.js
@@ -16,5 +16,6 @@ module.exports = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });

--- a/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
+++ b/packages/cli/create-strapi-app/templates/vanilla/config/admin.ts
@@ -18,6 +18,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => 
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/packages/core/admin/admin/custom.d.ts
+++ b/packages/core/admin/admin/custom.d.ts
@@ -24,6 +24,7 @@ interface BrowserStrapi {
   flags: {
     promoteEE?: boolean;
     nps?: boolean;
+    docLinks?: boolean;
   };
   projectType: 'Community' | 'Enterprise';
   telemetryDisabled: boolean;

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -22,17 +22,11 @@ import { useDeviceType } from '../../hooks/useDeviceType';
 import { useElementOnScreen } from '../../hooks/useElementOnScreen';
 import { useIsMobile } from '../../hooks/useMediaQuery';
 
-import { getMatchingDocLink } from './utils/getMatchingDocLink';
+import { getMatchingDocLink, type DocLink } from './utils/getMatchingDocLink';
 
 /* -------------------------------------------------------------------------------------------------
  * BaseHeaderLayout
  * -----------------------------------------------------------------------------------------------*/
-
-interface DocLink {
-  link: string;
-  title: string;
-  path: string;
-}
 
 interface BaseHeaderLayoutProps extends Omit<TypographyProps<'div'>, 'tag'> {
   navigationAction?: React.ReactNode;

--- a/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
+++ b/packages/core/admin/admin/src/components/Layouts/HeaderLayout.tsx
@@ -1,19 +1,38 @@
 import * as React from 'react';
 
-import { Box, Flex, Typography, TypographyProps, useCallbackRef } from '@strapi/design-system';
+import {
+  Box,
+  Flex,
+  Typography,
+  TypographyProps,
+  useCallbackRef,
+  IconButton,
+} from '@strapi/design-system';
+import { Question } from '@strapi/icons';
+import { useIntl } from 'react-intl';
+import { useLocation, Link } from 'react-router-dom';
 
 import {
   HEIGHT_TOP_NAVIGATION,
   HEIGHT_TOP_NAVIGATION_MEDIUM,
   RESPONSIVE_DEFAULT_SPACING,
 } from '../../constants/theme';
+import { useTracking } from '../../features/Tracking';
 import { useDeviceType } from '../../hooks/useDeviceType';
 import { useElementOnScreen } from '../../hooks/useElementOnScreen';
 import { useIsMobile } from '../../hooks/useMediaQuery';
 
+import { getMatchingDocLink } from './utils/getMatchingDocLink';
+
 /* -------------------------------------------------------------------------------------------------
  * BaseHeaderLayout
  * -----------------------------------------------------------------------------------------------*/
+
+interface DocLink {
+  link: string;
+  title: string;
+  path: string;
+}
 
 interface BaseHeaderLayoutProps extends Omit<TypographyProps<'div'>, 'tag'> {
   navigationAction?: React.ReactNode;
@@ -22,15 +41,45 @@ interface BaseHeaderLayoutProps extends Omit<TypographyProps<'div'>, 'tag'> {
   subtitle?: React.ReactNode;
   sticky?: boolean;
   width?: number;
+  docLink?: DocLink | null;
 }
 
 const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>(
   (
-    { navigationAction, primaryAction, secondaryAction, subtitle, title, sticky, width, ...props },
+    {
+      navigationAction,
+      primaryAction,
+      secondaryAction,
+      subtitle,
+      title,
+      sticky,
+      width,
+      docLink,
+      ...props
+    },
     ref
   ) => {
     const isMobile = useIsMobile();
     const isSubtitleString = typeof subtitle === 'string';
+
+    const { formatMessage } = useIntl();
+    const { trackUsage } = useTracking();
+
+    const docLinkButton = docLink ? (
+      <IconButton
+        onClick={() => trackUsage('didClickOnDocLink', { from: docLink.path, to: docLink.link })}
+        size="S"
+        label={formatMessage({
+          id: 'app.HeaderLayout.docLink.label',
+          defaultMessage: 'Learn more on our documentation',
+        })}
+        to={docLink.link}
+        tag={Link}
+        target="_blank"
+      >
+        <Question />
+      </IconButton>
+    ) : null;
 
     if (sticky) {
       return (
@@ -52,7 +101,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
           }}
           data-strapi-header-sticky
         >
-          <Flex alignItems="center" justifyContent="space-between" wrap="wrap" width="100%">
+          <Flex alignItems="center" justifyContent="space-between" wrap="wrap" width="100%" gap={2}>
             <Flex>
               {navigationAction && <Box paddingRight={3}>{navigationAction}</Box>}
               <Box>
@@ -69,7 +118,14 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
               </Box>
               {secondaryAction ? <Box paddingLeft={4}>{secondaryAction}</Box> : null}
             </Flex>
-            <Flex>{primaryAction ? <Box paddingLeft={2}>{primaryAction}</Box> : undefined}</Flex>
+            <Flex>
+              {primaryAction ? (
+                <Flex gap={2}>
+                  {docLinkButton}
+                  {primaryAction}
+                </Flex>
+              ) : undefined}
+            </Flex>
           </Flex>
         </Box>
       );
@@ -112,7 +168,10 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
                   {secondaryAction && <Box paddingLeft={4}>{secondaryAction}</Box>}
                 </Flex>
                 <Box paddingLeft={4} marginLeft="auto">
-                  {primaryAction}
+                  <Flex gap={2}>
+                    {docLinkButton}
+                    {primaryAction}
+                  </Flex>
                 </Box>
               </Flex>
               {isSubtitleString ? (
@@ -147,6 +206,7 @@ const BaseHeaderLayout = React.forwardRef<HTMLDivElement, BaseHeaderLayoutProps>
               {(primaryAction || secondaryAction) && (
                 <Flex gap={3}>
                   {secondaryAction}
+                  {docLinkButton}
                   {primaryAction}
                 </Flex>
               )}
@@ -169,6 +229,11 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
   const [headerSize, setHeaderSize] = React.useState<DOMRect | null>(null);
   const [isVisible, setIsVisible] = React.useState(true);
   const deviceType = useDeviceType();
+  const location = useLocation();
+  const docLink = React.useMemo(() => {
+    if (window.strapi.flags.docLinks === false) return null;
+    return getMatchingDocLink(location.pathname);
+  }, [location]);
 
   const containerRef = useElementOnScreen<HTMLDivElement>(setIsVisible, {
     root: null,
@@ -200,16 +265,18 @@ const HeaderLayout = (props: HeaderLayoutProps) => {
   }, [containerRef]);
 
   if (deviceType === 'mobile') {
-    return <BaseHeaderLayout {...props} />;
+    return <BaseHeaderLayout {...props} docLink={docLink} />;
   }
 
   return (
     <div ref={containerRef}>
       <div style={{ height: headerSize?.height }}>
-        {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} />}
+        {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} docLink={docLink} />}
       </div>
 
-      {!isVisible && <BaseHeaderLayout {...props} sticky width={headerSize?.width} />}
+      {!isVisible && (
+        <BaseHeaderLayout {...props} sticky width={headerSize?.width} docLink={docLink} />
+      )}
     </div>
   );
 };

--- a/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
+++ b/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
@@ -1,5 +1,11 @@
 import { matchRoutes, RouteObject } from 'react-router-dom';
 
+export interface DocLink {
+  link: string;
+  title: string;
+  path: string;
+}
+
 type DocRoute = RouteObject & { link: string; title: string };
 
 const matchingLinks: DocRoute[] = [
@@ -150,7 +156,7 @@ const matchingLinks: DocRoute[] = [
   },
 ];
 
-export function getMatchingDocLink(pathname: string) {
+export function getMatchingDocLink(pathname: string): DocLink | null {
   const matches = matchRoutes(matchingLinks, pathname);
   const match = matches?.[0];
 

--- a/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
+++ b/packages/core/admin/admin/src/components/Layouts/utils/getMatchingDocLink.ts
@@ -1,0 +1,163 @@
+import { matchRoutes, RouteObject } from 'react-router-dom';
+
+type DocRoute = RouteObject & { link: string; title: string };
+
+const matchingLinks: DocRoute[] = [
+  {
+    path: '/content-manager/*',
+    link: 'https://docs.strapi.io/cms/features/content-manager',
+    title: 'Content Manager',
+  },
+  {
+    path: '/plugins/content-type-builder/*',
+    link: 'https://docs.strapi.io/cms/features/content-type-builder',
+    title: 'Content-Type Builder',
+  },
+  {
+    path: '/plugins/upload/*',
+    link: 'https://docs.strapi.io/cms/features/media-library',
+    title: 'Media Library',
+  },
+  {
+    path: '/plugins/content-releases/*',
+    link: 'https://docs.strapi.io/cms/features/releases',
+    title: 'Releases',
+  },
+  {
+    path: '/settings/purchase-content-releases/*',
+    link: 'https://docs.strapi.io/cms/features/releases',
+    title: 'Releases',
+  },
+  {
+    path: '/plugins/documentation/*',
+    link: 'https://docs.strapi.io/cms/plugins/documentation',
+    title: 'Documentation plugin',
+  },
+  {
+    path: '/settings/list-plugins/*',
+    link: 'https://docs.strapi.io/cms/plugins-development/developing-plugins',
+    title: 'Plugins',
+  },
+  {
+    path: '/settings/application-infos/*',
+    link: 'https://docs.strapi.io/cms/features/admin-panel',
+    title: 'General settings',
+  },
+  {
+    path: '/settings/api-tokens/*',
+    link: 'https://docs.strapi.io/cms/features/api-tokens',
+    title: 'API Tokens settings',
+  },
+  {
+    path: '/settings/documentation/*',
+    link: 'https://docs.strapi.io/cms/plugins/documentation',
+    title: 'Documentation plugin settings',
+  },
+  {
+    path: '/settings/internationalization/*',
+    link: 'https://docs.strapi.io/cms/features/internationalization#settings',
+    title: 'Internationalization settings (i18n)',
+  },
+  {
+    path: '/settings/media-library/*',
+    link: 'https://docs.strapi.io/cms/features/media-library#configuration',
+    title: 'Media Library settings',
+  },
+  {
+    path: '/settings/review-workflows/*',
+    link: 'https://docs.strapi.io/cms/features/review-workflows',
+    title: 'Review Workflows settings',
+  },
+  {
+    path: '/settings/purchase-review-workflows/*',
+    link: 'https://docs.strapi.io/cms/features/review-workflows',
+    title: 'Review Workflows settings',
+  },
+  {
+    path: '/settings/single-sign-on/*',
+    link: 'https://docs.strapi.io/cms/features/sso',
+    title: 'SSO settings',
+  },
+  {
+    path: '/settings/purchase-single-sign-on/*',
+    link: 'https://docs.strapi.io/cms/features/sso',
+    title: 'SSO settings',
+  },
+  {
+    path: '/settings/purchase-content-history/*',
+    link: 'https://docs.strapi.io/cms/features/content-history',
+    title: 'Content History',
+  },
+  {
+    path: '/settings/transfer-tokens/*',
+    link: 'https://docs.strapi.io/cms/features/data-management',
+    title: 'Transfer Tokens',
+  },
+  {
+    path: '/settings/webhooks/*',
+    link: 'https://docs.strapi.io/cms/backend-customization/webhooks',
+    title: 'Webhooks',
+  },
+  {
+    path: '/settings/roles/*',
+    link: 'https://docs.strapi.io/cms/features/rbac#configuration',
+    title: 'Users & Permissions',
+  },
+  {
+    path: '/settings/users/*',
+    link: 'https://docs.strapi.io/cms/features/rbac#usage',
+    title: 'Users & Permissions',
+  },
+  {
+    path: '/settings/audit-logs/*',
+    link: 'https://docs.strapi.io/cms/features/audit-logs',
+    title: 'Audit Logs',
+  },
+  {
+    path: '/settings/purchase-audit-logs/*',
+    link: 'https://docs.strapi.io/cms/features/audit-logs',
+    title: 'Audit Logs',
+  },
+  {
+    path: '/settings/email/*',
+    link: 'https://docs.strapi.io/cms/features/email',
+    title: 'Email plugin',
+  },
+  {
+    path: '/settings/users-permissions/roles/*',
+    link: 'https://docs.strapi.io/cms/features/users-permissions',
+    title: 'End-users roles',
+  },
+  {
+    path: '/settings/users-permissions/providers/*',
+    link: 'https://docs.strapi.io/cms/features/users-permissions#providers',
+    title: 'Providers',
+  },
+  {
+    path: '/settings/users-permissions/email-templates/*',
+    link: 'https://docs.strapi.io/cms/features/users-permissions#email-templates',
+    title: 'Email Templates',
+  },
+  {
+    path: '/settings/users-permissions/advanced-settings/*',
+    link: 'https://docs.strapi.io/cms/features/users-permissions#advanced-settings',
+    title: 'U&P Advanced settings',
+  },
+  {
+    path: '/me/*',
+    link: 'https://docs.strapi.io/cms/features/admin-panel#modifying-profile-information-name-email-username',
+    title: 'Administrator profile',
+  },
+];
+
+export function getMatchingDocLink(pathname: string) {
+  const matches = matchRoutes(matchingLinks, pathname);
+  const match = matches?.[0];
+
+  if (!match) {
+    return null;
+  }
+
+  const { link, title } = match.route;
+  return { path: match.pathnameBase, link, title };
+}

--- a/packages/core/admin/admin/src/components/Layouts/utils/tests/getMatchingDocLink.test.ts
+++ b/packages/core/admin/admin/src/components/Layouts/utils/tests/getMatchingDocLink.test.ts
@@ -1,0 +1,52 @@
+import { getMatchingDocLink } from '../getMatchingDocLink';
+
+describe('getMatchingDocLink', () => {
+  it('returns null for unmapped admin routes', () => {
+    expect(getMatchingDocLink('/')).toBeNull();
+    expect(getMatchingDocLink('/settings/admin-tokens')).toBeNull();
+  });
+
+  it('matches content manager routes', () => {
+    expect(getMatchingDocLink('/content-manager/collection-types/api::article.article')).toEqual({
+      path: '/content-manager',
+      link: 'https://docs.strapi.io/cms/features/content-manager',
+      title: 'Content Manager',
+    });
+  });
+
+  it('prefers more specific settings paths over shared prefixes', () => {
+    expect(getMatchingDocLink('/settings/users-permissions/providers')).toEqual({
+      path: '/settings/users-permissions/providers',
+      link: 'https://docs.strapi.io/cms/features/users-permissions#providers',
+      title: 'Providers',
+    });
+
+    expect(getMatchingDocLink('/settings/users/1')).toEqual({
+      path: '/settings/users',
+      link: 'https://docs.strapi.io/cms/features/rbac#usage',
+      title: 'Users & Permissions',
+    });
+
+    expect(getMatchingDocLink('/settings/roles/1')).toEqual({
+      path: '/settings/roles',
+      link: 'https://docs.strapi.io/cms/features/rbac#configuration',
+      title: 'Users & Permissions',
+    });
+  });
+
+  it('matches plugin routes under /plugins', () => {
+    expect(getMatchingDocLink('/plugins/content-type-builder/content-types')).toEqual({
+      path: '/plugins/content-type-builder',
+      link: 'https://docs.strapi.io/cms/features/content-type-builder',
+      title: 'Content-Type Builder',
+    });
+  });
+
+  it('matches profile route', () => {
+    expect(getMatchingDocLink('/me')).toEqual({
+      path: '/me',
+      link: 'https://docs.strapi.io/cms/features/admin-panel#modifying-profile-information-name-email-username',
+      title: 'Administrator profile',
+    });
+  });
+});

--- a/packages/core/admin/admin/src/features/Tracking.tsx
+++ b/packages/core/admin/admin/src/features/Tracking.tsx
@@ -284,6 +284,14 @@ interface WillNavigateEvent {
   };
 }
 
+interface DidClickOnDocLink {
+  name: 'didClickOnDocLink';
+  properties: {
+    from: string;
+    to: string;
+  };
+}
+
 interface DidAccessTokenListEvent {
   name: 'didAccessTokenList';
   properties: {
@@ -484,6 +492,7 @@ type EventsWithProperties =
   | UpdateEntryEvents
   | WillModifyTokenEvent
   | WillNavigateEvent
+  | DidClickOnDocLink
   | DidPublishRelease
   | MediaEvents
   | DidUpdateCTBSchema

--- a/packages/core/admin/admin/src/render.ts
+++ b/packages/core/admin/admin/src/render.ts
@@ -57,6 +57,7 @@ const renderAdmin = async (
     flags: {
       nps: false,
       promoteEE: true,
+      docLinks: true,
     },
     // eslint-disable-next-line
     // @ts-ignore – there's pollution from the global scope of Node. Cannot use @ts-expect-error because of build:code and build:types context collision.

--- a/packages/core/admin/admin/src/translations/en.json
+++ b/packages/core/admin/admin/src/translations/en.json
@@ -562,6 +562,7 @@
   "app.utils.ready-to-publish-changes": "Ready to publish changes",
   "app.utils.ready-to-unpublish-changes": "Ready to unpublish",
   "app.confirm.body": "Are you sure?",
+  "app.HeaderLayout.docLink.label": "Learn more on our documentation",
   "clearLabel": "Clear",
   "coming.soon": "This content is currently under construction and will be back in a few weeks!",
   "component.Input.error.validation.integer": "The value must be an integer",

--- a/packages/core/admin/ee/admin/custom.d.ts
+++ b/packages/core/admin/ee/admin/custom.d.ts
@@ -26,6 +26,7 @@ declare global {
       flags: {
         promoteEE?: boolean;
         nps?: boolean;
+        docLinks?: boolean;
       };
       projectType: 'Community' | 'Enterprise';
       telemetryDisabled: boolean;

--- a/packages/core/types/src/core/config/admin.ts
+++ b/packages/core/types/src/core/config/admin.ts
@@ -88,6 +88,7 @@ export interface FirstPublisedAtField {
 export interface Flags {
   nps?: boolean;
   promoteEE?: boolean;
+  docLinks?: boolean;
 }
 
 export interface PreviewHandlerParams {

--- a/templates/website/config/admin.ts
+++ b/templates/website/config/admin.ts
@@ -15,6 +15,7 @@ const config = ({ env }: Core.Config.Shared.ConfigParams): Core.Config.Admin => 
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
 });
 

--- a/tests/app-template/config/admin.js
+++ b/tests/app-template/config/admin.js
@@ -16,6 +16,7 @@ module.exports = ({ env }) => ({
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
+    docLinks: env.bool('FLAG_DOC_LINKS', true),
   },
   preview: {
     enabled: true,


### PR DESCRIPTION
> Revival of #23328 by @Mcastres — rebased on current develop, with all open review feedback addressed and additional improvements. Closes #23328.

### What does it do?

Adds a `?` IconButton next to the primary action in every page's `HeaderLayout`. Clicking it opens the matching docs.strapi.io page for that admin section in a new tab and fires a `didClickOnDocLink` tracking event with the originating route and the destination URL.

Changes beyond the original PR:

- **Match algorithm**: replace the hand-rolled `find`/`startsWith` lookup with `react-router`'s `matchRoutes`, so path entries are typed `RouteObject`s with `/*` splats and benefit from proper specificity ranking (no more array-order dependence between e.g. `/settings/users/*` and `/settings/users-permissions/*`).
- **Sync derivation**: drop the unnecessary `async` from `getMatchingDocLink` and derive `docLink` directly from `useLocation().pathname` in the component (no `useState`/`useEffect`). Memoized with `React.useMemo` against `location` to avoid recomputing on scroll/resize re-renders.
- **Canonical doc URLs**: every original link redirected (`/user-docs/*`, `/dev-docs/*` → `/cms/*`). Updated all 25 unique URLs to the current canonical paths. Restored 4 section anchors that were dropped on redirect (`#providers`, `#email-templates`, `#advanced-settings`, profile anchor on admin-panel) and disambiguated `/cms/features/rbac` with `#configuration` / `#usage` for `/settings/roles` vs `/settings/users`.
- **Path corrections**: aligned array entries with actually registered admin routes — `content-type-builder` / `content-releases` mount under `/plugins/...`, `purchase-content-releases` and `list-plugins` are under `/settings/...`. Dropped `/marketplace` (external link, never reaches HeaderLayout).
- **Opt-out flag** (per @derrickmehaffy's comment): added `admin.flags.docLinks` (default `true`). Mirrors the existing `nps` / `promoteEE` flag pattern. White-label deployments can disable all doc links with:
  ```ts
  // config/admin.ts
  flags: { docLinks: false }
  ```
  Type added to `Core.Config.Admin['Flags']` (server) and `BrowserStrapi['flags']` (client). All example/template `config/admin.{ts,js}` files updated to expose `FLAG_DOC_LINKS` env override.
- **Layout polish** (per @remidej review): doc link button has no own padding — instead a `gap` is set on the parent `Flex` wrapping `docLinkButton` + `primaryAction`, in both sticky and non-sticky variants.

### Why is it needed?

Original motivation from #23328 stands: gives users a one-click jump to relevant docs for the page they're on, and lets the team measure (via tracking) which sections users feel lost in.

### How to test it?

1. Start any example project (e.g. `examples/kitchensink-ts`):
   ```bash
   yarn build && yarn develop --watch-admin
   ```
2. Navigate the admin to e.g. Content Manager, Media Library, Settings → API Tokens, Settings → Users & Permissions → Providers, profile (`/me`).
3. A `?` IconButton should appear next to the primary action in the page header. Click it → new tab opens to the matching docs.strapi.io page.
4. Scroll a long page (e.g. `/me`) until the sticky header appears → doc link button should also appear in the sticky header.
5. To verify the opt-out flag:
   ```ts
   // config/admin.ts
   flags: { docLinks: false }
   ```
   Restart, confirm the `?` button is no longer rendered on any page.

### Related issue(s)/PR(s)

- Closes #23328 (original PR by @Mcastres)
- Addresses review feedback from @remidej and @jhoward1994
- Addresses white-label request from @derrickmehaffy

🤖 Generated with [Claude Code](https://claude.com/claude-code)