### PR TITLE
fix(admin): rate limit and serialize first admin registration

### DIFF
--- a/packages/core/admin/server/src/controllers/authentication.ts
+++ b/packages/core/admin/server/src/controllers/authentication.ts
@@ -26,6 +26,7 @@ import type {
   ForgotPassword,
   Login,
   Register,
+  RegisterAdmin,
   RegistrationInfo,
   ResetPassword,
 } from '../../../shared/contracts/authentication';
@@ -175,30 +176,11 @@ export default {
   },
 
   async registerAdmin(ctx: Context) {
-    const input = ctx.request.body as Register.Request['body'];
+    const input = ctx.request.body as RegisterAdmin.Request['body'];
 
     await validateAdminRegistrationInput(input);
 
-    const hasAdmin = await getService('user').exists();
-
-    if (hasAdmin) {
-      throw new ApplicationError('You cannot register a new super admin');
-    }
-
-    const superAdminRole = await getService('role').getSuperAdmin();
-
-    if (!superAdminRole) {
-      throw new ApplicationError(
-        "Cannot register the first admin because the super admin role doesn't exist."
-      );
-    }
-
-    const user = await getService('user').create({
-      ...input,
-      registrationToken: null,
-      isActive: true,
-      roles: superAdminRole ? [superAdminRole.id] : [],
-    });
+    const user = await getService('user').createFirstAdmin(input);
 
     strapi.telemetry.send('didCreateFirstAdmin');
 
@@ -234,7 +216,7 @@ export default {
           accessToken,
           user: getService('user').sanitizeUser(user),
         },
-      };
+      } satisfies RegisterAdmin.Response;
     } catch (error) {
       strapi.log.error('Failed to create admin refresh session during register-admin', error);
       return ctx.internalServerError();

--- a/packages/core/admin/server/src/routes/authentication.ts
+++ b/packages/core/admin/server/src/routes/authentication.ts
@@ -20,7 +20,10 @@ export default [
     method: 'POST',
     path: '/register-admin',
     handler: 'authentication.registerAdmin',
-    config: { auth: false },
+    config: {
+      auth: false,
+      middlewares: ['admin::rateLimit'],
+    },
   },
   {
     method: 'GET',

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -19,7 +19,7 @@ import constants from './constants';
 
 const { SUPER_ADMIN_CODE } = constants;
 
-const { ValidationError } = errors;
+const { ApplicationError, ValidationError } = errors;
 const sanitizeUserRoles = (role: AdminRole): SanitizedAdminRole =>
   _.pick(role, ['id', 'name', 'description', 'code']);
 
@@ -43,7 +43,7 @@ const sanitizeUser = (user: AdminUser): SanitizedAdminUser => {
  * Create and save a user in database
  * @param attributes A partial user object
  */
-const create = async (
+const createUserInDatabase = async (
   // isActive is added in the controller, it's not sent by the API.
   attributes: Partial<AdminUserCreationPayload> & { isActive?: true }
 ): Promise<AdminUser> => {
@@ -62,9 +62,60 @@ const create = async (
     .query('admin::user')
     .create({ data: user, populate: ['roles'] });
 
+  return createdUser;
+};
+
+const emitUserCreated = (user: AdminUser) => {
   getService('metrics').sendDidInviteUser();
 
-  strapi.eventHub.emit('user.create', { user: sanitizeUser(createdUser) });
+  strapi.eventHub.emit('user.create', { user: sanitizeUser(user) });
+};
+
+const create = async (
+  // isActive is added in the controller, it's not sent by the API.
+  attributes: Partial<AdminUserCreationPayload> & { isActive?: true }
+): Promise<AdminUser> => {
+  const createdUser = await createUserInDatabase(attributes);
+
+  emitUserCreated(createdUser);
+
+  return createdUser;
+};
+
+const createFirstAdmin = async (
+  attributes: Omit<Partial<AdminUserCreationPayload>, 'registrationToken' | 'isActive' | 'roles'>
+): Promise<AdminUser> => {
+  const createdUser = await strapi.db.transaction(async ({ trx }) => {
+    const superAdminRole = await strapi.db
+      .queryBuilder('admin::role')
+      .select(['id'])
+      .where({ code: SUPER_ADMIN_CODE })
+      .first()
+      .transacting(trx)
+      .forUpdate()
+      .execute<AdminRole | undefined>();
+
+    if (!superAdminRole) {
+      throw new ApplicationError(
+        "Cannot register the first admin because the super admin role doesn't exist."
+      );
+    }
+
+    const hasAdmin = await exists();
+
+    if (hasAdmin) {
+      throw new ApplicationError('You cannot register a new super admin');
+    }
+
+    return createUserInDatabase({
+      ...attributes,
+      registrationToken: null,
+      isActive: true,
+      roles: [superAdminRole.id],
+    });
+  });
+
+  emitUserCreated(createdUser);
 
   return createdUser;
 };
@@ -415,6 +466,7 @@ const getLanguagesInUse = async (): Promise<string[]> => {
 };
 export default {
   create,
+  createFirstAdmin,
   updateById,
   exists,
   findRegistrationInfo,

--- a/packages/core/admin/server/src/services/user.ts
+++ b/packages/core/admin/server/src/services/user.ts
@@ -86,6 +86,8 @@ const createFirstAdmin = async (
   attributes: Omit<Partial<AdminUserCreationPayload>, 'registrationToken' | 'isActive' | 'roles'>
 ): Promise<AdminUser> => {
   const createdUser = await strapi.db.transaction(async ({ trx }) => {
+    // Serialize first-admin creation across processes by locking a stable role row.
+    // SQLite ignores FOR UPDATE, but falls back to its single-writer transaction behavior.
     const superAdminRole = await strapi.db
       .queryBuilder('admin::role')
       .select(['id'])

--- a/tests/api/core/admin/register-admin-first-user.test.api.ts
+++ b/tests/api/core/admin/register-admin-first-user.test.api.ts
@@ -16,6 +16,56 @@ type TestResponse = {
   };
 };
 
+type RestorableAdminRole = {
+  id: string | number;
+};
+
+type RestorableAdminUser = {
+  id: string | number;
+  firstname?: string | null;
+  lastname?: string | null;
+  username?: string | null;
+  email: string;
+  password?: string | null;
+  resetPasswordToken?: string | null;
+  registrationToken?: string | null;
+  isActive?: boolean | null;
+  blocked?: boolean | null;
+  preferedLanguage?: string | null;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+  roles?: RestorableAdminRole[];
+};
+
+let originalAdminUsers: RestorableAdminUser[] | null = null;
+
+const snapshotAdminUsers = async (strapi: StrapiInstance) => {
+  if (originalAdminUsers !== null) {
+    return;
+  }
+
+  originalAdminUsers = (await strapi.db.query('admin::user').findMany({
+    populate: ['roles'],
+  })) as RestorableAdminUser[];
+};
+
+const clearAdminUsers = async (strapi: StrapiInstance) => {
+  await strapi.db.query('admin::user').deleteMany({});
+};
+
+const restoreOriginalAdminUsers = async (strapi: StrapiInstance) => {
+  await clearAdminUsers(strapi);
+
+  for (const { roles = [], ...user } of originalAdminUsers ?? []) {
+    await strapi.db.query('admin::user').create({
+      data: {
+        ...user,
+        roles: roles.map((role) => role.id),
+      },
+    });
+  }
+};
+
 describe('First admin registration', () => {
   let rq: TestRequest;
   let strapi: StrapiInstance;
@@ -26,11 +76,11 @@ describe('First admin registration', () => {
     });
     rq = createRequest({ strapi });
 
-    await strapi.db.query('admin::user').deleteMany({});
+    await snapshotAdminUsers(strapi);
+    await clearAdminUsers(strapi);
   });
 
   afterAll(async () => {
-    await strapi.db.query('admin::user').deleteMany({});
     await strapi.destroy();
   });
 
@@ -50,11 +100,12 @@ describe('First admin registration', () => {
       )
     );
 
-    expect(responses.slice(0, 5).map((res: TestResponse) => res.statusCode)).toEqual([
-      400, 400, 400, 400, 400,
-    ]);
-    expect(responses[5].statusCode).toBe(429);
-    expect(responses[5].body.error).toMatchObject({
+    const statusCodes = responses.map((res: TestResponse) => res.statusCode);
+    expect(statusCodes.filter((code) => code === 400)).toHaveLength(5);
+    expect(statusCodes.filter((code) => code === 429)).toHaveLength(1);
+
+    const rateLimitedResponse = responses.find((res: TestResponse) => res.statusCode === 429);
+    expect(rateLimitedResponse?.body.error).toMatchObject({
       name: 'RateLimitError',
       message: 'Too many requests, please try again later.',
     });
@@ -111,9 +162,12 @@ describe('First admin registration race protection', () => {
       ensureSuperAdmin: false,
     });
     rq = createRequest({ strapi });
+
+    await clearAdminUsers(strapi);
   });
 
   afterAll(async () => {
+    await restoreOriginalAdminUsers(strapi);
     await strapi.destroy();
   });
 

--- a/tests/api/core/admin/register-admin-first-user.test.api.ts
+++ b/tests/api/core/admin/register-admin-first-user.test.api.ts
@@ -1,0 +1,201 @@
+'use strict';
+
+import { createRequest } from 'api-tests/request';
+import { createStrapiInstance } from 'api-tests/strapi';
+
+type StrapiInstance = Awaited<ReturnType<typeof createStrapiInstance>>;
+type TestRequest = ReturnType<typeof createRequest>;
+type TestResponse = {
+  statusCode: number;
+  body: {
+    data?: unknown;
+    error?: {
+      name?: string;
+      message?: string;
+    };
+  };
+};
+
+describe('First admin registration', () => {
+  let rq: TestRequest;
+  let strapi: StrapiInstance;
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      ensureSuperAdmin: false,
+    });
+    rq = createRequest({ strapi });
+
+    await strapi.db.query('admin::user').deleteMany({});
+  });
+
+  afterAll(async () => {
+    await strapi.db.query('admin::user').deleteMany({});
+    await strapi.destroy();
+  });
+
+  test('applies the default admin rate limit to repeated registration attempts', async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        rq({
+          url: '/admin/register-admin',
+          method: 'POST',
+          body: {
+            email: 'attacker@example.com',
+            firstname: 'Admin',
+            lastname: 'User',
+            password: 'short',
+          },
+        })
+      )
+    );
+
+    expect(responses.slice(0, 5).map((res: TestResponse) => res.statusCode)).toEqual([
+      400, 400, 400, 400, 400,
+    ]);
+    expect(responses[5].statusCode).toBe(429);
+    expect(responses[5].body.error).toMatchObject({
+      name: 'RateLimitError',
+      message: 'Too many requests, please try again later.',
+    });
+  });
+
+  test('allows the first registerer to create the super admin', async () => {
+    const firstRegisterer = {
+      email: 'first-registerer@example.com',
+      firstname: 'Admin',
+      lastname: 'User',
+      password: 'Attacker1!',
+    };
+
+    const res = await rq({
+      url: '/admin/register-admin',
+      method: 'POST',
+      body: firstRegisterer,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toMatchObject({
+      token: expect.any(String),
+      accessToken: expect.any(String),
+      user: {
+        email: firstRegisterer.email,
+        firstname: firstRegisterer.firstname,
+        lastname: firstRegisterer.lastname,
+        isActive: true,
+      },
+    });
+
+    const nextRes = await rq({
+      url: '/admin/register-admin',
+      method: 'POST',
+      body: {
+        email: 'owner@example.com',
+        firstname: 'Real',
+        lastname: 'Owner',
+        password: 'Owner123!',
+      },
+    });
+
+    expect(nextRes.statusCode).toBe(400);
+    expect(nextRes.body.error.message).toBe('You cannot register a new super admin');
+  });
+});
+
+describe('First admin registration race protection', () => {
+  let rq: TestRequest;
+  let strapi: StrapiInstance;
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      ensureSuperAdmin: false,
+    });
+    rq = createRequest({ strapi });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  test('only allows one super admin when concurrent requests observe no existing admin', async () => {
+    const originalQuery = strapi.db.query.bind(strapi.db);
+    const pendingCreates: Array<() => void> = [];
+
+    strapi.db.query = ((uid: string) => {
+      const query = originalQuery(uid);
+
+      if (uid !== 'admin::user') {
+        return query;
+      }
+
+      return new Proxy(query, {
+        get(target, prop: string | symbol) {
+          if (prop !== 'create') {
+            const value = target[prop];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+
+          return async (...args: unknown[]) => {
+            await new Promise((resolve) => {
+              pendingCreates.push(resolve as () => void);
+
+              if (pendingCreates.length === 2) {
+                pendingCreates.forEach((release) => release());
+                return;
+              }
+
+              setTimeout(resolve, 50);
+            });
+
+            return target.create(...args);
+          };
+        },
+      });
+    }) as typeof strapi.db.query;
+
+    try {
+      const responses = await Promise.all([
+        rq({
+          url: '/admin/register-admin',
+          method: 'POST',
+          body: {
+            email: 'attacker-a@example.com',
+            firstname: 'Admin',
+            lastname: 'A',
+            password: 'Attacker1!',
+          },
+        }),
+        rq({
+          url: '/admin/register-admin',
+          method: 'POST',
+          body: {
+            email: 'attacker-b@example.com',
+            firstname: 'Admin',
+            lastname: 'B',
+            password: 'Attacker1!',
+          },
+        }),
+      ]);
+
+      expect(responses.map((res: TestResponse) => res.statusCode).sort()).toEqual([200, 400]);
+
+      const adminUsers = await strapi.db.query('admin::user').findMany({
+        where: {
+          email: {
+            $in: ['attacker-a@example.com', 'attacker-b@example.com'],
+          },
+        },
+        populate: ['roles'],
+      });
+
+      expect(adminUsers).toHaveLength(1);
+      expect(
+        adminUsers.every(
+          (user: { roles: Array<{ code: string }> }) => user.roles[0].code === 'strapi-super-admin'
+        )
+      ).toBe(true);
+    } finally {
+      strapi.db.query = originalQuery;
+    }
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds admin rate limiting to `POST /admin/register-admin` and moves first-admin creation into a DB-locked service path so concurrent setup requests cannot create multiple super admins.

### Why is it needed?

The first-admin registration endpoint was unauthenticated, not rate-limited, and used a separate `exists()` then `create()` flow. Concurrent requests could pass the check before either write completed.

### How to test it?

Run:

```bash
yarn test:api tests/api/core/admin/register-admin-first-user.test.api.ts
yarn test:api tests/api/core/admin/admin-auth.test.api.js
```

Verify that first-admin registration still succeeds once, repeated attempts are rate-limited, and concurrent first-admin requests only create one super admin.

### Related issue(s)/PR(s)

Fixes #26494