### PR TITLE
fix(document-service): preserve published relations from non-dp sources

### DIFF
--- a/packages/core/core/src/services/document-service/__tests__/draft-and-publish.test.ts
+++ b/packages/core/core/src/services/document-service/__tests__/draft-and-publish.test.ts
@@ -1,0 +1,56 @@
+import type { Struct } from '@strapi/types';
+
+import { setStatusToDraft } from '../draft-and-publish';
+
+const createContentType = (draftAndPublish: boolean): Struct.CollectionTypeSchema => ({
+  uid: 'api::test.test',
+  kind: 'collectionType',
+  collectionName: 'tests',
+  modelName: 'test',
+  modelType: 'contentType',
+  globalId: 'Test',
+  info: {
+    displayName: 'Test',
+    singularName: 'test',
+    pluralName: 'tests',
+  },
+  options: {
+    draftAndPublish,
+  },
+  attributes: {},
+});
+
+const dpContentType = createContentType(true);
+const nonDpContentType = createContentType(false);
+
+describe('Draft and Publish transforms', () => {
+  describe('setStatusToDraft', () => {
+    it('defaults Draft & Publish content types to draft when status is undefined', () => {
+      expect(setStatusToDraft(dpContentType, { data: {} })).toMatchObject({
+        data: {},
+        status: 'draft',
+      });
+    });
+
+    it('forces Draft & Publish content types to draft when status is provided', () => {
+      expect(setStatusToDraft(dpContentType, { data: {}, status: 'published' })).toMatchObject({
+        data: {},
+        status: 'draft',
+      });
+    });
+
+    it('preserves non-Draft & Publish params when status is undefined', () => {
+      const params = { data: {} };
+
+      expect(setStatusToDraft(nonDpContentType, params)).toBe(params);
+      expect(params).not.toHaveProperty('status');
+    });
+
+    it('preserves non-Draft & Publish params when status is provided', () => {
+      expect(setStatusToDraft(nonDpContentType, { data: {}, status: 'published' })).toMatchObject({
+        data: {},
+        status: 'published',
+      });
+    });
+  });
+});

