### PR TITLE
docs: deprecate Node 20 in contributor documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Strapi Monorepo — Agent Guide
 
 Strapi is an open-source headless CMS.
-Yarn workspaces + Nx monorepo. Node ≥20 ≤26, Yarn 4.
+Yarn workspaces + Nx monorepo. Node ≥22 ≤26, Yarn 4.
 Target branch: `develop` (not `main`). All PRs go to `develop`.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ The Strapi core team will review your pull request and either merge it, request 
 
 ## Contribution Prerequisites
 
-- You have [Node.js](https://nodejs.org/en/) at version `>= v20 and <= v26` and [Yarn](https://yarnpkg.com/en/) at v1.2.0+ installed.
+- You have [Node.js](https://nodejs.org/en/) at version `>= v22 and <= v26` and [Yarn](https://yarnpkg.com/en/) at v1.2.0+ installed.
 - You are familiar with [Git](https://git-scm.com).
 
 **Before submitting your pull request** make sure the following requirements are fulfilled:

--- a/packages/core/strapi/README.md
+++ b/packages/core/strapi/README.md
@@ -92,14 +92,15 @@ Complete installation requirements can be found in the documentation under <a hr
 
 Strapi only supports maintenance and LTS versions of Node.js. Please refer to the <a href="https://nodejs.org/en/about/releases/">Node.js release schedule</a> for more information. NPM versions installed by default with Node.js are supported. Generally it's recommended to use yarn over npm where possible.
 
-| Strapi Version  | Recommended | Minimum |
-| --------------- | ----------- | ------- |
-| 5.31.0 and up   | 24.x        | 20.x    |
-| 5.0.0 to 5.30.1 | 20.x        | 18.x    |
-| 4.14.5 and up   | 20.x        | 18.x    |
-| 4.11.0 and up   | 18.x        | 16.x    |
-| 4.3.9 to 4.10.x | 18.x        | 14.x    |
-| 4.0.x to 4.3.8  | 16.x        | 14.x    |
+| Strapi Version    | Recommended | Minimum |
+| ----------------- | ----------- | ------- |
+| 5.48.1 and up     | 24.x        | 22.x    |
+| 5.31.0 to v5.48.0 | 24.x        | 20.x    |
+| 5.0.0 to 5.30.1   | 20.x        | 18.x    |
+| 4.14.5 and up     | 20.x        | 18.x    |
+| 4.11.0 and up     | 18.x        | 16.x    |
+| 4.3.9 to 4.10.x   | 18.x        | 14.x    |
+| 4.0.x to 4.3.8    | 16.x        | 14.x    |
 
 **Database:**
 
@@ -116,7 +117,6 @@ Database driver packages often have their own minimum versions for each version 
 
 | Node Version | PostgreSQL (pg) | MySQL (mysql2) | SQLite (better-sqlite3) |
 | ------------ | --------------- | -------------- | ----------------------- |
-| 20           | pg@8.x          | mysql2@3.x     | better-sqlite3@9.4.x    |
 | 22           | pg@8.x          | mysql2@3.x     | better-sqlite3@11.x     |
 | 24           | pg@8.x          | mysql2@3.x     | better-sqlite3@12.x     |
 

--- a/tests/scripts/run-api-tests.js
+++ b/tests/scripts/run-api-tests.js
@@ -46,7 +46,7 @@ const jestCmd = 'jest --config jest.config.api.js --runInBand --forceExit'.split
 
 const runAllTests = async (args) => {
   // Required for Jest: code run under Jest (including app code loaded by tests) can execute in a context
-  // where Node treats dynamic import() as VM-bound; from Node v20.10+ that requires this flag.
+  // where Node treats dynamic import() as VM-bound; supported Node versions require this flag.
   // ESM-only deps (e.g. file-type in upload) use dynamic import(); without the flag we get
   // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG. Other dynamic imports (plop, prettier) run in the
   // main process (CLI/scripts) or browser (admin), so they never hit this.

--- a/tests/utils/e2e-edition.ts
+++ b/tests/utils/e2e-edition.ts
@@ -27,8 +27,8 @@ function hasStrapiLicense() {
  *
  * This file lives next to Playwright `.ts` helpers but is loaded via `require('../utils/e2e-edition.ts')`
  * from `tests/scripts/run-tests.js` (plain Node, not Playwright). Node resolves `.ts` when the extension
- * is explicit; **body stays JS-parseable** so Node 20 (supported by `package.json` engines) does not
- * need type stripping or SWC. Node 22+ would accept TypeScript syntax here too.
+ * is explicit; **body stays JS-parseable** (no type annotations) so plain `require()` works without
+ * type stripping or SWC on supported Node versions.
  *
  * @returns {E2eEdition}
  */


### PR DESCRIPTION
### What does it do?

- Updates contributor-facing documentation to reflect that Node **22** is the new minimum supported version (through Node 26).
- Changes `CONTRIBUTING.md` prerequisite from `>= v20` to `>= v22` (also published on [contributor.strapi.io](https://contributor.strapi.io) via the embedded contributing guide).
- Updates `AGENTS.md` to `Node ≥22 ≤26`.
- Updates `packages/core/strapi/README.md`:
  - Splits the Strapi 5 compatibility table: **5.48.1+** requires Node **22.x** minimum; **5.31.0–5.48.0** keeps the historical **20.x** minimum.
  - Removes the Node **20** row from the database driver compatibility table.
- Rewords two test infrastructure comments that referenced Node 20 (`tests/utils/e2e-edition.ts`, `tests/scripts/run-api-tests.js`).

`package.json` `engines` fields are **unchanged** (`>=20.0.0 <=26.x.x` remains for now).

### Why is it needed?

Follow-up to #26609, which dropped Node 20 from the CI test matrix. Contributor documentation still stated Node 20 as a supported/minimum version, which is misleading now that Node 20 is no longer tested in CI and is being officially deprecated. Aligning docs avoids contributors setting up on an unsupported runtime.

### How to test it?

- Read `CONTRIBUTING.md` and confirm the Node prerequisite reads `>= v22 and <= v26`.
- Read `AGENTS.md` and confirm `Node ≥22 ≤26`.
- Read `packages/core/strapi/README.md` and confirm the Strapi 5.48.1+ row shows minimum **22.x** and the Node 20 DB driver row is gone.
- Optional: run `yarn start` in `docs/` and verify the contributing page renders the updated prerequisite on the contributor docs preview.

### Related issues / PRs

- Follow-up to #26609 (chore(ci): drop Node 20 from test workflow matrices)
- User-facing docs update (`docs.strapi.io`) is a separate follow-up