### PR TITLE
docs: fix typos and grammar slips in content-manager docs

### DIFF
--- a/docs/docs/docs/01-core/content-manager/03-RBAC.md
+++ b/docs/docs/docs/01-core/content-manager/03-RBAC.md
@@ -28,7 +28,7 @@ Each document's permission's object will contain `properties.fields` which is an
 }
 ```
 
-The above permissions relate to what fields the user can create on the article content-type. The list of fields are their names in the schema, not their labels (which can be overridden in the EditViewSettings), components are dot separated paths where the component name will be the first part of said path, repeatable compoenents **will not** have indexes in the path and finally, in dynamic zones all fields are always allowed.
+The above permissions relate to what fields the user can create on the article content-type. The list of fields are their names in the schema, not their labels (which can be overridden in the EditViewSettings), components are dot separated paths where the component name will be the first part of said path, repeatable components **will not** have indexes in the path and finally, in dynamic zones all fields are always allowed.
 
 ## DocumentRBAC Component
 

--- a/docs/docs/docs/01-core/content-manager/04-relations.mdx
+++ b/docs/docs/docs/01-core/content-manager/04-relations.mdx
@@ -104,7 +104,7 @@ utility function. This function in short, takes an end path (in this case the re
 when it finds the endpath (an empty array in this case). It then recursively reduces the paths to the relational field mapping
 through arrays if necessary (in the instance of repetable components for example) replacing the endpath with the primitive.
 
-When this is done, we have sucessfully prepared our initial data for usage with relations.
+When this is done, we have successfully prepared our initial data for usage with relations.
 
 ### Handling updates to relation fields
 

--- a/docs/docs/docs/01-core/content-manager/features/review-workflows.mdx
+++ b/docs/docs/docs/01-core/content-manager/features/review-workflows.mdx
@@ -22,7 +22,7 @@ means at any place in the admin app displaying a stage, it has to be prepared to
 If the feature is enabled for a content-type a new column will show up, displaying the current stage of an entity. If no stage was assigned to an entity,
 the column is displayed as empty.
 
-The information which stage is currently assigned to an entity is send as part of the content-type response payload for each entity in the attribute `strapi_stage`.
+The information which stage is currently assigned to an entity is sent as part of the content-type response payload for each entity in the attribute `strapi_stage`.
 Please refer to the [type definitions](/settings/review-workflows) for more information.
 
 ```ts


### PR DESCRIPTION
## Summary
Fix three small slips in the content-manager contributor docs: two typos and one verb-form error.

## Changes
- `content-manager/03-RBAC.md`: `compoenents` -> `components`
- `content-manager/04-relations.mdx`: `sucessfully` -> `successfully`
- `content-manager/features/review-workflows.mdx`: `is send as part` -> `is sent as part`

## Testing
- Visual diff review; no code or behavior changes.

---
Fixes CPR-412