### PR TITLE
fix(content-manager): widgets show error when role has no access to mainfield of ct

### DIFF
--- a/packages/core/content-manager/server/src/homepage/services/__tests__/homepage-query-utils.test.ts
+++ b/packages/core/content-manager/server/src/homepage/services/__tests__/homepage-query-utils.test.ts
@@ -1,0 +1,120 @@
+import type { Schema } from '@strapi/types';
+
+import {
+  buildHomepageQueryFields,
+  compactSanitizedFields,
+  FALLBACK_MAIN_FIELD,
+  resolveReadableMainField,
+  resolveTitleField,
+  type HomepagePermissionChecker,
+} from '../homepage-query-utils';
+
+const localizedArticleContentType = {
+  uid: 'api::article.article',
+  options: { draftAndPublish: true },
+  pluginOptions: { i18n: { localized: true } },
+  attributes: {
+    title: { type: 'string' },
+    price: { type: 'integer' },
+  },
+} as unknown as Schema.ContentType;
+
+const simpleContentType = {
+  uid: 'api::page.page',
+  options: { draftAndPublish: false },
+  attributes: {
+    slug: { type: 'string' },
+  },
+} as unknown as Schema.ContentType;
+
+const createPermissionChecker = (unreadableFields: string[] = []): HomepagePermissionChecker => ({
+  cannot: {
+    read: (_entity, field) => unreadableFields.includes(field),
+  },
+});
+
+describe('Homepage query utils', () => {
+  describe('compactSanitizedFields', () => {
+    it('drops undefined and non-string entries left after admin field sanitization', () => {
+      expect(compactSanitizedFields(['documentId', 'updatedAt', undefined, 'title'])).toEqual([
+        'documentId',
+        'updatedAt',
+        'title',
+      ]);
+    });
+
+    it('returns undefined when fields is not a string array', () => {
+      expect(compactSanitizedFields(undefined)).toBeUndefined();
+      expect(compactSanitizedFields('title')).toBeUndefined();
+    });
+  });
+
+  describe('resolveReadableMainField', () => {
+    const configuration = { settings: { mainField: 'title' } };
+
+    it('falls back to documentId when the role cannot read the configured main field', () => {
+      expect(
+        resolveReadableMainField(
+          localizedArticleContentType,
+          configuration,
+          createPermissionChecker(['title'])
+        )
+      ).toBe(FALLBACK_MAIN_FIELD);
+    });
+
+    it('keeps the configured main field when the role can read it', () => {
+      expect(
+        resolveReadableMainField(
+          localizedArticleContentType,
+          configuration,
+          createPermissionChecker()
+        )
+      ).toBe('title');
+    });
+
+    it('uses the schema default main field when configuration is missing', () => {
+      expect(
+        resolveReadableMainField(localizedArticleContentType, undefined, createPermissionChecker())
+      ).toBe('title');
+    });
+  });
+
+  describe('buildHomepageQueryFields', () => {
+    it('requests base, status, and locale fields without duplicating documentId as main field', () => {
+      expect(buildHomepageQueryFields(localizedArticleContentType, FALLBACK_MAIN_FIELD)).toEqual([
+        'documentId',
+        'updatedAt',
+        'publishedAt',
+        'locale',
+      ]);
+    });
+
+    it('includes the readable main field for draft & publish localized content types', () => {
+      expect(buildHomepageQueryFields(localizedArticleContentType, 'title')).toEqual([
+        'documentId',
+        'updatedAt',
+        'publishedAt',
+        'title',
+        'locale',
+      ]);
+    });
+
+    it('requests only documentId, updatedAt, and main field for simple content types', () => {
+      expect(buildHomepageQueryFields(simpleContentType, 'slug')).toEqual([
+        'documentId',
+        'updatedAt',
+        'slug',
+      ]);
+    });
+  });
+
+  describe('resolveTitleField', () => {
+    it('falls back to documentId when sanitization removed the main field', () => {
+      expect(resolveTitleField('title', ['documentId', 'updatedAt'])).toBe(FALLBACK_MAIN_FIELD);
+    });
+
+    it('keeps the main field when it is still present after sanitization', () => {
+      expect(resolveTitleField('title', ['documentId', 'title'])).toBe('title');
+    });
+  });
+});