--- a/packages/core/core/src/services/document-service/draft-and-publish.ts
+++ b/packages/core/core/src/services/document-service/draft-and-publish.ts
@@ -15,7 +15,7 @@ type TransformWithContentType = (
  * DP disabled -> Used mostly for parsing relations, so there is not a need for a default.
  */
 const setStatusToDraft: TransformWithContentType = (contentType, params) => {
-  if (!contentTypes.hasDraftAndPublish(contentType) && params.status) {
+  if (!contentTypes.hasDraftAndPublish(contentType)) {
     return params;
   }
 

--- a/packages/core/core/src/services/document-service/transform/__tests__/id-transform-no-dp.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/id-transform-no-dp.test.ts
@@ -83,6 +83,30 @@ describe('Transform relational data', () => {
       });
     });
 
+    it('Connect relation operation to the published product version', async () => {
+      const { data } = await transformParamsDocumentId(SHOP_UID, {
+        data: {
+          name: 'test',
+          products: {
+            connect: {
+              documentId: 'product-1',
+              locale: 'en',
+              status: 'published',
+            },
+          },
+        },
+        locale: 'en',
+        status: 'draft',
+      });
+
+      expect(data).toMatchObject({
+        name: 'test',
+        products: {
+          connect: [{ id: 'product-1-en-published' }],
+        },
+      });
+    });
+
     it('Connect to both draft and publish by default', async () => {
       // Should connect to the default locale if not provided in the relation
       const { data } = await transformParamsDocumentId(SHOP_UID, {

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -53,6 +53,26 @@ const articleModel = {
   collectionName: '',
 };
 
+const optInModel = {
+  attributes: {
+    caption: {
+      type: 'string',
+    },
+    user: {
+      type: 'relation',
+      relation: 'manyToOne',
+      target: 'plugin::users-permissions.user',
+      targetAttribute: 'optIns',
+    },
+  },
+  draftAndPublish: true,
+  displayName: 'OptIn',
+  singularName: 'opt-in',
+  pluralName: 'opt-ins',
+  description: '',
+  collectionName: '',
+};
+
 let userSeq = 0;
 const createUser = async (overrides = {}) => {
   userSeq += 1;
@@ -71,10 +91,30 @@ const createUser = async (overrides = {}) => {
 const createArticle = (title = 'Article') =>
   strapi.db.query('api::article.article').create({ data: { title } });
 
+const createPublishedOptIn = async () => {
+  const optIn = await strapi.documents('api::opt-in.opt-in').create({
+    data: { caption: 'Drafted Opt-In' },
+  });
+
+  await strapi.documents('api::opt-in.opt-in').publish({ documentId: optIn.documentId });
+
+  await strapi.documents('api::opt-in.opt-in').update({
+    documentId: optIn.documentId,
+    data: { caption: 'Drafted Opt-In Modified' },
+  });
+
+  const [publishedOptIn] = await strapi.documents('api::opt-in.opt-in').findMany({
+    status: 'published',
+    filters: { documentId: optIn.documentId },
+  });
+
+  return publishedOptIn;
+};
+
 const readUser = (id) =>
   strapi.db.query('plugin::users-permissions.user').findOne({
     where: { id },
-    populate: ['favoriteArticles', 'favoriteArticle', 'role'],
+    populate: ['favoriteArticles', 'favoriteArticle', 'role', 'optIns'],
   });
 
 const putUser = (id, body) => rq({ method: 'PUT', url: `/users/${id}`, body });
@@ -82,7 +122,7 @@ const putUser = (id, body) => rq({ method: 'PUT', url: `/users/${id}`, body });
 describe('U&P users REST relation handling (issue 26606)', () => {
   beforeAll(async () => {
     builder = createTestBuilder();
-    await builder.addContentType(articleModel).build();
+    await builder.addContentTypes([articleModel, optInModel]).build();
     strapi = await createStrapiInstance();
     rq = await createContentAPIRequest({ strapi });
 
@@ -328,6 +368,31 @@ describe('U&P users REST relation handling (issue 26606)', () => {
       const after = await readUser(user.id);
       expect(after.favoriteArticle).not.toBeNull();
       expect(after.favoriteArticle.documentId).toBe(article.documentId);
+    });
+
+    test('Document Service connects a users-permissions user to a published DP target', async () => {
+      const user = await createUser();
+      const optIn = await createPublishedOptIn();
+
+      const updatedUser = await strapi.documents('plugin::users-permissions.user').update({
+        documentId: user.documentId,
+        data: {
+          optIns: {
+            connect: {
+              documentId: optIn.documentId,
+              status: 'published',
+            },
+          },
+        },
+        populate: 'optIns',
+      });
+
+      expect(updatedUser.optIns).toHaveLength(1);
+      expect(updatedUser.optIns[0]).toMatchObject({
+        documentId: optIn.documentId,
+        caption: 'Drafted Opt-In',
+        publishedAt: expect.any(String),
+      });
     });
   });
 });

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -98,12 +98,14 @@ const createPublishedOptIn = async () => {
 
   await strapi.documents('api::opt-in.opt-in').publish({ documentId: optIn.documentId });
 
+  // Keep the draft row different from the published row so tests can prove the populated
+  // relation selected the published version rather than the later draft.
   await strapi.documents('api::opt-in.opt-in').update({
     documentId: optIn.documentId,
     data: { caption: 'Drafted Opt-In Modified' },
   });
 
-  const [publishedOptIn] = await strapi.documents('api::opt-in.opt-in').findMany({
+  const publishedOptIn = await strapi.documents('api::opt-in.opt-in').findFirst({
     status: 'published',
     filters: { documentId: optIn.documentId },
   });
@@ -389,6 +391,32 @@ describe('U&P users REST relation handling (issue 26606)', () => {
 
       expect(updatedUser.optIns).toHaveLength(1);
       expect(updatedUser.optIns[0]).toMatchObject({
+        id: optIn.id,
+        documentId: optIn.documentId,
+        caption: 'Drafted Opt-In',
+        publishedAt: expect.any(String),
+      });
+    });
+
+    test('PUT connects a users-permissions user to a published DP target', async () => {
+      const user = await createUser();
+      const optIn = await createPublishedOptIn();
+
+      const res = await putUser(user.id, {
+        optIns: {
+          connect: {
+            documentId: optIn.documentId,
+            status: 'published',
+          },
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+
+      const after = await readUser(user.id);
+      expect(after.optIns).toHaveLength(1);
+      expect(after.optIns[0]).toMatchObject({
+        id: optIn.id,
         documentId: optIn.documentId,
         caption: 'Drafted Opt-In',
         publishedAt: expect.any(String),


### PR DESCRIPTION
### What does it do?
Fixes Document Service relation updates from non-Draft & Publish sources so an explicitly connected published Draft & Publish target remains visible in populated mutation responses.

### Why is it needed?
`plugin::users-permissions.user` could connect to a published target row, but the update response populated the relation with an internal draft filter and returned an empty relation.

### How to test it?
Run:

```bash
yarn test:api tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
yarn test:api tests/api/core/strapi/document-service/relations/no-dp.test.api.ts
```

### Related issue(s)/PR(s)
- Fixes #21948 

