### PR TITLE
fix(database): escape wildcards in LIKE filters

### DIFF
--- a/packages/core/database/src/__tests__/index.test.ts
+++ b/packages/core/database/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import knex from 'knex';
 import { Database, DatabaseConfig } from '../index';
 import createQueryBuilder from '../query/query-builder';
+import { applyWhere } from '../query/helpers/where';
 import type { Model } from '../types';
 
 // create an in-memory db connection to test
@@ -424,5 +425,89 @@ describe('Query builder pagination order stability (GH #26030)', () => {
     expect(lower).not.toContain('`t0`.`id`');
 
     await dbNoId.destroy();
+  });
+});
+
+const wildcardFilterModel: Model = {
+  uid: 'api::wildcard-filter.article',
+  singularName: 'wildcard-filter-article',
+  tableName: 'wildcard_filter_articles',
+  attributes: {
+    id: { type: 'integer' },
+    title: { type: 'string' },
+  },
+};
+
+describe('Query builder LIKE wildcard filters (GH #26468)', () => {
+  let db: Database;
+
+  const getWhereSql = (where: Record<string, unknown>) => {
+    const query = createQueryBuilder(wildcardFilterModel.uid, db)
+      .init({
+        select: ['title'],
+        where,
+        orderBy: { title: 'asc' },
+      })
+      .getKnexQuery()
+      .toSQL();
+
+    return {
+      sql: query.sql.toLowerCase(),
+      bindings: query.bindings,
+    };
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+    db = new Database(paginationQueryBuilderConfig);
+    await db.init({ models: [wildcardFilterModel] });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('treats percent and underscore as literal text in LIKE filters', async () => {
+    const contains = getWhereSql({ title: { $contains: '100%' } });
+    expect(contains.sql).toContain("like ? escape '\\'");
+    expect(contains.bindings).toContain('%100\\%%');
+
+    const startsWith = getWhereSql({ title: { $startsWith: 'code_' } });
+    expect(startsWith.sql).toContain("like ? escape '\\'");
+    expect(startsWith.bindings).toContain('code\\_%');
+  });
+
+  it('does not treat wildcards as patterns in case-insensitive filters', async () => {
+    const containsi = getWhereSql({ title: { $containsi: 'case%' } });
+    expect(containsi.sql).toContain("like lower(?) escape '\\'");
+    expect(containsi.bindings).toContain('%case\\%%');
+
+    const eqi = getWhereSql({ title: { $eqi: 'case% value' } });
+    expect(eqi.sql).toContain(' = lower(?)');
+    expect(eqi.sql).not.toContain(' like ');
+    expect(eqi.bindings).toContain('case% value');
+  });
+
+  it('escapes backslashes before applying the LIKE escape character', async () => {
+    const contains = getWhereSql({ title: { $contains: 'C:\\Temp' } });
+    expect(contains.sql).toContain("like ? escape '\\'");
+    expect(contains.bindings).toContain('%C:\\\\Temp%');
+  });
+
+  it('keeps MySQL LIKE SQL compatible while escaping bound wildcard values', () => {
+    const qb = knex({ client: 'mysql' }).from('wildcard_filter_articles');
+
+    applyWhere(qb, { title: { $contains: '100%' } });
+
+    const query = qb.toSQL();
+    const sql = query.sql.toLowerCase();
+
+    expect(sql).toContain('like ?');
+    expect(sql).not.toContain('escape');
+    expect(query.bindings).toContain('%100\\%%');
   });
 });

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -223,6 +223,43 @@ type Operator =
   | '$endsWithi'
   | '$jsonSupersetOf';
 
+const LIKE_ESCAPE_CHARACTER = '\\';
+const LIKE_SPECIAL_CHARACTERS = `%_${LIKE_ESCAPE_CHARACTER}`;
+
+const escapeLikeValue = (value: unknown) => {
+  return `${value}`
+    .split('')
+    .reduce(
+      (escapedValue, char) =>
+        LIKE_SPECIAL_CHARACTERS.includes(char)
+          ? `${escapedValue}${LIKE_ESCAPE_CHARACTER}${char}`
+          : `${escapedValue}${char}`,
+      ''
+    );
+};
+
+const getLikeEscapeClause = (qb: Knex.QueryBuilder) => {
+  return ['mysql', 'mysql2'].includes(qb.client.dialect) ? '' : " ESCAPE '\\'";
+};
+
+const applyLike = (
+  qb: Knex.QueryBuilder,
+  column: any,
+  value: unknown,
+  { prefix = '', suffix = '', caseInsensitive = false, not = false } = {}
+) => {
+  const operator = not ? 'NOT LIKE' : 'LIKE';
+  const pattern = `${prefix}${escapeLikeValue(value)}${suffix}`;
+  const escapeClause = getLikeEscapeClause(qb);
+
+  if (caseInsensitive) {
+    qb.whereRaw(`${fieldLowerFn(qb)} ${operator} LOWER(?)${escapeClause}`, [column, pattern]);
+    return;
+  }
+
+  qb.whereRaw(`?? ${operator} ?${escapeClause}`, [column, pattern]);
+};
+
 // TODO: add type casting per operator at some point
 const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, value: any) => {
   if (Array.isArray(value) && !isOperatorOfType('array', operator)) {
@@ -270,7 +307,7 @@ const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, v
         qb.whereNull(column);
         break;
       }
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `${value}`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} = LOWER(?)`, [column, `${value}`]);
       break;
     }
     case '$ne': {
@@ -287,7 +324,7 @@ const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, v
         qb.whereNotNull(column);
         break;
       }
-      qb.whereRaw(`${fieldLowerFn(qb)} NOT LIKE LOWER(?)`, [column, `${value}`]);
+      qb.whereRaw(`${fieldLowerFn(qb)} <> LOWER(?)`, [column, `${value}`]);
       break;
     }
     case '$gt': {
@@ -327,38 +364,43 @@ const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, v
       break;
     }
     case '$startsWith': {
-      qb.where(column, 'like', `${value}%`);
+      applyLike(qb, column, value, { suffix: '%' });
       break;
     }
     case '$startsWithi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `${value}%`]);
+      applyLike(qb, column, value, { suffix: '%', caseInsensitive: true });
       break;
     }
     case '$endsWith': {
-      qb.where(column, 'like', `%${value}`);
+      applyLike(qb, column, value, { prefix: '%' });
       break;
     }
     case '$endsWithi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${value}`]);
