### PR TITLE
fix: avoid buffering large uploads for MIME detection

### DIFF
--- a/packages/core/upload/server/src/utils/__tests__/mime-validation.test.ts
+++ b/packages/core/upload/server/src/utils/__tests__/mime-validation.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { fileTypeFromBuffer } from 'file-type';
 import {
   detectMimeType,
@@ -15,8 +15,24 @@ jest.mock('file-type', () => ({
   fileTypeFromBuffer: jest.fn(),
 }));
 
-const mockReadFile = jest.mocked(readFile);
+const mockOpen = jest.mocked(open);
 const mockFileTypeFromBuffer = jest.mocked(fileTypeFromBuffer);
+
+const mockFileRead = (content: Buffer | string) => {
+  const source = Buffer.isBuffer(content) ? content : Buffer.from(content);
+  const fileHandle = {
+    read: jest.fn(async (buffer: Buffer, offset: number, length: number) => {
+      const bytesRead = source.copy(buffer, offset, 0, Math.min(source.length, length));
+
+      return { bytesRead, buffer };
+    }),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+
+  mockOpen.mockResolvedValue(fileHandle as any);
+
+  return fileHandle;
+};
 
 const mockStrapi = {
   log: {
@@ -39,7 +55,7 @@ describe('mime-validation', () => {
 
   describe('detectMimeType', () => {
     it('should throw error when file reading fails', async () => {
-      mockReadFile.mockRejectedValue(new Error('File not found'));
+      mockOpen.mockRejectedValue(new Error('File not found'));
 
       await expect(detectMimeType({ path: '/nonexistent/file.jpg' })).rejects.toThrow(
         'Failed to read file: File not found'
@@ -48,7 +64,7 @@ describe('mime-validation', () => {
 
     it('should return undefined when MIME type detection returns no result', async () => {
       const mockBuffer = Buffer.from('unknown data');
-      mockReadFile.mockResolvedValue(mockBuffer);
+      mockFileRead(mockBuffer);
       mockFileTypeFromBuffer.mockResolvedValue(undefined);
 
       const result = await detectMimeType({ path: '/path/to/unknown.file' });
@@ -56,14 +72,28 @@ describe('mime-validation', () => {
       expect(result).toBeUndefined();
     });
 
+    it('should only read the first bytes needed for MIME detection', async () => {
+      const fileHandle = mockFileRead(Buffer.alloc(10_000, 'a'));
+      mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
+
+      const result = await detectMimeType({ path: '/path/to/large-video.mp4' });
+
+      expect(result).toBe('image/jpeg');
+      expect(mockOpen).toHaveBeenCalledWith('/path/to/large-video.mp4', 'r');
+      expect(fileHandle.read).toHaveBeenCalledWith(expect.any(Buffer), 0, 4100, 0);
+      expect(fileHandle.close).toHaveBeenCalledTimes(1);
+      expect(mockFileTypeFromBuffer.mock.calls[0][0]).toHaveLength(4100);
+    });
+
     it('should throw error when MIME type detection fails', async () => {
       const mockBuffer = Buffer.from('corrupted data');
-      mockReadFile.mockResolvedValue(mockBuffer);
+      const fileHandle = mockFileRead(mockBuffer);
       mockFileTypeFromBuffer.mockRejectedValue(new Error('Invalid file format'));
 
       await expect(detectMimeType({ path: '/path/to/corrupted.file' })).rejects.toThrow(
         'Failed to detect MIME type: Invalid file format'
       );
+      expect(fileHandle.close).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -197,7 +227,7 @@ describe('mime-validation', () => {
     });
 
     it('when no config, runs detection and returns detectedMime so stored file uses detected type when declared is octet-stream', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake docx content'));
+      mockFileRead(Buffer.from('fake docx content'));
       mockFileTypeFromBuffer.mockResolvedValue({
         mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         ext: 'docx',
@@ -217,12 +247,12 @@ describe('mime-validation', () => {
       expect(result.detectedMime).toBe(
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       );
-      expect(mockReadFile).toHaveBeenCalled();
+      expect(mockOpen).toHaveBeenCalled();
       expect(mockFileTypeFromBuffer).toHaveBeenCalled();
     });
 
     it('when no config and detection returns nothing, uses extension so stored mime is not octet-stream', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('unknown binary'));
+      mockFileRead(Buffer.from('unknown binary'));
       mockFileTypeFromBuffer.mockResolvedValue(undefined);
 
       const fileWithOctetStream = {
@@ -240,7 +270,7 @@ describe('mime-validation', () => {
     });
 
     it('should validate MIME type successfully', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake image'));
+      mockFileRead(Buffer.from('fake image'));
       mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
 
       const config: SecurityConfig = {
@@ -253,7 +283,7 @@ describe('mime-validation', () => {
     });
 
     it('should reject disallowed MIME type', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake image'));
+      mockFileRead(Buffer.from('fake image'));
       mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
 
       const config: SecurityConfig = {
@@ -272,7 +302,7 @@ describe('mime-validation', () => {
     });
 
     it('should reject all files when allowedTypes is explicit empty array', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake image'));
+      mockFileRead(Buffer.from('fake image'));
       mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
 
       const config: SecurityConfig = { allowedTypes: [] };
@@ -288,7 +318,7 @@ describe('mime-validation', () => {
     });
 
     it('should reject undetectable file when allowedTypes is explicit empty array', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('binary data'));
+      mockFileRead(Buffer.from('binary data'));
       mockFileTypeFromBuffer.mockResolvedValue(undefined);
 
       const fileWithOctetStream = {
@@ -313,7 +343,7 @@ describe('mime-validation', () => {
       const result = await validateFile(fileWithoutPath, config, mockStrapi);
 
       expect(result.isValid).toBe(true);
-      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(mockOpen).not.toHaveBeenCalled();
     });
 
     it('should extract file info from various file object formats', async () => {
@@ -356,7 +386,7 @@ describe('mime-validation', () => {
     });
 
     it('should handle single file', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake image'));
+      mockFileRead(Buffer.from('fake image'));
       mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
 
       const results = await validateFiles(mockFile1, mockStrapi);
@@ -366,7 +396,7 @@ describe('mime-validation', () => {
     });
 
     it('should handle array of files', async () => {
-      mockReadFile.mockResolvedValue(Buffer.from('fake data'));
+      mockFileRead(Buffer.from('fake data'));
       mockFileTypeFromBuffer
         .mockResolvedValueOnce({ mime: 'image/jpeg', ext: 'jpg' })
         .mockResolvedValueOnce({ mime: 'application/pdf', ext: 'pdf' });
@@ -384,7 +414,7 @@ describe('mime-validation', () => {
     });
 
     it('should handle validation errors gracefully', async () => {
-      mockReadFile.mockRejectedValue(new Error('Unexpected error'));
+      mockOpen.mockRejectedValue(new Error('Unexpected error'));
       mockStrapi.config.get.mockReturnValue({
         allowedTypes: ['application/pdf'],
       });
@@ -411,7 +441,7 @@ describe('mime-validation', () => {
 
     it('when no config, still runs detection and returns detectedMime so enforceUploadSecurity can set detectedMimeType for octet-stream', async () => {
       mockStrapi.config.get.mockReturnValue({});
-      mockReadFile.mockResolvedValue(Buffer.from('fake docx'));
+      mockFileRead(Buffer.from('fake docx'));
       mockFileTypeFromBuffer.mockResolvedValue({
         mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         ext: 'docx',
@@ -482,7 +512,7 @@ describe('mime-validation', () => {
       mockStrapi.config.get.mockReturnValue({
         allowedTypes: ['image/jpeg'],
       });
-      mockReadFile.mockResolvedValue(Buffer.from('fake image'));
+      mockFileRead(Buffer.from('fake image'));
       mockFileTypeFromBuffer.mockResolvedValue({ mime: 'image/jpeg', ext: 'jpg' });
     });
 
@@ -498,7 +528,7 @@ describe('mime-validation', () => {
       mockStrapi.config.get.mockReturnValue({
         allowedTypes: ['application/*'],
       });
-      mockReadFile.mockResolvedValue(Buffer.from('fake docx'));
+      mockFileRead(Buffer.from('fake docx'));
       mockFileTypeFromBuffer.mockResolvedValue({
         mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         ext: 'docx',
@@ -522,7 +552,7 @@ describe('mime-validation', () => {
 
     it('when no config, enriches file with detectedMimeType when declared is application/octet-stream so stored mime is detected type', async () => {
       mockStrapi.config.get.mockReturnValue({});
-      mockReadFile.mockResolvedValue(Buffer.from('fake docx'));
+      mockFileRead(Buffer.from('fake docx'));
       mockFileTypeFromBuffer.mockResolvedValue({
         mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         ext: 'docx',
@@ -546,7 +576,7 @@ describe('mime-validation', () => {
 
     it('when no config and detection fails (undefined), uses extension so stored mime is not octet-stream', async () => {
       mockStrapi.config.get.mockReturnValue({});
-      mockReadFile.mockResolvedValue(Buffer.from('content'));
+      mockFileRead(Buffer.from('content'));
       mockFileTypeFromBuffer.mockResolvedValue(undefined);
 
       const fileWithExtOnly = {

--- a/packages/core/upload/server/src/utils/mime-validation.ts
+++ b/packages/core/upload/server/src/utils/mime-validation.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { lookup } from 'mime-types';
 import type { Core } from '@strapi/types';
@@ -27,8 +27,16 @@ type ErrorDetail = {
 };
 
 async function readFileChunk(filePath: string, chunkSize: number = 4100): Promise<Buffer> {
-  const buffer = await readFile(filePath);
-  return buffer.length > chunkSize ? buffer.subarray(0, chunkSize) : buffer;
+  const file = await open(filePath, 'r');
+
+  try {
+    const buffer = Buffer.alloc(chunkSize);
+    const { bytesRead } = await file.read(buffer, 0, chunkSize, 0);
+
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await file.close();
+  }
 }
 
 export async function detectMimeType(file: any): Promise<string | undefined> {


### PR DESCRIPTION
### What does it do?

Reads only the first 4100 bytes needed for upload MIME detection when a file path is available, instead of loading the full temporary file into memory before slicing it. The file handle is closed in a `finally` block so failed reads do not leak descriptors.

It also updates the MIME validation tests to mock the file-handle read path and adds coverage that large files are only read through the detection window.

### Why is it needed?

Large uploads can exceed Node's buffer limits when MIME detection calls `readFile()` on the complete file. MIME probing only needs the header bytes, so reading the whole payload can fail before validation has a chance to complete.

### How to test it?

- `corepack yarn install --immutable`
- `corepack yarn workspace @strapi/utils build:code`
- `corepack yarn workspace @strapi/upload test:unit server/src/utils/__tests__/mime-validation.test.ts --runInBand`
- `corepack yarn workspace @strapi/upload build:code`
- `corepack yarn eslint packages/core/upload/server/src/utils/mime-validation.ts packages/core/upload/server/src/utils/__tests__/mime-validation.test.ts`
- `git diff --check`

Note: `corepack yarn workspace @strapi/upload test:ts:back` currently requires additional internal declaration packages to be built first; in this fresh checkout it stops on existing workspace type-resolution errors before reaching this change.

### Related issue(s)/PR(s)

Fixes #26674