### PR TITLE
fix(ci): avoid syncing CPR labels to CMS tickets

### DIFF
--- a/.github/actions/community-pr-triage/dist/index.cjs
+++ b/.github/actions/community-pr-triage/dist/index.cjs
@@ -54615,6 +54615,11 @@ async function updateTicket(issueId, pr2, analysis, labelMap, teamId) {
   const labelIds = await buildLabelIds(analysis, labelMap, teamId);
   await linearClient.updateIssue(issueId, { title, description, labelIds });
 }
+async function updateTicketMetadata(issueId, pr2, analysis) {
+  const title = `PR #${pr2.number}: ${pr2.title}`;
+  const description = buildDescription(pr2, analysis);
+  await linearClient.updateIssue(issueId, { title, description });
+}
 async function updateTicketLabels(issueId, analysis, labelMap, teamId) {
   const labelIds = await buildLabelIds(analysis, labelMap, teamId);
   await linearClient.updateIssue(issueId, { labelIds });
@@ -54910,8 +54915,10 @@ async function syncPR(prNumber, triggerLabel, inputs) {
     linearTicketId: null,
     linearTicketDbId: null
   };
+  const cprTicket = await findTicketByPRNumber(inputs.cprTeamId, prNumber);
+  const cmsTicket = cprTicket ? null : await findTicketByPRNumber(inputs.cmsTeamId, prNumber);
+  const existing = cprTicket ?? cmsTicket;
   const labelMap = await resolveTeamLabels(inputs.cprTeamId, inputs.labelMap);
-  const existing = await findTicketByPRNumber(inputs.cprTeamId, prNumber) ?? await findTicketByPRNumber(inputs.cmsTeamId, prNumber);
   if (!existing) {
     const ticket = await createTicket(
       pr2,
@@ -54930,7 +54937,11 @@ async function syncPR(prNumber, triggerLabel, inputs) {
   } else {
     analysis.linearTicketId = existing.identifier;
     analysis.linearTicketDbId = existing.id;
-    await updateTicket(existing.id, pr2, analysis, labelMap, inputs.cprTeamId);
+    if (cprTicket) {
+      await updateTicket(existing.id, pr2, analysis, labelMap, inputs.cprTeamId);
+    } else {
+      await updateTicketMetadata(existing.id, pr2, analysis);
+    }
   }
 }
 

--- a/.github/actions/community-pr-triage/src/lib/linear.ts
+++ b/.github/actions/community-pr-triage/src/lib/linear.ts
@@ -241,6 +241,17 @@ export async function updateTicket(
   await linearClient.updateIssue(issueId, { title, description, labelIds });
 }
 
+export async function updateTicketMetadata(
+  issueId: string,
+  pr: CommunityPR,
+  analysis: PRAnalysis
+): Promise<void> {
+  const title = `PR #${pr.number}: ${pr.title}`;
+  const description = buildDescription(pr, analysis);
+
+  await linearClient.updateIssue(issueId, { title, description });
+}
+
 export async function updateTicketLabels(
   issueId: string,
   analysis: PRAnalysis,

--- a/.github/actions/community-pr-triage/src/modes/sync-pr.ts
+++ b/.github/actions/community-pr-triage/src/modes/sync-pr.ts
@@ -23,11 +23,13 @@ export async function syncPR(
     linearTicketDbId: null,
   };
 
-  const labelMap = await linear.resolveTeamLabels(inputs.cprTeamId, inputs.labelMap);
   // Check CPR first, then CMS — avoids creating a duplicate if already picked up
-  const existing =
-    (await linear.findTicketByPRNumber(inputs.cprTeamId, prNumber)) ??
-    (await linear.findTicketByPRNumber(inputs.cmsTeamId, prNumber));
+  const cprTicket = await linear.findTicketByPRNumber(inputs.cprTeamId, prNumber);
+  const cmsTicket = cprTicket
+    ? null
+    : await linear.findTicketByPRNumber(inputs.cmsTeamId, prNumber);
+  const existing = cprTicket ?? cmsTicket;
+  const labelMap = await linear.resolveTeamLabels(inputs.cprTeamId, inputs.labelMap);
 
   if (!existing) {
     const ticket = await linear.createTicket(
@@ -48,6 +50,10 @@ export async function syncPR(
   } else {
     analysis.linearTicketId = existing.identifier;
     analysis.linearTicketDbId = existing.id;
-    await linear.updateTicket(existing.id, pr, analysis, labelMap, inputs.cprTeamId);
+    if (cprTicket) {
+      await linear.updateTicket(existing.id, pr, analysis, labelMap, inputs.cprTeamId);
+    } else {
+      await linear.updateTicketMetadata(existing.id, pr, analysis);
+    }
   }
 }


### PR DESCRIPTION
### What does it do?

Updates the community PR triage action so existing tickets found on the CMS team are refreshed without rewriting Linear labels. CPR-owned tickets still keep the existing label sync behavior, and the bundled action output is rebuilt.

### Why is it needed?

Community PR sync can find a ticket that has already been picked up on the CMS team, then try to update it with labels from the CMS-Community-PRs team. Linear rejects those team-scoped label IDs, causing the `Community PR — Create Linear Ticket` job to fail with:

```
LabelIds for incorrect team - The label 'content-manager' is not associated with the same team as the issue.
```

### How to test it?

- `yarn workspace community-pr-triage typecheck`
- `yarn workspace community-pr-triage build`

### Related issue(s)/PR(s)

Fixes the failing triage run: https://github.com/strapi/strapi/actions/runs/27430000679/job/81077570040