### PR TITLE
fix(admin): add default empty arrays to prevent LeftMenu crash on undefined links

### DIFF
--- a/packages/core/admin/admin/src/components/LeftMenu.tsx
+++ b/packages/core/admin/admin/src/components/LeftMenu.tsx
@@ -62,8 +62,8 @@ const MenuDetails = styled(Flex)`
 `;
 
 const LeftMenu = ({
-  generalSectionLinks,
-  pluginsSectionLinks,
+  generalSectionLinks = [],
+  pluginsSectionLinks = [],
   topMobileNavigation,
   burgerMobileNavigation,
 }: LeftMenuProps) => {

--- a/packages/core/admin/admin/src/components/tests/LeftMenu.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/LeftMenu.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@tests/utils';
+
+import { LeftMenu } from '../LeftMenu';
+
+describe('LeftMenu', () => {
+  // Regression for #26389: when a plugin incompatibility leaves the section
+  // links undefined, `[...pluginsSectionLinks, ...generalSectionLinks].sort()`
+  // threw "... is not iterable" and crashed the whole admin UI. The `= []`
+  // prop defaults make the component render an (empty) menu instead.
+  it('renders without crashing when section links are undefined', () => {
+    expect(() =>
+      // generalSectionLinks / pluginsSectionLinks intentionally omitted.
+      render(<LeftMenu topMobileNavigation={[]} burgerMobileNavigation={[]} />)
+    ).not.toThrow();
+  });
+
+  it('renders without crashing when section links are provided', () => {
+    expect(() =>
+      render(
+        <LeftMenu
+          generalSectionLinks={[]}
+          pluginsSectionLinks={[]}
+          topMobileNavigation={[]}
+          burgerMobileNavigation={[]}
+        />
+      )
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #26389 - Admin UI crash with `Cannot read properties of undefined (reading 'sort')` error.

### Root Cause

The `LeftMenu` component destructures `generalSectionLinks` and `pluginsSectionLinks` from props without default values. When these props are `undefined` (e.g., due to plugin incompatibilities), the spread operator in:

```tsx
[...pluginsSectionLinks, ...generalSectionLinks].sort(...)
```

...crashes the entire admin UI because `undefined` is not iterable, and the subsequent `.filter()` call on `pluginsSectionLinks` also throws.

### Changes

- Added default empty array values (`= []`) to `generalSectionLinks` and `pluginsSectionLinks` props in the `LeftMenu` component.

This defensive fix ensures the admin UI gracefully handles missing/corrupted plugin link data instead of crashing with an unhandled TypeError.

### How to test

The issue was confirmed via fault injection (as documented by @akash-dabhi-qed in the issue thread) - forcing these props to `undefined` reproduces the crash. With this fix, the UI renders properly even when these props are missing.

---
Fixes CPR-386

---

## Test verification (RED → GREEN)

Added `packages/core/admin/admin/src/components/tests/LeftMenu.test.tsx`.

Command: `yarn workspace @strapi/admin test:front admin/src/components/tests/LeftMenu.test.tsx`

**GREEN — with the `= []` defaults:**
```
PASS Core admin admin/src/components/tests/LeftMenu.test.tsx
  LeftMenu
    ✓ renders without crashing when section links are undefined
    ✓ renders without crashing when section links are provided
Tests: 2 passed, 2 total
```

**RED — defaults reverted (`generalSectionLinks` / `pluginsSectionLinks` with no `= []`):**
```
  LeftMenu
    ✕ renders without crashing when section links are undefined
    ✓ renders without crashing when section links are provided
  ● Error: Uncaught [TypeError: pluginsSectionLinks is not iterable]
Tests: 1 failed, 1 passed, 2 total
```
Without the patch, rendering with undefined section links throws `TypeError: pluginsSectionLinks is not iterable` (the `[...pluginsSectionLinks, ...generalSectionLinks]` spread) — the exact #26389 crash. The patch makes both cases pass.
