### PR TITLE
fix(ci): replace blocked actions-cool/issues-helper with github-script

### DIFF
--- a/.github/workflows/issues_dailyCron.yml
+++ b/.github/workflows/issues_dailyCron.yml
@@ -13,14 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check for inactive issues that can't be reproduced
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'status: can not reproduce'
-          inactive-day: 14
-          close-reason: 'completed'
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             Hello!
 
             As we have not received any new or updated information to reproduce this issue in the last 14 days we are marking this issue as closed. Should you have new information please feel free to respond and we will consider reopening it.
@@ -28,3 +23,36 @@ jobs:
             If anyone else have updated information for this issue, please open up a new bug report and simply reference this closed bug report so that we can get any new information you may have. If you have questions please refer to the [contributor's guide](https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md#reporting-an-issue) on opening issues.
 
             Thank you and have a great day!
+        with:
+          script: |
+            const label = 'status: can not reproduce';
+            const inactiveDays = 14;
+            const cutoff = Date.now() - inactiveDays * 24 * 60 * 60 * 1000;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              // listForRepo returns PRs too; skip them.
+              if (issue.pull_request) continue;
+              if (new Date(issue.updated_at).getTime() >= cutoff) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: process.env.ISSUE_BODY,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/.github/workflows/issues_handleLabel.yml
+++ b/.github/workflows/issues_handleLabel.yml
@@ -20,12 +20,9 @@ jobs:
       # Unable to Reproduce Tasks
       - name: 'Comment: unable to reproduce'
         if: "${{ github.event.label.name == 'status: can not reproduce' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -36,16 +33,21 @@ jobs:
             Please note that issues labeled with `status: can not reproduce` will be closed in 14 days if there is no activity.
 
             Thank you!
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
 
       # v3 Legacy Issues
       - name: 'Comment: unsupported v3 issues'
         if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -61,24 +63,33 @@ jobs:
             For now this issue is marked as closed.
 
             Thank You
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
       - name: 'Close: unsupported v3 issues'
         if: "${{ github.event.label.name == 'flag: v3-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            })
 
       # v4 Legacy Issues
       - name: 'Comment: unsupported v4 issues'
         if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -98,24 +109,33 @@ jobs:
             For now this issue is marked as closed.
 
             Thank You
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
       - name: 'Close: unsupported v4 issues'
         if: "${{ github.event.label.name == 'flag: v4-unsupported' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            })
 
       # Feature request redirections
       - name: 'Comment: redirect feature request to canny'
         if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -130,24 +150,33 @@ jobs:
             In order to keep our GitHub issues clean and for valid bug reports this issue will be marked as closed, but please feel free to continue the discussion with other community members here.
 
             Thank you for your insight and have a good day.
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
       - name: 'Close: redirect feature request to canny'
         if: "${{ github.event.label.name == 'issue: feature request' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'completed'
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'completed',
+            })
 
       # Invalid bug report template actions
       - name: 'Comment: invalid bug report template'
         if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -158,24 +187,33 @@ jobs:
             Please create a new issue and completely fill out the issue template, you can [open a new issue here](https://github.com/strapi/strapi/issues/new?template=BUG_REPORT.yml).
 
             Thank you.
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
       - name: 'Close: invalid bug report template'
         if: "${{ github.event.label.name == 'flag: invalid template' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'not_planned'
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            })
 
       # Redirect questions to community sources
       - name: 'Comment: redirect question to community'
         if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@v7
+        env:
+          ISSUE_BODY: |
             > This is a templated message
 
             Hello @${{ github.event.issue.user.login }},
@@ -188,14 +226,26 @@ jobs:
             Please see the following contributing guidelines for asking a question [here](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md#reporting-an-issue).
 
             Thank you.
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: process.env.ISSUE_BODY,
+            })
       - name: 'Close: redirect question to community'
         if: "${{ github.event.label.name == 'flag: question' }}"
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v7
         with:
-          actions: 'close-issue'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          close-reason: 'complete'
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              state: 'closed',
+              state_reason: 'completed',
+            })
 
       - name: assign issues to DevExp squad project
         uses: actions/add-to-project@v0.4.1


### PR DESCRIPTION
## What

The `actions-cool/issues-helper` action repository was **blocked by GitHub for a ToS violation on 2026-05-19**:

\`\`\`
GET repos/actions-cool/issues-helper
403 {"message":"Repository access blocked","block":{"reason":"tos",...}}
\`\`\`

Because GitHub refuses to download the action, every **Issue Labeled** run and the **Daily Cron** job now fail at `Set up job` with `Repository access blocked` — before any step executes. (e.g. runs 27092524592, 27092524568, 27092524566, 27092524553 on `develop`.)

## Fix

Port the comment/close behaviour to the official `actions/github-script@v7`, which needs no third-party action download:

- `create-comment` → `issues.createComment` (body passed via `env` to avoid template-escaping issues)
- `close-issue` → `issues.update(state=closed, state_reason=…)`
- `close-issues` (cron) → paginate open issues by label and close those inactive > 14 days

`actions/add-to-project` is untouched (not blocked). Behaviour is preserved.

## Files

- `.github/workflows/issues_handleLabel.yml`
- `.github/workflows/issues_dailyCron.yml`

---
Fixes CPR-387