### PR TITLE
test(e2e): add critical conditional fields toggle test

### DIFF
--- a/tests/e2e/tests/content-manager/conditional-fields/boolean-conditional-select-relation.spec.ts
+++ b/tests/e2e/tests/content-manager/conditional-fields/boolean-conditional-select-relation.spec.ts
@@ -48,4 +48,33 @@ test.describe('Conditional Fields - Boolean-controlled conditional relation fiel
     // Verify the relation was saved
     await expect(page.getByText('Whiskers')).toBeVisible();
   });
+
+  test(
+    'As a user toggling a boolean condition shows and hides conditional fields correctly',
+    { tag: ['@critical'] },
+    async ({ page }) => {
+      await navToHeader(page, ['Content Manager', 'Dog'], 'Dog');
+      await page.getByRole('link', { name: 'Create new entry' }).last().click();
+
+      await fillField(page, { name: 'name*', type: 'text', value: 'Rex' });
+
+      // likesCats defaults to false — conditional fields should be hidden
+      await expect(page.getByLabel('bestFriendCats')).not.toBeVisible();
+      await expect(page.getByLabel('preferredCatPersonality')).not.toBeVisible();
+
+      // Toggle likesCats to true — conditional fields should appear
+      await fillField(page, { name: 'likesCats', type: 'boolean', value: true });
+      await expect(page.getByLabel('bestFriendCats')).toBeVisible();
+      await expect(page.getByLabel('preferredCatPersonality')).toBeVisible();
+
+      // Toggle back to false — fields should hide again (regression path for 5.33.1 desync bug)
+      await fillField(page, { name: 'likesCats', type: 'boolean', value: false });
+      await expect(page.getByLabel('bestFriendCats')).not.toBeVisible();
+      await expect(page.getByLabel('preferredCatPersonality')).not.toBeVisible();
+
+      // Save cleanly — no conditional field data should leak
+      await page.getByRole('button', { name: 'Save' }).click();
+      await findAndClose(page, 'Saved Document');
+    }
+  );
 });


### PR DESCRIPTION
## What
Adds a `@critical` E2E test for conditional field show/hide behavior in the Content Manager.

## Why
Critical path #8 (cm.conditional-fields). The 5.33.1 regression was a desync between UI visibility and API validation when toggling a boolean condition. This test catches that exact pattern.

## What the test does
1. Creates a Dog entry (likesCats defaults to false)
2. Asserts bestFriendCats and preferredCatPersonality are hidden
3. Toggles likesCats to true → asserts both fields appear
4. Toggles back to false → asserts both fields hide again (regression path)
5. Saves cleanly

## Part of
E2E coverage focus — Phase 1