### PR TITLE
chore(repo): skip change freeze ownership check when freeze disabled

### DIFF
--- a/.github/workflows/changeFreeze.yml
+++ b/.github/workflows/changeFreeze.yml
@@ -7,8 +7,16 @@ on:
 permissions: read-all
 
 jobs:
+  change-freeze-disabled:
+    name: 'Change freeze not active'
+    if: vars.CHANGE_FREEZE_ENABLED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Change freeze is not enabled"
+
   check-ownership:
     name: 'Check if PR was created by a Strapi Team Member'
+    if: vars.CHANGE_FREEZE_ENABLED == 'true'
     runs-on: ubuntu-latest
     outputs:
       isTeamMember: ${{ steps.get-user-teams-membership.outputs.isTeamMember }}
@@ -25,7 +33,7 @@ jobs:
     permissions:
       pull-requests: write
     needs: [check-ownership]
-    if: ${{ needs.check-ownership.outputs.isTeamMember == 'false' && vars.CHANGE_FREEZE_ENABLED == 'true' }}
+    if: ${{ needs.check-ownership.outputs.isTeamMember == 'false' }}
     steps:
       - uses: thollander/actions-comment-pull-request@v2
         with:


### PR DESCRIPTION
## Summary

- Skip the token-backed team membership check when `CHANGE_FREEZE_ENABLED` is not `true`
- Add a lightweight pass job so fork PRs get a green check instead of failing on missing `CHECK_OWNERSHIP_TOKEN`
- Remove redundant `CHANGE_FREEZE_ENABLED` guard from the alert job (ownership check already only runs during an active freeze)

## Why is it needed?

The Check Change Freeze workflow fails on fork PRs even when no change freeze is active. GitHub does not expose repository secrets to `pull_request` workflows from forks, so `CHECK_OWNERSHIP_TOKEN` is empty and the membership action errors before it can run. This produces a misleading red check on community PRs.

## How to test it?

1. Open a PR from a fork with `CHANGE_FREEZE_ENABLED=false` (current state) and confirm the workflow reports **Change freeze not active** instead of failing on `GITHUB_TOKEN`
2. With `CHANGE_FREEZE_ENABLED=true`, confirm same-repo PRs still run the team membership check and post the freeze comment for non-team members

## Related issue(s)/PR(s)

Fixes CMS-1089