### PR TITLE
fix(content-manager): use ReadonlyArray for layout prop and fix Repeatable test fixture

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/Input.tsx
@@ -25,7 +25,7 @@ interface ComponentInputProps
    * We need layout to come from the props, and not via a hook, because Content History needs
    * a way to modify the normal component layout to add hidden fields.
    */
-  layout: EditFieldLayout[][];
+  layout: ReadonlyArray<ReadonlyArray<EditFieldLayout>>;
 }
 
 const ComponentInput = ({

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/tests/Repeatable.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Component/tests/Repeatable.test.tsx
@@ -3,7 +3,7 @@ import { render as renderRTL, screen } from '@tests/utils';
 import { Route, Routes } from 'react-router-dom';
 
 import { ComponentProvider } from '../../ComponentContext';
-import { RepeatableComponent } from '../Repeatable';
+import { RepeatableComponent, RepeatableComponentProps } from '../Repeatable';
 
 const FIELD_NAME = 'repeatableComponent';
 
@@ -57,12 +57,22 @@ describe('RepeatableComponent', () => {
       repeatable: true,
     },
     disabled: false,
-    layout: [[{ name: 'name', label: 'name', type: 'string', size: 12 }]],
+    layout: [
+      [
+        {
+          attribute: { type: 'string' },
+          name: 'name',
+          label: 'name',
+          type: 'string',
+          size: 12,
+        },
+      ],
+    ],
     mainField: { name: 'name', type: 'string' },
     name: FIELD_NAME,
     type: 'component',
     children: () => 'INPUTS',
-  } as const;
+  } satisfies RepeatableComponentProps;
 
   const render = (initialFormValues: Record<string, unknown>) =>
     renderRTL(


### PR DESCRIPTION
### What does it do?

- Changes the `layout` prop type in `ComponentInputProps` from `EditFieldLayout[][]` to `ReadonlyArray<ReadonlyArray<EditFieldLayout>>` to accept readonly arrays.
- Updates the `Repeatable.test.tsx` fixture to use `satisfies RepeatableComponentProps` instead of `as const`, and adds the missing `attribute` field to match the full `EditFieldLayout` shape.

### Why is it needed?

The previous `EditFieldLayout[][]` type rejected readonly array sources, causing type errors when passing immutable data. The test fixture was also incomplete — missing the `attribute` field — and relied on `as const` instead of a proper type assertion, hiding shape mismatches.

### How to test it?

Run the content-manager unit tests:
```
yarn workspace @strapi/content-manager test -- --testPathPattern="Repeatable"
```
Verify no TypeScript errors in `Input.tsx` and `Repeatable.test.tsx`.

### Related issue(s)/PR(s)

- #26421
