### PR TITLE
fix(content-manager): use top-level Core type import in MCP types

### DIFF
--- a/packages/core/content-manager/server/src/mcp/types.ts
+++ b/packages/core/content-manager/server/src/mcp/types.ts
@@ -1,4 +1,4 @@
-import type { Struct, Modules } from '@strapi/types';
+import type { Struct, Modules, Core } from '@strapi/types';
 import type { z } from '@strapi/utils';
 
 export type ContentManagerModelForMcp = Pick<
@@ -30,7 +30,7 @@ export type DerivedTool = {
   resolveInputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
   resolveOutputSchema: (context: Modules.MCP.McpHandlerContext) => z.ZodObject<z.ZodRawShape>;
   createHandler: (
-    strapi: import('@strapi/types').Core.Strapi,
+    strapi: Core.Strapi,
     context: Modules.MCP.McpHandlerContext
   ) => Modules.MCP.McpToolHandler<z.ZodObject<z.ZodRawShape>, z.ZodObject<z.ZodRawShape>>;
 };


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Import `Core` from `@strapi/types` alongside `Struct` and `Modules`, and use it for the `strapi` parameter type in `DerivedTool.createHandler` instead of the inline `import('@strapi/types').Core.Strapi`. This keeps type imports consistent and avoids the inline dynamic import.

### Why is it needed?

Type definition was making a redundant import.

### How to test it?

```
yarn build
```

### Related issue(s)/PR(s)

- ø
