### PR TITLE
test: stabilize flaky e2e patterns (WIP)

### DIFF
--- a/packages/core/admin/admin/src/components/RelativeTime.tsx
+++ b/packages/core/admin/admin/src/components/RelativeTime.tsx
@@ -43,11 +43,17 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
       // see https://github.com/date-fns/date-fns/issues/2891 – No idea why it's all partial it returns it every time.
     }) as Required<Duration>;
 
-    const unit = intervals.find((intervalUnit) => {
-      return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
-    })!;
+    const unit =
+      intervals.find((intervalUnit) => {
+        return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
+      }) ?? 'seconds';
 
-    const relativeTime = isPast(timestamp) ? -interval[unit] : interval[unit];
+    const value = interval[unit];
+    const relativeTime = isPast(timestamp) ? -value : value;
+
+    // Sub-second elapsed time (or minor clock skew) — avoid NaN and "in 0 seconds" on createdAt.
+    const showZeroSecondsAgo =
+      value === 0 && unit === 'seconds' && (isPast(timestamp) || timestamp.getTime() > Date.now());
 
     // Display custom text if interval is less than the threshold
     const customInterval = customIntervals.find(
@@ -56,7 +62,9 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
 
     const displayText = customInterval
       ? customInterval.text
-      : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
+      : showZeroSecondsAgo
+        ? formatRelativeTime(-0, 'seconds', { numeric: 'always' })
+        : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
 
     return (
       <time

--- a/packages/core/admin/admin/src/components/tests/RelativeTime.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/RelativeTime.test.tsx
@@ -38,4 +38,12 @@ describe('RelativeTime', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent('5 minutes ago');
   });
+
+  it('renders 0 seconds ago when the timestamp is less than a second old', () => {
+    const now = 1443686400000;
+    spiedDateNow = setDateNow(now);
+    render(<RelativeTime timestamp={new Date(now - 500)} />);
+
+    expect(screen.getByRole('time')).toHaveTextContent('0 seconds ago');
+  });
 });

--- a/packages/core/content-manager/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-manager/admin/src/components/RelativeTime.tsx
@@ -48,7 +48,11 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
         return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
       }) ?? 'seconds';
 
-    const relativeTime = isPast(timestamp) ? -interval[unit] : interval[unit];
+    const value = interval[unit];
+    const relativeTime = isPast(timestamp) ? -value : value;
+
+    const showZeroSecondsAgo =
+      value === 0 && unit === 'seconds' && (isPast(timestamp) || timestamp.getTime() > Date.now());
 
     // Display custom text if interval is less than the threshold
     const customInterval = customIntervals.find(
@@ -57,7 +61,9 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
 
     const displayText = customInterval
       ? customInterval.text
-      : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
+      : showZeroSecondsAgo
+        ? formatRelativeTime(-0, 'seconds', { numeric: 'always' })
+        : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
 
     return (
       <time

--- a/packages/core/content-releases/admin/src/components/RelativeTime.tsx
+++ b/packages/core/content-releases/admin/src/components/RelativeTime.tsx
@@ -43,11 +43,16 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
       // see https://github.com/date-fns/date-fns/issues/2891 – No idea why it's all partial it returns it every time.
     }) as Required<Duration>;
 
-    const unit = intervals.find((intervalUnit) => {
-      return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
-    })!;
+    const unit =
+      intervals.find((intervalUnit) => {
+        return interval[intervalUnit] > 0 && Object.keys(interval).includes(intervalUnit);
+      }) ?? 'seconds';
 
