### PR TITLE
chore(upload): remove aiMetadataJobsCleanup cron job

### DIFF
--- a/packages/core/upload/server/src/__tests__/bootstrap.test.ts
+++ b/packages/core/upload/server/src/__tests__/bootstrap.test.ts
@@ -62,9 +62,6 @@ describe('Upload plugin bootstrap function', () => {
             weeklyMetrics: {
               registerCron() {},
             },
-            aiMetadataJobs: {
-              registerCron() {},
-            },
             extensions: {
               signFileUrlsOnDocumentService: jest.fn(),
             },

--- a/packages/core/upload/server/src/bootstrap.ts
+++ b/packages/core/upload/server/src/bootstrap.ts
@@ -41,9 +41,6 @@ export async function bootstrap({ strapi }: { strapi: Core.Strapi }) {
   await registerWebhookEvents();
 
   await getService('weeklyMetrics').registerCron();
-  if (strapi.ai.admin.isEnabled() === true) {
-    await getService('aiMetadataJobs').registerCron();
-  }
 
   getService('metrics').sendUploadPluginMetrics();
 

--- a/packages/core/upload/server/src/services/ai-metadata-jobs.ts
+++ b/packages/core/upload/server/src/services/ai-metadata-jobs.ts
@@ -44,29 +44,6 @@ export const createAIMetadataJobsService = ({ strapi }: { strapi: Core.Strapi })
       orderBy: { createdAt: 'desc' },
     });
   },
-
-  async registerCron() {
-    strapi.cron.add({
-      aiMetadataJobsCleanup: {
-        async task() {
-          try {
-            const result = await strapi.db.query(AI_METADATA_JOB_UID).deleteMany({
-              where: {
-                status: { $ne: 'processing' },
-              },
-            });
-
-            if (result.count > 0) {
-              strapi.log.info(`Cleaned up ${result.count} old AI metadata jobs`);
-            }
-          } catch (error) {
-            strapi.log.error('Failed to cleanup AI metadata jobs:', error);
-          }
-        },
-        options: '0 0 * * *', // Run once a day at midnight
-      },
-    });
-  },
 });
 
 export type { AIMetadataJob };


### PR DESCRIPTION
### What does it do?

Removes the `aiMetadataJobsCleanup` cron job that ran daily at midnight to delete completed/failed rows from `strapi_ai_metadata_jobs`.

- Drops the `registerCron` method from `packages/core/upload/server/src/services/ai-metadata-jobs.ts`
- Drops the conditional `aiMetadataJobs.registerCron()` call from the upload plugin bootstrap
- Removes the now-unused `aiMetadataJobs` mock entry from the bootstrap test

The job table, CRUD methods (`createJob`, `getJob`, `updateJob`, `deleteJob`, `getLatestActiveJob`), and all consumer flows are untouched.

### Why is it needed?

The cleanup cron was waking up otherwise-idle Strapi Cloud instances every night just to delete a handful of rows. The cleanup is not necessary:

- Jobs are only created when an admin clicks "generate AI metadata for existing images" in Settings — not on regular uploads — so accumulation is negligible.
- No code iterates, counts, or aggregates across the table. The only read path (`getLatestActiveJob`) orders by `createdAt desc` and returns a single row, so old records do not affect correctness.
- The admin hook (`useAIMetadataJob`) handles stale `completed`/`failed` rows gracefully: `previousJobStatus` starts `null`, polling halts when the latest status isn't `processing`, and the transition notification only fires for genuine `processing -> completed`/`failed` flips.

Removing the cron eliminates the nightly wakeup without any functional regression.

### How to test it?

Confirm AI retroactive metadata generation works as expected

1. Start he dev server for examples getstarted with a growth license containing AI features
2. Go to settings -> media library and ensure AI is turned OFF
3. Go to the media library and upload an image or two. Do NOT add caption or alt text
4. Go settings -> media library and turn AI on
5. You should see a message that some images are missing metadata and option to generate it
6. Click generate and it should work
