### PR TITLE
feat(upload): add paginated GET /api/upload/files/page endpoint

### DIFF
--- a/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
+++ b/packages/core/upload/server/src/controllers/__tests__/content-api.test.ts
@@ -1,0 +1,281 @@
+import type { Context } from 'koa';
+
+import contentApiController from '../content-api';
+import { getService } from '../../utils';
+
+jest.mock('../../utils');
+
+const mockGetService = getService as jest.MockedFunction<typeof getService>;
+
+describe('Content API Controller - find / findPage', () => {
+  let mockContext: Context;
+  let mockUploadService: any;
+  let mockFileService: any;
+  let mockValidateQuery: jest.Mock;
+  let mockSanitizeQuery: jest.Mock;
+  let mockSanitizeOutput: jest.Mock;
+
+  const buildController = () => contentApiController({ strapi: globalThis.strapi as any });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUploadService = {
+      findMany: jest.fn(),
+      findPage: jest.fn(),
+      findAndCountPage: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    mockFileService = {
+      signFileUrls: jest.fn((file) => Promise.resolve(file)),
+    };
+
+    mockGetService.mockImplementation((serviceName: string) => {
+      if (serviceName === 'upload') return mockUploadService;
+      if (serviceName === 'file') return mockFileService;
+      return {};
+    });
+
+    mockValidateQuery = jest.fn().mockResolvedValue(undefined);
+    mockSanitizeQuery = jest.fn((query) => Promise.resolve(query));
+    mockSanitizeOutput = jest.fn((data) => Promise.resolve(data));
+
+    globalThis.strapi = {
+      getModel: jest.fn().mockReturnValue({ uid: 'plugin::upload.file' }),
+      contentAPI: {
+        validate: { query: mockValidateQuery },
+        sanitize: { query: mockSanitizeQuery, output: mockSanitizeOutput },
+      },
+    } as any;
+
+    mockContext = {
+      query: {} as any,
+      state: { auth: {} },
+      body: undefined,
+      notFound: jest.fn(),
+    } as unknown as Context;
+  });
+
+  describe('find - legacy flat-array endpoint (GET /files)', () => {
+    it('returns a flat array and calls findMany (never findPage/findAndCountPage)', async () => {
+      const mockFiles = [
+        { id: 1, name: 'file1.jpg', url: '/uploads/file1.jpg' },
+        { id: 2, name: 'file2.jpg', url: '/uploads/file2.jpg' },
+      ];
+      mockUploadService.findMany.mockResolvedValue(mockFiles);
+
+      await buildController().find(mockContext);
+
+      expect(mockUploadService.findMany).toHaveBeenCalledWith({});
+      expect(mockUploadService.findPage).not.toHaveBeenCalled();
+      expect(mockUploadService.findAndCountPage).not.toHaveBeenCalled();
+
+      expect(mockContext.body).toEqual(mockFiles);
+      expect(mockContext.body).not.toHaveProperty('data');
+      expect(mockContext.body).not.toHaveProperty('meta');
+    });
+
+    it('keeps the flat-array shape even when pagination params are present', async () => {
+      // The legacy endpoint must ignore pagination (current v5 behavior) — it does not
+      // shape-shift. Pagination is only honored by the dedicated findPage handler.
+      mockContext.query = { pagination: { pageSize: 2 } } as any;
+      mockSanitizeQuery.mockResolvedValue({ pagination: { pageSize: 2 } });
+
+      const mockFiles = [{ id: 1, name: 'file1.jpg' }];
+      mockUploadService.findMany.mockResolvedValue(mockFiles);
+
+      await buildController().find(mockContext);
+
+      expect(mockUploadService.findMany).toHaveBeenCalledWith({ pagination: { pageSize: 2 } });
+      expect(mockUploadService.findAndCountPage).not.toHaveBeenCalled();
+      expect(Array.isArray(mockContext.body)).toBe(true);
+      expect(mockContext.body).toEqual(mockFiles);
+    });
+
+    it('signs urls and sanitizes the output', async () => {
+      const mockFiles = [{ id: 1, name: 'file1.jpg', secretField: 'secret' }];
+      const sanitizedFiles = [{ id: 1, name: 'file1.jpg' }];
+
+      mockUploadService.findMany.mockResolvedValue(mockFiles);
+      mockSanitizeOutput.mockResolvedValue(sanitizedFiles);
+
+      await buildController().find(mockContext);
+
+      expect(mockFileService.signFileUrls).toHaveBeenCalledTimes(mockFiles.length);
+      expect(mockSanitizeOutput).toHaveBeenCalled();
+      expect(mockContext.body).toEqual(sanitizedFiles);
+    });
+
+    it('validates and sanitizes the query before hitting the service', async () => {
+      mockContext.query = { filters: { name: { $contains: 'test' } } } as any;
+      mockUploadService.findMany.mockResolvedValue([]);
+
+      await buildController().find(mockContext);
+
+      expect(mockValidateQuery).toHaveBeenCalled();
+      expect(mockSanitizeQuery).toHaveBeenCalled();
+    });
+  });
+
+  describe('findPage - paginated endpoint (GET /files/page)', () => {
+    it('returns the { data, meta: { pagination } } envelope', async () => {
+      mockContext.query = { pagination: { pageSize: 2 } } as any;
+
+      const mockFiles = [
+        { id: 1, name: 'file1.jpg' },
+        { id: 2, name: 'file2.jpg' },
+      ];
+      const mockPagination = { page: 1, pageSize: 2, pageCount: 5, total: 10 };
+
+      mockSanitizeQuery.mockResolvedValue({ pagination: { pageSize: 2 } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: mockFiles,
+        pagination: mockPagination,
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect(mockUploadService.findAndCountPage).toHaveBeenCalledWith({
+        pagination: { pageSize: 2 },
+      });
+      expect(mockUploadService.findMany).not.toHaveBeenCalled();
+
+      expect(mockContext.body).toEqual({
+        data: mockFiles,
+        meta: { pagination: mockPagination },
+      });
+    });
+
+    it('passes pagination[page]/pagination[pageSize] through to the service', async () => {
+      mockContext.query = { pagination: { page: 2, pageSize: 2 } } as any;
+
+      const mockFiles = [
+        { id: 3, name: 'file3.jpg' },
+        { id: 4, name: 'file4.jpg' },
+      ];
+      mockSanitizeQuery.mockResolvedValue({ pagination: { page: 2, pageSize: 2 } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: mockFiles,
+        pagination: { page: 2, pageSize: 2, pageCount: 5, total: 10 },
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect(mockUploadService.findAndCountPage).toHaveBeenCalledWith({
+        pagination: { page: 2, pageSize: 2 },
+      });
+      expect((mockContext.body as any)?.meta.pagination.page).toBe(2);
+      expect((mockContext.body as any)?.data).toEqual(mockFiles);
+    });
+
+    it('forwards offset-based pagination meta unchanged (start/limit)', async () => {
+      mockContext.query = { pagination: { start: 0, limit: 3 } } as any;
+      mockSanitizeQuery.mockResolvedValue({ pagination: { start: 0, limit: 3 } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: [],
+        pagination: { start: 0, limit: 3, total: 10 },
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect((mockContext.body as any)?.meta.pagination).toEqual({
+        start: 0,
+        limit: 3,
+        total: 10,
+      });
+    });
+
+    it('forwards withCount-omitted pagination meta (no total/pageCount)', async () => {
+      mockContext.query = { pagination: { pageSize: 2, withCount: false } } as any;
+      mockSanitizeQuery.mockResolvedValue({ pagination: { pageSize: 2, withCount: false } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: [{ id: 1, name: 'file1.jpg' }],
+        pagination: { page: 1, pageSize: 2 },
+      });
+
+      await buildController().findPage(mockContext);
+
+      const { pagination } = (mockContext.body as any).meta;
+      expect(pagination).toEqual({ page: 1, pageSize: 2 });
+      expect(pagination).not.toHaveProperty('total');
+      expect(pagination).not.toHaveProperty('pageCount');
+    });
+
+    it('returns an empty data array with pagination when no files exist', async () => {
+      mockContext.query = { pagination: { pageSize: 10 } } as any;
+      const mockPagination = { page: 1, pageSize: 10, pageCount: 0, total: 0 };
+
+      mockSanitizeQuery.mockResolvedValue({ pagination: { pageSize: 10 } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: [],
+        pagination: mockPagination,
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect(mockContext.body).toEqual({ data: [], meta: { pagination: mockPagination } });
+    });
+
+    it('sanitizes the output (drops private fields) in paginated mode', async () => {
+      mockContext.query = { pagination: { pageSize: 5 } } as any;
+
+      const mockFiles = [{ id: 1, name: 'file1.jpg', secretField: 'secret' }];
+      const sanitizedFiles = [{ id: 1, name: 'file1.jpg' }];
+
+      mockSanitizeQuery.mockResolvedValue({ pagination: { pageSize: 5 } });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: mockFiles,
+        pagination: { page: 1, pageSize: 5, pageCount: 1, total: 1 },
+      });
+      mockSanitizeOutput.mockResolvedValue(sanitizedFiles);
+
+      await buildController().findPage(mockContext);
+
+      expect(mockSanitizeOutput).toHaveBeenCalled();
+      expect(mockSanitizeOutput.mock.calls[0][0]).toEqual(mockFiles);
+      expect((mockContext.body as any)?.data).toEqual(sanitizedFiles);
+      expect((mockContext.body as any)?.data[0]).not.toHaveProperty('secretField');
+    });
+
+    it('preserves filters and sort alongside pagination', async () => {
+      const sanitizedQuery = {
+        pagination: { pageSize: 5 },
+        filters: { mime: { $startsWith: 'image/' } },
+        sort: 'createdAt:desc',
+      };
+      mockContext.query = sanitizedQuery as any;
+      mockSanitizeQuery.mockResolvedValue(sanitizedQuery);
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: [{ id: 1, name: 'image.jpg', mime: 'image/jpeg' }],
+        pagination: { page: 1, pageSize: 5, pageCount: 1, total: 1 },
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect(mockUploadService.findAndCountPage).toHaveBeenCalledWith(sanitizedQuery);
+      expect((mockContext.body as any)?.data).toHaveLength(1);
+    });
+
+    it('validates and sanitizes the query before hitting the service', async () => {
+      mockContext.query = {
+        pagination: { pageSize: 100 },
+        filters: { name: { $contains: 'test' } },
+      } as any;
+      mockSanitizeQuery.mockResolvedValue({
+        pagination: { pageSize: 100 },
+        filters: { name: { $contains: 'test' } },
+      });
+      mockUploadService.findAndCountPage.mockResolvedValue({
+        results: [],
+        pagination: { page: 1, pageSize: 100, pageCount: 0, total: 0 },
+      });
+
+      await buildController().findPage(mockContext);
+
+      expect(mockValidateQuery).toHaveBeenCalled();
+      expect(mockSanitizeQuery).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/upload/server/src/controllers/content-api.ts
+++ b/packages/core/upload/server/src/controllers/content-api.ts
@@ -46,6 +46,17 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       ctx.body = await sanitizeOutput(signedFiles, ctx);
     },
 
+    async findPage(ctx: Context) {
+      await validateQuery(ctx.query, ctx);
+      const sanitizedQuery = await sanitizeQuery(ctx.query, ctx);
+
+      const { results, pagination } = await getService('upload').findAndCountPage(sanitizedQuery);
+
+      const data = await sanitizeOutput(results, ctx);
+
+      ctx.body = { data, meta: { pagination } };
+    },
+
     async findOne(ctx: Context) {
       const {
         params: { id },

--- a/packages/core/upload/server/src/routes/content-api.ts
+++ b/packages/core/upload/server/src/routes/content-api.ts
@@ -34,6 +34,21 @@ const createRoutes = createContentApiRoutesFactory((): Core.RouterInput['routes'
     },
     {
       method: 'GET',
+      path: '/files/page',
+      handler: 'content-api.findPage',
+      request: {
+        query: {
+          fields: validator.queryFields.optional(),
+          populate: validator.queryPopulate.optional(),
+          sort: validator.querySort.optional(),
+          pagination: validator.pagination.optional(),
+          filters: validator.filters.optional(),
+        },
+      },
+      response: validator.paginatedFiles,
+    },
+    {
+      method: 'GET',
       path: '/files/:id',
       handler: 'content-api.findOne',
       request: {

--- a/packages/core/upload/server/src/routes/validation/upload.ts
+++ b/packages/core/upload/server/src/routes/validation/upload.ts
@@ -57,6 +57,35 @@ export class UploadRouteValidator extends AbstractRouteValidator {
   }
 
   /**
+   * Paginated files response schema: `{ data, meta: { pagination } }`.
+   *
+   * Pagination meta is either page-based (`page`/`pageSize`) or offset-based
+   * (`start`/`limit`), and `total`/`pageCount` are omitted when
+   * `pagination[withCount]=false`.
+   */
+  get paginatedFiles() {
+    const pagedPagination = z.object({
+      page: z.number().int(),
+      pageSize: z.number().int(),
+      pageCount: z.number().int().optional(),
+      total: z.number().int().optional(),
+    });
+
+    const offsetPagination = z.object({
+      start: z.number().int(),
+      limit: z.number().int(),
+      total: z.number().int().optional(),
+    });
+
+    return z.object({
+      data: this.files,
+      meta: z.object({
+        pagination: z.union([pagedPagination, offsetPagination]),
+      }),
+    });
+  }
+
+  /**
    * File ID parameter validation
    */
   get fileId() {

--- a/packages/core/upload/server/src/services/__tests__/upload/findAndCountPage.test.ts
+++ b/packages/core/upload/server/src/services/__tests__/upload/findAndCountPage.test.ts
@@ -1,0 +1,150 @@
+import createUploadService from '../../upload';
+import imageManipulation from '../../image-manipulation';
+import fileService from '../../file';
+
+const files = [
+  { id: 1, name: 'a.png', provider: 'local' },
+  { id: 2, name: 'b.png', provider: 'local' },
+];
+
+const findMany = jest.fn().mockResolvedValue(files);
+const count = jest.fn().mockResolvedValue(42);
+
+// Echo the resolved query so we can assert the offset/limit handed to the DB layer.
+const transform = jest.fn().mockImplementation((_uid: string, query: any) => query);
+
+const config: Record<string, unknown> = {};
+
+const buildStrapi = () =>
+  ({
+    plugins: {
+      upload: {
+        services: {
+          'image-manipulation': imageManipulation,
+          file: {
+            ...fileService,
+            signFileUrls: (file: unknown) => file,
+          },
+          metrics: { trackUsage: jest.fn() },
+        },
+      },
+    },
+    plugin: (name: string) => (global.strapi as any).plugins[name],
+    db: {
+      query: () => ({ findMany, count }),
+    },
+    get: () => ({ transform }),
+    config: {
+      get: (key: string, defaultValue?: unknown) => (key in config ? config[key] : defaultValue),
+    },
+    getModel: () => ({ attributes: {} }),
+  }) as any;
+
+describe('findAndCountPage', () => {
+  let uploadService: ReturnType<typeof createUploadService>;
+
+  beforeEach(() => {
+    findMany.mockClear().mockResolvedValue(files);
+    count.mockClear().mockResolvedValue(42);
+    transform.mockClear();
+    for (const k of Object.keys(config)) delete config[k];
+    global.strapi = buildStrapi();
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+  });
+
+  test('page-based: returns results + page-based pagination meta with count', async () => {
+    const { results, pagination } = await uploadService.findAndCountPage({
+      pagination: { page: 2, pageSize: 10 },
+    });
+
+    expect(results).toEqual(files);
+    // page 2, pageSize 10 -> offset 10, limit 10 handed to the DB layer
+    const [, query] = transform.mock.calls[0];
+    expect(query).toMatchObject({ start: 10, limit: 10 });
+    expect(query.pagination).toBeUndefined();
+
+    expect(count).toHaveBeenCalledTimes(1);
+    expect(pagination).toEqual({ page: 2, pageSize: 10, pageCount: 5, total: 42 });
+  });
+
+  test('defaults to api.rest.defaultLimit (25) when no pagination provided', async () => {
+    const { pagination } = await uploadService.findAndCountPage({});
+
+    const [, query] = transform.mock.calls[0];
+    expect(query).toMatchObject({ start: 0, limit: 25 });
+    expect(pagination).toEqual({ page: 1, pageSize: 25, pageCount: 2, total: 42 });
+  });
+
+  test('respects a configured api.rest.defaultLimit', async () => {
+    config['api.rest.defaultLimit'] = 5;
+    global.strapi = buildStrapi();
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+
+    const { pagination } = await uploadService.findAndCountPage({});
+
+    const [, query] = transform.mock.calls[0];
+    expect(query).toMatchObject({ limit: 5 });
+    expect(pagination).toMatchObject({ pageSize: 5 });
+  });
+
+  test('caps pageSize at api.rest.maxLimit', async () => {
+    config['api.rest.maxLimit'] = 50;
+    global.strapi = buildStrapi();
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+
+    await uploadService.findAndCountPage({ pagination: { page: 1, pageSize: 1000 } });
+
+    const [, query] = transform.mock.calls[0];
+    expect(query.limit).toBe(50);
+  });
+
+  test('offset-based: start/limit honored and offset pagination meta returned', async () => {
+    const { pagination } = await uploadService.findAndCountPage({
+      pagination: { start: 20, limit: 5 },
+    });
+
+    const [, query] = transform.mock.calls[0];
+    expect(query).toMatchObject({ start: 20, limit: 5 });
+    expect(pagination).toEqual({ start: 20, limit: 5, total: 42 });
+  });
+
+  test('withCount=false skips the count query and omits total/pageCount', async () => {
+    const { pagination } = await uploadService.findAndCountPage({
+      pagination: { page: 1, pageSize: 10, withCount: 'false' },
+    });
+
+    expect(count).not.toHaveBeenCalled();
+    expect(pagination).toEqual({ page: 1, pageSize: 10 });
+    expect(pagination).not.toHaveProperty('total');
+    expect(pagination).not.toHaveProperty('pageCount');
+  });
+
+  test('respects api.rest.withCount=false config default', async () => {
+    config['api.rest.withCount'] = false;
+    global.strapi = buildStrapi();
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+
+    const { pagination } = await uploadService.findAndCountPage({
+      pagination: { page: 1, pageSize: 10 },
+    });
+
+    expect(count).not.toHaveBeenCalled();
+    expect(pagination).not.toHaveProperty('total');
+  });
+
+  test('throws on invalid withCount value', async () => {
+    await expect(
+      uploadService.findAndCountPage({ pagination: { withCount: 'nope' } })
+    ).rejects.toThrow(/Invalid withCount parameter/);
+  });
+
+  test('signs file urls for every returned result', async () => {
+    const signFileUrls = jest.fn((file: unknown) => file);
+    global.strapi.plugins.upload.services.file.signFileUrls = signFileUrls;
+    uploadService = createUploadService({ strapi: global.strapi } as any);
+
+    await uploadService.findAndCountPage({ pagination: { page: 1, pageSize: 10 } });
+
+    expect(signFileUrls).toHaveBeenCalledTimes(files.length);
+  });
+});

--- a/packages/core/upload/server/src/services/upload.ts
+++ b/packages/core/upload/server/src/services/upload.ts
@@ -10,7 +10,9 @@ import {
   contentTypes as contentTypesUtils,
   errors,
   file as fileUtils,
+  pagination as paginationUtils,
 } from '@strapi/utils';
+import { has, toNumber, isNil } from 'lodash/fp';
 
 import type { Core, UID } from '@strapi/types';
 
@@ -531,6 +533,91 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     };
   }
 
+  /**
+   * Resolve whether the count query should run, mirroring core-api's `shouldCount`.
+   * Defaults to the `api.rest.withCount` config (true) when not specified on the request.
+   */
+  function resolveWithCount(pagination: Record<string, unknown>): boolean {
+    if (has('withCount', pagination)) {
+      const withCount = pagination.withCount;
+
+      if (typeof withCount === 'boolean') {
+        return withCount;
+      }
+
+      if (typeof withCount === 'undefined') {
+        return false;
+      }
+
+      if (['true', 't', '1', 1].includes(withCount as string | number)) {
+        return true;
+      }
+
+      if (['false', 'f', '0', 0].includes(withCount as string | number)) {
+        return false;
+      }
+
+      throw new errors.ValidationError(
+        'Invalid withCount parameter. Expected "t","1","true","false","0","f"'
+      );
+    }
+
+    return Boolean(strapi.config.get('api.rest.withCount', true));
+  }
+
+  /**
+   * REST-aware paginated find for the content API.
+   *
+   * Unlike `findPage` (used by the admin API), this honors the standard nested
+   * `pagination` query object (`pagination[page]`, `pagination[pageSize]`,
+   * `pagination[start]`, `pagination[limit]`, `pagination[withCount]`) and the
+   * `api.rest.defaultLimit` / `api.rest.maxLimit` / `api.rest.withCount` config,
+   * exactly like every other Strapi REST collection-type endpoint.
+   */
+  async function findAndCountPage(query: any = {}) {
+    const { pagination = {} } = query;
+
+    const defaultLimit = toNumber(strapi.config.get('api.rest.defaultLimit', 25));
+    const maxLimit = toNumber(strapi.config.get('api.rest.maxLimit')) || null;
+
+    // Whether the consumer used page-based pagination (default) vs offset-based.
+    const isOffset = has('start', pagination) || has('limit', pagination);
+    const isPaged = !isOffset;
+
+    // Resolve start/limit applying defaults and the maxLimit cap.
+    const { start, limit } = paginationUtils.withDefaultPagination(pagination, {
+      defaults: { offset: { limit: defaultLimit }, page: { pageSize: defaultLimit } },
+      maxLimit: maxLimit || -1,
+    });
+
+    // Feed the transform the resolved offset/limit so it ignores the nested
+    // `pagination` object (which it cannot read) and applies real bounds.
+    const transformed = strapi
+      .get('query-params')
+      .transform(FILE_MODEL_UID, { ...query, pagination: undefined, start, limit });
+
+    const shouldCount = resolveWithCount(pagination);
+
+    const [results, total] = await Promise.all([
+      strapi.db.query(FILE_MODEL_UID).findMany(transformed),
+      shouldCount ? strapi.db.query(FILE_MODEL_UID).count(transformed) : Promise.resolve(undefined),
+    ]);
+
+    const signedResults = await async.map(results, (file: File) => fileService.signFileUrls(file));
+
+    const transform = isPaged
+      ? paginationUtils.transformPagedPaginationInfo
+      : paginationUtils.transformOffsetPaginationInfo;
+
+    const paginationInfo = transform({ start, limit }, total as number);
+
+    return {
+      results: signedResults,
+      // Omit total & pageCount when counting is disabled (withCount=false).
+      pagination: isNil(total) ? _.omit(paginationInfo, ['total', 'pageCount']) : paginationInfo,
+    };
+  }
+
   async function remove(file: File) {
     const config = strapi.config.get<Config>('plugin::upload');
 
@@ -598,6 +685,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
     findOne,
     findMany,
     findPage,
+    findAndCountPage,
     remove,
     getSettings,
     setSettings,

--- a/tests/api/core/upload/content-api/files-pagination.test.api.js
+++ b/tests/api/core/upload/content-api/files-pagination.test.api.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createContentAPIRequest } = require('api-tests/request');
+
+const builder = createTestBuilder();
+let strapi;
+let rq;
+
+const uploadFile = (rq, filename = 'rec.jpg') =>
+  rq({
+    method: 'POST',
+    url: '/upload',
+    formData: {
+      files: fs.createReadStream(path.join(__dirname, '../utils/rec.jpg')),
+      fileInfo: JSON.stringify({ name: filename }),
+    },
+  });
+
+describe('Upload content API - GET /upload/files/page (pagination)', () => {
+  const uploadedIds = [];
+
+  beforeAll(async () => {
+    await builder.build();
+    strapi = await createStrapiInstance();
+    rq = createContentAPIRequest({ strapi });
+
+    // Seed a few files so pagination has something to slice.
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await uploadFile(rq, `paginated-${i}.jpg`);
+      uploadedIds.push(res.body[0].id);
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all(
+      uploadedIds.map((id) => rq({ method: 'DELETE', url: `/upload/files/${id}` }))
+    );
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  test('returns the { data, meta: { pagination } } envelope', async () => {
+    const res = await rq({ method: 'GET', url: '/upload/files/page' });
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.meta).toBeDefined();
+    expect(res.body.meta.pagination).toEqual(
+      expect.objectContaining({
+        page: 1,
+        pageSize: expect.any(Number),
+        pageCount: expect.any(Number),
+        total: expect.any(Number),
+      })
+    );
+    expect(res.body.meta.pagination.total).toBeGreaterThanOrEqual(5);
+  });
+
+  test('honors pagination[pageSize] and pagination[page]', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: '/upload/files/page',
+      qs: { pagination: { page: 1, pageSize: 2 } },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta.pagination).toEqual(expect.objectContaining({ page: 1, pageSize: 2 }));
+
+    const page2 = await rq({
+      method: 'GET',
+      url: '/upload/files/page',
+      qs: { pagination: { page: 2, pageSize: 2 } },
+    });
+
+    expect(page2.statusCode).toBe(200);
+    expect(page2.body.meta.pagination.page).toBe(2);
+    // The two pages must not overlap.
+    const ids1 = res.body.data.map((f) => f.id);
+    const ids2 = page2.body.data.map((f) => f.id);
+    expect(ids1.filter((id) => ids2.includes(id))).toHaveLength(0);
+  });
+
+  test('honors offset-based pagination[start]/pagination[limit]', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: '/upload/files/page',
+      qs: { pagination: { start: 0, limit: 3 } },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.meta.pagination).toEqual(
+      expect.objectContaining({ start: 0, limit: 3, total: expect.any(Number) })
+    );
+  });
+
+  test('omits total/pageCount when pagination[withCount]=false', async () => {
+    const res = await rq({
+      method: 'GET',
+      url: '/upload/files/page',
+      qs: { pagination: { page: 1, pageSize: 2, withCount: false } },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.pagination).not.toHaveProperty('total');
+    expect(res.body.meta.pagination).not.toHaveProperty('pageCount');
+  });
+
+  test('the legacy GET /upload/files endpoint still returns a flat array', async () => {
+    const res = await rq({ method: 'GET', url: '/upload/files' });
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).not.toHaveProperty('meta');
+  });
+});

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -25145,6 +25145,441 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
         ],
       },
     },
+    "/upload/files/page": {
+      "get": {
+        "operationId": "upload/get/upload_files_page",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Select specific fields to return in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "populate",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "const": "*",
+                  "type": "string",
+                },
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+              ],
+              "description": "Specify which relations to populate in the response",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "anyOf": [
+                {
+                  "type": "string",
+                },
+                {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                {
+                  "additionalProperties": {
+                    "enum": [
+                      "asc",
+                      "desc",
+                    ],
+                    "type": "string",
+                  },
+                  "propertyNames": {
+                    "type": "string",
+                  },
+                  "type": "object",
+                },
+                {
+                  "items": {
+                    "additionalProperties": {
+                      "enum": [
+                        "asc",
+                        "desc",
+                      ],
+                      "type": "string",
+                    },
+                    "propertyNames": {
+                      "type": "string",
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              ],
+              "description": "Sort the results by specified fields",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "pagination",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "allOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "withCount": {
+                      "description": "Include total count in response",
+                      "type": "boolean",
+                    },
+                  },
+                  "type": "object",
+                },
+                {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Page-based pagination",
+                      "properties": {
+                        "page": {
+                          "description": "Page number (1-based)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "pageSize": {
+                          "description": "Number of entries per page",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "page",
+                        "pageSize",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "description": "Offset-based pagination",
+                      "properties": {
+                        "limit": {
+                          "description": "Maximum number of entries to return",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991,
+                          "type": "integer",
+                        },
+                        "start": {
+                          "description": "Number of entries to skip",
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer",
+                        },
+                      },
+                      "required": [
+                        "start",
+                        "limit",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              ],
+              "description": "Pagination parameters",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+          {
+            "in": "query",
+            "name": "filters",
+            "required": false,
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "additionalProperties": {},
+              "description": "Apply filters to the query",
+              "propertyNames": {
+                "type": "string",
+              },
+              "type": "object",
+            },
+            "x-strapi-serialize": "querystring",
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "additionalProperties": false,
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "alternativeText": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "caption": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "createdAt": {
+                            "type": "string",
+                          },
+                          "createdBy": {
+                            "type": "number",
+                          },
+                          "documentId": {
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+                            "type": "string",
+                          },
+                          "ext": {
+                            "type": "string",
+                          },
+                          "folder": {
+                            "type": "number",
+                          },
+                          "folderPath": {
+                            "type": "string",
+                          },
+                          "formats": {
+                            "additionalProperties": {},
+                            "propertyNames": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                          "id": {
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991,
+                            "type": "integer",
+                          },
+                          "mime": {
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                          "previewUrl": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "provider": {
+                            "type": "string",
+                          },
+                          "provider_metadata": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": {},
+                                "propertyNames": {
+                                  "type": "string",
+                                },
+                                "type": "object",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "size": {
+                            "type": "number",
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                          },
+                          "updatedBy": {
+                            "type": "number",
+                          },
+                          "url": {
+                            "type": "string",
+                          },
+                          "width": {
+                            "maximum": 9007199254740991,
+                            "minimum": -9007199254740991,
+                            "type": "integer",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "documentId",
+                          "name",
+                          "hash",
+                          "mime",
+                          "size",
+                          "url",
+                          "folderPath",
+                          "provider",
+                          "createdAt",
+                          "updatedAt",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "meta": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "pagination": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "page": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                                "pageCount": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                                "pageSize": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                                "total": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                              },
+                              "required": [
+                                "page",
+                                "pageSize",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "limit": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                                "start": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                                "total": {
+                                  "maximum": 9007199254740991,
+                                  "minimum": -9007199254740991,
+                                  "type": "integer",
+                                },
+                              },
+                              "required": [
+                                "start",
+                                "limit",
+                              ],
+                              "type": "object",
+                            },
+                          ],
+                        },
+                      },
+                      "required": [
+                        "pagination",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "meta",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": {
+            "description": "Bad request",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "403": {
+            "description": "Forbidden",
+          },
+          "404": {
+            "description": "Not found",
+          },
+          "500": {
+            "description": "Internal server error",
+          },
+        },
+        "tags": [
+          "upload",
+        ],
+      },
+    },
     "/upload/files/{id}": {
       "delete": {
         "operationId": "upload/delete/upload_files_by_id",

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -83,6 +83,7 @@ exports[`routes:list should output list of routes 1`] = `
 │ POST               │ /api/email                                                                      │
 │ POST               │ /api/upload                                                                     │
 │ HEAD|GET           │ /api/upload/files                                                               │
+│ HEAD|GET           │ /api/upload/files/page                                                          │
 │ HEAD|GET           │ /api/upload/files/:id                                                           │
 │ DELETE             │ /api/upload/files/:id                                                           │
 │ HEAD|GET           │ /api/i18n/locales                                                               │


### PR DESCRIPTION
## What does it do?

Adds a new content-API endpoint **`GET /api/upload/files/page`** that returns the standard paginated envelope:

```json
{ "data": [ ... ], "meta": { "pagination": { "page": 1, "pageSize": 25, "pageCount": 4, "total": 100 } } }
```

The existing `GET /api/upload/files` is left **byte-for-byte unchanged** (flat array, params ignored), so there is no breaking change for current v5 consumers.

## Why?

`GET /api/upload/files` ignores pagination params and returns a flat array of every file in the media library. For large libraries this is unusable and can crash both server and client. See #24624 / CMS-287.

The earlier community attempt (#25034) made the existing endpoint change shape when `pagination` is provided — a request-dependent response shape the team ruled out. This PR instead ships a dedicated endpoint, which the team agreed was the cleaner direction.

## How?

- **`services/upload.ts`** — new REST-aware `findAndCountPage` (plus a `resolveWithCount` helper). It reuses the same `@strapi/utils` `pagination.*` primitives the core REST collection-type service uses, so it honors the full nested format and REST config defaults. The existing `findPage` (used by the admin API) is left untouched.
- **`controllers/content-api.ts`** — new `findPage` handler returning the `{ data, meta }` envelope.
- **`routes/content-api.ts`** — new `GET /files/page` route, registered before `/files/:id`.
- **`routes/validation/upload.ts`** — new `paginatedFiles` response schema (union of page-based and offset-based meta).

### Supported (all matching every other REST endpoint)

- `pagination[page]` / `pagination[pageSize]`
- offset-based `pagination[start]` / `pagination[limit]`
- `pagination[withCount]` (skips the count query and omits `total`/`pageCount` when false)
- `api.rest.defaultLimit` (25) / `api.rest.maxLimit` cap / `api.rest.withCount` config
- combined with `filters` / `sort` / `fields` / `populate`

## How to manually test (QA)

### Setup

1. Check out this branch and install/build, then start a sandbox app:
   ```bash
   yarn install && yarn setup
   cd examples/getstarted && yarn develop
   ```
2. In the admin panel, upload **a handful of files** (say 5+) to the Media Library so pagination has something to slice.
3. Expose the content-API endpoints to the **Public** role (no token needed):
   - **Settings → Users & Permissions Plugin → Roles → Public → Upload**
   - Enable both **`find`** and **`findPage`** ✅ then **Save**.
   - ⚠️ `findPage` is a **separate permission** from `find`. If it's not checked, `GET /upload/files/page` returns **403**. (This is the main thing to verify in the permissions UI — the new action shows up and gates the new route.)

> All example URLs below assume the default `http://localhost:1337`. Bracket params must be URL-encoded in a browser; `curl` examples quote them so the shell doesn't expand the brackets.

### Happy path — the new endpoint

```bash
# 1. Default envelope (page 1, default pageSize 25, with counts)
curl "http://localhost:1337/api/upload/files/page"
```
**Expect:** `{ "data": [...], "meta": { "pagination": { "page": 1, "pageSize": 25, "pageCount": <n>, "total": <n> } } }` — a `data` array (not a bare array) plus a `meta.pagination` object.

```bash
# 2. Page-based pagination
curl "http://localhost:1337/api/upload/files/page?pagination[page]=1&pagination[pageSize]=2"
curl "http://localhost:1337/api/upload/files/page?pagination[page]=2&pagination[pageSize]=2"
```
**Expect:** each returns **2** items; `meta.pagination.page` reflects the requested page; the two pages contain **different** file IDs (no overlap).

```bash
# 3. Offset-based pagination
curl "http://localhost:1337/api/upload/files/page?pagination[start]=0&pagination[limit]=3"
```
**Expect:** **3** items; `meta.pagination` is offset-shaped: `{ "start": 0, "limit": 3, "total": <n> }`.

```bash
# 4. withCount=false — counts omitted, count query skipped
curl "http://localhost:1337/api/upload/files/page?pagination[pageSize]=2&pagination[withCount]=false"
```
**Expect:** `meta.pagination` has `page`/`pageSize` but **no `total` and no `pageCount`**.

```bash
# 5. Combined with filters / sort / fields
curl "http://localhost:1337/api/upload/files/page?pagination[pageSize]=2&sort=name:asc&filters[mime][\$startsWith]=image/&fields[0]=name&fields[1]=url"
```
**Expect:** only image files, sorted by name asc, paginated to 2, with the response files honoring the field selection — and still wrapped in `{ data, meta }`.

### Edge / error cases

```bash
# Empty library (delete all files first, or filter to match nothing)
curl "http://localhost:1337/api/upload/files/page?filters[name][\$eq]=__nope__"
# Expect: { "data": [], "meta": { "pagination": { ... "total": 0, "pageCount": 0 } } }

# Mixing page-based and offset-based params is invalid
curl -i "http://localhost:1337/api/upload/files/page?pagination[page]=1&pagination[limit]=5"
# Expect: 400

# Invalid withCount value
curl -i "http://localhost:1337/api/upload/files/page?pagination[withCount]=banana"
# Expect: 400 (ValidationError: Invalid withCount parameter)

# findPage permission NOT granted on the role
# Expect: 403 until you enable the `findPage` action for the role
```

### Regression — the legacy endpoint must be unchanged

```bash
curl "http://localhost:1337/api/upload/files"
curl "http://localhost:1337/api/upload/files?pagination[pageSize]=2"
```
**Expect (both):** a **flat array** of files (`[ {...}, {...} ]`), **no `meta` key**, and pagination params **ignored** (the second call still returns every file). This is the critical "we didn't break anyone" check.

### Optional config check

Set in `config/api.js` (or `.ts`) of the sandbox app and restart:
```js
module.exports = { rest: { defaultLimit: 5, maxLimit: 10, withCount: true } };
```
**Expect:** `GET /upload/files/page` with no params now returns 5 items (`pageSize: 5`); requesting `pagination[pageSize]=1000` is capped at `pageSize: 10`.

### What to verify in the admin (permissions UI)

- Under **Users & Permissions → Roles → (any role) → Upload**, a **`findPage`** action checkbox is present alongside `find`, `findOne`, `destroy`.
- Toggling it on/off correctly grants/denies access to `GET /api/upload/files/page` (200 vs 403), independently of `find`.

## Follow-ups (out of scope)

- Documentation PR (strapi/documentation): document the new endpoint + deprecate the flat response on `/files`.
- Next-major: fold `/files/page` behavior back into `/files`.
- Credit / close the loop on community PRs #25034, #24952, #24711 and issue #24624.

Closes #24624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
