### PR TITLE
fix(admin): admin users logged out mid-session by access-token expiry timer

### DIFF
--- a/packages/core/admin/admin/src/features/Auth.tsx
+++ b/packages/core/admin/admin/src/features/Auth.tsx
@@ -8,7 +8,13 @@ import { useTypedDispatch, useTypedSelector } from '../core/store/hooks';
 import { useStrapiApp } from '../features/StrapiApp';
 import { useIdleSessionLogout } from '../hooks/useIdleSessionLogout';
 import { useQueryParams } from '../hooks/useQueryParams';
-import { login as loginAction, logout as logoutAction, setLocale, setToken } from '../reducer';
+import {
+  getStoredToken,
+  login as loginAction,
+  logout as logoutAction,
+  setLocale,
+  setToken,
+} from '../reducer';
 import { adminApi } from '../services/api';
 import {
   useGetMeQuery,
@@ -19,7 +25,11 @@ import {
 } from '../services/auth';
 import { normalizeAdminLocale } from '../translations/normalizeAdminLocale';
 import { getOrCreateDeviceId } from '../utils/deviceId';
-import { setOnSessionExpired, setOnTokenUpdate } from '../utils/getFetchClient';
+import {
+  attemptTokenRefresh,
+  setOnSessionExpired,
+  setOnTokenUpdate,
+} from '../utils/getFetchClient';
 
 import type {
   Permission as PermissionContract,
@@ -141,6 +151,66 @@ const AuthProvider = ({
     navigate('/auth/login');
   }, [dispatch, navigate]);
 
+  /**
+   * Clear *only this tab's* session and redirect to login, without removing the
+   * shared `isLoggedIn`/`jwtToken` storage keys. Unlike `clearStateAndLogout`,
+   * this does not dispatch `logoutAction`, so it does not fire the cross-tab
+   * `storage` event that logs every tab out. Used by the speculative idle timer,
+   * which fires per-tab at the access token's `exp`: an idle tab must never tear
+   * down a session that another tab is still actively using. A genuine logout
+   * (user-initiated, or a server-confirmed 401 via `setOnSessionExpired`) still
+   * goes through `clearStateAndLogout` and broadcasts to all tabs.
+   */
+  const clearLocalSessionAndRedirect = React.useCallback(() => {
+    dispatch(adminApi.util.resetApiState());
+    dispatch(setToken(null));
+    navigate('/auth/login');
+  }, [dispatch, navigate]);
+
+  const resyncToken = React.useCallback(
+    (newToken: string) => {
+      dispatch(setToken(newToken));
+    },
+    [dispatch]
+  );
+
+  /**
+   * Track the timestamp of the user's last interaction. This is the activity
+   * signal `useIdleSessionLogout` uses to tell an active user (silently renew
+   * their session) apart from a genuinely idle one (log out). Successful API
+   * calls don't refresh the short-lived access token on their own, so without
+   * this an actively-working user is logged out the moment the token expires.
+   */
+  const lastActivityRef = React.useRef(Date.now());
+  React.useEffect(() => {
+    const markActivity = () => {
+      lastActivityRef.current = Date.now();
+    };
+    const events = ['pointerdown', 'keydown', 'click', 'scroll', 'touchstart'];
+    events.forEach((event) =>
+      window.addEventListener(event, markActivity, { passive: true, capture: true })
+    );
+
+    return () => {
+      events.forEach((event) => window.removeEventListener(event, markActivity, { capture: true }));
+    };
+  }, []);
+  const getLastActivityAt = React.useCallback(() => lastActivityRef.current, []);
+
+  /**
+   * Silently rotate the refresh token and mint a new access token. Returns
+   * `true` on success (the resulting `setToken` re-arms the idle timer) and
+   * `false` when the server rejects it (session genuinely over).
+   */
+  const renewSession = React.useCallback(async () => {
+    try {
+      await attemptTokenRefresh();
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
   React.useEffect(() => {
     if (user) {
       if (user.preferedLanguage) {
@@ -180,13 +250,21 @@ const AuthProvider = ({
   }, [clearStateAndLogout]);
 
   /**
-   * Proactive idle-session detection. See `useIdleSessionLogout` for the full
-   * rationale and the UX trade-off (a user actively typing in a form with no
-   * outgoing API calls will still be logged out at `exp`).
+   * Session lifecycle at access-token expiry. The timer fires per-tab; the hook
+   * then either (1) re-syncs from a token another tab refreshed, (2) silently
+   * renews when the user has been active, or (3) logs out. Idle logout is local
+   * so an idle tab can't force-logout an actively-used one; a server-confirmed
+   * dead session (renewal rejected) broadcasts globally. See
+   * `useIdleSessionLogout` for the full rationale.
    */
   useIdleSessionLogout({
     token,
-    onExpired: clearStateAndLogout,
+    onExpired: clearLocalSessionAndRedirect,
+    onSessionDead: clearStateAndLogout,
+    getStoredToken,
+    onResync: resyncToken,
+    getLastActivityAt,
+    renewSession,
     disabled: _disableRenewToken,
   });
 

--- a/packages/core/admin/admin/src/hooks/tests/useIdleSessionLogout.test.ts
+++ b/packages/core/admin/admin/src/hooks/tests/useIdleSessionLogout.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useIdleSessionLogout, SESSION_EXPIRY_BUFFER_MS } from '../useIdleSessionLogout';
+import {
+  useIdleSessionLogout,
+  SESSION_EXPIRY_BUFFER_MS,
+  SESSION_RENEW_MARGIN_MS,
+} from '../useIdleSessionLogout';
 
 /**
  * Build a JWT-shaped string whose payload encodes `{ exp: <expSeconds> }`.
@@ -15,6 +19,9 @@ const buildJwt = (expSeconds: number): string => {
 
 const ACCESS_TOKEN_LIFESPAN_MS = 30_000;
 const NOW_MS = 1_700_000_000_000;
+// When the renew timer (which fires ahead of expiry) runs. Active tabs renew /
+// idle tabs re-sync at this point, before the logout timer.
+const RENEW_AT_MS = ACCESS_TOKEN_LIFESPAN_MS - SESSION_RENEW_MARGIN_MS;
 
 describe('useIdleSessionLogout', () => {
   beforeEach(() => {
@@ -150,6 +157,171 @@ describe('useIdleSessionLogout', () => {
       jest.advanceTimersByTime(60_000);
     });
 
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('re-syncs instead of expiring when another tab refreshed the shared token', () => {
+    const onExpired = jest.fn();
+    const onResync = jest.fn();
+
+    // In-memory token expires at NOW + 30s.
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    // Another tab refreshed: the shared token in storage has a later exp.
+    const storedToken = buildJwt((NOW_MS + 5 * ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    const getStoredToken = jest.fn(() => storedToken);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired, getStoredToken, onResync }));
+
+    // Advance to the renew timer (ahead of expiry). The idle tab spots the
+    // active sibling's fresher token and adopts it. In a real app the resulting
+    // setToken re-renders and cancels the logout timer; here we stop before it.
+    act(() => {
+      jest.advanceTimersByTime(RENEW_AT_MS + 1);
+    });
+
+    expect(onResync).toHaveBeenCalledTimes(1);
+    expect(onResync).toHaveBeenCalledWith(storedToken);
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('expires when the stored token is not newer than the in-memory token', () => {
+    const onExpired = jest.fn();
+    const onResync = jest.fn();
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    // No tab refreshed: storage holds the same (now-expired) token.
+    const getStoredToken = jest.fn(() => token);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired, getStoredToken, onResync }));
+
+    act(() => {
+      jest.advanceTimersByTime(ACCESS_TOKEN_LIFESPAN_MS + SESSION_EXPIRY_BUFFER_MS);
+    });
+
+    expect(onResync).not.toHaveBeenCalled();
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires when storage has a stale token with an earlier exp', () => {
+    const onExpired = jest.fn();
+    const onResync = jest.fn();
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    // Storage somehow holds an older token (e.g. a stale write); never re-sync
+    // to an earlier exp.
+    const staleToken = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS / 2) / 1000);
+    const getStoredToken = jest.fn(() => staleToken);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired, getStoredToken, onResync }));
+
+    act(() => {
+      jest.advanceTimersByTime(ACCESS_TOKEN_LIFESPAN_MS + SESSION_EXPIRY_BUFFER_MS);
+    });
+
+    expect(onResync).not.toHaveBeenCalled();
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires (legacy behavior) when no cross-tab callbacks are provided', () => {
+    const onExpired = jest.fn();
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired }));
+
+    act(() => {
+      jest.advanceTimersByTime(ACCESS_TOKEN_LIFESPAN_MS + SESSION_EXPIRY_BUFFER_MS);
+    });
+
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('silently renews instead of logging out when the user was active', async () => {
+    const onExpired = jest.fn();
+    const renewSession = jest.fn().mockResolvedValue(true);
+    // Activity recorded after the timer is armed (i.e. during the token's life).
+    const getLastActivityAt = jest.fn(() => NOW_MS + 10_000);
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired, getLastActivityAt, renewSession }));
+
+    // Renewal happens ahead of expiry; stop before the logout timer.
+    await act(async () => {
+      jest.advanceTimersByTime(RENEW_AT_MS + 1);
+    });
+
+    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('logs out (idle) when there was no activity during the token lifetime', async () => {
+    const onExpired = jest.fn();
+    const renewSession = jest.fn().mockResolvedValue(true);
+    // Last activity predates the arm time → idle.
+    const getLastActivityAt = jest.fn(() => NOW_MS - 5_000);
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+
+    renderHook(() => useIdleSessionLogout({ token, onExpired, getLastActivityAt, renewSession }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(ACCESS_TOKEN_LIFESPAN_MS + SESSION_EXPIRY_BUFFER_MS);
+    });
+
+    expect(renewSession).not.toHaveBeenCalled();
+    expect(onExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSessionDead (global) when an active renewal is rejected by the server', async () => {
+    const onExpired = jest.fn();
+    const onSessionDead = jest.fn();
+    const renewSession = jest.fn().mockResolvedValue(false);
+    const getLastActivityAt = jest.fn(() => NOW_MS + 10_000);
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+
+    renderHook(() =>
+      useIdleSessionLogout({ token, onExpired, onSessionDead, getLastActivityAt, renewSession })
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(RENEW_AT_MS + 1);
+      // Flush the renewSession promise chain.
+      await Promise.resolve();
+    });
+
+    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(onSessionDead).toHaveBeenCalledTimes(1);
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it('prefers cross-tab re-sync over renewal when a newer shared token exists', async () => {
+    const onExpired = jest.fn();
+    const onResync = jest.fn();
+    const renewSession = jest.fn().mockResolvedValue(true);
+    const getLastActivityAt = jest.fn(() => NOW_MS + 10_000);
+
+    const token = buildJwt((NOW_MS + ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    const storedToken = buildJwt((NOW_MS + 5 * ACCESS_TOKEN_LIFESPAN_MS) / 1000);
+    const getStoredToken = jest.fn(() => storedToken);
+
+    renderHook(() =>
+      useIdleSessionLogout({
+        token,
+        onExpired,
+        getStoredToken,
+        onResync,
+        getLastActivityAt,
+        renewSession,
+      })
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(RENEW_AT_MS + 1);
+    });
+
+    expect(onResync).toHaveBeenCalledWith(storedToken);
+    expect(renewSession).not.toHaveBeenCalled();
     expect(onExpired).not.toHaveBeenCalled();
   });
 

--- a/packages/core/admin/admin/src/hooks/useIdleSessionLogout.ts
+++ b/packages/core/admin/admin/src/hooks/useIdleSessionLogout.ts
@@ -3,6 +3,13 @@ import * as React from 'react';
 import { decodeAccessTokenExpiry } from '../utils/jwt';
 
 const SESSION_EXPIRY_BUFFER_MS = 1000;
+/**
+ * How long before the access token's `exp` an active tab renews. Renewing
+ * ahead of expiry (rather than at it) means the refreshed token is already in
+ * shared storage by the time any *other* tab's logout timer fires — so an idle
+ * sibling re-syncs instead of racing the refresh and logging itself out.
+ */
+const SESSION_RENEW_MARGIN_MS = 10_000;
 
 interface UseIdleSessionLogoutOptions {
   /**
@@ -10,10 +17,47 @@ interface UseIdleSessionLogoutOptions {
    */
   token: string | null;
   /**
-   * Called when the timer fires. Typically clears local auth state and
-   * navigates to /auth/login.
+   * Called when the timer fires and the user is genuinely idle. Should clear
+   * *this tab's* local auth state and navigate to /auth/login. It must NOT
+   * broadcast a global logout (e.g. by removing the shared `isLoggedIn` key),
+   * otherwise an idle tab firing on a stale token would log out other tabs that
+   * are still active — see the cross-tab handling below.
    */
   onExpired: () => void;
+  /**
+   * Called when a renewal attempt is rejected by the server (the session is
+   * truly over: refresh token idle/max window elapsed). This is a
+   * server-confirmed end of session, so unlike `onExpired` it SHOULD broadcast
+   * a global logout to every tab. Falls back to `onExpired` when omitted.
+   */
+  onSessionDead?: () => void;
+  /**
+   * Read the access token currently in shared storage (localStorage/cookie).
+   * Because every open tab shares the same refresh cookie, an active tab that
+   * refreshes writes a newer access token here. When omitted, the hook never
+   * re-syncs across tabs.
+   */
+  getStoredToken?: () => string | null;
+  /**
+   * Adopt a newer shared token instead of expiring. Typically dispatches
+   * `setToken`, which updates Redux and causes this hook to re-arm against the
+   * later `exp`. Only called when `getStoredToken` returns a token whose `exp`
+   * is later than the in-memory one.
+   */
+  onResync?: (token: string) => void;
+  /**
+   * Epoch ms of the user's last interaction (pointer, key, scroll, …). Used to
+   * decide whether to silently renew (active) or log out (idle) when the access
+   * token expires. When omitted, the hook always treats expiry as idle.
+   */
+  getLastActivityAt?: () => number;
+  /**
+   * Silently renew the session (rotate the refresh token + mint a new access
+   * token). Resolves `true` on success — the resulting `setToken` re-arms this
+   * hook against the new `exp` — or `false` when the server rejects it. Only
+   * called when the user was active during the current token's lifetime.
+   */
+  renewSession?: () => Promise<boolean>;
   /**
    * Escape hatch for tests / dev environments where we don't want the
    * automatic logout behavior. Mirrors the existing `_disableRenewToken`
@@ -23,20 +67,35 @@ interface UseIdleSessionLogoutOptions {
 }
 
 /**
- * Schedule a one-shot logout when the access token's `exp` elapses.
+ * Keep the admin session alive while the user is active, and end it when they
+ * are genuinely idle — without one tab tearing down another.
  *
- * The hook re-runs whenever `token` changes. While the user is active, every
- * API call that hits a 401 transparently refreshes the access token (see
- * `withTokenRefresh` in `getFetchClient.ts`), which dispatches `setToken` and
- * causes this effect to re-arm with the new, later `exp`.
+ * The access token is short-lived (`accessTokenLifespan`, e.g. 30 min) and is
+ * meant to be refreshed, not to be the session length. Two timers are armed per
+ * token:
  *
- * If the JWT can't be decoded (malformed, missing `exp`), the timer is
- * skipped silently — the active-tab redirect on 401 still covers the
- * symptom on the next user-initiated request.
+ * - Renew (at `exp` minus a margin): if the user interacted during this token's
+ *   lifetime, silently renew *ahead* of expiry. The new `setToken` re-arms the
+ *   hook; a server rejection (`onSessionDead`) ends the session globally.
+ *   Renewing early guarantees the refreshed token reaches shared storage before
+ *   any sibling tab's logout timer fires.
+ * - Logout (just after `exp`): the fallback when this tab did not renew. It
+ *   first re-syncs from a token another tab refreshed (so an idle tab rides on
+ *   an active sibling), then renews if activity arrived late, and only otherwise
+ *   logs out — locally, so idle tabs never force-logout active ones.
+ *
+ * If the JWT can't be decoded (malformed, missing `exp`), the timers are skipped
+ * silently — the active-tab redirect on 401 still covers the symptom on the next
+ * user-initiated request.
  */
 const useIdleSessionLogout = ({
   token,
   onExpired,
+  onSessionDead,
+  getStoredToken,
+  onResync,
+  getLastActivityAt,
+  renewSession,
   disabled = false,
 }: UseIdleSessionLogoutOptions): void => {
   React.useEffect(() => {
@@ -49,20 +108,77 @@ const useIdleSessionLogout = ({
       return undefined;
     }
 
-    const msUntilExpiry = expiry - Date.now() + SESSION_EXPIRY_BUFFER_MS;
+    // When this token became active. Activity recorded after this point means
+    // the user was present during the token's lifetime.
+    const armedAt = Date.now();
+    const wasActive = () =>
+      typeof getLastActivityAt === 'function' && getLastActivityAt() >= armedAt;
 
-    const timeoutId = window.setTimeout(
-      () => {
-        onExpired();
-      },
-      Math.max(msUntilExpiry, 0)
-    );
+    // Adopt a fresher token another tab wrote to shared storage. Returns true
+    // when it re-synced (caller should stop).
+    const tryResync = (): boolean => {
+      const storedToken = getStoredToken?.() ?? null;
+      if (storedToken && storedToken !== token && onResync) {
+        const storedExpiry = decodeAccessTokenExpiry(storedToken);
+        if (storedExpiry !== null && storedExpiry > expiry) {
+          onResync(storedToken);
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const renew = () => {
+      renewSession!().then((renewed) => {
+        if (!renewed) {
+          // Server rejected the refresh: the session is truly over.
+          (onSessionDead ?? onExpired)();
+        }
+        // On success, storeToken -> setToken updates the token prop, which
+        // re-runs this effect and re-arms against the new exp.
+      });
+    };
+
+    // Renew ahead of expiry while the user is active.
+    const renewDelay = Math.max(expiry - armedAt - SESSION_RENEW_MARGIN_MS, 0);
+    const renewTimeoutId = window.setTimeout(() => {
+      if (tryResync()) {
+        return;
+      }
+      if (wasActive() && renewSession) {
+        renew();
+      }
+    }, renewDelay);
+
+    // Fallback decision just after expiry, for tabs that did not renew.
+    const logoutDelay = Math.max(expiry - armedAt + SESSION_EXPIRY_BUFFER_MS, 0);
+    const logoutTimeoutId = window.setTimeout(() => {
+      if (tryResync()) {
+        return;
+      }
+      if (wasActive() && renewSession) {
+        renew();
+        return;
+      }
+      // Genuinely idle: log out only this tab.
+      onExpired();
+    }, logoutDelay);
 
     return () => {
-      window.clearTimeout(timeoutId);
+      window.clearTimeout(renewTimeoutId);
+      window.clearTimeout(logoutTimeoutId);
     };
-  }, [token, onExpired, disabled]);
+  }, [
+    token,
+    onExpired,
+    onSessionDead,
+    getStoredToken,
+    onResync,
+    getLastActivityAt,
+    renewSession,
+    disabled,
+  ]);
 };
 
-export { useIdleSessionLogout, SESSION_EXPIRY_BUFFER_MS };
+export { useIdleSessionLogout, SESSION_EXPIRY_BUFFER_MS, SESSION_RENEW_MARGIN_MS };
 export type { UseIdleSessionLogoutOptions };


### PR DESCRIPTION
### What does it do?

Reworks the admin panel's idle-session timer so it keeps **active** sessions alive instead of logging users out when the short-lived access token expires, and stops one tab from logging out another.

Changes (admin frontend only):

- **`packages/core/admin/admin/src/hooks/useIdleSessionLogout.ts`** — The hook no longer treats access-token `exp` as a hard logout. It now arms **two** timers per token:
  - a **renew** timer that fires *ahead* of expiry: if the user interacted during the token's lifetime, it silently renews the session (`renewSession`); a server-rejected renewal ends the session globally (`onSessionDead`). Renewing *before* expiry guarantees the refreshed token is in shared storage before any sibling tab's logout timer fires.
  - a **logout** timer just after `exp` (fallback for tabs that didn't renew): it first re-syncs from a token another tab refreshed (`getStoredToken`/`onResync`), renews if activity arrived late, and only otherwise logs out — **locally**, so an idle tab can't force-logout an active one.
- **`packages/core/admin/admin/src/features/Auth.tsx`** — Wires it up:
  - tracks last user interaction (`pointerdown`/`keydown`/`click`/`scroll`/`touchstart`) as the activity signal;
  - `renewSession` rotates the refresh token via the existing `attemptTokenRefresh` (the resulting `setToken` re-arms the hook);
  - adds `clearLocalSessionAndRedirect` (local, no `logoutAction`) for idle logout, while `clearStateAndLogout` (global) stays for user-initiated logout and server-confirmed 401s (`setOnSessionExpired`).

Tests: `useIdleSessionLogout.test.ts` expanded to 15 cases covering silent renewal on activity, idle logout, server-rejected renewal (global), cross-tab re-sync, re-sync-vs-renew precedence, and the legacy/disabled/malformed paths.

### Why is it needed?

The proactive idle timer introduced in #26165 logged users out when the access token hit its `exp`, rather than refreshing it. The token is only renewed *reactively* on a 401, which produced two failures:

1. **Single active tab (#26571):** while the user works, requests succeed with the still-valid token, so nothing refreshes it — and at `accessTokenLifespan` (default 30 min) the timer logs them out mid-task, discarding unsaved work.
2. **Multiple tabs (#26677):** the logout cleared the shared `isLoggedIn` key, whose `storage` event logs out *every* tab. Refreshes in an active tab only updated Redux locally and never propagated, so an idle/abandoned tab fired on its stale token and tore down sessions the user was actively using.

The access token is meant to be a short refresh cadence, not the session length — the server's refresh-token idle/max windows are the real session bounds. This change makes the client behave accordingly: keep active sessions alive, end only genuinely idle ones, and never let one tab speculatively log out another.

### How to test it?

Environment: 5.47+ admin using session/JWT auth. To make the timers fast, set a short lifespan in `config/admin.{js,ts}`:

```js
module.exports = ({ env }) => ({
  auth: {
    secret: env('ADMIN_JWT_SECRET'),
    sessions: { accessTokenLifespan: 60 }, // 60s for testing
  },
});
```

Run the example app (`examples/getstarted`): `yarn develop --watch-admin` (+ `yarn watch` in `packages/core/admin`). Log in, then:

1. **Single tab, active** — interact (click/scroll/type) at least once per window, wait past 60s → **stays logged in**; a `POST /admin/access-token` fires ~10s before each expiry.
2. **Single tab, idle** — don't touch it for ~70s → **redirected to `/auth/login`** (idle logout still works).
3. **Two tabs** — keep interacting in Tab A, leave Tab B idle, wait past 60s → **both stay logged in** (B re-syncs from A's refresh); neither is kicked out.
4. **Explicit logout / server rejection** — clicking Logout, or a real 401 after the session truly ends, logs out **all** tabs.

Automated:

```bash
nvm use 22
cd packages/core/admin
yarn test:front useIdleSessionLogout   # 15 passing
```

### Behavior change

Idle logout is now driven by real user interaction rather than by access-token expiry alone:

- **Before:** the user was logged out exactly when the access token expired (default 30 min), regardless of whether they were active.
- **After:** as long as the user interacts at least once per `accessTokenLifespan`, the session is silently renewed and they stay logged in. A user who stops interacting is logged out after one idle `accessTokenLifespan`.

The server's `idleSessionLifespan` / `maxSessionLifespan` / refresh-token windows remain the hard caps: a renewal past those is rejected and ends the session globally. Net effect on the configured *idle* window: with the defaults (`accessTokenLifespan` 30 min, `idleSessionLifespan` 2 h), effective idle logout becomes ~30 min of inactivity instead of 2 h — i.e. stricter, never longer than configured. If you rely on the longer idle window, align `accessTokenLifespan` accordingly.

### Related issue(s)/PR(s)

- Fixes #26677 — idle/abandoned tab logs out other active tabs (cross-tab cascade).
- Refs #26571 — single-tab logout during inactivity. Active editing no longer triggers a logout (typing counts as activity, so the session is renewed); the separate concern of the redirect bypassing the unsaved-changes navigation guard is **not** addressed here.
- Regression introduced by #26165 (`fix(admin): redirect active tab to login on session expiry`).
- Builds on the session model from #24346 (Advanced Session Configuration).


---
Fixes CPR-416