### PR TITLE
Add support for `initiallySelectedAssets` on the MediaLibraryDialog

### DIFF
--- a/packages/core/upload/admin/src/components/MediaLibraryDialog/MediaLibraryDialog.tsx
+++ b/packages/core/upload/admin/src/components/MediaLibraryDialog/MediaLibraryDialog.tsx
@@ -16,6 +16,7 @@ import type { AllowedTypes } from '../AssetCard/AssetCard';
 export interface MediaLibraryDialogProps {
   allowedTypes?: AllowedTypes[];
   multiple?: boolean;
+  initiallySelectedAssets?: File[];
   onClose: () => void;
   onSelectAssets: (selectedAssets: File[]) => void;
 }
@@ -25,6 +26,7 @@ export const MediaLibraryDialog = ({
   onSelectAssets,
   allowedTypes = ['files', 'images', 'videos', 'audios'],
   multiple = true,
+  initiallySelectedAssets = [],
 }: MediaLibraryDialogProps) => {
   const [step, setStep] = React.useState(STEPS.AssetSelect);
   const [folderId, setFolderId] = React.useState<number | null>(null);
@@ -38,6 +40,7 @@ export const MediaLibraryDialog = ({
           open
           onClose={onClose}
           onValidate={onSelectAssets}
+          initiallySelectedAssets={initiallySelectedAssets}
           onAddAsset={() => setStep(STEPS.AssetUpload)}
           onAddFolder={() => setStep(STEPS.FolderCreate)}
           onChangeFolder={(folderId) => setFolderId(folderId)}


### PR DESCRIPTION
### What does it do?

Add support for setting `initiallySelectedAssets` on the MediaLibraryDialog, this make developing custom components with upload capabilities much easier. 

### Why is it needed?

Custom upload components currently don't ever show selected items initially breaking user flows.

### How to test it?

Make a custom input and grab the media-library from useStrapiApp components.

```js
const components = useStrapiApp('MyCustomComponent', (state) => state.components);
const MediaLibraryDialog = components['media-library'];
```

This component can now take an array of assets to show what is already selected on initial dialog render.

### Related issue(s)/PR(s)

N/A