### PR TITLE
fix(users-permissions): support documentId user relations

### DIFF
--- a/packages/plugins/users-permissions/server/services/user.js
+++ b/packages/plugins/users-permissions/server/services/user.js
@@ -59,8 +59,12 @@ module.exports = ({ strapi }) => ({
    * @return {Promise}
    */
   async add(values) {
-    return strapi.db.query(USER_MODEL_UID).create({
-      data: await this.ensureHashedPasswords(values),
+    // Use the Document Service so relation inputs accept both the internal
+    // numeric id (legacy) and the documentId (v5 default) syntax, consistent
+    // with every other content-type endpoint. The Document Service hashes
+    // `password` attributes itself, so we must not pre-hash here.
+    return strapi.documents(USER_MODEL_UID).create({
+      data: values,
       populate: ['role'],
     });
   },
@@ -72,9 +76,22 @@ module.exports = ({ strapi }) => ({
    * @return {Promise}
    */
   async edit(userId, params = {}) {
-    return strapi.db.query(USER_MODEL_UID).update({
-      where: { id: userId },
-      data: await this.ensureHashedPasswords(params),
+    // The user is addressed by its numeric id (e.g. the `/users/:id` route),
+    // but the Document Service updates by documentId. Resolve it first so the
+    // relation inputs are processed by the Document Service, which accepts both
+    // numeric ids (legacy) and documentIds (v5 default). The Document Service
+    // hashes `password` attributes itself, so we must not pre-hash here.
+    const entry = await strapi.db
+      .query(USER_MODEL_UID)
+      .findOne({ where: { id: userId }, select: ['documentId'] });
+
+    if (!entry) {
+      return null;
+    }
+
+    return strapi.documents(USER_MODEL_UID).update({
+      documentId: entry.documentId,
+      data: params,
       populate: ['role'],
     });
   },

--- a/tests/api/plugins/users-permissions/content-api/auth-refresh.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/auth-refresh.test.api.js
@@ -88,6 +88,10 @@ const recreateStrapiInstance = async (config = {}) => {
       }
     },
   });
+  // The previous instance already seeded `internals.user`; remove it before
+  // re-seeding so we don't attempt to create a duplicate (the user service now
+  // goes through the Document Service, which validates uniqueness).
+  await strapi.db.query('plugin::users-permissions.user').deleteMany();
   await createAuthenticatedUser({ strapi, userInfo: internals.user });
 };
 

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -230,10 +230,40 @@ describe('U&P users REST relation handling (issue 26606)', () => {
 
     test('PUT silently ignores an unrecognized field (200, no-op)', async () => {
       const user = await createUser();
+      const before = await readUser(user.id);
 
       const res = await putUser(user.id, { thisFieldDoesNotExist: 'value' });
 
       expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.username).toBe(before.username);
+      expect(after.email).toBe(before.email);
+      expect(after).not.toHaveProperty('thisFieldDoesNotExist');
+    });
+
+    // Regression guard for https://github.com/strapi/strapi/pull/26101
+    //
+    // Before #26101 an unrecognized attribute carrying a relation-style
+    // `documentId` connect payload was silently dropped (200, no-op). #26101
+    // tightened numeric validation, which turned this same payload into a 500
+    // because the bogus value reached the DB layer. Routing the user service
+    // through the Document Service restores the original 200/no-op: unknown
+    // attributes are never traversed as relations, so nothing is written and a
+    // valid relation is left untouched.
+    test('PUT silently ignores an unknown relation-looking attribute (200, no-op)', async () => {
+      const article = await createArticle('unknown relation noop');
+      const user = await createUser({ favoriteArticles: { connect: [article.id] } });
+
+      const res = await putUser(user.id, {
+        notARealRelation: { connect: [article.documentId] },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      // the unknown key is ignored and the real relation is left as-is
+      expect(after).not.toHaveProperty('notARealRelation');
+      expect(after.favoriteArticles).toHaveLength(1);
+      expect(after.favoriteArticles[0].id).toBe(article.id);
     });
   });
 

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -1,0 +1,303 @@
+'use strict';
+
+// Coverage for https://github.com/strapi/strapi/issues/26606
+//
+// `PUT /api/users/:id` (and `POST /api/users`) go through the
+// users-permissions user service (`add` / `edit`). This suite has two parts:
+//
+//  1. "existing behavior" — a regression safety net locking in everything the
+//     endpoint already does (scalars, password hashing, relations by numeric
+//     id, uniqueness checks, 404, unknown-key handling). These must stay green
+//     before and after the fix.
+//
+//  2. "documentId relation support" — the v5 behavior the issue asks for:
+//     updating relation fields using the standard `documentId` connect syntax.
+//     These are RED before the fix and GREEN after.
+
+const bcrypt = require('bcryptjs');
+const { createTestBuilder } = require('api-tests/builder');
+const { createStrapiInstance } = require('api-tests/strapi');
+const { createContentAPIRequest } = require('api-tests/request');
+
+let strapi;
+let rq;
+let builder;
+
+let authenticatedRole;
+let publicRole;
+
+const articleModel = {
+  attributes: {
+    title: {
+      type: 'string',
+    },
+    // creates a oneToMany `favoriteArticles` on the user
+    owner: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'plugin::users-permissions.user',
+      targetAttribute: 'favoriteArticles',
+    },
+    // creates a manyToOne `favoriteArticle` on the user
+    fans: {
+      type: 'relation',
+      relation: 'oneToMany',
+      target: 'plugin::users-permissions.user',
+      targetAttribute: 'favoriteArticle',
+    },
+  },
+  displayName: 'Article',
+  singularName: 'article',
+  pluralName: 'articles',
+  description: '',
+  collectionName: '',
+};
+
+let userSeq = 0;
+const createUser = async (overrides = {}) => {
+  userSeq += 1;
+  return strapi.db.query('plugin::users-permissions.user').create({
+    data: {
+      username: `reluser${userSeq}`,
+      email: `reluser${userSeq}@strapi.io`,
+      password: 'password123',
+      provider: 'local',
+      role: authenticatedRole.id,
+      ...overrides,
+    },
+  });
+};
+
+const createArticle = (title = 'Article') =>
+  strapi.db.query('api::article.article').create({ data: { title } });
+
+const readUser = (id) =>
+  strapi.db.query('plugin::users-permissions.user').findOne({
+    where: { id },
+    populate: ['favoriteArticles', 'favoriteArticle', 'role'],
+  });
+
+const putUser = (id, body) => rq({ method: 'PUT', url: `/users/${id}`, body });
+
+describe('U&P users REST relation handling (issue 26606)', () => {
+  beforeAll(async () => {
+    builder = createTestBuilder();
+    await builder.addContentType(articleModel).build();
+    strapi = await createStrapiInstance();
+    rq = await createContentAPIRequest({ strapi });
+
+    authenticatedRole = await strapi.db
+      .query('plugin::users-permissions.role')
+      .findOne({ where: { type: 'authenticated' } });
+    publicRole = await strapi.db
+      .query('plugin::users-permissions.role')
+      .findOne({ where: { type: 'public' } });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+    await builder.cleanup();
+  });
+
+  describe('existing behavior (regression safety net)', () => {
+    test('POST /users creates a user (201) with role populated and hashed password', async () => {
+      const payload = {
+        username: 'created_user',
+        email: 'created_user@strapi.io',
+        password: 'password123',
+        role: authenticatedRole.id,
+      };
+
+      const res = await rq({ method: 'POST', url: '/users', body: payload });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toMatchObject({
+        username: payload.username,
+        email: payload.email,
+        role: { id: authenticatedRole.id },
+      });
+
+      const dbUser = await strapi.db
+        .query('plugin::users-permissions.user')
+        .findOne({ where: { email: payload.email } });
+      expect(bcrypt.compareSync(payload.password, dbUser.password)).toBe(true);
+    });
+
+    test('PUT updates a scalar field without touching the password', async () => {
+      const user = await createUser();
+      const before = await readUser(user.id);
+
+      const res = await putUser(user.id, { username: 'renamed_user' });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.username).toBe('renamed_user');
+      expect(after.password).toBe(before.password);
+    });
+
+    test('PUT re-hashes the password when it is changed', async () => {
+      const user = await createUser();
+      const before = await readUser(user.id);
+
+      const res = await putUser(user.id, { password: 'newpassword123' });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.password).not.toBe(before.password);
+      expect(bcrypt.compareSync('newpassword123', after.password)).toBe(true);
+    });
+
+    test('PUT changes the role by numeric id', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, { role: publicRole.id });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.role.id).toBe(publicRole.id);
+    });
+
+    test('PUT connects a oneToMany relation by numeric id', async () => {
+      const user = await createUser();
+      const article = await createArticle('numeric connect');
+
+      const res = await putUser(user.id, { favoriteArticles: { connect: [article.id] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(1);
+      expect(after.favoriteArticles[0].id).toBe(article.id);
+    });
+
+    test('PUT disconnects a oneToMany relation by numeric id', async () => {
+      const article = await createArticle('numeric disconnect');
+      const user = await createUser({ favoriteArticles: { connect: [article.id] } });
+
+      const res = await putUser(user.id, { favoriteArticles: { disconnect: [article.id] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(0);
+    });
+
+    test('PUT sets a oneToMany relation by numeric id', async () => {
+      const articleA = await createArticle('numeric set A');
+      const articleB = await createArticle('numeric set B');
+      const user = await createUser({ favoriteArticles: { connect: [articleA.id] } });
+
+      const res = await putUser(user.id, { favoriteArticles: { set: [articleB.id] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(1);
+      expect(after.favoriteArticles[0].id).toBe(articleB.id);
+    });
+
+    test('PUT connects a manyToOne relation by numeric id', async () => {
+      const user = await createUser();
+      const article = await createArticle('numeric manyToOne');
+
+      const res = await putUser(user.id, { favoriteArticle: { connect: [article.id] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticle).not.toBeNull();
+      expect(after.favoriteArticle.id).toBe(article.id);
+    });
+
+    test('PUT on an unknown user returns 404', async () => {
+      const res = await putUser(99999999, { username: 'whatever' });
+      expect(res.statusCode).toBe(404);
+    });
+
+    test('PUT rejects a duplicate email', async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+
+      const res = await putUser(userB.id, { email: userA.email });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('PUT rejects a duplicate username', async () => {
+      const userA = await createUser();
+      const userB = await createUser();
+
+      const res = await putUser(userB.id, { username: userA.username });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('PUT silently ignores an unrecognized field (200, no-op)', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, { thisFieldDoesNotExist: 'value' });
+
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('documentId relation support (expected after fix)', () => {
+    test('PUT connects a oneToMany relation by documentId', async () => {
+      const user = await createUser();
+      const article = await createArticle('docId connect');
+
+      const res = await putUser(user.id, { favoriteArticles: { connect: [article.documentId] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(1);
+      expect(after.favoriteArticles[0].documentId).toBe(article.documentId);
+    });
+
+    test('PUT sets a oneToMany relation by documentId', async () => {
+      const articleA = await createArticle('docId set A');
+      const articleB = await createArticle('docId set B');
+      const user = await createUser({ favoriteArticles: { connect: [articleA.id] } });
+
+      const res = await putUser(user.id, { favoriteArticles: { set: [articleB.documentId] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(1);
+      expect(after.favoriteArticles[0].documentId).toBe(articleB.documentId);
+    });
+
+    test('PUT disconnects a oneToMany relation by documentId', async () => {
+      const article = await createArticle('docId disconnect');
+      const user = await createUser({ favoriteArticles: { connect: [article.id] } });
+
+      const res = await putUser(user.id, {
+        favoriteArticles: { disconnect: [article.documentId] },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticles).toHaveLength(0);
+    });
+
+    test('PUT connects a manyToOne relation by documentId', async () => {
+      const user = await createUser();
+      const article = await createArticle('docId manyToOne');
+
+      const res = await putUser(user.id, { favoriteArticle: { connect: [article.documentId] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticle).not.toBeNull();
+      expect(after.favoriteArticle.documentId).toBe(article.documentId);
+    });
+
+    test('PUT connects a manyToOne relation by documentId shorthand', async () => {
+      const user = await createUser();
+      const article = await createArticle('docId manyToOne shorthand');
+
+      const res = await putUser(user.id, { favoriteArticle: article.documentId });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.favoriteArticle).not.toBeNull();
+      expect(after.favoriteArticle.documentId).toBe(article.documentId);
+    });
+  });
+});


### PR DESCRIPTION
## What does it do?

- Routes users-permissions user create/update through the Document Service so relation inputs support both legacy numeric ids and v5 documentIds.
- Resolves the numeric `/users/:id` route parameter to `documentId` before update while keeping read paths on the existing DB query layer.
- Restores the pre-#26101 behaviour for unknown attributes: an unrecognized, relation-looking payload (e.g. `{ notARealRelation: { connect: ["<documentId>"] } }`) is again silently ignored (200, no-op) instead of erroring.
- Adds regression coverage for existing numeric-id behaviour, new documentId relation updates, and the unknown-attribute no-op case.

## Why is it needed?

`PUT /api/users/:id` previously used the low-level DB query layer, which processes relation inputs by internal numeric id only. Standard v5 REST/client payloads using `documentId` failed to update custom relations on the user content type.

In addition, #26101 (stricter numeric validation) turned a previously harmless unknown-attribute payload from a 200/no-op into a 500, because the bogus value reached the DB layer. Going through the Document Service drops unknown attributes before they get there, so that case returns to 200/no-op while real documentId relations now work.

## How to test it?

We have to be careful here that this does not cause any breaking changes for legacy behaviour, since that's the only behaviour that was available until now. So I have added tests to cover existing legacy behaviour, but please review them to make sure it's thorough enough.

- `yarn test:api user-update-relations`
- `yarn test:api --db=postgres user-update-relations`
- `yarn test:api "plugins/users-permissions"`
- `yarn test:api --db=postgres "plugins/users-permissions"`
- `yarn setup`

## Related issue(s)/PR(s)

Fixes #26606
Fixes CMS-1165