### PR TITLE
enhancement(admin): remove deploy-now widget in production mode

### DIFF
--- a/packages/core/admin/admin/src/StrapiApp.tsx
+++ b/packages/core/admin/admin/src/StrapiApp.tsx
@@ -327,6 +327,8 @@ class StrapiApp {
   getPlugin = (pluginId: PluginConfig['id']) => this.plugins[pluginId];
 
   async register(customRegister?: unknown) {
+    const { backendURL } = window.strapi;
+
     this.widgets.register([
       {
         icon: User,
@@ -362,19 +364,23 @@ class StrapiApp {
         id: 'key-statistics',
         roles: ['strapi-super-admin'],
       },
-      {
-        icon: Cloud,
-        title: {
-          id: 'widget.deploy-now.title',
-          defaultMessage: 'Deploy',
-        },
-        component: async () => {
-          const { DeployNowWidget } = await import('./components/Widgets');
-          return DeployNowWidget;
-        },
-        pluginId: 'admin',
-        id: 'deploy-now',
-      },
+      ...(backendURL?.includes('localhost')
+        ? [
+            {
+              icon: Cloud,
+              title: {
+                id: 'widget.deploy-now.title',
+                defaultMessage: 'Deploy',
+              },
+              component: async () => {
+                const { DeployNowWidget } = await import('./components/Widgets');
+                return DeployNowWidget;
+              },
+              pluginId: 'admin',
+              id: 'deploy-now',
+            },
+          ]
+        : []),
     ]);
 
     Object.keys(this.appPlugins).forEach((plugin) => {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This change only removes the deploy-now widget in production, like the "deploy to cloud page"


### How to test it?

Run the app in production and check for the 'deploy-now' widget; it should not be there

### Related issue(s)/PR(s)

[Remove the deploy widget](https://feedback.strapi.io/customization/p/option-to-remove-the-default-deploy-widget-in-dashboard)

---
Fixes CPR-385