--- a/packages/core/content-manager/server/src/homepage/services/homepage-query-utils.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage-query-utils.ts
@@ -1,0 +1,78 @@
+import type { Schema } from '@strapi/types';
+import { contentTypes } from '@strapi/utils';
+
+import { getDefaultMainField } from '../../services/utils/configuration/attributes';
+
+export const FALLBACK_MAIN_FIELD = 'documentId';
+
+export type HomepagePermissionChecker = {
+  cannot: {
+    read: (entity: null, field: string) => boolean;
+  };
+};
+
+/**
+ * Removes invalid entries left in the fields array after permission sanitization.
+ */
+export const compactSanitizedFields = (fields: unknown): string[] | undefined => {
+  if (!Array.isArray(fields)) {
+    return undefined;
+  }
+
+  return fields.filter((field): field is string => typeof field === 'string');
+};
+
+/**
+ * Resolves the main field used for homepage widgets, falling back when the user cannot read it.
+ */
+export const resolveReadableMainField = (
+  contentType: Schema.ContentType,
+  configuration: { settings?: { mainField?: string } } | undefined,
+  permissionChecker: HomepagePermissionChecker
+): string => {
+  const candidateMainField = configuration?.settings?.mainField ?? getDefaultMainField(contentType);
+
+  if (permissionChecker.cannot.read(null, candidateMainField)) {
+    return FALLBACK_MAIN_FIELD;
+  }
+
+  return candidateMainField;
+};
+
+/**
+ * Builds the fields array requested before permission sanitization.
+ */
+export const buildHomepageQueryFields = (
+  contentType: Schema.ContentType,
+  mainField: string
+): string[] => {
+  const fields = [FALLBACK_MAIN_FIELD, 'updatedAt'];
+
+  if (contentTypes.hasDraftAndPublish(contentType)) {
+    fields.push('publishedAt');
+  }
+
+  if (mainField !== FALLBACK_MAIN_FIELD && !fields.includes(mainField)) {
+    fields.push(mainField);
+  }
+
+  if ((contentType.pluginOptions?.i18n as { localized?: boolean } | undefined)?.localized) {
+    fields.push('locale');
+  }
+
+  return fields;
+};
+
+/**
+ * Picks a main field that is present in the sanitized fields selection.
+ */
+export const resolveTitleField = (
+  mainField: string,
+  sanitizedFields: string[] | undefined
+): string => {
+  if (sanitizedFields?.includes(mainField)) {
+    return mainField;
+  }
+
+  return FALLBACK_MAIN_FIELD;
+};

--- a/packages/core/content-manager/server/src/homepage/services/homepage.ts
+++ b/packages/core/content-manager/server/src/homepage/services/homepage.ts
@@ -8,6 +8,13 @@ import type {
   RecentDocument,
 } from '../../../../shared/contracts/homepage';
 
+import {
+  buildHomepageQueryFields,
+  compactSanitizedFields,
+  resolveReadableMainField,
+  resolveTitleField,
+} from './homepage-query-utils';
+
 const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
   const MAX_DOCUMENTS = 4;
 
@@ -62,6 +69,13 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     uid: RecentDocument['contentTypeUid'];
   };
 
