### PR TITLE
fix(data-transfer): preserve core store when config stage is excluded

### DIFF
--- a/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
+++ b/packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
@@ -110,6 +110,64 @@ describe('Restore ', () => {
     expect(count).toBe(entities.length);
   });
 
+  test('Should not delete internal models when entities.include lists content types only', async () => {
+    const coreStoreDeleteMany = jest.fn(async () => ({ count: 5 }));
+    const webhookDeleteMany = jest.fn(async () => ({ count: 2 }));
+
+    const strapi = getStrapiFactory({
+      contentTypes: getContentTypes(),
+      query: jest.fn((uid: string) => {
+        if (uid === 'strapi::core-store') {
+          return { deleteMany: coreStoreDeleteMany, findMany: jest.fn(), create };
+        }
+        if (uid === 'strapi::webhook') {
+          return { deleteMany: webhookDeleteMany, findMany: jest.fn(), create };
+        }
+
+        return query(uid);
+      }),
+      getModel,
+      get() {
+        return {
+          get() {
+            return [
+              { uid: 'strapi::core-store' },
+              { uid: 'strapi::webhook' },
+              ...getStrapiModels(),
+            ];
+          },
+        };
+      },
+      db: {
+        query: jest.fn((uid: string) => {
+          if (uid === 'strapi::core-store') {
+            return { deleteMany: coreStoreDeleteMany, findMany: jest.fn(), create };
+          }
+          if (uid === 'strapi::webhook') {
+            return { deleteMany: webhookDeleteMany, findMany: jest.fn(), create };
+          }
+
+          return query(uid);
+        }),
+      },
+    })();
+
+    setGlobalStrapi(strapi);
+
+    await deleteRecords(strapi, {
+      entities: {
+        include: ['foo', 'bar'],
+      },
+      configuration: {
+        coreStore: false,
+        webhook: false,
+      },
+    });
+
+    expect(coreStoreDeleteMany).not.toHaveBeenCalled();
+    expect(webhookDeleteMany).not.toHaveBeenCalled();
+  });
+
   test('Should only delete chosen contentType', async () => {
     const strapi = getStrapiFactory({
       contentTypes: getContentTypes(),

--- a/packages/core/strapi/src/cli/utils/__tests__/parse-restore-from-options.test.ts
+++ b/packages/core/strapi/src/cli/utils/__tests__/parse-restore-from-options.test.ts
@@ -1,0 +1,67 @@
+import type { Core } from '@strapi/types';
+
+import { parseRestoreFromOptions } from '../data-transfer';
+
+const mockStrapi = {
+  contentTypes: {
+    'api::article.article': {},
+    'api::category.category': {},
+    'admin::user': {},
+    'plugin::content-releases.release': {},
+    'plugin::upload.file': {},
+  },
+} as unknown as Core.Strapi;
+
+describe('parseRestoreFromOptions', () => {
+  test('full transfer deletes all entities before restore', () => {
+    const restore = parseRestoreFromOptions({}, mockStrapi);
+
+    expect(restore.entities?.include).toBeUndefined();
+    expect(restore.configuration?.coreStore).toBe(true);
+    expect(restore.configuration?.webhook).toBe(true);
+    expect(restore.assets).toBe(true);
+  });
+
+  test('--only content preserves config and scopes entity deletion to content types', () => {
+    const restore = parseRestoreFromOptions({ only: ['content'] }, mockStrapi);
+
+    expect(restore.entities?.include).toEqual([
+      'api::article.article',
+      'api::category.category',
+      'plugin::upload.file',
+    ]);
+    expect(restore.configuration?.coreStore).toBe(false);
+    expect(restore.configuration?.webhook).toBe(false);
+    expect(restore.assets).toBe(false);
+  });
+
+  test('--exclude config preserves config and scopes entity deletion to content types', () => {
+    const restore = parseRestoreFromOptions({ exclude: ['config'] }, mockStrapi);
+
+    expect(restore.entities?.include).toEqual([
+      'api::article.article',
+      'api::category.category',
+      'plugin::upload.file',
+    ]);
+    expect(restore.configuration?.coreStore).toBe(false);
+    expect(restore.configuration?.webhook).toBe(false);
+    expect(restore.assets).toBe(true);
+  });
+
+  test('--only content,config still wipes all entities before restore', () => {
+    const restore = parseRestoreFromOptions({ only: ['content', 'config'] }, mockStrapi);
+
+    expect(restore.entities?.include).toBeUndefined();
+    expect(restore.configuration?.coreStore).toBe(true);
+    expect(restore.configuration?.webhook).toBe(true);
+  });
+
+  test('--only config does not delete entities before restore', () => {
+    const restore = parseRestoreFromOptions({ only: ['config'] }, mockStrapi);
+
+    expect(restore.entities?.include).toEqual([]);
+    expect(restore.configuration?.coreStore).toBe(true);
+    expect(restore.configuration?.webhook).toBe(true);
+    expect(restore.assets).toBe(false);
+  });
+});

--- a/packages/core/strapi/src/cli/utils/data-transfer.ts
+++ b/packages/core/strapi/src/cli/utils/data-transfer.ts
@@ -547,9 +547,20 @@ const parseRestoreFromOptions = (
     include: undefined,
   };
 
-  // if content is not included, send an empty array for include
-  if ((opts.only && !opts.only.includes('content')) || opts.exclude?.includes('content')) {
+  const contentInScope = !(
+    (opts.only && !opts.only.includes('content')) ||
+    opts.exclude?.includes('content')
+  );
+
+  if (!contentInScope) {
+    // Nothing from the entities stage is transferred; do not delete any records beforehand.
     entitiesOptions.include = [];
+  } else if (shouldSkipStage(opts, 'config')) {
+    // When config is excluded, scope pre-transfer deletion to user content types only.
+    // Internal models (e.g. strapi::core-store) must not be wiped via the entities path.
+    entitiesOptions.include = Object.keys(strapi.contentTypes).filter(
+      (uid) => !isIgnoredContentType(uid)
+    );
   }
 
   const restoreConfig: strapiDataTransfer.providers.ILocalStrapiDestinationProviderOptions['restore'] =


### PR DESCRIPTION
## What does it do?

Fixes a bug where `strapi transfer --only content` (and `--exclude config`) wiped `strapi_core_store_settings` on the destination even though the configuration stage was skipped and not restored.

When config is excluded, pre-transfer deletion is now scoped to transferable user content types only. Internal models such as `strapi::core-store` and `strapi::webhook` are no longer deleted via the entities path. Full transfers and `--only content,config` still wipe everything before restore.

## Why is it needed?

Running `--only content` to push content to a remote instance left the destination with an empty core store and a broken admin UI. The `configuration.coreStore: false` flag was set correctly, but `entities.include` stayed undefined, which caused `deleteEntitiesRecords` to clear all internal models anyway.

Fixes #23967

## How to test it?

1. On a remote Strapi instance, confirm `strapi_core_store_settings` has rows.
2. Run `strapi transfer --to <remote> --to-token <token> --only content --force` from a local instance with content.
3. After transfer, confirm the remote admin loads and `strapi_core_store_settings` is not empty.

Unit tests:

```bash
yarn test:unit -- packages/core/strapi/src/cli/utils/__tests__/parse-restore-from-options.test.ts packages/core/data-transfer/src/strapi/providers/local-destination/__tests__/restore.test.ts
```

## Related issue(s)/PR(s)

Fixes #23967
Fixes CMS-939