### PR TITLE
[CI] Add smoke test gate to nightly release workflow before npm publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,12 +5,29 @@ on:
     - cron: '0 0 * * 2-6'
 
 permissions:
-  contents: read # to fetch code (actions/checkout)
+  contents: read
 
 jobs:
+  test:
+    name: 'Smoke test before publish'
+    runs-on: ubuntu-latest
+    if: github.repository == 'strapi/strapi'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - name: Run unit tests
+        run: yarn test:unit:vitest
+
   publish:
     name: 'Publish'
     runs-on: ubuntu-latest
+    needs: [test]
     if: github.repository == 'strapi/strapi'
     steps:
       - uses: actions/checkout@v6
@@ -18,7 +35,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 20
       - run: yarn
       - run: ./scripts/pre-publish.sh --yes
         env:


### PR DESCRIPTION
### What does it do?
Adds a `test` job to the nightly release workflow that runs a 
build and unit test smoke check. The `publish` job now declares
`needs: [test]` so npm publishing is blocked if tests fail.

### Why is it needed?
The nightly workflow previously published directly to npm@next 
with zero test gate. If a breaking change was merged into develop 
during the day, it would be silently published to npm that night.
The `tests.yml` workflow runs 15+ jobs across 3 Node versions 
before any production release — the nightly had none of this.

### How to test it?
1. Observe the workflow YAML — publish now has needs: [test]
2. A failing unit test on develop now blocks nightly publish
3. A clean develop branch publishes normally as before

### Related issue(s)/PR(s)
Fix #26492

---
Fixes CPR-372