### PR TITLE
test(api): use lightweight resources for document-service query tests

### DIFF
--- a/tests/api/core/strapi/document-service/discard-draft.test.api.ts
+++ b/tests/api/core/strapi/document-service/discard-draft.test.api.ts
@@ -2,7 +2,7 @@ import type { Core } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
-import resources from './resources/index';
+import resources from './resources/article-query';
 import { ARTICLE_UID, findArticleDb, findArticlesDb } from './utils';
 
 describe('Document Service', () => {

--- a/tests/api/core/strapi/document-service/find-first.test.api.ts
+++ b/tests/api/core/strapi/document-service/find-first.test.api.ts
@@ -1,7 +1,7 @@
 import type { Core } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
-import resources from './resources/index';
+import resources from './resources/article-query';
 import { ARTICLE_UID, findArticleDb } from './utils';
 
 describe('Document Service', () => {

--- a/tests/api/core/strapi/document-service/find-many.test.api.ts
+++ b/tests/api/core/strapi/document-service/find-many.test.api.ts
@@ -1,7 +1,7 @@
 import type { Core, Modules } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
-import resources from './resources/index';
+import resources from './resources/article-query';
 import { ARTICLE_UID, findArticlesDb } from './utils';
 
 let strapi: Core.Strapi;

--- a/tests/api/core/strapi/document-service/middlewares.test.api.ts
+++ b/tests/api/core/strapi/document-service/middlewares.test.api.ts
@@ -1,7 +1,7 @@
 import type { Core } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
-import resources from './resources/index';
+import resources from './resources/middlewares';
 import { ARTICLE_UID } from './utils';
 
 describe('Document Service', () => {
@@ -27,7 +27,7 @@ describe('Document Service', () => {
         return next();
       });
 
-      const articles = await strapi.documents('api::article.article').findMany();
+      const articles = await strapi.documents(ARTICLE_UID).findMany();
 
       expect(articles).toHaveLength(1);
     });

--- a/tests/api/core/strapi/document-service/publication-filter.test.api.ts
+++ b/tests/api/core/strapi/document-service/publication-filter.test.api.ts
@@ -1,7 +1,7 @@
 import type { Core } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
-import resources from './resources/index';
+import { withoutFixtures as resources } from './resources/article-query';
 import { ARTICLE_UID } from './utils';
 
 type ApiEntry = {

--- a/tests/api/core/strapi/document-service/publish.test.api.ts
+++ b/tests/api/core/strapi/document-service/publish.test.api.ts
@@ -2,7 +2,7 @@ import type { Core, Modules } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
-import resources from './resources/index';
+import resources from './resources/article-query';
 import { ARTICLE_UID, findArticleDb, findArticlesDb } from './utils';
 
 let strapi: Core.Strapi;

--- a/tests/api/core/strapi/document-service/resources/article-query.ts
+++ b/tests/api/core/strapi/document-service/resources/article-query.ts
@@ -1,0 +1,101 @@
+import type { BuilderResources } from '../../../../utils/builder-helper';
+
+/**
+ * Lightweight article + i18n setup for document-service query/lifecycle tests
+ * that only need ARTICLE_UID and the standard Article1/Article2 fixture corpus.
+ *
+ * Omits the extra content types, components, and relation fixtures from ./index.
+ */
+const articleSchema = {
+  kind: 'collectionType',
+  collectionName: 'articles',
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  draftAndPublish: true,
+  pluginOptions: {
+    i18n: {
+      localized: true,
+    },
+  },
+  attributes: {
+    title: {
+      type: 'string',
+      pluginOptions: {
+        i18n: {
+          localized: true,
+        },
+      },
+    },
+  },
+};
+
+const locales = [
+  { name: 'nl', code: 'nl' },
+  { name: 'it', code: 'it' },
+  { name: 'es', code: 'es' },
+];
+
+const articleFixtures = [
+  {
+    documentId: 'Article1',
+    title: 'Article1-Draft-EN',
+    publishedAt: null,
+    locale: 'en',
+    createdBy: 1,
+    updatedBy: 1,
+  },
+  {
+    documentId: 'Article2',
+    title: 'Article2-Draft-EN',
+    publishedAt: null,
+    locale: 'en',
+    createdBy: 1,
+    updatedBy: 1,
+  },
+  {
+    documentId: 'Article1',
+    title: 'Article1-Draft-NL',
+    publishedAt: null,
+    locale: 'nl',
+    createdBy: 1,
+    updatedBy: 1,
+  },
+  {
+    documentId: 'Article1',
+    title: 'Article1-Draft-IT',
+    publishedAt: null,
+    locale: 'it',
+    createdBy: 1,
+    updatedBy: 1,
+  },
+  {
+    documentId: 'Article2',
+    title: 'Article2-Published-EN',
+    publishedAt: '2019-01-01T00:00:00.000Z',
+    locale: 'en',
+    createdBy: 1,
+    updatedBy: 1,
+  },
+];
+
+const createResources = (fixtures: typeof articleFixtures): BuilderResources => ({
+  schemas: {
+    'content-types': {
+      'api::article.article': articleSchema,
+    },
+    components: {},
+  },
+  fixtures: {
+    'content-types': {
+      'api::article.article': fixtures,
+    },
+  },
+  locales,
+});
+
+/** Article schema, locales, and the shared Article1/Article2 fixture corpus. */
+export default createResources(articleFixtures);
+
+/** Same schema and locales; no pre-seeded entries (tests create their own data). */
+export const withoutFixtures = createResources([]);

--- a/tests/api/core/strapi/document-service/resources/middlewares.ts
+++ b/tests/api/core/strapi/document-service/resources/middlewares.ts
@@ -1,0 +1,42 @@
+import type { BuilderResources } from '../../../../utils/builder-helper';
+
+const articleSchema = {
+  kind: 'collectionType',
+  collectionName: 'articles',
+  singularName: 'article',
+  pluralName: 'articles',
+  displayName: 'Article',
+  draftAndPublish: true,
+  attributes: {
+    title: {
+      type: 'string',
+    },
+  },
+};
+
+const resources: BuilderResources = {
+  schemas: {
+    'content-types': {
+      'api::article.article': articleSchema,
+    },
+    components: {},
+  },
+  fixtures: {
+    'content-types': {
+      'api::article.article': [
+        {
+          documentId: 'Article1',
+          title: 'Article1-Draft-EN',
+          publishedAt: null,
+        },
+        {
+          documentId: 'Article2',
+          title: 'Article2-Draft-EN',
+          publishedAt: null,
+        },
+      ],
+    },
+  },
+};
+
+export default resources;

--- a/tests/api/core/strapi/document-service/unpublish.test.api.ts
+++ b/tests/api/core/strapi/document-service/unpublish.test.api.ts
@@ -2,7 +2,7 @@ import type { Core, Modules } from '@strapi/types';
 
 import { createTestSetup, destroyTestSetup } from '../../../utils/builder-helper';
 import { testInTransaction } from '../../../utils/index';
-import resources from './resources/index';
+import resources from './resources/article-query';
 import { ARTICLE_UID, findArticleDb, findPublishedArticlesDb } from './utils';
 
 let strapi: Core.Strapi;


### PR DESCRIPTION
## What does it do?

Adds lightweight document-service test resource bundles under `resources/` and switches query/lifecycle API tests that only need `ARTICLE_UID` to use them instead of the full shared `./resources/index` pack (4 content types, 5 components, relation fixtures, etc.).

- `resources/article-query.ts` — i18n article schema, locales, and the standard Article1/Article2 fixture corpus (shared by find/publish/unpublish/discard-draft tests)
- `resources/article-query.ts` `withoutFixtures` export — same schema/locales, no pre-seeded rows (publication-filter)
- `resources/middlewares.ts` — minimal non-i18n article setup for the middleware test

## Why is it needed?

Several document-service API suites were flaky on CI with `afterAll` hook timeouts. The tests themselves are fast; setup/teardown was expensive because each suite loaded the full resource pack and triggered many Strapi boot/destroy cycles via the test builder. These suites only exercise article queries or lifecycle actions and do not need the full schema.

## How to test it?

```bash
yarn test:api --testPathPattern="document-service/(middlewares|find-first|find-many|unpublish|publish|discard-draft|publication-filter)" --generate-app=false
```

All 80 tests in those files should pass. Locally the middlewares suite drops from ~18s to ~4s.

## Related issue(s)/PR(s)

N/A — CI flake investigation on `middlewares.test.api.ts` teardown timeouts.