+  const permissionCheckerService = strapi.plugin('content-manager').service('permission-checker');
+  const getPermissionChecker = (uid: string) =>
+    permissionCheckerService.create({
+      userAbility: strapi.requestContext.get()?.state.userAbility,
+      model: uid,
+    });
+
   const getContentTypesMeta = (
     allowedContentTypeUids: RecentDocument['contentTypeUid'][],
     configurations: ContentTypeConfiguration[]
@@ -69,28 +83,17 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     return allowedContentTypeUids.map((uid) => {
       const configuration = configurations.find((config) => config.uid === uid);
       const contentType = strapi.contentType(uid);
-      const fields = ['documentId', 'updatedAt'];
-
-      // Add fields required to get the status if D&P is enabled
+      const mainField = resolveReadableMainField(
+        contentType,
+        configuration,
+        getPermissionChecker(uid)
+      );
+      const fields = buildHomepageQueryFields(contentType, mainField);
       const hasDraftAndPublish = contentTypes.hasDraftAndPublish(contentType);
-      if (hasDraftAndPublish) {
-        fields.push('publishedAt');
-      }
-
-      // Only add the main field if it's defined
-      if (configuration?.settings.mainField) {
-        fields.push(configuration.settings.mainField);
-      }
-
-      // Only add locale if it's localized
-      const isLocalized = (contentType.pluginOptions?.i18n as any)?.localized;
-      if (isLocalized) {
-        fields.push('locale');
-      }
 
       return {
         fields,
-        mainField: configuration!.settings.mainField,
+        mainField,
         contentType,
         hasDraftAndPublish,
         uid,
@@ -127,12 +130,27 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
     });
   };
 
-  const permissionCheckerService = strapi.plugin('content-manager').service('permission-checker');
-  const getPermissionChecker = (uid: string) =>
-    permissionCheckerService.create({
-      userAbility: strapi.requestContext.get()?.state.userAbility,
-      model: uid,
+  const sanitizeHomepageQuery = async (
+    meta: ContentTypeMeta,
+    additionalQueryParams?: Record<string, unknown>
+  ) => {
+    const permissionQuery = await getPermissionChecker(meta.uid).sanitizedQuery.read({
+      limit: MAX_DOCUMENTS,
+      fields: meta.fields,
+      ...additionalQueryParams,
+      locale: '*',
     });
+
+    const sanitizedFields = compactSanitizedFields(permissionQuery.fields);
+    if (sanitizedFields !== undefined) {
+      permissionQuery.fields = sanitizedFields;
+    }
+
+    return {
+      permissionQuery,
+      titleField: resolveTitleField(meta.mainField, sanitizedFields),
+    };
+  };
 
   return {
     async addStatusToDocuments(documents: RecentDocument[]): Promise<RecentDocument[]> {
@@ -183,17 +201,15 @@ const createHomepageService = ({ strapi }: { strapi: Core.Strapi }) => {
 
       const recentDocuments = await Promise.all(
         contentTypesMeta.map(async (meta) => {
-          const permissionQuery = await getPermissionChecker(meta.uid).sanitizedQuery.read({
-            limit: MAX_DOCUMENTS,
-            fields: meta.fields,
-            ...additionalQueryParams,
-            locale: '*',
-          });
+          const { permissionQuery, titleField } = await sanitizeHomepageQuery(
+            meta,
+            additionalQueryParams
+          );
 
           const docs = await strapi.documents(meta.uid).findMany(permissionQuery);
           const populate = additionalQueryParams?.populate as string[];
 
-          return formatDocuments(docs, meta, populate);
+          return formatDocuments(docs, { ...meta, mainField: titleField }, populate);
         })
       );
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?
If the main field of a content-type is unreadable (role doesn't have access to it, or other reasons...), the widgets fetch the document's id to display as a fallback instead of the main field.
Added:
* permission check at build time
* post-sanitization verification

### Why is it needed?
If a role has access to parts of a content-type but not its main field, the Widgets in the homepage show a message error.
**BEFORE**
https://github.com/user-attachments/assets/36a59053-2a6b-4f8b-965a-0a2446e404f1

**AFTER** 
https://github.com/user-attachments/assets/873b286f-0a70-4cc5-b8e6-7787579cd7ef

### How to test it?
* In the CTB, create a content type with a few fields.
* In the CM, create an entry for that content type. 
* In the Settings/Roles page, create another Role (different from Super Admin).
* In the Settings/Users page, create a new User with that new role.
* In the Settings/Roles page, modify the access of that role for the content type created previously, so that the main field isn't available for them.
* Log in to the Strapi dashboard with that new User and check that the homepage widgets show that new entry with the entry's documentId as the main field:
<img width="875" height="380" alt="Capture d’écran 2026-06-03 à 14 15 19" src="https://github.com/user-attachments/assets/790f711e-29ef-461b-86bd-b27ba9890b47" />