### PR TITLE
fix(utils): ignore empty sort when building orderBy

### DIFF
--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -1,4 +1,4 @@
-import { createTransformer } from '../convert-query-params';
+import { createTransformer, type Params } from '../convert-query-params';
 import { Model } from '../types';
 
 const models = {
@@ -306,7 +306,7 @@ describe('convert-query-params', () => {
         unknownParam: 'ignored',
       };
 
-      const result = transformer.transformQueryParams('api::dog.dog', params);
+      const result = transformer.transformQueryParams('api::dog.dog', params as unknown as Params);
 
       expect(result.where).toEqual({ title: 'Hello' });
       expect(result.orderBy).toEqual({ title: 'asc' });
@@ -379,9 +379,20 @@ describe('convert-query-params', () => {
   });
 
   describe('transformQueryParams', () => {
-    it('treats an empty sort array as no sort', () => {
+    it.each<[string, Params]>([
+      ['missing sort', {}],
+      ['null sort', { sort: null } as unknown as Params],
+      ['empty sort array', { sort: [] }],
+      ['empty sort string', { sort: '' }],
+      ['comma-only sort string', { sort: ',' }],
+      ['empty sort object', { sort: {} }],
+      ['array of empty strings', { sort: [''] }],
+      ['array of empty sort objects', { sort: [{}] }],
+      ['array with only null (qs sort[])', { sort: [null] } as unknown as Params],
+      ['object sort with empty order', { sort: { title: '' } } as unknown as Params],
+    ])('treats %s as no sort', (_label, params) => {
       const result = transformer.transformQueryParams('api::dog.dog', {
-        sort: [],
+        ...params,
         limit: 10,
       });
 
@@ -389,12 +400,88 @@ describe('convert-query-params', () => {
       expect(result.limit).toBe(10);
     });
 
-    it('treats a missing sort as no sort', () => {
+    it('still applies sort when a field is present', () => {
       const result = transformer.transformQueryParams('api::dog.dog', {
+        sort: 'title:asc',
         limit: 10,
       });
 
-      expect(result.orderBy).toBeUndefined();
+      expect(result.orderBy).toEqual([{ title: 'asc' }]);
+    });
+
+    it.each([
+      ['trailing comma', 'title:asc,', [{ title: 'asc' }]],
+      ['trailing comma and space', 'title:asc, ', [{ title: 'asc' }]],
+      [
+        'multiple fields with trailing comma',
+        'title:asc,createdAt:desc,',
+        [{ title: 'asc' }, { createdAt: 'desc' }],
+      ],
+    ])('drops empty segments from %s', (_label, sort, expectedOrderBy) => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        sort,
+        limit: 10,
+      });
+
+      expect(result.orderBy).toEqual(expectedOrderBy);
+    });
+
+    it.each([
+      ['empty sort array', []],
+      ['empty sort string', ''],
+      ['comma-only sort string', ','],
+    ])('does not set nested populate orderBy for %s', (_label, sortValue) => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        populate: {
+          one_to_one: {
+            sort: sortValue,
+            limit: 5,
+          },
+        },
+      });
+
+      expect(result.populate).toMatchObject({
+        one_to_one: { limit: 5 },
+      });
+      expect(
+        (result.populate as { one_to_one?: Record<string, unknown> }).one_to_one
+      ).not.toHaveProperty('orderBy');
+    });
+
+    it('sets nested populate orderBy when sort has a field', () => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        populate: {
+          one_to_one: {
+            sort: 'title:asc',
+            limit: 5,
+          },
+        },
+      });
+
+      expect(result.populate).toMatchObject({
+        one_to_one: {
+          orderBy: [{ title: 'asc' }],
+          limit: 5,
+        },
+      });
+    });
+
+    it('drops trailing comma segments in nested populate sort', () => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        populate: {
+          one_to_one: {
+            sort: 'title:asc,',
+            limit: 5,
+          },
+        },
+      });
+
+      expect(result.populate).toMatchObject({
+        one_to_one: {
+          orderBy: [{ title: 'asc' }],
+          limit: 5,
+        },
+      });
     });
   });
 

--- a/packages/core/utils/src/__tests__/convert-query-params.test.ts
+++ b/packages/core/utils/src/__tests__/convert-query-params.test.ts
@@ -378,5 +378,25 @@ describe('convert-query-params', () => {
     });
   });
 
+  describe('transformQueryParams', () => {
+    it('treats an empty sort array as no sort', () => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        sort: [],
+        limit: 10,
+      });
+
+      expect(result.orderBy).toBeUndefined();
+      expect(result.limit).toBe(10);
+    });
+
+    it('treats a missing sort as no sort', () => {
+      const result = transformer.transformQueryParams('api::dog.dog', {
+        limit: 10,
+      });
+
+      expect(result.orderBy).toBeUndefined();
+    });
+  });
+
   test.todo('transformParamsToQuery');
 });

