### PR TITLE
feat(openapi): gate endpoint access with config

### DIFF
--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -40,12 +40,9 @@ const defaultServerConfig = {
   },
   openapi: {
     'content-api': {
-      enabled: false,
+      access: 'disabled',
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated',
       },
       cache: {
         enabled: true,
@@ -54,12 +51,9 @@ const defaultServerConfig = {
       },
     },
     admin: {
-      enabled: false,
+      access: 'disabled',
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated',
       },
       cache: {
         enabled: true,

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -37,11 +37,16 @@ let ctx = createCtx();
 
 const createStrapiMock = (
   openapiConfig: Record<string, unknown> = {},
-  options: { apiPrefix?: string; adminPath?: string } = {}
+  options: { apiPrefix?: string; adminPath?: string; futureFlagEnabled?: boolean } = {}
 ) => {
-  const { apiPrefix = '/api', adminPath = '/admin' } = options;
+  const { apiPrefix = '/api', adminPath = '/admin', futureFlagEnabled = true } = options;
 
   return {
+    features: {
+      future: {
+        isEnabled: jest.fn((name: string) => name === 'unstableOpenapi' && futureFlagEnabled),
+      },
+    },
     config: {
       get: jest.fn((key: string, defaultValue?: unknown) => {
         if (key === 'server.openapi') {
@@ -87,16 +92,30 @@ describe('registerOpenAPIRoute', () => {
     expect(strapi.server.routes).not.toHaveBeenCalled();
   });
 
-  test('registers one route per enabled endpoint', () => {
+  test('does not register route when the unstableOpenapi future flag is disabled', () => {
+    const strapi = createStrapiMock(
+      {
+        'content-api': { access: 'authenticated' },
+        admin: { access: 'authenticated' },
+      },
+      { futureFlagEnabled: false }
+    );
+
+    registerOpenAPIRoute(strapi as any);
+
+    expect(strapi.server.routes).not.toHaveBeenCalled();
+  });
+
+  test('registers one route per configured endpoint', () => {
     const strapi = createStrapiMock({
       'content-api': {
-        enabled: true,
+        access: 'authenticated',
         route: {
           path: '/spec.json',
         },
       },
       admin: {
-        enabled: true,
+        access: 'authenticated',
       },
     });
 
@@ -110,23 +129,22 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes).toHaveLength(1);
     expect(contentApiRouter.routes[0].method).toBe('GET');
     expect(contentApiRouter.routes[0].path).toBe('/spec.json');
-    expect(contentApiRouter.routes[0].config.auth).toEqual({});
+    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
 
     expect(adminRouter.type).toBe('admin');
     expect(adminRouter.prefix).toBe('/admin');
     expect(adminRouter.routes).toHaveLength(1);
     expect(adminRouter.routes[0].method).toBe('GET');
     expect(adminRouter.routes[0].path).toBe('/openapi.json');
-    expect(adminRouter.routes[0].config.auth).toEqual({});
+    // admin endpoint requires an authenticated admin
+    expect(adminRouter.routes[0].config.policies).toEqual(['admin::isAuthenticatedAdmin']);
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
   });
 
-  test('supports public access mode', () => {
+  test('content-api public access disables auth', () => {
     const strapi = createStrapiMock({
       'content-api': {
-        enabled: true,
-        access: {
-          mode: 'public',
-        },
+        access: 'public',
       },
     });
 
@@ -137,14 +155,24 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes[0].config.auth).toBe(false);
   });
 
-  test('supports authenticated access mode with scoped auth', () => {
+  test('content-api authenticated access uses default content API auth (no scope)', () => {
+    const strapi = createStrapiMock({
+      'content-api': {
+        access: 'authenticated',
+      },
+    });
+
+    registerOpenAPIRoute(strapi as any);
+
+    expect(strapi.server.routes).toHaveBeenCalledTimes(1);
+    const [contentApiRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
+    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
+  });
+
+  test('admin authenticated access requires an authenticated admin', () => {
     const strapi = createStrapiMock({
       admin: {
-        enabled: true,
-        access: {
-          mode: 'authenticated',
-          roles: ['admin::users.read', 'admin::roles.read'],
-        },
+        access: 'authenticated',
       },
     });
 
@@ -152,9 +180,20 @@ describe('registerOpenAPIRoute', () => {
 
     expect(strapi.server.routes).toHaveBeenCalledTimes(1);
     const [adminRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
-    expect(adminRouter.routes[0].config.auth).toEqual({
-      scope: ['admin::users.read', 'admin::roles.read'],
+    expect(adminRouter.routes[0].config.policies).toEqual(['admin::isAuthenticatedAdmin']);
+    expect(adminRouter.routes[0].config.auth).toBeUndefined();
+  });
+
+  test('throws when the admin endpoint is configured as public', () => {
+    const strapi = createStrapiMock({
+      admin: {
+        access: 'public',
+      },
     });
+
+    expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
+      'OpenAPI admin endpoint does not support access "public"'
+    );
   });
 
   test('serves fresh file cache when available', async () => {
@@ -162,7 +201,7 @@ describe('registerOpenAPIRoute', () => {
     const document = { openapi: '3.1.0', info: { title: 'Cached' } };
     const strapi = createStrapiMock({
       'content-api': {
-        enabled: true,
+        access: 'authenticated',
         cache: {
           enabled: true,
           maxAgeMs: 60_000,
@@ -190,7 +229,7 @@ describe('registerOpenAPIRoute', () => {
     const document = { openapi: '3.1.0', info: { title: 'Generated', version: '1.0.0' } };
     const strapi = createStrapiMock({
       'content-api': {
-        enabled: true,
+        access: 'authenticated',
         cache: {
           enabled: true,
           maxAgeMs: 50,
@@ -216,10 +255,10 @@ describe('registerOpenAPIRoute', () => {
   test('does not expose admin route when admin endpoint is disabled', () => {
     const strapi = createStrapiMock({
       'content-api': {
-        enabled: true,
+        access: 'authenticated',
       },
       admin: {
-        enabled: false,
+        access: 'disabled',
       },
     });
 
@@ -233,7 +272,7 @@ describe('registerOpenAPIRoute', () => {
   test('supports admin paths that include admin prefix without double prefixing', () => {
     const strapi = createStrapiMock({
       admin: {
-        enabled: true,
+        access: 'authenticated',
         route: {
           path: '/admin/spec.json',
         },
@@ -253,13 +292,13 @@ describe('registerOpenAPIRoute', () => {
     const strapi = createStrapiMock(
       {
         'content-api': {
-          enabled: true,
+          access: 'authenticated',
           route: {
             path: '/openapi.json',
           },
         },
         admin: {
-          enabled: true,
+          access: 'authenticated',
         },
       },
       { adminPath: '/api' }
@@ -270,34 +309,15 @@ describe('registerOpenAPIRoute', () => {
     );
   });
 
-  test('throws when roles are used with public mode', () => {
+  test('throws for unsupported access values', () => {
     const strapi = createStrapiMock({
       admin: {
-        enabled: true,
-        access: {
-          mode: 'public',
-          roles: ['admin::users.read'],
-        },
+        access: 'unknown-access',
       },
     });
 
     expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'OpenAPI endpoint "admin" only supports roles when access.mode is "authenticated"'
-    );
-  });
-
-  test('throws for unsupported access modes', () => {
-    const strapi = createStrapiMock({
-      admin: {
-        enabled: true,
-        access: {
-          mode: 'unknown-mode',
-        },
-      },
-    });
-
-    expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'Invalid OpenAPI access mode "unknown-mode" for "admin". Expected one of: public, authenticated'
+      'Invalid OpenAPI access "unknown-access" for "admin". Expected one of: disabled, public, authenticated'
     );
   });
 });

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -37,16 +37,11 @@ let ctx = createCtx();
 
 const createStrapiMock = (
   openapiConfig: Record<string, unknown> = {},
-  options: { apiPrefix?: string; adminPath?: string; futureFlagEnabled?: boolean } = {}
+  options: { apiPrefix?: string; adminPath?: string } = {}
 ) => {
-  const { apiPrefix = '/api', adminPath = '/admin', futureFlagEnabled = true } = options;
+  const { apiPrefix = '/api', adminPath = '/admin' } = options;
 
   return {
-    features: {
-      future: {
-        isEnabled: jest.fn((name: string) => name === 'unstableOpenapi' && futureFlagEnabled),
-      },
-    },
     config: {
       get: jest.fn((key: string, defaultValue?: unknown) => {
         if (key === 'server.openapi') {
@@ -86,20 +81,6 @@ describe('registerOpenAPIRoute', () => {
 
   test('does not register route when disabled', () => {
     const strapi = createStrapiMock({});
-
-    registerOpenAPIRoute(strapi as any);
-
-    expect(strapi.server.routes).not.toHaveBeenCalled();
-  });
-
-  test('does not register route when the unstableOpenapi future flag is disabled', () => {
-    const strapi = createStrapiMock(
-      {
-        'content-api': { access: 'authenticated' },
-        admin: { access: 'authenticated' },
-      },
-      { futureFlagEnabled: false }
-    );
 
     registerOpenAPIRoute(strapi as any);
 

--- a/packages/core/core/src/services/server/__tests__/openapi.test.ts
+++ b/packages/core/core/src/services/server/__tests__/openapi.test.ts
@@ -90,7 +90,7 @@ describe('registerOpenAPIRoute', () => {
   test('registers one route per configured endpoint', () => {
     const strapi = createStrapiMock({
       'content-api': {
-        access: 'authenticated',
+        access: 'public',
         route: {
           path: '/spec.json',
         },
@@ -110,7 +110,7 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes).toHaveLength(1);
     expect(contentApiRouter.routes[0].method).toBe('GET');
     expect(contentApiRouter.routes[0].path).toBe('/spec.json');
-    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
+    expect(contentApiRouter.routes[0].config.auth).toBe(false);
 
     expect(adminRouter.type).toBe('admin');
     expect(adminRouter.prefix).toBe('/admin');
@@ -136,18 +136,16 @@ describe('registerOpenAPIRoute', () => {
     expect(contentApiRouter.routes[0].config.auth).toBe(false);
   });
 
-  test('content-api authenticated access uses default content API auth (no scope)', () => {
+  test('throws when the content-api endpoint is configured as authenticated', () => {
     const strapi = createStrapiMock({
       'content-api': {
         access: 'authenticated',
       },
     });
 
-    registerOpenAPIRoute(strapi as any);
-
-    expect(strapi.server.routes).toHaveBeenCalledTimes(1);
-    const [contentApiRouter] = (strapi.server.routes as jest.Mock).mock.calls[0];
-    expect(contentApiRouter.routes[0].config.auth).toBeUndefined();
+    expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
+      'Invalid OpenAPI access "authenticated" for "content-api". Expected one of: disabled, public'
+    );
   });
 
   test('admin authenticated access requires an authenticated admin', () => {
@@ -173,7 +171,7 @@ describe('registerOpenAPIRoute', () => {
     });
 
     expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'OpenAPI admin endpoint does not support access "public"'
+      'Invalid OpenAPI access "public" for "admin". Expected one of: disabled, authenticated'
     );
   });
 
@@ -182,7 +180,7 @@ describe('registerOpenAPIRoute', () => {
     const document = { openapi: '3.1.0', info: { title: 'Cached' } };
     const strapi = createStrapiMock({
       'content-api': {
-        access: 'authenticated',
+        access: 'public',
         cache: {
           enabled: true,
           maxAgeMs: 60_000,
@@ -210,7 +208,7 @@ describe('registerOpenAPIRoute', () => {
     const document = { openapi: '3.1.0', info: { title: 'Generated', version: '1.0.0' } };
     const strapi = createStrapiMock({
       'content-api': {
-        access: 'authenticated',
+        access: 'public',
         cache: {
           enabled: true,
           maxAgeMs: 50,
@@ -236,7 +234,7 @@ describe('registerOpenAPIRoute', () => {
   test('does not expose admin route when admin endpoint is disabled', () => {
     const strapi = createStrapiMock({
       'content-api': {
-        access: 'authenticated',
+        access: 'public',
       },
       admin: {
         access: 'disabled',
@@ -273,7 +271,7 @@ describe('registerOpenAPIRoute', () => {
     const strapi = createStrapiMock(
       {
         'content-api': {
-          access: 'authenticated',
+          access: 'public',
           route: {
             path: '/openapi.json',
           },
@@ -298,7 +296,7 @@ describe('registerOpenAPIRoute', () => {
     });
 
     expect(() => registerOpenAPIRoute(strapi as any)).toThrow(
-      'Invalid OpenAPI access "unknown-access" for "admin". Expected one of: disabled, public, authenticated'
+      'Invalid OpenAPI access "unknown-access" for "admin". Expected one of: disabled, authenticated'
     );
   });
 });

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -4,11 +4,16 @@ import * as openapi from '@strapi/openapi';
 import type { Core } from '@strapi/types';
 
 type OpenAPIConfig = Core.Config.OpenAPI;
-type OpenAPIEndpointConfig = NonNullable<OpenAPIConfig['content-api']>;
-type OpenAPIAccess = NonNullable<OpenAPIEndpointConfig['access']>;
 type OpenAPIRouteType = keyof OpenAPIConfig;
+type OpenAPIEndpointConfig = NonNullable<OpenAPIConfig[OpenAPIRouteType]>;
+type OpenAPIAccess =
+  | NonNullable<NonNullable<OpenAPIConfig['content-api']>['access']>
+  | NonNullable<NonNullable<OpenAPIConfig['admin']>['access']>;
 
-const SUPPORTED_ACCESS: OpenAPIAccess[] = ['disabled', 'public', 'authenticated'];
+const SUPPORTED_ACCESS = {
+  'content-api': ['disabled', 'public'],
+  admin: ['disabled', 'authenticated'],
+} as const satisfies Record<OpenAPIRouteType, readonly OpenAPIAccess[]>;
 
 interface ResolvedEndpointConfig {
   type: OpenAPIRouteType;
@@ -86,16 +91,12 @@ const resolveEndpointConfig = (
       ? joinPaths(normalizePath(apiPrefix), routePath)
       : joinPaths(routerPrefix!, routePath);
   const access = rawConfig?.access ?? DEFAULTS.access;
+  const supportedAccess = SUPPORTED_ACCESS[type];
 
-  if (!SUPPORTED_ACCESS.includes(access)) {
+  if (!(supportedAccess as readonly OpenAPIAccess[]).includes(access)) {
     throw new Error(
-      `Invalid OpenAPI access "${access}" for "${type}". Expected one of: ${SUPPORTED_ACCESS.join(', ')}`
+      `Invalid OpenAPI access "${access}" for "${type}". Expected one of: ${supportedAccess.join(', ')}`
     );
-  }
-
-  // The admin spec is never public.
-  if (type === 'admin' && access === 'public') {
-    throw new Error('OpenAPI admin endpoint does not support access "public"');
   }
 
   const cacheEnabled = rawConfig?.cache?.enabled ?? DEFAULTS.cacheEnabled;
@@ -121,18 +122,17 @@ const resolveEndpointConfig = (
  * Build the route `config` (auth + policies) for an endpoint.
  *
  * - `admin`: requires an authenticated admin via the `admin::isAuthenticatedAdmin`
- *   policy. Only `authenticated` reaches here (`public` is rejected for admin).
+ *   policy.
  *   Granular per-permission RBAC is intentionally left for a later iteration.
- * - `content-api`: `authenticated` relies on the standard Content API auth
- *   (authenticated users-permissions user or full-access API token); `public`
- *   disables auth so anyone can read the spec.
+ * - `content-api`: only supports public access for now, which disables auth so
+ *   anyone can read the spec.
  */
 const buildRouteConfig = (config: ResolvedEndpointConfig): Record<string, unknown> => {
   if (config.type === 'admin') {
     return { policies: ['admin::isAuthenticatedAdmin'] };
   }
 
-  return config.access === 'public' ? { auth: false } : {};
+  return { auth: false };
 };
 
 const resolveOpenAPIConfig = (strapi: Core.Strapi) => {

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -8,9 +8,6 @@ type OpenAPIEndpointConfig = NonNullable<OpenAPIConfig['content-api']>;
 type OpenAPIAccess = NonNullable<OpenAPIEndpointConfig['access']>;
 type OpenAPIRouteType = keyof OpenAPIConfig;
 
-// Future flag gating the (still unstable) OpenAPI HTTP endpoints.
-const FUTURE_FLAG = 'unstableOpenapi';
-
 const SUPPORTED_ACCESS: OpenAPIAccess[] = ['disabled', 'public', 'authenticated'];
 
 interface ResolvedEndpointConfig {
@@ -175,12 +172,6 @@ const generateDocument = (strapi: Core.Strapi, type: OpenAPIRouteType) => {
 };
 
 export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
-  // The OpenAPI HTTP endpoints are still experimental and only registered when
-  // the `future.unstableOpenapi` flag is explicitly enabled.
-  if (!strapi.features.future.isEnabled(FUTURE_FLAG)) {
-    return;
-  }
-
   const configs = resolveOpenAPIConfig(strapi);
 
   if (!configs.length) {

--- a/packages/core/core/src/services/server/openapi.ts
+++ b/packages/core/core/src/services/server/openapi.ts
@@ -5,17 +5,20 @@ import type { Core } from '@strapi/types';
 
 type OpenAPIConfig = Core.Config.OpenAPI;
 type OpenAPIEndpointConfig = NonNullable<OpenAPIConfig['content-api']>;
-type OpenAPIAccessMode = NonNullable<NonNullable<OpenAPIEndpointConfig['access']>['mode']>;
+type OpenAPIAccess = NonNullable<OpenAPIEndpointConfig['access']>;
 type OpenAPIRouteType = keyof OpenAPIConfig;
+
+// Future flag gating the (still unstable) OpenAPI HTTP endpoints.
+const FUTURE_FLAG = 'unstableOpenapi';
+
+const SUPPORTED_ACCESS: OpenAPIAccess[] = ['disabled', 'public', 'authenticated'];
 
 interface ResolvedEndpointConfig {
   type: OpenAPIRouteType;
-  enabled: boolean;
+  access: OpenAPIAccess;
   routePath: string;
   routerPrefix?: string;
   fullPath: string;
-  accessMode: OpenAPIAccessMode;
-  accessRoles: string[];
   cacheEnabled: boolean;
   cacheMaxAgeMs: number;
   absoluteCachePath: string;
@@ -23,7 +26,7 @@ interface ResolvedEndpointConfig {
 
 const DEFAULTS = {
   routePath: '/openapi.json',
-  accessMode: 'authenticated' as const,
+  access: 'disabled' as const,
   cacheEnabled: true,
   cacheMaxAgeMs: 60_000,
   cacheRelativeFilePaths: {
@@ -85,30 +88,19 @@ const resolveEndpointConfig = (
     type === 'content-api'
       ? joinPaths(normalizePath(apiPrefix), routePath)
       : joinPaths(routerPrefix!, routePath);
-  const accessMode = rawConfig?.access?.mode ?? DEFAULTS.accessMode;
-  const supportedAccessModes = ['public', 'authenticated'];
+  const access = rawConfig?.access ?? DEFAULTS.access;
 
-  if (!supportedAccessModes.includes(accessMode)) {
+  if (!SUPPORTED_ACCESS.includes(access)) {
     throw new Error(
-      `Invalid OpenAPI access mode "${accessMode}" for "${type}". Expected one of: ${supportedAccessModes.join(', ')}`
+      `Invalid OpenAPI access "${access}" for "${type}". Expected one of: ${SUPPORTED_ACCESS.join(', ')}`
     );
   }
 
-  const accessRoles = rawConfig?.access?.roles;
-
-  if (accessRoles !== undefined && !Array.isArray(accessRoles)) {
-    throw new Error(
-      `Invalid OpenAPI roles configuration for "${type}". Expected an array of scopes.`
-    );
+  // The admin spec is never public.
+  if (type === 'admin' && access === 'public') {
+    throw new Error('OpenAPI admin endpoint does not support access "public"');
   }
 
-  const normalizedAccessRoles = accessRoles ?? [];
-
-  if (normalizedAccessRoles.length > 0 && accessMode !== 'authenticated') {
-    throw new Error(
-      `OpenAPI endpoint "${type}" only supports roles when access.mode is "authenticated"`
-    );
-  }
   const cacheEnabled = rawConfig?.cache?.enabled ?? DEFAULTS.cacheEnabled;
   const cacheMaxAgeMs = rawConfig?.cache?.maxAgeMs ?? DEFAULTS.cacheMaxAgeMs;
   const configuredCachePath = rawConfig?.cache?.filePath ?? DEFAULTS.cacheRelativeFilePaths[type];
@@ -118,30 +110,32 @@ const resolveEndpointConfig = (
 
   return {
     type,
-    enabled: rawConfig?.enabled === true,
+    access,
     routePath,
     routerPrefix,
     fullPath,
-    accessMode,
-    accessRoles: normalizedAccessRoles,
     cacheEnabled,
     cacheMaxAgeMs,
     absoluteCachePath,
   };
 };
 
-const getRouteAuthConfig = (config: ResolvedEndpointConfig) => {
-  if (config.accessMode === 'public') {
-    return false as const;
+/**
+ * Build the route `config` (auth + policies) for an endpoint.
+ *
+ * - `admin`: requires an authenticated admin via the `admin::isAuthenticatedAdmin`
+ *   policy. Only `authenticated` reaches here (`public` is rejected for admin).
+ *   Granular per-permission RBAC is intentionally left for a later iteration.
+ * - `content-api`: `authenticated` relies on the standard Content API auth
+ *   (authenticated users-permissions user or full-access API token); `public`
+ *   disables auth so anyone can read the spec.
+ */
+const buildRouteConfig = (config: ResolvedEndpointConfig): Record<string, unknown> => {
+  if (config.type === 'admin') {
+    return { policies: ['admin::isAuthenticatedAdmin'] };
   }
 
-  if (config.accessRoles.length > 0) {
-    return {
-      scope: config.accessRoles,
-    };
-  }
-
-  return {};
+  return config.access === 'public' ? { auth: false } : {};
 };
 
 const resolveOpenAPIConfig = (strapi: Core.Strapi) => {
@@ -150,7 +144,7 @@ const resolveOpenAPIConfig = (strapi: Core.Strapi) => {
   return [
     resolveEndpointConfig(strapi, rawConfig['content-api'], 'content-api'),
     resolveEndpointConfig(strapi, rawConfig.admin, 'admin'),
-  ].filter((config) => config.enabled);
+  ].filter((config) => config.access !== 'disabled');
 };
 
 const readCache = async (cachePath: string, maxAgeMs: number) => {
@@ -181,6 +175,12 @@ const generateDocument = (strapi: Core.Strapi, type: OpenAPIRouteType) => {
 };
 
 export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
+  // The OpenAPI HTTP endpoints are still experimental and only registered when
+  // the `future.unstableOpenapi` flag is explicitly enabled.
+  if (!strapi.features.future.isEnabled(FUTURE_FLAG)) {
+    return;
+  }
+
   const configs = resolveOpenAPIConfig(strapi);
 
   if (!configs.length) {
@@ -235,9 +235,7 @@ export const registerOpenAPIRoute = (strapi: Core.Strapi) => {
           info: {
             type: config.type,
           },
-          config: {
-            auth: getRouteAuthConfig(config),
-          },
+          config: buildRouteConfig(config),
         },
       ],
     };

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -14,22 +14,8 @@ This command generates a `content-api` specification by default.
 
 ## Expose `/openapi.json` from the server
 
-> **Experimental / unstable.** The HTTP endpoints are gated behind the
-> `future.unstableOpenapi` flag. Their config and behaviour may change without
-> following semver until the feature is stabilised.
-
-First, enable the feature flag:
-
-```js
-// config/features.js
-module.exports = () => ({
-  future: {
-    unstableOpenapi: true,
-  },
-});
-```
-
-Then add `server.openapi` config in your app:
+Strapi can expose a generated OpenAPI document over HTTP. Both endpoints are
+disabled by default; opt in per endpoint via `server.openapi`:
 
 ```js
 // config/server.js
@@ -75,9 +61,8 @@ module.exports = () => ({
 
 ### Access control
 
-A single `access` value per endpoint controls both whether the endpoint exists and how it is protected
-(in addition to enabling the feature flag). Access is governed by Strapi's existing auth, not by a
-bespoke access surface:
+A single `access` value per endpoint controls both whether the endpoint exists and how it is protected.
+Access is governed by Strapi's existing auth, not by a bespoke access surface:
 
 - `disabled` (default): the endpoint is not registered.
 - `public` (**content-api only**): no authentication — anyone can read the spec.

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -14,23 +14,32 @@ This command generates a `content-api` specification by default.
 
 ## Expose `/openapi.json` from the server
 
-Strapi can expose a generated OpenAPI document over HTTP using the core generator.
+> **Experimental / unstable.** The HTTP endpoints are gated behind the
+> `future.unstableOpenapi` flag. Their config and behaviour may change without
+> following semver until the feature is stabilised.
 
-Add `server.openapi` config in your app:
+First, enable the feature flag:
+
+```js
+// config/features.js
+module.exports = () => ({
+  future: {
+    unstableOpenapi: true,
+  },
+});
+```
+
+Then add `server.openapi` config in your app:
 
 ```js
 // config/server.js
 module.exports = () => ({
   openapi: {
     'content-api': {
-      enabled: true,
+      // 'disabled' (default) | 'public' | 'authenticated'
+      access: 'public',
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated', // public | authenticated
-        // Optional scopes to further restrict authenticated access:
-        // roles: ['plugin::users-permissions.authenticated'],
       },
       cache: {
         enabled: true,
@@ -39,13 +48,10 @@ module.exports = () => ({
       },
     },
     admin: {
-      enabled: false,
+      // 'disabled' (default) | 'authenticated' ('public' is not allowed)
+      access: 'authenticated',
       route: {
         path: '/openapi.json',
-      },
-      access: {
-        mode: 'authenticated',
-        roles: ['admin::marketplace.read'],
       },
       cache: {
         enabled: true,
@@ -61,17 +67,28 @@ module.exports = () => ({
 
 - `server.openapi['content-api']`: config for the Content API OpenAPI endpoint.
 - `server.openapi.admin`: config for the Admin API OpenAPI endpoint.
-- `enabled`: enables the endpoint when `true`.
+- `access`: controls exposure and protection in a single setting (default `disabled`). See below.
 - `route.path`: endpoint subpath to register (resolved under `/api` for content-api and under `/admin` for admin by default).
-- `access.mode`: endpoint access mode (`public`, `authenticated`).
-- `access.roles`: optional auth scopes when `access.mode` is `authenticated`.
 - `cache.enabled`: enables file-based cache for generated output.
 - `cache.maxAgeMs`: cache validity in milliseconds.
 - `cache.filePath`: output file path for cached spec (absolute or app-root relative).
 
-### Security note
+### Access control
 
-By default, endpoints use `authenticated` access mode. You can explicitly set `public` for unauthenticated
-access, or add `access.roles` to further restrict authenticated users/tokens by scope. Exposing API specs
-may still be sensitive in some deployments, so both endpoints are disabled by default and should be
-explicitly opted into.
+A single `access` value per endpoint controls both whether the endpoint exists and how it is protected
+(in addition to enabling the feature flag). Access is governed by Strapi's existing auth, not by a
+bespoke access surface:
+
+- `disabled` (default): the endpoint is not registered.
+- `public` (**content-api only**): no authentication — anyone can read the spec.
+- `authenticated`:
+  - **Content API** (`/api/openapi.json`): requires standard Content API auth — an authenticated
+    users-permissions user or a full-access API token.
+  - **Admin** (`/admin/openapi.json`): requires an authenticated admin (any role). Granular
+    per-permission RBAC is intentionally left for a later iteration.
+
+The admin endpoint is never public; setting `access: 'public'` for it throws at startup.
+
+> **Security note:** a `public` content-api spec describes your entire Content API surface — including
+> content types that are not publicly readable — to anyone. If you need a gated spec, use the admin
+> endpoint or `authenticated`. Review who can reach each endpoint before enabling it.

--- a/packages/core/openapi/README.md
+++ b/packages/core/openapi/README.md
@@ -22,7 +22,7 @@ disabled by default; opt in per endpoint via `server.openapi`:
 module.exports = () => ({
   openapi: {
     'content-api': {
-      // 'disabled' (default) | 'public' | 'authenticated'
+      // 'disabled' (default) | 'public'
       access: 'public',
       route: {
         path: '/openapi.json',
@@ -66,14 +66,12 @@ Access is governed by Strapi's existing auth, not by a bespoke access surface:
 
 - `disabled` (default): the endpoint is not registered.
 - `public` (**content-api only**): no authentication — anyone can read the spec.
-- `authenticated`:
-  - **Content API** (`/api/openapi.json`): requires standard Content API auth — an authenticated
-    users-permissions user or a full-access API token.
-  - **Admin** (`/admin/openapi.json`): requires an authenticated admin (any role). Granular
-    per-permission RBAC is intentionally left for a later iteration.
+- `authenticated` (**admin only**): requires an authenticated admin (any role). Granular
+  per-permission RBAC is intentionally left for a later iteration.
 
-The admin endpoint is never public; setting `access: 'public'` for it throws at startup.
+The content-api endpoint is only available as public for now. The admin endpoint is never public.
+Unsupported access values throw at startup.
 
 > **Security note:** a `public` content-api spec describes your entire Content API surface — including
 > content types that are not publicly readable — to anyone. If you need a gated spec, use the admin
-> endpoint or `authenticated`. Review who can reach each endpoint before enabling it.
+> endpoint with `authenticated`. Review who can reach each endpoint before enabling it.

--- a/packages/core/types/src/core/config/openapi.ts
+++ b/packages/core/types/src/core/config/openapi.ts
@@ -2,15 +2,14 @@
  * Controls whether an OpenAPI endpoint is exposed and how it is protected.
  *
  * - `disabled` (default): the endpoint is not registered.
- * - `public`: the endpoint is registered without authentication (anyone can
- *   read the spec). Not supported for the `admin` endpoint.
- * - `authenticated`:
- *   - `content-api`: requires standard Content API auth (an authenticated
- *     users-permissions user or a full-access API token).
- *   - `admin`: requires an authenticated admin. Granular per-permission RBAC is
- *     intentionally left for a later iteration.
+ * - `public`: content-api only; the endpoint is registered without
+ *   authentication (anyone can read the spec).
+ * - `authenticated`: admin only; requires an authenticated admin. Granular
+ *   per-permission RBAC is intentionally left for a later iteration.
  */
-export type OpenAPIAccess = 'disabled' | 'public' | 'authenticated';
+export type OpenAPIContentAPIAccess = 'disabled' | 'public';
+export type OpenAPIAdminAccess = 'disabled' | 'authenticated';
+export type OpenAPIAccess = OpenAPIContentAPIAccess | OpenAPIAdminAccess;
 
 export interface OpenAPIRoute {
   path?: string;
@@ -27,13 +26,13 @@ export interface OpenAPICache {
   filePath?: string;
 }
 
-export interface OpenAPIEndpoint {
-  access?: OpenAPIAccess;
+export interface OpenAPIEndpoint<TAccess extends OpenAPIAccess = OpenAPIAccess> {
+  access?: TAccess;
   route?: OpenAPIRoute;
   cache?: OpenAPICache;
 }
 
 export interface OpenAPI {
-  'content-api'?: OpenAPIEndpoint;
-  admin?: OpenAPIEndpoint;
+  'content-api'?: OpenAPIEndpoint<OpenAPIContentAPIAccess>;
+  admin?: OpenAPIEndpoint<OpenAPIAdminAccess>;
 }

--- a/packages/core/types/src/core/config/openapi.ts
+++ b/packages/core/types/src/core/config/openapi.ts
@@ -1,16 +1,19 @@
-export type OpenAPIAccessMode = 'public' | 'authenticated';
+/**
+ * Controls whether an OpenAPI endpoint is exposed and how it is protected.
+ *
+ * - `disabled` (default): the endpoint is not registered.
+ * - `public`: the endpoint is registered without authentication (anyone can
+ *   read the spec). Not supported for the `admin` endpoint.
+ * - `authenticated`:
+ *   - `content-api`: requires standard Content API auth (an authenticated
+ *     users-permissions user or a full-access API token).
+ *   - `admin`: requires an authenticated admin. Granular per-permission RBAC is
+ *     intentionally left for a later iteration.
+ */
+export type OpenAPIAccess = 'disabled' | 'public' | 'authenticated';
 
 export interface OpenAPIRoute {
   path?: string;
-}
-
-export interface OpenAPIAccess {
-  mode?: OpenAPIAccessMode;
-  /**
-   * Authorization scopes required when access mode is `authenticated`.
-   * If omitted, any authenticated user/token is allowed.
-   */
-  roles?: string[];
 }
 
 export interface OpenAPICache {
@@ -25,9 +28,8 @@ export interface OpenAPICache {
 }
 
 export interface OpenAPIEndpoint {
-  enabled?: boolean;
-  route?: OpenAPIRoute;
   access?: OpenAPIAccess;
+  route?: OpenAPIRoute;
   cache?: OpenAPICache;
 }
 

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,6 +1,7 @@
 export interface FeaturesConfig {
   future?: {
     unstableMediaLibrary?: boolean;
+    unstableOpenapi?: boolean;
   };
 }
 

--- a/packages/core/types/src/modules/features.ts
+++ b/packages/core/types/src/modules/features.ts
@@ -1,7 +1,6 @@
 export interface FeaturesConfig {
   future?: {
     unstableMediaLibrary?: boolean;
-    unstableOpenapi?: boolean;
   };
 }
 

--- a/tests/api/core/strapi/api/openapi-access.test.api.ts
+++ b/tests/api/core/strapi/api/openapi-access.test.api.ts
@@ -4,10 +4,9 @@ import { createStrapiInstance } from 'api-tests/strapi';
 import { createRequest, createContentAPIRequest, createAuthRequest } from 'api-tests/request';
 
 /**
- * API tests for the access control of the (unstable) OpenAPI HTTP endpoints.
+ * API tests for the access control of the OpenAPI HTTP endpoints.
  *
- * The endpoints are gated behind the `future.unstableOpenapi` flag and rely on
- * Strapi's existing auth (no bespoke OpenAPI permission):
+ * The endpoints rely on Strapi's existing auth (no bespoke OpenAPI permission):
  *  - content-api (`/api/openapi.json`): controlled by `server.openapi['content-api'].access`.
  *    `authenticated` requires standard Content API auth (authenticated user or
  *    full-access API token); `public` disables auth entirely.
@@ -17,10 +16,6 @@ import { createRequest, createContentAPIRequest, createAuthRequest } from 'api-t
 
 const CONTENT_API_PATH = '/api/openapi.json';
 const ADMIN_PATH = '/admin/openapi.json';
-
-const enableUnstableOpenapi = (instance: Core.Strapi) => {
-  instance.config.set('features', { future: { unstableOpenapi: true } });
-};
 
 const expectOpenAPIDocument = (body: any) => {
   expect(body).toBeDefined();
@@ -38,7 +33,6 @@ describe('OpenAPI endpoints – access control', () => {
       strapi = await createStrapiInstance({
         bypassAuth: false,
         register: ({ strapi: instance }) => {
-          enableUnstableOpenapi(instance);
           instance.config.set('server.openapi', {
             'content-api': { access: 'authenticated' },
           });
@@ -108,7 +102,6 @@ describe('OpenAPI endpoints – access control', () => {
       strapi = await createStrapiInstance({
         bypassAuth: false,
         register: ({ strapi: instance }) => {
-          enableUnstableOpenapi(instance);
           instance.config.set('server.openapi', {
             'content-api': { access: 'public' },
           });
@@ -145,7 +138,6 @@ describe('OpenAPI endpoints – access control', () => {
       strapi = await createStrapiInstance({
         bypassAuth: false,
         register: ({ strapi: instance }) => {
-          enableUnstableOpenapi(instance);
           instance.config.set('server.openapi', {
             admin: { access: 'authenticated' },
           });

--- a/tests/api/core/strapi/api/openapi-access.test.api.ts
+++ b/tests/api/core/strapi/api/openapi-access.test.api.ts
@@ -1,0 +1,204 @@
+import type { Core } from '@strapi/types';
+
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createRequest, createContentAPIRequest, createAuthRequest } from 'api-tests/request';
+
+/**
+ * API tests for the access control of the (unstable) OpenAPI HTTP endpoints.
+ *
+ * The endpoints are gated behind the `future.unstableOpenapi` flag and rely on
+ * Strapi's existing auth (no bespoke OpenAPI permission):
+ *  - content-api (`/api/openapi.json`): controlled by `server.openapi['content-api'].access`.
+ *    `authenticated` requires standard Content API auth (authenticated user or
+ *    full-access API token); `public` disables auth entirely.
+ *  - admin (`/admin/openapi.json`): requires an authenticated admin via
+ *    `admin::isAuthenticatedAdmin`. No public option; granular RBAC comes later.
+ */
+
+const CONTENT_API_PATH = '/api/openapi.json';
+const ADMIN_PATH = '/admin/openapi.json';
+
+const enableUnstableOpenapi = (instance: Core.Strapi) => {
+  instance.config.set('features', { future: { unstableOpenapi: true } });
+};
+
+const expectOpenAPIDocument = (body: any) => {
+  expect(body).toBeDefined();
+  expect(typeof body.openapi).toBe('string');
+  expect(body.paths).toBeDefined();
+};
+
+describe('OpenAPI endpoints – access control', () => {
+  describe('content-api (authenticated mode, default)', () => {
+    let strapi: Core.Strapi;
+    let fullAccessToken: string;
+    let readOnlyToken: string;
+
+    beforeAll(async () => {
+      strapi = await createStrapiInstance({
+        bypassAuth: false,
+        register: ({ strapi: instance }) => {
+          enableUnstableOpenapi(instance);
+          instance.config.set('server.openapi', {
+            'content-api': { access: 'authenticated' },
+          });
+        },
+      });
+
+      // Required so content-api tokens can be created (their access key is encrypted at rest).
+      strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key-for-openapi-tests');
+
+      const createContentApiToken = async (attributes: Record<string, unknown>) => {
+        const token = await strapi
+          .service('admin::api-token-content-api')
+          .create({ description: '', ...attributes });
+
+        return token.accessKey as string;
+      };
+
+      fullAccessToken = await createContentApiToken({
+        name: 'openapi-full-access',
+        type: 'full-access',
+      });
+      readOnlyToken = await createContentApiToken({
+        name: 'openapi-read-only',
+        type: 'read-only',
+      });
+    });
+
+    afterAll(async () => {
+      await strapi.db.query('admin::api-token').deleteMany({
+        where: { name: { $startsWith: 'openapi-' } },
+      });
+      await strapi.destroy();
+    });
+
+    test('Denies an anonymous request (not 200)', async () => {
+      const rq = createRequest({ strapi });
+
+      const res = await rq({ method: 'GET', url: CONTENT_API_PATH });
+
+      expect(res.statusCode).not.toBe(200);
+      expect([401, 403]).toContain(res.statusCode);
+    });
+
+    test('Allows a full-access token (200)', async () => {
+      const rq = createContentAPIRequest({ strapi, auth: { token: fullAccessToken } });
+
+      const res = await rq({ method: 'GET', url: '/openapi.json' });
+
+      expect(res.statusCode).toBe(200);
+      expectOpenAPIDocument(res.body);
+    });
+
+    test('Denies a read-only token (no matching scope)', async () => {
+      const rq = createContentAPIRequest({ strapi, auth: { token: readOnlyToken } });
+
+      const res = await rq({ method: 'GET', url: '/openapi.json' });
+
+      expect(res.statusCode).not.toBe(200);
+      expect([401, 403]).toContain(res.statusCode);
+    });
+  });
+
+  describe('content-api (public mode)', () => {
+    let strapi: Core.Strapi;
+
+    beforeAll(async () => {
+      strapi = await createStrapiInstance({
+        bypassAuth: false,
+        register: ({ strapi: instance }) => {
+          enableUnstableOpenapi(instance);
+          instance.config.set('server.openapi', {
+            'content-api': { access: 'public' },
+          });
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await strapi.destroy();
+    });
+
+    test('Allows an anonymous request (200)', async () => {
+      const rq = createRequest({ strapi });
+
+      const res = await rq({ method: 'GET', url: CONTENT_API_PATH });
+
+      expect(res.statusCode).toBe(200);
+      expectOpenAPIDocument(res.body);
+    });
+  });
+
+  describe('admin (authenticated)', () => {
+    let strapi: Core.Strapi;
+    let restrictedRoleId: number | string;
+
+    const restrictedUser = {
+      email: 'openapi-restricted@strapi.io',
+      password: 'Test1234',
+      firstname: 'OpenAPI',
+      lastname: 'Restricted',
+    };
+
+    beforeAll(async () => {
+      strapi = await createStrapiInstance({
+        bypassAuth: false,
+        register: ({ strapi: instance }) => {
+          enableUnstableOpenapi(instance);
+          instance.config.set('server.openapi', {
+            admin: { access: 'authenticated' },
+          });
+        },
+      });
+
+      const role = await strapi.service('admin::role').create({
+        name: 'openapi-restricted-role',
+        description: 'Role used for OpenAPI admin endpoint access tests',
+      });
+
+      restrictedRoleId = role.id;
+
+      await strapi.service('admin::user').create({
+        ...restrictedUser,
+        registrationToken: null,
+        isActive: true,
+        roles: [role.id],
+      });
+    });
+
+    afterAll(async () => {
+      await strapi.db.query('admin::user').deleteMany({ where: { email: restrictedUser.email } });
+      await strapi.service('admin::role').deleteByIds([restrictedRoleId]);
+      await strapi.destroy();
+    });
+
+    test('Denies an unauthenticated request (401)', async () => {
+      const rq = createRequest({ strapi });
+
+      const res = await rq({ method: 'GET', url: ADMIN_PATH });
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('Allows the super admin (200)', async () => {
+      const rq = await createAuthRequest({ strapi });
+
+      const res = await rq({ method: 'GET', url: ADMIN_PATH });
+
+      expect(res.statusCode).toBe(200);
+      expectOpenAPIDocument(res.body);
+    });
+
+    test('Allows any authenticated admin, regardless of role/permissions (200)', async () => {
+      // Access is currently gated only by `admin::isAuthenticatedAdmin`; granular
+      // per-permission RBAC will be added in a later iteration.
+      const rq = await createAuthRequest({ strapi, userInfo: restrictedUser });
+
+      const res = await rq({ method: 'GET', url: ADMIN_PATH });
+
+      expect(res.statusCode).toBe(200);
+      expectOpenAPIDocument(res.body);
+    });
+  });
+});

--- a/tests/api/core/strapi/api/openapi-access.test.api.ts
+++ b/tests/api/core/strapi/api/openapi-access.test.api.ts
@@ -1,21 +1,30 @@
 import type { Core } from '@strapi/types';
 
 import { createStrapiInstance } from 'api-tests/strapi';
-import { createRequest, createContentAPIRequest, createAuthRequest } from 'api-tests/request';
+import { createRequest, createAuthRequest } from 'api-tests/request';
 
 /**
  * API tests for the access control of the OpenAPI HTTP endpoints.
  *
  * The endpoints rely on Strapi's existing auth (no bespoke OpenAPI permission):
  *  - content-api (`/api/openapi.json`): controlled by `server.openapi['content-api'].access`.
- *    `authenticated` requires standard Content API auth (authenticated user or
- *    full-access API token); `public` disables auth entirely.
+ *    Only `public` is supported for now, which disables auth entirely.
  *  - admin (`/admin/openapi.json`): requires an authenticated admin via
  *    `admin::isAuthenticatedAdmin`. No public option; granular RBAC comes later.
  */
 
 const CONTENT_API_PATH = '/api/openapi.json';
 const ADMIN_PATH = '/admin/openapi.json';
+
+const createOpenAPIStrapiInstance = (openapiConfig: Core.Config.OpenAPI) =>
+  createStrapiInstance({
+    bypassAuth: false,
+    register: ({ strapi }: { strapi: Core.Strapi }) => {
+      strapi.config.set('server.openapi', openapiConfig);
+    },
+  } as Parameters<typeof createStrapiInstance>[0] & {
+    register: (args: { strapi: Core.Strapi }) => void;
+  });
 
 const expectOpenAPIDocument = (body: any) => {
   expect(body).toBeDefined();
@@ -24,88 +33,12 @@ const expectOpenAPIDocument = (body: any) => {
 };
 
 describe('OpenAPI endpoints – access control', () => {
-  describe('content-api (authenticated mode, default)', () => {
-    let strapi: Core.Strapi;
-    let fullAccessToken: string;
-    let readOnlyToken: string;
-
-    beforeAll(async () => {
-      strapi = await createStrapiInstance({
-        bypassAuth: false,
-        register: ({ strapi: instance }) => {
-          instance.config.set('server.openapi', {
-            'content-api': { access: 'authenticated' },
-          });
-        },
-      });
-
-      // Required so content-api tokens can be created (their access key is encrypted at rest).
-      strapi.config.set('admin.secrets.encryptionKey', 'test-encryption-key-for-openapi-tests');
-
-      const createContentApiToken = async (attributes: Record<string, unknown>) => {
-        const token = await strapi
-          .service('admin::api-token-content-api')
-          .create({ description: '', ...attributes });
-
-        return token.accessKey as string;
-      };
-
-      fullAccessToken = await createContentApiToken({
-        name: 'openapi-full-access',
-        type: 'full-access',
-      });
-      readOnlyToken = await createContentApiToken({
-        name: 'openapi-read-only',
-        type: 'read-only',
-      });
-    });
-
-    afterAll(async () => {
-      await strapi.db.query('admin::api-token').deleteMany({
-        where: { name: { $startsWith: 'openapi-' } },
-      });
-      await strapi.destroy();
-    });
-
-    test('Denies an anonymous request (not 200)', async () => {
-      const rq = createRequest({ strapi });
-
-      const res = await rq({ method: 'GET', url: CONTENT_API_PATH });
-
-      expect(res.statusCode).not.toBe(200);
-      expect([401, 403]).toContain(res.statusCode);
-    });
-
-    test('Allows a full-access token (200)', async () => {
-      const rq = createContentAPIRequest({ strapi, auth: { token: fullAccessToken } });
-
-      const res = await rq({ method: 'GET', url: '/openapi.json' });
-
-      expect(res.statusCode).toBe(200);
-      expectOpenAPIDocument(res.body);
-    });
-
-    test('Denies a read-only token (no matching scope)', async () => {
-      const rq = createContentAPIRequest({ strapi, auth: { token: readOnlyToken } });
-
-      const res = await rq({ method: 'GET', url: '/openapi.json' });
-
-      expect(res.statusCode).not.toBe(200);
-      expect([401, 403]).toContain(res.statusCode);
-    });
-  });
-
   describe('content-api (public mode)', () => {
     let strapi: Core.Strapi;
 
     beforeAll(async () => {
-      strapi = await createStrapiInstance({
-        bypassAuth: false,
-        register: ({ strapi: instance }) => {
-          instance.config.set('server.openapi', {
-            'content-api': { access: 'public' },
-          });
-        },
+      strapi = await createOpenAPIStrapiInstance({
+        'content-api': { access: 'public' },
       });
     });
 
@@ -135,13 +68,8 @@ describe('OpenAPI endpoints – access control', () => {
     };
 
     beforeAll(async () => {
-      strapi = await createStrapiInstance({
-        bypassAuth: false,
-        register: ({ strapi: instance }) => {
-          instance.config.set('server.openapi', {
-            admin: { access: 'authenticated' },
-          });
-        },
+      strapi = await createOpenAPIStrapiInstance({
+        admin: { access: 'authenticated' },
       });
 
       const role = await strapi.service('admin::role').create({


### PR DESCRIPTION
## What does it do?

Adds opt-in HTTP endpoints for the generated OpenAPI specs, controlled by a single `access` setting per endpoint.

`access` accepts endpoint-specific values:

- **Content API** (`/api/openapi.json`):
  - `disabled` (default): the endpoint is not registered.
  - `public`: the endpoint is registered without authentication (anyone can read the spec).
- **Admin** (`/admin/openapi.json`):
  - `disabled` (default): the endpoint is not registered.
  - `authenticated`: requires an authenticated admin (any role).

The first iteration intentionally avoids introducing a bespoke OpenAPI permission/action or changing global content-api token semantics. Granular per-permission/role RBAC can be added in a follow-up once the core-owned permission shape is agreed.

## Why is it needed?

The earlier config-based access design (`mode` + `roles`) was the wrong abstraction: `roles` was misnamed (it held auth scopes, not roles) and was silently unenforced for the admin endpoint.

This PR keeps the feature fully opt-in and limited to the unambiguous cases:

- publish a public Content API spec when a project explicitly wants one;
- expose a gated Admin API spec to authenticated admins;
- keep both endpoints disabled by default so existing projects are unaffected.

## How to test it?

1. Configure `server.openapi` and verify behavior:
   - no config, or `access: 'disabled'` → no OpenAPI endpoint is registered.
   - `content-api: { access: 'public' }` → anonymous `GET /api/openapi.json` returns 200.
   - `content-api: { access: 'authenticated' }` → throws at startup.
   - `admin: { access: 'authenticated' }` → unauthenticated returns 401; any authenticated admin returns 200.
   - `admin: { access: 'public' }` → throws at startup.
2. Automated:
   - `yarn jest packages/core/core/src/services/server/__tests__/openapi.test.ts`
   - `yarn test:api tests/api/core/strapi/api/openapi-access.test.api.ts`

## Related issue(s)/PR(s)

- Builds on #26239