### PR TITLE
fix(core): remove config-based access control from openapi endpoints

### DIFF
--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -44,9 +44,6 @@ const defaultServerConfig = {
       route: {
         path: '/openapi.json',
       },
-      access: {
-        mode: 'authenticated',
-      },
       cache: {
         enabled: true,
         maxAgeMs: 60_000,
@@ -57,9 +54,6 @@ const defaultServerConfig = {
       enabled: false,
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated',
       },
       cache: {
         enabled: true,

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -110,14 +110,41 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes).toHaveLength(1);
     expect(contentApiRouter.routes[0].method).toBe('GET');
     expect(contentApiRouter.routes[0].path).toBe('/spec.json');
-    // no explicit auth: relies on the default strategies for the route type
-    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
+    // content-api spec is public when the endpoint is enabled
+    expect(contentApiRouter.routes[0].config.auth).toBe(false);
 
     expect(adminRouter.type).toBe('admin');
     expect(adminRouter.prefix).toBe('/admin');
     expect(adminRouter.routes).toHaveLength(1);
     expect(adminRouter.routes[0].method).toBe('GET');
     expect(adminRouter.routes[0].path).toBe('/openapi.json');
+    // admin spec requires an authenticated admin (default admin auth)
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
+  });
+
+  test('content-api spec is public when enabled', () => {
+    const strapi = createStrapiMock({
+      'content-api': {
+        enabled: true,
+      },
+    });
+
+    registerOpenAPIRoute(strapi as any);
+
+    const [contentApiRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
+    expect(contentApiRouter.routes[0].config.auth).toBe(false);
+  });
+
+  test('admin spec requires authentication when enabled', () => {
+    const strapi = createStrapiMock({
+      admin: {
+        enabled: true,
+      },
+    });
+
+    registerOpenAPIRoute(strapi as any);
+
+    const [adminRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
     expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -110,7 +110,7 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes).toHaveLength(1);
     expect(contentApiRouter.routes[0].method).toBe('GET');
     expect(contentApiRouter.routes[0].path).toBe('/spec.json');
-    // authenticated mode: no explicit auth key, relies on route-type strategies
+    // no explicit auth: relies on the default strategies for the route type
     expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
 
     expect(adminRouter.type).toBe('admin');
@@ -118,40 +118,6 @@ describe('registerOpenAPIRoute', () => {
     expect(adminRouter.routes).toHaveLength(1);
     expect(adminRouter.routes[0].method).toBe('GET');
     expect(adminRouter.routes[0].path).toBe('/openapi.json');
-    expect(adminRouter.routes[0].config.auth).toBeUndefined();
-  });
-
-  test('supports public access mode', () => {
-    const strapi = createStrapiMock({
-      'content-api': {
-        enabled: true,
-        access: {
-          mode: 'public',
-        },
-      },
-    });
-
-    registerOpenAPIRoute(strapi as any);
-
-    expect(strapi.server.routes).toHaveBeenCalledTimes(1);
-    const [contentApiRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
-    expect(contentApiRouter.routes[0].config.auth).toBe(false);
-  });
-
-  test('authenticated mode leaves auth to the route-type strategies', () => {
-    const strapi = createStrapiMock({
-      admin: {
-        enabled: true,
-        access: {
-          mode: 'authenticated',
-        },
-      },
-    });
-
-    registerOpenAPIRoute(strapi as any);
-
-    expect(strapi.server.routes).toHaveBeenCalledTimes(1);
-    const [adminRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
     expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 
@@ -268,18 +234,18 @@ describe('registerOpenAPIRoute', () => {
     );
   });
 
-  test('throws for unsupported access modes', () => {
+  test('still derives admin prefix when admin endpoint has minimal config', () => {
     const strapi = createStrapiMock({
       admin: {
         enabled: true,
-        access: {
-          mode: 'unknown-mode',
-        },
       },
     });
 
-    expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'Invalid OpenAPI access mode "unknown-mode" for "admin". Expected one of: public, authenticated'
-    );
+    registerOpenAPIRoute(strapi as any);
+
+    const [adminRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
+    expect(adminRouter.type).toBe('admin');
+    expect(adminRouter.prefix).toBe('/admin');
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 });

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -110,14 +110,15 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes).toHaveLength(1);
     expect(contentApiRouter.routes[0].method).toBe('GET');
     expect(contentApiRouter.routes[0].path).toBe('/spec.json');
-    expect(contentApiRouter.routes[0].config.auth).toEqual({});
+    // authenticated mode: no explicit auth key, relies on route-type strategies
+    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
 
     expect(adminRouter.type).toBe('admin');
     expect(adminRouter.prefix).toBe('/admin');
     expect(adminRouter.routes).toHaveLength(1);
     expect(adminRouter.routes[0].method).toBe('GET');
     expect(adminRouter.routes[0].path).toBe('/openapi.json');
-    expect(adminRouter.routes[0].config.auth).toEqual({});
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 
   test('supports public access mode', () => {
@@ -137,13 +138,12 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes[0].config.auth).toBe(false);
   });
 
-  test('supports authenticated access mode with scoped auth', () => {
+  test('authenticated mode leaves auth to the route-type strategies', () => {
     const strapi = createStrapiMock({
       admin: {
         enabled: true,
         access: {
           mode: 'authenticated',
-          roles: ['admin::users.read', 'admin::roles.read'],
         },
       },
     });
@@ -152,9 +152,7 @@ describe('registerOpenAPIRoute', () => {
 
     expect(strapi.server.routes).toHaveBeenCalledTimes(1);
     const [adminRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
-    expect(adminRouter.routes[0].config.auth).toEqual({
-      scope: ['admin::users.read', 'admin::roles.read'],
-    });
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 
   test('serves fresh file cache when available', async () => {
@@ -267,22 +265,6 @@ describe('registerOpenAPIRoute', () => {
 
     expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
       'Duplicate OpenAPI endpoint path detected: "/api/openapi.json"'
-    );
-  });
-
-  test('throws when roles are used with public mode', () => {
-    const strapi = createStrapiMock({
-      admin: {
-        enabled: true,
-        access: {
-          mode: 'public',
-          roles: ['admin::users.read'],
-        },
-      },
-    });
-
-    expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'OpenAPI endpoint "admin" only supports roles when access.mode is "authenticated"'
     );
   });
 

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -100,6 +100,25 @@ const resolveEndpointConfig = (
   };
 };
 
+/**
+ * Build the route `config` for an endpoint.
+ *
+ * Access is intentionally minimal here: there is no access configuration.
+ *
+ * - `content-api`: the spec is public when the endpoint is enabled (an OpenAPI
+ *   document describing the public Content API).
+ * - `admin`: requires an authenticated admin user (the default admin auth).
+ *
+ * Fine-grained, permission-based access control is added in a follow-up.
+ */
+const buildRouteConfig = (config: ResolvedEndpointConfig): Record<string, unknown> => {
+  if (config.type === 'content-api') {
+    return { auth: false };
+  }
+
+  return {};
+};
+
 const resolveOpenAPIConfig = (strapi: Core.Strapi) => {
   const rawConfig = strapi.config.get('server.openapi', {}) as OpenAPIConfig;
 
@@ -191,11 +210,7 @@ export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
           info: {
             type: config.type,
           },
-          // Authentication is handled by the default strategies for the route
-          // type (Content API tokens / users-permissions for `content-api`,
-          // admin auth for `admin`). Public Content API access is granted via
-          // the users-permissions "Public" role like any other route.
-          config: {},
+          config: buildRouteConfig(config),
         },
       ],
     };

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -15,7 +15,6 @@ interface ResolvedEndpointConfig {
   routerPrefix?: string;
   fullPath: string;
   accessMode: OpenAPIAccessMode;
-  accessRoles: string[];
   cacheEnabled: boolean;
   cacheMaxAgeMs: number;
   absoluteCachePath: string;
@@ -94,21 +93,6 @@ const resolveEndpointConfig = (
     );
   }
 
-  const accessRoles = rawConfig?.access?.roles;
-
-  if (accessRoles !== undefined && !Array.isArray(accessRoles)) {
-    throw new Error(
-      `Invalid OpenAPI roles configuration for "${type}". Expected an array of scopes.`
-    );
-  }
-
-  const normalizedAccessRoles = accessRoles ?? [];
-
-  if (normalizedAccessRoles.length > 0 && accessMode !== 'authenticated') {
-    throw new Error(
-      `OpenAPI endpoint "${type}" only supports roles when access.mode is "authenticated"`
-    );
-  }
   const cacheEnabled = rawConfig?.cache?.enabled ?? DEFAULTS.cacheEnabled;
   const cacheMaxAgeMs = rawConfig?.cache?.maxAgeMs ?? DEFAULTS.cacheMaxAgeMs;
   const configuredCachePath = rawConfig?.cache?.filePath ?? DEFAULTS.cacheRelativeFilePaths[type];
@@ -123,22 +107,24 @@ const resolveEndpointConfig = (
     routerPrefix,
     fullPath,
     accessMode,
-    accessRoles: normalizedAccessRoles,
     cacheEnabled,
     cacheMaxAgeMs,
     absoluteCachePath,
   };
 };
 
-const getRouteAuthConfig = (config: ResolvedEndpointConfig) => {
+/**
+ * Build the route `config` for an endpoint.
+ *
+ * - `public`: authentication is disabled.
+ * - `authenticated`: rely on the default auth strategies for the route type
+ *   (Content API tokens / users-permissions for `content-api`, admin auth for
+ *   `admin`). No explicit `auth` key is set so the route is authenticated but
+ *   not scoped.
+ */
+const buildRouteConfig = (config: ResolvedEndpointConfig): Record<string, unknown> => {
   if (config.accessMode === 'public') {
-    return false as const;
-  }
-
-  if (config.accessRoles.length > 0) {
-    return {
-      scope: config.accessRoles,
-    };
+    return { auth: false };
   }
 
   return {};
@@ -235,9 +221,7 @@ export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
           info: {
             type: config.type,
           },
-          config: {
-            auth: getRouteAuthConfig(config),
-          },
+          config: buildRouteConfig(config),
         },
       ],
     };

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -5,7 +5,6 @@ import type { Core } from '@strapi/types';
 
 type OpenAPIConfig = Core.Config.OpenAPI;
 type OpenAPIEndpointConfig = NonNullable<OpenAPIConfig['content-api']>;
-type OpenAPIAccessMode = NonNullable<NonNullable<OpenAPIEndpointConfig['access']>['mode']>;
 type OpenAPIRouteType = keyof OpenAPIConfig;
 
 interface ResolvedEndpointConfig {
@@ -14,7 +13,6 @@ interface ResolvedEndpointConfig {
   routePath: string;
   routerPrefix?: string;
   fullPath: string;
-  accessMode: OpenAPIAccessMode;
   cacheEnabled: boolean;
   cacheMaxAgeMs: number;
   absoluteCachePath: string;
@@ -22,7 +20,6 @@ interface ResolvedEndpointConfig {
 
 const DEFAULTS = {
   routePath: '/openapi.json',
-  accessMode: 'authenticated' as const,
   cacheEnabled: true,
   cacheMaxAgeMs: 60_000,
   cacheRelativeFilePaths: {
@@ -84,15 +81,6 @@ const resolveEndpointConfig = (
     type === 'content-api'
       ? joinPaths(normalizePath(apiPrefix), routePath)
       : joinPaths(routerPrefix!, routePath);
-  const accessMode = rawConfig?.access?.mode ?? DEFAULTS.accessMode;
-  const supportedAccessModes = ['public', 'authenticated'];
-
-  if (!supportedAccessModes.includes(accessMode)) {
-    throw new Error(
-      `Invalid OpenAPI access mode "${accessMode}" for "${type}". Expected one of: ${supportedAccessModes.join(', ')}`
-    );
-  }
-
   const cacheEnabled = rawConfig?.cache?.enabled ?? DEFAULTS.cacheEnabled;
   const cacheMaxAgeMs = rawConfig?.cache?.maxAgeMs ?? DEFAULTS.cacheMaxAgeMs;
   const configuredCachePath = rawConfig?.cache?.filePath ?? DEFAULTS.cacheRelativeFilePaths[type];
@@ -106,28 +94,10 @@ const resolveEndpointConfig = (
     routePath,
     routerPrefix,
     fullPath,
-    accessMode,
     cacheEnabled,
     cacheMaxAgeMs,
     absoluteCachePath,
   };
-};
-
-/**
- * Build the route `config` for an endpoint.
- *
- * - `public`: authentication is disabled.
- * - `authenticated`: rely on the default auth strategies for the route type
- *   (Content API tokens / users-permissions for `content-api`, admin auth for
- *   `admin`). No explicit `auth` key is set so the route is authenticated but
- *   not scoped.
- */
-const buildRouteConfig = (config: ResolvedEndpointConfig): Record<string, unknown> => {
-  if (config.accessMode === 'public') {
-    return { auth: false };
-  }
-
-  return {};
 };
 
 const resolveOpenAPIConfig = (strapi: Core.Strapi) => {
@@ -221,7 +191,11 @@ export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
           info: {
             type: config.type,
           },
-          config: buildRouteConfig(config),
+          // Authentication is handled by the default strategies for the route
+          // type (Content API tokens / users-permissions for `content-api`,
+          // admin auth for `admin`). Public Content API access is granted via
+          // the users-permissions "Public" role like any other route.
+          config: {},
         },
       ],
     };

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -29,8 +29,6 @@ module.exports = () => ({
       },
       access: {
         mode: 'authenticated', // public | authenticated
-        // Optional scopes to further restrict authenticated access:
-        // roles: ['plugin::users-permissions.authenticated'],
       },
       cache: {
         enabled: true,
@@ -45,7 +43,6 @@ module.exports = () => ({
       },
       access: {
         mode: 'authenticated',
-        roles: ['admin::marketplace.read'],
       },
       cache: {
         enabled: true,
@@ -64,7 +61,6 @@ module.exports = () => ({
 - `enabled`: enables the endpoint when `true`.
 - `route.path`: endpoint subpath to register (resolved under `/api` for content-api and under `/admin` for admin by default).
 - `access.mode`: endpoint access mode (`public`, `authenticated`).
-- `access.roles`: optional auth scopes when `access.mode` is `authenticated`.
 - `cache.enabled`: enables file-based cache for generated output.
 - `cache.maxAgeMs`: cache validity in milliseconds.
 - `cache.filePath`: output file path for cached spec (absolute or app-root relative).
@@ -72,6 +68,5 @@ module.exports = () => ({
 ### Security note
 
 By default, endpoints use `authenticated` access mode. You can explicitly set `public` for unauthenticated
-access, or add `access.roles` to further restrict authenticated users/tokens by scope. Exposing API specs
-may still be sensitive in some deployments, so both endpoints are disabled by default and should be
-explicitly opted into.
+access. Exposing API specs may still be sensitive in some deployments, so both endpoints are disabled by
+default and should be explicitly opted into.

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -27,9 +27,6 @@ module.exports = () => ({
       route: {
         path: '/openapi.json',
       },
-      access: {
-        mode: 'authenticated', // public | authenticated
-      },
       cache: {
         enabled: true,
         maxAgeMs: 60_000,
@@ -40,9 +37,6 @@ module.exports = () => ({
       enabled: false,
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated',
       },
       cache: {
         enabled: true,
@@ -60,13 +54,22 @@ module.exports = () => ({
 - `server.openapi.admin`: config for the Admin API OpenAPI endpoint.
 - `enabled`: enables the endpoint when `true`.
 - `route.path`: endpoint subpath to register (resolved under `/api` for content-api and under `/admin` for admin by default).
-- `access.mode`: endpoint access mode (`public`, `authenticated`).
 - `cache.enabled`: enables file-based cache for generated output.
 - `cache.maxAgeMs`: cache validity in milliseconds.
 - `cache.filePath`: output file path for cached spec (absolute or app-root relative).
 
-### Security note
+### Access control
 
-By default, endpoints use `authenticated` access mode. You can explicitly set `public` for unauthenticated
-access. Exposing API specs may still be sensitive in some deployments, so both endpoints are disabled by
-default and should be explicitly opted into.
+Both endpoints are disabled by default and must be explicitly opted into.
+
+When enabled, access is handled by Strapi's standard authentication:
+
+- **Content API** (`/api/openapi.json`): requires an authenticated Content API caller (a
+  users-permissions user or an API token).
+- **Admin** (`/admin/openapi.json`): requires an authenticated admin user.
+
+Exposing API specs can be sensitive in some deployments, so review who can reach each endpoint before
+enabling it.
+
+> Fine-grained, permission-based access control (including making the Content API spec publicly readable
+> through the users-permissions **Public** role) is added in a follow-up change.

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -60,16 +60,16 @@ module.exports = () => ({
 
 ### Access control
 
-Both endpoints are disabled by default and must be explicitly opted into.
+Both endpoints are disabled by default and must be explicitly opted into. There is no access
+configuration: enabling an endpoint exposes it with a fixed access policy.
 
-When enabled, access is handled by Strapi's standard authentication:
-
-- **Content API** (`/api/openapi.json`): requires an authenticated Content API caller (a
-  users-permissions user or an API token).
+- **Content API** (`/api/openapi.json`): **public** when enabled. The document describes the public
+  Content API, so the spec is served without authentication.
 - **Admin** (`/admin/openapi.json`): requires an authenticated admin user.
 
-Exposing API specs can be sensitive in some deployments, so review who can reach each endpoint before
-enabling it.
+Exposing API specs can be sensitive in some deployments, so only enable the endpoint you need.
 
-> Fine-grained, permission-based access control (including making the Content API spec publicly readable
-> through the users-permissions **Public** role) is added in a follow-up change.
+> Fine-grained, permission-based access control (RBAC for the admin endpoint, and gating the Content API
+> spec behind a permission that can be granted to the users-permissions **Public** role) is added in a
+> follow-up change. When that lands, a public Content API spec will require granting that permission to
+> the Public role.

--- a/packages/core/types/src/core/config/openapi.ts
+++ b/packages/core/types/src/core/config/openapi.ts
@@ -1,11 +1,5 @@
-export type OpenAPIAccessMode = 'public' | 'authenticated';
-
 export interface OpenAPIRoute {
   path?: string;
-}
-
-export interface OpenAPIAccess {
-  mode?: OpenAPIAccessMode;
 }
 
 export interface OpenAPICache {
@@ -22,7 +16,6 @@ export interface OpenAPICache {
 export interface OpenAPIEndpoint {
   enabled?: boolean;
   route?: OpenAPIRoute;
-  access?: OpenAPIAccess;
   cache?: OpenAPICache;
 }
 

--- a/packages/core/types/src/core/config/openapi.ts
+++ b/packages/core/types/src/core/config/openapi.ts
@@ -6,11 +6,6 @@ export interface OpenAPIRoute {
 
 export interface OpenAPIAccess {
   mode?: OpenAPIAccessMode;
-  /**
-   * Authorization scopes required when access mode is `authenticated`.
-   * If omitted, any authenticated user/token is allowed.
-   */
-  roles?: string[];
 }
 
 export interface OpenAPICache {


### PR DESCRIPTION
## What does it do?

Strips the entire **config-based access-control surface** from the OpenAPI HTTP
endpoint feature (added in #26239, not yet released). Both knobs that existed —
`access.roles` and `access.mode` — are removed, along with the `access` block
itself. There is no longer any OpenAPI-specific access configuration.

An endpoint is configured with only `enabled` + `route` + `cache`, and each one
gets a fixed, predictable access policy:

- **content-api** (`/api/openapi.json`): **public** when enabled. The document
  describes the public Content API, so the spec is served without authentication.
- **admin** (`/admin/openapi.json`): requires an authenticated admin user.

## Why is it needed?

We're releasing soon and don't want to ship the half-baked access config:

- `access.roles` was misnamed (it held auth scopes, not roles) and was **silently
  unenforced on the admin endpoint** (admin strategies don't verify route scope).
- `access.mode` duplicated access control that, in Strapi, already lives in the
  permission systems (users-permissions / RBAC) rather than per-feature config.

Shipping it would mean either living with a misleading API or making a breaking
change later. Reducing the feature to on/off with a sensible fixed policy avoids
both: there is **no access config to break**. Proper permission-based access
control (RBAC) lands in the follow-up (#26574), with its own review/QA.

> Note: when the RBAC follow-up ships, the content-api spec becomes
> permission-gated; keeping it public will then require granting the
> `strapi::openapi.openapi.read` permission to the users-permissions **Public**
> role. This will be called out in release notes.

## How to test it?

- `yarn jest packages/core/core/src/services/server/__tests__/openapi.test.ts`
- Enable `content-api`; fetch `/api/openapi.json` with no credentials → 200.
- Enable `admin`; fetch `/admin/openapi.json` with no credentials → 401, and with
  an authenticated admin → 200.

## Related issue(s)/PR(s)

- Builds on #26239
- Follow-up that introduces RBAC the correct way: #26574 (stacked on this branch)