### PR TITLE
fix(openapi): include content api prefix in generated paths

### DIFF
--- a/packages/core/openapi/__tests__/mocks/strapi.mock.ts
+++ b/packages/core/openapi/__tests__/mocks/strapi.mock.ts
@@ -1,6 +1,18 @@
 import { routes } from '../fixtures';
 
 export class StrapiMock {
+  get config() {
+    return {
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        if (key === 'api.rest.prefix') {
+          return '/api';
+        }
+
+        return defaultValue;
+      }),
+    };
+  }
+
   get apis() {
     return {
       'api-a': {

--- a/packages/core/openapi/__tests__/routes/api-routes-provider.test.ts
+++ b/packages/core/openapi/__tests__/routes/api-routes-provider.test.ts
@@ -17,6 +17,83 @@ describe('ApiRoutesProvider', () => {
       // Assert
       expect(routes).toHaveLength(routesFixtures.test.length + routesFixtures.foobar.length);
     });
+
+    it('should prepend the content API prefix to API route paths', () => {
+      const strapiMock = {
+        config: {
+          get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'api.rest.prefix') {
+              return '/api';
+            }
+
+            return defaultValue;
+          }),
+        },
+        apis: {
+          article: {
+            routes: {
+              article: {
+                routes: [
+                  {
+                    info: { type: 'content-api' },
+                    method: 'GET',
+                    path: '/articles',
+                    handler: 'api::article.article.find',
+                  },
+                  {
+                    info: { type: 'content-api' },
+                    method: 'GET',
+                    path: '/api/prefixed',
+                    handler: 'api::article.article.findPrefixed',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as Core.Strapi;
+
+      const provider = new ApiRoutesProvider(strapiMock);
+      const { routes } = provider;
+
+      expect(routes[0].path).toBe('/api/articles');
+      expect(routes[1].path).toBe('/api/prefixed');
+    });
+
+    it('should support custom content API prefixes', () => {
+      const strapiMock = {
+        config: {
+          get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'api.rest.prefix') {
+              return '/rest';
+            }
+
+            return defaultValue;
+          }),
+        },
+        apis: {
+          article: {
+            routes: {
+              article: {
+                routes: [
+                  {
+                    info: { type: 'content-api' },
+                    method: 'GET',
+                    path: '/articles',
+                    handler: 'api::article.article.find',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as Core.Strapi;
+
+      const provider = new ApiRoutesProvider(strapiMock);
+      const { routes } = provider;
+
+      expect(routes[0].path).toBe('/rest/articles');
+    });
   });
 
   describe('Symbol.Iterator', () =>

--- a/packages/core/openapi/__tests__/routes/plugins-route-provider.test.ts
+++ b/packages/core/openapi/__tests__/routes/plugins-route-provider.test.ts
@@ -50,8 +50,8 @@ describe('PluginRoutesProvider', () => {
       const { routes } = provider;
 
       expect(routes).toHaveLength(2);
-      expect(routes[0].path).toBe('/upload');
-      expect(routes[1].path).toBe('/upload/files/:id');
+      expect(routes[0].path).toBe('/api/upload');
+      expect(routes[1].path).toBe('/api/upload/files/:id');
     });
 
     it('should use route config.prefix instead of router prefix when present', () => {
@@ -89,8 +89,8 @@ describe('PluginRoutesProvider', () => {
 
       expect(routes).toHaveLength(2);
       // These routes have config.prefix = '', so they bypass the router prefix
-      expect(routes[0].path).toBe('/auth/local');
-      expect(routes[1].path).toBe('/users/me');
+      expect(routes[0].path).toBe('/api/auth/local');
+      expect(routes[1].path).toBe('/api/users/me');
     });
 
     it('should handle mix of routes with and without config.prefix', () => {
@@ -127,9 +127,9 @@ describe('PluginRoutesProvider', () => {
 
       expect(routes).toHaveLength(2);
       // config.prefix = '' bypasses router prefix
-      expect(routes[0].path).toBe('/auth/local');
+      expect(routes[0].path).toBe('/api/auth/local');
       // No config.prefix, uses router prefix
-      expect(routes[1].path).toBe('/users-permissions/roles');
+      expect(routes[1].path).toBe('/api/users-permissions/roles');
     });
 
     it('should handle routes with no router prefix', () => {
@@ -157,7 +157,7 @@ describe('PluginRoutesProvider', () => {
       const { routes } = provider;
 
       expect(routes).toHaveLength(1);
-      expect(routes[0].path).toBe('/items');
+      expect(routes[0].path).toBe('/api/items');
     });
   });
 

--- a/packages/core/openapi/src/routes/providers/abstract.ts
+++ b/packages/core/openapi/src/routes/providers/abstract.ts
@@ -31,6 +31,29 @@ export abstract class AbstractRoutesProvider implements RoutesProvider {
    */
   public abstract get routes(): Core.Route[];
 
+  protected withContentApiPrefix(route: Core.Route): Core.Route {
+    if (route.info.type !== 'content-api') {
+      return route;
+    }
+
+    const apiPrefix = this._strapi.config?.get<string>('api.rest.prefix', '/api') ?? '/api';
+    const normalizedPrefix = apiPrefix.startsWith('/') ? apiPrefix : `/${apiPrefix}`;
+    const normalizedPath = route.path.startsWith('/') ? route.path : `/${route.path}`;
+
+    if (normalizedPath === normalizedPrefix || normalizedPath.startsWith(`${normalizedPrefix}/`)) {
+      return route;
+    }
+
+    const path =
+      (`${normalizedPrefix}${normalizedPath}` || '/').replace(/\/+/g, '/').replace(/\/$/, '') ||
+      '/';
+
+    return {
+      ...route,
+      path,
+    };
+  }
+
   /**
    * Iterator to traverse the routes.
    *

--- a/packages/core/openapi/src/routes/providers/api.ts
+++ b/packages/core/openapi/src/routes/providers/api.ts
@@ -29,7 +29,8 @@ export class ApiRoutesProvider extends AbstractRoutesProvider {
       // Extract and flatten each router from every API
       .flatMap((api) => Object.values(api.routes))
       // Extract and flatten the routes from each router
-      .flatMap((router) => router.routes);
+      .flatMap((router) => router.routes)
+      .map((route) => this.withContentApiPrefix(route));
 
     debug('found %o routes in Strapi APIs', routes.length);
 

--- a/packages/core/openapi/src/routes/providers/plugin.ts
+++ b/packages/core/openapi/src/routes/providers/plugin.ts
@@ -46,10 +46,10 @@ export class PluginRoutesProvider extends AbstractRoutesProvider {
                   .replace(/\/+/g, '/')
                   .replace(/\/$/, '') || '/';
 
-              return {
+              return this.withContentApiPrefix({
                 ...route,
                 path: fullPath,
-              };
+              });
             });
           });
     });


### PR DESCRIPTION
Fixes #25493

### What does it do?

Adds the configured content API REST prefix to generated OpenAPI paths for API and plugin content-api routes. Already-prefixed paths are left unchanged, so the generated document does not double-prefix routes.

### Why is it needed?

OpenAPI generation could emit paths like `/articles`, while the actual public REST endpoint is `/api/articles` by default.

### How to test it?

- `yarn workspace @strapi/openapi test:unit --runInBand`

---
Fixes CPR-391