### PR TITLE
[CI] Add missing health checks to docker-compose.test.yml database services

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,6 +10,11 @@ services:
       POSTGRES_DB: strapi_test
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U strapi']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   mysql:
     image: mysql:8
@@ -24,6 +29,11 @@ services:
       - mysqldata_test:/var/lib/mysql
     ports:
       - '3306:3306'
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 volumes:
   pgdata_test:


### PR DESCRIPTION
### What does it do?
Adds `healthcheck` blocks to the postgres and mysql services in
`docker-compose.test.yml`, mirroring the health check configuration
already present in the GitHub Actions CI workflow (`tests.yml`).

### Why is it needed?
Without health checks, database containers report as "started" before
they are actually ready to accept connections. Contributors running
tests locally immediately after `docker compose up` experience random
`ECONNREFUSED` errors. CI never hits this because GitHub Actions
service health checks are already configured — this is purely a
local development infrastructure gap.

### How to test it?
1. Run: `docker compose -f docker-compose.test.yml up -d`
2. Run API integration tests immediately after
3. Confirm no connection errors — tests wait for DB readiness

### Related issue(s)/PR(s)
Fix #26490

---
Fixes CPR-371