### PR TITLE
fix(content-manager): preserve parent changes when creating relations

### DIFF
--- a/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/DocumentActions.tsx
@@ -128,42 +128,50 @@ const connectRelationToParent = (
   data: Create.Response['data'] | Publish.Response['data'],
   fieldToConnectUID?: string
 ) => {
+  const relationToConnect = {
+    id: data.documentId,
+    documentId: data.documentId,
+    locale: data.locale,
+  };
   /*
    * Check if the fieldToConnect is already present in the parentDataToUpdate.
    * This happens in particular when in the parentDocument you have created
    * a new component without saving.
    */
   const isFieldPresent = !!get(parentDataToUpdate, fieldToConnect);
+  const fieldValue = get(parentDataToUpdate, fieldToConnect);
+  const existingConnect = Array.isArray(fieldValue?.connect) ? fieldValue.connect : [];
+  const connect = existingConnect.some(
+    (relation) =>
+      relation.documentId === relationToConnect.documentId &&
+      relation.locale === relationToConnect.locale
+  )
+    ? existingConnect
+    : [...existingConnect, relationToConnect];
   const fieldToConnectPath = isFieldPresent
     ? fieldToConnect
     : // Compute the path to the parent object
       fieldToConnect.split('.').slice(0, -1).join('.');
   const fieldToConnectValue = isFieldPresent
     ? {
-        connect: [
-          {
-            id: data.documentId,
-            documentId: data.documentId,
-            locale: data.locale,
-          },
-        ],
+        ...fieldValue,
+        connect,
       }
     : {
         [fieldToConnect.split('.').pop()!]: {
-          connect: [
-            {
-              id: data.documentId,
-              documentId: data.documentId,
-              locale: data.locale,
-            },
-          ],
+          connect,
           disconnect: [],
         },
         // In case the object was not present you need to pass the componentUID of the parent document
         __component: fieldToConnectUID,
       };
+
+  if (isFieldPresent) {
+    return set(structuredClone(parentDataToUpdate), fieldToConnect, fieldToConnectValue);
+  }
+
   const objectToConnect = set({}, fieldToConnectPath, fieldToConnectValue);
-  return merge(parentDataToUpdate, objectToConnect);
+  return merge({}, parentDataToUpdate, objectToConnect);
 };
 
 const DocumentActions = ({ actions }: DocumentActionsProps) => {
@@ -572,6 +580,25 @@ const transformData = (data: Record<string, any>): any => {
   return data;
 };
 
+const prepareParentDataForRelationUpdate = (
+  parentFormValues: AnyData | undefined,
+  fallbackParentFormValues: AnyData | undefined,
+  options: Parameters<typeof handleInvisibleAttributes>[1]
+) => {
+  const parentDataToUpdate = parentFormValues ?? fallbackParentFormValues;
+
+  if (!parentDataToUpdate) {
+    return parentDataToUpdate;
+  }
+
+  const { data } = handleInvisibleAttributes(transformData(parentDataToUpdate), {
+    ...options,
+    initialValues: fallbackParentFormValues,
+  });
+
+  return data;
+};
+
 /* -------------------------------------------------------------------------------------------------
  * DocumentActionComponents
  * -----------------------------------------------------------------------------------------------*/
@@ -640,6 +667,11 @@ const PublishAction: DocumentActionComponent = ({
   const documentHistory = useRelationModal(
     'PublishAction',
     (state) => state.state.documentHistory,
+    false
+  );
+  const parentFormValues = useRelationModal(
+    'PublishAction',
+    (state) => state.state.parentFormValues,
     false
   );
   const rootDocumentMeta = useRelationModal('PublishAction', (state) => state.rootDocumentMeta);
@@ -857,10 +889,18 @@ const PublishAction: DocumentActionComponent = ({
             (parentDocumentMetaToUpdate.documentId ||
               parentDocumentMetaToUpdate.collectionType === SINGLE_TYPES)
           ) {
-            const parentDataToUpdate =
+            const fallbackParentFormValues =
               parentDocumentMetaToUpdate.collectionType === SINGLE_TYPES
                 ? getInitialFormValues()
                 : parentDocumentData.getInitialFormValues();
+            const parentDataToUpdate = prepareParentDataForRelationUpdate(
+              parentFormValues,
+              fallbackParentFormValues,
+              {
+                schema: parentDocumentData.schema,
+                components: parentDocumentData.components,
+              }
+            );
             const metaDocumentToUpdate = documentHistory.at(-2) ?? rootDocumentMeta;
 
             const dataToUpdate = connectRelationToParent(
@@ -1069,6 +1109,11 @@ const UpdateAction: DocumentActionComponent = ({
     (state) => state.state.documentHistory,
     false
   );
+  const parentFormValues = useRelationModal(
+    'UpdateAction',
+    (state) => state.state.parentFormValues,
+    false
+  );
   const rootDocumentMeta = useRelationModal('UpdateAction', (state) => state.rootDocumentMeta);
   const fromRelationModal = relationContext != undefined;
 
@@ -1208,10 +1253,18 @@ const UpdateAction: DocumentActionComponent = ({
               (parentDocumentMetaToUpdate.documentId ||
                 parentDocumentMetaToUpdate.collectionType === SINGLE_TYPES)
             ) {
-              const parentDataToUpdate =
+              const fallbackParentFormValues =
                 parentDocumentMetaToUpdate.collectionType === SINGLE_TYPES
                   ? getInitialFormValues()
                   : parentDocumentData.getInitialFormValues();
+              const parentDataToUpdate = prepareParentDataForRelationUpdate(
+                parentFormValues,
+                fallbackParentFormValues,
+                {
+                  schema: parentDocumentData.schema,
+                  components: parentDocumentData.components,
+                }
+              );
 
               const dataToUpdate = connectRelationToParent(
                 parentDataToUpdate,

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/RelationModal.tsx
@@ -42,6 +42,7 @@ import { ComponentProvider } from '../ComponentContext';
 
 import type { RelationOpenMode } from '../../../../../../../shared/contracts/content-types';
 import type { ContentManagerPlugin, DocumentActionProps } from '../../../../../content-manager';
+import type { AnyData } from '../../../utils/data';
 
 export function getCollectionType(url: string) {
   const regex = new RegExp(`(${COLLECTION_TYPES}|${SINGLE_TYPES})`);
@@ -81,6 +82,7 @@ interface State {
   hasUnsavedChanges: boolean;
   fieldToConnect?: string;
   fieldToConnectUID?: string;
+  parentFormValues?: AnyData;
 }
 
 type Action =
@@ -91,6 +93,7 @@ type Action =
         shouldBypassConfirmation: boolean;
         fieldToConnect?: string;
         fieldToConnectUID?: string;
+        parentFormValues?: AnyData;
       };
     }
   | {
@@ -107,6 +110,7 @@ type Action =
         shouldBypassConfirmation: boolean;
         fieldToConnect?: string;
         fieldToConnectUID?: string;
+        parentFormValues?: AnyData;
       };
     }
   | {
@@ -130,6 +134,7 @@ function reducer(state: State, action: Action): State {
           confirmDialogIntent: action.payload.document,
           fieldToConnect: action.payload.fieldToConnect,
           fieldToConnectUID: action.payload.fieldToConnectUID,
+          parentFormValues: action.payload.parentFormValues,
         };
       }
 
@@ -146,6 +151,7 @@ function reducer(state: State, action: Action): State {
         isModalOpen: true,
         fieldToConnect: hasToResetDocumentHistory ? undefined : action.payload.fieldToConnect,
         fieldToConnectUID: hasToResetDocumentHistory ? undefined : action.payload.fieldToConnectUID,
+        parentFormValues: hasToResetDocumentHistory ? undefined : action.payload.parentFormValues,
       };
     case 'GO_BACK':
       if (state.hasUnsavedChanges && !action.payload.shouldBypassConfirmation) {
@@ -180,6 +186,7 @@ function reducer(state: State, action: Action): State {
         isModalOpen: true,
         fieldToConnect: undefined,
         fieldToConnectUID: undefined,
+        parentFormValues: undefined,
       };
     case 'CANCEL_CONFIRM_DIALOG':
       return {
@@ -197,6 +204,9 @@ function reducer(state: State, action: Action): State {
         confirmDialogIntent: null,
         hasUnsavedChanges: false,
         isModalOpen: false,
+        fieldToConnect: undefined,
+        fieldToConnectUID: undefined,
+        parentFormValues: undefined,
       };
     case 'SET_HAS_UNSAVED_CHANGES':
       return {
@@ -524,7 +534,13 @@ const RelationModalBody = () => {
     } else if ('documentId' in state.confirmDialogIntent) {
       dispatch({
         type: 'GO_TO_RELATION',
-        payload: { document: state.confirmDialogIntent, shouldBypassConfirmation: true },
+        payload: {
+          document: state.confirmDialogIntent,
+          shouldBypassConfirmation: true,
+          fieldToConnect: state.fieldToConnect,
+          fieldToConnectUID: state.fieldToConnectUID,
+          parentFormValues: state.parentFormValues,
+        },
       });
     }
   };

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/Relations.tsx
@@ -28,6 +28,7 @@ import {
 import { Cross, Drag, ArrowClockwise, Link as LinkIcon, Plus, WarningCircle } from '@strapi/icons';
 import { generateNKeysBetween } from 'fractional-indexing';
 import pipe from 'lodash/fp/pipe';
+import set from 'lodash/set';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { useIntl } from 'react-intl';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
@@ -697,6 +698,16 @@ const RelationModalWithContext = ({
   const canCreate = useDocumentRBAC('RelationModalWrapper', (state) => state.canCreate);
   const fieldRef = useFocusInputField<HTMLInputElement>(name);
   const componentUID = useComponent('RelationsField', (state) => state.uid);
+  const getParentFormValues = useForm('RelationModalWrapper', (state) => state.getValues);
+  const getParentFormValuesWithCurrentRelation = () => {
+    const parentFormValues = structuredClone(getParentFormValues());
+
+    if (fieldValue) {
+      set(parentFormValues, name, fieldValue);
+    }
+
+    return parentFormValues;
+  };
 
   const handleLoadMore = () => {
     if (!data || !data.pagination) {
@@ -737,6 +748,7 @@ const RelationModalWithContext = ({
                   shouldBypassConfirmation: false,
                   fieldToConnect: name,
                   fieldToConnectUID: componentUID,
+                  parentFormValues: getParentFormValuesWithCurrentRelation(),
                 },
               });
             }

--- a/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/EditView/components/FormInputs/Relations/tests/RelationModal.test.tsx
@@ -19,6 +19,15 @@ describe('Document Modal Reducer', () => {
     collectionType: 'collection-types',
     params: { locale: 'en' },
   };
+  const parentFormValues = {
+    blocks: [
+      {
+        __component: 'page-blocks.product-carousel',
+        __temp_key__: 'parent-component-key',
+        title: 'Summer shoes',
+      },
+    ],
+  };
 
   // Initial state for most tests
   const initialState: State = {
@@ -114,6 +123,112 @@ describe('Document Modal Reducer', () => {
         confirmDialogIntent: null,
         isModalOpen: true,
         hasUnsavedChanges: true,
+      });
+    });
+
+    it('should store parent form values when opening a relation', () => {
+      const action: Action = {
+        type: 'GO_TO_RELATION',
+        payload: {
+          document: doc3,
+          shouldBypassConfirmation: false,
+          fieldToConnect: 'blocks.0.products',
+          fieldToConnectUID: 'page-blocks.product-carousel',
+          parentFormValues,
+        },
+      };
+
+      const result = reducer(stateWithHistory, action);
+
+      expect(result).toEqual({
+        ...stateWithHistory,
+        documentHistory: [doc1, doc2, doc3],
+        confirmDialogIntent: null,
+        fieldToConnect: 'blocks.0.products',
+        fieldToConnectUID: 'page-blocks.product-carousel',
+        parentFormValues,
+      });
+    });
+
+    it('should preserve parent form values while waiting for confirmation', () => {
+      const action: Action = {
+        type: 'GO_TO_RELATION',
+        payload: {
+          document: doc3,
+          shouldBypassConfirmation: false,
+          fieldToConnect: 'blocks.0.products',
+          fieldToConnectUID: 'page-blocks.product-carousel',
+          parentFormValues,
+        },
+      };
+
+      const result = reducer(stateWithUnsavedChanges, action);
+
+      expect(result).toEqual({
+        ...stateWithUnsavedChanges,
+        confirmDialogIntent: doc3,
+        fieldToConnect: 'blocks.0.products',
+        fieldToConnectUID: 'page-blocks.product-carousel',
+        parentFormValues,
+      });
+    });
+
+    it('should preserve parent form values when bypassing confirmation', () => {
+      const stateWithDialog: State = {
+        ...stateWithUnsavedChanges,
+        confirmDialogIntent: doc3,
+        fieldToConnect: 'blocks.0.products',
+        fieldToConnectUID: 'page-blocks.product-carousel',
+        parentFormValues,
+      };
+      const action: Action = {
+        type: 'GO_TO_RELATION',
+        payload: {
+          document: doc3,
+          shouldBypassConfirmation: true,
+          fieldToConnect: stateWithDialog.fieldToConnect,
+          fieldToConnectUID: stateWithDialog.fieldToConnectUID,
+          parentFormValues: stateWithDialog.parentFormValues,
+        },
+      };
+
+      const result = reducer(stateWithDialog, action);
+
+      expect(result).toEqual({
+        ...stateWithDialog,
+        documentHistory: [doc1, doc2, doc3],
+        confirmDialogIntent: null,
+        isModalOpen: true,
+      });
+    });
+  });
+
+  describe('GO_TO_CREATED_RELATION action', () => {
+    it('should clear parent form values after connecting the created relation', () => {
+      const action: Action = {
+        type: 'GO_TO_CREATED_RELATION',
+        payload: {
+          document: doc3,
+          shouldBypassConfirmation: true,
+        },
+      };
+
+      const result = reducer(
+        {
+          ...stateWithHistory,
+          fieldToConnect: 'blocks.0.products',
+          fieldToConnectUID: 'page-blocks.product-carousel',
+          parentFormValues,
+        },
+        action
+      );
+
+      expect(result).toEqual({
+        ...stateWithHistory,
+        documentHistory: [doc1, doc3],
+        fieldToConnect: undefined,
+        fieldToConnectUID: undefined,
+        parentFormValues: undefined,
       });
     });
   });
@@ -267,6 +382,33 @@ describe('Document Modal Reducer', () => {
         confirmDialogIntent: null,
         isModalOpen: false,
         hasUnsavedChanges: false,
+      });
+    });
+
+    it('should clear parent form values when closing the modal', () => {
+      const action: Action = {
+        type: 'CLOSE_MODAL',
+        payload: {
+          shouldBypassConfirmation: true,
+        },
+      };
+
+      const result = reducer(
+        {
+          ...stateWithUnsavedChanges,
+          fieldToConnect: 'blocks.0.products',
+          fieldToConnectUID: 'page-blocks.product-carousel',
+          parentFormValues,
+        },
+        action
+      );
+
+      expect(result).toEqual({
+        documentHistory: [],
+        confirmDialogIntent: null,
+        isModalOpen: false,
+        hasUnsavedChanges: false,
+        parentFormValues: undefined,
       });
     });
   });

--- a/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-in-new-component-and-save.spec.ts
+++ b/tests/e2e/tests/content-manager/relations-on-the-fly/create-relation-in-new-component-and-save.spec.ts
@@ -1,7 +1,82 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { login } from '../../../../utils/login';
 import { resetDatabaseAndImportDataFromPath } from '../../../../utils/dts-import';
 import { clickAndWait } from '../../../../utils/shared';
+
+const createProductInNewCarousel = async (
+  page: Page,
+  {
+    action,
+    carouselTitle,
+    productName,
+    existingProductName,
+  }: {
+    action: 'Save' | 'Publish';
+    carouselTitle: string;
+    productName: string;
+    existingProductName?: string;
+  }
+) => {
+  await login({ page });
+  await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
+  // Step 1. Got to Shop single-type
+  await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
+  // Step 2. Add a new component
+  await clickAndWait(page, page.getByRole('button', { name: 'Add a component to content' }));
+  // Step 3. Choose the new product carousel component and open its toggle
+  await clickAndWait(page, page.getByRole('button', { name: 'Product carousel' }).first());
+
+  const productCarousel = page.getByRole('region', { name: /Product carousel/ });
+  const carouselTitleInput = productCarousel.getByRole('textbox', { name: 'title' });
+  await carouselTitleInput.fill(carouselTitle);
+  await expect(carouselTitleInput).toHaveValue(carouselTitle);
+
+  // Step 4. Select a product
+  await page.getByRole('combobox', { name: 'products' }).click();
+  if (existingProductName) {
+    await page.getByRole('option', { name: existingProductName }).click();
+    await expect(page.getByRole('button', { name: existingProductName })).toBeVisible();
+    await page.getByRole('combobox', { name: 'products' }).click();
+  }
+  // Step 5. Open the relation modal
+  await page.getByRole('option', { name: 'Create a relation' }).click();
+  await expect(page.getByText('Create a relation')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+
+  // Change the name of the article
+  const name = page.getByRole('textbox', { name: 'name' });
+  await name.fill(productName);
+
+  // Step 6. Save or publish the related document
+  await clickAndWait(page, page.getByRole('button', { name: action }));
+  await expect(name).toHaveValue(productName);
+  await expect(
+    page.getByRole('status', { name: action === 'Save' ? 'Draft' : 'Published' }).first()
+  ).toBeVisible();
+
+  // Step 7. Close the relation modal to see the updated relation on the root document
+  await expect(page.getByText('Edit a relation')).toBeVisible();
+  await clickAndWait(page, page.getByRole('button', { name: 'Close modal' }));
+
+  // Wait for the button to be visible with a more specific selector
+  if (existingProductName) {
+    await expect(page.getByRole('button', { name: existingProductName })).toBeVisible();
+  }
+  await expect(page.getByRole('button', { name: productName })).toBeVisible();
+  await expect(carouselTitleInput).toHaveValue(carouselTitle);
+
+  await page.reload();
+  const productCarouselToggle = page.getByRole('button', {
+    name: new RegExp(`Product carousel - ${carouselTitle}`),
+  });
+  await expect(productCarouselToggle).toBeVisible();
+
+  if (existingProductName) {
+    await clickAndWait(page, productCarouselToggle);
+    await expect(page.getByRole('button', { name: existingProductName })).toBeVisible();
+    await expect(page.getByRole('button', { name: productName })).toBeVisible();
+  }
+};
 
 test.describe('Relations on the fly - Create a Relation inside a new component and Save', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,37 +85,29 @@ test.describe('Relations on the fly - Create a Relation inside a new component a
   });
 
   test('I want to create a relation inside a new component, and save', async ({ page }) => {
-    // Step 0. Login as admin
-    await login({ page });
-    await clickAndWait(page, page.getByRole('link', { name: 'Content Manager' }));
-    // Step 1. Got to Shop single-type
-    await clickAndWait(page, page.getByRole('link', { name: 'Shop' }));
-    // Step 2. Add a new component
-    await clickAndWait(page, page.getByRole('button', { name: 'Add a component to content' }));
-    // Step 3. Choose the new product carousel component and open its toggle
-    await clickAndWait(page, page.getByRole('button', { name: 'Product carousel' }).first());
+    await createProductInNewCarousel(page, {
+      action: 'Save',
+      carouselTitle: 'Summer shoes',
+      productName: 'Nike Zoom Kd Iv Gold C800',
+    });
+  });
 
-    // Step 4. Select a product
-    await page.getByRole('combobox', { name: 'products' }).click();
-    // Step 5. Open the relation modal
-    await page.getByRole('option', { name: 'Create a relation' }).click();
-    await expect(page.getByText('Create a relation')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Untitled' })).toBeVisible();
+  test('I want to create a relation inside a new component, and publish', async ({ page }) => {
+    await createProductInNewCarousel(page, {
+      action: 'Publish',
+      carouselTitle: 'Winter boots',
+      productName: 'Nike Zoom Kd Iv Gold C801',
+    });
+  });
 
-    // Change the name of the article
-    const name = page.getByRole('textbox', { name: 'name' });
-    await name.fill('Nike Zoom Kd Iv Gold C800');
-
-    // Step 6. Save the related document as draft
-    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
-    await expect(name).toHaveValue('Nike Zoom Kd Iv Gold C800');
-    await expect(page.getByRole('status', { name: 'Draft' }).first()).toBeVisible();
-
-    // Step 7. Close the relation modal to see the updated relation on the root document
-    await expect(page.getByText('Edit a relation')).toBeVisible();
-    await clickAndWait(page, page.getByRole('button', { name: 'Close modal' }));
-
-    // Wait for the button to be visible with a more specific selector
-    await expect(page.getByRole('button', { name: 'Nike Zoom Kd Iv Gold C800' })).toBeVisible();
+  test('I want to keep a selected relation when creating another relation inside a new component', async ({
+    page,
+  }) => {
+    await createProductInNewCarousel(page, {
+      action: 'Save',
+      carouselTitle: 'Sale picks',
+      productName: 'Nike Zoom Kd Iv Gold C802',
+      existingProductName: 'Nike Mens 23/24 Away Stadium Jersey',
+    });
   });
 });


### PR DESCRIPTION
Fixes #24933.

## What does it do?

Fixes relation creation on the fly from a newly added dynamic-zone component so unsaved parent form changes are preserved when the created relation is connected back to the parent document.

The parent update now uses the current parent form values captured before opening the relation modal, then connects the created relation without dropping existing pending relation changes in the same field.

A regression e2e test was added for creating a relation from a newly added `Product carousel` component, including the case where an existing relation is already selected in the same field.

## Why is it needed?

When creating a relation on the fly inside a new component, the parent document update was based on initial form values. This could discard unsaved edits made to the new component before the relation modal was opened.

## How to test it?

- Add a new `Product carousel` component to the `Shop` single type.
- Fill the component title.
- Create a product relation on the fly from the component's `products` relation field.
- Save or publish the created product.
- Close the relation modal.
- Reload the parent document and confirm the component title and relation are still present.


---
Fixes CPR-384