### PR TITLE
fix(admin-test-utils): bridge jsdom FormData to Node realm in Request constructor

### DIFF
--- a/packages/admin-test-utils/src/environment.ts
+++ b/packages/admin-test-utils/src/environment.ts
@@ -25,7 +25,12 @@ type EnvContext = ConstructorParameters<typeof TestEnvironment>[1];
  *   3. `patchRequestBodyStash`  — work around undici's
  *                                 `Request.clone() locks original stream`
  *                                 behaviour that msw triggers on every
- *                                 handler dispatch.
+ *                                 handler dispatch; also bridges jsdom-realm
+ *                                 `FormData` bodies to Node/undici `FormData`
+ *                                 inside the Request constructor Proxy so
+ *                                 undici emits a real `multipart/form-data`
+ *                                 body instead of stringifying to
+ *                                 `"[object FormData]"`.
  *
  * Each patch owns its own state, its own sanity checks, and its own teardown.
  * The orchestrator keeps the teardown stack in setup order and pops in

--- a/packages/admin-test-utils/src/patches/node-globals.ts
+++ b/packages/admin-test-utils/src/patches/node-globals.ts
@@ -33,6 +33,10 @@ import type { Global, Teardown } from './types';
  *         falls back to `toString` (`"[object Blob]"` → size 13).
  *         Polyfilling `File` too "fixes" that chain but breaks the next:
  *         jsdom's `FileReader` / `Image` only accept jsdom-realm `File`/`Blob`.
+ *     The jsdom-realm `FormData` that app code builds and passes to `fetch` is
+ *     instead bridged to a Node-realm `FormData` inside the `Request`
+ *     constructor Proxy in `patchRequestBodyStash` (see request-body-stash.ts),
+ *     which intercepts before undici's Request constructor sees the body.
  *
  *   - `URL` / `URLSearchParams` — NOT polyfilled. jsdom already provides
  *     browser-spec versions, and Node's `URL.createObjectURL` only accepts

--- a/packages/admin-test-utils/src/patches/request-body-stash.ts
+++ b/packages/admin-test-utils/src/patches/request-body-stash.ts
@@ -1,33 +1,52 @@
+import { isForeignFormData, bridgeFormDataBody } from './request-formdata-realm';
 import type { Global, Teardown } from './types';
 
 /* -------------------------------------------------------------------------------------------------
- * Request body stash for msw v2 + undici
+ * Request body stash + FormData realm bridge for msw v2 + undici
  *
- * The problem
- * -----------
+ * Problem 1: Body unusable (clone/tee lock)
+ * -----------------------------------------
  * MSW v2's `RequestHandler.run()` calls `request.clone()` BEFORE invoking the
  * resolver (to keep a copy around for post-hoc logging). Under Node's undici,
  * `Request.clone()` tees the underlying `ReadableStream`, which locks the
  * original body — so when the resolver then does `await request.json()`,
  * undici throws `TypeError: Body is unusable: Body has already been read`.
  *
- * The fix
- * -------
- * Stash the stringified body on every `new Request(…)` under a private Symbol,
- * and have `.text()` / `.json()` return the stash when present. Handlers get
- * what the test fired off regardless of how many times msw clones the request
- * internally. The stash is read-through: if an existing stashed Request is
- * passed as the first argument to `new Request(original, init)`, the stash
- * propagates to the new instance.
+ * Fix: Stash the stringified body on every `new Request(…)` under a private
+ * Symbol, and have `.text()` / `.json()` return the stash when present.
+ * Handlers get what the test fired off regardless of how many times msw clones
+ * the request internally. The stash is read-through: if an existing stashed
+ * Request is passed as the first argument to `new Request(original, init)`, the
+ * stash propagates to the new instance.
  *
- * Scope
- * -----
- * Only string bodies are stashed. `FormData` / `Blob` / `ArrayBuffer` bodies
- * are not — no current handler in the repo reads those shapes, and extending
- * the stash to cover them needs realm-aware handling (see node-globals.ts).
- * A handler that calls `request.formData()` or `request.arrayBuffer()` under
- * this env will hit the undici "Body is unusable" error directly; widen this
- * patch if that case arises.
+ * Problem 2: jsdom-realm FormData → "text/plain" coercion
+ * --------------------------------------------------------
+ * `applyNodeGlobals` keeps jsdom's `FormData` on the global (see node-globals.ts
+ * for the rationale). App code builds a jsdom-realm `FormData` and passes it to
+ * `getFetchClient.post(…)`. msw v2's `FetchInterceptor` constructs a
+ * `new FetchRequest(input, init)` (where `FetchRequest extends Request`) from
+ * the original `fetch()` arguments. undici's `Request` constructor does not
+ * recognise a foreign-realm `FormData` and calls `.toString()` on it, producing
+ * the string `"[object FormData]"` with `Content-Type: text/plain`.
+ *
+ * Fix: In the same Request constructor Proxy (problem 1's fix), detect a
+ * jsdom-realm `FormData` in `init.body` and replace it with a Node/undici
+ * `FormData` **before** calling `Reflect.construct`. Only string-valued entries
+ * are bridged synchronously; see `request-formdata-realm.ts` for the rationale
+ * and the TODO for File/Blob entries.
+ *
+ * Why the Request constructor proxy, not a fetch wrapper
+ * -------------------------------------------------------
+ * msw's `FetchInterceptor` wraps `globalThis.fetch` and constructs a
+ * `FetchRequest` from the call arguments immediately. By the time a patched
+ * outer `fetch` wrapper would run, msw has already consumed the body through
+ * that construction. Intercepting the `Request` constructor (which `FetchRequest`
+ * inherits) is the earliest point where we can replace the body.
+ *
+ * Scope / stash
+ * -------------
+ * Only string bodies and bridged FormData bodies are handled here. `Blob` /
+ * `ArrayBuffer` bodies are not stashed — no current handler reads those shapes.
  * -----------------------------------------------------------------------------------------------*/
 
 const BODY_STASH = Symbol('strapi.mswBodyStash');
