### PR TITLE
fix(i18n): preserve non-localized prefill when revisiting locale drafts

### DIFF
--- a/packages/core/content-manager/admin/src/hooks/tests/useDocument.test.tsx
+++ b/packages/core/content-manager/admin/src/hooks/tests/useDocument.test.tsx
@@ -349,6 +349,267 @@ describe('useDocument', () => {
 });
 
 /**
+ * Regression test: Non-localized fields should copy values from a sibling locale
+ * when creating a new locale draft. This inheritance must persist across form resets.
+ * This is now handled in `getInitialFormValues` to keep `initialValues` as the trusted source.
+ */
+describe('useDocument · getInitialFormValues · i18n non-localized inheritance', () => {
+  const I18N_CT_UID = 'api::i18n-bug.i18n-bug';
+
+  type AttributeMap = Record<string, Record<string, unknown>>;
+
+  const sharedButtonComponent = {
+    uid: 'shared.button',
+    apiID: 'button',
+    category: 'shared',
+    isDisplayed: true,
+    options: {},
+    info: { displayName: 'Button', description: '', icon: 'cursor' },
+    attributes: {
+      label: { type: 'string' },
+    },
+  };
+
+  /**
+   * Mocks `/content-manager/init` so the schema for `I18N_CT_UID` uses the supplied attributes.
+   * Other endpoints remain unchanged.
+   */
+  const mockSchema = (attributes: AttributeMap) => {
+    server.use(
+      http.get('/content-manager/init', () =>
+        HttpResponse.json({
+          data: {
+            components: [sharedButtonComponent],
+            contentTypes: [
+              {
+                uid: I18N_CT_UID,
+                isDisplayed: true,
+                apiID: 'i18n-bug',
+                kind: 'collectionType',
+                pluginOptions: { i18n: { localized: true } },
+                options: {},
+                info: {
+                  displayName: 'I18n Bug',
+                  singularName: 'i18n-bug',
+                  pluralName: 'i18n-bugs',
+                  description: '',
+                },
+                attributes: {
+                  documentId: { type: 'string' },
+                  ...attributes,
+                },
+              },
+            ],
+            fieldSizes: {},
+          },
+        })
+      )
+    );
+  };
+
+  /**
+   * Mocks the document GET for a missing-locale scenario:
+   * Returns empty `data` and, if given, a single sibling's values in `meta.availableLocales[0]`.
+   */
+  const mockMissingLocale = (sibling?: Record<string, unknown>) => {
+    server.use(
+      http.get('/content-manager/:collectionType/:uid/:id', () =>
+        HttpResponse.json({
+          data: {},
+          meta: {
+            availableLocales: sibling ? [sibling] : [],
+            availableStatus: [],
+          },
+        })
+      )
+    );
+  };
+
+  const localized = { pluginOptions: { i18n: { localized: true } } };
+  const nonLocalized = { pluginOptions: { i18n: { localized: false } } };
+
+  const renderUseDocument = () =>
+    renderHook(() =>
+      useDocument({
+        collectionType: 'collection-types',
+        model: I18N_CT_UID,
+        documentId: 'abc',
+      })
+    );
+
+  it('merges non-localized scalar values from meta.availableLocales[0] into the baseline', async () => {
+    mockSchema({
+      title: { type: 'string', ...nonLocalized },
+      body: { type: 'string', ...localized },
+    });
+    mockMissingLocale({
+      id: 1,
+      locale: 'en',
+      title: 'Inherited title',
+      body: 'should not leak',
+      updatedAt: '',
+      createdAt: '',
+      publishedAt: '',
+      status: 'draft',
+    });
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.getInitialFormValues(true)).toEqual({
+      title: 'Inherited title',
+    });
+  });
+
+  it('inherits non-localized media values', async () => {
+    const cover = { id: 7, name: 'cover.png', url: '/uploads/cover.png' };
+    mockSchema({
+      cover: { type: 'media', multiple: false, ...nonLocalized },
+      body: { type: 'string', ...localized },
+    });
+    mockMissingLocale({
+      id: 1,
+      locale: 'en',
+      cover,
+      updatedAt: '',
+      createdAt: '',
+      publishedAt: '',
+      status: 'draft',
+    });
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.getInitialFormValues(true)).toEqual({ cover });
+  });
+
+  it('returns an empty object if meta.availableLocales is empty', async () => {
+    mockSchema({
+      title: { type: 'string', ...nonLocalized },
+      body: { type: 'string', ...localized },
+    });
+    mockMissingLocale();
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.getInitialFormValues(true)).toEqual({});
+  });
+
+  it('returns the current document data if document.id exists, ignoring meta.availableLocales', async () => {
+    mockSchema({
+      title: { type: 'string', ...nonLocalized },
+      body: { type: 'string', ...localized },
+    });
+    server.use(
+      http.get('/content-manager/:collectionType/:uid/:id', () =>
+        HttpResponse.json({
+          data: {
+            id: 99,
+            documentId: 'abc',
+            title: 'From the actual locale',
+            body: 'localized body',
+            createdAt: '',
+            updatedAt: '',
+            publishedAt: '',
+          },
+          meta: {
+            availableLocales: [
+              {
+                id: 1,
+                locale: 'en',
+                title: 'Should be ignored',
+                updatedAt: '',
+                createdAt: '',
+                publishedAt: '',
+                status: 'draft',
+              },
+            ],
+            availableStatus: [],
+          },
+        })
+      )
+    );
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.getInitialFormValues()).toEqual({
+      documentId: 'abc',
+      title: 'From the actual locale',
+      body: 'localized body',
+    });
+  });
+
+  it('does not inherit fields when all are localized', async () => {
+    mockSchema({
+      body: { type: 'string', ...localized },
+      title: { type: 'string', ...localized },
+    });
+    mockMissingLocale({
+      id: 1,
+      locale: 'en',
+      title: 'EN title',
+      body: 'EN body',
+      updatedAt: '',
+      createdAt: '',
+      publishedAt: '',
+      status: 'draft',
+    });
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.getInitialFormValues(true)).toEqual({});
+  });
+
+  it('does not inherit non-localized component, dynamiczone, or relation fields (these are outside server availableLocales scope)', async () => {
+    mockSchema({
+      slug: { type: 'string', ...nonLocalized },
+      cta: {
+        type: 'component',
+        component: 'shared.button',
+        repeatable: false,
+        ...nonLocalized,
+      },
+      blocks: {
+        type: 'dynamiczone',
+        components: ['shared.button'],
+        ...nonLocalized,
+      },
+      categories: {
+        type: 'relation',
+        relation: 'manyToMany',
+        target: 'api::category.category',
+        targetModel: 'api::category.category',
+        ...nonLocalized,
+      },
+    });
+    mockMissingLocale({
+      id: 1,
+      locale: 'en',
+      slug: 'inherited-slug',
+      cta: { label: 'Click me' },
+      blocks: [{ __component: 'shared.button', label: 'block-1' }],
+      categories: [{ id: 1 }, { id: 2 }],
+      updatedAt: '',
+      createdAt: '',
+      publishedAt: '',
+      status: 'draft',
+    });
+
+    const { result } = renderUseDocument();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const initial = result.current.getInitialFormValues(true) ?? {};
+
+    // Only non-localized scalar fields should be inherited. Component, dynamiczone,
+    // and relation values are not included, since they are not populated by the server in meta.availableLocales.
+    expect(initial).toEqual({ slug: 'inherited-slug' });
+  });
+});
+
+/**
  * useDoc is an abstraction around useDocument that extracts the model, collection type & id from the url
  * and passes this automatically to useDocument.
  */

