### PR TITLE
fix(content-type-builder): show configure view outside development mode

### DIFF
--- a/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/ListView.tsx
@@ -116,36 +116,40 @@ const ListView = () => {
 
   const isDeleted = type.status === 'REMOVED';
 
-  const primaryAction = isInDevelopmentMode && (
+  const primaryAction = (
     <Flex gap={2}>
       <LinkToCMSettingsView
         key="link-to-cm-settings-view"
         type={type}
         disabled={type.status === 'NEW' || isDeleted}
       />
-      <Button
-        startIcon={<Pencil />}
-        variant="tertiary"
-        onClick={onEdit}
-        disabled={!canEdit || isDeleted}
-      >
-        {formatMessage({
-          id: 'app.utils.edit',
-          defaultMessage: 'Edit',
-        })}
-      </Button>
+      {isInDevelopmentMode && (
+        <>
+          <Button
+            startIcon={<Pencil />}
+            variant="tertiary"
+            onClick={onEdit}
+            disabled={!canEdit || isDeleted}
+          >
+            {formatMessage({
+              id: 'app.utils.edit',
+              defaultMessage: 'Edit',
+            })}
+          </Button>
 
-      <Button
-        startIcon={<Plus />}
-        variant="secondary"
-        minWidth="max-content"
-        onClick={() => {
-          onOpenModalAddField({ forTarget, targetUid: type.uid });
-        }}
-        disabled={isDeleted}
-      >
-        {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
-      </Button>
+          <Button
+            startIcon={<Plus />}
+            variant="secondary"
+            minWidth="max-content"
+            onClick={() => {
+              onOpenModalAddField({ forTarget, targetUid: type.uid });
+            }}
+            disabled={isDeleted}
+          >
+            {type.attributes.length === 0 ? addNewFieldLabel : addAnotherFieldLabel}
+          </Button>
+        </>
+      )}
     </Flex>
   );
 

--- a/packages/core/content-type-builder/admin/src/pages/ListView/tests/ListView.test.tsx
+++ b/packages/core/content-type-builder/admin/src/pages/ListView/tests/ListView.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable check-file/filename-naming-convention */
+import { render, screen } from '@strapi/admin/strapi-admin/test';
+import { Route, Routes } from 'react-router-dom';
+
+import { useDataManager } from '../../../components/DataManager/useDataManager';
+import ListView from '../ListView';
+
+import type { DataManagerContextValue } from '../../../components/DataManager/DataManagerContext';
+
+jest.mock('../../../components/CTBSession/ctbSession', () => ({
+  useCTBTracking: () => ({
+    trackUsage: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../components/DataManager/useDataManager', () => ({
+  useDataManager: jest.fn(),
+}));
+
+jest.mock('../../../components/FormModalNavigation/useFormModalNavigation', () => ({
+  useFormModalNavigation: () => ({
+    onOpenModalAddComponentsToDZ: jest.fn(),
+    onOpenModalAddField: jest.fn(),
+    onOpenModalEditSchema: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../components/List', () => ({
+  List: () => <div />,
+}));
+
+jest.mock('../LinkToCMSettingsView', () => ({
+  LinkToCMSettingsView: ({ disabled }: { disabled: boolean }) => (
+    <button type="button" disabled={disabled}>
+      Configure the view
+    </button>
+  ),
+}));
+
+const mockedUseDataManager = jest.mocked(useDataManager);
+
+const contentType = {
+  uid: 'api::article.article',
+  modelType: 'contentType',
+  kind: 'collectionType',
+  visible: true,
+  status: 'UNCHANGED',
+  info: {
+    displayName: 'article',
+  },
+  plugin: undefined,
+  attributes: [{ name: 'title' }],
+};
+
+const getDataManagerValue = (
+  overrides: Partial<DataManagerContextValue> = {}
+): DataManagerContextValue =>
+  ({
+    isLoading: false,
+    isInDevelopmentMode: true,
+    contentTypes: {
+      'api::article.article': contentType,
+    },
+    components: {},
+    ...overrides,
+  }) as unknown as DataManagerContextValue;
+
+const renderListView = () =>
+  render(
+    <Routes>
+      <Route
+        path="/plugins/content-type-builder/content-types/:contentTypeUid"
+        element={<ListView />}
+      />
+    </Routes>,
+    {
+      initialEntries: ['/plugins/content-type-builder/content-types/api::article.article'],
+    }
+  );
+
+describe('<ListView />', () => {
+  beforeEach(() => {
+    mockedUseDataManager.mockReturnValue(getDataManagerValue());
+  });
+
+  it('shows schema actions in development mode', () => {
+    renderListView();
+
+    expect(screen.getByRole('button', { name: 'Configure the view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add another field' })).toBeInTheDocument();
+  });
+
+  it('keeps the configure view action outside development mode', () => {
+    mockedUseDataManager.mockReturnValue(
+      getDataManagerValue({
+        isInDevelopmentMode: false,
+      })
+    );
+
+    renderListView();
+
+    expect(screen.getByRole('button', { name: 'Configure the view' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add another field' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #25783

### What does it do?

Keeps the Content-Type Builder "Configure the view" shortcut visible outside development mode, while preserving schema-edit actions as development-only.

### Why is it needed?

The current header action group is entirely gated by `isInDevelopmentMode`, which also hides the read-only Content Manager configuration shortcut in production mode.

### How to test it?

- `yarn workspace @strapi/content-type-builder test:front ListView.test.tsx --runInBand`

Note: local package lint currently fails on existing workspace resolver issues for `@strapi/admin/strapi-admin` imports across the package; the targeted regression test passes.

---
Fixes CPR-390