### PR TITLE
docs: fix typos across contributor docs

### DIFF
--- a/docs/docs/docs/01-core/admin/02-permissions/01-how-they-work.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/01-how-they-work.mdx
@@ -10,7 +10,7 @@ tags:
 The RBAC permission system relies under the hood on the [CASL](https://casl.js.org) library.
 
 A `permission` is the combination of an `action`, a `subject`, some `properties` and some `conditions`.
-The logic is that: a user can perform an `action` on a `subject` and some of its `properties` only if it its role has the `permission` and if the `conditions` associated to the permission pass.
+The logic is that: a user can perform an `action` on a `subject` and some of its `properties` only if its role has the `permission` and if the `conditions` associated to the permission pass.
 The creation and edition of permissions is done through the [edit page](http://localhost:1337/admin/settings/roles/2) of a role by checking or unchecking checkboxes.
 
 Example 1: the action `update` can be applied on the subject `article` and property `title`, this result is the permission to update the title of an article.
@@ -19,11 +19,11 @@ Example 2: the condition `isCreator` added to the previous permission will ensur
 
 Example 3: the action `access the Marketplace page` has no subject to apply on. The permission only contains the action `admin::marketplace.read`.
 
-The permissions are attached to a role. Each role can have different permissions independentely. There is no inheritance system.
+The permissions are attached to a role. Each role can have different permissions independently. There is no inheritance system.
 To check if an action can be performed by a user, frontend and backend simply retrieve the list of the permissions associated with the user's roles and check if it contains the permission associated with the action about to be performed. The backend also runs the associated conditions.
 
 :::tip
-If a user has several role, the user will be allowed to perform an action if at least one of its roles is allowed to perform it.
+If a user has several roles, the user will be allowed to perform an action if at least one of its roles is allowed to perform it.
 :::
 
 ## Actions

--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/fetching-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/fetching-permissions.mdx
@@ -17,7 +17,7 @@ At the very root of the entire admin panel we handle 4 routes:
 - Collecting information from a first time user
 - The authenticated application (where you use the CMS)
 
-Permissions, along with other vital application information is fetched in in the `AuthenticatedApp` component, located
+Permissions, along with other vital application information is fetched in the `AuthenticatedApp` component, located
 in the `packages/core/admin/admin/src/AuthenticatedApp` folder. The cache key (used with `react-query`'s `useQueries` hook)
 for the particular call is `admin-users-permission`.
 

--- a/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
+++ b/docs/docs/docs/01-core/admin/02-permissions/02-frontend/using-permissions.mdx
@@ -58,7 +58,7 @@ type CheckPagePermissions = (props: CheckPagePermissionsProps) => JSX.Element;
 ## useRBAC
 
 Is a wrapper around the [`hasPermissions`](#haspermissions) function which calls the `/admin/permissions/check` endpoint with a provided
-list of permissions to assertain if a user can do a specific action. This hook is typically used with plugin permissions alongside the
+list of permissions to ascertain if a user can do a specific action. This hook is typically used with plugin permissions alongside the
 global permissions object generated from the [`useRBACProvider`](#userbacprovider) hook which can either be passed or will be accessed internally.
 
 ### `hasPermissions`

--- a/docs/docs/docs/01-core/content-releases/02-frontend/02-release-details-page.mdx
+++ b/docs/docs/docs/01-core/content-releases/02-frontend/02-release-details-page.mdx
@@ -11,7 +11,7 @@ The release details page allows users with appropriate permissions to do the fol
 
 #### Group entries:
 
-Entries in a release can be be grouped by the following options:
+Entries in a release can be grouped by the following options:
 
 - Content-Types: Group all entries with the same content type together
 - Locales: Group all entries with the same locale together.

--- a/docs/docs/docs/01-core/utils/traverse-entity.md
+++ b/docs/docs/docs/01-core/utils/traverse-entity.md
@@ -112,7 +112,7 @@ interface Path {
 Tracks the traversal path:
 
 - **`raw`**: The traversal path on the entity
-- **`attribute`**: The same traversal path on the schema if the attibute exists
+- **`attribute`**: The same traversal path on the schema if the attribute exists
 - **`rawWithIndices`**: The traversal path on the entity including array indices using dot notation (e.g., `components.4.field.relations.2.name`)
 
 ### Parent


### PR DESCRIPTION
## Summary
Fix seven small typos in the contributor documentation under `docs/docs/docs/01-core/`: misspellings, doubled words, a stray pronoun, and a missing plural.

## Changes
- `utils/traverse-entity.md`: `attibute` → `attribute`
- `admin/02-permissions/01-how-they-work.mdx`: drop stray "it" in "only if it its role has"
- `admin/02-permissions/01-how-they-work.mdx`: `independentely` → `independently`
- `admin/02-permissions/01-how-they-work.mdx`: `several role` → `several roles`
- `admin/02-permissions/02-frontend/fetching-permissions.mdx`: doubled "in in" → "in"
- `admin/02-permissions/02-frontend/using-permissions.mdx`: `assertain` → `ascertain`
- `content-releases/02-frontend/02-release-details-page.mdx`: doubled "be be" → "be"

## Testing
- Visual diff review; no code or behavior changes.