-    const relativeTime = isPast(timestamp) ? -interval[unit] : interval[unit];
+    const value = interval[unit];
+    const relativeTime = isPast(timestamp) ? -value : value;
+
+    const showZeroSecondsAgo =
+      value === 0 && unit === 'seconds' && (isPast(timestamp) || timestamp.getTime() > Date.now());
 
     // Display custom text if interval is less than the threshold
     const customInterval = customIntervals.find(
@@ -56,7 +61,9 @@ const RelativeTime = React.forwardRef<HTMLTimeElement, RelativeTimeProps>(
 
     const displayText = customInterval
       ? customInterval.text
-      : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
+      : showZeroSecondsAgo
+        ? formatRelativeTime(-0, 'seconds', { numeric: 'always' })
+        : formatRelativeTime(relativeTime, unit, { numeric: 'auto' });
 
     return (
       <time

--- a/tests/e2e/tests/admin/home-customization.spec.ts
+++ b/tests/e2e/tests/admin/home-customization.spec.ts
@@ -44,47 +44,35 @@ test.describe('Homepage Widget Customization', () => {
 
     // Hover over the widget to make delete button visible
     await profileWidget.hover();
-    await page.waitForTimeout(1000); // Wait for hover effects to appear
+    const deleteButton = profileWidget.getByRole('button', { name: 'Delete' });
+    await expect(deleteButton).toBeVisible();
 
-    // Look for delete button (it has text "Delete" but aria-label is null)
-    const deleteButton = profileWidget.locator('button').first();
+    // Click delete button
+    await clickAndWait(page, deleteButton);
 
-    if ((await deleteButton.count()) > 0) {
-      // Click delete button
-      await clickAndWait(page, deleteButton);
+    // Verify widget is removed
+    await expect(profileWidget).not.toBeVisible();
 
-      // Verify widget is removed
-      await expect(profileWidget).not.toBeVisible();
+    // Now try to add it back through the modal
+    const addWidgetButton = page.locator('button:has-text("Add Widget")').first();
+    await expect(addWidgetButton).toBeVisible();
+    await clickAndWait(page, addWidgetButton);
 
-      // Now try to add it back through the modal
-      const addWidgetButton = page.locator('button:has-text("Add Widget")').first();
-      await expect(addWidgetButton).toBeVisible();
-      await clickAndWait(page, addWidgetButton);
+    // Look for widget selection modal
+    const widgetModal = page.locator('[role="dialog"]').first();
+    await expect(widgetModal).toBeVisible();
 
-      // Look for widget selection modal
-      const widgetModal = page.locator('[role="dialog"]').first();
-      await expect(widgetModal).toBeVisible();
+    // Look for the Profile widget preview in the modal (it should now be available to add)
+    const profileWidgetInModal = widgetModal.locator('h2:has-text("Profile")').first();
+    await expect(profileWidgetInModal).toBeVisible();
 
-      // Look for the Profile widget preview in the modal (it should now be available to add)
-      const profileWidgetInModal = widgetModal.locator('h2:has-text("Profile")').first();
+    // Click to add the widget back
+    await clickAndWait(page, profileWidgetInModal);
 
-      if ((await profileWidgetInModal.count()) > 0) {
-        // Click to add the widget back
-        await clickAndWait(page, profileWidgetInModal);
+    // Verify the modal is closed
+    await expect(widgetModal).not.toBeVisible();
 
-        // Verify the modal is closed
-        await expect(widgetModal).not.toBeVisible();
-
-        // Verify the Profile widget is visible again
-        await expect(profileWidget).toBeVisible();
-      } else {
-        // Close the modal
-        const cancelButton = widgetModal.locator('button:has-text("Cancel")').first();
-        await cancelButton.click();
-      }
-    } else {
-      // Verify widget is still visible (no deletion occurred)
-      await expect(profileWidget).toBeVisible();
-    }
+    // Verify the Profile widget is visible again
+    await expect(profileWidget).toBeVisible();
   });
 });

--- a/tests/e2e/tests/admin/transfer-tokens.spec.ts
+++ b/tests/e2e/tests/admin/transfer-tokens.spec.ts
@@ -48,16 +48,11 @@ test.describe('Transfer Tokens', () => {
   test('Created tokens list page should be correct', async ({ page }) => {
     await createTransferToken(page, 'my test token', 'unlimited', 'Full access');
 
-    // if we don't wait until createdAt is at least 1s, we see "NaN" for the timestamp
-    // TODO: fix the bug and remove this
-    await page.waitForTimeout(1100);
-
     await navToHeader(page, ['Settings', 'Transfer Tokens'], 'Transfer Tokens');
 
     const row = page.getByRole('row').filter({ hasText: 'my test token' });
     await expect(row).toBeVisible();
 
-    // Check the time element within the specific row
     await expect(row.getByText(/\d+ (second|minute)s? ago/)).toBeVisible();
     // TODO: expand on this test, it could check edit and delete icons
   });

--- a/tests/e2e/tests/content-manager/history.spec.ts
+++ b/tests/e2e/tests/content-manager/history.spec.ts
@@ -158,7 +158,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       await expect(titleInput).toHaveValue('Being from Kansas City');
       // Assert the previous version in the list is the expected version
       const previousVersion = versionCards.nth(1);
-      previousVersion.click();
+      await previousVersion.click();
       await expect(titleInput).toHaveValue('Being from Kansas is a pity');
       await expect(previousVersion.getByText('(current)')).not.toBeVisible();
 
@@ -177,7 +177,7 @@ describeOnCondition(edition === 'EE')('History', () => {
       // The current version is the most recent draft
       await expect(currentVersion.getByText('Published')).toBeVisible();
       await expect(titleInput).toHaveValue('Being from Kansas City');
-      previousVersion.click();
+      await previousVersion.click();
       await expect(titleInput).toHaveValue('Being from Kansas City');
 
       // Go back to the entry

--- a/tests/e2e/tests/content-manager/home-widgets.spec.ts
+++ b/tests/e2e/tests/content-manager/home-widgets.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
-import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
+import {
+  clickAndWait,
+  findAndClose,
+  navToHeader,
+  withContentManagerPublish,
+  withContentManagerSave,
+} from '../../../utils/shared';
 
 test.describe('Homepage - Content Manager Widgets', () => {
   test.beforeEach(async ({ page }) => {
@@ -20,12 +26,14 @@ test.describe('Homepage - Content Manager Widgets', () => {
 
     const nameBox = page.getByLabel(/name/i);
     await nameBox.fill('Nike Mens newer!');
-    await page.getByRole('button', { name: /save/i }).click();
+    await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
     await findAndClose(page, 'Saved document');
 
     // Go back to the home page, the updated entry should be the first in the table
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const mostRecentEntry = recentlyEditedWidget.getByRole('row').nth(0);
+    const mostRecentEntry = recentlyEditedWidget
+      .getByRole('row')
+      .filter({ hasText: /nike mens newer!/i });
     await expect(mostRecentEntry).toBeVisible();
     await expect(
       mostRecentEntry.getByRole('gridcell', { name: /nike mens newer!/i })
@@ -40,12 +48,16 @@ test.describe('Homepage - Content Manager Widgets', () => {
     // Make content update in the CM
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
 
     // Go back to the home page, the published entry should be the first in the table with published status
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const mostRecentPublishedEntry = recentlyPublishedWidget.getByRole('row').nth(0);
+    const mostRecentPublishedEntry = recentlyPublishedWidget
+      .getByRole('row')
+      .filter({ hasText: 'West Ham post match analysis' });
     await expect(mostRecentPublishedEntry).toBeVisible();
     await expect(
       mostRecentPublishedEntry.getByRole('gridcell', { name: 'West Ham post match analysis' })
@@ -59,12 +71,14 @@ test.describe('Homepage - Content Manager Widgets', () => {
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
     const title = page.getByLabel(/title/i);
     await title.fill('West Ham pre match pep talk');
-    await page.getByRole('button', { name: /save/i }).click();
+    await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
     await findAndClose(page, 'Saved document');
 
     // Go back to the home page, the published entry should be the first in the table with modified status
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const mostRecentModifiedEntry = recentlyPublishedWidget.getByRole('row').nth(0);
+    const mostRecentModifiedEntry = recentlyPublishedWidget
+      .getByRole('row')
+      .filter({ hasText: 'West Ham post match analysis' });
     await expect(
       // It should still be the published data, not the modified draft data
       mostRecentModifiedEntry.getByRole('gridcell', { name: 'West Ham post match analysis' })
@@ -86,7 +100,9 @@ test.describe('Homepage - Content Manager Widgets', () => {
     );
     const titleFieldEnglish = page.getByLabel(/title/i);
     await titleFieldEnglish.fill('West Ham Football Team');
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
 
     // Create and publish a French entry
@@ -99,7 +115,9 @@ test.describe('Homepage - Content Manager Widgets', () => {
     );
     const titleFieldFrench = page.getByLabel(/title/i);
     await titleFieldFrench.fill("L'équipe de West Ham");
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
 
     // Go back to the home page, the recently published widget should show entries from different locales
@@ -139,7 +157,9 @@ test.describe('Homepage - Content Manager Widgets', () => {
     // Publish an entry
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
 
     // Modify an entry
@@ -148,11 +168,13 @@ test.describe('Homepage - Content Manager Widgets', () => {
       page,
       page.getByRole('gridcell', { name: 'Why I prefer football over soccer' })
     );
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
     const title = page.getByLabel(/title/i);
     await title.fill('West Ham pre match pep talk');
-    await page.getByRole('button', { name: /save/i }).click();
+    await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
     await findAndClose(page, 'Saved document');
 
     // Go back to the home page

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -100,7 +100,7 @@ test.describe('Uniqueness', () => {
   const EDIT_URL = /\/admin\/content-manager\/collection-types\/api::unique.unique\/[^/]+(\?.*)?/;
 
   const clickSave = async (page: Page) => {
-    await page.getByRole('button', { name: 'Save' }).isEnabled();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     await clickAndWait(page, page.getByRole('tab', { name: 'Draft' }));
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await expect(page.getByText('Saved document')).toBeVisible();

--- a/tests/e2e/tests/content-releases/document-status.spec.ts
+++ b/tests/e2e/tests/content-releases/document-status.spec.ts
@@ -4,6 +4,7 @@ import {
   describeOnCondition,
   findAndClose,
   navToHeader,
+  withContentManagerPublish,
 } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 import { resetFiles } from '../../../utils/file-reset';
@@ -30,16 +31,21 @@ describeOnCondition(edition === 'EE')('Releases - Document status', () => {
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
 
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
-    await page.getByRole('button', { name: /publish/i }).click();
+    await withContentManagerPublish(page, () =>
+      page.getByRole('button', { name: /publish/i }).click()
+    );
     await findAndClose(page, 'Published document');
     await clickAndWait(page, page.getByRole('link', { name: 'Back' }));
 
-    await expect(
-      page.getByRole('row').nth(1).getByRole('status', { name: 'published' })
-    ).toBeVisible();
-    await expect(page.getByRole('row').nth(2).getByRole('status', { name: 'draft' })).toBeVisible();
+    const westHamRow = page.getByRole('row').filter({ hasText: 'West Ham post match analysis' });
+    const footballRow = page
+      .getByRole('row')
+      .filter({ hasText: 'Why I prefer football over soccer' });
 
-    await page.getByRole('row').nth(2).getByRole('button', { name: 'Row actions' }).click();
+    await expect(westHamRow.getByRole('status', { name: 'published' })).toBeVisible();
+    await expect(footballRow.getByRole('status', { name: 'draft' })).toBeVisible();
+
+    await footballRow.getByRole('button', { name: 'Row actions' }).click();
     await page.getByRole('menuitem', { name: 'Add to release' }).click();
     await page.getByRole('combobox', { name: 'Select a release' }).click();
     await page.getByRole('option', { name: releaseName }).click();
@@ -51,10 +57,8 @@ describeOnCondition(edition === 'EE')('Releases - Document status', () => {
     await clickAndWait(page, page.getByRole('button', { name: 'Publish', exact: true }));
 
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
-    await expect(page.getByRole('row').nth(1).getByRole('status', { name: 'draft' })).toBeVisible();
-    await expect(
-      page.getByRole('row').nth(2).getByRole('status', { name: 'published' })
-    ).toBeVisible();
+    await expect(westHamRow.getByRole('status', { name: 'draft' })).toBeVisible();
+    await expect(footballRow.getByRole('status', { name: 'published' })).toBeVisible();
 
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
     await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();

--- a/tests/e2e/tests/content-releases/home-widgets.spec.ts
+++ b/tests/e2e/tests/content-releases/home-widgets.spec.ts
@@ -6,6 +6,7 @@ import {
   describeOnCondition,
   findAndClose,
   navToHeader,
+  withContentManagerSave,
 } from '../../../utils/shared';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
@@ -63,16 +64,17 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
 
     // Go back to the homepage
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const nextReleaseRow = upcomingReleasesWidget.getByRole('row').nth(1);
+    const nextReleaseRow = upcomingReleasesWidget
+      .getByRole('row')
+      .filter({ hasText: nextReleaseName });
     await expect(nextReleaseRow).toBeVisible();
-    await expect(nextReleaseRow.getByRole('gridcell', { name: nextReleaseName })).toBeVisible();
     await expect(nextReleaseRow.getByRole('gridcell', { name: /empty/i })).toBeVisible();
 
     // Add an entry to the release
     await navToHeader(page, ['Content Manager', 'Cat'], 'Cat');
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
     await page.getByRole('textbox', { name: /age/i }).fill('1');
-    await page.getByRole('button', { name: /save/i }).click();
+    await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
     await page.getByRole('button', { name: 'More document actions' }).click();
     await page.getByRole('menuitem', { name: 'Add to release' }).click();
     const addToReleaseDialog = await page.getByRole('dialog', { name: 'Add to release' });
@@ -84,6 +86,11 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
 
     // Go back to the homepage and check that the widget was updated
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    await expect(nextReleaseRow.getByRole('gridcell', { name: /blocked/i })).toBeVisible();
+    await expect(
+      upcomingReleasesWidget
+        .getByRole('row')
+        .filter({ hasText: nextReleaseName })
+        .getByRole('gridcell', { name: /blocked/i })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-collection-type.spec.ts
@@ -148,6 +148,7 @@ test.describe('Edit collection type', () => {
       await page.getByRole('tab', { name: 'Advanced settings' }).click();
       await page.getByRole('textbox', { name: 'Default value' }).fill(field.defaultValue);
       await page.getByRole('button', { name: 'Finish' }).click();
+      await expect(page.getByLabel('Name', { exact: true })).toBeHidden();
     }
 
     await page.getByRole('button', { name: 'Save' }).click();

--- a/tests/e2e/tests/content-type-builder/collection-type/uid-generation.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/uid-generation.spec.ts
@@ -28,11 +28,11 @@ test.describe('Content Type UID Generation', () => {
     const displayName = page.getByLabel('Display name');
     await displayName.fill('Members');
 
-    // Wait for auto-generation
-    await page.waitForTimeout(500);
+    const singularIdField = page.getByLabel('API ID (Singular)');
+    const pluralIdField = page.getByLabel('API ID (Plural)');
+    await expect(pluralIdField).toHaveValue('members');
 
     // manually change singular name to "member"
-    const singularIdField = page.getByLabel('API ID (Singular)');
     await singularIdField.clear();
     await singularIdField.fill('member');
 
@@ -40,7 +40,6 @@ test.describe('Content Type UID Generation', () => {
     await expect(singularIdField).toHaveValue('member');
 
     // Verify plural name is "members"
-    const pluralIdField = page.getByLabel('API ID (Plural)');
     await expect(pluralIdField).toHaveValue('members');
 
     // Continue to add fields
@@ -85,10 +84,6 @@ test.describe('Content Type UID Generation', () => {
     const displayName = page.getByLabel('Display name');
     await displayName.fill('Cities');
 
-    // Wait for auto-generation
-    await page.waitForTimeout(500);
-
-    // Singular name will be auto-generated as "cities" (just slugified, NOT singularized)
     const singularIdField = page.getByLabel('API ID (Singular)');
     await expect(singularIdField).toHaveValue('cities');
 

--- a/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
+++ b/tests/e2e/tests/content-type-builder/single-type/edit-single-type.spec.ts
@@ -146,6 +146,7 @@ test.describe('Edit single type', () => {
       await page.getByRole('tab', { name: 'Advanced settings' }).click();
       await page.getByRole('textbox', { name: 'Default value' }).fill(field.defaultValue);
       await page.getByRole('button', { name: 'Finish' }).click();
+      await expect(page.getByLabel('Name', { exact: true })).toBeHidden();
     }
 
     await page.getByRole('button', { name: 'Save' }).click();


### PR DESCRIPTION
## Summary

Draft PR bundling broader e2e stabilization work and a product fix for `RelativeTime` rendering `NaN` on sub-second timestamps.

- **RelativeTime** (admin, content-manager, content-releases): default to seconds when duration is zero; show "0 seconds ago" instead of NaN for freshly created timestamps
- **E2E tests**: replace blind sleeps with condition waits; use `withContentManagerSave`/`Publish` for homepage widgets; fix unawaited clicks in history; target rows by content instead of index; CTB modal close wait after field add

## Why is it needed?

Follow-up to reduce CI flake across several domains. Complements the focused dynamic zone insert fix in #26450.

## How to test it?

Run affected specs individually on Firefox, e.g.:

```bash
yarn test:e2e --domains=admin -c 1 -- transfer-tokens.spec.ts --project=firefox --retries=0 --grep "Created tokens list"
yarn test:e2e --domains=content-manager -c 1 -- home-widgets.spec.ts --project=firefox --retries=0
```

## Related issue(s)/PR(s)

- #26450 (dynamic zone insert — separate, focused PR)

## Status

Draft — not ready for review until individual test runs are verified on CI.