### PR TITLE
fix(ci): run build:size as full command for compressed-size-action v3

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: preactjs/compressed-size-action@v3
         with:
           install-script: 'sh /tmp/install-and-build.sh'
-          build-script: 'build:size'
+          build-script: 'yarn run build:size'
           pattern: '**/build/**/*.{js,css,html,svg}'
           strip-hash: "-([-\\w]{8})(\\.\\w+)$"
           minimum-change-threshold: '5%'


### PR DESCRIPTION
### What does it do?

Updates the `build-script` input of the Admin bundle-size workflow from `build:size` to `yarn run build:size`.

### Why is it needed?

`preactjs/compressed-size-action@v3` ([#126](https://github.com/preactjs/compressed-size-action/pull/126)) is a breaking release: `clean`/`install`/`build` scripts now run as **raw shell commands** instead of being passed to the package manager. The dependabot bump to v3 ([#26498](https://github.com/strapi/strapi/pull/26498)) left `build-script: 'build:size'`, which is no longer a valid command under v3 (previously it was implicitly run as `yarn build:size`). The action would try to execute `build:size` directly and fail.

`build:size` is defined in the root `package.json`:

```json
"build:size": "cd examples/getstarted && yarn build",
```

so it must be invoked as `yarn run build:size`. The `install-script` already uses a raw command (`sh /tmp/install-and-build.sh`), so no change is needed there.

### How to test it?

Open a PR touching one of the workflow's trigger paths (e.g. `**/admin/src/**.js` or `yarn.lock`) and confirm the `Admin bundle-size` job runs `build:size` successfully and posts its size-comparison comment, instead of failing on an unknown `build:size` command.

### Related issue(s)/PR(s)

- Follows up #26498 (bump to v3)
- Upstream breaking change: preactjs/compressed-size-action#126