### PR TITLE
test(e2e): add critical edit-schema no-data-loss test

### DIFF
--- a/tests/e2e/tests/content-type-builder/collection-type/edit-schema-no-data-loss.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-schema-no-data-loss.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { resetFiles } from '../../../../utils/file-reset';
+import { sharedSetup } from '../../../../utils/setup';
+import { addAttributesToContentType } from '../../../../utils/content-types';
+import { clickAndWait, navToHeader, findAndClose } from '../../../../utils/shared';
+import { waitForRestart } from '../../../../utils/restart';
+
+test.describe('CTB - Edit schema without data loss', { tag: ['@critical'] }, () => {
+  // Long timeout — triggers multiple server restarts
+  test.describe.configure({ timeout: 500000 });
+
+  test.beforeEach(async ({ page }) => {
+    await sharedSetup('ctb-edit-schema-no-data-loss', page, {
+      resetFiles: true,
+      importData: 'with-admin',
+      login: true,
+      resetAlways: true,
+    });
+  });
+
+  test.afterAll(async () => {
+    await resetFiles();
+  });
+
+  // KNOWN LIMITATION — not a test bug, skipped intentionally.
+  // Strapi does not preserve data when a field is renamed. The CTB writes the new attribute name
+  // to the schema; on restart the DB sync (packages/core/database/src/schema/diff.ts) matches
+  // columns by name, so the old column is treated as "removed" and dropped (builder.ts ~L355) while
+  // the new column is created empty. There is no renameColumn operation for user-initiated renames.
+  // Confirmed "expected, not a bug" by maintainers: https://github.com/strapi/strapi/issues/25076
+  // (see also #19075, #12626, #12597). Tracked as a feature request:
+  // https://feedback.strapi.io/developer-experience/p/gracefully-handle-renaming-of-content-types-and-fields-in-the-ctb
+  // Flip this back to a real `test(...)` if/when the CTB supports rename-with-migration.
+  test.fixme('Renaming a field preserves existing content data', async ({ page }) => {
+    await addAttributesToContentType(page, 'Article', [{ type: 'text', name: 'bio' }]);
+
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('link', { name: 'Create new entry' }).last());
+    await page.getByRole('textbox', { name: 'title' }).fill('Rename test entry');
+    await page.getByRole('textbox', { name: 'bio' }).fill('preserved bio content');
+    await clickAndWait(page, page.getByRole('button', { name: 'Save' }));
+    await findAndClose(page, 'Saved Document');
+
+    await navToHeader(page, ['Content-Type Builder', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('button', { name: 'Edit bio' }));
+    await page.getByLabel('Name', { exact: true }).fill('biography');
+    await clickAndWait(page, page.getByRole('button', { name: 'Finish' }));
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'Rename test entry' }));
+    await expect(page.getByRole('textbox', { name: 'biography' })).toHaveValue(
+      'preserved bio content'
+    );
+  });
+
+  test('Adding then removing a field does not corrupt existing entries', async ({ page }) => {
+    // Baseline: the seeded entry has its title
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
+      'West Ham post match analysis'
+    );
+
+    // Add a new field — existing data must survive the schema change + restart
+    await addAttributesToContentType(page, 'Article', [{ type: 'text', name: 'tempnotes' }]);
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
+      'West Ham post match analysis'
+    );
+
+    // Remove the field again — existing data must still survive
+    await navToHeader(page, ['Content-Type Builder', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('button', { name: 'Delete tempnotes' }));
+    await page.getByRole('button', { name: 'Save' }).click();
+    await waitForRestart(page);
+
+    await navToHeader(page, ['Content Manager', 'Article'], 'Article');
+    await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
+    await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
+      'West Ham post match analysis'
+    );
+  });
+});

--- a/tests/e2e/tests/content-type-builder/collection-type/edit-schema-no-data-loss.spec.ts
+++ b/tests/e2e/tests/content-type-builder/collection-type/edit-schema-no-data-loss.spec.ts
@@ -62,6 +62,9 @@ test.describe('CTB - Edit schema without data loss', { tag: ['@critical'] }, () 
     await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
       'West Ham post match analysis'
     );
+    await expect(page.getByRole('textbox', { name: 'slug' })).toHaveValue(
+      'west-ham-post-match-analysis'
+    );
 
     // Add a new field — existing data must survive the schema change + restart
     await addAttributesToContentType(page, 'Article', [{ type: 'text', name: 'tempnotes' }]);
@@ -69,6 +72,9 @@ test.describe('CTB - Edit schema without data loss', { tag: ['@critical'] }, () 
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
     await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
       'West Ham post match analysis'
+    );
+    await expect(page.getByRole('textbox', { name: 'slug' })).toHaveValue(
+      'west-ham-post-match-analysis'
     );
 
     // Remove the field again — existing data must still survive
@@ -81,6 +87,9 @@ test.describe('CTB - Edit schema without data loss', { tag: ['@critical'] }, () 
     await clickAndWait(page, page.getByRole('gridcell', { name: 'West Ham post match analysis' }));
     await expect(page.getByRole('textbox', { name: 'title' })).toHaveValue(
       'West Ham post match analysis'
+    );
+    await expect(page.getByRole('textbox', { name: 'slug' })).toHaveValue(
+      'west-ham-post-match-analysis'
     );
   });
 });


### PR DESCRIPTION
## What
Adds a `@critical` E2E test for **gap #4 — `ctb.edit-schema.no-data-loss`**: changing a content type's schema in the Content-Type Builder must not destroy existing entry data.

## What the test does
**`Adding then removing a field does not corrupt existing entries`** (active ✅)
1. Opens the seeded "West Ham post match analysis" Article and records its title.
2. Adds a `tempnotes` text field → reopens the entry → title still intact across the restart.
3. Deletes `tempnotes` → reopens the entry → title still intact across the second restart.

This is the genuine "no data loss" guarantee for the critical path, and it passes on chromium / firefox / webkit.

## The field-rename scenario (intentional `test.fixme`)
The file also includes a `test.fixme` for *renaming* a field while preserving its data. This is **kept as a documented skip, not a failing assertion**, because renaming does not preserve data in Strapi by design:

- The CTB writes the new attribute name into the schema; on restart the DB sync (`packages/core/database/src/schema/diff.ts`) matches columns **by name**, so the old column is treated as "removed" and dropped (`builder.ts`) while the new column is created empty. There is no `renameColumn` for user-initiated renames.
- Confirmed **"expected, not a bug"** by maintainers in [#25076](https://github.com/strapi/strapi/issues/25076) (see also [#19075](https://github.com/strapi/strapi/issues/19075), [#12626](https://github.com/strapi/strapi/issues/12626), [#12597](https://github.com/strapi/strapi/issues/12597)), tracked as a [feature request](https://feedback.strapi.io/developer-experience/p/gracefully-handle-renaming-of-content-types-and-fields-in-the-ctb).

Keeping it as a `fixme` documents the coverage gap (visible in test reports) without a red `@critical` test, and it can be flipped to a real assertion if/when the CTB supports rename-with-migration. No new bug filed — the existing closed issues already cover it.

## Part of
E2E coverage focus — Phase 1.


