### PR TITLE
feat(server): built-in Node.js cluster mode with primary-worker deduplication

### DIFF
--- a/packages/core/core/src/Strapi.ts
+++ b/packages/core/core/src/Strapi.ts
@@ -18,6 +18,8 @@ import createStrapiFs from './services/fs';
 import createEventHub from './services/event-hub';
 import { createServer } from './services/server';
 import { createReloader } from './services/reloader';
+import { createClusterService, isPrimary } from './services/cluster';
+
 
 import { providers } from './providers';
 import createEntityService from './services/entity-service';
@@ -299,6 +301,7 @@ class Strapi extends Container implements Core.Strapi {
         );
       })
       .add('reload', () => createReloader(this))
+      this.add('cluster', () => createClusterService(this));
       .add('content-source-maps', () => createContentSourceMapsService(this));
   }
 

--- a/packages/core/core/src/configuration/index.ts
+++ b/packages/core/core/src/configuration/index.ts
@@ -23,6 +23,10 @@ const defaultConfig = {
     host: process.env.HOST || os.hostname() || 'localhost',
     port: Number(process.env.PORT) || 1337,
     proxy: false,
+    cluster: {
+            enabled: false,
+            workers: 0,  // 0 = use os.cpus().length automatically
+              },
     cron: { enabled: false },
     admin: { autoOpen: false },
     dirs: { public: './public' },

--- a/packages/core/core/src/services/cron.ts
+++ b/packages/core/core/src/services/cron.ts
@@ -1,6 +1,8 @@
 import { Job, Spec } from 'node-schedule';
 import { isFunction } from 'lodash/fp';
 import type { Core } from '@strapi/types';
+import { isPrimary } from './cluster';
+
 
 interface JobSpec {
   job: Job;
@@ -79,8 +81,16 @@ const createCronService = () => {
     },
 
     start() {
-      jobsSpecs.forEach(({ job, options }) => job.schedule(options));
+      if (!isPrimary()) {
+        strapi.log.info(
+          '[cron] Worker process — cron jobs disabled on non-primary instances'
+        );
+        return this;
+      }
       running = true;
+      for (const { job, options } of jobsSpecs) {
+        job.schedule(options);
+      }
       return this;
     },
 

--- a/packages/core/core/src/services/webhook-runner.ts
+++ b/packages/core/core/src/services/webhook-runner.ts
@@ -1,7 +1,7 @@
 /**
  * The event hub is Strapi's event control center.
  */
-
+import { isPrimary } from './cluster';
 import createdDebugger from 'debug';
 import _ from 'lodash';
 import type { Logger } from '@strapi/logger';
@@ -96,6 +96,7 @@ class WebhookRunner {
 
     this.listeners.set(event, listen);
     this.eventHub.on(event, listen);
+   
   }
 
   async executeListener({ event, info }: Event) {
@@ -149,19 +150,24 @@ class WebhookRunner {
       });
   }
 
-  add(webhook: Webhook) {
-    debug(`Registering webhook '${webhook.id}'`);
-    const { events } = webhook;
+add(webhook: Webhook) {
+  debug(`Registering webhook '${webhook.id}'`);
+  const { events } = webhook;
 
-    events.forEach((event) => {
-      if (this.webhooksMap.has(event)) {
-        this.webhooksMap.get(event)?.push(webhook);
-      } else {
-        this.webhooksMap.set(event, [webhook]);
-        this.createListener(event);
-      }
-    });
+  if (!isPrimary()) {
+    debug(`Skipping webhook registration on non-primary worker`);
+    return;
   }
+
+  events.forEach((event) => {
+    if (this.webhooksMap.has(event)) {
+      this.webhooksMap.get(event)?.push(webhook);
+    } else {
+      this.webhooksMap.set(event, [webhook]);
+      this.createListener(event);
+    }
+  });
+}
 
   update(webhook: Webhook) {
     debug(`Refreshing webhook '${webhook.id}'`);


### PR DESCRIPTION
## What does it do?
Adds opt-in built-in Node.js cluster support to Strapi v5. When
`server.cluster.enabled: true` is set in config, Strapi forks N worker
processes (default: one per CPU core). Only the primary process runs
cron jobs and webhook delivery. Workers handle all HTTP traffic,
load-balanced by the OS.

## Why is it needed?
`server/index.ts` mounts the admin panel, content API, cron jobs,
webhook runner, and uploads all on one Koa app in one OS process.
Running multiple external instances (pm2, Kubernetes replicas) causes
cron tasks to fire on every instance simultaneously and webhooks to
be delivered multiple times — producing duplicate emails, duplicate
webhook calls, and race conditions with no built-in solution.

## Changes
- `packages/core/core/src/configuration/index.ts` — added
  `server.cluster` defaults: `{ enabled: false, workers: 0 }`.
  `workers: 0` means use `os.cpus().length` automatically.

- `packages/core/core/src/services/cluster.ts` — new service.
  When `cluster.enabled` is true, the primary process forks N workers
  and auto-restarts any that crash. Exports `isPrimary()` helper that
  checks both `cluster.isPrimary` (built-in fork) and the
  `STRAPI_CLUSTER_PRIMARY` env variable (external pm2/K8s instances).

- `packages/core/core/src/Strapi.ts` — added import of
  `createClusterService` and `isPrimary` from `./services/cluster`,
  and registered the cluster service via
  `this.add('cluster', () => createClusterService(this))` inside
  `registerInternalServices()`, consistent with all other services.

- `packages/core/core/src/services/cron.ts` — added `isPrimary()`
  guard at the top of the `start()` method. Non-primary workers log
  a message and return early without scheduling any jobs.

- `packages/core/core/src/services/webhook-runner.ts` — added
  `isPrimary()` guard at the top of the `add()` method. Non-primary
  workers return early before `createListener()` is called, which
  prevents `this.eventHub.on(event, listen)` from ever registering
  on worker processes.

## Breaking changes
None. `server.cluster.enabled` defaults to `false`. All existing
single-process deployments are completely unaffected.

## Related
Related community feedback:
https://feedback.strapi.io/other/p/featserver-built-in-nodejs-cluster-mode-all-services-share-one-process-impossibl
Related: #3976 (cluster mode question, closed 2019)
Related: #15634 (cron race condition, open/stale, no PR merged)

## Test plan
1. Set `server.cluster.enabled: true`, `server.cluster.workers: 2`
   in `config/server.ts`
2. Start Strapi — confirm 2 worker processes appear in `ps aux`
3. Configure a cron task — confirm it fires only once per schedule
   across both workers
4. Kill one worker process manually — confirm it restarts automatically
5. Set `server.cluster.enabled: false` — confirm behaviour is
   identical to the current single-process mode

---
Fixes CPR-415