### PR TITLE
fix(database): escape LIKE wildcard characters in filter operators

### DIFF
--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -14,6 +14,17 @@ import type { Attribute } from '../../types';
 
 type WhereCtx = Ctx & { alias?: string; isGroupRoot?: boolean };
 
+/**
+ * Escapes special LIKE wildcard characters (%, _) in a string value
+ * so they are treated as literal characters in SQL LIKE patterns.
+ */
+const escapeLikeWildcards = (value: string): string => {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('%', '\\%')
+    .replaceAll('_', '\\_');
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> => isPlainObject(value);
 
 const castValue = (value: unknown, attribute: Attribute | null) => {
@@ -327,38 +338,38 @@ const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, v
       break;
     }
     case '$startsWith': {
-      qb.where(column, 'like', `${value}%`);
+      qb.where(column, 'like', `${escapeLikeWildcards(`${value}`)}%`);
       break;
     }
     case '$startsWithi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `${value}%`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `${escapeLikeWildcards(`${value}`)}%`]);
       break;
     }
     case '$endsWith': {
-      qb.where(column, 'like', `%${value}`);
+      qb.where(column, 'like', `%${escapeLikeWildcards(`${value}`)}`);
       break;
     }
     case '$endsWithi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${value}`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${escapeLikeWildcards(`${value}`)}`]);
       break;
     }
     case '$contains': {
-      qb.where(column, 'like', `%${value}%`);
+      qb.where(column, 'like', `%${escapeLikeWildcards(`${value}`)}%`);
       break;
     }
 
     case '$notContains': {
-      qb.whereNot(column, 'like', `%${value}%`);
+      qb.whereNot(column, 'like', `%${escapeLikeWildcards(`${value}`)}%`);
       break;
     }
 
     case '$containsi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${value}%`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${escapeLikeWildcards(`${value}`)}%`]);
       break;
     }
 
     case '$notContainsi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} NOT LIKE LOWER(?)`, [column, `%${value}%`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} NOT LIKE LOWER(?)`, [column, `%${escapeLikeWildcards(`${value}`)}%`]);
       break;
     }
 


### PR DESCRIPTION
## Summary

Fixes #26468

This PR escapes SQL LIKE wildcard characters (`%` and `_`) in filter operator values before they are used in LIKE patterns.

### Problem

Filter operators that use SQL LIKE (`$startsWith`, `$endsWith`, `$contains`, `$notContains`, and their case-insensitive variants) directly interpolate user-provided values into LIKE patterns without escaping wildcard characters. This means:

- A filter like `endsWith=100%` would match values ending with `100` followed by any characters (because the trailing `%` in the value is treated as a SQL wildcard)
- A filter like `contains=test_value` would match `testvalue` (because `_` matches any single character)

### Solution

Added an `escapeLikeWildcards` function that escapes `\`, `%`, and `_` characters in filter values by prepending a backslash, so they are treated as literal characters in the LIKE pattern.

### Changes

- Added `escapeLikeWildcards()` helper function in `packages/core/database/src/query/helpers/where.ts`
- Applied escaping to all LIKE-based filter operators: `$startsWith`, `$startsWithi`, `$endsWith`, `$endsWithi`, `$contains`, `$notContains`, `$containsi`, `$notContainsi`

### Test Plan

1. Create a content type with a string field
2. Add entries containing `%` or `_` in the field value (e.g., "100%", "test_value")
3. Test filter operators:
   - `filters[field][$endsWith]=100%` should only match values literally ending with "100%"
   - `filters[field][$contains]=test_value` should only match values containing literal "test_value"
4. Verify case-insensitive variants work similarly


---
Fixes CPR-368