### PR TITLE
fix(admin): convert exact datetime filters to day ranges

### DIFF
--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -203,6 +203,11 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
 
     return { ...values, filter: getDefaultFilterOperator(filter), value: undefined };
   }, [editingFilter, options]);
+  const hasSanitizedEditingFilter =
+    editingFilter !== null &&
+    (initialValues.name !== editingFilter.name ||
+      initialValues.filter !== editingFilter.filter ||
+      initialValues.value !== editingFilter.value);
 
   if (options.length === 0) {
     return null;
@@ -344,7 +349,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
                   />
                 ) : null}
                 <Button
-                  disabled={!modified || isSubmitting}
+                  disabled={(!modified && !hasSanitizedEditingFilter) || isSubmitting}
                   size="L"
                   variant="secondary"
                   startIcon={<Plus />}

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -348,6 +348,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
                     type={filter.mainField?.type ?? filter.type}
                   />
                 ) : null}
+                {/* Allow saving when an existing URL filter uses an operator that is no longer offered. */}
                 <Button
                   disabled={(!modified && !hasSanitizedEditingFilter) || isSubmitting}
                   size="L"

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -71,10 +71,10 @@ const getDateRange = (value: string): { start: string; end: string } | null => {
   }
 
   const start = new Date(date);
-  start.setHours(0, 0, 0, 0);
+  start.setUTCHours(0, 0, 0, 0);
 
   const end = new Date(start);
-  end.setDate(end.getDate() + 1);
+  end.setUTCDate(end.getUTCDate() + 1);
 
   return { start: start.toISOString(), end: end.toISOString() };
 };
