### PR TITLE
fix(users-permissions): correct "occured" → "occurred" typo in error notifications

### DIFF
--- a/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx
@@ -61,7 +61,7 @@ const AdvancedSettingsPage = () => {
           type: 'danger',
           message: formatMessage({
             id: getTrad('notification.error'),
-            defaultMessage: 'An error occured',
+            defaultMessage: 'An error occurred',
           }),
         });
       },

--- a/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
+++ b/packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx
@@ -89,7 +89,7 @@ export const RolesListPage = () => {
     } catch (error) {
       toggleNotification({
         type: 'danger',
-        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occured' }),
+        message: formatMessage({ id: 'notification.error', defaultMessage: 'An error occurred' }),
       });
     }
   };


### PR DESCRIPTION
### What does it do?

Fixes the misspelling `occured` → `occurred` in two user-facing error notification messages in the **users-permissions** admin plugin:

- `packages/plugins/users-permissions/admin/src/pages/AdvancedSettings/index.jsx` — `defaultMessage: 'An error occured'`
- `packages/plugins/users-permissions/admin/src/pages/Roles/pages/ListPage/index.jsx` — `defaultMessage: 'An error occured'`

These `defaultMessage` strings are shown to users as toast notifications when an error occurs while saving advanced settings or loading roles.

### Why is it needed?

`occured` is a misspelling; the correct English spelling is `occurred` (double `r`). The fix only touches the English fallback copy — no logic, IDs, or translation keys change.

### Related issue(s)

N/A — trivial copy fix.

---
Fixes CPR-373