### PR TITLE
fix(server): graceful shutdown drain before process.send('reload') — fixes #26629

### DIFF
--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -23,6 +23,7 @@ const defaultConfig = {
     host: process.env.HOST || os.hostname() || 'localhost',
     port: Number(process.env.PORT) || 1337,
     proxy: false,
+    shutdownTimeout: 30_000,
     cron: { enabled: false },
     admin: { autoOpen: false },
     dirs: { public: './public' },

--- a/packages/core/core/src/services/reloader.ts
+++ b/packages/core/core/src/services/reloader.ts
@@ -6,18 +6,46 @@ export const createReloader = (strapi: Core.Strapi) => {
     isWatching: true,
   };
 
-  function reload() {
-    if (state.shouldReload > 0) {
-      // Reset the reloading state
-      state.shouldReload -= 1;
-      reload.isReloading = false;
-      return;
+async function reload() {
+  if (state.shouldReload > 0) {
+    state.shouldReload -= 1;
+    reload.isReloading = false;
+    return;
+  }
+
+  if (strapi.config.get('autoReload')) {
+    const server = strapi.server?.httpServer;
+    if (server) {
+      const timeout: number =
+        strapi.config.get('server.shutdownTimeout', 30_000);
+
+      strapi.log.info(
+        `[reloader] Draining in-flight requests before reload ` +
+        `(timeout: ${timeout}ms)...`
+      );
+
+      server.closeIdleConnections();
+
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(() => {
+          strapi.log.warn(
+            '[reloader] Drain timeout reached, proceeding with reload'
+          );
+          resolve();
+        }, timeout);
+
+        server.close(() => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
     }
 
-    if (strapi.config.get('autoReload')) {
-      process.send?.('reload');
-    }
+    process.send?.('reload');
   }
+}
+
+  
 
   Object.defineProperty(reload, 'isWatching', {
     configurable: true,

--- a/packages/core/core/src/services/server/http-server.ts
+++ b/packages/core/core/src/services/server/http-server.ts
@@ -63,6 +63,31 @@ const createHTTPServer = (strapi: Core.Strapi, koaApp: Koa): Server => {
     });
   };
 
+process.once('SIGTERM', async () => {
+    const timeout: number =
+      strapi.config.get('server.shutdownTimeout', 30_000);
+
+    strapi.log.info(
+      `[server] SIGTERM received — draining connections (${timeout}ms timeout)`
+    );
+
+    server.closeIdleConnections();
+
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        strapi.log.warn('[server] Forced close after timeout');
+        resolve();
+      }, timeout);
+
+      server.close(() => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+
+    process.exit(0);
+  });
+  
   return Object.assign(server, { destroy });
 };
 


### PR DESCRIPTION
## What does it do?
Adds a configurable drain period to `reloader.ts` and `http-server.ts`
so in-flight HTTP requests (e.g. a content editor's save) are allowed
to complete before `process.send('reload')` is called on a schema
change restart.

## Why is it needed?
Fixes #26629. Without this change, a schema change by one user
kills any concurrent save requests from other editors silently,
causing data loss with no user-facing error.

## Changes
- `reloader.ts` — made `reload()` async; added drain via
  `httpServer.closeIdleConnections()` + `httpServer.close()`
  with configurable timeout before the reload signal
- `http-server.ts` — added `SIGTERM` handler with same drain logic
- `index.ts` — added `server.shutdownTimeout` default (30000ms)

## Related issue(s)
Closes #26629
Related: #5912 (v3 graceful shutdown, closed)

## Test plan
1. Start Strapi in development mode
2. Open Content Manager and begin a slow save (throttle network in DevTools)
3. Trigger a schema reload from Content-Type Builder simultaneously
4. Confirm the save completes successfully before the server reloads

---
Fixes CPR-394