@@ -743,7 +743,7 @@ namespace Filters {
        * }
        * ```
        */
-      $and?: Array<Record<string, Record<string, string | Record<string, string>>>>;
+      $and?: Array<Record<string, unknown>>;
     };
     page?: number;
   }

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -43,6 +43,11 @@ interface FitlersContextValue {
 
 const [FiltersProvider, useFilters] = createContext<FitlersContextValue>('Filters');
 
+const DATETIME_FILTERS = [
+  ...BASE_FILTERS.filter(({ value }) => value === '$null' || value === '$notNull'),
+  ...NUMERIC_FILTERS,
+];
+
 const getFilterDetails = (
   filterEntry: Record<string, unknown>,
   options: Filters.Filter[]
@@ -185,7 +190,18 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
   const setEditingFilter = useFilters('Popover', ({ setEditingFilter }) => setEditingFilter);
 
   const initialValues = React.useMemo(() => {
-    return editingFilter ?? { name: options[0]?.name, filter: BASE_FILTERS[0].value };
+    const values = editingFilter ?? {
+      name: options[0]?.name,
+      filter: getDefaultFilterOperator(options[0]),
+    };
+    const filter = options.find((filter) => filter.name === values.name);
+    const operatorValues = getFilterOperatorValues(filter);
+
+    if (operatorValues.includes(values.filter)) {
+      return values;
+    }
+
+    return { ...values, filter: getDefaultFilterOperator(filter), value: undefined };
   }, [editingFilter, options]);
 
   if (options.length === 0) {
@@ -265,7 +281,7 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
               : 'create'
           }
         >
-          {({ values: formValues, modified, isSubmitting }) => {
+          {({ values: formValues, modified, isSubmitting, onChange }) => {
             const filter = options.find((filter) => filter.name === formValues.name);
             const Input = filter?.input || InputRenderer;
             return (
@@ -281,6 +297,13 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
                       label: filter.label,
                       value: filter.name,
                     })),
+                    onChange: (value: string) => {
+                      const nextFilter = options.find((filter) => filter.name === value);
+
+                      onChange('name', value);
+                      onChange('filter', getDefaultFilterOperator(nextFilter));
+                      onChange('value', undefined);
+                    },
                     placholder: formatMessage({
                       id: 'app.utils.select-field',
                       defaultMessage: 'Select field',
@@ -378,7 +401,7 @@ const getFilterList = (filter?: Filters.Filter): FilterOption[] => {
     }
 
     case 'datetime': {
-      return [...BASE_FILTERS, ...NUMERIC_FILTERS];
+      return DATETIME_FILTERS;
     }
 
     case 'enumeration': {
@@ -388,6 +411,14 @@ const getFilterList = (filter?: Filters.Filter): FilterOption[] => {
     default:
       return [...BASE_FILTERS, ...IS_SENSITIVE_FILTERS];
   }
+};
+
+const getFilterOperatorValues = (filter?: Filters.Filter): string[] => {
+  return (filter?.operators ?? getFilterList(filter)).map(({ value }) => value);
+};
+
+const getDefaultFilterOperator = (filter?: Filters.Filter): string => {
+  return getFilterOperatorValues(filter)[0] ?? BASE_FILTERS[0].value;
 };
 
 /* -------------------------------------------------------------------------------------------------
@@ -488,30 +519,32 @@ const AttributeTag = ({
 
   let formattedValue: string = value;
 
-  switch (type) {
-    case 'date':
-      formattedValue = formatDate(value, { dateStyle: 'full' });
-      break;
-    case 'datetime':
-      formattedValue = formatDate(value, { dateStyle: 'full', timeStyle: 'short' });
-      break;
-    case 'time':
-      const [hour, minute] = value.split(':');
-      const date = new Date();
-      date.setHours(Number(hour));
-      date.setMinutes(Number(minute));
+  if (!FILTERS_WITH_NO_VALUE.includes(operator)) {
+    switch (type) {
+      case 'date':
+        formattedValue = formatDate(value, { dateStyle: 'full' });
+        break;
+      case 'datetime':
+        formattedValue = formatDate(value, { dateStyle: 'full', timeStyle: 'short' });
+        break;
+      case 'time':
+        const [hour, minute] = value.split(':');
+        const date = new Date();
+        date.setHours(Number(hour));
+        date.setMinutes(Number(minute));
 
-      formattedValue = formatTime(date, {
-        hour: 'numeric',
-        minute: 'numeric',
-      });
-      break;
-    case 'float':
-    case 'integer':
-    case 'biginteger':
-    case 'decimal':
-      formattedValue = formatNumber(Number(value));
-      break;
+        formattedValue = formatTime(date, {
+          hour: 'numeric',
+          minute: 'numeric',
+        });
+        break;
+      case 'float':
+      case 'integer':
+      case 'biginteger':
+      case 'decimal':
+        formattedValue = formatNumber(Number(value));
+        break;
+    }
   }
 
   // Handle custom input

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -199,9 +199,7 @@ const isFilterMatch = (
     return true;
   }
 
-  const decoded =
-    typeof details.value === 'string' ? decodeURIComponent(details.value) : details.value;
-  return decoded === target.value;
+  return details.value === target.value;
 };
 
 interface RootProps
@@ -592,12 +590,13 @@ const AttributeTag = ({
   const { formatMessage, formatDate, formatTime, formatNumber } = useIntl();
   const setOpen = useFilters('AttributeTag', ({ setOpen }) => setOpen);
   const setEditingFilter = useFilters('AttributeTag', ({ setEditingFilter }) => setEditingFilter);
+  const parsedValue = FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : value;
 
   const handleEdit = () => {
     setEditingFilter({
       name,
       filter: operator,
-      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
+      value: parsedValue,
     });
     setOpen(true);
   };
@@ -605,14 +604,14 @@ const AttributeTag = ({
   const handleRemove = () => {
     onRemove({
       name,
-      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
+      value: parsedValue,
       filter: operator,
     });
   };
 
   const type = mainField?.type ?? filter.type;
 
-  const decodedValue = FILTERS_WITH_NO_VALUE.includes(operator) ? value : decodeURIComponent(value);
+  const decodedValue = parsedValue ?? value;
   let formattedValue: string = decodedValue;
 
   if (!FILTERS_WITH_NO_VALUE.includes(operator)) {
@@ -623,7 +622,7 @@ const AttributeTag = ({
       case 'datetime':
         formattedValue = formatDate(decodedValue, { dateStyle: 'full', timeStyle: 'short' });
         break;
-      case 'time':
+      case 'time': {
         const [hour, minute] = decodedValue.split(':');
         const date = new Date();
         date.setHours(Number(hour));
@@ -634,6 +633,7 @@ const AttributeTag = ({
           minute: 'numeric',
         });
         break;
+      }
       case 'float':
       case 'integer':
       case 'biginteger':

--- a/packages/core/admin/admin/src/components/Filters.tsx
+++ b/packages/core/admin/admin/src/components/Filters.tsx
@@ -43,28 +43,139 @@ interface FitlersContextValue {
 
 const [FiltersProvider, useFilters] = createContext<FitlersContextValue>('Filters');
 
-const DATETIME_FILTERS = [
-  ...BASE_FILTERS.filter(({ value }) => value === '$null' || value === '$notNull'),
-  ...NUMERIC_FILTERS,
-];
+const DATETIME_FILTERS = [...BASE_FILTERS, ...NUMERIC_FILTERS];
+
+const getFilterType = (filter?: Filters.Filter) => filter?.mainField?.type ?? filter?.type;
+
+const getOperatorObject = (
+  filterEntry: Record<string, unknown>,
+  option: Filters.Filter
+): Record<string, unknown> | null => {
+  const operatorObj =
+    option.type === 'relation'
+      ? (filterEntry[option.name] as Record<string, unknown>)?.[option.mainField?.name ?? 'id']
+      : filterEntry[option.name];
+
+  if (typeof operatorObj !== 'object' || operatorObj === null || Array.isArray(operatorObj)) {
+    return null;
+  }
+
+  return operatorObj as Record<string, unknown>;
+};
+
+const getDateRange = (value: string): { start: string; end: string } | null => {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+
+  return { start: start.toISOString(), end: end.toISOString() };
+};
+
+const createFilterEntry = (
+  fieldOptions: Filters.Filter,
+  operatorValuePairing: Record<string, unknown>
+) => ({
+  [fieldOptions.name]:
+    fieldOptions.type === 'relation'
+      ? {
+          [fieldOptions.mainField?.name ?? 'id']: operatorValuePairing,
+        }
+      : operatorValuePairing,
+});
+
+const createFilterEntries = (
+  fieldOptions: Filters.Filter,
+  data: FilterFormData,
+  value: string
+): Array<Record<string, unknown>> => {
+  if (
+    getFilterType(fieldOptions) === 'datetime' &&
+    (data.filter === '$eq' || data.filter === '$ne')
+  ) {
+    const range = getDateRange(data.value ?? '');
+
+    if (range) {
+      const start = encodeURIComponent(range.start);
+      const end = encodeURIComponent(range.end);
+
+      if (data.filter === '$eq') {
+        return [createFilterEntry(fieldOptions, { $gte: start, $lt: end })];
+      }
+
+      return [
+        {
+          $or: [
+            createFilterEntry(fieldOptions, { $lt: start }),
+            createFilterEntry(fieldOptions, { $gte: end }),
+          ],
+        },
+      ];
+    }
+  }
+
+  return [createFilterEntry(fieldOptions, { [data.filter]: value })];
+};
 
 const getFilterDetails = (
   filterEntry: Record<string, unknown>,
   options: Filters.Filter[]
 ): { name: string; operator: string; value: unknown } | null => {
+  const orEntries = Array.isArray(filterEntry.$or)
+    ? filterEntry.$or
+    : typeof filterEntry.$or === 'object' && filterEntry.$or !== null
+      ? Object.values(filterEntry.$or)
+      : null;
+
+  if (orEntries) {
+    for (const option of options) {
+      if (getFilterType(option) !== 'datetime') {
+        continue;
+      }
+
+      const rangeParts = orEntries
+        .map((entry) =>
+          typeof entry === 'object' && entry !== null
+            ? getOperatorObject(entry as Record<string, unknown>, option)
+            : null
+        )
+        .filter((entry): entry is Record<string, unknown> => entry !== null);
+
+      const lower = rangeParts.find((entry) => typeof entry.$lt === 'string')?.$lt;
+      const upper = rangeParts.find((entry) => typeof entry.$gte === 'string')?.$gte;
+
+      if (typeof lower === 'string' && typeof upper === 'string') {
+        return { name: option.name, operator: '$ne', value: lower };
+      }
+    }
+
+    return null;
+  }
+
   const [name] = Object.keys(filterEntry);
   const option = options.find((o) => o.name === name);
   if (!option) {
     return null;
   }
 
-  const operatorObj =
-    option.type === 'relation'
-      ? (filterEntry[name] as Record<string, unknown>)?.[option.mainField?.name ?? 'id']
-      : filterEntry[name];
-
-  if (typeof operatorObj !== 'object' || operatorObj === null) {
+  const operatorObj = getOperatorObject(filterEntry, option);
+  if (!operatorObj) {
     return null;
+  }
+
+  if (
+    getFilterType(option) === 'datetime' &&
+    typeof operatorObj.$gte === 'string' &&
+    typeof operatorObj.$lt === 'string'
+  ) {
+    return { name, operator: '$eq', value: operatorObj.$gte };
   }
 
   const [operator] = Object.keys(operatorObj as Record<string, unknown>);
@@ -231,41 +342,19 @@ const PopoverImpl = ({ zIndex }: { zIndex?: number }) => {
      */
     const fieldOptions = options.find((filter) => filter.name === data.name)!;
 
-    /**
-     * If the filter is a relation, we need to nest the filter object,
-     * we filter based on the mainField of the relation, if there is no mainField, we use the id.
-     * At the end, we pass the operator & value. This value _could_ look like:
-     * ```json
-     * {
-     *  "$eq": "1",
-     * }
-     * ```
-     */
-    const operatorValuePairing = {
-      [data.filter]: value,
-    };
-
-    const newFilterEntry = {
-      [data.name]:
-        fieldOptions.type === 'relation'
-          ? {
-              [fieldOptions.mainField?.name ?? 'id']: operatorValuePairing,
-            }
-          : operatorValuePairing,
-    };
-
+    const newFilterEntries = createFilterEntries(fieldOptions, data, value);
     const existingFilters = query.filters?.$and ?? [];
 
     const newFilterQuery = editingFilter
       ? {
           ...query.filters,
           $and: existingFilters.map((filter) =>
-            isFilterMatch(filter, options, editingFilter) ? newFilterEntry : filter
+            isFilterMatch(filter, options, editingFilter) ? newFilterEntries[0] : filter
           ),
         }
       : {
           ...query.filters,
-          $and: [...existingFilters, newFilterEntry],
+          $and: [...existingFilters, ...newFilterEntries],
         };
 
     setQuery({ filters: newFilterQuery, page: 1 }, 'push', true);
@@ -381,7 +470,7 @@ const getFilterList = (filter?: Filters.Filter): FilterOption[] => {
     return [];
   }
 
-  const type = filter.mainField?.type ? filter.mainField.type : filter.type;
+  const type = getFilterType(filter);
 
   switch (type) {
     case 'email':
@@ -447,11 +536,7 @@ const List = () => {
         return true;
       }
 
-      return !(
-        details.name === data.name &&
-        details.operator === data.filter &&
-        details.value === data.value
-      );
+      return !isFilterMatch(filter, options, data);
     });
 
     setQuery({ filters: { $and: nextFilters }, page: 1 });
@@ -518,23 +603,28 @@ const AttributeTag = ({
   };
 
   const handleRemove = () => {
-    onRemove({ name, value, filter: operator });
+    onRemove({
+      name,
+      value: FILTERS_WITH_NO_VALUE.includes(operator) ? undefined : decodeURIComponent(value),
+      filter: operator,
+    });
   };
 
-  const type = mainField?.type ? mainField.type : filter.type;
+  const type = mainField?.type ?? filter.type;
 
-  let formattedValue: string = value;
+  const decodedValue = FILTERS_WITH_NO_VALUE.includes(operator) ? value : decodeURIComponent(value);
+  let formattedValue: string = decodedValue;
 
   if (!FILTERS_WITH_NO_VALUE.includes(operator)) {
     switch (type) {
       case 'date':
-        formattedValue = formatDate(value, { dateStyle: 'full' });
+        formattedValue = formatDate(decodedValue, { dateStyle: 'full' });
         break;
       case 'datetime':
-        formattedValue = formatDate(value, { dateStyle: 'full', timeStyle: 'short' });
+        formattedValue = formatDate(decodedValue, { dateStyle: 'full', timeStyle: 'short' });
         break;
       case 'time':
-        const [hour, minute] = value.split(':');
+        const [hour, minute] = decodedValue.split(':');
         const date = new Date();
         date.setHours(Number(hour));
         date.setMinutes(Number(minute));
@@ -548,7 +638,7 @@ const AttributeTag = ({
       case 'integer':
       case 'biginteger':
       case 'decimal':
-        formattedValue = formatNumber(Number(value));
+        formattedValue = formatNumber(Number(decodedValue));
         break;
     }
   }

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -145,6 +145,22 @@ describe('Filters', () => {
     await waitFor(() => expect(screen.queryByText('Name $eq Jimbob')).not.toBeInTheDocument());
   });
 
+  it('should remove parsed filter values that contain literal percent signs', async () => {
+    render({
+      initialEntries: [
+        {
+          pathname: '/',
+          search: `filters[$and][0][name][$eq]=${encodeURIComponent('100%')}&page=1`,
+        },
+      ],
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Name $eq 100%' }));
+
+    await waitFor(() => expect(screen.queryByText('Name $eq 100%')).not.toBeInTheDocument());
+    expect(screen.getByTestId('location')).toHaveValue('?page=1');
+  });
+
   it('should display a list of the filter names when the combobox named Select field is pressed', async () => {
     const { user } = render();
 
@@ -251,7 +267,9 @@ describe('Filters', () => {
     await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
     await user.click(await screen.findByRole('option', { name: 'Updated At' }));
 
-    expect(await screen.findByRole('combobox', { name: 'Select filter' })).toHaveTextContent('is');
+    expect(await screen.findByRole('combobox', { name: 'Select filter' })).toHaveTextContent(
+      /^is$/
+    );
     expect(screen.queryByRole('textbox', { name: 'Name' })).not.toBeInTheDocument();
     expect(screen.getByLabelText('Updated At')).toBeInTheDocument();
 

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render as renderRTL, screen, waitFor } from '@tests/utils';
+import { useLocation } from 'react-router-dom';
 
 import { Filters } from '../Filters';
+import { useField } from '../Form';
 
+import type { InputProps } from '../FormInputs/types';
 import type { RenderOptions } from '@tests/utils';
 
 const DEFAULT_FILTERS = [
@@ -32,16 +35,56 @@ const DEFAULT_FILTERS = [
   },
 ] satisfies Filters.Filter[];
 
+const LocationDisplay = () => {
+  const location = useLocation();
+
+  return <input aria-label="location" data-testid="location" readOnly value={location.search} />;
+};
+
+const DateTimeTextInput = ({ 'aria-label': ariaLabel, label, name }: InputProps) => {
+  const field = useField<string>(name);
+
+  return (
+    <input
+      aria-label={ariaLabel ?? label ?? name}
+      name={name}
+      onChange={(event) => field.onChange(name, event.target.value)}
+      value={field.value ?? ''}
+    />
+  );
+};
+
 describe('Filters', () => {
   const render = ({ initialEntries, ...props }: Partial<Filters.Props> & RenderOptions = {}) =>
     renderRTL(
-      <Filters.Root options={DEFAULT_FILTERS} {...props}>
-        <Filters.Trigger />
-        <Filters.Popover />
-        <Filters.List />
-      </Filters.Root>,
+      <>
+        <Filters.Root options={DEFAULT_FILTERS} {...props}>
+          <Filters.Trigger />
+          <Filters.Popover />
+          <Filters.List />
+        </Filters.Root>
+        <LocationDisplay />
+      </>,
       { initialEntries }
     );
+
+  const renderWithTextDateTimeInput = (props: Partial<Filters.Props> & RenderOptions = {}) =>
+    render({
+      ...props,
+      options: DEFAULT_FILTERS.map((filter) =>
+        filter.name === 'updatedAt' ? { ...filter, input: DateTimeTextInput } : filter
+      ),
+    });
+
+  const getDayRange = (value: string) => {
+    const start = new Date(value);
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+
+    return { start: start.toISOString(), end: end.toISOString() };
+  };
 
   it('should open the popover when the trigger is clicked', async () => {
     const { user } = render();
@@ -138,69 +181,106 @@ describe('Filters', () => {
     expect(await screen.findByRole('option', { name: 'Published' })).toBeInTheDocument();
   });
 
-  it('should not show exact equality operators for datetime filters', async () => {
-    const { user } = render();
+  it('should convert exact datetime equality filters to a day range', async () => {
+    const { user } = renderWithTextDateTimeInput();
+    const selectedDate = '2026-06-13T10:15:00.000Z';
+    const { start, end } = getDayRange(selectedDate);
 
     await user.click(screen.getByRole('button', { name: 'Filters' }));
     await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
     await user.click(await screen.findByRole('option', { name: 'Updated At' }));
     await user.click(await screen.findByRole('combobox', { name: 'Select filter' }));
 
-    expect(screen.queryByRole('option', { name: 'is' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: 'is not' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'is' })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'is not' })).toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'is null' })).toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'is greater than' })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('option', { name: 'is null' }));
+    await user.click(screen.getByRole('option', { name: 'is' }));
+    await user.type(screen.getByRole('textbox', { name: 'Updated At' }), selectedDate);
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
-    await screen.findByText('Updated At $null');
-    expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveValue(
+        expect.stringContaining('filters[$and][0][updatedAt][$gte]')
+      )
+    );
+
+    const search = screen.getByTestId('location').getAttribute('value') ?? '';
+    const searchParams = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+    expect(searchParams.get('filters[$and][0][updatedAt][$gte]')).toEqual(start);
+    expect(searchParams.get('filters[$and][0][updatedAt][$lt]')).toEqual(end);
+    expect(searchParams.has('filters[$and][0][updatedAt][$eq]')).toBe(false);
+    expect(await screen.findByText(/Updated At \$eq/)).toBeInTheDocument();
+  });
+
+  it('should convert exact datetime non-equality filters to an outside-day range', async () => {
+    const { user } = renderWithTextDateTimeInput();
+    const selectedDate = '2026-06-13T10:15:00.000Z';
+    const { start, end } = getDayRange(selectedDate);
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+    await user.click(await screen.findByRole('option', { name: 'Updated At' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Select filter' }));
+    await user.click(await screen.findByRole('option', { name: 'is not' }));
+    await user.type(screen.getByRole('textbox', { name: 'Updated At' }), selectedDate);
+    fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveValue(
+        expect.stringContaining('filters[$and][0][$or][0][updatedAt][$lt]')
+      )
+    );
+
+    const search = screen.getByTestId('location').getAttribute('value') ?? '';
+    const searchParams = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+    expect(searchParams.get('filters[$and][0][$or][0][updatedAt][$lt]')).toEqual(start);
+    expect(searchParams.get('filters[$and][0][$or][1][updatedAt][$gte]')).toEqual(end);
+    expect(searchParams.has('filters[$and][0][updatedAt][$ne]')).toBe(false);
+    expect(await screen.findByText(/Updated At \$ne/)).toBeInTheDocument();
   });
 
   it('should reset the operator and value when changing fields', async () => {
-    const { user } = render();
+    const { user } = renderWithTextDateTimeInput();
 
     await user.click(screen.getByRole('button', { name: 'Filters' }));
     await user.type(await screen.findByRole('textbox', { name: 'Name' }), 'Jimbob');
     await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
     await user.click(await screen.findByRole('option', { name: 'Updated At' }));
 
-    expect(await screen.findByRole('combobox', { name: 'Select filter' })).toHaveTextContent(
-      'is null'
-    );
+    expect(await screen.findByRole('combobox', { name: 'Select filter' })).toHaveTextContent('is');
     expect(screen.queryByRole('textbox', { name: 'Name' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Updated At')).toBeInTheDocument();
 
+    await user.type(screen.getByLabelText('Updated At'), '2026-06-13T10:15:00.000Z');
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
-    await screen.findByText('Updated At $null');
+    await screen.findByText(/Updated At \$eq/);
     expect(screen.queryByText(/Jimbob/)).not.toBeInTheDocument();
   });
 
-  it('should sanitize removed operators when editing existing datetime filters', async () => {
-    const { user } = render({
+  it('should remove a generated datetime range as one filter', async () => {
+    const selectedDate = '2026-06-13T10:15:00.000Z';
+    const { start, end } = getDayRange(selectedDate);
+    render({
       initialEntries: [
         {
           pathname: '/',
-          search: 'filters[$and][0][updatedAt][$eq]=2026-06-13T10:15:00.000Z&' + 'page=1',
+          search:
+            `filters[$and][0][updatedAt][$gte]=${encodeURIComponent(start)}&` +
+            `filters[$and][0][updatedAt][$lt]=${encodeURIComponent(end)}&` +
+            'page=1',
         },
       ],
     });
 
-    const filterTagWithExactOperator = await screen.findByText(/Updated At \$eq/);
-    await user.click(filterTagWithExactOperator);
+    fireEvent.click(await screen.findByRole('button', { name: /Updated At \$eq/ }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Update filter' })).toBeInTheDocument();
-    });
-
-    expect(screen.getByRole('combobox', { name: 'Select filter' })).toHaveTextContent('is null');
-    expect(screen.queryByLabelText('Updated At')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
-
-    await screen.findByText('Updated At $null');
-    expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument());
+    expect(screen.getByTestId('location')).toHaveValue('?page=1');
   });
 
   it('should replace existing filter when editing instead of adding a duplicate', async () => {

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -62,6 +62,16 @@ describe('Filters', () => {
     expect(addFilterButton).toBeDisabled();
   });
 
+  it('should not render the popover content when no filters are provided', async () => {
+    const { user } = render({ options: [] });
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+    expect(screen.queryByRole('combobox', { name: 'Select field' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Select filter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add filter' })).not.toBeInTheDocument();
+  });
+
   it("should add a filter to the list when the 'Add filter' button is clicked & close the popover", async () => {
     const { user } = render();
 

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -217,7 +217,7 @@ describe('Filters', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
     await waitFor(() =>
-      expect(screen.getByTestId('location')).toHaveValue(
+      expect(screen.getByTestId('location').getAttribute('value')).toEqual(
         expect.stringContaining('filters[$and][0][updatedAt][$gte]')
       )
     );
@@ -245,7 +245,7 @@ describe('Filters', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
     await waitFor(() =>
-      expect(screen.getByTestId('location')).toHaveValue(
+      expect(screen.getByTestId('location').getAttribute('value')).toEqual(
         expect.stringContaining('filters[$and][0][$or][0][updatedAt][$lt]')
       )
     );

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render as renderRTL, screen, waitFor } from '@tests/utils';
 
 import { Filters } from '../Filters';
 
+import type { RenderOptions } from '@tests/utils';
+
 const DEFAULT_FILTERS = [
   {
     name: 'name',
@@ -31,13 +33,14 @@ const DEFAULT_FILTERS = [
 ] satisfies Filters.Filter[];
 
 describe('Filters', () => {
-  const render = (props?: Partial<Filters.Props>) =>
+  const render = ({ initialEntries, ...props }: Partial<Filters.Props> & RenderOptions = {}) =>
     renderRTL(
       <Filters.Root options={DEFAULT_FILTERS} {...props}>
         <Filters.Trigger />
         <Filters.Popover />
         <Filters.List />
-      </Filters.Root>
+      </Filters.Root>,
+      { initialEntries }
     );
 
   it('should open the popover when the trigger is clicked', async () => {
@@ -140,6 +143,51 @@ describe('Filters', () => {
 
     await user.click(screen.getByRole('option', { name: 'is null' }));
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
+
+    await screen.findByText('Updated At $null');
+    expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument();
+  });
+
+  it('should reset the operator and value when changing fields', async () => {
+    const { user } = render();
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.type(await screen.findByRole('textbox', { name: 'Name' }), 'Jimbob');
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+    await user.click(await screen.findByRole('option', { name: 'Updated At' }));
+
+    expect(await screen.findByRole('combobox', { name: 'Select filter' })).toHaveTextContent(
+      'is null'
+    );
+    expect(screen.queryByRole('textbox', { name: 'Name' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
+
+    await screen.findByText('Updated At $null');
+    expect(screen.queryByText(/Jimbob/)).not.toBeInTheDocument();
+  });
+
+  it('should sanitize removed operators when editing existing datetime filters', async () => {
+    const { user } = render({
+      initialEntries: [
+        {
+          pathname: '/',
+          search: 'filters[$and][0][updatedAt][$eq]=2026-06-13T10:15:00.000Z&' + 'page=1',
+        },
+      ],
+    });
+
+    const filterTagWithExactOperator = await screen.findByText(/Updated At \$eq/);
+    await user.click(filterTagWithExactOperator);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Update filter' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('combobox', { name: 'Select filter' })).toHaveTextContent('is null');
+    expect(screen.queryByLabelText('Updated At')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update filter' }));
 
     await screen.findByText('Updated At $null');
     expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument();

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -23,6 +23,11 @@ const DEFAULT_FILTERS = [
     label: 'Created At',
     type: 'date',
   },
+  {
+    name: 'updatedAt',
+    label: 'Updated At',
+    type: 'datetime',
+  },
 ] satisfies Filters.Filter[];
 
 describe('Filters', () => {
@@ -118,6 +123,26 @@ describe('Filters', () => {
     expect(await screen.findByRole('option', { name: 'Draft' })).toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'Modified' })).toBeInTheDocument();
     expect(await screen.findByRole('option', { name: 'Published' })).toBeInTheDocument();
+  });
+
+  it('should not show exact equality operators for datetime filters', async () => {
+    const { user } = render();
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
+    await user.click(await screen.findByRole('option', { name: 'Updated At' }));
+    await user.click(await screen.findByRole('combobox', { name: 'Select filter' }));
+
+    expect(screen.queryByRole('option', { name: 'is' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'is not' })).not.toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'is null' })).toBeInTheDocument();
+    expect(await screen.findByRole('option', { name: 'is greater than' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: 'is null' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
+
+    await screen.findByText('Updated At $null');
+    expect(screen.queryByText(/Updated At \$eq/)).not.toBeInTheDocument();
   });
 
   it('should replace existing filter when editing instead of adding a duplicate', async () => {

--- a/packages/core/admin/admin/src/components/tests/Filters.test.tsx
+++ b/packages/core/admin/admin/src/components/tests/Filters.test.tsx
@@ -4,7 +4,6 @@ import { useLocation } from 'react-router-dom';
 import { Filters } from '../Filters';
 import { useField } from '../Form';
 
-import type { InputProps } from '../FormInputs/types';
 import type { RenderOptions } from '@tests/utils';
 
 const DEFAULT_FILTERS = [
@@ -41,12 +40,12 @@ const LocationDisplay = () => {
   return <input aria-label="location" data-testid="location" readOnly value={location.search} />;
 };
 
-const DateTimeTextInput = ({ 'aria-label': ariaLabel, label, name }: InputProps) => {
+const DateTimeTextInput = ({ 'aria-label': ariaLabel, name }: Filters.ValueInputProps) => {
   const field = useField<string>(name);
 
   return (
     <input
-      aria-label={ariaLabel ?? label ?? name}
+      aria-label={ariaLabel}
       name={name}
       onChange={(event) => field.onChange(name, event.target.value)}
       value={field.value ?? ''}
@@ -78,10 +77,10 @@ describe('Filters', () => {
 
   const getDayRange = (value: string) => {
     const start = new Date(value);
-    start.setHours(0, 0, 0, 0);
+    start.setUTCHours(0, 0, 0, 0);
 
     const end = new Date(start);
-    end.setDate(end.getDate() + 1);
+    end.setUTCDate(end.getUTCDate() + 1);
 
     return { start: start.toISOString(), end: end.toISOString() };
   };
@@ -201,6 +200,10 @@ describe('Filters', () => {
     const { user } = renderWithTextDateTimeInput();
     const selectedDate = '2026-06-13T10:15:00.000Z';
     const { start, end } = getDayRange(selectedDate);
+    expect({ start, end }).toEqual({
+      start: '2026-06-13T00:00:00.000Z',
+      end: '2026-06-14T00:00:00.000Z',
+    });
 
     await user.click(screen.getByRole('button', { name: 'Filters' }));
     await user.click(await screen.findByRole('combobox', { name: 'Select field' }));
@@ -217,8 +220,8 @@ describe('Filters', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
     await waitFor(() =>
-      expect(screen.getByTestId('location').getAttribute('value')).toEqual(
-        expect.stringContaining('filters[$and][0][updatedAt][$gte]')
+      expect((screen.getByTestId('location') as HTMLInputElement).value).toContain(
+        'filters[$and][0][updatedAt][$gte]'
       )
     );
 
@@ -245,8 +248,8 @@ describe('Filters', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Add filter' }));
 
     await waitFor(() =>
-      expect(screen.getByTestId('location').getAttribute('value')).toEqual(
-        expect.stringContaining('filters[$and][0][$or][0][updatedAt][$lt]')
+      expect((screen.getByTestId('location') as HTMLInputElement).value).toContain(
+        'filters[$and][0][$or][0][updatedAt][$lt]'
       )
     );
 

--- a/packages/core/admin/admin/src/hooks/useQueryParams.ts
+++ b/packages/core/admin/admin/src/hooks/useQueryParams.ts
@@ -22,7 +22,7 @@ const useQueryParams = <TQuery extends object = QueryParams>(initialParams?: TQu
       return initialParams;
     }
 
-    return { ...initialParams, ...parse(searchQuery) } as TQuery;
+    return { ...initialParams, ...parse(searchQuery, { depth: 10 }) } as TQuery;
   }, [search, initialParams]);
 
   const setQuery = useCallback(


### PR DESCRIPTION
## Summary
- convert datetime `is` filters into an inclusive/exclusive day range with `$gte` and `$lt`
- convert datetime `is not` filters into the outside-day range with `$or`
- keep generated datetime range filters displayed and editable as single `is` / `is not` chips
- reset stale operators when switching filter fields and keep filter tag values safe for literal percent strings
- parse deeper nested query objects so generated datetime ranges survive URL round-tripping

## Testing
- `yarn workspace @strapi/admin test:front Filters.test.tsx --runInBand`
- `yarn workspace @strapi/admin test:front useQueryParams.test.tsx --runInBand`
- `yarn workspace @strapi/admin test:ts`
- `yarn prettier --check packages/core/admin/admin/src/components/Filters.tsx packages/core/admin/admin/src/components/tests/Filters.test.tsx packages/core/admin/admin/src/hooks/useQueryParams.ts`
- `git diff --check origin/develop...HEAD`

Fixes #26614
