### PR TITLE
ci: gate nightly publish behind validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,8 +8,25 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  validate:
+    name: 'Validate'
+    runs-on: ubuntu-latest
+    if: github.repository == 'strapi/strapi'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Monorepo install
+        uses: ./.github/actions/yarn-nm-install
+      - name: Monorepo build
+        uses: ./.github/actions/run-build
+      - name: Run Vitest unit smoke
+        run: yarn test:unit:vitest
+
   publish:
     name: 'Publish'
+    needs: validate
     runs-on: ubuntu-latest
     if: github.repository == 'strapi/strapi'
     steps:


### PR DESCRIPTION
## What does it do?

Adds a `validate` job to the nightly release workflow and makes the `publish` job depend on it. The validation job runs on Node 24, installs the monorepo, builds the monorepo, and runs the Vitest unit smoke suite before nightly packages can be published.

## Why is it needed?

The scheduled nightly workflow currently installs dependencies and publishes `next` packages without any build or test gate. If `develop` is broken when the cron runs, the broken packages can be published automatically.

## How to test it?

```bash
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/nightly.yml'); puts 'yaml ok'"\nGOBIN=/tmp/strapi-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest\n/tmp/strapi-bin/actionlint .github/workflows/nightly.yml\ngit diff --check\n```\n\nI also tried `yarn prettier .github/workflows/nightly.yml --check`, but this fresh clone does not have `node_modules` installed, so Yarn stops before running the script.\n\n## Related issue(s)/PR(s)\n\nFixes #26492

---
Fixes CPR-378