### PR TITLE
fix(admin): open "Upgrade your admin panel" link in new tab

### DIFF
--- a/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
+++ b/packages/core/admin/admin/src/pages/Settings/pages/ApplicationInfo/ApplicationInfoPage.tsx
@@ -186,6 +186,7 @@ const ApplicationInfoPage = () => {
                           href={`https://github.com/strapi/strapi/releases/tag/${latestStrapiReleaseTag}`}
                           endIcon={<ExternalLink />}
                           target="_blank"
+                          rel="noopener noreferrer"
                         >
                           {formatMessage({
                             id: 'Settings.application.link-upgrade',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add target="_blank" and rel="noopener noreferrer" so users don't lose their admin panel context when checking the latest Strapi release notes on GitHub.

### Why is it needed?

Currently it opens in the same tab, even though it has the "external link" icon next to it, confusing users

### How to test it?

Open an out-of-date Strapi instance and click "Upgrade your admin panel"

### Related issue(s)/PR(s)

n/a

---
Fixes CPR-377