### PR TITLE
test(e2e): tag bulk-actions test @extended (#20)

### DIFF
--- a/tests/e2e/tests/content-manager/listview.spec.ts
+++ b/tests/e2e/tests/content-manager/listview.spec.ts
@@ -130,138 +130,143 @@ test.describe('List View', () => {
     await expect(page.getByRole('link', { name: 'Next page' })).toBeDisabled();
   });
 
-  test('A user should be able to perform bulk actions on entries', async ({ page }) => {
-    await test.step('bulk publish', async () => {
-      await page.getByRole('link', { name: 'Content Manager' }).click();
-      // Select all entries to publish
-      await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
-      const items = page.getByRole('gridcell', { name: 'Draft' });
-      await expect(items).toHaveCount(2);
-      const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
-      await checkbox.check();
-      const publishButton = page.getByRole('button', { name: 'Publish' }).first();
-      await publishButton.click();
+  // @critical-path #20 (cm.bulk-delete-publish-unpublish): bulk publish → unpublish → delete on N entries.
+  test(
+    'A user should be able to perform bulk actions on entries',
+    { tag: ['@extended'] },
+    async ({ page }) => {
+      await test.step('bulk publish', async () => {
+        await page.getByRole('link', { name: 'Content Manager' }).click();
+        // Select all entries to publish
+        await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
+        const items = page.getByRole('gridcell', { name: 'Draft' });
+        await expect(items).toHaveCount(2);
+        const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
+        await checkbox.check();
+        const publishButton = page.getByRole('button', { name: 'Publish' }).first();
+        await publishButton.click();
 
-      await page.waitForSelector('text=Ready to publish');
+        await page.waitForSelector('text=Ready to publish');
 
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Already published 0',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Ready to publish 2',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Waiting for action 0',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Ready to publish changes 0',
-        })
-      ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Already published 0',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Ready to publish 2',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Waiting for action 0',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Ready to publish changes 0',
+          })
+        ).toBeVisible();
 
-      const entry1 = page
-        .getByLabel('Publish entries')
-        .getByRole('row', { name: 'West Ham post match analysis' })
-        .getByLabel('Select');
-      const entry2 = page
-        .getByLabel('Publish entries')
-        .getByRole('row', { name: 'Why I prefer football over soccer' })
-        .getByLabel('Select');
+        const entry1 = page
+          .getByLabel('Publish entries')
+          .getByRole('row', { name: 'West Ham post match analysis' })
+          .getByLabel('Select');
+        const entry2 = page
+          .getByLabel('Publish entries')
+          .getByRole('row', { name: 'Why I prefer football over soccer' })
+          .getByLabel('Select');
 
-      await expect(entry1).toBeChecked();
-      await expect(entry2).toBeChecked();
+        await expect(entry1).toBeChecked();
+        await expect(entry2).toBeChecked();
 
-      const selectAll = page
-        .getByLabel('Publish entries')
-        .getByRole('checkbox', { name: 'Select all entries' });
-      await selectAll.uncheck();
+        const selectAll = page
+          .getByLabel('Publish entries')
+          .getByRole('checkbox', { name: 'Select all entries' });
+        await selectAll.uncheck();
 
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Already published 0',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Ready to publish 0',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Waiting for action 0',
-        })
-      ).toBeVisible();
-      await expect(
-        page.getByRole('gridcell', {
-          name: 'Ready to publish changes 0',
-        })
-      ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Already published 0',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Ready to publish 0',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Waiting for action 0',
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('gridcell', {
+            name: 'Ready to publish changes 0',
+          })
+        ).toBeVisible();
 
-      // Check if the publish button is disabled
-      const publishModalButton = page
-        .getByLabel('Publish entries')
-        .getByRole('button', { name: 'Publish' });
-      expect(await publishModalButton.isDisabled()).toBeTruthy();
+        // Check if the publish button is disabled
+        const publishModalButton = page
+          .getByLabel('Publish entries')
+          .getByRole('button', { name: 'Publish' });
+        expect(await publishModalButton.isDisabled()).toBeTruthy();
 
-      // Select all entries to publish
-      await selectAll.check();
-      await publishModalButton.click();
+        // Select all entries to publish
+        await selectAll.check();
+        await publishModalButton.click();
 
-      // Wait for the confirmation dialog to appear
-      await page.waitForSelector('text=Are you sure you want to publish these entries?');
+        // Wait for the confirmation dialog to appear
+        await page.waitForSelector('text=Are you sure you want to publish these entries?');
 
-      const confirmPublishButton = page
-        .getByLabel('Confirm')
-        .getByRole('button', { name: 'Publish' });
-      await confirmPublishButton.click();
+        const confirmPublishButton = page
+          .getByLabel('Confirm')
+          .getByRole('button', { name: 'Publish' });
+        await confirmPublishButton.click();
 
-      await expect(page.getByRole('gridcell', { name: 'published' })).toHaveCount(2);
-    });
+        await expect(page.getByRole('gridcell', { name: 'published' })).toHaveCount(2);
+      });
 