@@ -57,6 +76,18 @@ function stashFor(
   return undefined;
 }
 
+/**
+ * If `init.body` is a jsdom-realm `FormData`, bridge it to a Node/undici
+ * `FormData` synchronously and return a new `init` with the replaced body.
+ * Returns the original `init` unchanged if no bridging is needed.
+ */
+function bridgeInit(init: RequestInit | undefined): RequestInit | undefined {
+  if (init !== undefined && isForeignFormData(init.body)) {
+    return { ...init, body: bridgeFormDataBody(init.body) };
+  }
+  return init;
+}
+
 export function patchRequestBodyStash(global: Global): Teardown {
   const NativeRequest = global.Request as typeof Request;
   const jsdomJSON = global.JSON as typeof JSON;
@@ -67,7 +98,9 @@ export function patchRequestBodyStash(global: Global): Teardown {
   const PatchedRequest = new Proxy(NativeRequest, {
     construct(target, args) {
       const [input, init] = args as [RequestInfo | URL | undefined, RequestInit | undefined];
-      const request = Reflect.construct(target, args) as Stashed;
+      const bridgedInit = bridgeInit(init);
+      const bridgedArgs = bridgedInit !== init ? [input, bridgedInit] : args;
+      const request = Reflect.construct(target, bridgedArgs) as Stashed;
       const body = stashFor(input, init, NativeRequest);
       if (body !== undefined) {
         Object.defineProperty(request, BODY_STASH, { value: body });

--- a/packages/admin-test-utils/src/patches/request-formdata-realm.ts
+++ b/packages/admin-test-utils/src/patches/request-formdata-realm.ts
@@ -1,0 +1,131 @@
+/* -------------------------------------------------------------------------------------------------
+ * FormData realm bridge for jsdom + undici + msw v2
+ *
+ * The problem
+ * -----------
+ * `applyNodeGlobals` intentionally keeps jsdom's `FormData`/`Blob`/`File` on
+ * the global (see node-globals.ts for the rationale). App code therefore builds
+ * a *jsdom-realm* `FormData` and passes it to `getFetchClient.post(…)`, which
+ * deletes the `Content-Type` header and forwards the body straight to the
+ * global `Request` constructor (undici). undici does not recognise a
+ * foreign-realm `FormData` (it fails its internal `instanceof FormData` guard),
+ * so it falls back to `.toString()` and sends the body as the string
+ * `"[object FormData]"` with `Content-Type: text/plain`.
+ *
+ * Consequences:
+ *   1. Tests that inspect the wire content-type see `text/plain` instead of
+ *      `multipart/form-data`.
+ *   2. msw handlers that call `await request.formData()` cannot parse the body.
+ *   3. The msw response never resolves → mutations error ("Failed to update the
+ *      file." toast) → `captured` stays `null` → test assertions fail.
+ *
+ * The fix
+ * -------
+ * This module exports `bridgeFormDataBody`, a helper used inside the Request
+ * constructor Proxy in `patchRequestBodyStash`. When a `new Request(url, init)`
+ * call carries a jsdom-realm `FormData` in `init.body`, the Proxy calls
+ * `bridgeFormDataBody` to convert it to a Node/undici `FormData` (string
+ * fields only, synchronously) before passing the args to the native Request
+ * constructor. undici then serialises the Node-realm `FormData` correctly and
+ * emits a proper `multipart/form-data` body.
+ *
+ * Why patch `Request` construction rather than `fetch`
+ * ----------------------------------------------------
+ * msw v2 (`FetchInterceptor`) wraps `globalThis.fetch` and internally constructs
+ * a `new FetchRequest(input, init)` where `FetchRequest extends Request`. By the
+ * time our patched `fetch` wrapper would run, msw has already consumed the body
+ * via that FetchRequest construction. Patching the `Request` constructor (which
+ * `FetchRequest` inherits) intercepts the body before undici touches it.
+ *
+ * Why wrap `Request` rather than replacing `FormData`
+ * ---------------------------------------------------
+ * Replacing the global `FormData` with undici's version breaks:
+ *   - `new FormData(htmlFormElement)` (jsdom-only API used by LogoInput).
+ *   - jsdom `FileReader` / `Image` / `URL.createObjectURL` (realm-sensitive).
+ * See node-globals.ts for full rationale.
+ *
+ * Scope / edge cases
+ * ------------------
+ * Only string-valued FormData entries are bridged synchronously. `File`/`Blob`
+ * entries require async (`arrayBuffer()`) and are not covered here — no current
+ * handler in the repo calls `request.formData()` on a body that contains files.
+ * TODO @Nico: widen bridgeFormDataBody to async-bridge File/Blob entries if a
+ *             file-upload handler needs `request.formData()` in the future.
+ * -----------------------------------------------------------------------------------------------*/
+
+/**
+ * Captured at module load time, BEFORE jest-environment-jsdom has a chance to
+ * shadow the globals. At this point `FormData`/`Blob`/`File` are the Node/undici
+ * versions — identical to what `applyNodeGlobals` captures for fetch/Request.
+ */
+const NodeFormData = FormData;
+const NodeBlob = Blob;
+const NodeFile = File;
+
+/**
+ * Returns `true` when `value` is a `FormData`-shaped object from a *different*
+ * realm than the Node/undici `FormData` captured above (e.g. jsdom's FormData).
+ *
+ * We cannot use `value instanceof FormData` here because at module scope
+ * `FormData` IS `NodeFormData` — a jsdom FormData instance is NOT
+ * `instanceof NodeFormData`. We detect it via duck-typing + realm check.
+ */
+type FormDataShaped = { entries: unknown; append: unknown; get: unknown };
+
+export function isForeignFormData(value: unknown): value is FormData {
+  if (value instanceof NodeFormData) return false;
+  if (value === null || typeof value !== 'object') return false;
+  const shaped = value as FormDataShaped;
+  return (
+    typeof shaped.entries === 'function' &&
+    typeof shaped.append === 'function' &&
+    typeof shaped.get === 'function'
+  );
+}
+
+/**
+ * Synchronously converts a jsdom-realm `FormData` into a Node/undici `FormData`
+ * that undici can serialise as a proper `multipart/form-data` body.
+ *
+ * - String entries: copied verbatim.
+ * - File/Blob entries: converted to a Node File/Blob with the same MIME type
+ *   and filename but **placeholder bytes** (the jsdom Blob byte content is only
+ *   accessible via async `arrayBuffer()` which cannot be called here). The
+ *   placeholder approach is sufficient for tests that inspect the content-type
+ *   header or the presence/absence of the body — it is NOT suitable for tests
+ *   that parse the multipart payload and read the actual file bytes.
+ *
+ * TODO @Nico: async-bridge the actual file bytes for tests that call
+ *             `request.formData()` on a body containing uploaded files.
+ *             The Request constructor Proxy that calls this function is sync, so
+ *             that requires a different interception point (e.g. a fetch wrapper
+ *             that runs before msw's FetchInterceptor installs — which means
+ *             wiring it into `beforeAll` via a helper rather than the environment
+ *             setup phase).
+ */
+export function bridgeFormDataBody(jsdomFD: FormData): InstanceType<typeof NodeFormData> {
+  const nodeFD = new NodeFormData();
+
+  for (const [name, value] of jsdomFD.entries()) {
+    if (typeof value === 'string') {
+      nodeFD.append(name, value);
+    } else {
+      // value is a jsdom-realm File (subclass of jsdom Blob).
+      // We cannot read the bytes synchronously so we create a Node File with
+      // placeholder bytes. The MIME type and filename are preserved so undici
+      // emits the correct multipart boundary and part headers.
+      const filename = value instanceof File ? value.name : 'blob';
+      const nodeFile = new NodeFile([], filename, { type: value.type });
+      nodeFD.append(name, nodeFile, filename);
+    }
+  }
+
+  return nodeFD;
+}
+
+// Re-export the captured Node constructors so patchRequestBodyStash can use them
+// without duplicating the module-load-time capture logic.
+export { NodeFormData, NodeBlob, NodeFile };
+
+// This module is a helper library for `patchRequestBodyStash`. It does not
+// install any global patches itself. All wiring lives in `patchRequestBodyStash`.


### PR DESCRIPTION
### What does it do?

Adds a new helper module `packages/admin-test-utils/src/patches/request-formdata-realm.ts` and extends the existing `Request` constructor Proxy in `patchRequestBodyStash` to detect and bridge jsdom-realm `FormData` bodies to Node/undici `FormData` before undici's `Request` constructor processes the body.

Key changes:
- **`request-formdata-realm.ts`** (new): captures Node/undici `FormData`/`Blob`/`File` at module-load time (before jsdom shadows them); exports `isForeignFormData` (duck-type + realm check) and `bridgeFormDataBody` (sync bridge — string entries verbatim, File/Blob as same-MIME placeholder Node Files).
- **`request-body-stash.ts`**: extends the `construct` trap of the existing `Request` Proxy to call `bridgeFormDataBody` on `init.body` when it is a jsdom-realm `FormData`, replacing it with a Node `FormData` before `Reflect.construct` runs.
- **`environment.ts`** / **`node-globals.ts`**: updated JSDoc to document the new bridge and where it lives.

### Why is it needed?

Four tests in `AssetDetailsDrawer.test.tsx` were deterministically failing (appearing "flaky" in CI because they only run under `nx affected` when upload/admin changes):

```
● AssetDetails › enables save when a field is edited …        (captured.id was null)
● AssetDetails › sends the selected folder id …               (captured.body was null)
● AssetDetails › keeps location selectable and dirty-tracks … (captured.body was null)
● AssetDetails › opens the confirm dialog … uploads the file  (content-type was text/plain)
```

Root cause: `applyNodeGlobals` deliberately keeps jsdom's `FormData`/`Blob`/`File` on the global (needed for `new FormData(htmlFormElement)`, `FileReader`, `URL.createObjectURL`). App code builds a jsdom-realm `FormData` and passes it to `getFetchClient.post(…)`. msw v2's `FetchInterceptor` wraps `globalThis.fetch` and immediately constructs `new FetchRequest(input, init)` (where `FetchRequest extends Request`). undici's `Request` constructor does not recognise a foreign-realm `FormData`, falls back to `.toString()`, producing `"[object FormData]"` with `Content-Type: text/plain`. The msw handler then cannot call `request.formData()`, the mutation errors with "Failed to update the file.", and `captured` stays `null`.

Patching the `Request` constructor (not wrapping `fetch`) is the correct interception point because msw consumes the body through `FetchRequest` construction before any outer `fetch` wrapper would run.

### How to test it?

```bash
yarn nx build @strapi/admin-test-utils

# Previously failing suite — expect 9 passed, 0 failed
cd packages/core/upload
yarn test:front admin/src/future/pages/Assets/components/AssetDetails/tests/AssetDetailsDrawer.test.tsx --runInBand

# Full upload frontend suite — expect 504 passed
yarn test:front --runInBand

# Full admin frontend suite — no new failures
cd ../admin && yarn test:front --runInBand
```

### Related issues / PRs

- CI run showing the 4 failures: https://github.com/strapi/strapi/actions/runs/27330069112/job/80790272566?pr=26232
- Related to the msw 1→2 migration that introduced the test environment patches (#26065)
- Related to `AssetDetailsDrawer` tests added in #26366 and #26436