### PR TITLE
fix(tsconfig): remove lodash from server compilerOptions.types

### DIFF
--- a/packages/core/admin/server/tsconfig.json
+++ b/packages/core/admin/server/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "rootDir": "../",
     "baseUrl": ".",
-    "types": ["lodash", "jest"],
+    "types": ["jest"],
     "esModuleInterop": true
   }
 }

--- a/packages/core/content-manager/server/tsconfig.json
+++ b/packages/core/content-manager/server/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "rootDir": "../",
     "baseUrl": ".",
-    "types": ["lodash", "jest"],
+    "types": ["jest"],
     "esModuleInterop": true
   }
 }

--- a/packages/core/content-type-builder/server/tsconfig.json
+++ b/packages/core/content-type-builder/server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": ["lodash", "jest"],
+    "types": ["jest"],
     "esModuleInterop": true,
     "rootDir": "../",
     "baseUrl": "."


### PR DESCRIPTION
### What does it do?

Removes `lodash` from `compilerOptions.types` in the server tsconfigs for `@strapi/admin`, `@strapi/content-manager`, and `@strapi/content-type-builder`.

### Why is it needed?

When `compilerOptions.types` is set, only the listed `@types/*` packages are injected into the global scope. These packages import lodash as a module (`import _ from 'lodash'`, etc.), so module types are resolved without listing `lodash` in `types`. Keeping it there only adds an unused global `_` declaration from `@types/lodash`'s UMD export.

Follow-up to review [feedback](https://github.com/strapi/strapi/pull/25873#discussion_r3250946446) on #25873.

### How to test it?

```bash
yarn tsc --noEmit -p packages/core/admin/server/tsconfig.json
yarn tsc --noEmit -p packages/core/content-manager/server/tsconfig.json
yarn tsc --noEmit -p packages/core/content-type-builder/server/tsconfig.json
```

All three should exit 0.

### Related issue(s)/PR(s)

- #25873