### PR TITLE
ci(tests): skip SonarQube on Dependabot PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -583,10 +583,11 @@ jobs:
   sonarqube:
     name: SonarQube Analysis
     runs-on: ubuntu-latest
-    # Dependabot PRs cannot access repository secrets (SONAR_TOKEN), so skip analysis.
+    # On pull requests, only run for local branches (is_local also excludes forks and
+    # Dependabot, which cannot access repository secrets such as SONAR_TOKEN). Pushes to
+    # develop/main still run the analysis.
     if: >-
-      ${{ !github.event.pull_request.head.repo.fork
-      && (github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'))
+      ${{ (github.event_name != 'pull_request' || needs.conditions.outputs.is_local == 'true')
       && (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true') }}
     needs: [conditions, unit_back, unit_front]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -583,7 +583,11 @@ jobs:
   sonarqube:
     name: SonarQube Analysis
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.head.repo.fork && (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true') }}
+    # Dependabot PRs cannot access repository secrets (SONAR_TOKEN), so skip analysis.
+    if: >-
+      ${{ !github.event.pull_request.head.repo.fork
+      && (github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'))
+      && (needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.frontend == 'true') }}
     needs: [conditions, unit_back, unit_front]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What does it do?

Skips the SonarQube Analysis job on pull requests opened by Dependabot.

## Why is it needed?

Dependabot-triggered workflows cannot access repository secrets (`SONAR_TOKEN`, `SONAR_HOST_URL`). SonarQube still runs today because Dependabot branches are in-repo (not forks), so the existing fork guard does not apply. The scan fails with an empty host URL, which causes `aggregate_test_result` to fail and blocks merging dependency PRs (e.g. #26457).

EE API jobs already use the `is_local` condition for the same reason; this applies the same pattern to SonarQube while still running analysis on pushes to `develop`/`main`.

## How to test it?

1. Merge this PR to `develop`.
2. Re-run checks (or `@dependabot rebase`) on a blocked Dependabot PR such as #26457.
3. Confirm **SonarQube Analysis** is skipped and **aggregate_test_result** passes.

## Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/26457