### PR TITLE
test(e2e): add extended advanced-filters UI/API parity test (#21)

### DIFF
--- a/tests/e2e/tests/content-manager/advanced-filters.spec.ts
+++ b/tests/e2e/tests/content-manager/advanced-filters.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { login } from '../../../utils/login';
+import { navToHeader } from '../../../utils/shared';
+import { resetDatabaseAndImportDataFromPath } from '../../../utils/dts-import';
+import { ADMIN_EMAIL_ADDRESS, ADMIN_PASSWORD } from '../../constants';
+
+// Critical path #21 — cm.advanced-filters (@extended)
+//
+// For a representative set of operators on a text field, assert the list-view filter UI and a direct
+// API query with the equivalent filter return the same set of rows.
+//
+// Uses Author: non-localized (no locale confound) with three distinct seeded names — Ted Lasso,
+// Coach Beard, Led Tasso. The API side uses the admin content-manager endpoint (the same data source
+// the list view reads), so the comparison validates that the filter UI builds a query whose result
+// set matches the API's.
+const AUTHOR_UID = 'api::author.author';
+
+const cases = [
+  {
+    operatorLabel: 'contains',
+    query: 'filters[name][$contains]=Lasso',
+    value: 'Lasso',
+    expected: ['Ted Lasso'],
+  },
+  {
+    operatorLabel: 'is',
+    query: `filters[name][$eq]=${encodeURIComponent('Coach Beard')}`,
+    value: 'Coach Beard',
+    expected: ['Coach Beard'],
+  },
+  {
+    operatorLabel: 'is not',
+    query: `filters[name][$ne]=${encodeURIComponent('Ted Lasso')}`,
+    value: 'Ted Lasso',
+    expected: ['Coach Beard', 'Led Tasso'],
+  },
+] as const;
+
+const ALL_AUTHORS = ['Ted Lasso', 'Coach Beard', 'Led Tasso'];
+
+test.describe('Content Manager - advanced filters', { tag: ['@extended'] }, () => {
+  test.describe.configure({ timeout: 300000 });
+
+  test.beforeEach(async ({ page }) => {
+    await resetDatabaseAndImportDataFromPath('with-admin');
+    await page.goto('/admin');
+    await login({ page });
+  });
+
+  const applyFilter = async (
+    page: Page,
+    fieldLabel: string,
+    operatorLabel: string,
+    value: string
+  ) => {
+    await page.getByRole('button', { name: 'Filters' }).click();
+    await page.getByRole('combobox', { name: 'Select field' }).click();
+    await page.getByRole('option', { name: fieldLabel, exact: true }).click();
+    await page.getByRole('combobox', { name: 'Select filter' }).click();
+    await page.getByRole('option', { name: operatorLabel, exact: true }).click();
+    await page.getByRole('textbox', { name: fieldLabel }).fill(value);
+    await page.getByRole('button', { name: 'Add filter' }).click();
+  };
+
+  const apiFilterNames = async (
+    request: APIRequestContext,
+    headers: Record<string, string>,
+    query: string
+  ) => {
+    const res = await request.get(`/content-manager/collection-types/${AUTHOR_UID}?${query}`, {
+      headers,
+    });
+    expect(res.ok(), `admin CM query failed: ${query}`).toBeTruthy();
+    return (await res.json()).results.map((r: any) => r.name).sort();
+  };
+
+  test('list-view filters and the API return the same rows for each operator', async ({ page }) => {
+    const adminLogin = await page.request.post('/admin/login', {
+      data: { email: ADMIN_EMAIL_ADDRESS, password: ADMIN_PASSWORD },
+    });
+    const adminToken = (await adminLogin.json()).data?.token;
+    expect(adminToken, 'admin API login failed').toBeTruthy();
+    const adminHeaders = { Authorization: `Bearer ${adminToken}` };
+
+    // Sanity: all three authors are present before filtering.
+    await navToHeader(page, ['Content Manager', 'Author'], 'Author');
+    for (const name of ALL_AUTHORS) {
+      await expect(page.getByRole('gridcell', { name, exact: true })).toBeVisible();
+    }
+
+    for (const { operatorLabel, query, value, expected } of cases) {
+      await test.step(`name ${operatorLabel} "${value}"`, async () => {
+        await applyFilter(page, 'name', operatorLabel, value);
+
+        // UI: exactly the expected rows are shown.
+        for (const name of ALL_AUTHORS) {
+          const cell = page.getByRole('gridcell', { name, exact: true });
+          if (expected.includes(name)) {
+            await expect(cell, `${name} should be visible`).toBeVisible();
+          } else {
+            await expect(cell, `${name} should be filtered out`).toHaveCount(0);
+          }
+        }
+
+        // API: the equivalent query returns the same set of rows.
+        const apiNames = await apiFilterNames(page.request, adminHeaders, query);
+        expect(apiNames, `API rows for "${operatorLabel}"`).toEqual([...expected].sort());
+
+        // Remove the filter chip so the next case starts from an unfiltered list.
+        // (The CM persists the list query, so navigating wouldn't clear it.)
+        await page.getByRole('button', { name: `name ${operatorLabel} ${value}` }).click();
+        await expect(page.getByRole('gridcell', { name: 'Ted Lasso', exact: true })).toBeVisible();
+      });
+    }
+  });
+});

--- a/tests/e2e/tests/content-manager/advanced-filters.spec.ts
+++ b/tests/e2e/tests/content-manager/advanced-filters.spec.ts
@@ -92,6 +92,10 @@ test.describe('Content Manager - advanced filters', { tag: ['@extended'] }, () =
       await test.step(`name ${operatorLabel} "${value}"`, async () => {
         await applyFilter(page, 'name', operatorLabel, value);
 
+        // The filter is applied — its chip is shown.
+        const chip = page.getByRole('button', { name: `name ${operatorLabel} ${value}` });
+        await expect(chip).toBeVisible();
+
         // UI: exactly the expected rows are shown.
         for (const name of ALL_AUTHORS) {
           const cell = page.getByRole('gridcell', { name, exact: true });
@@ -108,7 +112,8 @@ test.describe('Content Manager - advanced filters', { tag: ['@extended'] }, () =
 
         // Remove the filter chip so the next case starts from an unfiltered list.
         // (The CM persists the list query, so navigating wouldn't clear it.)
-        await page.getByRole('button', { name: `name ${operatorLabel} ${value}` }).click();
+        await chip.click();
+        await expect(chip).toHaveCount(0);
         await expect(page.getByRole('gridcell', { name: 'Ted Lasso', exact: true })).toBeVisible();
       });
     }


### PR DESCRIPTION
## What
Adds an `@extended` E2E test for **Phase 2 path #21 — `cm.advanced-filters`**: "each operator × field type, UI and API return the same rows."

## What the test does
For a text field (`name`) across three operators — **contains**, **is** (`$eq`), **is not** (`$ne`) — it:
1. Applies the filter through the list-view Filters UI.
2. Asserts exactly the expected rows render in the list.
3. Asserts a direct admin content-manager query with the equivalent filter returns the **same set of rows**.
4. Removes the filter chip before the next case.

## Notes
- Uses **Author**: non-localized (so there's no locale confound — Article's en/fr titles both contain "West"/"soccer") with three distinct seeded names: Ted Lasso, Coach Beard, Led Tasso.
- The API side queries the admin content-manager endpoint (the same data source the list view reads), so the comparison validates that the filter UI builds a query whose result set matches the API's.
- Discovered while writing: the CM **persists the list-view query** (sessionStorage), so navigating to the bare list URL does **not** clear an active filter — the test removes the filter chip between cases instead.

Verified passing on chromium, firefox, and webkit.

## Part of
E2E coverage focus — Phase 2 (@extended). https://app.notion.com/p/strapi/E2E-coverage-focus-3738f35980748111a75bcc596272f8d7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
