### PR TITLE
fix(ci): restore allowed paths-filter pin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2 # need to check out previous 2 commits to see what has changed
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: .github/filters.yaml


### PR DESCRIPTION
## What does it do?

Reverts the `dorny/paths-filter` action in `.github/workflows/tests.yml` from the v4 SHA back to the previously allowed v3 SHA.

## Why is it needed?

The v4 SHA is currently blocked by the GitHub Actions allowlist, causing the `Tests` workflow on `develop` to fail at startup before any jobs are created.

## How to test it?

- Verify the PR diff only restores the allowed `dorny/paths-filter` v3 pin.
- Let GitHub Actions run on this PR / after merge to confirm the `Tests` workflow starts again.

## Related issue(s)/PR(s)

Reverts the CI-breaking workflow action bump from #26566.