### PR TITLE
chore(workflows): make documentation flag name more obvious

### DIFF
--- a/.github/workflows/docs-flag-notification.yml
+++ b/.github/workflows/docs-flag-notification.yml
@@ -1,4 +1,4 @@
-name: Notify docs team on "flag: requires manual documentation" label
+name: 'Notify docs team on "flag: requires manual documentation" label'
 
 on:
   pull_request:

--- a/.github/workflows/docs-flag-notification.yml
+++ b/.github/workflows/docs-flag-notification.yml
@@ -1,4 +1,4 @@
-name: Notify docs team on flag:documentation label
+name: Notify docs team on "flag: requires manual documentation" label
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   notify-docs:
-    if: "github.event.label.name == 'flag: documentation'"
+    if: "github.event.label.name == 'flag: requires manual documentation'"
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack


### PR DESCRIPTION
Upon further discussion with the Engineering team, it wasn't obvious when to use the label to flag documentation to be manually handled.

This short and simple PR just replaces the flag to detect: before: `flag: documentation` → after: `flag: requires manual documentation`

❗ Once merged, please update the current GitHub label name. 
