### PR TITLE
feat(core/mcp): add server-side MCP analytics telemetry

### DIFF
--- a/docs/docs/docs/01-core/admin/04-features/telemetry.md
+++ b/docs/docs/docs/01-core/admin/04-features/telemetry.md
@@ -1,0 +1,254 @@
+---
+title: Admin telemetry (frontend)
+description: How the admin panel sends usage events from the browser — useTracking, event types, and plugin patterns.
+tags:
+  - admin
+  - telemetry
+  - analytics
+---
+
+The admin panel sends usage events **directly from the browser** to the Strapi analytics hub. This is separate from server-side telemetry (`strapi.telemetry.send`) documented in [Server-side telemetry](/docs/core/strapi/telemetry).
+
+For the public overview of collected data, see [Usage information](https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html).
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  React components / hooks                                        │
+│    trackUsage('didSaveContentType')                              │
+│    trackUsage('didCreateEntry', { documentId, status })          │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │
+┌────────────────────────────▼─────────────────────────────────────┐
+│  packages/core/admin/admin/src/features/Tracking.tsx             │
+│    TrackingProvider  → context (uuid, telemetryProperties)       │
+│    useTracking()     → trackUsage()                              │
+└────────────┬───────────────────────────────┬───────────────────────┘
+             │                               │
+             │ GET /admin/telemetry-properties│ POST /api/v2/track
+             ▼                               ▼
+     Strapi backend                   analytics.strapi.io
+     (group metadata)                 (override: STRAPI_ANALYTICS_URL)
+```
+
+There is **no server proxy** for routine UI events — the admin SPA posts to the analytics endpoint with `axios`. Failures are swallowed; tracking never blocks UI flows.
+
+---
+
+## Core API
+
+### `useTracking()`
+
+Primary hook for admin and plugins:
+
+```tsx
+import { useTracking } from '@strapi/admin/strapi-admin';
+
+const MyComponent = () => {
+  const { trackUsage } = useTracking();
+
+  const handleSave = () => {
+    trackUsage('didSaveContentType');
+    // or with properties:
+    trackUsage('didCreateEntry', { documentId: 'abc', status: 'draft' });
+  };
+};
+```
+
+Implementation: `packages/core/admin/admin/src/features/Tracking.tsx`.
+
+Exported from `@strapi/admin` via `packages/core/admin/admin/src/index.ts`.
+
+### `TrackingProvider`
+
+Mounted in `packages/core/admin/admin/src/components/Providers.tsx`, wrapping the authenticated app tree.
+
+Responsibilities:
+
+1. Reads project `uuid` from `useInitQuery()` (`GET /admin/init`).
+2. Fetches `telemetryProperties` via `useTelemetryPropertiesQuery()` when the user is logged in.
+3. Fires **`didInitializeAdministration`** once when both `uuid` and telemetry properties are available (anonymous — empty `userId`).
+
+---
+
+## When events are sent (opt-in gates)
+
+`trackUsage` only fires when **all** of the following are true:
+
+| Gate                                        | Source                                                                   |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| Project `uuid` is truthy                    | `GET /admin/init` — `false` when telemetry is disabled in `package.json` |
+| `window.strapi.telemetryDisabled === false` | Set at build time from `STRAPI_TELEMETRY_DISABLED` in `render.ts`        |
+
+If either gate fails, `trackUsage` returns `null` without making a network request.
+
+Server-side `strapi.telemetry.isDisabled` also affects whether `/admin/telemetry-properties` returns data (204 when disabled), so group metadata is unavailable when telemetry is off.
+
+---
+
+## Request payload
+
+Each `trackUsage` call POSTs to:
+
+```
+${STRAPI_ANALYTICS_URL || 'https://analytics.strapi.io'}/api/v2/track
+```
+
+Body shape (same endpoint as server-side telemetry):
+
+| Field                       | Frontend source                                                                                |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| `event`                     | First argument to `trackUsage`                                                                 |
+| `userId`                    | SHA-256 hash of admin email (`hashAdminUserEmail` in `AuthenticatedLayout`)                    |
+| `eventProperties`           | Second argument to `trackUsage` (action-specific)                                              |
+| `userProperties.deviceType` | `'desktop' \| 'tablet' \| 'mobile'` from `useDeviceType()` (user-agent heuristic)              |
+| `groupProperties`           | Spread of `telemetryProperties` + `projectId: uuid` + `projectType: window.strapi.projectType` |
+
+Header: `X-Strapi-Event: <event name>`.
+
+### Group properties from the server
+
+`GET /admin/telemetry-properties` (`packages/core/admin/server/src/controllers/admin.ts`):
+
+- `useTypescriptOnServer`, `useTypescriptOnAdmin`
+- `isHostedOnStrapiCloud`
+- `numberOfAllContentTypes`, `numberOfComponents`, `numberOfDynamicZones`
+
+Requires authenticated admin. Returns 204 when `strapi.telemetry.isDisabled`.
+
+---
+
+## Lifecycle / session events
+
+These fire automatically — you usually do not add them in feature code:
+
+| Event                                  | When                                        | Notes                                                        |
+| -------------------------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `didInitializeAdministration`          | First load with uuid + telemetry properties | Anonymous (`userId: ''`); uses raw `fetch`, not `trackUsage` |
+| `didAccessAuthenticatedAdministration` | Authenticated layout mount                  | Includes `registeredWidgets`, `projectId`                    |
+
+`didAccessAuthenticatedAdministration` is sent from `packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx` when `projectId` becomes available.
+
+---
+
+## Event naming conventions
+
+Same vocabulary as server-side telemetry, with more **`will*`** intent events (user started an action in UI):
+
+| Pattern   | Meaning                           | Examples                                                  |
+| --------- | --------------------------------- | --------------------------------------------------------- |
+| `will*`   | User initiated / about to perform | `willCreateEntry`, `willNavigate`, `willSaveContentType`  |
+| `did*`    | Completed action                  | `didCreateEntry`, `didSaveContentType`, `didPublishEntry` |
+| `didNot*` | Failed or cancelled               | `didNotCreateEntry`, `didNotDeleteEntry`                  |
+
+Event names are defined as a **TypeScript union** in `Tracking.tsx` (`TrackingEvent`). Known events split into:
+
+- `EventWithoutProperties` — no second argument
+- `EventsWithProperties` — typed property shapes per event (content manager entries, media library, tokens, guided tour, etc.)
+
+Adding a new event requires updating the union in `Tracking.tsx` so callers get type checking and autocomplete.
+
+---
+
+## Plugin and package patterns
+
+Plugins import `useTracking` from `@strapi/admin/strapi-admin` and call `trackUsage` in components or hooks. Major consumers:
+
+| Package                        | Typical events                                            |
+| ------------------------------ | --------------------------------------------------------- |
+| `@strapi/admin`                | Settings, roles, tokens, navigation, guided tour, widgets |
+| `@strapi/content-manager`      | Entry CRUD, bulk actions, list config, filters, history   |
+| `@strapi/content-type-builder` | Schema editing, AI chat (via wrapper below)               |
+| `@strapi/upload`               | Media library actions (via wrapper below)                 |
+| `@strapi/content-releases`     | `didPublishRelease`                                       |
+
+### Wrapper hooks (enrich properties, don't replace the API)
+
+**Content-type builder — `useCTBTracking`**
+
+`packages/core/content-type-builder/admin/src/components/CTBSession/useCTBTracking.ts`
+
+Wraps `useTracking` and merges `ctbSessionId` into every event's properties. Accepts arbitrary event name strings (relaxed typing for CTB-specific events).
+
+**Upload — `useTracking`**
+
+`packages/core/upload/admin/src/hooks/useTracking.ts`
+
+Wraps `useTracking` and adds `isAiMediaLibraryConfigured` when AI is available (mirrors server upload metrics pattern).
+
+When adding plugin telemetry, prefer wrapping the core hook if you need consistent extra properties — do not POST to analytics directly.
+
+---
+
+## Other analytics endpoints (not `trackUsage`)
+
+These bypass `Tracking.tsx` but hit the same analytics host:
+
+| Endpoint             | Component                     | Purpose                                        |
+| -------------------- | ----------------------------- | ---------------------------------------------- |
+| `POST /api/v2/track` | `Tracking.tsx`, `useTracking` | Standard events                                |
+| `POST /register`     | `UseCasePage.tsx`             | First-admin persona registration (email, role) |
+| `POST /submit-nps`   | `NpsSurvey.tsx`               | NPS survey responses — see [NPS](./nps.md)     |
+
+---
+
+## Volume and rate limiting
+
+Unlike server-side telemetry, the **admin frontend has no rate limiter or batching**. Every `trackUsage` call that passes the opt-in gates results in one HTTP request.
+
+Conventions that keep volume reasonable in practice:
+
+- Pair **`will*`** with **`did*`** / **`didNot*`** only at meaningful completion points (not on every keystroke).
+- Prefer property **categories** over high-cardinality identifiers where possible (though some events do include `documentId`).
+- Navigation tracking (`willNavigate`) fires on menu clicks, not on every route render.
+
+Do not add per-render or high-frequency tracking without an explicit product need.
+
+---
+
+## `window.strapi` telemetry fields
+
+Set in `packages/core/admin/admin/src/render.ts`:
+
+```typescript
+window.strapi.telemetryDisabled = process.env.STRAPI_TELEMETRY_DISABLED === 'true';
+window.strapi.projectType = 'Community' | 'Enterprise'; // updated after /admin/project-type
+```
+
+Typed in `packages/core/admin/admin/custom.d.ts`.
+
+---
+
+## Adding a new frontend event — checklist
+
+1. **Choose a name** — follow `will*` / `did*` / `didNot*` conventions.
+2. **Update types** — add to `EventWithoutProperties` or create a new interface in `Tracking.tsx` and include it in `EventsWithProperties`.
+3. **Call `trackUsage`** from the component or hook at the right lifecycle moment (button click, mutation success/error).
+4. **Properties** — use `eventProperties` for action context; rely on automatic `groupProperties` / `userProperties` for project and device metadata.
+5. **Plugin?** — import from `@strapi/admin/strapi-admin`; consider a wrapper hook if every event needs extra fields.
+6. **Tests** — mock `axios.post` and/or `useTracking` (see `Tracking.test.tsx` and plugin `__mocks__/useTracking.ts`).
+
+Do **not** add frontend tracking for features that only exist server-side (e.g. MCP) — use `strapi.telemetry.send` instead.
+
+---
+
+## Testing
+
+`packages/core/admin/admin/src/features/tests/Tracking.test.tsx` covers:
+
+- Payload shape (`userId`, `eventProperties`, `groupProperties`, `userProperties.deviceType`)
+- No request when `telemetryDisabled` or missing `uuid`
+- Graceful failure when `axios.post` rejects
+
+Plugin tests often use `jest.mock('@strapi/admin/strapi-admin', () => ({ useTracking: … }))` or local `__mocks__/useTracking.ts`.
+
+---
+
+## Related docs
+
+- [Server-side telemetry](/docs/core/strapi/telemetry) — `strapi.telemetry`, rate limiting, cron aggregates
+- [NPS](/docs/core/admin/features/nps) — survey timing and `/submit-nps`
+- [Telemetry Service](/api/Telemetry) — public `telemetry.send()` reference (server)

--- a/docs/docs/docs/01-core/strapi/telemetry.md
+++ b/docs/docs/docs/01-core/strapi/telemetry.md
@@ -1,0 +1,341 @@
+---
+title: Server-side telemetry
+description: How server-side analytics works in the monorepo — strapi.telemetry.send, event naming, rate limiting, and package metrics services.
+tags:
+  - core
+  - telemetry
+  - analytics
+---
+
+# Server-side telemetry
+
+Strapi collects anonymous usage data to understand feature adoption and improve the product. This document describes how **server-side** telemetry works in the monorepo — where events are sent, how they are named, and the patterns used to avoid flooding the analytics backend.
+
+For the public-facing overview of what is collected, see [Usage information](https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html).
+
+Admin panel (browser) events are a separate channel — see [Admin telemetry (frontend)](/docs/core/admin/features/telemetry). MCP and other server-only features should use the **server-side** patterns below.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Feature code (controller, service, bootstrap, CLI, cron)       │
+│       strapi.telemetry.send('didSomething', { ...payload })     │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+┌────────────────────────────▼────────────────────────────────────┐
+│  packages/core/core/src/services/metrics/                       │
+│    index.ts        → createTelemetryInstance, LIMITED_EVENTS    │
+│    sender.ts       → POST body assembly + strapi.fetch()        │
+│    rate-limiter.ts → once-per-24h dedup for selected events    │
+│    middleware.ts   → didReceiveRequest (REST, capped at 1000/d) │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+              https://analytics.strapi.io/api/v2/track
+              (override: STRAPI_ANALYTICS_URL)
+```
+
+### Registration
+
+Telemetry is wired through the `telemetry` provider:
+
+- `packages/core/core/src/providers/telemetry.ts` — registers `strapi.telemetry` on the Strapi container.
+- `packages/core/core/src/services/metrics/index.ts` — factory that exposes `send()`, `register()`, `isDisabled`.
+
+On `register()` (when telemetry is enabled):
+
+1. A daily cron job sends a `ping` event (`0 0 12 * * *`).
+2. REST request middleware is mounted to emit `didReceiveRequest` (see [Volume controls](#volume-controls)).
+
+### Sending an event
+
+```typescript
+strapi.telemetry.send('didCreateContentType', {
+  eventProperties: { kind: 'collectionType' },
+  userProperties: {
+    /* optional, per-user */
+  },
+  groupProperties: {
+    /* optional, project-level */
+  },
+});
+```
+
+Implementation: `packages/core/core/src/services/metrics/sender.ts`.
+
+Each request is a single HTTP `POST` with JSON body:
+
+| Field             | Purpose                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `event`           | Event name (also sent as `X-Strapi-Event` header)              |
+| `userId`          | Hashed admin user when available (`generateAdminUserHash`)     |
+| `installId`       | Stable install identifier from project uuid + package.json     |
+| `eventProperties` | Context specific to this occurrence                            |
+| `userProperties`  | User/environment traits (OS, Node version, etc.)               |
+| `groupProperties` | Project traits (Strapi version, DB client, EE plan, counts, …) |
+
+Default metadata is merged automatically (Docker/CI, TypeScript usage, `projectId`, `projectType`, EE subscription fields when present).
+
+Errors are swallowed — telemetry must never break application behaviour. Call sites often append `.catch(() => {})` or fire-and-forget without awaiting.
+
+### When telemetry is disabled
+
+Telemetry is **off** when any of the following is true (`packages/core/core/src/services/metrics/index.ts`):
+
+- No project `uuid` in config (typical for fresh clones before first run).
+- `STRAPI_TELEMETRY_DISABLED` env is truthy (`1`, `true`, etc.).
+- `package.json` → `strapi.telemetryDisabled: true`.
+
+`strapi.telemetry.isDisabled` reflects this. Admin routes that expose telemetry data use the `admin::isTelemetryEnabled` policy.
+
+---
+
+## Event naming conventions
+
+Server-side events follow a consistent vocabulary:
+
+| Pattern                        | Meaning                                              | Examples                                             |
+| ------------------------------ | ---------------------------------------------------- | ---------------------------------------------------- |
+| `did*`                         | Completed action                                     | `didCreateContentType`, `didInviteUser`              |
+| `didNot*`                      | Failed or aborted action                             | `didNotCreateContentType`, `didNotOpenTab`           |
+| `didCreateFirst*`              | First occurrence in project lifetime                 | `didCreateFirstAdmin`, `didCreateFirstContentType`   |
+| `didInitialize*`               | Plugin/feature bootstrap snapshot                    | `didInitializeI18n`, `didInitializePluginUpload`     |
+| `did*ProcessStart/Finish/Fail` | Long-running process lifecycle                       | `didDEITSProcessStart` (data export/import/transfer) |
+| `didSend*OnceAWeek`            | Weekly aggregated snapshot                           | `didSendUploadPropertiesOnceAWeek`                   |
+| `ping`                         | Heartbeat                                            | Daily cron                                           |
+| `will*`                        | Intent (mostly **admin frontend**, rare server-side) | —                                                    |
+
+Casing is camelCase with no separators. Event names are flat strings — there is no namespacing prefix (e.g. no `mcp.didCallTool`).
+
+---
+
+## Payload conventions
+
+### `eventProperties`
+
+Action-specific, per-event context. Examples in the codebase:
+
+- `kind` — content type kind on create
+- `model` — content type UID on first entry create
+- `url`, `success`, `statusCode` — REST middleware
+- `source`, `destination` — data transfer providers
+- `error` — failure messages
+
+Prefer **categories and counts** over identifiers when volume is a concern. Some existing events do include UIDs (`model`, `workflowId`); new features should avoid repeating user-specific or content-specific names when a category suffices.
+
+### `userProperties`
+
+Traits of the acting user or anonymous environment:
+
+- Auto-attached on server: `environment`, `os`, `nodeVersion`, …
+- Explicit: `languagesInUse` (`didChangeInterfaceLanguage`)
+
+Some events are explicitly anonymous (empty `userId`), e.g. `didStartServer`, `didChangeInterfaceLanguage`.
+
+### `groupProperties`
+
+Project/install-level state, often counts or configuration:
+
+- `numberOfAllContentTypes`, `numberOfComponents`, `database`, `plugins` — startup
+- `numberOfLocales` — i18n
+- `uploadProvider`, `privateProvider` — upload init
+- `numberOfActiveAdminUsers` — admin cron
+- Aggregated weekly metrics objects — upload / review workflows
+
+---
+
+## Where server events are emitted
+
+### Core / startup
+
+| Event                          | Location                                                      | Notes                                                |
+| ------------------------------ | ------------------------------------------------------------- | ---------------------------------------------------- |
+| `didStartServer`               | `packages/core/core/src/Strapi.ts` → `sendStartupTelemetry()` | Fired once per process start; rich `groupProperties` |
+| `didOpenTab` / `didNotOpenTab` | `Strapi.ts` → `openAdmin()`                                   | Dev auto-open browser only                           |
+| `ping`                         | metrics `register()` cron                                     | Daily noon                                           |
+| `didReceiveRequest`            | `packages/core/core/src/services/metrics/middleware.ts`       | REST API only; not MCP/GraphQL/admin                 |
+
+### Admin (`packages/core/admin/server`)
+
+| Event                         | Trigger                         |
+| ----------------------------- | ------------------------------- |
+| `didCreateFirstAdmin`         | First admin registration        |
+| `didInviteUser`               | User invitation                 |
+| `didUpdateRolePermissions`    | Role permissions save           |
+| `didChangeInterfaceLanguage`  | Language preference change      |
+| `didUpdateProjectInformation` | Bootstrap + daily midnight cron |
+| `didUpdateSSOSettings`        | EE SSO settings (EE)            |
+| `didWatchAnAuditLog`          | EE audit log view (EE)          |
+
+Metrics service: `packages/core/admin/server/src/services/metrics.ts`.
+
+### Content-type builder
+
+| Event                                                | Trigger                                                |
+| ---------------------------------------------------- | ------------------------------------------------------ |
+| `didCreateFirstContentType` / `didCreateContentType` | Content type create (`_.isEmpty(strapi.apis)` → first) |
+| `didNotCreateContentType`                            | Create failure                                         |
+| `didCreateFirstComponent` / `didCreateComponent`     | Component create (registry size check)                 |
+
+### Content manager
+
+| Event                            | Trigger                                                    |
+| -------------------------------- | ---------------------------------------------------------- |
+| `didCreateFirstContentTypeEntry` | First document in a collection type (`totalEntries === 0`) |
+| `didConfigureListView`           | List view configuration save                               |
+
+Metrics service: `packages/core/content-manager/server/src/services/metrics.ts`.
+
+### Content releases
+
+`didCreateContentRelease`, `didUpdateContentRelease`, `didDeleteContentRelease`, `didPublishContentRelease` — `packages/core/content-releases/server/src/services/release.ts`.
+
+### Review workflows (EE)
+
+Per-action: `didCreateStage`, `didEditStage`, `didDeleteStage`, `didChangeEntryStage`, `didCreateWorkflow`, `didEditWorkflow`, `didEditAssignee`.
+
+Weekly aggregate: `didSendReviewWorkflowPropertiesOnceAWeek` via cron in `packages/core/review-workflows/server/src/services/metrics/weekly-metrics.ts`.
+
+### Upload
+
+| Event                                                                   | Trigger                               |
+| ----------------------------------------------------------------------- | ------------------------------------- |
+| `didInitializePluginUpload`                                             | Plugin bootstrap (rate-limited daily) |
+| `didSaveMediaWithCaption` / `didSaveMediaWithAlternativeText`           | Media save (rate-limited daily)       |
+| `didEnableResponsiveDimensions` / `didDisableResponsiveDimensions`      | Settings (rate-limited daily)         |
+| `didUploadImage`                                                        | Image upload                          |
+| `didBulkDeleteMediaLibraryElements` / `didBulkMoveMediaLibraryElements` | Bulk operations                       |
+| `didSendUploadPropertiesOnceAWeek`                                      | Weekly cron aggregate                 |
+
+Metrics wrapper: `packages/core/upload/server/src/services/metrics.ts` → `trackUsage()`.
+
+### i18n
+
+| Event                  | Trigger          |
+| ---------------------- | ---------------- |
+| `didInitializeI18n`    | Plugin bootstrap |
+| `didUpdateI18nLocales` | Locale CRUD      |
+
+### CLI (in-process Strapi or standalone)
+
+| Event                              | Context                                      |
+| ---------------------------------- | -------------------------------------------- |
+| `didDEITSProcessStart/Finish/Fail` | Export, import, transfer                     |
+| `didOptOutTelemetry`               | `strapi telemetry:disable`                   |
+| `will/did*` project creation       | `packages/cli/create-strapi-app`             |
+| Cloud CLI events                   | Proxied via Cloud API (`packages/cli/cloud`) |
+
+---
+
+### MCP (core)
+
+| Event                          | Trigger                                                                                                                                                                    |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `didStartMcpServer`            | MCP server started with `server.mcp.enabled: true` (`eventProperties.path`; `groupProperties.numberOfTools` / `numberOfPrompts` / `numberOfResources`; rate-limited daily) |
+| `didUseMcpServer`              | Authenticated MCP HTTP request (`handlePost.ts`; rate-limited daily)                                                                                                       |
+| `didNotAuthenticateMcpRequest` | MCP request rejected before handling (`eventProperties.errorClass`: `missing_token` \| `invalid_token`; rate-limited daily)                                                |
+| `didNotHandleMcpRequest`       | Authenticated MCP request failed during connect/handle (`eventProperties.errorClass`: `timeout` \| `error`; rate-limited daily)                                            |
+| `didExecuteMcpCapability`      | Successful capability execution (`eventProperties.type`: `tool` \| `prompt` \| `resource`; `action`; `source`)                                                             |
+| `didNotExecuteMcpCapability`   | Capability returned `isError: true` (same shape + `errorClass`: `execution_error`)                                                                                         |
+
+Implementation: `packages/core/core/src/services/mcp/metrics/`. Capability names are normalized to coarse `action` values — never content-type slugs. Request-level events use the core rate limiter; capability execute/not-execute events deduplicate **per type + action + source** in `metrics.ts`. Compare `didStartMcpServer` vs `didUseMcpServer` to see installs with MCP enabled but unused. Prompt/resource execution telemetry activates when normalization rules exist.
+
+---
+
+## Package-level metrics services
+
+Several packages wrap `strapi.telemetry.send` in a dedicated `metrics` service rather than calling telemetry directly from controllers:
+
+```
+packages/core/admin/server/src/services/metrics.ts
+packages/core/content-manager/server/src/services/metrics.ts
+packages/core/upload/server/src/services/metrics.ts
+packages/core/core/src/services/mcp/metrics/metrics.ts
+packages/plugins/i18n/server/src/services/metrics.ts
+packages/core/review-workflows/server/src/services/metrics/index.ts
+packages/core/admin/ee/server/src/services/metrics.ts
+```
+
+Pattern: thin service with `sendDid…()` helpers; controllers/services call the metrics service. Tests mock `strapi.telemetry.send` or the metrics service.
+
+---
+
+## Volume controls
+
+There is **no batching API** — each event is one HTTP request. Strapi uses several complementary strategies to limit volume:
+
+### 1. Daily rate limiter (per event name)
+
+`packages/core/core/src/services/metrics/rate-limiter.ts` wraps the sender for events listed in `LIMITED_EVENTS`.
+
+For listed events: **at most one send per event name per 24 hours** (in-memory cache, resets on rolling 24h window).
+
+Important: deduplication is by **event name only**, not by `eventProperties`. If one event name covers multiple categories (e.g. `didExecuteMcpCapability` with different `type` / `action` values), apply per-category dedup **before** calling `strapi.telemetry.send` (see MCP `metrics.ts`) rather than adding many names to `LIMITED_EVENTS`.
+
+To rate-limit a new high-frequency event, either:
+
+- Add its exact event name to `LIMITED_EVENTS`, or
+- Use separate event names per category (each added to `LIMITED_EVENTS`), or
+- Dedupe locally by category before send (MCP tool actions), or
+- Use weekly aggregation (below).
+
+### 2. REST middleware cap
+
+`didReceiveRequest` is capped at **1000 events per 24 hours** per process (`middleware.ts`). Counter resets on rolling 24h window. Only matches URLs under the REST API prefix; static assets and non-GET/PUT/POST/DELETE methods are skipped.
+
+MCP requests (`/mcp`) do **not** pass through this middleware.
+
+### 3. Weekly aggregated cron jobs
+
+For noisy domains, compute metrics locally and send **one event per week**:
+
+- Upload: `didSendUploadPropertiesOnceAWeek` — folder depth stats, asset counts (`weekly-metrics.ts` + `strapi.store` for schedule jitter).
+- Review workflows: `didSendReviewWorkflowPropertiesOnceAWeek` — workflow/stage counts.
+
+Schedule is randomized per install (stored in `strapi.store`) to spread load.
+
+### 4. First vs subsequent
+
+“First use” pattern without persistent store:
+
+- `didCreateFirstContentType` when `_.isEmpty(strapi.apis)` before create.
+- `didCreateFirstComponent` when component registry is empty.
+- `didCreateFirstAdmin` on registration flow.
+- `didCreateFirstContentTypeEntry` when `totalEntries === 0`.
+
+Subsequent actions use the non-`First` event (`didCreateContentType`, `didCreateComponent`, …).
+
+### 5. Fire-and-forget / non-blocking
+
+Startup telemetry and many call sites do not `await` the send. Failures are ignored. Timeout on fetch defaults to 1s.
+
+---
+
+## Admin frontend telemetry (separate channel)
+
+See [Admin telemetry (frontend)](/docs/core/admin/features/telemetry) for `useTracking()`, event types, plugin wrappers, and lifecycle events.
+
+New **server-side** features (like MCP) should use `strapi.telemetry.send`, not the React tracking hook.
+
+---
+
+## Adding a new server-side event — checklist
+
+1. **Name** — `did*` past tense; use `didCreateFirst*` or `didInitialize*` when appropriate.
+2. **Payload** — put action context in `eventProperties`; project-level counts in `groupProperties`.
+3. **Privacy** — avoid PII, secrets, and high-cardinality identifiers (content type UIDs, document IDs) unless strictly necessary.
+4. **Volume** — if the action can happen frequently, apply rate limiting or weekly aggregation from day one.
+5. **Location** — prefer a `metrics` service in the owning package; call from controller/service after success.
+6. **Disable guard** — `strapi.telemetry.send` no-ops when disabled; no extra check needed unless you perform expensive metric computation first.
+7. **Tests** — mock `strapi.telemetry.send` in unit tests (see existing `__tests__/metrics.test.ts` files).
+
+---
+
+## API reference
+
+Public API: [Telemetry Service](/api/Telemetry).
+
+Key types: `packages/core/core/src/services/metrics/sender.ts` → `Payload`, `Sender`.

--- a/packages/core/content-manager/server/src/mcp/derive-content-type-mcp-tools.ts
+++ b/packages/core/content-manager/server/src/mcp/derive-content-type-mcp-tools.ts
@@ -222,6 +222,7 @@ const buildCollectionTools = (
   const tools: DerivedTool[] = [
     {
       name: `list_${slug}`,
+      telemetry: { source: 'content-manager', name: 'list' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'list' }),
       auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveListInputSchema,
@@ -231,6 +232,7 @@ const buildCollectionTools = (
     },
     {
       name: `get_${slug}`,
+      telemetry: { source: 'content-manager', name: 'get' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'get' }),
       auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveGetInputSchema,
@@ -239,6 +241,7 @@ const buildCollectionTools = (
     },
     {
       name: `create_${slug}`,
+      telemetry: { source: 'content-manager', name: 'create' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'create' }),
       auth: { policies: [{ action: ACTIONS.create, subject: uid }] },
       resolveInputSchema: resolveCreateInputSchema,
@@ -247,6 +250,7 @@ const buildCollectionTools = (
     },
     {
       name: `update_${slug}`,
+      telemetry: { source: 'content-manager', name: 'update' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'update' }),
       auth: { policies: [{ action: ACTIONS.update, subject: uid }] },
       resolveInputSchema: resolveUpdateInputSchema,
@@ -255,6 +259,7 @@ const buildCollectionTools = (
     },
     {
       name: `delete_${slug}`,
+      telemetry: { source: 'content-manager', name: 'delete' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'delete' }),
       auth: { policies: [{ action: ACTIONS.delete, subject: uid }] },
       resolveInputSchema: resolveDeleteInputSchema,
@@ -268,6 +273,7 @@ const buildCollectionTools = (
     tools.push(
       {
         name: `publish_${slug}`,
+        telemetry: { source: 'content-manager', name: 'publish' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'publish' }),
         auth: { policies: [{ action: ACTIONS.publish, subject: uid }] },
         resolveInputSchema: resolvePublishInputSchema,
@@ -276,6 +282,7 @@ const buildCollectionTools = (
       },
       {
         name: `unpublish_${slug}`,
+        telemetry: { source: 'content-manager', name: 'unpublish' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'unpublish' }),
         auth: { policies: [{ action: ACTIONS.unpublish, subject: uid }] },
         resolveInputSchema: resolveUnpublishInputSchema,
@@ -284,6 +291,7 @@ const buildCollectionTools = (
       },
       {
         name: `discard_${slug}_draft`,
+        telemetry: { source: 'content-manager', name: 'discard_draft' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'discard_draft' }),
         auth: { policies: [{ action: ACTIONS.discard, subject: uid }] },
         resolveInputSchema: resolveDiscardDraftInputSchema,
@@ -436,6 +444,7 @@ const buildSingleTypeTools = (
   const tools: DerivedTool[] = [
     {
       name: `get_${slug}`,
+      telemetry: { source: 'content-manager', name: 'get' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'get' }),
       auth: { policies: [{ action: ACTIONS.read, subject: uid }] },
       resolveInputSchema: resolveGetInputSchema,
@@ -444,6 +453,7 @@ const buildSingleTypeTools = (
     },
     {
       name: `write_${slug}`,
+      telemetry: { source: 'content-manager', name: 'write' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'write' }),
       auth: {
         policies: [
@@ -457,6 +467,7 @@ const buildSingleTypeTools = (
     },
     {
       name: `delete_${slug}`,
+      telemetry: { source: 'content-manager', name: 'delete' },
       ...describeTool({ apiID: model.apiID, uid, operation: 'delete' }),
       auth: { policies: [{ action: ACTIONS.delete, subject: uid }] },
       resolveInputSchema: resolveDeleteInputSchema,
@@ -470,6 +481,7 @@ const buildSingleTypeTools = (
     tools.push(
       {
         name: `publish_${slug}`,
+        telemetry: { source: 'content-manager', name: 'publish' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'publish' }),
         auth: { policies: [{ action: ACTIONS.publish, subject: uid }] },
         resolveInputSchema: resolvePublishInputSchema,
@@ -478,6 +490,7 @@ const buildSingleTypeTools = (
       },
       {
         name: `unpublish_${slug}`,
+        telemetry: { source: 'content-manager', name: 'unpublish' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'unpublish' }),
         auth: { policies: [{ action: ACTIONS.unpublish, subject: uid }] },
         resolveInputSchema: resolveUnpublishInputSchema,
@@ -486,6 +499,7 @@ const buildSingleTypeTools = (
       },
       {
         name: `discard_${slug}_draft`,
+        telemetry: { source: 'content-manager', name: 'discard_draft' },
         ...describeTool({ apiID: model.apiID, uid, operation: 'discard_draft' }),
         auth: { policies: [{ action: ACTIONS.discard, subject: uid }] },
         resolveInputSchema: resolveDiscardDraftInputSchema,

--- a/packages/core/content-manager/server/src/mcp/types.ts
+++ b/packages/core/content-manager/server/src/mcp/types.ts
@@ -23,6 +23,7 @@ export type McpToolsBuildContext = {
 
 export type DerivedTool = {
   name: string;
+  telemetry: { source: 'content-manager'; name: string };
   title: string;
   description: string;
   auth: Modules.MCP.McpCapabilityAuth;

--- a/packages/core/core/src/services/mcp/__tests__/authentication.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/authentication.test.ts
@@ -1,0 +1,77 @@
+import type { Core } from '@strapi/types';
+import { createMcpAdminTokenAuthenticator } from '../authentication';
+
+describe('createMcpAdminTokenAuthenticator', () => {
+  let authenticateAdminToken: jest.Mock;
+  let authenticator: ReturnType<typeof createMcpAdminTokenAuthenticator>;
+
+  beforeEach(() => {
+    authenticateAdminToken = jest.fn();
+    authenticator = createMcpAdminTokenAuthenticator({
+      admin: {
+        services: {
+          'api-token-admin': {
+            authenticateAdminToken,
+          },
+        },
+      },
+    } as unknown as Core.Strapi);
+  });
+
+  const makeCtx = (authorization?: string) =>
+    ({
+      request: {
+        header: authorization === undefined ? {} : { authorization },
+      },
+    }) as any;
+
+  test('returns missing_token when authorization header is absent', async () => {
+    const result = await authenticator.authenticate(makeCtx());
+
+    expect(result).toEqual({ authenticated: false, reason: 'missing_token' });
+    expect(authenticateAdminToken).not.toHaveBeenCalled();
+  });
+
+  test('returns missing_token when authorization header is malformed', async () => {
+    const result = await authenticator.authenticate(makeCtx('Token abc123'));
+
+    expect(result).toEqual({ authenticated: false, reason: 'missing_token' });
+    expect(authenticateAdminToken).not.toHaveBeenCalled();
+  });
+
+  test('returns invalid_token when admin token authentication fails', async () => {
+    authenticateAdminToken.mockResolvedValue({
+      authenticated: false,
+      error: new Error('Invalid token'),
+    });
+
+    const result = await authenticator.authenticate(makeCtx('Bearer bad-token'));
+
+    expect(result).toEqual({
+      authenticated: false,
+      reason: 'invalid_token',
+      error: expect.any(Error),
+    });
+    expect(authenticateAdminToken).toHaveBeenCalledWith('bad-token');
+  });
+
+  test('returns authenticated user context when admin token is valid', async () => {
+    const ability = { can: jest.fn() };
+    authenticateAdminToken.mockResolvedValue({
+      authenticated: true,
+      credentials: { id: 42 },
+      user: { id: 42 },
+      ability,
+    });
+
+    const result = await authenticator.authenticate(makeCtx('Bearer good-token'));
+
+    expect(result).toEqual({
+      authenticated: true,
+      credentials: { id: 42 },
+      user: { id: 42 },
+      ability,
+    });
+    expect(authenticateAdminToken).toHaveBeenCalledWith('good-token');
+  });
+});

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -9,7 +9,10 @@ describe('MCP Service Integration', () => {
   let logInfoSpy: jest.Mock;
   let logErrorSpy: jest.Mock;
 
+  let mockTelemetrySend: jest.Mock;
+
   beforeEach(() => {
+    mockTelemetrySend = jest.fn().mockResolvedValue(true);
     logDebugSpy = jest.fn();
     logInfoSpy = jest.fn();
     logErrorSpy = jest.fn();
@@ -36,6 +39,9 @@ describe('MCP Service Integration', () => {
       server: {
         routes: mockServerRoutes,
         use: mockServerUse,
+      } as any,
+      telemetry: {
+        send: mockTelemetrySend,
       } as any,
     };
   });
@@ -130,6 +136,34 @@ describe('MCP Service Integration', () => {
       expect(logInfoSpy).toHaveBeenCalledWith(
         '[MCP] Server available at http://localhost:1337/mcp'
       );
+      expect(mockTelemetrySend).toHaveBeenCalledWith('didStartMcpServer', {
+        eventProperties: { path: '/mcp' },
+        groupProperties: {
+          numberOfTools: 1,
+          numberOfPrompts: 0,
+          numberOfResources: 0,
+        },
+      });
+    });
+
+    test('should not send start telemetry when service is disabled', async () => {
+      const disabledStrapi = {
+        ...mockStrapi,
+        config: {
+          get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'server.mcp.enabled') {
+              return false;
+            }
+            return defaultValue;
+          }),
+        } as any,
+      };
+
+      const service = createMcpService(disabledStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(mockTelemetrySend).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/core/src/services/mcp/authentication.ts
+++ b/packages/core/core/src/services/mcp/authentication.ts
@@ -4,8 +4,10 @@ import type { Context } from 'koa';
 
 export type McpAdminTokenAbility = Ability;
 
+export type McpAuthFailureReason = 'missing_token' | 'invalid_token';
+
 export type McpAdminTokenAuthResult =
-  | { authenticated: false; error?: Error }
+  | { authenticated: false; reason: McpAuthFailureReason; error?: Error }
   | {
       authenticated: true;
       credentials: { id: Data.ID };
@@ -34,7 +36,7 @@ export const createMcpAdminTokenAuthenticator = (strapi: Core.Strapi) => ({
     const token = extractBearerToken(ctx);
 
     if (token === null) {
-      return { authenticated: false };
+      return { authenticated: false, reason: 'missing_token' };
     }
 
     const authResult = (await strapi.admin.services['api-token-admin'].authenticateAdminToken(
@@ -42,7 +44,11 @@ export const createMcpAdminTokenAuthenticator = (strapi: Core.Strapi) => ({
     )) as McpAdminTokenAuthResult;
 
     if (authResult.authenticated === false) {
-      return authResult;
+      return {
+        authenticated: false,
+        reason: 'invalid_token',
+        error: authResult.error,
+      };
     }
 
     return {

--- a/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
+++ b/packages/core/core/src/services/mcp/handlers/__tests__/handlePost.test.ts
@@ -6,9 +6,21 @@ import { createPostHandler } from '../handlePost';
 import type { McpHandlerDependencies } from '../types';
 
 import { withTimeout } from '../../utils/withTimeout';
+import {
+  sendDidNotAuthenticateMcpRequest,
+  sendDidNotHandleMcpRequest,
+  sendDidUseMcpServer,
+} from '../../metrics/metrics';
 
 jest.mock('../../utils/withTimeout', () => ({
   withTimeout: jest.fn((promise) => promise),
+}));
+
+jest.mock('../../metrics/metrics', () => ({
+  sendDidUseMcpServer: jest.fn(),
+  sendDidNotAuthenticateMcpRequest: jest.fn(),
+  sendDidNotHandleMcpRequest: jest.fn(),
+  classifyMcpRequestFailure: jest.requireActual('../../metrics/metrics').classifyMcpRequestFailure,
 }));
 
 jest.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
@@ -25,6 +37,9 @@ describe('handlePost', () => {
   beforeEach(() => {
     logErrorSpy = jest.fn();
     logInfoSpy = jest.fn();
+    jest.mocked(sendDidUseMcpServer).mockClear();
+    jest.mocked(sendDidNotAuthenticateMcpRequest).mockClear();
+    jest.mocked(sendDidNotHandleMcpRequest).mockClear();
     mockStrapi = {
       log: {
         error: logErrorSpy,
@@ -94,9 +109,7 @@ describe('handlePost', () => {
   test('should return AUTHENTICATION_REQUIRED when authentication fails', async () => {
     mockAuthenticationStrategy.authenticate = jest.fn().mockResolvedValue({
       authenticated: false,
-      credentials: null,
-      ability: null,
-      error: null,
+      reason: 'invalid_token',
     });
 
     const deps: McpHandlerDependencies = {
@@ -125,6 +138,59 @@ describe('handlePost', () => {
         id: null,
       })
     );
+    expect(sendDidUseMcpServer).not.toHaveBeenCalled();
+    expect(sendDidNotAuthenticateMcpRequest).toHaveBeenCalledWith(mockStrapi, 'invalid_token');
+    expect(sendDidNotHandleMcpRequest).not.toHaveBeenCalled();
+  });
+
+  test('should record missing_token auth failure telemetry', async () => {
+    mockAuthenticationStrategy.authenticate = jest.fn().mockResolvedValue({
+      authenticated: false,
+      reason: 'missing_token',
+    });
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createPostHandler(deps);
+    const { res } = makeRes();
+    const ctx = makeCtx(makeReq(), res);
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(sendDidNotAuthenticateMcpRequest).toHaveBeenCalledWith(mockStrapi, 'missing_token');
+    expect(sendDidUseMcpServer).not.toHaveBeenCalled();
+    expect(sendDidNotHandleMcpRequest).not.toHaveBeenCalled();
+  });
+
+  test('should not send handle failure telemetry when authentication throws', async () => {
+    mockAuthenticationStrategy.authenticate = jest
+      .fn()
+      .mockRejectedValue(new Error('Auth service unavailable'));
+
+    const deps: McpHandlerDependencies = {
+      strapi: mockStrapi as Core.Strapi,
+      authenticationStrategy: mockAuthenticationStrategy,
+      config: mockConfig,
+      createServerWithRegistries: jest.fn(),
+      capabilityDefinitions: {} as any,
+    };
+
+    const handler = createPostHandler(deps);
+    const { res, writeHeadSpy } = makeRes();
+    const ctx = makeCtx(makeReq(), res);
+
+    await handler(ctx, () => Promise.resolve());
+
+    expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+    expect(sendDidUseMcpServer).not.toHaveBeenCalled();
+    expect(sendDidNotAuthenticateMcpRequest).not.toHaveBeenCalled();
+    expect(sendDidNotHandleMcpRequest).not.toHaveBeenCalled();
   });
 
   test('should create ephemeral server + stateless transport, connect and handle request', async () => {
@@ -177,6 +243,7 @@ describe('handlePost', () => {
     expect(StreamableHTTPServerTransport).toHaveBeenCalledWith({ sessionIdGenerator: undefined });
     expect(mockMcpServer.connect).toHaveBeenCalledWith(mockTransport);
     expect(mockTransport.handleRequest).toHaveBeenCalledWith(req, res, requestBody);
+    expect(sendDidUseMcpServer).toHaveBeenCalledWith(mockStrapi);
     expect(mockMcpServer.close).toHaveBeenCalledTimes(1);
   });
 
@@ -300,6 +367,7 @@ describe('handlePost', () => {
       );
       expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
       expect(mockMcpServer.close).toHaveBeenCalledTimes(1);
+      expect(sendDidNotHandleMcpRequest).toHaveBeenCalledWith(mockStrapi, 'error');
     });
 
     test('should return INTERNAL_ERROR when mcpServer.connect throws', async () => {
@@ -338,6 +406,7 @@ describe('handlePost', () => {
       );
       expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
       expect(mockMcpServer.close).toHaveBeenCalledTimes(1);
+      expect(sendDidNotHandleMcpRequest).toHaveBeenCalledWith(mockStrapi, 'error');
     });
 
     test('should handle non-Error exceptions', async () => {
@@ -375,6 +444,78 @@ describe('handlePost', () => {
         expect.objectContaining({ error: 'Unknown error' })
       );
       expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+      expect(sendDidNotHandleMcpRequest).toHaveBeenCalledWith(mockStrapi, 'error');
+    });
+
+    test('should record usage and handle failure telemetry when an authenticated request fails', async () => {
+      const mockMcpServer = {
+        connect: jest.fn().mockRejectedValue(new Error('Connect failed')),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const createServerWithRegistries = jest.fn().mockReturnValue({
+        mcpServer: mockMcpServer,
+        registries: {},
+      });
+
+      const { StreamableHTTPServerTransport } = jest.requireMock(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      StreamableHTTPServerTransport.mockImplementation(() => ({ handleRequest: jest.fn() }));
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
+        config: mockConfig,
+        createServerWithRegistries,
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+      const { res } = makeRes();
+      const ctx = makeCtx(makeReq(), res);
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(sendDidUseMcpServer).toHaveBeenCalledWith(mockStrapi);
+      expect(sendDidNotHandleMcpRequest).toHaveBeenCalledWith(mockStrapi, 'error');
+      expect(sendDidNotAuthenticateMcpRequest).not.toHaveBeenCalled();
+    });
+
+    test('should classify timeout failures', async () => {
+      const mockMcpServer = {
+        connect: jest
+          .fn()
+          .mockRejectedValue(new Error("Operation 'mcpServer.connect' timed out after 30000ms")),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const createServerWithRegistries = jest.fn().mockReturnValue({
+        mcpServer: mockMcpServer,
+        registries: {},
+      });
+
+      const { StreamableHTTPServerTransport } = jest.requireMock(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      StreamableHTTPServerTransport.mockImplementation(() => ({ handleRequest: jest.fn() }));
+
+      const deps: McpHandlerDependencies = {
+        strapi: mockStrapi as Core.Strapi,
+        authenticationStrategy: mockAuthenticationStrategy,
+        config: mockConfig,
+        createServerWithRegistries,
+        capabilityDefinitions: {} as any,
+      };
+
+      const handler = createPostHandler(deps);
+      const { res, writeHeadSpy } = makeRes();
+      const ctx = makeCtx(makeReq(), res);
+
+      await handler(ctx, () => Promise.resolve());
+
+      expect(writeHeadSpy).toHaveBeenCalledWith(500, { 'Content-Type': 'application/json' });
+      expect(sendDidNotHandleMcpRequest).toHaveBeenCalledWith(mockStrapi, 'timeout');
     });
   });
 });

--- a/packages/core/core/src/services/mcp/handlers/handlePost.ts
+++ b/packages/core/core/src/services/mcp/handlers/handlePost.ts
@@ -1,6 +1,12 @@
 // eslint-disable-next-line import/extensions
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Core } from '@strapi/types';
+import {
+  classifyMcpRequestFailure,
+  sendDidNotAuthenticateMcpRequest,
+  sendDidNotHandleMcpRequest,
+  sendDidUseMcpServer,
+} from '../metrics/metrics';
 import { sendJsonRpcError } from '../utils/sendJsonRpcError';
 import { withTimeout } from '../utils/withTimeout';
 import type { McpHandlerDependencies } from './types';
@@ -22,12 +28,18 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
     const req = ctx.req;
     const res = ctx.res;
 
+    let hadAuthenticatedMcpRequest = false;
+
     try {
       const authResult = await authenticationStrategy.authenticate(ctx);
       if (authResult.authenticated === false) {
+        sendDidNotAuthenticateMcpRequest(strapi, authResult.reason);
         sendJsonRpcError(res, 'AUTHENTICATION_REQUIRED');
         return;
       }
+
+      hadAuthenticatedMcpRequest = true;
+      sendDidUseMcpServer(strapi);
 
       const { mcpServer } = createServerWithRegistries({
         strapi,
@@ -64,6 +76,10 @@ export const createPostHandler = (deps: McpHandlerDependencies): Core.Middleware
       });
 
       sendJsonRpcError(res, 'INTERNAL_ERROR');
+
+      if (hadAuthenticatedMcpRequest) {
+        sendDidNotHandleMcpRequest(strapi, classifyMcpRequestFailure(error));
+      }
     }
   };
 };

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -7,6 +7,7 @@ import { McpConfiguration } from './internal/McpConfiguration';
 import { createMcpServerWithRegistries } from './internal/McpServerFactory';
 import { createOAuthDiscoveryFallbackMiddleware } from './middleware/oauthDiscoveryFallback';
 import { createMcpRoutes } from './routes';
+import { sendDidStartMcpServer } from './metrics/metrics';
 import { logToolDefinition } from './tools/log';
 
 /**
@@ -109,6 +110,13 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
       strapi.server.routes(routes);
 
       serverStatus = 'running';
+
+      sendDidStartMcpServer(strapi, {
+        path: config.path,
+        numberOfTools: toolDefinitions.size,
+        numberOfPrompts: promptDefinitions.size,
+        numberOfResources: resourceDefinitions.size,
+      });
 
       const baseUrl = strapi.config.get('server.url', 'http://localhost:1337');
       strapi.log.info(`[MCP] Server available at ${baseUrl}${config.path}`);

--- a/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
+++ b/packages/core/core/src/services/mcp/internal/__tests__/McpServerFactory.test.ts
@@ -46,7 +46,16 @@ describe('createMcpServerWithRegistries', () => {
   >;
 
   beforeEach(() => {
-    mockStrapi = {} as Core.Strapi;
+    mockStrapi = {
+      log: {
+        error: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+      },
+      telemetry: {
+        send: jest.fn().mockResolvedValue(true),
+      },
+    } as Core.Strapi;
     mockAbility = { can: jest.fn(() => false) };
     mockUser = { id: 1 };
     toolDefinitions = new McpCapabilityDefinitionRegistry<'tool', Modules.MCP.McpToolDefinition>(

--- a/packages/core/core/src/services/mcp/metrics/__tests__/metrics.test.ts
+++ b/packages/core/core/src/services/mcp/metrics/__tests__/metrics.test.ts
@@ -1,0 +1,161 @@
+import {
+  classifyMcpRequestFailure,
+  resetMcpMetricsStateForTests,
+  sendDidExecuteMcpCapability,
+  sendDidNotAuthenticateMcpRequest,
+  sendDidNotExecuteMcpCapability,
+  sendDidNotHandleMcpRequest,
+  sendDidStartMcpServer,
+  sendDidUseMcpServer,
+} from '../metrics';
+
+describe('MCP metrics', () => {
+  beforeEach(() => {
+    resetMcpMetricsStateForTests();
+  });
+
+  test('sendDidStartMcpServer sends path and capability counts', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidStartMcpServer(strapi, {
+      path: '/mcp',
+      numberOfTools: 12,
+      numberOfPrompts: 1,
+      numberOfResources: 0,
+    });
+
+    expect(send).toHaveBeenCalledWith('didStartMcpServer', {
+      eventProperties: { path: '/mcp' },
+      groupProperties: {
+        numberOfTools: 12,
+        numberOfPrompts: 1,
+        numberOfResources: 0,
+      },
+    });
+  });
+
+  test('sendDidUseMcpServer sends a rate-limited adoption event', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidUseMcpServer(strapi);
+
+    expect(send).toHaveBeenCalledWith('didUseMcpServer');
+  });
+
+  test('sendDidNotAuthenticateMcpRequest sends errorClass without token details', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidNotAuthenticateMcpRequest(strapi, 'missing_token');
+
+    expect(send).toHaveBeenCalledWith('didNotAuthenticateMcpRequest', {
+      eventProperties: { errorClass: 'missing_token' },
+    });
+  });
+
+  test('sendDidNotHandleMcpRequest sends errorClass without error messages', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidNotHandleMcpRequest(strapi, 'timeout');
+
+    expect(send).toHaveBeenCalledWith('didNotHandleMcpRequest', {
+      eventProperties: { errorClass: 'timeout' },
+    });
+  });
+
+  test('classifyMcpRequestFailure distinguishes timeouts from other errors', () => {
+    expect(
+      classifyMcpRequestFailure(
+        new Error("Operation 'transport.handleRequest' timed out after 1ms")
+      )
+    ).toBe('timeout');
+    expect(classifyMcpRequestFailure(new Error('Connect failed'))).toBe('error');
+    expect(classifyMcpRequestFailure('failure')).toBe('error');
+  });
+
+  test('sendDidExecuteMcpCapability sends type, source and capability name', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidExecuteMcpCapability(strapi, {
+      type: 'tool',
+      source: 'content-manager',
+      name: 'create',
+    });
+
+    expect(send).toHaveBeenCalledWith('didExecuteMcpCapability', {
+      eventProperties: { type: 'tool', source: 'content-manager', name: 'create' },
+    });
+  });
+
+  test('sendDidNotExecuteMcpCapability sends errorClass, source and capability name', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidNotExecuteMcpCapability(
+      strapi,
+      { type: 'tool', source: 'content-manager', name: 'create' },
+      'execution_error'
+    );
+
+    expect(send).toHaveBeenCalledWith('didNotExecuteMcpCapability', {
+      eventProperties: {
+        type: 'tool',
+        source: 'content-manager',
+        name: 'create',
+        errorClass: 'execution_error',
+      },
+    });
+  });
+
+  test('sendDidExecuteMcpCapability rate-limits per capability identity within 24h', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+    const identity = {
+      type: 'tool' as const,
+      source: 'content-manager',
+      name: 'create',
+    };
+
+    sendDidExecuteMcpCapability(strapi, identity);
+    sendDidExecuteMcpCapability(strapi, identity);
+    sendDidExecuteMcpCapability(strapi, { ...identity, name: 'update' });
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('success and failure capability metrics are deduped independently', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+    const identity = {
+      type: 'tool' as const,
+      source: 'content-manager',
+      name: 'create',
+    };
+
+    sendDidExecuteMcpCapability(strapi, identity);
+    sendDidNotExecuteMcpCapability(strapi, identity, 'execution_error');
+    sendDidExecuteMcpCapability(strapi, identity);
+    sendDidNotExecuteMcpCapability(strapi, identity, 'execution_error');
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('dedup distinguishes same name across different sources', () => {
+    const send = jest.fn().mockReturnValue(Promise.resolve(true));
+    const strapi = { telemetry: { send } } as any;
+
+    sendDidExecuteMcpCapability(strapi, {
+      type: 'tool',
+      source: 'content-manager',
+      name: 'create',
+    });
+    sendDidExecuteMcpCapability(strapi, { type: 'tool', source: 'plugin', name: 'create' });
+    sendDidExecuteMcpCapability(strapi, { type: 'tool', source: 'unknown', name: 'create' });
+
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/core/core/src/services/mcp/metrics/__tests__/normalizeMcpCapability.test.ts
+++ b/packages/core/core/src/services/mcp/metrics/__tests__/normalizeMcpCapability.test.ts
@@ -1,0 +1,61 @@
+import { normalizeMcpCapability } from '../normalizeMcpCapability';
+
+describe('normalizeMcpCapability', () => {
+  it('falls back to unknown source and raw name when no telemetry is provided', () => {
+    expect(normalizeMcpCapability('tool', 'create_article')).toEqual({
+      type: 'tool',
+      source: 'unknown',
+      name: 'create_article',
+    });
+  });
+
+  it('resolves content-manager source and sanitized name from telemetry', () => {
+    expect(
+      normalizeMcpCapability('tool', 'create_article', {
+        source: 'content-manager',
+        name: 'create',
+      })
+    ).toEqual({
+      type: 'tool',
+      source: 'content-manager',
+      name: 'create',
+    });
+  });
+
+  it('passes through any non-empty source string as-is (plugin case)', () => {
+    expect(normalizeMcpCapability('tool', 'some_plugin_tool', { source: 'my-plugin' })).toEqual({
+      type: 'tool',
+      source: 'my-plugin',
+      name: 'some_plugin_tool',
+    });
+  });
+
+  it('uses raw name when telemetry provides source but no name override', () => {
+    expect(normalizeMcpCapability('tool', 'log', { source: 'unknown' })).toEqual({
+      type: 'tool',
+      source: 'unknown',
+      name: 'log',
+    });
+  });
+
+  it('falls back to unknown source when telemetry is provided without source', () => {
+    expect(normalizeMcpCapability('tool', 'custom_plugin_tool', { name: 'custom' })).toEqual({
+      type: 'tool',
+      source: 'unknown',
+      name: 'custom',
+    });
+  });
+
+  it('tracks prompts and resources with unknown source fallback', () => {
+    expect(normalizeMcpCapability('prompt', 'summarize_entry')).toEqual({
+      type: 'prompt',
+      source: 'unknown',
+      name: 'summarize_entry',
+    });
+    expect(normalizeMcpCapability('resource', 'project://readme')).toEqual({
+      type: 'resource',
+      source: 'unknown',
+      name: 'project://readme',
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/metrics/__tests__/wrapCapabilityHandlerForMetrics.test.ts
+++ b/packages/core/core/src/services/mcp/metrics/__tests__/wrapCapabilityHandlerForMetrics.test.ts
@@ -1,0 +1,94 @@
+import { sendDidExecuteMcpCapability, sendDidNotExecuteMcpCapability } from '../metrics';
+import { wrapCapabilityHandlerForMetrics } from '../wrapCapabilityHandlerForMetrics';
+
+jest.mock('../metrics', () => ({
+  sendDidExecuteMcpCapability: jest.fn(),
+  sendDidNotExecuteMcpCapability: jest.fn(),
+}));
+
+describe('wrapCapabilityHandlerForMetrics', () => {
+  beforeEach(() => {
+    jest.mocked(sendDidExecuteMcpCapability).mockClear();
+    jest.mocked(sendDidNotExecuteMcpCapability).mockClear();
+  });
+
+  test('records metrics with content-manager source when telemetry is provided', async () => {
+    const strapi = { telemetry: { send: jest.fn() } } as any;
+    const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const wrapped = wrapCapabilityHandlerForMetrics(
+      strapi,
+      'tool',
+      'create_article',
+      { source: 'content-manager', name: 'create' },
+      handler
+    );
+    await wrapped({ args: {} });
+
+    expect(sendDidExecuteMcpCapability).toHaveBeenCalledWith(strapi, {
+      type: 'tool',
+      source: 'content-manager',
+      name: 'create',
+    });
+    expect(sendDidNotExecuteMcpCapability).not.toHaveBeenCalled();
+  });
+
+  test('falls back to unknown source and raw name when telemetry is undefined', async () => {
+    const strapi = { telemetry: { send: jest.fn() } } as any;
+    const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const wrapped = wrapCapabilityHandlerForMetrics(strapi, 'tool', 'log', undefined, handler);
+    await wrapped({ args: {} });
+
+    expect(sendDidExecuteMcpCapability).toHaveBeenCalledWith(strapi, {
+      type: 'tool',
+      source: 'unknown',
+      name: 'log',
+    });
+    expect(sendDidNotExecuteMcpCapability).not.toHaveBeenCalled();
+  });
+
+  test('records failure metrics when the handler returns an error result', async () => {
+    const strapi = { telemetry: { send: jest.fn() } } as any;
+    const handler = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'failed' }],
+      isError: true,
+    });
+
+    const wrapped = wrapCapabilityHandlerForMetrics(
+      strapi,
+      'tool',
+      'create_article',
+      { source: 'content-manager', name: 'create' },
+      handler
+    );
+    await wrapped({ args: {} });
+
+    expect(sendDidNotExecuteMcpCapability).toHaveBeenCalledWith(
+      strapi,
+      { type: 'tool', source: 'content-manager', name: 'create' },
+      'execution_error'
+    );
+    expect(sendDidExecuteMcpCapability).not.toHaveBeenCalled();
+  });
+
+  test('records plugin source when telemetry provides only a source string', async () => {
+    const strapi = { telemetry: { send: jest.fn() } } as any;
+    const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const wrapped = wrapCapabilityHandlerForMetrics(
+      strapi,
+      'tool',
+      'some_plugin_tool',
+      { source: 'my-plugin' },
+      handler
+    );
+    await wrapped({ args: {} });
+
+    expect(sendDidExecuteMcpCapability).toHaveBeenCalledWith(strapi, {
+      type: 'tool',
+      source: 'my-plugin',
+      name: 'some_plugin_tool',
+    });
+  });
+});

--- a/packages/core/core/src/services/mcp/metrics/metrics.ts
+++ b/packages/core/core/src/services/mcp/metrics/metrics.ts
@@ -1,0 +1,153 @@
+import type { Core } from '@strapi/types';
+
+import type { McpCapabilityIdentity } from './normalizeMcpCapability';
+
+/** Rate-limited via core telemetry `LIMITED_EVENTS`. */
+export const MCP_LIMITED_TELEMETRY_EVENTS = {
+  didStartMcpServer: 'didStartMcpServer',
+  didUseMcpServer: 'didUseMcpServer',
+  didNotAuthenticateMcpRequest: 'didNotAuthenticateMcpRequest',
+  didNotHandleMcpRequest: 'didNotHandleMcpRequest',
+} as const;
+
+export type McpLimitedTelemetryEvent =
+  (typeof MCP_LIMITED_TELEMETRY_EVENTS)[keyof typeof MCP_LIMITED_TELEMETRY_EVENTS];
+
+export type McpAuthErrorClass = 'missing_token' | 'invalid_token';
+export type McpRequestErrorClass = 'timeout' | 'error';
+export type McpCapabilityErrorClass = 'execution_error';
+
+export type McpStartTelemetryProperties = {
+  path: string;
+  numberOfTools: number;
+  numberOfPrompts: number;
+  numberOfResources: number;
+};
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+let capabilityCacheExpiresAt = Date.now() + ONE_DAY_MS;
+const executedCapabilities = new Set<string>();
+const failedCapabilities = new Set<string>();
+
+const capabilityCacheKey = (identity: McpCapabilityIdentity, succeeded: boolean): string =>
+  `${succeeded ? 'execute' : 'notExecute'}:${identity.type}:${identity.source}:${identity.name}`;
+
+/** Resets in-memory capability metrics state (unit tests only). */
+export const resetMcpMetricsStateForTests = (): void => {
+  executedCapabilities.clear();
+  failedCapabilities.clear();
+  capabilityCacheExpiresAt = Date.now() + ONE_DAY_MS;
+};
+
+const shouldSendCapabilityEvent = (
+  identity: McpCapabilityIdentity,
+  succeeded: boolean
+): boolean => {
+  const cache = succeeded ? executedCapabilities : failedCapabilities;
+
+  if (Date.now() > capabilityCacheExpiresAt) {
+    executedCapabilities.clear();
+    failedCapabilities.clear();
+    capabilityCacheExpiresAt = Date.now() + ONE_DAY_MS;
+  }
+
+  const key = capabilityCacheKey(identity, succeeded);
+
+  if (cache.has(key)) {
+    return false;
+  }
+
+  cache.add(key);
+  return true;
+};
+
+export const classifyMcpRequestFailure = (error: unknown): McpRequestErrorClass => {
+  if (error instanceof Error && error.message.includes('timed out')) {
+    return 'timeout';
+  }
+
+  return 'error';
+};
+
+export const sendDidStartMcpServer = (
+  strapi: Core.Strapi,
+  properties: McpStartTelemetryProperties
+): void => {
+  strapi.telemetry
+    .send(MCP_LIMITED_TELEMETRY_EVENTS.didStartMcpServer, {
+      eventProperties: { path: properties.path },
+      groupProperties: {
+        numberOfTools: properties.numberOfTools,
+        numberOfPrompts: properties.numberOfPrompts,
+        numberOfResources: properties.numberOfResources,
+      },
+    })
+    .catch(() => {});
+};
+
+export const sendDidUseMcpServer = (strapi: Core.Strapi): void => {
+  strapi.telemetry.send(MCP_LIMITED_TELEMETRY_EVENTS.didUseMcpServer).catch(() => {});
+};
+
+export const sendDidNotAuthenticateMcpRequest = (
+  strapi: Core.Strapi,
+  errorClass: McpAuthErrorClass
+): void => {
+  strapi.telemetry
+    .send(MCP_LIMITED_TELEMETRY_EVENTS.didNotAuthenticateMcpRequest, {
+      eventProperties: { errorClass },
+    })
+    .catch(() => {});
+};
+
+export const sendDidNotHandleMcpRequest = (
+  strapi: Core.Strapi,
+  errorClass: McpRequestErrorClass
+): void => {
+  strapi.telemetry
+    .send(MCP_LIMITED_TELEMETRY_EVENTS.didNotHandleMcpRequest, {
+      eventProperties: { errorClass },
+    })
+    .catch(() => {});
+};
+
+export const sendDidExecuteMcpCapability = (
+  strapi: Core.Strapi,
+  identity: McpCapabilityIdentity
+): void => {
+  if (!shouldSendCapabilityEvent(identity, true)) {
+    return;
+  }
+
+  strapi.telemetry
+    .send('didExecuteMcpCapability', {
+      eventProperties: {
+        type: identity.type,
+        source: identity.source,
+        name: identity.name,
+      },
+    })
+    .catch(() => {});
+};
+
+export const sendDidNotExecuteMcpCapability = (
+  strapi: Core.Strapi,
+  identity: McpCapabilityIdentity,
+  errorClass: McpCapabilityErrorClass
+): void => {
+  if (!shouldSendCapabilityEvent(identity, false)) {
+    return;
+  }
+
+  strapi.telemetry
+    .send('didNotExecuteMcpCapability', {
+      eventProperties: {
+        type: identity.type,
+        source: identity.source,
+        name: identity.name,
+        errorClass,
+      },
+    })
+    .catch(() => {});
+};

--- a/packages/core/core/src/services/mcp/metrics/normalizeMcpCapability.ts
+++ b/packages/core/core/src/services/mcp/metrics/normalizeMcpCapability.ts
@@ -1,0 +1,17 @@
+export type McpCapabilityType = 'tool' | 'prompt' | 'resource';
+
+export type McpCapabilityIdentity = {
+  type: McpCapabilityType;
+  source: string;
+  name: string;
+};
+
+export const normalizeMcpCapability = (
+  type: McpCapabilityType,
+  rawName: string,
+  telemetry?: { source?: string; name?: string }
+): McpCapabilityIdentity => ({
+  type,
+  source: telemetry?.source ?? 'unknown',
+  name: telemetry?.name ?? rawName,
+});

--- a/packages/core/core/src/services/mcp/metrics/wrapCapabilityHandlerForMetrics.ts
+++ b/packages/core/core/src/services/mcp/metrics/wrapCapabilityHandlerForMetrics.ts
@@ -1,0 +1,37 @@
+import type { Core, Modules } from '@strapi/types';
+
+import { normalizeMcpCapability, type McpCapabilityType } from './normalizeMcpCapability';
+import { sendDidExecuteMcpCapability, sendDidNotExecuteMcpCapability } from './metrics';
+
+const isCapabilityFailure = (result: unknown): boolean => {
+  if (result === null || typeof result !== 'object') {
+    return false;
+  }
+
+  return 'isError' in result && result.isError === true;
+};
+
+export const wrapCapabilityHandlerForMetrics = <
+  THandler extends (...args: never[]) => Promise<unknown>,
+>(
+  strapi: Core.Strapi,
+  type: McpCapabilityType,
+  capabilityName: string,
+  telemetry: Modules.MCP.McpCapabilityTelemetry | undefined,
+  handler: THandler
+): THandler => {
+  const wrapped = async (...args: Parameters<THandler>) => {
+    const result = await handler(...args);
+    const identity = normalizeMcpCapability(type, capabilityName, telemetry);
+
+    if (isCapabilityFailure(result)) {
+      sendDidNotExecuteMcpCapability(strapi, identity, 'execution_error');
+    } else {
+      sendDidExecuteMcpCapability(strapi, identity);
+    }
+
+    return result;
+  };
+
+  return wrapped as THandler;
+};

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -8,6 +8,7 @@ import {
   McpCapabilityRegistryBase,
 } from './internal/McpCapabilityRegistry';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandlerForMetrics';
 
 export const makeMcpPromptDefinition = <Definition extends Modules.MCP.McpPromptDefinition>(
   prompt: Definition
@@ -28,11 +29,13 @@ export class McpPromptRegistry
   }
 
   bind(mcpServer: McpServer) {
+    const strapi = this.#strapi;
+
     super.register((definition) => {
       const { name, title, description, argsSchema, createHandler } = definition;
 
       return createSafeCapabilityRegistration({
-        strapi: this.#strapi,
+        strapi,
         capabilityType: 'Prompt',
         name,
         createHandler,
@@ -63,6 +66,14 @@ export class McpPromptRegistry
           };
         },
         registerWithSdk(safeHandler) {
+          const sdkHandler = wrapCapabilityHandlerForMetrics(
+            strapi,
+            'prompt',
+            name,
+            definition.telemetry,
+            safeHandler
+          );
+
           return mcpServer.registerPrompt(
             name,
             {
@@ -71,7 +82,7 @@ export class McpPromptRegistry
               // @ts-expect-error - Internal handler type mismatch due to optional argsSchema
               argsSchema,
             },
-            safeHandler
+            sdkHandler
           );
         },
       });

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -10,6 +10,7 @@ import {
   McpCapabilityRegistryBase,
 } from './internal/McpCapabilityRegistry';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
+import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandlerForMetrics';
 
 export const makeMcpResourceDefinition = <Definition extends Modules.MCP.McpResourceDefinition>(
   resource: Definition
@@ -34,11 +35,13 @@ export class McpResourceRegistry
   }
 
   bind(mcpServer: McpServer) {
+    const strapi = this.#strapi;
+
     super.register((definition) => {
       const { name, uri, metadata, createHandler } = definition;
 
       return createSafeCapabilityRegistration({
-        strapi: this.#strapi,
+        strapi,
         capabilityType: 'Resource',
         name,
         createHandler,
@@ -65,7 +68,15 @@ export class McpResourceRegistry
           };
         },
         registerWithSdk(safeHandler) {
-          return mcpServer.registerResource(name, uri, metadata, safeHandler);
+          const sdkHandler = wrapCapabilityHandlerForMetrics(
+            strapi,
+            'resource',
+            name,
+            definition.telemetry,
+            safeHandler
+          );
+
+          return mcpServer.registerResource(name, uri, metadata, sdkHandler);
         },
       });
     });

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -7,6 +7,7 @@ import {
   type McpCapabilityRegistry,
   McpCapabilityRegistryBase,
 } from './internal/McpCapabilityRegistry';
+import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandlerForMetrics';
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 import type { McpAdminTokenAbility } from './authentication';
 
@@ -63,6 +64,8 @@ export class McpToolRegistry
   }
 
   bind(mcpServer: McpServer) {
+    const strapi = this.#strapi;
+
     super.register((definition) => {
       const { name, title, description, resolveInputSchema, resolveOutputSchema, createHandler } =
         definition;
@@ -76,7 +79,7 @@ export class McpToolRegistry
       const createHandlerWithContext = (strapi: Core.Strapi) => createHandler(strapi, context);
 
       return createSafeCapabilityRegistration({
-        strapi: this.#strapi,
+        strapi,
         capabilityType: 'Tool',
         name,
         createHandler: createHandlerWithContext,
@@ -109,11 +112,19 @@ export class McpToolRegistry
 
           // Adapt from our object-literal handler `({ args, extra })` to
           // the MCP SDK's positional form `(args, extra)` / `(extra)`.
-          const sdkHandler =
+          const baseHandler =
             inputSchema !== undefined
               ? (args: unknown, extra: unknown) =>
                   safeHandler({ args, extra } as Parameters<typeof safeHandler>[0])
               : (extra: unknown) => safeHandler({ extra } as Parameters<typeof safeHandler>[0]);
+
+          const sdkHandler = wrapCapabilityHandlerForMetrics(
+            strapi,
+            'tool',
+            name,
+            definition.telemetry,
+            baseHandler
+          );
 
           return mcpServer.registerTool(
             name,

--- a/packages/core/core/src/services/mcp/tools/log.ts
+++ b/packages/core/core/src/services/mcp/tools/log.ts
@@ -23,6 +23,7 @@ export const logToolDefinition = makeMcpToolDefinition({
   description: 'Logs a message to the Strapi logger with specified level',
   resolveInputSchema: () => inputSchema,
   resolveOutputSchema: () => outputSchema,
+  telemetry: { source: 'core', name: 'log' },
   devModeOnly: true,
   createHandler:
     (strapi) =>

--- a/packages/core/core/src/services/metrics/__tests__/index.test.ts
+++ b/packages/core/core/src/services/metrics/__tests__/index.test.ts
@@ -222,6 +222,45 @@ describe('metrics', () => {
     fetch.mockClear();
   });
 
+  test('Rate limits MCP request lifecycle events', async () => {
+    const { send } = metrics({
+      config: {
+        get(path: string | string[]) {
+          return get(path, this);
+        },
+        uuid: 'test',
+        environment: 'dev',
+        info: {
+          strapi: '0.0.0',
+        },
+      },
+      server: {
+        use() {},
+      },
+      dirs: {
+        app: {
+          root: process.cwd(),
+        },
+      },
+      requestContext: {
+        get: jest.fn(() => ({})),
+      },
+      cron: {
+        add: jest.fn(),
+      },
+      fetch,
+    } as any);
+
+    await send('didUseMcpServer');
+    await send('didUseMcpServer');
+    await send('didStartMcpServer');
+    await send('didStartMcpServer');
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    fetch.mockClear();
+  });
+
   test('Does not include EE fields when absent', () => {
     const { send } = metrics({
       config: {

--- a/packages/core/core/src/services/metrics/index.ts
+++ b/packages/core/core/src/services/metrics/index.ts
@@ -9,6 +9,7 @@ import wrapWithRateLimit from './rate-limiter';
 import createSender from './sender';
 import createMiddleware from './middleware';
 import isTruthy from './is-truthy';
+import { MCP_LIMITED_TELEMETRY_EVENTS } from '../mcp/metrics/metrics';
 
 const LIMITED_EVENTS = [
   'didSaveMediaWithAlternativeText',
@@ -16,6 +17,7 @@ const LIMITED_EVENTS = [
   'didDisableResponsiveDimensions',
   'didEnableResponsiveDimensions',
   'didInitializePluginUpload',
+  ...Object.values(MCP_LIMITED_TELEMETRY_EVENTS),
 ];
 
 const createTelemetryInstance = (strapi: Core.Strapi) => {

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -49,11 +49,18 @@ export type McpCapabilityAccess =
       auth: McpCapabilityAuth;
     };
 
+export type McpCapabilityTelemetry = {
+  source?: string;
+  /** Sanitized name override — replaces raw capability name in analytics */
+  name?: string;
+};
+
 /**
  * Base definition for Strapi MCP capabilities
  */
 export type McpCapabilityDefinition<Name extends string = string> = {
   name: Name;
+  telemetry?: McpCapabilityTelemetry;
 } & McpCapabilityAccess;
 
 /**


### PR DESCRIPTION
## What does it do?

Adds privacy-safe, rate-limited server-side telemetry for the MCP server, plus contributor docs for server-side and admin telemetry.

Request-level events use existing `LIMITED_EVENTS` daily rate limiting (once per event name per 24h). Capability events dedupe locally per `{ type, action, source }` (and per success/failure) in `metrics.ts`.

### Telemetry events

| Event | When it fires | Rate limit | `eventProperties` | `groupProperties` |
| --- | --- | --- | --- | --- |
| `didStartMcpServer` | MCP server starts (`server.mcp.enabled: true`) | Daily (`LIMITED_EVENTS`) | `path` | `numberOfTools`, `numberOfPrompts`, `numberOfResources` |
| `didUseMcpServer` | First authenticated MCP POST handled per day | Daily (`LIMITED_EVENTS`) | — | — |
| `didNotAuthenticateMcpRequest` | POST rejected before handling (missing/invalid token) | Daily (`LIMITED_EVENTS`) | `errorClass`: `missing_token` \| `invalid_token` | — |
| `didNotHandleMcpRequest` | Authenticated POST fails during connect/handle (timeout or other error) | Daily (`LIMITED_EVENTS`) | `errorClass`: `timeout` \| `error` | — |
| `didExecuteMcpCapability` | Tool/prompt/resource handler completes successfully | Per `{ type, action, source }` per day (local dedup) | `type`: `tool` \| `prompt` \| `resource`; `action`; `source` | — |
| `didNotExecuteMcpCapability` | Handler returns `isError: true` or throws | Per `{ type, action, source }` per day (local dedup) | `type`; `action`; `source`; `errorClass`: `execution_error` | — |

**Normalization (tools only today):** `action` is a coarse category (`list`, `get`, `create`, `update`, `delete`, `publish`, `unpublish`, `discard_draft`, `write`, `log`) — never a content-type slug. `source` is `core` or `content-manager`. Prompt/resource handlers are wired for metrics; events emit once normalization rules exist.

## Why is it needed?

We need observability into MCP adoption and failure modes (enabled vs used, auth errors, handler timeouts, tool execution) without expanding core telemetry infrastructure or leaking project-specific identifiers.

## How to test it?

1. Start Strapi with MCP enabled (`examples/getstarted` or your sandbox).
2. Hit the MCP endpoint (authenticated POST, unauthenticated POST, tool call success/failure).
3. Confirm events via telemetry logs or a local sink.
4. Run unit tests:

```bash
yarn test:unit --testPathPattern="mcp/|services/metrics/__tests__"
yarn nx run @strapi/core:build:types
```

## Related issue(s)/PR(s)

Fixes CMS-1078

- Related alternative: https://github.com/strapi/strapi/pull/26443 — simpler lifecycle/request telemetry on `feat/mcp/analytics`; this PR extends that direction with adoption funnel events, normalized capability payloads, daily rate limiting, failure `errorClass` taxonomy, and contributor documentation.
