### PR TITLE
chore: normalize prettier formatting and extend .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,9 +3,13 @@ test-apps
 dist
 build
 .strapi
+.yarn
 /.nx/cache
 /.nx/workspace-data
 # Strapi DTS dump fixtures: entire per-fixture dirs (JSONL, metadata.json, assets/metadata, assets/uploads, …)
 tests/e2e/data/**
 # Local DTS export trees (e.g. examples/complex/tmp-dts-export) — same layout; avoid Prettier EOF/newline churn
 **/tmp-dts-export/**
+/docs/.docusaurus
+/docs/docs/exports
+/packages/generators/generators/src/templates/**/*.hbs

--- a/docs/docs/docs/01-core/strapi/commands/01-build.md
+++ b/docs/docs/docs/01-core/strapi/commands/01-build.md
@@ -124,7 +124,7 @@ interface BuildContext {
 
 ### Static Files
 
-The next step is to create a `runtime` folder in the root of the strapi project, a generic name `.strapi` is used and the build specifically uses a subfolder called `client`. This leaves more space for us to expand as and when we require it. We only generate two files for this – an `index.html` which is a static rendered React Component from the `@strapi/admin` package (DefaultDocument) & an `entry.js` file which calls the `renderAdmin` function & provides a mount point & plugin object.
+The next step is to create a `runtime` folder in the root of the strapi project, a generic name `.strapi` is used and the build specifically uses a subfolder called `client`. This leaves more space for us to expand as and when we require it. We only generate two files for this – an `index.html` which is a static rendered React Component from the `@strapi/admin` package (DefaultDocument) & an `app.js` file which calls the `renderAdmin` function & provides a mount point & plugin object.
 
 ### Bundling
 

--- a/packages/plugins/color-picker/rollup.config.mjs
+++ b/packages/plugins/color-picker/rollup.config.mjs
@@ -1,3 +1,3 @@
 import { basePluginConfig } from '../../../rollup.utils.mjs';
 
-export default basePluginConfig()
+export default basePluginConfig();

--- a/packages/plugins/documentation/server/src/public/index.html
+++ b/packages/plugins/documentation/server/src/public/index.html
@@ -1,4 +1,4 @@
-<!-- HTML for static distribution bundle build --><!DOCTYPE html>
+<!-- HTML for static distribution bundle build --><!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/plugins/documentation/server/src/public/login.html
+++ b/packages/plugins/documentation/server/src/public/login.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <title>Login - Documentation</title>

--- a/packages/plugins/i18n/rollup.config.mjs
+++ b/packages/plugins/i18n/rollup.config.mjs
@@ -1,3 +1,3 @@
 import { basePluginConfig } from '../../../rollup.utils.mjs';
 
-export default basePluginConfig()
+export default basePluginConfig();

--- a/packages/plugins/users-permissions/rollup.config.mjs
+++ b/packages/plugins/users-permissions/rollup.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from 'rollup';
-import {  baseConfig } from '../../../rollup.utils.mjs';
+import { baseConfig } from '../../../rollup.utils.mjs';
 
 export default defineConfig([
   baseConfig({
@@ -11,9 +11,9 @@ export default defineConfig([
   }),
   baseConfig({
     input: {
-      index: './server/index.js'
+      index: './server/index.js',
     },
     rootDir: './server',
     outDir: './dist/server',
-  })
+  }),
 ]);

--- a/scripts/open-api/public/index.html
+++ b/scripts/open-api/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
### What does it do?

Housekeeping changes, no runtime behaviour change:

- **Prettier formatting** on files that drifted from the repo style:
  - `packages/plugins/color-picker/rollup.config.mjs`, `packages/plugins/i18n/rollup.config.mjs`, `packages/plugins/users-permissions/rollup.config.mjs` — add trailing/terminating semicolons and collapse a double space in an import.
  - `packages/plugins/documentation/server/src/public/{index,login}.html`, `scripts/open-api/public/index.html` — lowercase `<!doctype html>` per Prettier's HTML rule.
- **`.prettierignore`** — ignore generated/vendored trees so they stop producing formatting churn: `.yarn`, `/docs/.docusaurus`, `/docs/docs/exports`, and `packages/generators/generators/src/templates/**/*.hbs`.
- **Docs typo** in `docs/docs/docs/01-core/strapi/commands/01-build.md` — the build emits an `app.js` entry file, not `entry.js`. Confirmed against `packages/core/strapi/src/node/staticFiles.ts` (writes `app.js`) and `create-build-context.ts`.

### Why is it needed?

The listed files were inconsistent with what `prettier --write` produces, so they surfaced as noise in unrelated diffs. The `.prettierignore` additions cover generated output (Docusaurus build, DTS exports, Handlebars generator templates) and the Yarn cache, which should never be reformatted. The docs reference to `entry.js` was simply wrong.

### How to test it?

```sh
yarn prettier --check "packages/plugins/{color-picker,i18n,users-permissions}/rollup.config.mjs" "packages/plugins/documentation/server/src/public/*.html" "scripts/open-api/public/index.html"
```

Should report no formatting issues. For the docs fix, grep the build source to confirm the runtime entry file is `app.js`.

### Related issue(s)/PR(s)

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Fixes CPR-411