-    await test.step('bulk unpublish', async () => {
-      await page.getByRole('link', { name: 'Content Manager' }).click();
+      await test.step('bulk unpublish', async () => {
+        await page.getByRole('link', { name: 'Content Manager' }).click();
 
-      await expect(page).toHaveTitle('Article | Strapi');
-      await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
-      const items = page.getByRole('gridcell', { name: 'published' });
-      await expect(items).toHaveCount(2);
-      const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
+        await expect(page).toHaveTitle('Article | Strapi');
+        await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
+        const items = page.getByRole('gridcell', { name: 'published' });
+        await expect(items).toHaveCount(2);
+        const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
 
-      // Select all entries to unpublish
-      await checkbox.check();
-      const unpublish = page.getByRole('button', { name: 'Unpublish' });
-      await unpublish.click();
+        // Select all entries to unpublish
+        await checkbox.check();
+        const unpublish = page.getByRole('button', { name: 'Unpublish' });
+        await unpublish.click();
 
-      // Wait for the confirmation dialog to appear
-      await page.waitForSelector('text=Are you sure you want to unpublish these entries?');
-      const unpublishButton = page.getByLabel('Confirm').getByRole('button', { name: 'Confirm' });
-      await unpublishButton.click();
+        // Wait for the confirmation dialog to appear
+        await page.waitForSelector('text=Are you sure you want to unpublish these entries?');
+        const unpublishButton = page.getByLabel('Confirm').getByRole('button', { name: 'Confirm' });
+        await unpublishButton.click();
 
-      await expect(page.getByRole('gridcell', { name: 'draft' })).toHaveCount(2);
-    });
+        await expect(page.getByRole('gridcell', { name: 'draft' })).toHaveCount(2);
+      });
 
-    await test.step('bulk delete', async () => {
-      // Select all entries to delete
-      await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
-      const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
-      await checkbox.check();
-      const deleteButton = page.getByRole('button', { name: 'Delete', exact: true });
-      await deleteButton.click();
+      await test.step('bulk delete', async () => {
+        // Select all entries to delete
+        await expect(page.getByRole('heading', { name: 'Article' })).toBeVisible();
+        const checkbox = page.getByRole('checkbox', { name: 'Select all entries' });
+        await checkbox.check();
+        const deleteButton = page.getByRole('button', { name: 'Delete', exact: true });
+        await deleteButton.click();
 
-      // Wait for the selected entries modal to appear
-      await page.waitForSelector('text=Are you sure you want to delete these entries?');
-      const confirmDeleteButton = page
-        .getByLabel('Confirm')
-        .getByRole('button', { name: 'Confirm' });
-      await confirmDeleteButton.click();
+        // Wait for the selected entries modal to appear
+        await page.waitForSelector('text=Are you sure you want to delete these entries?');
+        const confirmDeleteButton = page
+          .getByLabel('Confirm')
+          .getByRole('button', { name: 'Confirm' });
+        await confirmDeleteButton.click();
 
-      await expect(page.getByText('No content found')).toBeVisible();
-    });
-  });
+        await expect(page.getByText('No content found')).toBeVisible();
+      });
+    }
+  );
 });


### PR DESCRIPTION
## What
Tags the existing bulk-actions test `@extended` for **Phase 2 path #20 — `cm.bulk-delete-publish-unpublish`**.

## Why no new test
Path #20 is **already fully covered** by `listview.spec.ts` → *"A user should be able to perform bulk actions on entries"*, which exercises, on N entries with their confirmation modals:
- **bulk publish** (select all → Publish entries modal → Confirm → assert published),
- **bulk unpublish** (select all → Unpublish → confirm → assert draft),
- **bulk delete** (select all → Delete → confirm → assert "No content found").

Rather than duplicate it, this PR adds `{ tag: ['@extended'] }` so it joins the nightly suite — consistent with Phase 0's "tag what already exists" approach. (Prettier reflowed the test wrapper to multi-line, which reindents the test body; no logic changed.)

Verified passing on chromium, firefox, and webkit; `yarn test:e2e --grep @extended` selects it.

> Note: the matrix mentions an "audit trail assertion" for #20 — audit logs are an EE feature and out of scope for this CE-level nightly smoke; flag if you want a separate EE-gated test.

## Part of
E2E coverage focus — Phase 2 (@extended). https://app.notion.com/p/strapi/E2E-coverage-focus-3738f35980748111a75bcc596272f8d7


