### PR TITLE
feat(mcp): export defineTool/defineResource/definePrompt builders

### DIFF
--- a/packages/core/core/src/ai.ts
+++ b/packages/core/core/src/ai.ts
@@ -1,0 +1,1 @@
+export * as mcp from './mcp';

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -6,7 +6,7 @@ import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from
 
 export { default as compileStrapi } from './compile';
 export * as factories from './factories';
-export * as mcp from './mcp';
+export * as ai from './ai';
 
 export const createStrapi = (options: Partial<StrapiOptions> = {}): Core.Strapi => {
   const strapi = new Strapi({

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -6,6 +6,7 @@ import { destroyOnSignal, resolveWorkingDirectories, createUpdateNotifier } from
 
 export { default as compileStrapi } from './compile';
 export * as factories from './factories';
+export * as mcp from './mcp';
 
 export const createStrapi = (options: Partial<StrapiOptions> = {}): Core.Strapi => {
   const strapi = new Strapi({

--- a/packages/core/core/src/mcp.ts
+++ b/packages/core/core/src/mcp.ts
@@ -1,0 +1,3 @@
+export { makeMcpToolDefinition as defineTool } from './services/mcp/tool-registry';
+export { makeMcpResourceDefinition as defineResource } from './services/mcp/resource-registry';
+export { makeMcpPromptDefinition as definePrompt } from './services/mcp/prompt-registry';

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -10,9 +10,38 @@ import {
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandlerForMetrics';
 
-export const makeMcpPromptDefinition = <Definition extends Modules.MCP.McpPromptDefinition>(
-  prompt: Definition
-): Definition => prompt;
+/**
+ * Defines a Strapi MCP prompt with full type inference, ready to pass to
+ * `strapi.ai.mcp.registerPrompt()`. Exposed publicly as `mcp.definePrompt`.
+ *
+ * The returned value is the definition unchanged — this builder only exists to
+ * infer the `name`/`argsSchema` and narrow the access variant (`devModeOnly` vs
+ * `auth`) so the result is directly assignable to `registerPrompt`.
+ *
+ * @param prompt - The prompt definition. Provide either `devModeOnly: true`
+ * (dev-only, no auth) or an `auth` policy set — never both.
+ * @returns The same definition, with its access variant narrowed.
+ *
+ * @example
+ * ```ts
+ * import { mcp } from '@strapi/strapi';
+ *
+ * const context = mcp.definePrompt({
+ *   name: 'app-context',
+ *   title: 'App Context',
+ *   description: 'Provides context about the app',
+ *   devModeOnly: true,
+ *   createHandler: (strapi) => async () => ({
+ *     messages: [{ role: 'user', content: { type: 'text', text: 'You are connected to Strapi.' } }],
+ *   }),
+ * });
+ *
+ * // later, in register() or bootstrap():
+ * strapi.ai.mcp.registerPrompt(context);
+ * ```
+ */
+export const makeMcpPromptDefinition = ((definition: Modules.MCP.McpPromptDefinition) =>
+  definition) as unknown as Modules.MCP.McpPromptBuilder;
 
 export class McpPromptRegistry
   extends McpCapabilityRegistryBase<'prompt', Modules.MCP.McpPromptDefinition, RegisteredPrompt>

--- a/packages/core/core/src/services/mcp/prompt-registry.ts
+++ b/packages/core/core/src/services/mcp/prompt-registry.ts
@@ -12,7 +12,7 @@ import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandler
 
 /**
  * Defines a Strapi MCP prompt with full type inference, ready to pass to
- * `strapi.ai.mcp.registerPrompt()`. Exposed publicly as `mcp.definePrompt`.
+ * `strapi.ai.mcp.registerPrompt()`. Exposed publicly as `ai.mcp.definePrompt`.
  *
  * The returned value is the definition unchanged — this builder only exists to
  * infer the `name`/`argsSchema` and narrow the access variant (`devModeOnly` vs
@@ -24,9 +24,9 @@ import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandler
  *
  * @example
  * ```ts
- * import { mcp } from '@strapi/strapi';
+ * import { ai } from '@strapi/strapi';
  *
- * const context = mcp.definePrompt({
+ * const context = ai.mcp.definePrompt({
  *   name: 'app-context',
  *   title: 'App Context',
  *   description: 'Provides context about the app',

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -12,9 +12,38 @@ import {
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandlerForMetrics';
 
-export const makeMcpResourceDefinition = <Definition extends Modules.MCP.McpResourceDefinition>(
-  resource: Definition
-): Definition => resource;
+/**
+ * Defines a Strapi MCP resource with full type inference, ready to pass to
+ * `strapi.ai.mcp.registerResource()`. Exposed publicly as `mcp.defineResource`.
+ *
+ * The returned value is the definition unchanged — this builder only exists to
+ * infer the `name` and narrow the access variant (`devModeOnly` vs `auth`) so the
+ * result is directly assignable to `registerResource`.
+ *
+ * @param resource - The resource definition. Provide either `devModeOnly: true`
+ * (dev-only, no auth) or an `auth` policy set — never both.
+ * @returns The same definition, with its access variant narrowed.
+ *
+ * @example
+ * ```ts
+ * import { mcp } from '@strapi/strapi';
+ *
+ * const appInfo = mcp.defineResource({
+ *   name: 'app-info',
+ *   uri: 'strapi://app/info',
+ *   metadata: { description: 'Metadata about the app', mimeType: 'application/json' },
+ *   devModeOnly: true,
+ *   createHandler: (strapi) => async (uri) => ({
+ *     contents: [{ uri: uri.href, mimeType: 'application/json', text: JSON.stringify({ ok: true }) }],
+ *   }),
+ * });
+ *
+ * // later, in register() or bootstrap():
+ * strapi.ai.mcp.registerResource(appInfo);
+ * ```
+ */
+export const makeMcpResourceDefinition = ((definition: Modules.MCP.McpResourceDefinition) =>
+  definition) as unknown as Modules.MCP.McpResourceBuilder;
 
 export class McpResourceRegistry
   extends McpCapabilityRegistryBase<

--- a/packages/core/core/src/services/mcp/resource-registry.ts
+++ b/packages/core/core/src/services/mcp/resource-registry.ts
@@ -14,7 +14,7 @@ import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandler
 
 /**
  * Defines a Strapi MCP resource with full type inference, ready to pass to
- * `strapi.ai.mcp.registerResource()`. Exposed publicly as `mcp.defineResource`.
+ * `strapi.ai.mcp.registerResource()`. Exposed publicly as `ai.mcp.defineResource`.
  *
  * The returned value is the definition unchanged — this builder only exists to
  * infer the `name` and narrow the access variant (`devModeOnly` vs `auth`) so the
@@ -26,9 +26,9 @@ import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandler
  *
  * @example
  * ```ts
- * import { mcp } from '@strapi/strapi';
+ * import { ai } from '@strapi/strapi';
  *
- * const appInfo = mcp.defineResource({
+ * const appInfo = ai.mcp.defineResource({
  *   name: 'app-info',
  *   uri: 'strapi://app/info',
  *   metadata: { description: 'Metadata about the app', mimeType: 'application/json' },

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -12,7 +12,7 @@ import type { McpAdminTokenAbility } from './authentication';
 
 /**
  * Defines a Strapi MCP tool with full type inference, ready to pass to
- * `strapi.ai.mcp.registerTool()`. Exposed publicly as `mcp.defineTool`.
+ * `strapi.ai.mcp.registerTool()`. Exposed publicly as `ai.mcp.defineTool`.
  *
  * The returned value is the definition unchanged — this builder only exists to
  * infer the `name`, input/output schemas and handler types, and to narrow the
@@ -25,10 +25,10 @@ import type { McpAdminTokenAbility } from './authentication';
  *
  * @example
  * ```ts
- * import { mcp } from '@strapi/strapi';
+ * import { ai } from '@strapi/strapi';
  * import { z } from '@strapi/utils';
  *
- * const greet = mcp.defineTool({
+ * const greet = ai.mcp.defineTool({
  *   name: 'greet',
  *   title: 'Greet',
  *   description: 'Greets a user by name',

--- a/packages/core/core/src/services/mcp/tool-registry.ts
+++ b/packages/core/core/src/services/mcp/tool-registry.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/extensions
 import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Core, Modules } from '@strapi/types';
-import { z } from '@strapi/utils';
 import { McpCapabilityDefinitionRegistry } from './internal/McpCapabilityDefinitionRegistry';
 import {
   type McpCapabilityRegistry,
@@ -11,35 +10,43 @@ import { wrapCapabilityHandlerForMetrics } from './metrics/wrapCapabilityHandler
 import { createSafeCapabilityRegistration } from './utils/createSafeCapabilityRegistration';
 import type { McpAdminTokenAbility } from './authentication';
 
-export function makeMcpToolDefinition<
-  Name extends string,
-  Title extends string,
-  Description extends string,
-  OutputSchema extends z.ZodObject<z.ZodRawShape>,
-  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
-  Access extends Modules.MCP.McpCapabilityAccess = Modules.MCP.McpCapabilityAccess,
->(
-  tool: {
-    name: Name;
-    title: Title;
-    description: Description;
-    resolveInputSchema?: (context: Modules.MCP.McpHandlerContext) => InputSchema;
-    resolveOutputSchema: (context: Modules.MCP.McpHandlerContext) => OutputSchema;
-    createHandler: (
-      strapi: Core.Strapi,
-      context: Modules.MCP.McpHandlerContext
-    ) => Modules.MCP.McpToolHandler<NoInfer<InputSchema>, NoInfer<OutputSchema>>;
-  } & Access
-): Modules.MCP.McpToolDefinition<Name, InputSchema, OutputSchema, Title, Description> & Access {
-  return tool as Modules.MCP.McpToolDefinition<
-    Name,
-    InputSchema,
-    OutputSchema,
-    Title,
-    Description
-  > &
-    Access;
-}
+/**
+ * Defines a Strapi MCP tool with full type inference, ready to pass to
+ * `strapi.ai.mcp.registerTool()`. Exposed publicly as `mcp.defineTool`.
+ *
+ * The returned value is the definition unchanged — this builder only exists to
+ * infer the `name`, input/output schemas and handler types, and to narrow the
+ * access variant (`devModeOnly` vs `auth`) so the result is directly assignable
+ * to `registerTool`.
+ *
+ * @param tool - The tool definition. Provide either `devModeOnly: true` (dev-only,
+ * no auth) or an `auth` policy set — never both.
+ * @returns The same definition, with its access variant narrowed.
+ *
+ * @example
+ * ```ts
+ * import { mcp } from '@strapi/strapi';
+ * import { z } from '@strapi/utils';
+ *
+ * const greet = mcp.defineTool({
+ *   name: 'greet',
+ *   title: 'Greet',
+ *   description: 'Greets a user by name',
+ *   devModeOnly: true,
+ *   resolveInputSchema: () => z.object({ name: z.string() }),
+ *   resolveOutputSchema: () => z.object({ message: z.string() }),
+ *   createHandler: (strapi) => async ({ args }) => {
+ *     const message = `Hello, ${args.name}!`;
+ *     return { content: [{ type: 'text', text: message }], structuredContent: { message } };
+ *   },
+ * });
+ *
+ * // later, in register() or bootstrap():
+ * strapi.ai.mcp.registerTool(greet);
+ * ```
+ */
+export const makeMcpToolDefinition = ((definition: Modules.MCP.McpToolDefinition) =>
+  definition) as unknown as Modules.MCP.McpToolBuilder;
 
 export class McpToolRegistry
   extends McpCapabilityRegistryBase<'tool', Modules.MCP.McpToolDefinition, RegisteredTool>

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -39,15 +39,19 @@ export type McpHandlerContext = {
   user: { id: string | number };
 };
 
-export type McpCapabilityAccess =
-  | {
-      devModeOnly: true;
-      auth?: never;
-    }
-  | {
-      devModeOnly?: never;
-      auth: McpCapabilityAuth;
-    };
+/** Access variant for dev-mode-only capabilities (no auth policies). */
+export type McpDevModeAccess = {
+  devModeOnly: true;
+  auth?: never;
+};
+
+/** Access variant for capabilities gated by CASL auth policies. */
+export type McpAuthAccess = {
+  devModeOnly?: never;
+  auth: McpCapabilityAuth;
+};
+
+export type McpCapabilityAccess = McpDevModeAccess | McpAuthAccess;
 
 export type McpCapabilityTelemetry = {
   source?: string;
@@ -102,6 +106,33 @@ export type McpToolHandlerReturn<
 export type McpToolSchemaResolver<Schema> = (context: McpHandlerContext) => Schema;
 
 /**
+ * Access-agnostic fields of a Strapi MCP tool definition.
+ * Shared by the `defineTool` builder ({@link McpToolBuilder}) and
+ * `McpService.registerTool`, then intersected with an access variant
+ * ({@link McpDevModeAccess} or {@link McpAuthAccess}).
+ */
+export type McpToolDefinitionFields<
+  Name extends string = string,
+  InputSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  OutputSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
+  Title extends string = string,
+  Description extends string = string,
+> = {
+  name: Name;
+  title: Title;
+  description: Description;
+  telemetry?: McpCapabilityTelemetry;
+  resolveInputSchema?: McpToolSchemaResolver<InputSchema>;
+  resolveOutputSchema: McpToolSchemaResolver<OutputSchema>;
+  createHandler: (
+    strapi: Core.Strapi,
+    context: McpHandlerContext
+  ) => McpToolHandler<NoInfer<InputSchema>, NoInfer<OutputSchema>>;
+};
+
+/**
  * Definition for Strapi MCP tools
  */
 export type McpToolDefinition<
@@ -112,16 +143,38 @@ export type McpToolDefinition<
   OutputSchema extends z.ZodObject<z.ZodRawShape> = z.ZodObject<z.ZodRawShape>,
   Title extends string = string,
   Description extends string = string,
-> = McpCapabilityDefinition<Name> & {
-  title: Title;
-  description: Description;
-  resolveInputSchema?: McpToolSchemaResolver<InputSchema>;
-  resolveOutputSchema: McpToolSchemaResolver<OutputSchema>;
-  createHandler: (
-    strapi: Core.Strapi,
-    context: McpHandlerContext
-  ) => McpToolHandler<NoInfer<InputSchema>, NoInfer<OutputSchema>>;
-};
+> = McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+  McpCapabilityAccess;
+
+/**
+ * Builder for Strapi MCP tool definitions, exposed publicly as `mcp.defineTool`.
+ * Identity at runtime — its only job is to infer and narrow the access variant
+ * (`devModeOnly` vs `auth`) so the result is directly assignable to
+ * {@link McpService.registerTool}.
+ */
+export interface McpToolBuilder {
+  <
+    Name extends string,
+    OutputSchema extends z.ZodObject<z.ZodRawShape>,
+    Title extends string,
+    Description extends string,
+    InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+  >(
+    tool: McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+      McpDevModeAccess
+  ): McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+    McpDevModeAccess;
+  <
+    Name extends string,
+    OutputSchema extends z.ZodObject<z.ZodRawShape>,
+    Title extends string,
+    Description extends string,
+    InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
+  >(
+    tool: McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+      McpAuthAccess
+  ): McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> & McpAuthAccess;
+}
 
 /**
  * Callback function for Strapi MCP prompts
@@ -135,6 +188,27 @@ export type McpPromptCallback<ArgsSchema extends z.ZodObject<z.ZodRawShape> | un
     : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => Promise<GetPromptResult>;
 
 /**
+ * Access-agnostic fields of a Strapi MCP prompt definition.
+ * Shared by the `definePrompt` builder ({@link McpPromptBuilder}) and
+ * `McpService.registerPrompt`, then intersected with an access variant.
+ */
+export type McpPromptDefinitionFields<
+  Name extends string = string,
+  ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined =
+    | z.ZodObject<z.ZodRawShape>
+    | undefined,
+  Title extends string = string,
+  Description extends string = string,
+> = {
+  name: Name;
+  title: Title;
+  description: Description;
+  argsSchema?: ArgsSchema;
+  telemetry?: McpCapabilityTelemetry;
+  createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
+};
+
+/**
  * Definition for Strapi MCP prompts
  */
 export type McpPromptDefinition<
@@ -144,12 +218,30 @@ export type McpPromptDefinition<
     | undefined,
   Title extends string = string,
   Description extends string = string,
-> = McpCapabilityDefinition<Name> & {
-  title: Title;
-  description: Description;
-  argsSchema?: ArgsSchema;
-  createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
-};
+> = McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpCapabilityAccess;
+
+/**
+ * Builder for Strapi MCP prompt definitions, exposed publicly as `mcp.definePrompt`.
+ * Identity at runtime — narrows the access variant for {@link McpService.registerPrompt}.
+ */
+export interface McpPromptBuilder {
+  <
+    Name extends string,
+    ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+    Title extends string,
+    Description extends string,
+  >(
+    prompt: McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpDevModeAccess
+  ): McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpDevModeAccess;
+  <
+    Name extends string,
+    ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
+    Title extends string,
+    Description extends string,
+  >(
+    prompt: McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpAuthAccess
+  ): McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpAuthAccess;
+}
 
 /**
  * Callback function for Strapi MCP resources
@@ -160,13 +252,36 @@ export type McpResourceCallback = (
 ) => Promise<ReadResourceResult>;
 
 /**
- * Definition for Strapi MCP resources
+ * Access-agnostic fields of a Strapi MCP resource definition.
+ * Shared by the `defineResource` builder ({@link McpResourceBuilder}) and
+ * `McpService.registerResource`, then intersected with an access variant.
  */
-export type McpResourceDefinition<Name extends string = string> = McpCapabilityDefinition<Name> & {
+export type McpResourceDefinitionFields<Name extends string = string> = {
+  name: Name;
   uri: string;
   metadata: ResourceMetadata;
+  telemetry?: McpCapabilityTelemetry;
   createHandler: (strapi: Core.Strapi) => McpResourceCallback;
 };
+
+/**
+ * Definition for Strapi MCP resources
+ */
+export type McpResourceDefinition<Name extends string = string> =
+  McpResourceDefinitionFields<Name> & McpCapabilityAccess;
+
+/**
+ * Builder for Strapi MCP resource definitions, exposed publicly as `mcp.defineResource`.
+ * Identity at runtime — narrows the access variant for {@link McpService.registerResource}.
+ */
+export interface McpResourceBuilder {
+  <Name extends string>(
+    resource: McpResourceDefinitionFields<Name> & McpDevModeAccess
+  ): McpResourceDefinitionFields<Name> & McpDevModeAccess;
+  <Name extends string>(
+    resource: McpResourceDefinitionFields<Name> & McpAuthAccess
+  ): McpResourceDefinitionFields<Name> & McpAuthAccess;
+}
 
 export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
 
@@ -200,38 +315,20 @@ export interface McpService {
     Title extends string,
     Description extends string,
     InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
-  >(tool: {
-    name: Name;
-    title: Title;
-    description: Description;
-    resolveInputSchema?: McpToolSchemaResolver<InputSchema>;
-    resolveOutputSchema: McpToolSchemaResolver<OutputSchema>;
-    devModeOnly: true;
-    auth?: never;
-    createHandler: (
-      strapi: Core.Strapi,
-      context: McpHandlerContext
-    ) => McpToolHandler<NoInfer<InputSchema>, NoInfer<OutputSchema>>;
-  }): void;
+  >(
+    tool: McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+      McpDevModeAccess
+  ): void;
   registerTool<
     Name extends string,
     OutputSchema extends z.ZodObject<z.ZodRawShape>,
     Title extends string,
     Description extends string,
     InputSchema extends z.ZodObject<z.ZodRawShape> | undefined = undefined,
-  >(tool: {
-    name: Name;
-    title: Title;
-    description: Description;
-    resolveInputSchema?: McpToolSchemaResolver<InputSchema>;
-    resolveOutputSchema: McpToolSchemaResolver<OutputSchema>;
-    devModeOnly?: never;
-    auth: McpCapabilityAuth;
-    createHandler: (
-      strapi: Core.Strapi,
-      context: McpHandlerContext
-    ) => McpToolHandler<NoInfer<InputSchema>, NoInfer<OutputSchema>>;
-  }): void;
+  >(
+    tool: McpToolDefinitionFields<Name, InputSchema, OutputSchema, Title, Description> &
+      McpAuthAccess
+  ): void;
 
   /**
    * Register a single MCP prompt.
@@ -244,29 +341,17 @@ export interface McpService {
     ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
     Title extends string,
     Description extends string,
-  >(prompt: {
-    name: Name;
-    title: Title;
-    description: Description;
-    argsSchema?: ArgsSchema;
-    devModeOnly: true;
-    auth?: never;
-    createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
-  }): void;
+  >(
+    prompt: McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpDevModeAccess
+  ): void;
   registerPrompt<
     Name extends string,
     ArgsSchema extends z.ZodObject<z.ZodRawShape> | undefined,
     Title extends string,
     Description extends string,
-  >(prompt: {
-    name: Name;
-    title: Title;
-    description: Description;
-    argsSchema?: ArgsSchema;
-    devModeOnly?: never;
-    auth: McpCapabilityAuth;
-    createHandler: (strapi: Core.Strapi) => McpPromptCallback<ArgsSchema>;
-  }): void;
+  >(
+    prompt: McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpAuthAccess
+  ): void;
 
   /**
    * Register a single MCP resource.
@@ -274,22 +359,12 @@ export interface McpService {
    * In Strapi's load lifecycle, call only from the register phase (plugin register() or app register()).
    * @throws Error if called after the MCP server has started
    */
-  registerResource<Name extends string>(resource: {
-    name: Name;
-    uri: string;
-    metadata: ResourceMetadata;
-    devModeOnly: true;
-    auth?: never;
-    createHandler: (strapi: Core.Strapi) => McpResourceCallback;
-  }): void;
-  registerResource<Name extends string>(resource: {
-    name: Name;
-    uri: string;
-    metadata: ResourceMetadata;
-    devModeOnly?: never;
-    auth: McpCapabilityAuth;
-    createHandler: (strapi: Core.Strapi) => McpResourceCallback;
-  }): void;
+  registerResource<Name extends string>(
+    resource: McpResourceDefinitionFields<Name> & McpDevModeAccess
+  ): void;
+  registerResource<Name extends string>(
+    resource: McpResourceDefinitionFields<Name> & McpAuthAccess
+  ): void;
 
   /**
    * Start the MCP server

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -147,7 +147,7 @@ export type McpToolDefinition<
   McpCapabilityAccess;
 
 /**
- * Builder for Strapi MCP tool definitions, exposed publicly as `mcp.defineTool`.
+ * Builder for Strapi MCP tool definitions, exposed publicly as `ai.mcp.defineTool`.
  * Identity at runtime — its only job is to infer and narrow the access variant
  * (`devModeOnly` vs `auth`) so the result is directly assignable to
  * {@link McpService.registerTool}.
@@ -221,7 +221,7 @@ export type McpPromptDefinition<
 > = McpPromptDefinitionFields<Name, ArgsSchema, Title, Description> & McpCapabilityAccess;
 
 /**
- * Builder for Strapi MCP prompt definitions, exposed publicly as `mcp.definePrompt`.
+ * Builder for Strapi MCP prompt definitions, exposed publicly as `ai.mcp.definePrompt`.
  * Identity at runtime — narrows the access variant for {@link McpService.registerPrompt}.
  */
 export interface McpPromptBuilder {
@@ -271,7 +271,7 @@ export type McpResourceDefinition<Name extends string = string> =
   McpResourceDefinitionFields<Name> & McpCapabilityAccess;
 
 /**
- * Builder for Strapi MCP resource definitions, exposed publicly as `mcp.defineResource`.
+ * Builder for Strapi MCP resource definitions, exposed publicly as `ai.mcp.defineResource`.
  * Identity at runtime — narrows the access variant for {@link McpService.registerResource}.
  */
 export interface McpResourceBuilder {


### PR DESCRIPTION
### What does it do?

Nests the MCP builder exports under an `ai` namespace. The public surface is `ai.mcp.*` on `@strapi/strapi`:

- `ai.mcp.defineTool` — re-exports `makeMcpToolDefinition`
- `ai.mcp.defineResource` — re-exports `makeMcpResourceDefinition`
- `ai.mcp.definePrompt` — re-exports `makeMcpPromptDefinition`

Adds `packages/core/core/src/mcp.ts`, `packages/core/core/src/ai.ts`, and `export * as ai from './ai'` in `packages/core/core/src/index.ts`. Internal registry names and classes are unchanged.

### Why is it needed?

Plugin authors defining MCP capabilities currently have no ergonomic builder entry point — they must type definitions manually against `Modules.MCP.*` from `@strapi/types`. These identity helpers provide TypeScript inference and narrowing before calling `strapi.ai.mcp.registerTool/Prompt/Resource()`, mirroring the runtime `strapi.ai.mcp` API while keeping AI-related builders grouped under a dedicated namespace.

### How to test it?

1. Build `@strapi/core`: `yarn nx build @strapi/core`
2. In a plugin or sandbox, verify the import resolves and types infer:

```typescript
// mcp/my-tool.ts
import { ai } from '@strapi/strapi';

const myTool = ai.mcp.defineTool({
  name: 'my-tool',
  title: 'My Tool',
  description: 'Does something',
  resolveOutputSchema: () => z.object({ ok: z.boolean() }),
  createHandler: (strapi, context) => async (input) => ({ ok: true }),
});

// index / provider.ts
import type { Core } from '@strapi/strapi';

import { myTool } from './mcp/my-tool';

export default {
  register(/* { strapi }: { strapi: Core.Strapi } */) {},

  bootstrap({ strapi }: { strapi: Core.Strapi }) {
    strapi.ai.mcp.registerTool(myTool);
  },
};
```

3. Run `yarn test:ts:packages` — should pass (no new type regressions from the re-exports).

### Related issues / PRs

None.