### PR TITLE
chore(mcp): clarify registration lifecycle and simplify error messages

### DIFF
--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -189,7 +189,7 @@ describe('MCP Service Integration', () => {
           auth: { policies: [{ action: 'test.action' }] },
           createHandler: jest.fn(),
         });
-      }).toThrow('[MCP] Tools must be registered before MCP server starts');
+      }).toThrow('[MCP] Cannot register tools after the MCP server has started.');
     });
   });
 

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -64,9 +64,7 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
 
     registerTool(tool: Modules.MCP.McpToolDefinition) {
       if (serverStatus !== 'idle') {
-        throw new Error(
-          '[MCP] Tools must be registered before MCP server starts. Register during plugin register().'
-        );
+        throw new Error('[MCP] Cannot register tools after the MCP server has started.');
       }
 
       toolDefinitions.define(tool);
@@ -74,18 +72,14 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
 
     registerPrompt(prompt) {
       if (serverStatus !== 'idle') {
-        throw new Error(
-          '[MCP] Prompts must be registered before MCP server starts. Register during plugin register().'
-        );
+        throw new Error('[MCP] Cannot register prompts after the MCP server has started.');
       }
       promptDefinitions.define(prompt);
     },
 
     registerResource(resource) {
       if (serverStatus !== 'idle') {
-        throw new Error(
-          '[MCP] Resources must be registered before MCP server starts. Register during plugin register().'
-        );
+        throw new Error('[MCP] Cannot register resources after the MCP server has started.');
       }
       resourceDefinitions.define(resource);
     },

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -180,7 +180,9 @@ export interface McpService {
 
   /**
    * Register a single MCP tool.
-   * Must be called during plugin register() phase, before MCP server starts.
+   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
+   * Prefer bootstrap() when a tool depends on synced content-types, permissions, or database state.
    * @throws Error if called after MCP server has started
    */
   registerTool<
@@ -224,7 +226,9 @@ export interface McpService {
 
   /**
    * Register a single MCP prompt.
-   * Must be called during plugin register() phase, before MCP server starts.
+   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
+   * Prefer bootstrap() when a prompt depends on synced content-types, permissions, or database state.
    * @throws Error if called after MCP server has started
    */
   registerPrompt<
@@ -258,7 +262,9 @@ export interface McpService {
 
   /**
    * Register a single MCP resource.
-   * Must be called during plugin register() phase, before MCP server starts.
+   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
+   * Prefer bootstrap() when a resource depends on synced content-types, permissions, or database state.
    * @throws Error if called after MCP server has started
    */
   registerResource<Name extends string>(resource: {


### PR DESCRIPTION
### What does it do?

- Simplifies error messages thrown by `registerTool`, `registerPrompt`, and `registerResource` when called after the MCP server has started — removes the prescriptive "Register during plugin register()" hint from the thrown error.
- Expands JSDoc comments on all three `McpService` registration methods to clarify that registration is valid in both `register()` and `bootstrap()` phases, and recommends `bootstrap()` when the registration depends on synced content-types, permissions, or database state.
- Updates the integration test to match the new error message.

### Why is it needed?

The previous error messages and docs were too narrow: they told plugin authors to register MCP tools only during `register()`, but `bootstrap()` is equally valid (and preferred when the tool depends on initialized database or permission state). This led to confusion for plugin authors choosing the right lifecycle hook.

### How to test it?

1. Write a plugin that calls `strapi.ai.mcp.registerTool(...)` after `strapi.ai.mcp.start()` has run.
2. Confirm the error message reads `[MCP] Cannot register tools after the MCP server has started.`
3. Run the integration test suite: `yarn test packages/core/core/src/services/mcp/__tests__/service-integration.test.ts`

### Related issue(s)/PR(s)

- ø
