### PR TITLE
fix: match datetime "is"/"is not" filters on the selected minute inst…

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -43,6 +43,44 @@ interface FitlersContextValue {
 
 const [FiltersProvider, useFilters] = createContext<FitlersContextValue>('Filters');
 
+const DATETIME_FILTER_RANGE_MS = 60 * 1000;
+
+const createDateTimeRangeFilter = (operator: '$eq' | '$ne', isoValue: string) => {
+  const start = new Date(isoValue);
+  start.setUTCSeconds(0, 0);
+  const end = new Date(start.getTime() + DATETIME_FILTER_RANGE_MS);
+
+  const range = {
+    $gte: encodeURIComponent(start.toISOString()),
+    $lt: encodeURIComponent(end.toISOString()),
+  };
+
+  return operator === '$eq' ? range : { $not: range };
+};
+
+const parseDateTimeRangeFilter = (
+  operatorObj: Record<string, unknown>
+): { operator: string; value: unknown } | null => {
+  const keys = Object.keys(operatorObj);
+
+  if (keys.length === 2 && '$gte' in operatorObj && '$lt' in operatorObj) {
+    return { operator: '$eq', value: operatorObj.$gte };
+  }
+
+  const negated = operatorObj.$not;
+  if (
+    keys.length === 1 &&
+    negated !== null &&
+    typeof negated === 'object' &&
+    '$gte' in negated &&
+    '$lt' in negated
+  ) {
+    return { operator: '$ne', value: (negated as Record<string, unknown>).$gte };
+  }
+
+  return null;
+};
+
 const getFilterDetails = (
   filterEntry: Record<string, unknown>,
   options: Filters.Filter[]
@@ -60,6 +98,14 @@ const getFilterDetails = (
 
   if (typeof operatorObj !== 'object' || operatorObj === null) {
     return null;
+  }
+
+  const attributeType = option.mainField?.type ?? option.type;
+  if (attributeType === 'datetime') {
+    const range = parseDateTimeRangeFilter(operatorObj as Record<string, unknown>);
+    if (range) {
+      return { name, ...range };
+    }
   }
 
   const [operator] = Object.keys(operatorObj as Record<string, unknown>);
@@ -220,9 +266,14 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
      * }
      * ```
      */
-    const operatorValuePairing = {
-      [data.filter]: value,
-    };
+    const isDateTimeRange =
+      fieldOptions.type === 'datetime' && (data.filter === '$eq' || data.filter === '$ne');
+
+    const operatorValuePairing = isDateTimeRange
+      ? createDateTimeRangeFilter(data.filter as '$eq' | '$ne', data.value!)
+      : {
+          [data.filter]: value,
+        };
 
     const newFilterEntry = {
       [data.name]:
@@ -231,7 +282,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
               [fieldOptions.mainField?.name ?? 'id']: operatorValuePairing,
             }
           : operatorValuePairing,
-    };
+    } as NonNullable<NonNullable<Filters.Query['filters']>['$and']>[number];
 
     const existingFilters = query.filters?.$and ?? [];
 
@@ -620,4 +671,4 @@ namespace Filters {
   }
 }
 
-export { Filters };
+export { Filters, createDateTimeRangeFilter, parseDateTimeRangeFilter };

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render as renderRTL, screen, waitFor } from '@tests/utils';
 
-import { Filters } from '../Filters';
+import { Filters, createDateTimeRangeFilter, parseDateTimeRangeFilter } from '../Filters';
 
 const DEFAULT_FILTERS = [
   {
@@ -170,5 +170,58 @@ describe('Filters', () => {
     });
     expect(screen.queryByText(/hello world/)).not.toBeInTheDocument();
     expect(screen.queryAllByText(/hello there/)).toHaveLength(1);
+  });
+});
+
+describe('datetime range filters', () => {
+  it('translates $eq into a half-open minute range on the UTC instant the picker produced', () => {
+    expect(createDateTimeRangeFilter('$eq', '2026-06-12T14:30:00.000Z')).toEqual({
+      $gte: encodeURIComponent('2026-06-12T14:30:00.000Z'),
+      $lt: encodeURIComponent('2026-06-12T14:31:00.000Z'),
+    });
+  });
+
+  it('floors seconds & milliseconds so any instant within the selected minute matches', () => {
+    expect(createDateTimeRangeFilter('$eq', '2026-06-12T14:30:38.123Z')).toEqual({
+      $gte: encodeURIComponent('2026-06-12T14:30:00.000Z'),
+      $lt: encodeURIComponent('2026-06-12T14:31:00.000Z'),
+    });
+  });
+
+  it('wraps the range in $not for $ne', () => {
+    expect(createDateTimeRangeFilter('$ne', '2026-06-12T14:30:00.000Z')).toEqual({
+      $not: {
+        $gte: encodeURIComponent('2026-06-12T14:30:00.000Z'),
+        $lt: encodeURIComponent('2026-06-12T14:31:00.000Z'),
+      },
+    });
+  });
+
+  it('round-trips a $eq range back to the authored operator & value for chip display', () => {
+    expect(
+      parseDateTimeRangeFilter({
+        $gte: '2026-06-12T14:30:00.000Z',
+        $lt: '2026-06-12T14:31:00.000Z',
+      })
+    ).toEqual({ operator: '$eq', value: '2026-06-12T14:30:00.000Z' });
+  });
+
+  it('round-trips a $ne range back to the authored operator & value for chip display', () => {
+    expect(
+      parseDateTimeRangeFilter({
+        $not: { $gte: '2026-06-12T14:30:00.000Z', $lt: '2026-06-12T14:31:00.000Z' },
+      })
+    ).toEqual({ operator: '$ne', value: '2026-06-12T14:30:00.000Z' });
+  });
+
+  it('ignores entries that are not minute-range shaped', () => {
+    expect(parseDateTimeRangeFilter({ $gt: '2026-06-12T14:30:00.000Z' })).toBeNull();
+    expect(parseDateTimeRangeFilter({ $gte: '2026-06-12T14:30:00.000Z' })).toBeNull();
+    expect(
+      parseDateTimeRangeFilter({
+        $gte: '2026-06-12T14:30:00.000Z',
+        $lte: '2026-06-12T14:31:00.000Z',
+      })
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
…ead of an exact instant

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

[26614-fixed.webm](https://github.com/user-attachments/assets/23c36d62-1b53-499c-8e17-e780a7e85819)

 Translates `$eq`/`$ne` filters on `datetime` attributes into a one-minute range instead of a literal instant comparison.

  - `Filters.tsx` → `createDateTimeRangeFilter`: on submit, `is` becomes `{ $gte: minuteStart, $lt: nextMinute }` and `is not` becomes `{ $not: { $gte, $lt } }`. Seconds/milliseconds are floored and the range is computed on the  UTC instant the picker emitted, so the timezone offset is preserved.
  - `Filters.tsx` → `parseDateTimeRangeFilter` (used in `getFilterDetails`): reverse-maps that range back to the  authored `$eq`/`$ne` + value, so the filter chip and edit form keep displaying it as the user entered it. This  also handles the previously skipped object-shaped value in the chip rendering.
  - Added unit tests covering the range construction (`$eq`/`$ne`, seconds flooring) and the reverse round-trip.

### Why is it needed?

  In the Content Manager list view, filtering a `datetime` field (including Created At / Updated At) with `is` almost never returned results. The picker can only express minute precision (`HH:mm`, seconds/ms zeroed) and emits `date.toISOString()`, but stored timestamps carry sub-second precision (e.g. `…:38.123`). A literal `WHERE created_at = '…:00.000Z'` therefore only matched rows landing exactly on a zero-second boundary, so even selecting the exact minute an entry was created returned nothing. Range operators worked, which matched the reported "`is` returns nothing, `greater than` works".

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made.

### Related issue(s)/PR(s)

Fixes #26614 


---
Fixes CPR-395