### PR TITLE
fix(admin): preserve fetch error bodies for text responses

### DIFF
--- a/packages/core/admin/admin/src/utils/getFetchClient.ts
+++ b/packages/core/admin/admin/src/utils/getFetchClient.ts
@@ -301,6 +301,20 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
   // Check if the url has a prepending slash, if not add a slash
   const normalizeUrl = (url: string) => (hasProtocol(url) ? url : addPrependingSlash(url));
 
+  const parseErrorResponse = async (response: Response): Promise<ErrorResponse | undefined> => {
+    try {
+      const result = await response.json();
+
+      if (result?.error) {
+        return { data: result };
+      }
+    } catch {
+      return undefined;
+    }
+
+    return undefined;
+  };
+
   // Add a response interceptor to return the response
   const responseInterceptor = async <TData = any>(
     response: Response,
@@ -309,7 +323,11 @@ const getFetchClient = (defaultOptions: FetchConfig = {}): FetchClient => {
   ): Promise<FetchResponse<TData>> => {
     if (responseType !== 'json') {
       if (!response.ok && !validateStatus?.(response.status)) {
-        const fetchError = new FetchError('Server Error');
+        const errorResponse = await parseErrorResponse(response);
+        const fetchError = new FetchError(
+          errorResponse?.data.error.message ?? 'Server Error',
+          errorResponse
+        );
         fetchError.status = response.status;
         throw fetchError;
       }

--- a/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
@@ -228,6 +228,62 @@ describe('getFetchClient', () => {
       });
     });
 
+    it('should preserve JSON API errors for text requests', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 400,
+          ok: false,
+          json: () =>
+            Promise.resolve({
+              data: null,
+              error: {
+                status: 400,
+                name: 'BadRequestError',
+                message: 'Type is required',
+                details: {},
+              },
+            }),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+
+      await expect(fetchClient.get('/api/export', { responseType: 'text' })).rejects.toMatchObject({
+        name: 'FetchError',
+        message: 'Type is required',
+        status: 400,
+        response: {
+          data: {
+            data: null,
+            error: {
+              status: 400,
+              name: 'BadRequestError',
+              message: 'Type is required',
+              details: {},
+            },
+          },
+        },
+      });
+    });
+
+    it('should fall back to a generic FetchError when a blob error response is not JSON', async () => {
+      (window.fetch as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 500,
+          ok: false,
+          json: () => Promise.reject(new SyntaxError('Unexpected token')),
+        })
+      );
+
+      const fetchClient = getFetchClient();
+
+      await expect(fetchClient.get('/api/export', { responseType: 'blob' })).rejects.toMatchObject({
+        name: 'FetchError',
+        message: 'Server Error',
+        status: 500,
+      });
+    });
+
     it('should not send Accept and Content-Type headers for blob requests', async () => {
       (window.fetch as jest.Mock).mockImplementationOnce(() =>
         Promise.resolve({


### PR DESCRIPTION
## What does it do?

Preserves structured JSON API errors when `getFetchClient().get()` is called with a non-JSON `responseType`, such as `text`, and the server returns an error response. Non-JSON success responses still use the requested parser, and non-JSON/non-parseable error bodies still fall back to the existing generic `FetchError`.

## Why is it needed?

When callers request text/blob/arrayBuffer data, the non-2xx path currently throws `FetchError: Server Error` without reading the server error body. That loses useful API messages like `BadRequestError: Type is required`, making it difficult for callers to show actionable feedback.

## How to test it?

```bash
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn install --immutable
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn workspace @strapi/admin-test-utils build
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn jest packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts --config jest.config.front.js --runInBand -t "preserve JSON API errors"
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn jest packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts --config jest.config.front.js --runInBand
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn prettier packages/core/admin/admin/src/utils/getFetchClient.ts packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts --check
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn eslint packages/core/admin/admin/src/utils/getFetchClient.ts packages/core/admin/admin/src/utils/tests/getFetchClient.test.ts
git diff --check
```

I also ran:

```bash
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn nx run-many --target=build --projects=@strapi/types,@strapi/utils,@strapi/admin-test-utils --nx-ignore-cycles
PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" yarn workspace @strapi/admin test:ts:front
```

The targeted dependency build passed. `test:ts:front` still fails on existing admin self-export/type issues such as `Cannot find module @strapi/admin/strapi-admin/ee` and widget prop test errors, not on this fetch-client change. The full `@strapi/admin` lint target has the same existing unresolved self-import errors; targeted eslint for the changed files passes.

## Related issue(s)/PR(s)

Fixes #26199

---
Fixes CPR-380