### PR TITLE
test(content-manager): stabilize dynamic zone insert e2e on Firefox

### DIFF
--- a/tests/e2e/tests/content-manager/edit-view/single-type-edit-view.spec.ts
+++ b/tests/e2e/tests/content-manager/edit-view/single-type-edit-view.spec.ts
@@ -1,7 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import';
-import { clickAndWait, findAndClose, navToHeader } from '../../../../utils/shared';
+import {
+  clickAndWait,
+  findAndClose,
+  insertDynamicZoneComponent,
+  navToHeader,
+} from '../../../../utils/shared';
 
 test.describe('Edit View', () => {
   test.beforeEach(async ({ page }) => {
@@ -318,33 +323,27 @@ test.describe('Edit View', () => {
       await expect(componentsLocator.nth(1)).toHaveText(/content and image/i);
       await expect(componentsLocator.nth(2)).toHaveText(/product carousel/i);
 
-      // Add components at specific locations:
-      // - very last position
-      const moreActionsBtn1 = componentsLocator
-        .nth(1)
-        .getByRole('button', { name: /more actions/i });
-      await moreActionsBtn1.waitFor({ state: 'visible' });
-      await moreActionsBtn1.click({ force: true });
-      await page.getByRole('menuitem', { name: /add component below/i }).dispatchEvent('click');
-      await page.getByRole('menuitem', { name: /product carousel/i }).dispatchEvent('click');
+      // Add components at specific locations (stable accordion labels, not nth indices):
+      await insertDynamicZoneComponent(page, {
+        relativeToComponent: /content and image/i,
+        position: 'below',
+        componentToAdd: /product carousel/i,
+        expectedComponentCount: 4,
+      });
 
-      // - very first position
-      const moreActionsBtn2 = componentsLocator
-        .nth(0)
-        .getByRole('button', { name: /more actions/i });
-      await moreActionsBtn2.waitFor({ state: 'visible' });
-      await moreActionsBtn2.click({ force: true });
-      await page.getByRole('menuitem', { name: /add component above/i }).dispatchEvent('click');
-      await page.getByRole('menuitem', { name: /hero image/i }).dispatchEvent('click');
+      await insertDynamicZoneComponent(page, {
+        relativeToComponent: /product carousel - 23\/24 kits/i,
+        position: 'above',
+        componentToAdd: /hero image/i,
+        expectedComponentCount: 5,
+      });
 
-      // - middle position
-      const moreActionsBtn3 = componentsLocator
-        .nth(1)
-        .getByRole('button', { name: /more actions/i });
-      await moreActionsBtn3.waitFor({ state: 'visible' });
-      await moreActionsBtn3.click({ force: true });
-      await page.getByRole('menuitem', { name: /add component below/i }).dispatchEvent('click');
-      await page.getByRole('menuitem', { name: /hero image/i }).dispatchEvent('click');
+      await insertDynamicZoneComponent(page, {
+        relativeToComponent: /product carousel - 23\/24 kits/i,
+        position: 'below',
+        componentToAdd: /hero image/i,
+        expectedComponentCount: 6,
+      });
 
       // Make sure we get the desired components order
       const componentTexts = await page

--- a/tests/utils/shared.ts
+++ b/tests/utils/shared.ts
@@ -749,6 +749,53 @@ export const isElementBefore = async (firstLocator, secondLocator) => {
   }, secondHandle);
 };
 
+type DynamicZoneInsertPosition = 'above' | 'below';
+
+/**
+ * Insert a component in a dynamic zone relative to an existing component.
+ *
+ * Radix nested menus need a real click on the sub-trigger to open the picker; only the leaf
+ * component item uses `dispatchEvent('click')` (see DynamicComponent unit tests).
+ */
+export const insertDynamicZoneComponent = async (
+  page: Page,
+  options: {
+    relativeToComponent: RegExp | string;
+    position: DynamicZoneInsertPosition;
+    componentToAdd: RegExp | string;
+    expectedComponentCount?: number;
+  }
+) => {
+  const { relativeToComponent, position, componentToAdd, expectedComponentCount } = options;
+
+  const componentItem = page.getByRole('listitem').filter({
+    has: page.getByRole('button', { name: relativeToComponent }),
+  });
+
+  await expect(componentItem).toHaveCount(1);
+
+  const moreActionsBtn = componentItem.getByRole('button', { name: /more actions/i });
+  await moreActionsBtn.scrollIntoViewIfNeeded();
+  await moreActionsBtn.click();
+
+  const insertLabel = position === 'above' ? /add component above/i : /add component below/i;
+  const insertMenuItem = page.getByRole('menuitem', { name: insertLabel });
+  await expect(insertMenuItem).toBeVisible();
+  await insertMenuItem.click();
+
+  const componentMenuItem = page.getByRole('menuitem', { name: componentToAdd }).last();
+  await expect(componentMenuItem).toBeVisible();
+  await componentMenuItem.dispatchEvent('click');
+
+  const components = page.getByRole('listitem').filter({ has: page.getByRole('heading') });
+
+  if (expectedComponentCount !== undefined) {
+    await expect(components).toHaveCount(expectedComponentCount);
+  } else {
+    await expect(insertMenuItem).toBeHidden();
+  }
+};
+
 /**
  * Ensures that the specified checkbox is in the desired checked state.
  * If the checkbox's current state does not match the desired state, it clicks the checkbox to toggle it.


### PR DESCRIPTION
## Summary

- Adds `insertDynamicZoneComponent` helper that clicks Radix submenu triggers properly and only uses `dispatchEvent('click')` on the leaf component menu item (matching unit test patterns).
- Refactors the flaky Firefox CI test to target components by stable accordion labels and wait for expected component counts between insertions.

## Why is it needed?

The dynamic zone position e2e test was flaky on Firefox CI: `dispatchEvent('click')` on submenu triggers ("Add component above/below") does not reliably open nested Radix menus, causing timeouts and wrong component order.

## How to test it?

```bash
yarn test:e2e --domains=content-manager -c 1 -- edit-view/single-type-edit-view.spec.ts --project=firefox --retries=0 --grep "add a component to a dynamic zone"
```

## Related issue(s)/PR(s)