### PR TITLE
fix(admin): support array of links in StrapiApp.addSettingsLink

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -216,6 +216,12 @@ class StrapiApp {
     links: UnloadedSettingsLink[]
   ) => this.router.addSettingsLink(section, links);
 
+  /**
+   * Register one or more settings links under an existing or new section.
+   *
+   * @param sectionId - Section id string, or section metadata to create a new section
+   * @param link - A single link or an array of links to register
+   */
   addSettingsLink = (
     sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
     link: UnloadedSettingsLink | UnloadedSettingsLink[]

--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -218,8 +218,8 @@ class StrapiApp {
 
   addSettingsLink = (
     sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
-    link: UnloadedSettingsLink
-  ) => {
+    link: UnloadedSettingsLink | UnloadedSettingsLink[]
+  ): void => {
     this.router.addSettingsLink(sectionId, link);
   };
 

--- a/packages/core/admin/admin/src/core/apis/router.tsx
+++ b/packages/core/admin/admin/src/core/apis/router.tsx
@@ -202,12 +202,8 @@ class Router {
     links?: never
   ): void;
   public addSettingsLink(
-    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
-    link: UnloadedSettingsLink
-  ): void;
-  public addSettingsLink(
-    sectionId: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
-    link: UnloadedSettingsLink[]
+    section: string | Pick<StrapiAppSetting, 'id' | 'intlLabel'>,
+    link: UnloadedSettingsLink | UnloadedSettingsLink[]
   ): void;
   public addSettingsLink(
     section:

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -178,11 +178,18 @@ describe('ADMIN | new StrapiApp', () => {
           intlLabel: { id: 'bar', defaultMessage: 'bar' },
           permissions: [],
         },
+        {
+          Component: jest.fn(),
+          to: 'baz',
+          id: 'baz',
+          intlLabel: { id: 'baz', defaultMessage: 'baz' },
+          permissions: [],
+        },
       ];
 
       app.addSettingsLink('global', links);
 
-      expect(app.router.settings.global.links).toHaveLength(1);
+      expect(app.router.settings.global.links).toHaveLength(2);
       expect(app.router.settings.global.links).toEqual([
         {
           id: 'bar',
@@ -192,6 +199,15 @@ describe('ADMIN | new StrapiApp', () => {
           },
           permissions: [],
           to: 'bar',
+        },
+        {
+          id: 'baz',
+          intlLabel: {
+            defaultMessage: 'baz',
+            id: 'baz',
+          },
+          permissions: [],
+          to: 'baz',
         },
       ]);
     });

--- a/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
+++ b/packages/core/admin/admin/src/tests/StrapiApp.test.tsx
@@ -168,6 +168,34 @@ describe('ADMIN | new StrapiApp', () => {
       ]);
     });
 
+    it('should add an array of links via addSettingsLink to the global section', () => {
+      const app = new StrapiApp();
+      const links = [
+        {
+          Component: jest.fn(),
+          to: 'bar',
+          id: 'bar',
+          intlLabel: { id: 'bar', defaultMessage: 'bar' },
+          permissions: [],
+        },
+      ];
+
+      app.addSettingsLink('global', links);
+
+      expect(app.router.settings.global.links).toHaveLength(1);
+      expect(app.router.settings.global.links).toEqual([
+        {
+          id: 'bar',
+          intlLabel: {
+            defaultMessage: 'bar',
+            id: 'bar',
+          },
+          permissions: [],
+          to: 'bar',
+        },
+      ]);
+    });
+
     it('should warn if a user supplies an absolute link', () => {
       const originalWarn = console.warn;
       const consoleSpy = jest.fn();


### PR DESCRIPTION
### What does it do?

Aligns the public `StrapiApp.addSettingsLink` signature with the underlying `Router.addSettingsLink` overloads so plugins can pass either a single `UnloadedSettingsLink` or an array.

Also collapses the redundant `Router.addSettingsLink` overloads: the `(sectionId, link)` and `(sectionId, link[])` declarations are merged into a single overload accepting `UnloadedSettingsLink | UnloadedSettingsLink[]`.

### Why is it needed?

The [admin navigation settings docs](https://docs.strapi.io/cms/plugins-development/admin-navigation-settings) document registering multiple settings links in one call, but `StrapiApp.addSettingsLink` only typed the single-link form. Plugins following the docs hit a TypeScript error even though `Router.addSettingsLink` already supports arrays at runtime.

### How to test it?

1. From a plugin's `register` lifecycle, call `app.addSettingsLink(sectionId, [link1, link2])`.
2. TypeScript should compile and both links should appear under the section in the admin Settings sidebar.
3. The single-link form `app.addSettingsLink(sectionId, link)` should still compile and work as before.

### Related issue(s)/PR(s)

https://github.com/strapi/documentation/pull/3204

---
Fixes CPR-407