### PR TITLE
fix(content-manager): guard list-view filters against missing field config

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/Filters.tsx
@@ -182,11 +182,16 @@ const Root = ({ disabled, schema, layout, children }: FiltersProps) => {
 
         const attribute = attributes[name];
 
-        if (NOT_ALLOWED_FILTERS.includes(attribute.type)) {
+        if (!attribute || NOT_ALLOWED_FILTERS.includes(attribute.type)) {
           return null;
         }
 
-        const { mainField: mainFieldName = '', label } = metadata[name].list;
+        const fieldMetadata = metadata[name];
+        if (!fieldMetadata) {
+          return null;
+        }
+
+        const { mainField: mainFieldName = '', label } = fieldMetadata.list;
 
         let filter: Filters.Filter = {
           name,

--- a/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/tests/Filters.test.tsx
@@ -1,0 +1,45 @@
+import { mockData } from '@tests/mockData';
+import { render, screen, server } from '@tests/utils';
+import { http, HttpResponse } from 'msw';
+
+import { listViewFilters } from '../Filters';
+
+// #26396 — omits creator attributes (missing from the schema) and drops `slug` from the
+// configuration metadatas below, so the filter builder hits both missing-field lookups.
+const HOMEPAGE_SCHEMA = {
+  uid: 'api::homepage.homepage',
+  options: {},
+  attributes: {
+    id: { type: 'integer' },
+    documentId: { type: 'string' },
+    title: { type: 'string' },
+    slug: { type: 'string' },
+    createdAt: { type: 'datetime' },
+    updatedAt: { type: 'datetime' },
+  },
+} as unknown as Parameters<typeof listViewFilters.Root>[0]['schema'];
+
+const LAYOUT = { options: {} } as Parameters<typeof listViewFilters.Root>[0]['layout'];
+
+const renderFilters = () =>
+  render(
+    <listViewFilters.Root schema={HOMEPAGE_SCHEMA} layout={LAYOUT}>
+      <listViewFilters.Trigger />
+    </listViewFilters.Root>
+  );
+
+describe('ListView Filters (#26396)', () => {
+  it('does not crash when filter fields are missing from the schema or configuration', async () => {
+    server.use(
+      http.get('/content-manager/content-types/:model/configuration', () => {
+        const config = structuredClone(mockData.contentManager.singleTypeConfiguration);
+        delete (config.contentType.metadatas as Record<string, unknown>).slug;
+        return HttpResponse.json({ data: config });
+      })
+    );
+
+    renderFilters();
+
+    expect(await screen.findByRole('button', { name: /filters/i })).toBeInTheDocument();
+  });
+});

--- a/packages/core/content-manager/admin/src/utils/attributes.ts
+++ b/packages/core/content-manager/admin/src/utils/attributes.ts
@@ -33,10 +33,10 @@ const getMainField = (
 
   const mainFieldType =
     attribute.type === 'component'
-      ? components[attribute.component].attributes[mainFieldName].type
+      ? components[attribute.component]?.attributes[mainFieldName]?.type
       : // @ts-expect-error – `targetModel` does exist on the attribute for a relation.
         schemas.find((schema) => schema.uid === attribute.targetModel)?.attributes[mainFieldName]
-          .type;
+          ?.type;
 
   return {
     name: mainFieldName,

--- a/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
+++ b/packages/core/content-manager/admin/src/utils/tests/attributes.test.ts
@@ -1,6 +1,38 @@
-import { checkIfAttributeIsDisplayable } from '../attributes';
+import { checkIfAttributeIsDisplayable, getMainField } from '../attributes';
+
+import type { Schema } from '../../hooks/useDocument';
 
 describe('attributes', () => {
+  describe('getMainField (missing schema/config falls back to string)', () => {
+    it('falls back to string when a component attribute references an absent component schema', () => {
+      const attribute = {
+        type: 'component',
+        component: 'basic.missing',
+        repeatable: false,
+      } as const;
+
+      expect(getMainField(attribute, 'name', { schemas: [], components: {} })).toEqual({
+        name: 'name',
+        type: 'string',
+      });
+    });
+
+    it('falls back to string when the relation target schema is missing the mainField attribute', () => {
+      const attribute = {
+        type: 'relation',
+        relation: 'oneToOne',
+        target: 'api::cat.cat',
+        targetModel: 'api::cat.cat',
+      } as const;
+      const schemas = [{ uid: 'api::cat.cat', attributes: {} }] as unknown as Schema[];
+
+      expect(getMainField(attribute, 'name', { schemas, components: {} })).toEqual({
+        name: 'name',
+        type: 'string',
+      });
+    });
+  });
+
   describe('checkIfAttributeIsDisplayable', () => {
     it('should return false if the relation is morph', () => {
       const attribute = {


### PR DESCRIPTION
## Summary

Fixes #26396

The list view crashes with `Cannot read properties of undefined (reading 'list')` when a filterable field has no entry in the view-configuration `metadatas`. This happens when the schema and the persisted configuration desync (a field was added or renamed) or simply on the initial render before the configuration query resolves (`metadata` is `{}`).

`Filters.tsx` built each filter via `attributes[name].type` and `metadata[name].list` without checking the lookups existed, so a single missing entry took down the whole list view (caught by the router error boundary — the "Something went wrong" screen in the report).

- `ListView/components/Filters.tsx`: skip fields whose `attribute` or `metadata` entry is missing instead of crashing, mirroring the `useDocumentLayout` hardening from #26243.
- `utils/attributes.ts`: guard `getMainField`'s internal schema/component lookups with `?.` so its already-documented `'string'` fallback (`#sensible-defaults`) is actually reachable when a `mainField` points at an attribute/schema that is gone.

## Test plan

- [x] New regression test `ListView/components/tests/Filters.test.tsx` — renders the list-view filters for a schema/config missing the entries the builder reads (creator fields absent from `attributes`; `slug` absent from the config `metadatas`), exercising both guards; red before the fix (crash), green after.
- [x] `utils/tests/attributes.test.ts` — `getMainField` now falls back to `string` (instead of throwing) when a component/relation target schema is missing or no longer has the configured `mainField`.
- [x] Targeted suites green (7/7): `Filters.test.tsx` + `attributes.test.ts`.

## Note

The same `getMainField` hardening also guards the `Cannot read properties of undefined (reading 'attributes')` crash tracked in #25509 (partially touched by #26124); this PR does not claim to close it, as that flow (renaming a component label in *Configure the view*) was not reproduced here.

A sibling unguarded lookup exists on a different screen — `ListConfiguration/components/Settings.tsx` (sort options) reads `schema.attributes[field.name].type` without a guard — and is intentionally left out of scope to keep this PR focused on the reported crash.


---
Fixes CPR-410