### PR TITLE
chore(ci): drop Node 20 from test workflow matrices

### DIFF
--- a/.github/actions/check-pr-status/README.md
+++ b/.github/actions/check-pr-status/README.md
@@ -19,7 +19,7 @@ This action checks a PR labels, milestone and status to validate it is ready for
 
 ### Requirements
 
-- The code is compatible with Node 20, 22, 24, and 26
+- The code is compatible with Node 22, 24, and 26
 
 ### Dependencies
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -67,7 +67,7 @@ jobs:
     if: ${{ needs.conditions.outputs.docs == 'true' || needs.conditions.outputs.global == 'true' }}
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -130,7 +130,7 @@ jobs:
     if: needs.conditions.outputs.global == 'true' || needs.conditions.outputs.backend == 'true' || needs.conditions.outputs.backend == 'true'
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -159,7 +159,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -230,7 +230,7 @@ jobs:
         run: yarn nx affected --target=test:front --nx-ignore-cycles -- --runInBand --coverage
 
       - name: Upload coverage artifacts
-        if: matrix.node == 26 # Only upload from one node version to avoid conflicts
+        if: matrix.node == 24 # Only upload from one node version to avoid conflicts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: front-coverage-reports
@@ -303,7 +303,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Monorepo install
         uses: ./.github/actions/yarn-nm-install
@@ -345,7 +345,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -370,7 +370,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/4, 2/4, 3/4, 4/4]
     services:
       postgres:
@@ -411,7 +411,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/4, 2/4, 3/4, 4/4]
     services:
       mysql:
@@ -451,7 +451,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -478,7 +478,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       postgres:
@@ -522,7 +522,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/5, 2/5, 3/5, 4/5, 5/5]
     services:
       mysql:
@@ -565,7 +565,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24, 26]
+        node: [22, 24, 26]
         shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### What does it do?

- Removes Node **20** from all job matrices in `.github/workflows/tests.yml`, narrowing CI coverage to **22, 24, and 26**.
- Updates the `[EE] e2e` job pinned runner from Node **20** to **22** (aligned with `[CE] e2e`).
- Fixes the `unit_front` coverage artifact upload guard from `matrix.node == 26` to `matrix.node == 24` so uploads run on the sole matrix entry.
- Updates `.github/actions/check-pr-status/README.md` to reflect CI compatibility with Node 22, 24, and 26.

### Why is it needed?

Follow-up to #26232, which added Node 26 to the CI matrix. Node 20 is no longer needed in CI runners — dropping it reduces workflow fan-out and CI cost while keeping coverage on the supported active lines (22, 24, 26). Runtime `engines` constraints (`>=20.0.0 <=26.x.x`) are unchanged; this is CI-only.

### How to test it?

- Open the PR and confirm the **Tests** workflow runs successfully on matrix entries **22, 24, and 26** only (no Node 20 jobs).
- Verify `unit_front` uploads `front-coverage-reports` and SonarQube still receives frontend coverage.
- Confirm `[EE] e2e` runs on Node 22.

### Related issues / PRs

- Follow-up to #26232
- Related to #26291
