### PR TITLE
fix(admin): warn before logout when unsaved changes exist

### DIFF
--- a/packages/core/admin/admin/src/components/Form.tsx
+++ b/packages/core/admin/admin/src/components/Form.tsx
@@ -806,6 +806,15 @@ const Blocker = ({ onProceed = () => {}, onCancel = () => {} }: BlockerProps) =>
   // This hook will be triggered on dev mode because of the live reloads but it's fine as it's only for that scenario
   useWarnIfUnsavedChanges(modified && !isSubmitting);
 
+  React.useEffect(() => {
+    (window as any).__STRAPI_UNSAVED_CHANGES__ = modified && !isSubmitting;
+  }, [modified, isSubmitting]);
+
+  React.useEffect(() => {
+    return () => {
+      delete (window as any).__STRAPI_UNSAVED_CHANGES__;
+    };
+  }, []);
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     return (
       !isSubmitting &&

--- a/packages/core/admin/admin/src/features/Auth.tsx
+++ b/packages/core/admin/admin/src/features/Auth.tsx
@@ -136,11 +136,22 @@ const AuthProvider = ({
   const [logoutMutation] = useLogoutMutation();
 
   const clearStateAndLogout = React.useCallback(() => {
+    const hasUnsavedChanges = (window as any).__STRAPI_UNSAVED_CHANGES__;
+
+    if (hasUnsavedChanges) {
+      const shouldLogout = window.confirm(
+        'You have unsaved changes. Logging out will discard them. Continue?'
+      );
+
+      if (!shouldLogout) {
+        return;
+      }
+    }
+
     dispatch(adminApi.util.resetApiState());
     dispatch(logoutAction());
     navigate('/auth/login');
   }, [dispatch, navigate]);
-
   React.useEffect(() => {
     if (user) {
       if (user.preferedLanguage) {


### PR DESCRIPTION
## Summary

This PR addresses a data-loss scenario in the admin panel where session expiration can redirect a user to `/auth/login` while they have unsaved form changes.

### Problem

When a session expires, the logout flow navigates directly to the login page and discards in-memory form state. As a result, users can lose unsaved Content Manager edits without warning.

### Solution

Before clearing auth state and navigating to `/auth/login`, the logout flow now checks whether unsaved form changes are present.

If unsaved changes are detected, the user is shown a confirmation dialog:

> "You have unsaved changes. Logging out will discard them. Continue?"

If the user cancels, the logout navigation is aborted.

### Notes

* This change does **not** implement draft persistence.
* This change does **not** modify session lifetime behavior.
* The goal is to prevent silent data loss by warning users before session-expiry logout causes navigation away from an unsaved form.

### Testing

1. Open a Content Manager edit/create form.
2. Modify a field without saving.
3. Trigger the logout/session-expiry flow.
4. Verify that a warning is displayed before navigation.
5. Verify that cancelling the dialog keeps the user on the current page.


---
Fixes CPR-388