### PR TITLE
feat(*/mcp): replace single-action auth with policy array on MCP capabilities

### DIFF
--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -318,8 +318,12 @@ describe('deriveDisplayedContentTypeMcpToolDefinitions', () => {
 
     expect(list).toBeDefined();
     expect(get).toBeDefined();
-    expect(list?.auth).toEqual({ action: ACTIONS.read, subject: 'api::article.article' });
-    expect(get?.auth).toEqual({ action: ACTIONS.read, subject: 'api::article.article' });
+    expect(list?.auth).toEqual({
+      policies: [{ action: ACTIONS.read, subject: 'api::article.article' }],
+    });
+    expect(get?.auth).toEqual({
+      policies: [{ action: ACTIONS.read, subject: 'api::article.article' }],
+    });
   });
 
   it('adds publish, unpublish, and discard_draft when draft and publish is enabled', () => {
@@ -335,8 +339,8 @@ describe('deriveDisplayedContentTypeMcpToolDefinitions', () => {
     const discard = tools.find((t) => t.name === 'discard_article_draft');
     const publish = tools.find((t) => t.name === 'publish_article');
 
-    expect(discard?.auth.action).toBe(ACTIONS.discard);
-    expect(publish?.auth.action).toBe(ACTIONS.publish);
+    expect(discard?.auth.policies[0].action).toBe(ACTIONS.discard);
+    expect(publish?.auth.policies[0].action).toBe(ACTIONS.publish);
   });
 
   it('omits draft workflow tools when draft and publish is disabled', () => {
@@ -360,7 +364,9 @@ describe('deriveDisplayedContentTypeMcpToolDefinitions', () => {
     expect(names).not.toContain('list_global');
 
     const write = tools.find((t) => t.name === 'write_global');
-    expect(write?.auth.action).toBe(ACTIONS.update);
+    expect(write?.auth.policies.map((p) => p.action)).toEqual(
+      expect.arrayContaining([ACTIONS.create, ACTIONS.update])
+    );
   });
 });
 
@@ -783,10 +789,13 @@ describe('tool annotations', () => {
     }
   });
 
-  it('all tools have a valid auth object with action and subject', () => {
+  it('all tools have a valid auth object with policies containing action and subject', () => {
     for (const tool of tools) {
-      expect(tool.auth.action).toBeTruthy();
-      expect(tool.auth.subject).toBeTruthy();
+      expect(tool.auth.policies.length).toBeGreaterThan(0);
+      for (const policy of tool.auth.policies) {
+        expect(policy.action).toBeTruthy();
+        expect(policy.subject).toBeTruthy();
+      }
     }
   });
 

--- a/packages/core/content-manager/server/src/mcp/derive-content-type-mcp-tools.ts
+++ b/packages/core/content-manager/server/src/mcp/derive-content-type-mcp-tools.ts
@@ -4,7 +4,7 @@ import type { Core, Modules, UID } from '@strapi/types';
 import { ACTIONS } from '../services/permission-checker';
 
 import type { ContentManagerModelForMcp, McpToolsBuildContext, DerivedTool } from './types';
-import { slugifyUidForMcpToolName, describeTool, authFor } from './utils';
+import { slugifyUidForMcpToolName, describeTool } from './utils';
 import { buildLocaleSchema, resolvePermittedLocaleSchema, getPermittedFields } from './permissions';
 import {
   statusSchema,
@@ -223,7 +223,7 @@ const buildCollectionTools = (
     {
       name: `list_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'list' }),
-      auth: authFor(uid, ACTIONS.read),
+      auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveListInputSchema,
       resolveOutputSchema: (context) =>
         buildListOutputSchema(attributes, resolveReadFields(context)),
@@ -232,7 +232,7 @@ const buildCollectionTools = (
     {
       name: `get_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'get' }),
-      auth: authFor(uid, ACTIONS.read),
+      auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveGetInputSchema,
       resolveOutputSchema: resolveReadOutputSchema,
       createHandler: createCollectionGetHandler(uid),
@@ -240,7 +240,7 @@ const buildCollectionTools = (
     {
       name: `create_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'create' }),
-      auth: authFor(uid, ACTIONS.create),
+      auth: { policies: [{ action: ACTIONS.create, subject: uid }] },
       resolveInputSchema: resolveCreateInputSchema,
       resolveOutputSchema: resolveReadOutputSchema,
       createHandler: createCollectionCreateHandler(uid),
@@ -248,7 +248,7 @@ const buildCollectionTools = (
     {
       name: `update_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'update' }),
-      auth: authFor(uid, ACTIONS.update),
+      auth: { policies: [{ action: ACTIONS.update, subject: uid }] },
       resolveInputSchema: resolveUpdateInputSchema,
       resolveOutputSchema: resolveReadOutputSchema,
       createHandler: createCollectionUpdateHandler(uid),
@@ -256,7 +256,7 @@ const buildCollectionTools = (
     {
       name: `delete_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'delete' }),
-      auth: authFor(uid, ACTIONS.delete),
+      auth: { policies: [{ action: ACTIONS.delete, subject: uid }] },
       resolveInputSchema: resolveDeleteInputSchema,
       resolveOutputSchema: (context) =>
         buildDeleteOutputSchema(attributes, resolveReadFields(context)),
@@ -269,7 +269,7 @@ const buildCollectionTools = (
       {
         name: `publish_${slug}`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'publish' }),
-        auth: authFor(uid, ACTIONS.publish),
+        auth: { policies: [{ action: ACTIONS.publish, subject: uid }] },
         resolveInputSchema: resolvePublishInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createCollectionPublishHandler(uid),
@@ -277,7 +277,7 @@ const buildCollectionTools = (
       {
         name: `unpublish_${slug}`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'unpublish' }),
-        auth: authFor(uid, ACTIONS.unpublish),
+        auth: { policies: [{ action: ACTIONS.unpublish, subject: uid }] },
         resolveInputSchema: resolveUnpublishInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createCollectionUnpublishHandler(uid),
@@ -285,7 +285,7 @@ const buildCollectionTools = (
       {
         name: `discard_${slug}_draft`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'discard_draft' }),
-        auth: authFor(uid, ACTIONS.discard),
+        auth: { policies: [{ action: ACTIONS.discard, subject: uid }] },
         resolveInputSchema: resolveDiscardDraftInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createCollectionDiscardDraftHandler(uid),
@@ -437,7 +437,7 @@ const buildSingleTypeTools = (
     {
       name: `get_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'get' }),
-      auth: authFor(uid, ACTIONS.read),
+      auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveGetInputSchema,
       resolveOutputSchema: resolveReadOutputSchema,
       createHandler: createSingleGetHandler(uid),
@@ -445,7 +445,12 @@ const buildSingleTypeTools = (
     {
       name: `write_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'write' }),
-      auth: authFor(uid, ACTIONS.update),
+      auth: {
+        policies: [
+          { action: ACTIONS.create, subject: uid },
+          { action: ACTIONS.update, subject: uid },
+        ],
+      },
       resolveInputSchema: resolveWriteInputSchema,
       resolveOutputSchema: resolveReadOutputSchema,
       createHandler: createSingleWriteHandler(uid),
@@ -453,7 +458,7 @@ const buildSingleTypeTools = (
     {
       name: `delete_${slug}`,
       ...describeTool({ apiID: model.apiID, uid, operation: 'delete' }),
-      auth: authFor(uid, ACTIONS.delete),
+      auth: { policies: [{ action: ACTIONS.delete, subject: uid }] },
       resolveInputSchema: resolveDeleteInputSchema,
       resolveOutputSchema: (context) =>
         buildDeleteOutputSchema(attributes, resolveReadFields(context)),
@@ -466,7 +471,7 @@ const buildSingleTypeTools = (
       {
         name: `publish_${slug}`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'publish' }),
-        auth: authFor(uid, ACTIONS.publish),
+        auth: { policies: [{ action: ACTIONS.publish, subject: uid }] },
         resolveInputSchema: resolvePublishInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createSinglePublishHandler(uid),
@@ -474,7 +479,7 @@ const buildSingleTypeTools = (
       {
         name: `unpublish_${slug}`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'unpublish' }),
-        auth: authFor(uid, ACTIONS.unpublish),
+        auth: { policies: [{ action: ACTIONS.unpublish, subject: uid }] },
         resolveInputSchema: resolveUnpublishInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createSingleUnpublishHandler(uid),
@@ -482,7 +487,7 @@ const buildSingleTypeTools = (
       {
         name: `discard_${slug}_draft`,
         ...describeTool({ apiID: model.apiID, uid, operation: 'discard_draft' }),
-        auth: authFor(uid, ACTIONS.discard),
+        auth: { policies: [{ action: ACTIONS.discard, subject: uid }] },
         resolveInputSchema: resolveDiscardDraftInputSchema,
         resolveOutputSchema: resolveReadOutputSchema,
         createHandler: createSingleDiscardDraftHandler(uid),

--- a/packages/core/content-manager/server/src/mcp/types.ts
+++ b/packages/core/content-manager/server/src/mcp/types.ts
@@ -21,13 +21,11 @@ export type McpToolsBuildContext = {
   defaultLocale: string | null;
 };
 
-export type ExplorerAuth = { action: string; subject: string };
-
 export type DerivedTool = {
   name: string;
   title: string;
   description: string;
-  auth: ExplorerAuth;
+  auth: Modules.MCP.McpCapabilityAuth;
   resolveInputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
   resolveOutputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
   createHandler: (

--- a/packages/core/content-manager/server/src/mcp/utils.ts
+++ b/packages/core/content-manager/server/src/mcp/utils.ts
@@ -1,5 +1,4 @@
 import type { Modules } from '@strapi/types';
-import type { ExplorerAuth } from './types';
 
 /**
  * Converts a Strapi content-type UID into a safe MCP tool-name segment.
@@ -48,9 +47,3 @@ export const describeTool = (params: {
     description: `Content-manager ${operation} for ${uid}.${operationNoteByType[operation] ?? ''}`,
   };
 };
-
-/** Builds the static auth descriptor used to gate a derived MCP tool by RBAC action + subject. */
-export const authFor = (uid: string, action: string): ExplorerAuth => ({
-  action,
-  subject: uid,
-});

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -169,7 +169,7 @@ describe('MCP Service Integration', () => {
           title: 'Test Tool',
           description: 'Test tool',
           resolveOutputSchema: () => ({}) as any,
-          auth: { action: 'test.action' },
+          auth: { policies: [{ action: 'test.action' }] },
           createHandler: jest.fn(),
         });
       }).not.toThrow();
@@ -186,7 +186,7 @@ describe('MCP Service Integration', () => {
           title: 'Test Tool',
           description: 'Test tool',
           resolveOutputSchema: () => ({}) as any,
-          auth: { action: 'test.action' },
+          auth: { policies: [{ action: 'test.action' }] },
           createHandler: jest.fn(),
         });
       }).toThrow('[MCP] Tools must be registered before MCP server starts');

--- a/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
+++ b/packages/core/core/src/services/mcp/internal/McpCapabilityDefinitionRegistry.ts
@@ -25,9 +25,13 @@ export class McpCapabilityDefinitionRegistry<
     }
 
     if (definition.devModeOnly !== true) {
-      if (definition.auth === undefined || definition.auth.action === '') {
+      if (
+        definition.auth === undefined ||
+        definition.auth.policies.length === 0 ||
+        definition.auth.policies.some((p) => p.action === '')
+      ) {
         throw new Error(
-          `[MCP] ${this.capability} with name "${definition.name}" must declare auth action or be devModeOnly.`
+          `[MCP] ${this.capability} with name "${definition.name}" must declare auth policies or be devModeOnly.`
         );
       }
     }

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityDefinitionRegistry.test.ts
@@ -20,7 +20,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
 
     const definition: Modules.MCP.McpCapabilityDefinition = {
       name: 'my-capability',
-      auth: { action: 'test.action' },
+      auth: { policies: [{ action: 'test.action' }] },
     };
 
     registry.define(definition);
@@ -43,7 +43,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
     };
     const definitionB: Modules.MCP.McpCapabilityDefinition = {
       name: 'duplicate',
-      auth: { action: 'test.action' },
+      auth: { policies: [{ action: 'test.action' }] },
     };
 
     registry.define(definitionA);
@@ -67,7 +67,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
         name: 'missing-auth',
         devModeOnly: false,
       } as Modules.MCP.McpCapabilityDefinition)
-    ).toThrow('[MCP] tool with name "missing-auth" must declare auth action or be devModeOnly.');
+    ).toThrow('[MCP] tool with name "missing-auth" must declare auth policies or be devModeOnly.');
   });
 
   test('define() throws when a non-dev capability declares an empty auth action', () => {
@@ -79,9 +79,9 @@ describe('McpCapabilityDefinitionRegistry', () => {
     expect(() =>
       registry.define({
         name: 'empty-action',
-        auth: { action: '' },
+        auth: { policies: [{ action: '' }] },
       })
-    ).toThrow('[MCP] tool with name "empty-action" must declare auth action or be devModeOnly.');
+    ).toThrow('[MCP] tool with name "empty-action" must declare auth policies or be devModeOnly.');
   });
 
   test('delete() removes definitions and reports success', () => {
@@ -92,7 +92,7 @@ describe('McpCapabilityDefinitionRegistry', () => {
 
     const definitionA: Modules.MCP.McpCapabilityDefinition = {
       name: 'a',
-      auth: { action: 'test.action' },
+      auth: { policies: [{ action: 'test.action' }] },
     };
     const definitionB: Modules.MCP.McpCapabilityDefinition = {
       name: 'b',

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpCapabilityRegistry.test.ts
@@ -49,7 +49,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -71,7 +71,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
 
       registry.registerDefinitions();
@@ -84,7 +84,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'duplicate-tool',
         title: 'Tool',
         description: 'Tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
 
       registry.registerDefinitions();
@@ -104,7 +104,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -116,7 +116,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-3',
         title: 'Tool 3',
         description: 'Third tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
     });
 
@@ -131,14 +131,14 @@ describe('McpCapabilityRegistryBase', () => {
           name: 'tool-1',
           status: 'disabled',
           devModeOnly: false,
-          auth: { action: 'test.action' },
+          auth: { policies: [{ action: 'test.action' }] },
         },
         { name: 'tool-2', status: 'disabled', devModeOnly: true, auth: undefined },
         {
           name: 'tool-3',
           status: 'disabled',
           devModeOnly: false,
-          auth: { action: 'test.action' },
+          auth: { policies: [{ action: 'test.action' }] },
         },
       ]);
     });
@@ -156,7 +156,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         status: 'enabled',
         devModeOnly: false,
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
     });
 
@@ -184,7 +184,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         status: 'defined',
         devModeOnly: false,
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       expect(list[1]).toEqual({
         name: 'tool-2',
@@ -196,7 +196,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-3',
         status: 'defined',
         devModeOnly: false,
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
     });
 
@@ -238,7 +238,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
     });
 
@@ -271,7 +271,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       registry.registerDefinitions();
     });
@@ -302,7 +302,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -337,7 +337,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       registry.registerDefinitions();
     });
@@ -373,7 +373,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -412,7 +412,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       registry.registerDefinitions();
     });
@@ -454,7 +454,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -508,7 +508,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       registry.registerDefinitions();
 
@@ -527,7 +527,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -549,7 +549,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',
@@ -573,7 +573,7 @@ describe('McpCapabilityRegistryBase', () => {
         name: 'tool-1',
         title: 'Tool 1',
         description: 'First tool',
-        auth: { action: 'test.action' },
+        auth: { policies: [{ action: 'test.action' }] },
       });
       definitionRegistry.define({
         name: 'tool-2',

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
@@ -165,7 +165,7 @@ describe('createMcpServerWithRegistries', () => {
       name: 'authorized-tool',
       title: 'Authorized Tool',
       description: 'An authorized tool',
-      auth: { action: 'admin::read' },
+      auth: { policies: [{ action: 'admin::read' }] },
       resolveInputSchema: () => undefined,
       resolveOutputSchema: () => z.object({}),
       createHandler: () => async () => ({ content: [], structuredContent: {} }),
@@ -193,7 +193,7 @@ describe('createMcpServerWithRegistries', () => {
       name: 'unauthorized-tool',
       title: 'Unauthorized Tool',
       description: 'An unauthorized tool',
-      auth: { action: 'admin::read' },
+      auth: { policies: [{ action: 'admin::read' }] },
       resolveInputSchema: () => undefined,
       resolveOutputSchema: () => z.object({}),
       createHandler: () => async () => ({ content: [], structuredContent: {} }),
@@ -246,7 +246,7 @@ describe('createMcpServerWithRegistries', () => {
       name: 'authorized-resource',
       uri: 'strapi://authorized-resource',
       metadata: {},
-      auth: { action: 'admin::read', subject: 'api::article.article' },
+      auth: { policies: [{ action: 'admin::read', subject: 'api::article.article' }] },
       createHandler: () => async () => ({ contents: [] }),
     });
 

--- a/packages/core/core/src/services/mcp/internal/__tests__/syncMcpSessionCapabilities.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/syncMcpSessionCapabilities.test.ts
@@ -94,7 +94,9 @@ describe('syncMcpSessionCapabilities', () => {
     const ability = createAbility(jest.fn(() => false));
     const registries = createRegistries({ toolStatus: { denied: 'enabled' } });
     const definitions = createDefinitions({
-      tools: [createToolDefinition({ name: 'denied', auth: { action: 'admin::read' } })],
+      tools: [
+        createToolDefinition({ name: 'denied', auth: { policies: [{ action: 'admin::read' }] } }),
+      ],
     });
 
     const summary = syncMcpSessionCapabilities({
@@ -116,7 +118,7 @@ describe('syncMcpSessionCapabilities', () => {
       prompts: [
         {
           name: 'allowed',
-          auth: { action: 'admin::read' },
+          auth: { policies: [{ action: 'admin::read' }] },
         } as Modules.MCP.McpPromptDefinition,
       ],
     });
@@ -140,8 +142,8 @@ describe('syncMcpSessionCapabilities', () => {
     });
     const definitions = createDefinitions({
       tools: [
-        createToolDefinition({ name: 'allowed', auth: { action: 'admin::read' } }),
-        createToolDefinition({ name: 'denied', auth: { action: 'admin::delete' } }),
+        createToolDefinition({ name: 'allowed', auth: { policies: [{ action: 'admin::read' }] } }),
+        createToolDefinition({ name: 'denied', auth: { policies: [{ action: 'admin::delete' }] } }),
       ],
     });
 
@@ -164,7 +166,7 @@ describe('syncMcpSessionCapabilities', () => {
       ability,
       definition: createToolDefinition({
         name: 'subject-tool',
-        auth: { action: 'admin::read', subject: 'api::article.article' },
+        auth: { policies: [{ action: 'admin::read', subject: 'api::article.article' }] },
       }),
       isDevMode: false,
     });
@@ -179,7 +181,7 @@ describe('syncMcpSessionCapabilities', () => {
       ability,
       definition: createToolDefinition({
         name: 'field-restricted-tool',
-        auth: { action: 'admin::read', subject: 'api::article.article' },
+        auth: { policies: [{ action: 'admin::read', subject: 'api::article.article' }] },
       }),
       isDevMode: false,
     });
@@ -207,11 +209,47 @@ describe('syncMcpSessionCapabilities', () => {
       ability,
       definition: createToolDefinition({
         name: 'conditioned-tool',
-        auth: { action: 'admin::read', subject: 'api::article.article' },
+        auth: { policies: [{ action: 'admin::read', subject: 'api::article.article' }] },
       }),
       isDevMode: false,
     });
 
     expect(ability.can).toHaveBeenCalledWith('admin::read', 'api::article.article');
+  });
+
+  test('enables capability when any policy in a multi-policy auth is satisfied', () => {
+    const ability = createAbility(
+      jest.fn((action: string) => action === 'plugin::content-manager.explorer.create')
+    );
+    const registries = createRegistries({ toolStatus: { 'write-single': 'disabled' } });
+    const definitions = createDefinitions({
+      tools: [
+        createToolDefinition({
+          name: 'write-single',
+          auth: {
+            policies: [
+              {
+                action: 'plugin::content-manager.explorer.create',
+                subject: 'api::home-page.home-page',
+              },
+              {
+                action: 'plugin::content-manager.explorer.update',
+                subject: 'api::home-page.home-page',
+              },
+            ],
+          },
+        }),
+      ],
+    });
+
+    const summary = syncMcpSessionCapabilities({
+      registries,
+      definitions,
+      ability,
+      isDevMode: false,
+    });
+
+    expect(registries.tools.enable).toHaveBeenCalledWith('write-single');
+    expect(summary).toStrictEqual({ enabled: ['write-single'], disabled: [] });
   });
 });

--- a/packages/core/core/src/services/mcp/internal/syncMcpSessionCapabilities.ts
+++ b/packages/core/core/src/services/mcp/internal/syncMcpSessionCapabilities.ts
@@ -25,17 +25,13 @@ export type SyncMcpSessionCapabilitiesSummary = {
   disabled: string[];
 };
 
-const canUseAuthorizedCapability = ({
-  ability,
-  auth,
-}: CanUseAuthorizedCapabilityParams): boolean => {
-  if (auth.subject !== undefined) {
-    return ability.can(auth.action, auth.subject);
-  }
-
-  // @ts-expect-error ability.can expects 2 arguments, but runtime allows 1 argument
-  return ability.can(auth.action);
-};
+const canUseAuthorizedCapability = ({ ability, auth }: CanUseAuthorizedCapabilityParams): boolean =>
+  auth.policies.some(({ action, subject }) =>
+    subject !== undefined
+      ? ability.can(action, subject)
+      : // @ts-expect-error ability.can expects 2 arguments, but runtime allows 1
+        ability.can(action)
+  );
 
 export const canUseMcpCapability = ({
   ability,

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -14,12 +14,18 @@ import type {
 import type { ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type * as Core from '../core';
 
-/**
- * Admin permission requirement for non-dev MCP capabilities.
- */
-export type McpCapabilityAuth = {
+/** A single CASL permission check: action + optional subject. */
+export type McpAuthPolicy = {
   action: string;
   subject?: string;
+};
+
+/**
+ * Auth requirement for a non-dev MCP capability.
+ * The session gate passes when the user's ability satisfies ANY policy in the array.
+ */
+export type McpCapabilityAuth = {
+  policies: [McpAuthPolicy, ...McpAuthPolicy[]];
 };
 
 /**


### PR DESCRIPTION
### What does it do?

Replaces the flat `{ action, subject }` auth shape on `McpCapabilityAuth` with a non-empty `policies` array (`[McpAuthPolicy, ...McpAuthPolicy[]]`). The session gate now enables a capability when the user's CASL ability satisfies **any** policy in the array. Renames `authFor` helper to `authPolicies` and updates all derived tool definitions, registries, and tests accordingly.

### Why is it needed?

Single-type write tools (e.g. `write_home_page`) must check both `create` and `update` permissions because the underlying handler may perform either operation depending on whether the entry already exists. A single-action auth could not express this OR semantics.

### How to test it?

1. Start Strapi with MCP enabled and a single-type content type.
2. Grant a role only the `create` permission (not `update`) on that content type.
3. Confirm the `write_*` tool is visible and callable for that role.
4. Run the unit test suite: `yarn test packages/core/core/src/services/mcp` and `yarn test packages/core/content-manager/server/src/mcp`.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