--- a/packages/core/content-manager/admin/src/hooks/useDocument.ts
+++ b/packages/core/content-manager/admin/src/hooks/useDocument.ts
@@ -195,6 +195,40 @@ const useDocument: UseDocument = (args, opts) => {
   );
 
   /**
+   * Schema attributes that should be inherited from a sibling locale when
+   * creating a new locale draft.
+   *
+   * Scope intentionally matches what the server populates into
+   * `meta.availableLocales` (see `packages/core/content-manager/server/src/services/document-metadata.ts`):
+   *   - non-localized (`pluginOptions.i18n.localized === false`)
+   *   - scalar or media — `component` / `dynamiczone` / `relation` are excluded
+   *     because the server doesn't populate them in `availableLocales` either,
+   *     so there'd be nothing to copy from.
+   */
+  const nonLocalizedScalarAndMediaFields = React.useMemo(() => {
+    if (!schema?.attributes) {
+      return [];
+    }
+
+    return Object.keys(schema.attributes).filter((name) => {
+      const attribute = schema.attributes[name];
+      // `pluginOptions` is typed as `object` on the base attribute, so narrow it
+      // to the i18n shape rather than ambient-casting the whole attribute.
+      const i18nOptions = attribute.pluginOptions as { i18n?: { localized?: boolean } } | undefined;
+
+      if (i18nOptions?.i18n?.localized !== false) {
+        return false;
+      }
+
+      return (
+        attribute.type !== 'component' &&
+        attribute.type !== 'dynamiczone' &&
+        attribute.type !== 'relation'
+      );
+    });
+  }, [schema]);
+
+  /**
    * Here we prepare the form for editing, we need to:
    * - remove prohibited fields from the document (passwords | ADD YOURS WHEN THERES A NEW ONE)
    * - swap out count objects on relations for empty arrays
@@ -202,6 +236,11 @@ const useDocument: UseDocument = (args, opts) => {
    *
    * We also prepare the form for new documents, so we need to:
    * - set default values on fields
+   * - inherit non-localized scalar/media values from a sibling locale.
+   *   Baking the inheritance into `initialValues` here is what lets it survive
+   *   both `<Form>` re-inits (`SET_INITIAL_VALUES`) and `Blocker.resetForm()` —
+   *   neither of which the previous side-effect-based prefill in
+   *   `LocalePickerAction` could survive on revisits.
    */
   const getInitialFormValues = React.useCallback(
     (isCreatingDocument: boolean = false) => {
@@ -213,11 +252,37 @@ const useDocument: UseDocument = (args, opts) => {
        * Check that we have an ID so we know the
        * document has been created in some way.
        */
-      const form = document?.id ? document : createDefaultForm(schema, components);
+      if (document?.id) {
+        return transformDocument(schema, components)(document);
+      }
+
+      let form: AnyData = createDefaultForm(schema, components);
+
+      // Intentionally use `availableLocales[0]`:
+      // - Non-localized fields are always in sync across all locales (`copyNonLocalizedFields`).
+      // - Avoids depending on the i18n plugin just to find the default locale.
+      const sibling = meta?.availableLocales?.[0] as Record<string, unknown> | undefined;
+      if (sibling && nonLocalizedScalarAndMediaFields.length > 0) {
+        const inherited = nonLocalizedScalarAndMediaFields.reduce<AnyData>((acc, name) => {
+          if (name in sibling) {
+            acc[name] = sibling[name];
+          }
+          return acc;
+        }, {});
+
+        form = { ...form, ...inherited };
+      }
 
       return transformDocument(schema, components)(form);
     },
-    [document, isSingleType, schema, components]
+    [
+      document,
+      isSingleType,
+      schema,
+      components,
+      meta?.availableLocales,
+      nonLocalizedScalarAndMediaFields,
+    ]
   );
 
   const isLoading = isLoadingDocument || isFetchingDocument || isLoadingSchema;

--- a/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
+++ b/packages/plugins/i18n/admin/src/components/CMHeaderActions.tsx
@@ -161,7 +161,6 @@ const LocalePickerAction = ({
   });
   const { data: settings } = useGetSettingsQuery();
   const isAiAvailable = useAIAvailability();
-  const setValues = useForm('LocalePickerAction', (state) => state.setValues);
 
   const handleSelect = React.useCallback(
     (value: string) => {
@@ -181,56 +180,9 @@ const LocalePickerAction = ({
     [query.plugins, setQuery]
   );
 
-  const nonTranslatedFields = React.useMemo(() => {
-    if (!schema?.attributes) return [];
-    return Object.keys(schema.attributes).filter((field) => {
-      const attribute = schema.attributes[field] as Record<string, unknown>;
-      return (attribute?.pluginOptions as any)?.i18n?.localized === false;
-    });
-  }, [schema?.attributes]);
-
-  const sourceLocaleData = React.useMemo(() => {
-    if (!Array.isArray(locales) || !meta?.availableLocales) return null;
-
-    const defaultLocale = locales.find((locale: Locale) => locale.isDefault);
-    const existingLocales = meta.availableLocales.map((loc) => loc.locale);
-
-    const sourceLocaleCode =
-      defaultLocale &&
-      existingLocales.includes(defaultLocale.code) &&
-      defaultLocale.code !== currentDesiredLocale
-        ? defaultLocale.code
-        : existingLocales.find((locale) => locale !== currentDesiredLocale);
-
-    if (!sourceLocaleCode) return null;
-
-    // Find the document data from availableLocales (now includes non-translatable fields)
-    const sourceLocaleDoc = meta.availableLocales.find((loc) => loc.locale === sourceLocaleCode);
-
-    return sourceLocaleDoc
-      ? { locale: sourceLocaleCode, data: sourceLocaleDoc as Record<string, unknown> }
-      : null;
-  }, [locales, meta?.availableLocales, currentDesiredLocale]);
-
-  /**
-   * Prefilling form with non-translatable fields from already existing locale
-   */
-  React.useEffect(() => {
-    // Only run when creating a new locale (no document ID yet) and when we have non-translatable fields
-    if (!document?.id && nonTranslatedFields.length > 0 && sourceLocaleData?.data) {
-      const dataToSet = nonTranslatedFields.reduce(
-        (acc: Record<string, unknown>, field: string) => {
-          acc[field] = sourceLocaleData.data[field];
-          return acc;
-        },
-        {}
-      );
-
-      if (Object.keys(dataToSet).length > 0) {
-        setValues(dataToSet);
-      }
-    }
-  }, [document?.id, nonTranslatedFields, sourceLocaleData?.data, setValues]);
+  // Non-localized prefill is handled in `useDocument.getInitialFormValues`
+  // so inherited values persist in initial form state, even after form resets or re-initialization.
+  // Doing this here with setValues would not persist if the cache is reused.
 
   React.useEffect(() => {
     if (!Array.isArray(locales) || !hasI18n) {

--- a/tests/e2e/tests/content-releases/home-widgets.spec.ts
+++ b/tests/e2e/tests/content-releases/home-widgets.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { login } from '../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
 import {
@@ -6,9 +6,19 @@ import {
   describeOnCondition,
   findAndClose,
   navToHeader,
+  withContentManagerSave,
 } from '../../../utils/shared';
 
 const edition = process.env.STRAPI_DISABLE_EE === 'true' ? 'CE' : 'EE';
+
+/** Wait until the homepage upcoming-releases widget has finished loading its data. */
+const waitForUpcomingReleases = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'GET' &&
+      response.url().includes('/content-releases/homepage/upcoming-releases') &&
+      response.ok()
+  );
 
 describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () => {
   test.beforeEach(async ({ page }) => {
@@ -21,13 +31,11 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     const upcomingReleasesWidget = page.getByLabel(/upcoming releases/i, { exact: true });
     await expect(upcomingReleasesWidget).toBeVisible();
 
-    // Check that the not scheduled release is displayed
-    const firstReleaseRow = upcomingReleasesWidget.getByRole('row').nth(0);
-    await expect(firstReleaseRow).toBeVisible();
-    await expect(
-      firstReleaseRow.getByRole('gridcell', { name: /trent crimm: the independent/i })
-    ).toBeVisible();
-    await expect(firstReleaseRow.getByRole('gridcell', { name: /not scheduled/i })).toBeVisible();
+    const trentCrimmRow = upcomingReleasesWidget
+      .getByRole('row')
+      .filter({ hasText: /trent crimm: the independent/i });
+    await expect(trentCrimmRow).toBeVisible();
+    await expect(trentCrimmRow.getByRole('gridcell', { name: /not scheduled/i })).toBeVisible();
 
     // Create a new scheduled release in the future
     await navToHeader(page, ['Releases'], 'Releases');
@@ -61,18 +69,22 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     await page.getByRole('button', { name: /continue/i }).click();
     await findAndClose(page, 'Release created');
 
-    // Go back to the homepage
+    // Go back to the homepage and wait for the widget to refetch
+    const upcomingAfterCreate = waitForUpcomingReleases(page);
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    const nextReleaseRow = upcomingReleasesWidget.getByRole('row').nth(1);
+    await upcomingAfterCreate;
+
+    const nextReleaseRow = upcomingReleasesWidget
+      .getByRole('row')
+      .filter({ hasText: nextReleaseName });
     await expect(nextReleaseRow).toBeVisible();
-    await expect(nextReleaseRow.getByRole('gridcell', { name: nextReleaseName })).toBeVisible();
     await expect(nextReleaseRow.getByRole('gridcell', { name: /empty/i })).toBeVisible();
 
     // Add an entry to the release
     await navToHeader(page, ['Content Manager', 'Cat'], 'Cat');
     await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).first());
     await page.getByRole('textbox', { name: /age/i }).fill('1');
-    await page.getByRole('button', { name: /save/i }).click();
+    await withContentManagerSave(page, () => page.getByRole('button', { name: /save/i }).click());
     await page.getByRole('button', { name: 'More document actions' }).click();
     await page.getByRole('menuitem', { name: 'Add to release' }).click();
     const addToReleaseDialog = await page.getByRole('dialog', { name: 'Add to release' });
@@ -83,7 +95,14 @@ describeOnCondition(edition === 'EE')('Homepage - Content Releases Widgets', () 
     await findAndClose(page, 'Entry added to release');
 
     // Go back to the homepage and check that the widget was updated
+    const upcomingAfterAdd = waitForUpcomingReleases(page);
     await clickAndWait(page, page.getByRole('link', { name: /^home$/i }));
-    await expect(nextReleaseRow.getByRole('gridcell', { name: /blocked/i })).toBeVisible();
+    await upcomingAfterAdd;
+    await expect(
+      upcomingReleasesWidget
+        .getByRole('row')
+        .filter({ hasText: nextReleaseName })
+        .getByRole('gridcell', { name: /blocked/i })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/tests/i18n/editview.spec.ts
+++ b/tests/e2e/tests/i18n/editview.spec.ts
@@ -8,6 +8,7 @@ import {
   describeOnCondition,
   findAndClose,
   navToHeader,
+  withContentManagerSave,
 } from '../../../utils/shared';
 import { waitForRestart } from '../../../utils/restart';
 
@@ -588,6 +589,67 @@ test.describe('Edit view', () => {
     await findAndClose(page, 'Saved Document');
 
     // Remove the field from the content type
+    await navToHeader(page, ['Content-Type Builder', 'Products'], 'Products');
+    await page.getByRole('button', { name: 'Delete nonTranslatableField' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+  });
+
+  /**
+   * Regression test: Non-localized fields should stay pre-filled when switching between locale drafts,
+   * even if the draft is unsaved. Previously, switching back to a cached unsaved locale would clear
+   * non-localized values due to the prefill logic only running once.
+   */
+  test('non-localized fields remain pre-filled when revisiting an unsaved locale draft', async ({
+    page,
+  }) => {
+    const switchEditLocale = async (localeOption: string) => {
+      await page.getByRole('combobox', { name: 'Locales' }).click();
+      await page.getByRole('option', { name: localeOption }).click();
+      await expect(page.getByRole('combobox', { name: 'Locales' })).toHaveText(localeOption);
+    };
+
+    // Add a non-localized field to the Products content type
+    await navToHeader(page, ['Content-Type Builder', 'Products'], 'Products');
+    await page.getByRole('button', { name: /add another field to this collection type/i }).click();
+    await page
+      .getByRole('button', { name: 'Text Small or long text like title or description' })
+      .click();
+    await page.getByLabel('Name', { exact: true }).fill('nonTranslatableField');
+    await page.getByRole('tab', { name: 'Advanced settings' }).click();
+    await page.getByLabel('Enable localization for this').click();
+    await page.getByRole('button', { name: 'Finish' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+
+    // Create and save a new entry in the English locale
+    await navToHeader(page, ['Content Manager', 'Products'], 'Products');
+    await page.getByRole('link', { name: 'Create new entry' }).first().click();
+    await expect(page.getByRole('heading', { name: 'Create an entry' })).toBeVisible();
+    await page.getByLabel('name').fill('Revisit product');
+    await page.getByLabel('nonTranslatableField').fill('Shared across locales');
+    await withContentManagerSave(page, () => page.getByRole('button', { name: 'Save' }).click());
+    await findAndClose(page, 'Saved Document');
+
+    // Go to the unsaved French locale draft; non-localized field should be inherited
+    await switchEditLocale('French (fr)');
+    await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+    await expect(page.getByLabel('nonTranslatableField')).toHaveValue('Shared across locales');
+    await expect(page.getByLabel('name')).toHaveValue('');
+
+    // Switch back to English without saving French draft
+    await switchEditLocale('English (en)');
+    await expect(page.getByRole('heading', { name: 'Revisit product' })).toBeVisible();
+    await expect(page.getByLabel('name')).toHaveValue('Revisit product');
+
+    // Switch again to French locale; non-localized field should still be pre-filled
+    // Previously this would fail—field would be empty because prefill effect didn't rerun
+    await switchEditLocale('French (fr)');
+    await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+    await expect(page.getByLabel('nonTranslatableField')).toHaveValue('Shared across locales');
+    await expect(page.getByLabel('name')).toHaveValue('');
+
+    // Cleanup: remove the non-localized field so other tests are not affected
     await navToHeader(page, ['Content-Type Builder', 'Products'], 'Products');
     await page.getByRole('button', { name: 'Delete nonTranslatableField' }).click();
     await page.getByRole('button', { name: 'Save' }).click();


### PR DESCRIPTION
## Summary

- Move non-localized field inheritance into `useDocument.getInitialFormValues()` so shared fields stay populated when switching back to an unsaved locale draft (fixes revisit regression after #24659).
- Remove the one-shot `setValues` prefill effect from `LocalePickerAction` in the i18n plugin; initial form state is now the single source of truth.
- Add unit tests for i18n inheritance in `useDocument.test.tsx`.
- Stabilize flaky E2E: i18n edit-view regression test and content-releases upcoming-releases home widget test.

## Why is it needed?

After #24659, non-localized fields were prefilled on the first visit to a new locale, but cleared when revisiting that locale without saving—the `LocalePickerAction` effect did not survive form re-inits.

## How to test it?

1. **Manual:** Content Manager → localized type → save EN → switch to FR (unsaved) → verify non-localized fields → switch EN → switch FR again → fields still prefilled.
2. **Unit:** `cd packages/core/content-manager && yarn test:front useDocument`
3. **E2E (EE):** `yarn test:e2e --domains i18n content-releases`

## Related issue(s)/PR(s)

Fixes CMS-540

- Builds on #24659 (prefill non-translatable fields for new locale)