### PR TITLE
test: fix discarded boolean checks and missing awaits in e2e suite

### DIFF
--- a/tests/e2e/tests/content-manager/cloning.spec.ts
+++ b/tests/e2e/tests/content-manager/cloning.spec.ts
@@ -35,7 +35,7 @@ test.describe('Cloning', () => {
     await page.getByRole('link', { name: 'Author' }).click();
     await page.waitForURL(LIST_URL_AUTHOR);
     await expect(page.getByRole('row', { name: 'Coach Beard' })).toBeVisible();
-    expect(await page.getByRole('row', { name: 'Coach Beard' }).all()).toHaveLength(1);
+    await expect(page.getByRole('row', { name: 'Coach Beard' })).toHaveCount(1);
 
     /**
      * Open the row actions menu and click on the duplicate button.
@@ -61,7 +61,7 @@ test.describe('Cloning', () => {
     await page.getByRole('link', { name: 'Author' }).click();
     await page.waitForURL(LIST_URL_AUTHOR);
     await expect(page.getByRole('heading', { name: 'Author' })).toBeVisible();
-    expect(await page.getByRole('row', { name: 'Coach Beard' }).all()).toHaveLength(2);
+    await expect(page.getByRole('row', { name: 'Coach Beard' })).toHaveCount(2);
   });
 
   test('As a user I want to auto-clone a document in a different locale than the default one', async ({
@@ -135,9 +135,7 @@ test.describe('Cloning', () => {
      */
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
     await expect(page.getByRole('row', { name: 'West ham post match analysis' })).toBeVisible();
-    expect(
-      await page.getByRole('row', { name: 'West ham post match analysis' }).all()
-    ).toHaveLength(1);
+    await expect(page.getByRole('row', { name: 'West ham post match analysis' })).toHaveCount(1);
 
     /**
      * Open the row actions menu and click on the duplicate button.
@@ -177,8 +175,6 @@ test.describe('Cloning', () => {
     await page.getByRole('link', { name: 'Article' }).click();
     await page.waitForURL(LIST_URL_ARTICLE);
     await expect(page.getByRole('grid')).toBeVisible();
-    expect(
-      await page.getByRole('row', { name: 'West ham post match analysis' }).all()
-    ).toHaveLength(2);
+    await expect(page.getByRole('row', { name: 'West ham post match analysis' })).toHaveCount(2);
   });
 });

--- a/tests/e2e/tests/content-manager/conditional-fields/boolean-conditional-text-field-visibility.spec.ts
+++ b/tests/e2e/tests/content-manager/conditional-fields/boolean-conditional-text-field-visibility.spec.ts
@@ -34,14 +34,14 @@ test.describe('Conditional Fields - Boolean-controlled conditional text fields',
       { save: false, publish: false, verify: false }
     );
 
-    await page.getByLabel('sku').isVisible();
+    await expect(page.getByLabel('sku')).toBeVisible();
     await page.getByLabel('sku').fill('5');
     await fillField(page, {
       name: 'isAvailable',
       type: 'boolean',
       value: false,
     });
-    await page.getByLabel('sku').isHidden();
+    await expect(page.getByLabel('sku')).toBeHidden();
     await page.getByRole('button', { name: 'Save' }).click();
     await fillField(page, {
       name: 'isAvailable',

--- a/tests/e2e/tests/content-manager/conditional-fields/enum-conditional-text-field-visibility.spec.ts
+++ b/tests/e2e/tests/content-manager/conditional-fields/enum-conditional-text-field-visibility.spec.ts
@@ -39,7 +39,7 @@ test.describe('Conditional Fields - Enum-controlled conditional text fields and 
     await fillField(page, { name: 'personality', type: 'enumeration', value: 'lazy' });
 
     // Verify favoriteToy field is hidden
-    await page.getByLabel('favoriteToy').isHidden();
+    await expect(page.getByLabel('favoriteToy')).toBeHidden();
 
     // Save the content
     await page.getByRole('button', { name: 'Save' }).click();

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -100,7 +100,7 @@ test.describe('Uniqueness', () => {
   const EDIT_URL = /\/admin\/content-manager\/collection-types\/api::unique.unique\/[^/]+(\?.*)?/;
 
   const clickSave = async (page: Page) => {
-    await page.getByRole('button', { name: 'Save' }).isEnabled();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     await clickAndWait(page, page.getByRole('tab', { name: 'Draft' }));
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await expect(page.getByText('Saved document')).toBeVisible();

--- a/tests/e2e/tests/content-manager/uniqueness.spec.ts
+++ b/tests/e2e/tests/content-manager/uniqueness.spec.ts
@@ -100,8 +100,8 @@ test.describe('Uniqueness', () => {
   const EDIT_URL = /\/admin\/content-manager\/collection-types\/api::unique.unique\/[^/]+(\?.*)?/;
 
   const clickSave = async (page: Page) => {
-    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     await clickAndWait(page, page.getByRole('tab', { name: 'Draft' }));
+    await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
     await expect(page.getByText('Saved document')).toBeVisible();
   };

--- a/tests/e2e/tests/content-releases/release-details-page.spec.ts
+++ b/tests/e2e/tests/content-releases/release-details-page.spec.ts
@@ -34,7 +34,7 @@ describeOnCondition(edition === 'EE')('Release page', () => {
     await login({ page });
 
     await navToHeader(page, ['Releases'], 'Releases');
-    page.getByRole('link', { name: `${releaseName}` }).click();
+    await page.getByRole('link', { name: `${releaseName}` }).click();
     await page.waitForURL('/admin/plugins/content-releases/*');
   });
 

--- a/tests/e2e/tests/i18n/settings.spec.ts
+++ b/tests/e2e/tests/i18n/settings.spec.ts
@@ -27,9 +27,9 @@ test.describe('Settings', () => {
     /**
      * Assert that the page has the expected elements & data, the locales installed in the test-app.
      */
-    expect(await page.getByRole('row').all()).toHaveLength(5);
+    await expect(page.getByRole('row')).toHaveCount(5);
     for (const locale of LOCALES) {
-      expect(page.getByRole('gridcell', { name: locale, exact: true })).toBeVisible();
+      await expect(page.getByRole('gridcell', { name: locale, exact: true })).toBeVisible();
     }
 
     /**
@@ -37,7 +37,7 @@ test.describe('Settings', () => {
      */
     await page.getByRole('button', { name: 'Add new locale' }).click();
     await expect(page.getByRole('dialog', { name: 'Add new locale' })).toBeVisible();
-    expect(page.getByRole('heading', { name: 'Configuration' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Configuration' })).toBeVisible();
     await page.getByRole('combobox', { name: 'Locales' }).click();
     await page.press('body', 'I');
     await page.getByRole('option', { name: 'Italian (it)' }).click();
@@ -50,7 +50,7 @@ test.describe('Settings', () => {
      */
     await navToHeader(page, ['Content Manager', 'Shop'], 'UK Shop');
     await page.getByRole('combobox', { name: 'Locales' }).click();
-    expect(await page.getByRole('option').all()).toHaveLength(5);
+    await expect(page.getByRole('option')).toHaveCount(5);
     for (const locale of [...LOCALES, 'Italian (it)']) {
       await expect(page.getByRole('option', { name: locale })).toBeVisible();
     }
@@ -135,8 +135,10 @@ test.describe('Settings', () => {
      * and that all the expected locales exist in the select dropdown.
      */
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
-    expect(page.getByRole('combobox', { name: 'Select a locale' })).toHaveText('English (en)');
-    expect(await page.getByRole('row').all()).toHaveLength(3);
+    await expect(page.getByRole('combobox', { name: 'Select a locale' })).toHaveText(
+      'English (en)'
+    );
+    await expect(page.getByRole('row')).toHaveCount(3);
     await page.getByRole('combobox', { name: 'Select a locale' }).click();
     for (const locale of LOCALES) {
       await expect(page.getByRole('option', { name: locale })).toBeVisible();
@@ -157,8 +159,10 @@ test.describe('Settings', () => {
      * but we should not see the french locale option anymore.
      */
     await navToHeader(page, ['Content Manager', 'Article'], 'Article');
-    expect(page.getByRole('combobox', { name: 'Select a locale' })).toHaveText('English (en)');
-    expect(await page.getByRole('row').all()).toHaveLength(3);
+    await expect(page.getByRole('combobox', { name: 'Select a locale' })).toHaveText(
+      'English (en)'
+    );
+    await expect(page.getByRole('row')).toHaveCount(3);
     await page.getByRole('combobox', { name: 'Select a locale' }).click();
     for (const locale of LOCALES) {
       if (locale !== 'French (fr)') {
@@ -201,7 +205,7 @@ test.describe('Settings', () => {
     /**
      * It is 4 because it contains also the header row
      */
-    expect(await page.getByRole('row').all()).toHaveLength(4);
+    await expect(page.getByRole('row')).toHaveCount(4);
     await expect(page.getByRole('combobox', { name: 'Select a locale' })).toHaveText('UK English');
     await page.getByRole('combobox', { name: 'Select a locale' }).click();
     for (const locale of ['UK English', ...LOCALES].filter((locale) => locale !== 'English (en)')) {


### PR DESCRIPTION
### What does it do?

Strengthens existing Playwright E2E checks in the content-manager, content-releases, and i18n suites.

The changes are assertion-form fixes only:

- Convert `expect(await locator.all()).toHaveLength(n)` to `await expect(locator).toHaveCount(n)` so the count check retries instead of reading once.
- Prefix missing `await` on web-first assertions such as `toBeVisible()` and `toHaveText()`.
- Convert discarded locator booleans (`isVisible()`, `isHidden()`, `isEnabled()`) to Playwright assertions.
- Await a `click()` before `waitForURL()` in the content release setup.

### Why is it needed?

Several lines looked like checks but either discarded the returned boolean/promise or used one-shot reads. That means the E2E can pass without verifying the intended UI state, or race asynchronous UI updates.

The `clickSave` helper change is shared intentionally: it now waits for the Save button to be enabled before callers click it.

Blame check:

- Cloning, uniqueness, content release, and some i18n lines trace at least as far back as 579615d5d6 from 2024-03-13.
- The boolean conditional-field checks trace to 3e666b1ad96 from 2025-06-30.
- The enum conditional-field check and one i18n products count check trace to 116f52a58b1 from 2025-07-28.
- Several i18n locale checks trace to d1d589380e9 from 2024-11-28.

### How to test it?

Local verification performed:

- Re-fetched `origin/develop` on 2026-06-13.
- Applied commit 4bebaa8666f3b3c0093dcef0d50569e7c26eb8a8 to a temp worktree based on current `origin/develop` and ran:
  `bash scripts/pr-preflight.sh tmp/preflight-strapi tests/e2e/tests/content-manager/cloning.spec.ts tests/e2e/tests/content-manager/conditional-fields/boolean-conditional-text-field-visibility.spec.ts tests/e2e/tests/content-manager/conditional-fields/enum-conditional-text-field-visibility.spec.ts tests/e2e/tests/content-manager/uniqueness.spec.ts tests/e2e/tests/content-releases/release-details-page.spec.ts tests/e2e/tests/i18n/settings.spec.ts`
- Result: `PREFLIGHT 0 fail(s)` with scanner delta `total from 31 to 22, p0 from 10 to 1, ast from 13 to 0`; AST artifacts clean; diff hygiene clean; authoring clean with 0 added comments and no test renames.
- Follow-up after CI: pushed commit 5da6e6ae4da0aa6b45f1b4ae453b7272267c5003 to keep the new Save assertion, but check it after selecting the Draft tab. CI showed the Save button is disabled before that tab is selected.
- Rechecked the changed-file scanner delta against `origin/develop`: total from 26 to 22, P0 from 5 to 1, AST from 9 to 0. GitHub commit verification is valid for 5da6e6ae4da0aa6b45f1b4ae453b7272267c5003.

Not run locally:

- Full Strapi E2E. This clone has no installed dependencies or generated test app, so preflight skipped local tsc/lint/spec execution. The documented path requires repo setup plus `yarn test:e2e --setup --concurrency=1`.
- The `content-releases` spec is EE-gated and needs `STRAPI_LICENSE` in `tests/e2e/.env` to run locally.

### Related issue(s)/PR(s)

N/A. Test-only assertion correctness fix found while reviewing the suite with e2e-skills/e2e-reviewer.

---

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
