### PR TITLE
docs: fix broken relative cross-doc links

### DIFF
--- a/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
+++ b/docs/docs/docs/01-core/admin/01-ee/01-review-workflows.md
@@ -172,4 +172,4 @@ The Review Workflow feature is currently included as a core feature within the S
 - https://docs.strapi.io/user-docs/settings/review-workflows
 - https://docs.strapi.io/user-docs/content-type-builder/creating-new-content-type#creating-a-new-content-type
 - https://docs.strapi.io/user-docs/users-roles-permissions/configuring-administrator-roles#plugins-and-settings
-- [Content Manager Review Workflows](../../content-manager/features/review-workflows)
+- [Content Manager Review Workflows](../../content-manager/features/review-workflows.mdx)

--- a/docs/docs/docs/01-core/openapi/02-architecture.md
+++ b/docs/docs/docs/01-core/openapi/02-architecture.md
@@ -45,7 +45,7 @@ Additionally, the package centralizes all exports for the public API in an `src/
 
 This approach decouples the package root exports from the public programmatic API it exposes.
 
-For step-by-step extension guides, see the [Contributing](./contributing/overview) section.
+For step-by-step extension guides, see the [Contributing](./contributing/00-overview.md) section.
 
 ## Design Pattern
 

--- a/docs/docs/docs/01-core/openapi/contributing/00-overview.md
+++ b/docs/docs/docs/01-core/openapi/contributing/00-overview.md
@@ -9,20 +9,20 @@ toc_max_heading_level: 4
 
 # OpenAPI
 
-Guides for extending `@strapi/openapi`. Start with [Architecture](../architecture) if you need the overall pipeline.
+Guides for extending `@strapi/openapi`. Start with [Architecture](../02-architecture.md) if you need the overall pipeline.
 
 ---
 
 ## Extension points
 
-| Guide                                        | Use when you need to…                         |
-| -------------------------------------------- | --------------------------------------------- |
-| [Routes provider](./routes-provider)         | Collect routes from a new Strapi source       |
-| [Routes matcher rule](./routes-matcher-rule) | Filter which routes are documented            |
-| [Assemblers](./assemblers)                   | Build or extend OpenAPI document sections     |
-| [Context factory](./context-factory)         | Add a new assembly level with its own context |
-| [Processors](./processors)                   | Run logic before or after assembly            |
-| [Testing](./testing)                         | Write or debug unit tests                     |
+| Guide                                              | Use when you need to…                         |
+| -------------------------------------------------- | --------------------------------------------- |
+| [Routes provider](./01-routes-provider.md)         | Collect routes from a new Strapi source       |
+| [Routes matcher rule](./02-routes-matcher-rule.md) | Filter which routes are documented            |
+| [Assemblers](./03-assemblers.md)                   | Build or extend OpenAPI document sections     |
+| [Context factory](./04-context-factory.md)         | Add a new assembly level with its own context |
+| [Processors](./05-processors.md)                   | Run logic before or after assembly            |
+| [Testing](./06-testing.md)                         | Write or debug unit tests                     |
 
 Most changes touch **assemblers** (especially operation-level leaf assemblers) or **route collection**. Context factories and processors are needed less often.
 

--- a/docs/docs/docs/01-core/openapi/contributing/03-assemblers.md
+++ b/docs/docs/docs/01-core/openapi/contributing/03-assemblers.md
@@ -15,7 +15,7 @@ Learn how to add assemblers to the document generation pipeline.
 
 ## Assembler levels
 
-Assemblers build the OpenAPI document in layers. Each level has a matching context type (see [Context factory](./context-factory)).
+Assemblers build the OpenAPI document in layers. Each level has a matching context type (see [Context factory](./04-context-factory.md)).
 
 | Level     | Interface             | Example                        | Factory                     |
 | --------- | --------------------- | ------------------------------ | --------------------------- |
@@ -125,5 +125,5 @@ export class OperationAssembler implements Assembler.PathItem {
 Create or extend a factory (e.g. `PathItemAssemblerFactory`) that instantiates your composite assembler with its sub-assemblers and context factory, then register that factory in the parent level (`PathAssemblerFactory` or `DocumentAssemblerFactory`).
 
 :::tip
-Reuse `timer` and `registries` from the parent context when creating child contexts so timing and shared state stay consistent. Pass them via `PartialContext` (see [Context factory](./context-factory)).
+Reuse `timer` and `registries` from the parent context when creating child contexts so timing and shared state stay consistent. Pass them via `PartialContext` (see [Context factory](./04-context-factory.md)).
 :::

--- a/docs/docs/docs/01-core/openapi/contributing/06-testing.md
+++ b/docs/docs/docs/01-core/openapi/contributing/06-testing.md
@@ -110,4 +110,4 @@ Enable package debug output from the package directory:
 cd packages/core/openapi && DEBUG=strapi:core:openapi:* yarn test:unit
 ```
 
-See [Technologies](../technologies) for the debug namespace conventions.
+See [Technologies](../01-technologies.md) for the debug namespace conventions.


### PR DESCRIPTION
## Summary
Twelve relative markdown links in the contributor docs omit the `0X-` numeric prefix and `.md`/`.mdx` extension, so they fail to resolve as filesystem paths. The rest of `docs/docs/docs/` consistently uses the full filename. This PR aligns the outliers with that convention.

## Changes
- `admin/01-ee/01-review-workflows.md`: add `.mdx` extension to the Content Manager Review Workflows link
- `openapi/02-architecture.md`: `./contributing/overview` -> `./contributing/00-overview.md`
- `openapi/contributing/00-overview.md`: 7 links (one to `../02-architecture.md`, six to siblings in the same folder)
- `openapi/contributing/03-assemblers.md`: 2 links to `./04-context-factory.md`
- `openapi/contributing/06-testing.md`: `../technologies` -> `../01-technologies.md`

A grep across `docs/docs/docs/` confirms zero broken relative links remain after these changes.

## Testing
- Resolved every relative link in the docs tree against the filesystem; all 0 broken after the patch.
- No code or behavior changes.