### PR TITLE
chore: update .gitignore for AI tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,10 +154,19 @@ tests/cli/.env
 ############################
 # AI tools
 ############################
+.brain
+.brain.*
+
+# Claude
 CLAUDE.local.md
-.claude
-.agents/local-skills
-.agents/local-state
+.claude/
+
+# Cursor
+.cursor/
+!.cursor/worktrees.json
+
+# Codex
+.agents/
 
 ############################
 # Strapi


### PR DESCRIPTION
### What does it do?

Reorganizes the AI tools section in `.gitignore` by grouping entries per tool.

### Why is it needed?

The previous ignore rules were incomplete and unorganized, leaving some AI tooling directories and files untracked or ambiguously handled across different tools used in the project.

### How to test it?

Verify that `.claude/`, `.cursor/` (except `worktrees.json`), `.agents/`, and `.brain` are ignored by git while `.cursor/worktrees.json` remains tracked.

### Related issue(s)/PR(s)

- impacts #26431
- impacts #26428
