### PR TITLE
test(content-manager): cover self-referential publish relations

### DIFF
--- a/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
+++ b/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
@@ -12,6 +12,7 @@ interface CategoryEntry {
   parent?: CategoryRelation | null;
   children?: CategoryRelation[];
   related?: CategoryRelation[];
+  relatedMany?: CategoryRelation[];
 }
 
 const builder = createTestBuilder();
@@ -39,10 +40,16 @@ const category = {
       target: 'api::category.category',
       targetAttribute: 'children',
     },
-    // Unidirectional self-referential
+    // Unidirectional self-referential (one to many)
     related: {
       type: 'relation',
       relation: 'oneToMany',
+      target: 'api::category.category',
+    },
+    // Unidirectional self-referential (many to many)
+    relatedMany: {
+      type: 'relation',
+      relation: 'manyToMany',
       target: 'api::category.category',
     },
   },
@@ -58,6 +65,50 @@ const getCategory = async (
     qs: { status },
   });
   return res.body.data as CategoryEntry;
+};
+
+const createCategory = async (name: string): Promise<CategoryEntry> => {
+  const res = await rq({
+    method: 'POST',
+    url: '/content-manager/collection-types/api::category.category',
+    body: { name },
+  });
+
+  return res.body.data as CategoryEntry;
+};
+
+const updateCategory = async (documentId: string, body: Record<string, unknown>) =>
+  rq({
+    method: 'PUT',
+    url: `/content-manager/collection-types/api::category.category/${documentId}`,
+    body,
+  });
+
+const publishCategory = async (documentId: string) =>
+  rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/api::category.category/${documentId}/actions/publish`,
+  });
+
+const discardCategory = async (documentId: string) =>
+  rq({
+    method: 'POST',
+    url: `/content-manager/collection-types/api::category.category/${documentId}/actions/discard`,
+  });
+
+// Returns the target documentIds linked through `field` for the given status.
+const getRelationTargets = async (
+  documentId: string,
+  field: string,
+  status: 'draft' | 'published'
+): Promise<string[]> => {
+  const res = await rq({
+    method: 'GET',
+    url: `/content-manager/relations/api::category.category/${documentId}/${field}`,
+    qs: { status },
+  });
+
+  return res.body.results.map((result: { documentId: string }) => result.documentId);
 };
 
 describe('CM API - Self-referential relations with Draft & Publish', () => {
@@ -244,5 +295,88 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     const publishedLinks = joinRows.filter((row: any) => row[joinColumn.name] === publishedA.id);
     expect(publishedLinks).toHaveLength(1);
     expect(publishedLinks[0][inverseJoinColumn.name]).toBe(publishedB.id);
+  });
+
+  // A single entry whose unidirectional relation points at itself must keep that relation in
+  // its published version: during the delete-and-recreate publish cycle the self-link has to
+  // be re-pointed to the entry's own published version rather than dropped. These cover the
+  // unidirectional `oneToMany` and `manyToMany` self-links; the bidirectional `parent`
+  // self-link is covered by the tests above.
+  test('unidirectional oneToMany self-link (entry to itself) is preserved after first publish', async () => {
+    const cat = await createCategory('OneToMany self publish');
+
+    await updateCategory(cat.documentId, {
+      name: cat.name,
+      related: [{ documentId: cat.documentId, locale: null }],
+    });
+
+    expect(await getRelationTargets(cat.documentId, 'related', 'draft')).toEqual([cat.documentId]);
+
+    await publishCategory(cat.documentId);
+
+    // The published self-link must exist and point at the entry itself.
+    expect(await getRelationTargets(cat.documentId, 'related', 'published')).toEqual([
+      cat.documentId,
+    ]);
+  });
+
+  test('unidirectional manyToMany self-link (entry to itself) is preserved after first publish', async () => {
+    const cat = await createCategory('ManyToMany self publish');
+
+    await updateCategory(cat.documentId, {
+      name: cat.name,
+      relatedMany: [{ documentId: cat.documentId, locale: null }],
+    });
+
+    expect(await getRelationTargets(cat.documentId, 'relatedMany', 'draft')).toEqual([
+      cat.documentId,
+    ]);
+
+    await publishCategory(cat.documentId);
+
+    expect(await getRelationTargets(cat.documentId, 'relatedMany', 'published')).toEqual([
+      cat.documentId,
+    ]);
+  });
+
+  test('unidirectional self-link (entry to itself) is preserved when added before a republish', async () => {
+    const cat = await createCategory('Self republish');
+
+    // First publish with no self-link, so a published version already exists.
+    await publishCategory(cat.documentId);
+    expect(await getRelationTargets(cat.documentId, 'related', 'published')).toEqual([]);
+
+    // Add the self-link on the draft, then republish.
+    await updateCategory(cat.documentId, {
+      name: cat.name,
+      related: [{ documentId: cat.documentId, locale: null }],
+    });
+    await publishCategory(cat.documentId);
+
+    expect(await getRelationTargets(cat.documentId, 'related', 'published')).toEqual([
+      cat.documentId,
+    ]);
+  });
+
+  test('unidirectional self-link (entry to itself) is preserved after discarding the draft', async () => {
+    const cat = await createCategory('Self discard');
+
+    await updateCategory(cat.documentId, {
+      name: cat.name,
+      related: [{ documentId: cat.documentId, locale: null }],
+    });
+    await publishCategory(cat.documentId);
+
+    // Modify the draft (keeping the self-link), then discard back to the published version.
+    await updateCategory(cat.documentId, {
+      name: `${cat.name} - modified`,
+      related: [{ documentId: cat.documentId, locale: null }],
+    });
+    await discardCategory(cat.documentId);
+
+    expect(await getRelationTargets(cat.documentId, 'related', 'draft')).toEqual([cat.documentId]);
+    expect(await getRelationTargets(cat.documentId, 'related', 'published')).toEqual([
+      cat.documentId,
+    ]);
   });
 });

--- a/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
+++ b/tests/api/core/content-manager/api/self-referential-relations.test.api.ts
@@ -339,7 +339,7 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     ]);
   });
 
-  test('unidirectional self-link (entry to itself) is preserved when added before a republish', async () => {
+  test('unidirectional oneToMany self-link (entry to itself) is preserved when added before a republish', async () => {
     const cat = await createCategory('Self republish');
 
     // First publish with no self-link, so a published version already exists.
@@ -358,7 +358,7 @@ describe('CM API - Self-referential relations with Draft & Publish', () => {
     ]);
   });
 
-  test('unidirectional self-link (entry to itself) is preserved after discarding the draft', async () => {
+  test('unidirectional oneToMany self-link (entry to itself) is preserved after discarding the draft', async () => {
     const cat = await createCategory('Self discard');
 
     await updateCategory(cat.documentId, {

--- a/tests/app-template/src/api/dog/content-types/dog/schema.json
+++ b/tests/app-template/src/api/dog/content-types/dog/schema.json
@@ -84,6 +84,11 @@
     },
     "favoriteTreat": {
       "type": "string"
+    },
+    "related": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::dog.dog"
     }
   }
 }

--- a/tests/e2e/tests/content-manager/self-referential-relation-publish.spec.ts
+++ b/tests/e2e/tests/content-manager/self-referential-relation-publish.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../../../utils/login';
+import {
+  resetDatabaseAndImportDataFromPath,
+  resyncSuperAdminPermissionsAfterImport,
+} from '../../../utils/dts-import';
+import { clickAndWait, findAndClose, navToHeader } from '../../../utils/shared';
+
+/**
+ * A draft entry whose relation points at itself must keep that relation visible in the edit
+ * view immediately after publishing, without a manual page refresh.
+ *
+ * Server-side persistence of self-referential relations on publish is covered by the API
+ * integration tests (self-referential-relations.test.api.ts). This complements them at the UI
+ * layer: the explicit reload at the end distinguishes a front-end cache/invalidation problem
+ * (chip missing before reload, present after) from actual server-side data loss (missing in
+ * both).
+ */
+test.describe('Self-referential relation - publish reflects in the admin without a refresh', () => {
+  test.beforeEach(async ({ page }) => {
+    // coreStore: false keeps the freshly generated app's auto-synced Content Manager layout,
+    // which includes the `related` field. Restoring the snapshot config would hide it because
+    // the snapshot predates this field.
+    await resetDatabaseAndImportDataFromPath('with-admin', (cts) => cts, { coreStore: false });
+    // The restored permissions snapshot predates the `related` field, so Super Admin would see
+    // "No permissions to see this field". Resync rebuilds CM config + Super Admin permissions.
+    await resyncSuperAdminPermissionsAfterImport();
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  test('a draft entry related to itself keeps the relation visible after publishing (no refresh)', async ({
+    page,
+  }) => {
+    // 1. Create a new Dog entry.
+    await navToHeader(page, ['Content Manager', 'Dog'], 'Dog');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+
+    await page.getByRole('textbox', { name: 'name' }).fill('Rex');
+
+    // Save first so the entry exists and can be selected as its own relation target.
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    // 2. Point the "related" relation at the entry itself.
+    await page.getByRole('combobox', { name: 'related' }).click();
+    await clickAndWait(page, page.getByRole('option', { name: 'Rex' }));
+
+    // The self-relation chip is shown after selecting.
+    const relationChip = page.getByRole('button', { name: 'Rex' });
+    await expect(relationChip).toBeVisible();
+
+    // Persist the self-relation on the draft.
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+    await expect(relationChip).toBeVisible();
+
+    // 3. Publish without reloading the page afterwards.
+    await clickAndWait(page, page.getByRole('button', { name: 'Publish' }));
+    await findAndClose(page, 'Published Document');
+
+    // The self-relation must stay visible without a manual refresh: a missing chip here
+    // indicates a front-end cache/invalidation problem after publish.
+    await expect(relationChip).toBeVisible();
+
+    // After an explicit reload the relation must still be present, confirming it was persisted
+    // server-side. If the chip is missing before this reload but present after, the defect is
+    // front-end only; if it is missing in both, the relation was lost on the server.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(relationChip).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What does it do?
- Adds API regression coverage for unidirectional self-referential relations where an entry relates to itself across publish, republish, discard, one-to-many, and many-to-many flows.
- Adds a Content Manager E2E test that verifies a self-referential relation remains visible in the admin immediately after publishing, without a manual refresh.
- Adds a self-referential `related` relation to the Dog E2E app-template content type so the UI flow can be exercised.

## Why is it needed?
- The previous regression coverage focused on bidirectional self-links and two-entry unidirectional relations, leaving the single-entry unidirectional self-link publish flow unguarded.
- The E2E coverage ensures the relation is not only persisted server-side, but also reflected in the admin UI after publish without relying on a page reload.

## How to test it?
- `yarn test:api --testPathPattern self-referential-relations`
- `DATABASE_CLIENT=postgres DATABASE_HOST=localhost DATABASE_PORT=5432 DATABASE_NAME=strapi_self_ref_tests DATABASE_USERNAME=strapi DATABASE_PASSWORD=strapi yarn test:api --db=postgres --testPathPattern self-referential-relations`
- `PLAYWRIGHT_BROWSERS_PATH="$HOME/Library/Caches/ms-playwright" yarn test:e2e --setup --concurrency=1 --domains content-manager --grep "Self-referential relation - publish" --project=chromium --reporter=line`
- `PLAYWRIGHT_BROWSERS_PATH="$HOME/Library/Caches/ms-playwright" yarn test:e2e --concurrency=1 --domains content-manager --grep "Conditional Fields" --project=chromium --reporter=line`

## Related issue(s)/PR(s)
- Follow-up coverage for #26536.


Fixes CMS-1154