### PR TITLE
ci: use workflow token for QA checklist Claude action

### DIFF
--- a/.github/workflows/needs-qa-checklist.yml
+++ b/.github/workflows/needs-qa-checklist.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -26,6 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.PR_QA_ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
@@ -84,4 +84,4 @@ jobs:
             tied to files, behavior, or risks in the diff.
 
           claude_args: |
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api:*)"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"

--- a/.github/workflows/needs-qa-checklist.yml
+++ b/.github/workflows/needs-qa-checklist.yml
@@ -42,6 +42,9 @@ jobs:
             comment exists, update that comment instead of creating a duplicate. Identify the
             managed comment with this exact hidden marker:
             <!-- ai-generated-qa-checklist -->
+            Use `gh pr view --json comments` to find the managed comment. If it exists, update
+            that specific comment with:
+            `gh api repos/${{ github.repository }}/issues/comments/<comment_id> --method PATCH`.
 
             The comment must use this structure:
 
@@ -84,4 +87,4 @@ jobs:
             tied to files, behavior, or risks in the diff.
 
           claude_args: |
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api repos/${{ github.repository }}/issues/comments/*:*)"


### PR DESCRIPTION
### What does it do?

Updates the `needs-qa` checklist workflow to pass the GitHub Actions workflow token
directly to `anthropics/claude-code-action@v1` via `github_token`.

It also removes the unused `id-token: write` permission and narrows the Claude tool
allowlist by removing broad `gh api:*` access.

### Why is it needed?

The QA checklist workflow was failing before Claude could run because the action tried
to exchange a GitHub OIDC token for a Claude GitHub App token and received:

```text
401 Unauthorized - Invalid OIDC token
```

Using the scoped workflow token avoids that failing OIDC app-token exchange while
keeping the workflow limited to read-only repository access and PR comment writes.