+      applyLike(qb, column, value, { prefix: '%', caseInsensitive: true });
       break;
     }
     case '$contains': {
-      qb.where(column, 'like', `%${value}%`);
+      applyLike(qb, column, value, { prefix: '%', suffix: '%' });
       break;
     }
 
     case '$notContains': {
-      qb.whereNot(column, 'like', `%${value}%`);
+      applyLike(qb, column, value, { prefix: '%', suffix: '%', not: true });
       break;
     }
 
     case '$containsi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} LIKE LOWER(?)`, [column, `%${value}%`]);
+      applyLike(qb, column, value, { prefix: '%', suffix: '%', caseInsensitive: true });
       break;
     }
 
     case '$notContainsi': {
-      qb.whereRaw(`${fieldLowerFn(qb)} NOT LIKE LOWER(?)`, [column, `%${value}%`]);
+      applyLike(qb, column, value, {
+        prefix: '%',
+        suffix: '%',
+        caseInsensitive: true,
+        not: true,
+      });
       break;
     }
 


### PR DESCRIPTION
## What
- Escape `%`, `_`, and backslash in LIKE-based database filters so literal text is not treated as a wildcard pattern.
- Keep case-insensitive equality filters on equality comparisons instead of LIKE.
- Preserve MySQL-compatible SQL generation while using an explicit LIKE escape clause for other dialects.
- Add focused query-builder regression coverage for literal wildcard values.

## Testing
- `yarn test:unit packages/core/database/src/__tests__/index.test.ts --selectProjects "Core database" --runInBand -t "Query builder LIKE wildcard filters"`
- `yarn prettier --check packages/core/database/src/query/helpers/where.ts packages/core/database/src/__tests__/index.test.ts`
- `yarn workspace @strapi/database lint`
- `git diff --check`

Fixes #26468