--- a/packages/core/utils/src/__tests__/sort-query.test.ts
+++ b/packages/core/utils/src/__tests__/sort-query.test.ts
@@ -1,0 +1,26 @@
+import { hasSort } from '../sort-query';
+
+describe('hasSort', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty array', []],
+    ['empty string', ''],
+    ['comma-only string', ','],
+    ['empty object', {}],
+    ['array of empty strings', ['']],
+    ['array of empty sort objects', [{}]],
+    ['qs sort[] (null entry)', [null]],
+    ['object sort with empty order', { title: '' }],
+  ])('returns false for %s', (_label, sort) => {
+    expect(hasSort(sort)).toBe(false);
+  });
+
+  it.each([
+    ['string sort', 'title:asc'],
+    ['array with field', ['title:asc']],
+    ['object sort', { title: 'asc' }],
+  ])('returns true for %s', (_label, sort) => {
+    expect(hasSort(sort)).toBe(true);
+  });
+});

--- a/packages/core/utils/src/__tests__/validate.visitors.test.ts
+++ b/packages/core/utils/src/__tests__/validate.visitors.test.ts
@@ -204,6 +204,22 @@ describe('Validate visitors util', () => {
       );
     });
 
+    test.each([
+      ['empty sort array', []],
+      ['qs empty array (sort[])', [null]],
+      ['empty sort string', ''],
+      ['comma-only sort string', ','],
+      ['array of empty strings', ['']],
+    ])('accepts nested populate sort with no meaningful order (%s)', async (_label, sortValue) => {
+      const populate = {
+        category: {
+          sort: sortValue,
+        },
+      };
+
+      await expect(validators.defaultValidatePopulate(ctx, populate)).resolves.not.toThrow();
+    });
+
     test('throws ValidationError for private fields in nested sort within populate', async () => {
       const populate = {
         category: {

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -28,7 +28,15 @@ import { isOperator } from './operators';
 
 import parseType from './parse-type';
 import type { PublicationFilterMode } from './publication-filter';
+import {
+  getMeaningfulSortSegments,
+  hasSort,
+  type SortParams,
+  type SortParamsObject,
+} from './sort-query';
 import { Model } from './types';
+
+export type { SortParams, SortParamsObject } from './sort-query';
 
 const { ID_ATTRIBUTE, DOC_ID_ATTRIBUTE, PUBLISHED_AT_ATTRIBUTE } = constants;
 
@@ -38,56 +46,9 @@ export interface SortMap {
   [key: string]: SortOrder | SortMap;
 }
 
-export interface SortParamsObject {
-  [key: string]: SortOrder | SortParamsObject;
-}
-
-type SortParams = string | string[] | SortParamsObject | SortParamsObject[];
 type FieldsParams = string | string[];
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => _.isPlainObject(value);
-
-/**
- * Splits a REST sort string into trimmed segments with a non-empty field (drops '', ',', trailing commas).
- */
-function getMeaningfulSortSegments(sort: string): string[] {
-  return sort
-    .split(',')
-    .map((segment) => segment.trim())
-    .filter((segment) => {
-      if (segment.length === 0) {
-        return false;
-      }
-
-      const [field] = segment.split(':');
-      return field.trim().length > 0;
-    });
-}
-
-/**
- * Whether a nested sort object ({ field: 'asc' } or { relation: { name: 'desc' } }) specifies
- * at least one field to sort on. Empty objects and keys with blank orders are treated as no sort.
- */
-function hasMeaningfulSortObject(sort: SortParamsObject): boolean {
-  return Object.keys(sort).some((key) => {
-    const order = sort[key];
-
-    if (typeof order === 'string') {
-      return order.length > 0;
-    }
-
-    if (isPlainObject(order)) {
-      return hasMeaningfulSortObject(order as SortParamsObject);
-    }
-
-    return false;
-  });
-}
-
-/** Whether a REST-style sort string contains at least one meaningful segment. */
-function hasMeaningfulStringSort(sort: string): boolean {
-  return getMeaningfulSortSegments(sort).length > 0;
-}
 
 function isEmptySortMap(sortMap: SortMap): boolean {
   const keys = Object.keys(sortMap);
@@ -120,44 +81,6 @@ function normalizeOrderBy(orderBy: OrderByQuery): OrderByQuery | undefined {
   }
 
   return isEmptySortMap(orderBy) ? undefined : orderBy;
-}
-
-/**
- * Whether `sort` should be converted to `orderBy`. Empty or absent sort must stay undefined so
- * populated relations keep join-table connect order (GraphQL defaults nested sort to []).
- */
-function hasSort(sort?: SortParams | null): sort is SortParams {
-  if (sort === undefined || sort === null) {
-    return false;
-  }
-
-  if (typeof sort === 'string') {
-    return hasMeaningfulStringSort(sort);
-  }
-
-  if (Array.isArray(sort)) {
-    if (sort.length === 0) {
-      return false;
-    }
-
-    return sort.some((item) => {
-      if (typeof item === 'string') {
-        return hasMeaningfulStringSort(item);
-      }
-
-      if (isPlainObject(item)) {
-        return hasMeaningfulSortObject(item as SortParamsObject);
-      }
-
-      return false;
-    });
-  }
-
-  if (isPlainObject(sort)) {
-    return hasMeaningfulSortObject(sort as SortParamsObject);
-  }
-
-  return false;
 }
 
 type FiltersParams = unknown;

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -45,21 +45,120 @@ export interface SortParamsObject {
 type SortParams = string | string[] | SortParamsObject | SortParamsObject[];
 type FieldsParams = string | string[];
 
-const hasSort = (sort?: SortParams | null): sort is SortParams => {
-  if (sort == null) {
+const isPlainObject = (value: unknown): value is Record<string, unknown> => _.isPlainObject(value);
+
+/**
+ * Splits a REST sort string into trimmed segments with a non-empty field (drops '', ',', trailing commas).
+ */
+function getMeaningfulSortSegments(sort: string): string[] {
+  return sort
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => {
+      if (segment.length === 0) {
+        return false;
+      }
+
+      const [field] = segment.split(':');
+      return field.trim().length > 0;
+    });
+}
+
+/**
+ * Whether a nested sort object ({ field: 'asc' } or { relation: { name: 'desc' } }) specifies
+ * at least one field to sort on. Empty objects and keys with blank orders are treated as no sort.
+ */
+function hasMeaningfulSortObject(sort: SortParamsObject): boolean {
+  return Object.keys(sort).some((key) => {
+    const order = sort[key];
+
+    if (typeof order === 'string') {
+      return order.length > 0;
+    }
+
+    if (isPlainObject(order)) {
+      return hasMeaningfulSortObject(order as SortParamsObject);
+    }
+
+    return false;
+  });
+}
+
+/** Whether a REST-style sort string contains at least one meaningful segment. */
+function hasMeaningfulStringSort(sort: string): boolean {
+  return getMeaningfulSortSegments(sort).length > 0;
+}
+
+function isEmptySortMap(sortMap: SortMap): boolean {
+  const keys = Object.keys(sortMap);
+
+  if (keys.length === 0) {
+    return true;
+  }
+
+  return keys.every((key) => {
+    const value = sortMap[key];
+
+    if (typeof value === 'string') {
+      return value.trim().length === 0;
+    }
+
+    if (isPlainObject(value)) {
+      return isEmptySortMap(value as SortMap);
+    }
+
+    return true;
+  });
+}
+
+/** Drops empty sort maps so a trailing comma does not leave a truthy but meaningless `orderBy`. */
+function normalizeOrderBy(orderBy: OrderByQuery): OrderByQuery | undefined {
+  if (Array.isArray(orderBy)) {
+    const filtered = orderBy.filter((sortMap) => !isEmptySortMap(sortMap));
+
+    return filtered.length > 0 ? filtered : undefined;
+  }
+
+  return isEmptySortMap(orderBy) ? undefined : orderBy;
+}
+
+/**
+ * Whether `sort` should be converted to `orderBy`. Empty or absent sort must stay undefined so
+ * populated relations keep join-table connect order (GraphQL defaults nested sort to []).
+ */
+function hasSort(sort?: SortParams | null): sort is SortParams {
+  if (sort === undefined || sort === null) {
     return false;
   }
 
-  if (Array.isArray(sort)) {
-    return sort.length > 0;
-  }
-
   if (typeof sort === 'string') {
-    return sort.length > 0;
+    return hasMeaningfulStringSort(sort);
   }
 
-  return true;
-};
+  if (Array.isArray(sort)) {
+    if (sort.length === 0) {
+      return false;
+    }
+
+    return sort.some((item) => {
+      if (typeof item === 'string') {
+        return hasMeaningfulStringSort(item);
+      }
+
+      if (isPlainObject(item)) {
+        return hasMeaningfulSortObject(item as SortParamsObject);
+      }
+
+      return false;
+    });
+  }
+
+  if (isPlainObject(sort)) {
+    return hasMeaningfulSortObject(sort as SortParamsObject);
+  }
+
+  return false;
+}
 
 type FiltersParams = unknown;
 
@@ -165,7 +264,6 @@ const convertOrderingQueryParams = (ordering: unknown) => {
   return ordering;
 };
 
-const isPlainObject = (value: unknown): value is Record<string, unknown> => _.isPlainObject(value);
 const isStringArray = (value: unknown): value is string[] =>
   isArray(value) && value.every(isString);
 
@@ -198,30 +296,35 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
   };
 
   const convertStringSortQueryParam = (sortQuery: string): SortMap[] => {
-    return sortQuery.split(',').map((value) => convertSingleSortQueryParam(value));
+    return getMeaningfulSortSegments(sortQuery).map((segment) =>
+      convertSingleSortQueryParam(segment)
+    );
   };
 
   const convertSingleSortQueryParam = (sortQuery: string): SortMap => {
-    if (!sortQuery) {
+    const trimmed = sortQuery.trim();
+
+    if (!trimmed) {
       return {};
     }
 
-    if (!isString(sortQuery)) {
+    if (!isString(trimmed)) {
       throw new Error('Invalid sort query');
     }
 
     // split field and order param with default order to ascending
-    const [field, order = 'asc'] = sortQuery.split(':');
+    const [rawField, order = 'asc'] = trimmed.split(':');
+    const field = rawField.trim();
 
     if (field.length === 0) {
       throw new Error('Field cannot be empty');
     }
 
-    validateOrder(order);
+    validateOrder(order.trim());
 
     // TODO: field should be a valid path on an object model
 
-    return _.set({}, field, order);
+    return _.set({}, field, order.trim());
   };
 
   const convertNestedSortQueryParam = (sortQuery: SortParamsObject): SortMap => {
@@ -231,16 +334,36 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
       // this is a deep sort
       if (isPlainObject(order)) {
-        transformedSort[field] = convertNestedSortQueryParam(order);
+        const nested = convertNestedSortQueryParam(order as SortParamsObject);
+
+        if (!isEmptySortMap(nested)) {
+          transformedSort[field] = nested;
+        }
       } else if (typeof order === 'string') {
-        validateOrder(order);
-        transformedSort[field] = order;
+        const trimmedOrder = order.trim();
+
+        if (trimmedOrder.length > 0) {
+          validateOrder(trimmedOrder);
+          transformedSort[field] = trimmedOrder;
+        }
       } else {
         throw Error(`Invalid sort type expected object or string got ${typeof order}`);
       }
     }
 
     return transformedSort;
+  };
+
+  const applySortToQuery = (query: Query, sortParam?: SortParams | null) => {
+    if (!hasSort(sortParam)) {
+      return;
+    }
+
+    const orderBy = normalizeOrderBy(convertSortQueryParams(sortParam));
+
+    if (orderBy !== undefined) {
+      query.orderBy = orderBy;
+    }
   };
 
   /**
@@ -522,10 +645,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
     const query: Query = {};
 
-    const sortParam = sort;
-    if (hasSort(sortParam)) {
-      query.orderBy = convertSortQueryParams(sortParam);
-    }
+    applySortToQuery(query, sort);
 
     if (filters) {
       query.where = convertFiltersQueryParams(filters, schema);
@@ -735,10 +855,7 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
       query._q = _q;
     }
 
-    const sortParam = sort;
-    if (hasSort(sortParam)) {
-      query.orderBy = convertSortQueryParams(sortParam);
-    }
+    applySortToQuery(query, sort);
 
     if (!isNil(filters)) {
       query.where = convertFiltersQueryParams(filters, schema);

--- a/packages/core/utils/src/convert-query-params.ts
+++ b/packages/core/utils/src/convert-query-params.ts
@@ -45,6 +45,22 @@ export interface SortParamsObject {
 type SortParams = string | string[] | SortParamsObject | SortParamsObject[];
 type FieldsParams = string | string[];
 
+const hasSort = (sort?: SortParams | null): sort is SortParams => {
+  if (sort == null) {
+    return false;
+  }
+
+  if (Array.isArray(sort)) {
+    return sort.length > 0;
+  }
+
+  if (typeof sort === 'string') {
+    return sort.length > 0;
+  }
+
+  return true;
+};
+
 type FiltersParams = unknown;
 
 export interface PopulateAttributesParams {
@@ -506,8 +522,9 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
 
     const query: Query = {};
 
-    if (sort) {
-      query.orderBy = convertSortQueryParams(sort);
+    const sortParam = sort;
+    if (hasSort(sortParam)) {
+      query.orderBy = convertSortQueryParams(sortParam);
     }
 
     if (filters) {
@@ -718,8 +735,9 @@ const createTransformer = ({ getModel }: TransformerOptions) => {
       query._q = _q;
     }
 
-    if (!isNil(sort)) {
-      query.orderBy = convertSortQueryParams(sort);
+    const sortParam = sort;
+    if (hasSort(sortParam)) {
+      query.orderBy = convertSortQueryParams(sortParam);
     }
 
     if (!isNil(filters)) {

--- a/packages/core/utils/src/sort-query.ts
+++ b/packages/core/utils/src/sort-query.ts
@@ -1,0 +1,92 @@
+import _ from 'lodash';
+
+export type SortOrder = 'asc' | 'desc';
+
+export interface SortParamsObject {
+  [key: string]: SortOrder | SortParamsObject;
+}
+
+export type SortParams = string | string[] | SortParamsObject | SortParamsObject[];
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => _.isPlainObject(value);
+
+/**
+ * Splits a REST sort string into trimmed segments with a non-empty field (drops '', ',', trailing commas).
+ */
+export function getMeaningfulSortSegments(sort: string): string[] {
+  return sort
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => {
+      if (segment.length === 0) {
+        return false;
+      }
+
+      const [field] = segment.split(':');
+      return field.trim().length > 0;
+    });
+}
+
+/**
+ * Whether a nested sort object ({ field: 'asc' } or { relation: { name: 'desc' } }) specifies
+ * at least one field to sort on. Empty objects and keys with blank orders are treated as no sort.
+ */
+function hasMeaningfulSortObject(sort: SortParamsObject): boolean {
+  return Object.keys(sort).some((key) => {
+    const order = sort[key];
+
+    if (typeof order === 'string') {
+      return order.length > 0;
+    }
+
+    if (isPlainObject(order)) {
+      return hasMeaningfulSortObject(order as SortParamsObject);
+    }
+
+    return false;
+  });
+}
+
+/** Whether a REST-style sort string contains at least one meaningful segment. */
+function hasMeaningfulStringSort(sort: string): boolean {
+  return getMeaningfulSortSegments(sort).length > 0;
+}
+
+/**
+ * Whether `sort` carries a real ordering instruction. Empty or absent sort must stay undefined so
+ * populated relations keep join-table connect order (GraphQL defaults nested sort to []; REST qs
+ * `sort[]` with strictNullHandling parses to `[null]`).
+ */
+export function hasSort(sort?: unknown): sort is SortParams {
+  if (sort === undefined || sort === null) {
+    return false;
+  }
+
+  if (typeof sort === 'string') {
+    return hasMeaningfulStringSort(sort);
+  }
+
+  if (Array.isArray(sort)) {
+    if (sort.length === 0) {
+      return false;
+    }
+
+    return sort.some((item) => {
+      if (typeof item === 'string') {
+        return hasMeaningfulStringSort(item);
+      }
+
+      if (isPlainObject(item)) {
+        return hasMeaningfulSortObject(item as SortParamsObject);
+      }
+
+      return false;
+    });
+  }
+
+  if (isPlainObject(sort)) {
+    return hasMeaningfulSortObject(sort as SortParamsObject);
+  }
+
+  return false;
+}

--- a/packages/core/utils/src/traverse/query-sort.ts
+++ b/packages/core/utils/src/traverse/query-sort.ts
@@ -13,6 +13,7 @@ import {
   cloneDeep,
 } from 'lodash/fp';
 
+import { hasSort } from '../sort-query';
 import traverseFactory, { type Parent } from './factory';
 
 const ORDERS = { asc: 'asc', desc: 'desc' };
@@ -28,7 +29,12 @@ const isNestedSorts = (value: unknown): value is string =>
 
 const isObj = (value: unknown): value is Record<string, unknown> => isObject(value);
 
+/** Meaningless sort arrays (e.g. qs `sort[]` → `[null]`) must not be walked as `{ '0': null }`. */
+const isMeaninglessSortArray = (value: unknown): value is unknown[] =>
+  Array.isArray(value) && !hasSort(value);
+
 const sort = traverseFactory()
+  .intercept(isMeaninglessSortArray, async (_visitor, _options, sort) => sort)
   .intercept(
     // String with chained sorts (foo,bar,foobar) => split, map(recurse), then recompose
     isNestedSorts,

--- a/tests/api/core/strapi/document-service/relations/basic.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/basic.test.api.ts
@@ -178,22 +178,6 @@ describe('Document Service relations', () => {
     });
 
     testInTransaction(
-      'preserves manyToMany connect order when nested sort is omitted',
-      async () => {
-        const article = await strapi.documents(ARTICLE_UID).create({
-          locale: 'en',
-          data: {
-            title: 'Populate sort connect order test',
-            categories: ['Cat2', 'Cat1'],
-          },
-          populate: { categories: true },
-        });
-
-        expect(categoryNames(article)).toEqual(['Cat2-EN', 'Cat1-EN']);
-      }
-    );
-
-    testInTransaction(
       'reverses manyToMany connect order with ordering via db.query when sort is omitted',
       async () => {
         await strapi.documents(ARTICLE_UID).create({

--- a/tests/api/core/strapi/document-service/relations/empty-populate-sort.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/empty-populate-sort.test.api.ts
@@ -1,0 +1,161 @@
+/**
+ * Empty populate sort must not set orderBy, so join-table connect order is preserved (#26426).
+ *
+ * GraphQL nested fields default to sort: []. REST can send other empty shapes via qs.
+ */
+import type { Core } from '@strapi/types';
+import qs from 'qs';
+
+import { createTestSetup, destroyTestSetup } from '../../../../utils/builder-helper';
+import resources from '../resources/index';
+import { ARTICLE_UID } from '../utils';
+import { testInTransaction } from '../../../../utils';
+import { createContentAPIRequest } from 'api-tests/request';
+
+type ContentAPIRequest = ReturnType<typeof createContentAPIRequest>;
+
+const categoryNames = (article: { categories: Array<{ name: string }> }) =>
+  article.categories.map((category) => category.name);
+
+describe('Empty populate sort', () => {
+  let testUtils;
+  let strapi: Core.Strapi;
+  let rqContent: ContentAPIRequest;
+
+  beforeAll(async () => {
+    testUtils = await createTestSetup(resources);
+    strapi = testUtils.strapi;
+    rqContent = await createContentAPIRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await destroyTestSetup(testUtils);
+  });
+
+  describe('Document Service', () => {
+    testInTransaction(
+      'preserves manyToMany connect order when nested sort is omitted',
+      async () => {
+        const article = await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title: 'Empty populate sort omitted',
+            categories: ['Cat2', 'Cat1'],
+          },
+          populate: { categories: true },
+        });
+
+        expect(categoryNames(article)).toEqual(['Cat2-EN', 'Cat1-EN']);
+      }
+    );
+
+    testInTransaction.each([
+      ['empty array (GraphQL default)', { sort: [] }],
+      ['empty string', { sort: '' }],
+      ['empty object', { sort: {} }],
+    ])(
+      'preserves manyToMany connect order when populate sort is %s',
+      async (_label, populateCategories) => {
+        const article = await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title: `Empty populate sort ${_label}`,
+            categories: ['Cat2', 'Cat1'],
+          },
+          populate: { categories: populateCategories },
+        });
+
+        expect(categoryNames(article)).toEqual(['Cat2-EN', 'Cat1-EN']);
+      }
+    );
+  });
+
+  describe('REST Content API', () => {
+    const qsParseSettings = { strictNullHandling: true, arrayLimit: 100, depth: 20 };
+
+    const getArticleCategoriesViaRest = async (
+      title: string,
+      query: Record<string, unknown>
+    ): Promise<string[]> => {
+      const res = await rqContent({
+        method: 'GET',
+        url: '/articles',
+        qs: {
+          filters: { title: { $eq: title } },
+          locale: 'en',
+          status: 'draft',
+          ...query,
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+
+      const categories = res.body.data[0].categories as Array<{ name: string }>;
+
+      return categories.map((category) => category.name);
+    };
+
+    testInTransaction.each([
+      ['empty string (sort=)', { populate: { categories: { sort: '' } } }],
+      ['comma-only string', { populate: { categories: { sort: ',' } } }],
+      ['array of empty strings (sort[0]=)', { populate: { categories: { sort: [''] } } }],
+    ])('preserves connect order for REST %s', async (_label, query) => {
+      const title = `REST empty populate sort ${_label}`;
+
+      await strapi.documents(ARTICLE_UID).create({
+        locale: 'en',
+        data: {
+          title,
+          categories: ['Cat2', 'Cat1'],
+        },
+      });
+
+      const names = await getArticleCategoriesViaRest(title, query);
+
+      expect(names).toEqual(['Cat2-EN', 'Cat1-EN']);
+    });
+
+    testInTransaction(
+      'preserves connect order for REST populate[categories][sort][] (qs empty array)',
+      async () => {
+        const title = 'REST populate sort bracket empty array';
+
+        await strapi.documents(ARTICLE_UID).create({
+          locale: 'en',
+          data: {
+            title,
+            categories: ['Cat2', 'Cat1'],
+          },
+        });
+
+        const queryString = qs.stringify(
+          {
+            filters: { title: { $eq: title } },
+            locale: 'en',
+            status: 'draft',
+            populate: { categories: { sort: [] } },
+          },
+          { allowEmptyArrays: true }
+        );
+
+        const parsed = qs.parse(queryString, qsParseSettings);
+        expect(parsed.populate).toEqual({ categories: { sort: [null] } });
+
+        const res = await rqContent({
+          method: 'GET',
+          url: `/articles?${queryString}`,
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data).toHaveLength(1);
+
+        const names = (res.body.data[0].categories as Array<{ name: string }>).map(
+          (category) => category.name
+        );
+
+        expect(names).toEqual(['Cat2-EN', 'Cat1-EN']);
+      }
+    );
+  });
+});

--- a/tests/api/core/strapi/document-service/relations/empty-populate-sort.test.api.ts
+++ b/tests/api/core/strapi/document-service/relations/empty-populate-sort.test.api.ts
@@ -1,10 +1,10 @@
 /**
  * Empty populate sort must not set orderBy, so join-table connect order is preserved (#26426).
  *
- * GraphQL nested fields default to sort: []. REST can send other empty shapes via qs.
+ * GraphQL nested fields default to sort: []. REST clients typically omit sort or send empty
+ * strings (see REST cases below). qs `sort[]` → `[null]` is covered in @strapi/utils unit tests.
  */
 import type { Core } from '@strapi/types';
-import qs from 'qs';
 
 import { createTestSetup, destroyTestSetup } from '../../../../utils/builder-helper';
 import resources from '../resources/index';
@@ -71,8 +71,6 @@ describe('Empty populate sort', () => {
   });
 
   describe('REST Content API', () => {
-    const qsParseSettings = { strictNullHandling: true, arrayLimit: 100, depth: 20 };
-
     const getArticleCategoriesViaRest = async (
       title: string,
       query: Record<string, unknown>
@@ -115,47 +113,5 @@ describe('Empty populate sort', () => {
 
       expect(names).toEqual(['Cat2-EN', 'Cat1-EN']);
     });
-
-    testInTransaction(
-      'preserves connect order for REST populate[categories][sort][] (qs empty array)',
-      async () => {
-        const title = 'REST populate sort bracket empty array';
-
-        await strapi.documents(ARTICLE_UID).create({
-          locale: 'en',
-          data: {
-            title,
-            categories: ['Cat2', 'Cat1'],
-          },
-        });
-
-        const queryString = qs.stringify(
-          {
-            filters: { title: { $eq: title } },
-            locale: 'en',
-            status: 'draft',
-            populate: { categories: { sort: [] } },
-          },
-          { allowEmptyArrays: true }
-        );
-
-        const parsed = qs.parse(queryString, qsParseSettings);
-        expect(parsed.populate).toEqual({ categories: { sort: [null] } });
-
-        const res = await rqContent({
-          method: 'GET',
-          url: `/articles?${queryString}`,
-        });
-
-        expect(res.statusCode).toBe(200);
-        expect(res.body.data).toHaveLength(1);
-
-        const names = (res.body.data[0].categories as Array<{ name: string }>).map(
-          (category) => category.name
-        );
-
-        expect(names).toEqual(['Cat2-EN', 'Cat1-EN']);
-      }
-    );
   });
 });

--- a/tests/api/plugins/graphql/relation-order.test.api.js
+++ b/tests/api/plugins/graphql/relation-order.test.api.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+
+const menuItemModel = {
+  attributes: {
+    name: {
+      type: 'string',
+    },
+  },
+  singularName: 'menuitem',
+  pluralName: 'menuitems',
+  displayName: 'Menu item',
+};
+
+const menuItemsComponent = {
+  displayName: 'Menu Items',
+  attributes: {
+    menuItems: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'api::menuitem.menuitem',
+    },
+  },
+};
+
+const menuModel = {
+  kind: 'singleType',
+  singularName: 'menu',
+  pluralName: 'menus',
+  displayName: 'Menu',
+  attributes: {
+    left: {
+      type: 'component',
+      component: 'default.menu-items',
+      repeatable: false,
+    },
+  },
+};
+
+describe('GraphQL relation order (issue #26426)', () => {
+  const menuItemUids = [];
+
+  beforeAll(async () => {
+    await builder
+      .addContentTypes([menuItemModel])
+      .addComponent(menuItemsComponent)
+      .addContentTypes([menuModel])
+      .build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = (body) =>
+      rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+
+    for (const name of ['First', 'Second', 'Third']) {
+      const item = await strapi.documents('api::menuitem.menuitem').create({
+        data: { name },
+      });
+      menuItemUids.push(item.documentId);
+    }
+
+    // Deliberate non-creation order: Third, First, Second (refs #26426 admin reordering)
+    const updateRes = await graphqlQuery({
+      query: /* GraphQL */ `
+        mutation updateMenu($data: MenuInput!) {
+          updateMenu(data: $data) {
+            data {
+              documentId
+            }
+          }
+        }
+      `,
+      variables: {
+        data: {
+          left: {
+            menuItems: [menuItemUids[2], menuItemUids[0], menuItemUids[1]],
+          },
+        },
+      },
+    });
+
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.body.errors).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('returns component oneToMany relations in connect order', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        {
+          menu {
+            data {
+              attributes {
+                left {
+                  menuItems {
+                    documentId
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const menuItems = res.body.data.menu.data.attributes.left.menuItems;
+
+    const names = menuItems.map((item) => item.name ?? item.attributes?.name);
+
+    expect(names).toEqual(['Third', 'First', 'Second']);
+  });
+
+  test('returns oneToMany relations in connect order via _connection', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        {
+          menu {
+            data {
+              attributes {
+                left {
+                  menuItems_connection {
+                    nodes {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const nodes = res.body.data.menu.data.attributes.left.menuItems_connection.nodes;
+
+    const names = nodes.map((item) => item.name ?? item.attributes?.name);
+
+    expect(names).toEqual(['Third', 'First', 'Second']);
+  });
+});

--- a/tests/api/plugins/graphql/relation-order.test.api.js
+++ b/tests/api/plugins/graphql/relation-order.test.api.js
@@ -131,6 +131,34 @@ describe('GraphQL relation order (issue #26426)', () => {
     expect(names).toEqual(['Third', 'First', 'Second']);
   });
 
+  test('returns oneToMany relations in connect order when sort is explicitly empty', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        {
+          menu {
+            data {
+              attributes {
+                left {
+                  menuItems(sort: []) {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const menuItems = res.body.data.menu.data.attributes.left.menuItems;
+    const names = menuItems.map((item) => item.name ?? item.attributes?.name);
+
+    expect(names).toEqual(['Third', 'First', 'Second']);
+  });
+
   test('returns oneToMany relations in connect order via _connection', async () => {
     const res = await graphqlQuery({
       query: /* GraphQL */ `

--- a/tests/api/plugins/graphql/repeatable-component-order.test.api.js
+++ b/tests/api/plugins/graphql/repeatable-component-order.test.api.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createAuthRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+let graphqlQuery;
+let pageDocumentId;
+
+const chapterComponent = {
+  displayName: 'Chapter',
+  attributes: {
+    title: {
+      type: 'string',
+    },
+  },
+};
+
+const pageModel = {
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    chapters: {
+      type: 'component',
+      component: 'default.chapter',
+      repeatable: true,
+    },
+  },
+  singularName: 'page',
+  pluralName: 'pages',
+  displayName: 'Page',
+};
+
+describe('GraphQL repeatable component order (issue #26465)', () => {
+  beforeAll(async () => {
+    await builder.addComponent(chapterComponent).addContentTypes([pageModel]).build();
+
+    strapi = await createStrapiInstance();
+    rq = await createAuthRequest({ strapi });
+
+    graphqlQuery = (body) =>
+      rq({
+        url: '/graphql',
+        method: 'POST',
+        body,
+      });
+
+    const page = await strapi.documents('api::page.page').create({
+      data: {
+        title: 'Test page',
+        chapters: [{ title: 'First' }, { title: 'Second' }, { title: 'Third' }],
+      },
+      populate: { chapters: true },
+    });
+
+    pageDocumentId = page.documentId;
+
+    // Deliberate non-creation order (admin reorder): Third, First, Second
+    await strapi.documents('api::page.page').update({
+      documentId: pageDocumentId,
+      data: {
+        chapters: [page.chapters[2], page.chapters[0], page.chapters[1]],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('returns repeatable components in connect order', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query getPage($documentId: ID!) {
+          page(documentId: $documentId) {
+            data {
+              attributes {
+                chapters {
+                  title
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: pageDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const chapters = res.body.data.page.data.attributes.chapters;
+    const titles = chapters.map((chapter) => chapter.title ?? chapter.attributes?.title);
+
+    expect(titles).toEqual(['Third', 'First', 'Second']);
+  });
+
+  test('returns repeatable components in connect order when sort is explicitly empty', async () => {
+    const res = await graphqlQuery({
+      query: /* GraphQL */ `
+        query getPage($documentId: ID!) {
+          page(documentId: $documentId) {
+            data {
+              attributes {
+                chapters(sort: []) {
+                  title
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { documentId: pageDocumentId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const chapters = res.body.data.page.data.attributes.chapters;
+    const titles = chapters.map((chapter) => chapter.title ?? chapter.attributes?.title);
+
+    expect(titles).toEqual(['Third', 'First', 'Second']);
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds a `hasSort` type guard in `convert-query-params` so empty or missing `sort` (`[]`, `""`, `undefined`) does not set `orderBy`. Join-table ordinal ordering is preserved when GraphQL nested fields use the default `sort: []` argument.

Includes unit tests for `transformQueryParams` and API tests for:

- [#26426](https://github.com/strapi/strapi/issues/26426) — single type → component → `oneToMany` relation order via GraphQL (`relation-order.test.api.js`)
- [#26465](https://github.com/strapi/strapi/issues/26465) — collection type → repeatable component order via GraphQL (`repeatable-component-order.test.api.js`)

### Why is it needed?

Fix #26426, #26465

After Strapi 5.45+, GraphQL nested fields (repeatable components, relations inside components, etc.) pass default `sort: []`, which was converted to `orderBy: []`. The database layer treated that as an explicit sort and skipped join-table ordering, so children were returned in `id` order instead of the order set in the admin UI. REST was largely unaffected unless clients explicitly sent `sort: []`.

### How to test it?

```bash
yarn nx run @strapi/utils:build
yarn nx run @strapi/utils:test:unit --testPathPattern=convert-query-params
yarn test:api --generate-app tests/api/plugins/graphql/relation-order.test.api.js
yarn test:api --generate-app tests/api/plugins/graphql/repeatable-component-order.test.api.js
```

Manual check (optional):

- **#26426:** single type with a component containing a reorderable `oneToMany` relation — GraphQL relation order should match the admin.
- **#26465:** content type with a repeatable component (e.g. Page → Chapters) — GraphQL component list order should match the admin.

### Related issue(s)/PR(s)

- Fixes #26426
- Fixes #26465