### PR TITLE
fix(core): preserve createdBy/updatedBy on drafts created by discard-drafts migration

### DIFF
--- a/examples/complex/config/database.ts
+++ b/examples/complex/config/database.ts
@@ -40,10 +40,18 @@ export default ({ env }) => {
       },
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
+    sqlite: {
+      connection: {
+        filename: env('DATABASE_FILENAME', '.tmp/data.db'),
+      },
+      useNullAsDefault: true,
+    },
   };
 
   if (!connections[client]) {
-    throw new Error(`Unsupported DATABASE_CLIENT: ${client}. Use "postgres" or "mysql".`);
+    throw new Error(
+      `Unsupported DATABASE_CLIENT: ${client}. Use "postgres", "mysql", or "sqlite".`
+    );
   }
 
   return {

--- a/examples/complex/scripts/db-sqlite.js
+++ b/examples/complex/scripts/db-sqlite.js
@@ -5,20 +5,23 @@ const path = require('path');
 
 const SCRIPT_DIR = __dirname;
 const COMPLEX_DIR = path.resolve(SCRIPT_DIR, '..');
-const SNAPSHOTS_DIR = path.join(COMPLEX_DIR, 'snapshots');
+const MONOREPO_ROOT = path.resolve(COMPLEX_DIR, '../..');
+const V4_PROJECT_DIR = process.env.V4_OUTSIDE_DIR
+  ? path.resolve(process.cwd(), process.env.V4_OUTSIDE_DIR)
+  : path.resolve(MONOREPO_ROOT, '..', 'complex-v4');
 
 /**
  * SQLite lives entirely as files; no container and no compose runtime.
  *
- * The v4 project resolves its DB filename relative to its own cwd, so a
- * pair-compatible path is written to the v4 scaffold in setup-v4-project.js.
- * For operations run from here in the v5 `complex/` project, we use the same
- * filename so snapshots produced by either side are interchangeable.
+ * The v4 project stores its database under V4_PROJECT_DIR/.tmp/data.db.
+ * v5 reads/writes the same file so snapshots are interchangeable.
  */
 const DATABASE_FILENAME =
   process.env.SQLITE_DATABASE_FILENAME ||
   process.env.DATABASE_FILENAME ||
-  path.join(COMPLEX_DIR, '..', 'complex-v4', '.tmp', 'data.db');
+  path.join(V4_PROJECT_DIR, '.tmp', 'data.db');
+
+const SNAPSHOTS_DIR = path.join(COMPLEX_DIR, 'snapshots');
 
 const command = process.argv[2];
 const snapshotName = process.argv[3];

--- a/examples/complex/scripts/db-utils.js
+++ b/examples/complex/scripts/db-utils.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
+const path = require('path');
 const { runCompose, runContainer } = require('./compose');
 
 const COMPOSE_PROJECT_NAME = process.env.COMPOSE_PROJECT_NAME || 'strapi_complex';
@@ -221,7 +222,14 @@ function getDatabaseEnv(dbType) {
 
   if (dbType === 'sqlite') {
     env.DATABASE_CLIENT = 'sqlite';
-    env.DATABASE_FILENAME = env.DATABASE_FILENAME || '.tmp/data.db';
+    if (!env.DATABASE_FILENAME) {
+      const complexDir = path.resolve(__dirname, '..');
+      const monorepoRoot = path.resolve(complexDir, '../..');
+      const v4ProjectDir = process.env.V4_OUTSIDE_DIR
+        ? path.resolve(process.cwd(), process.env.V4_OUTSIDE_DIR)
+        : path.resolve(monorepoRoot, '..', 'complex-v4');
+      env.DATABASE_FILENAME = path.join(v4ProjectDir, '.tmp', 'data.db');
+    }
     return env;
   }
 

--- a/examples/complex/scripts/seed-v4.js
+++ b/examples/complex/scripts/seed-v4.js
@@ -1017,7 +1017,60 @@ class ContentSeeder {
     await this.seedRelationDp();
     await this.seedRelationDpI18n();
     await this.seedHcM2m();
+    await assignCreatorFieldsOnPublishedEntries(this.strapi);
     return this.results;
+  }
+}
+
+async function ensureAdminUser(strapi) {
+  const existing = await strapi.query('admin::user').findOne();
+  if (existing) {
+    return existing;
+  }
+
+  const superAdminRole = await strapi.query('admin::role').findOne({
+    where: { code: 'strapi-super-admin' },
+  });
+
+  return strapi.query('admin::user').create({
+    data: {
+      firstname: 'Seed',
+      lastname: 'Admin',
+      email: 'seed-admin@strapi.io',
+      password: 'SeedAdmin123!',
+      isActive: true,
+      roles: superAdminRole ? [superAdminRole.id] : [],
+    },
+  });
+}
+
+async function assignCreatorFieldsOnPublishedEntries(strapi) {
+  console.log('Assigning creator fields on published entries...');
+  const adminUser = await ensureAdminUser(strapi);
+  const knex = strapi.db.connection;
+
+  for (const [uid, contentType] of Object.entries(strapi.contentTypes)) {
+    if (!uid.startsWith('api::')) {
+      continue;
+    }
+    if (!contentType.options?.draftAndPublish) {
+      continue;
+    }
+
+    const table = contentType.collectionName;
+    const hasCreatedBy = await knex.schema.hasColumn(table, 'created_by_id');
+    if (!hasCreatedBy) {
+      continue;
+    }
+
+    const updated = await knex(table).whereNotNull('published_at').update({
+      created_by_id: adminUser.id,
+      updated_by_id: adminUser.id,
+    });
+
+    if (updated > 0) {
+      console.log(`  ${table}: ${updated} published row(s)`);
+    }
   }
 }
 

--- a/examples/complex/scripts/setup-v4-project.js
+++ b/examples/complex/scripts/setup-v4-project.js
@@ -84,8 +84,8 @@ const packageJson = {
     '@strapi/plugin-i18n': '4.26.0',
     '@strapi/plugin-users-permissions': '4.26.0',
     '@strapi/strapi': '4.26.0',
-    'better-sqlite3': '9.6.0',
     entities: '2.2.0',
+    sqlite3: '5.1.7',
     mysql2: '3.20.0',
     pg: '8.20.0',
     react: '^18.0.0',
@@ -132,7 +132,7 @@ module.exports = ({ env }) => {
   if (client === 'sqlite') {
     return {
       connection: {
-        client: 'better-sqlite3',
+        client: 'sqlite',
         connection: {
           filename: path.resolve(
             __dirname,

--- a/examples/complex/scripts/validate-migration.js
+++ b/examples/complex/scripts/validate-migration.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { createStrapi, compileStrapi } = require('@strapi/strapi');
-const path = require('path');
+const { getDatabaseEnv } = require('./db-utils');
 
 // Expected counts per run (kept small for example seeding in this repo)
 const EXPECTED_COUNTS_PER_RUN = {
@@ -644,11 +644,90 @@ async function validateNestedComponentRelationParity(strapi) {
   return { errors };
 }
 
+const DRAFT_PUBLISH_UIDS = [
+  'api::basic-dp.basic-dp',
+  'api::basic-dp-i18n.basic-dp-i18n',
+  'api::relation-dp.relation-dp',
+  'api::relation-dp-i18n.relation-dp-i18n',
+  'api::hc-m2m-source.hc-m2m-source',
+  'api::hc-m2m-target.hc-m2m-target',
+];
+
+async function validateCreatorFieldsOnClonedDrafts(strapi) {
+  const errors = [];
+  const conn = strapi.db.connection;
+
+  for (const uid of DRAFT_PUBLISH_UIDS) {
+    const meta = strapi.db.metadata.get(uid);
+    const contentType = strapi.contentTypes[uid];
+    if (!meta || !contentType) {
+      continue;
+    }
+
+    const createdCol = meta.attributes?.createdBy?.joinColumn?.name ?? 'created_by_id';
+    const updatedCol = meta.attributes?.updatedBy?.joinColumn?.name ?? 'updated_by_id';
+    const localized = isI18nContentType(contentType);
+
+    const rows = await conn(meta.tableName).select(
+      'document_id',
+      'locale',
+      'published_at',
+      createdCol,
+      updatedCol
+    );
+
+    const byKey = new Map();
+    for (const row of rows) {
+      if (!row.document_id) {
+        continue;
+      }
+      const key = localized ? `${row.document_id}::${row.locale || ''}` : row.document_id;
+      const bucket = byKey.get(key) || { published: null, draft: null };
+      if (row.published_at != null) {
+        bucket.published = row;
+      } else {
+        bucket.draft = row;
+      }
+      byKey.set(key, bucket);
+    }
+
+    for (const [key, pair] of byKey.entries()) {
+      if (!pair.published || !pair.draft) {
+        continue;
+      }
+
+      const pubCreated = pair.published[createdCol];
+      const draftCreated = pair.draft[createdCol];
+      if (pubCreated != null && draftCreated == null) {
+        errors.push(
+          `${uid} ${key}: cloned draft is missing ${createdCol} (published=${pubCreated})`
+        );
+      } else if (pubCreated != null && Number(draftCreated) !== Number(pubCreated)) {
+        errors.push(
+          `${uid} ${key}: draft ${createdCol}=${draftCreated} does not match published ${pubCreated}`
+        );
+      }
+
+      const pubUpdated = pair.published[updatedCol];
+      const draftUpdated = pair.draft[updatedCol];
+      if (pubUpdated != null && draftUpdated == null) {
+        errors.push(
+          `${uid} ${key}: cloned draft is missing ${updatedCol} (published=${pubUpdated})`
+        );
+      } else if (pubUpdated != null && Number(draftUpdated) !== Number(pubUpdated)) {
+        errors.push(
+          `${uid} ${key}: draft ${updatedCol}=${draftUpdated} does not match published ${pubUpdated}`
+        );
+      }
+    }
+  }
+
+  return { errors };
+}
+
 /**
- * Optional DB-level verification that the migration fixes are in effect.
- * Runs only when all validations pass. Prints evidence without failing the run.
- * - Bug 1: Morph rows for media: (1) relation-dp direct (none in this seed), (2) component media (e.g. shared.logo) under relation-dp.
- * - Bug 2: Draft and published use distinct nested component IDs for the same document.
+ * Optional DB-level verification for migration-specific regressions.
+ * Prints supplementary evidence when primary validations pass.
  */
 async function verifyMigrationFixAtDbLevel(strapi) {
   const out = [];
@@ -888,21 +967,18 @@ async function verifyMigrationFixAtDbLevel(strapi) {
         const dzRows = await conn(joinTableName)
           .whereIn(entityIdCol, [pair.published, pair.draft])
           .select(entityIdCol, componentIdCol, componentTypeCol);
-        const pubDz = new Set(
-          dzRows
-            .filter((row) => row[entityIdCol] === pair.published)
-            .map((row) => row[componentIdCol])
-        );
-        const draftDz = new Set(
-          dzRows.filter((row) => row[entityIdCol] === pair.draft).map((row) => row[componentIdCol])
-        );
-        if (pubDz.size === 0 && draftDz.size === 0) continue;
+        const pubRows = dzRows.filter((row) => row[entityIdCol] === pair.published);
+        const draftRows = dzRows.filter((row) => row[entityIdCol] === pair.draft);
+        if (pubRows.length === 0 && draftRows.length === 0) continue;
         docsWithDz += 1;
-        const overlaps = [...pubDz].filter((id) => draftDz.has(id));
+        const componentKey = (row) => `${row[componentTypeCol]}::${row[componentIdCol]}`;
+        const pubDzKeys = new Set(pubRows.map(componentKey));
+        const draftDzKeys = new Set(draftRows.map(componentKey));
+        const overlaps = [...pubDzKeys].filter((key) => draftDzKeys.has(key));
         if (overlaps.length > 0) {
           docsWithOverlap += 1;
           errors.push(
-            `relation-dp documentId ${docId}: ${overlaps.length} dynamic-zone component id(s) shared between published and draft`
+            `relation-dp documentId ${docId}: ${overlaps.length} dynamic-zone component(s) shared between published and draft (${overlaps.join(', ')})`
           );
         }
 
@@ -973,6 +1049,10 @@ async function run() {
   const argv = process.argv.slice(2);
   const opts = parseCliArgs(argv);
   const expected = getExpectedCounts(opts.multiplier);
+  const dbType = process.env.DATABASE_CLIENT || 'postgres';
+  if (['postgres', 'mysql', 'mariadb', 'sqlite'].includes(dbType)) {
+    Object.assign(process.env, getDatabaseEnv(dbType));
+  }
 
   console.log('🔍 Starting document-service validator (this will boot Strapi programmatically)...');
   console.log(`  multiplier: ${opts.multiplier}`);
@@ -1001,6 +1081,13 @@ async function run() {
     const docStruct = await validateDocumentStructure(strapi, expected);
     results.errors.push(...docStruct.errors);
     results.sections.push({ name: 'Draft/publish pairing', errors: docStruct.errors });
+
+    const creatorFields = await validateCreatorFieldsOnClonedDrafts(strapi);
+    results.errors.push(...creatorFields.errors);
+    results.sections.push({
+      name: 'Creator fields on cloned drafts',
+      errors: creatorFields.errors,
+    });
 
     const relPresence = await validateRelationsPresence(strapi);
     results.errors.push(...relPresence.errors);

--- a/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
+++ b/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
@@ -1,0 +1,155 @@
+import type { Database } from '@strapi/database';
+import { createConnection } from '../../../../database/src/connection';
+
+import { discardDocumentDrafts } from '../database/5.0.0-discard-drafts';
+
+const ARTICLE_UID = 'api::article.article';
+
+const articleAttributes = {
+  documentId: { type: 'string', columnName: 'document_id' },
+  title: { type: 'string', columnName: 'title' },
+  publishedAt: { type: 'datetime', columnName: 'published_at' },
+  createdAt: { type: 'datetime', columnName: 'created_at' },
+  updatedAt: { type: 'datetime', columnName: 'updated_at' },
+  locale: { type: 'string', columnName: 'locale' },
+  createdBy: {
+    type: 'relation',
+    relation: 'oneToOne',
+    target: 'admin::user',
+    joinColumn: { name: 'created_by_id', referencedColumn: 'id' },
+  },
+  updatedBy: {
+    type: 'relation',
+    relation: 'oneToOne',
+    target: 'admin::user',
+    joinColumn: { name: 'updated_by_id', referencedColumn: 'id' },
+  },
+};
+
+const articleMeta = {
+  uid: ARTICLE_UID,
+  tableName: 'articles',
+  singularName: 'article',
+  attributes: articleAttributes,
+};
+
+const adminUserMeta = {
+  uid: 'admin::user',
+  tableName: 'admin_users',
+  singularName: 'user',
+  attributes: {
+    id: { type: 'increments', columnName: 'id' },
+  },
+};
+
+const buildMigrationDb = (): Database =>
+  ({
+    metadata: {
+      get(uid: string) {
+        if (uid === ARTICLE_UID) {
+          return articleMeta;
+        }
+        if (uid === 'admin::user') {
+          return adminUserMeta;
+        }
+        return null;
+      },
+      values: () => [articleMeta],
+    },
+    dialect: {
+      getBatchInsertSize: () => 500,
+    },
+  }) as unknown as Database;
+
+const setupStrapi = (db: Database) => {
+  global.strapi = {
+    log: { info: jest.fn(), warn: jest.fn() },
+    getModel(uid: string) {
+      if (uid === ARTICLE_UID) {
+        return {
+          uid: ARTICLE_UID,
+          options: { draftAndPublish: true },
+          attributes: articleAttributes,
+        };
+      }
+      if (uid === 'admin::user') {
+        return {
+          uid: 'admin::user',
+          options: {},
+          attributes: adminUserMeta.attributes,
+        };
+      }
+      return null;
+    },
+    contentTypes: {
+      [ARTICLE_UID]: {
+        uid: ARTICLE_UID,
+        options: { draftAndPublish: true },
+        attributes: articleAttributes,
+      },
+    },
+    components: {},
+    plugins: {},
+    db,
+    plugin: () => undefined,
+  } as any;
+};
+
+describe('5.0.0-discard-drafts migration', () => {
+  const knexConnection = createConnection({
+    client: 'sqlite',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+
+  beforeAll(async () => {
+    await knexConnection.schema.createTable('articles', (table) => {
+      table.increments('id');
+      table.string('document_id');
+      table.string('title');
+      table.bigInteger('published_at');
+      table.string('locale');
+      table.bigInteger('created_at');
+      table.bigInteger('updated_at');
+      table.integer('created_by_id');
+      table.integer('updated_by_id');
+    });
+
+    await knexConnection('articles').insert({
+      id: 1,
+      document_id: 'doc1',
+      title: 'test1',
+      published_at: 1779746177147,
+      created_at: 1,
+      updated_at: 1,
+      created_by_id: 1,
+      updated_by_id: 1,
+    });
+
+    setupStrapi(buildMigrationDb());
+  });
+
+  afterAll(async () => {
+    await knexConnection.destroy();
+  });
+
+  describe('copyPublishedEntriesToDraft', () => {
+    it('copies join-column creator fields onto cloned draft rows', async () => {
+      const db = buildMigrationDb();
+      setupStrapi(db);
+
+      await knexConnection.transaction(async (trx) => {
+        await discardDocumentDrafts.up(trx, db);
+      });
+
+      const published = await knexConnection('articles').whereNotNull('published_at').first();
+      const draft = await knexConnection('articles').whereNull('published_at').first();
+
+      expect(published?.created_by_id).toBe(1);
+      expect(published?.updated_by_id).toBe(1);
+      expect(draft?.document_id).toBe('doc1');
+      expect(draft?.created_by_id).toBe(1);
+      expect(draft?.updated_by_id).toBe(1);
+    });
+  });
+});

--- a/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
+++ b/packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts
@@ -5,6 +5,18 @@ import { discardDocumentDrafts } from '../database/5.0.0-discard-drafts';
 
 const ARTICLE_UID = 'api::article.article';
 
+const i18nLocalizationsAttribute = {
+  type: 'relation',
+  relation: 'oneToMany',
+  target: ARTICLE_UID,
+  unstable_virtual: true,
+  joinColumn: {
+    name: 'document_id',
+    referencedColumn: 'document_id',
+    referencedTable: 'articles',
+  },
+};
+
 const articleAttributes = {
   documentId: { type: 'string', columnName: 'document_id' },
   title: { type: 'string', columnName: 'title' },
@@ -12,6 +24,7 @@ const articleAttributes = {
   createdAt: { type: 'datetime', columnName: 'created_at' },
   updatedAt: { type: 'datetime', columnName: 'updated_at' },
   locale: { type: 'string', columnName: 'locale' },
+  localizations: i18nLocalizationsAttribute,
   createdBy: {
     type: 'relation',
     relation: 'oneToOne',
@@ -115,17 +128,6 @@ describe('5.0.0-discard-drafts migration', () => {
       table.integer('updated_by_id');
     });
 
-    await knexConnection('articles').insert({
-      id: 1,
-      document_id: 'doc1',
-      title: 'test1',
-      published_at: 1779746177147,
-      created_at: 1,
-      updated_at: 1,
-      created_by_id: 1,
-      updated_by_id: 1,
-    });
-
     setupStrapi(buildMigrationDb());
   });
 
@@ -134,7 +136,21 @@ describe('5.0.0-discard-drafts migration', () => {
   });
 
   describe('copyPublishedEntriesToDraft', () => {
-    it('copies join-column creator fields onto cloned draft rows', async () => {
+    beforeEach(async () => {
+      await knexConnection('articles').delete();
+      await knexConnection('articles').insert({
+        id: 1,
+        document_id: 'doc1',
+        title: 'test1',
+        published_at: 1779746177147,
+        created_at: 1,
+        updated_at: 1,
+        created_by_id: 1,
+        updated_by_id: 1,
+      });
+    });
+
+    it('copies join-column creator fields onto cloned draft rows (with i18n localizations virtual relation)', async () => {
       const db = buildMigrationDb();
       setupStrapi(db);
 

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -147,6 +147,46 @@ const hasDraftAndPublish = async (trx: Knex, meta: any) => {
 };
 
 /**
+ * Join-column relations that are persisted on the row (e.g. createdBy), excluding virtual
+ * relations such as i18n `localizations` which reuse `document_id` and are not DB-owned.
+ */
+const isPersistedJoinColumnRelation = (attribute: any) =>
+  attribute?.type === 'relation' &&
+  !attribute.unstable_virtual &&
+  attribute.joinColumn &&
+  !attribute.joinTable;
+
+/**
+ * Column names copied when cloning a published row into a draft (stage 1).
+ * Scalars plus persisted join-column FKs; deduped so virtual relations cannot repeat columns.
+ */
+const getPublishedToDraftCloneColumns = (meta: { attributes: Record<string, unknown> }) => {
+  const seen = new Set<string>();
+  const columns: string[] = [];
+
+  const addColumn = (columnName: string | undefined) => {
+    if (!columnName || columnName === 'id' || seen.has(columnName)) {
+      return;
+    }
+    seen.add(columnName);
+    columns.push(columnName);
+  };
+
+  for (const attribute of Object.values(meta.attributes) as any[]) {
+    if (contentTypes.isScalarAttribute(attribute)) {
+      addColumn(attribute.columnName);
+      continue;
+    }
+
+    if (isPersistedJoinColumnRelation(attribute)) {
+      addColumn(attribute.joinColumn.name);
+    }
+  }
+
+  return columns;
+};
+
+/**
  * Copy published entries to draft rows, cloning scalar fields and join-column foreign keys.
  * Components, dynamic zones, and join-table relations are handled in later stages.
  */
@@ -161,22 +201,7 @@ async function copyPublishedEntriesToDraft({
 }) {
   const meta = db.metadata.get(uid);
 
-  const columnsToCopy = Object.values(meta.attributes).reduce((acc, attribute: any) => {
-    if (['id'].includes(attribute.columnName)) {
-      return acc;
-    }
-
-    if (contentTypes.isScalarAttribute(attribute)) {
-      acc.push(attribute.columnName);
-      return acc;
-    }
-
-    if (attribute.type === 'relation' && attribute.joinColumn && !attribute.joinTable) {
-      acc.push(attribute.joinColumn.name);
-    }
-
-    return acc;
-  }, [] as string[]);
+  const columnsToCopy = getPublishedToDraftCloneColumns(meta);
 
   /**
    * Query to copy the published entries into draft entries.
@@ -1728,7 +1753,7 @@ async function cloneComponentInstance({
   }
 
   for (const attribute of Object.values(componentMeta.attributes) as any) {
-    if (attribute.type !== 'relation') {
+    if (!isPersistedJoinColumnRelation(attribute)) {
       continue;
     }
 
@@ -2438,16 +2463,10 @@ async function updateJoinColumnRelations({
 
   // Find all JoinColumn relations (oneToOne, manyToOne without joinTable)
   for (const attribute of Object.values(meta.attributes) as any) {
-    if (attribute.type !== 'relation') {
+    if (!isPersistedJoinColumnRelation(attribute)) {
       continue;
     }
 
-    // Skip relations with joinTable (handled by copyRelationsToOtherContentTypes)
-    if (attribute.joinTable) {
-      continue;
-    }
-
-    // Only handle oneToOne and manyToOne relations that use joinColumn
     const joinColumn = attribute.joinColumn;
     if (!joinColumn) {
       continue;

--- a/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
+++ b/packages/core/core/src/migrations/database/5.0.0-discard-drafts.ts
@@ -1,7 +1,8 @@
 /**
  * Migration overview
  * ===================
- * 1. Create bare draft rows for every published entry, cloning only scalar fields (no relations/components yet).
+ * 1. Create bare draft rows for every published entry, cloning scalar fields and join-column
+ *    foreign keys (no components, dynamic zones, or join-table relations yet).
  *    We do this with a single INSERT … SELECT per content type to avoid touching the document service for every single v4 entry.
  *
  * 2. Rewire all relations so the newly created drafts behave exactly like calling `documentService.discardDraft()`
@@ -146,8 +147,8 @@ const hasDraftAndPublish = async (trx: Knex, meta: any) => {
 };
 
 /**
- * Copy all the published entries to draft entries, without it's components, dynamic zones or relations.
- * This ensures all necessary draft's exist before copying it's relations.
+ * Copy published entries to draft rows, cloning scalar fields and join-column foreign keys.
+ * Components, dynamic zones, and join-table relations are handled in later stages.
  */
 async function copyPublishedEntriesToDraft({
   db,
@@ -158,17 +159,20 @@ async function copyPublishedEntriesToDraft({
   trx: Knex;
   uid: string;
 }) {
-  // Extract all scalar attributes to use in the insert query
   const meta = db.metadata.get(uid);
 
-  // Get scalar attributes that will be copied over the new draft
-  const scalarAttributes = Object.values(meta.attributes).reduce((acc, attribute: any) => {
+  const columnsToCopy = Object.values(meta.attributes).reduce((acc, attribute: any) => {
     if (['id'].includes(attribute.columnName)) {
       return acc;
     }
 
     if (contentTypes.isScalarAttribute(attribute)) {
       acc.push(attribute.columnName);
+      return acc;
+    }
+
+    if (attribute.type === 'relation' && attribute.joinColumn && !attribute.joinTable) {
+      acc.push(attribute.joinColumn.name);
     }
 
     return acc;
@@ -184,16 +188,16 @@ async function copyPublishedEntriesToDraft({
   await trx
     // INSERT INTO tableName (columnName1, columnName2, columnName3, ...)
     .into(
-      trx.raw(`?? (${scalarAttributes.map(() => `??`).join(', ')})`, [
+      trx.raw(`?? (${columnsToCopy.map(() => `??`).join(', ')})`, [
         meta.tableName,
-        ...scalarAttributes,
+        ...columnsToCopy,
       ])
     )
     .insert((subQb: typeof trx) => {
       // SELECT columnName1, columnName2, columnName3, ...
       subQb
         .select(
-          ...scalarAttributes.map((att: string) => {
+          ...columnsToCopy.map((att: string) => {
             // NOTE: these literals reference Strapi's built-in system columns. They never get shortened by
             // the identifier migration (5.0.0-01-convert-identifiers-long-than-max-length) so we can safely
             // compare/use them directly here.


### PR DESCRIPTION
## Summary

- Fixes #26460
- Fixes CMS-1086
- Stage 1 of the `5.0.0-discard-drafts` migration now copies join-column foreign keys when cloning published rows to drafts, so `createdBy` / `updatedBy` are no longer NULL on the new draft rows the Admin UI reads after a v4→v5 upgrade.
- Adds a focused migration test (`5.0.0-discard-drafts.test.ts`) that runs the full discard-drafts migration against in-memory SQLite and asserts creator FKs are preserved on cloned drafts.
- Extends the complex example migration validator with a **Creator fields on cloned drafts** check, plus sqlite workflow fixes so the harness is runnable locally (`DATABASE_CLIENT=sqlite yarn test:migration`).

## Root cause

In Strapi 5, `createdBy` / `updatedBy` are relation attributes with join-column FKs (`created_by_id`, `updated_by_id`), not scalars. Stage 1 only copied scalar columns, and stage 5 skips non–Draft & Publish targets like `admin::user` under the assumption FKs were already copied.

## Notes

- Join-column FKs to Draft & Publish targets are still remapped in stage 5 as before.
- This fix applies to future upgrades only; already-migrated databases need the one-off repair SQL from the issue.

## Related issue(s)/PR(s)

- Fixes #26460
- Fixes CMS-1086

## Test plan

- [x] `yarn jest packages/core/core/src/migrations/__tests__/5.0.0-discard-drafts.test.ts`
- [x] Complex example sqlite workflow: seed v4 → `DATABASE_CLIENT=sqlite yarn test:migration` (passes with fix; 108 creator-field errors without fix)
- [ ] CI green