### PR TITLE
fix(core/core): mcp misleading lifecycle docs

### DIFF
--- a/packages/core/content-manager/server/src/mcp/register-content-manager-mcp-tools.ts
+++ b/packages/core/content-manager/server/src/mcp/register-content-manager-mcp-tools.ts
@@ -4,13 +4,16 @@ import { deriveDisplayedContentTypeMcpToolDefinitions } from './derive-content-t
 import { getService } from '../utils';
 
 /**
- * Registers derived content-type MCP tools during plugin bootstrap, before the MCP HTTP server starts.
+ * Registers derived content-type MCP tools via strapi.ai.mcp.registerTool().
+ * Must be called from the plugin register phase, before the MCP HTTP server starts.
  */
 export const registerContentManagerMcpTools = async ({
   strapi,
 }: {
   strapi: Core.Strapi;
 }): Promise<void> => {
+  // Performance only: registerTool() is safe when MCP is disabled (definitions are stored but
+  // never exposed). Skip the expensive derivation below when the MCP server will not start.
   if (strapi.ai.mcp.isEnabled() !== true) {
     return;
   }

--- a/packages/core/content-manager/server/src/mcp/schemas/data-schema.ts
+++ b/packages/core/content-manager/server/src/mcp/schemas/data-schema.ts
@@ -68,9 +68,6 @@ export function buildComponentInputSchema(
  * here to avoid a cross-package import from @strapi/content-manager into
  * @strapi/core (which is not a listed dependency).
  *
- * TODO — custom fields call `strapi.get('custom-fields')` at schema-build
- * time; confirm with an integration test that the registry is populated when MCP
- * tools are registered (post-bootstrap).
  */
 export const attributeToInputSchema = (
   strapi: Core.Strapi,

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -173,6 +173,9 @@ export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'e
 /**
  * Service providing Model Context Protocol (MCP) capabilities.
  * Available on strapi.ai.mcp.
+ *
+ * Call `registerTool`, `registerPrompt`, and `registerResource` only during
+ * Strapi's register phase. The MCP HTTP server starts during bootstrap.
  */
 export interface McpService {
   /**
@@ -187,10 +190,9 @@ export interface McpService {
 
   /**
    * Register a single MCP tool.
-   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
-   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
-   * Prefer bootstrap() when a tool depends on synced content-types, permissions, or database state.
-   * @throws Error if called after MCP server has started
+   * Must be called while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, call only from the register phase (plugin register() or app register()).
+   * @throws Error if called after the MCP server has started
    */
   registerTool<
     Name extends string,
@@ -233,10 +235,9 @@ export interface McpService {
 
   /**
    * Register a single MCP prompt.
-   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
-   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
-   * Prefer bootstrap() when a prompt depends on synced content-types, permissions, or database state.
-   * @throws Error if called after MCP server has started
+   * Must be called while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, call only from the register phase (plugin register() or app register()).
+   * @throws Error if called after the MCP server has started
    */
   registerPrompt<
     Name extends string,
@@ -269,10 +270,9 @@ export interface McpService {
 
   /**
    * Register a single MCP resource.
-   * Register while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
-   * In Strapi's load lifecycle, this includes plugin register() and plugin bootstrap().
-   * Prefer bootstrap() when a resource depends on synced content-types, permissions, or database state.
-   * @throws Error if called after MCP server has started
+   * Must be called while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, call only from the register phase (plugin register() or app register()).
+   * @throws Error if called after the MCP server has started
    */
   registerResource<Name extends string>(resource: {
     name: Name;


### PR DESCRIPTION
### What does it do?

Corrects JSDoc and inline comments around the MCP capability registration APIs (`registerTool`, `registerPrompt`, `registerResource`) on `strapi.ai.mcp`.

The documentation previously stated that plugins and apps could register MCP capabilities during both the **register** and **bootstrap** phases, and even recommended bootstrap when capabilities depend on synced content-types, permissions, or database state. That guidance is wrong.

Updated docs now state that:

- `registerTool`, `registerPrompt`, and `registerResource` must be called only during Strapi's **register** phase (plugin `register()` or app `register()`).
- The MCP HTTP server starts during **bootstrap** (via the MCP provider), so registration must complete before `strapi.ai.mcp.start()` runs.

No runtime behaviour changes in this PR.

### Why is it needed?

The incorrect lifecycle documentation could mislead plugin and application authors into registering MCP capabilities during bootstrap — after which registration throws (`[MCP] Cannot register tools after the MCP server has started.`). Aligning the public API docs with the actual constraint prevents integration mistakes.

### How to test it?

This is a documentation-only change; no functional tests are required.

1. Review the updated JSDoc on `Modules.MCP.McpService` in `packages/core/types/src/modules/mcp.ts`.
2. Confirm the removed "prefer bootstrap" guidance is gone from all `register*` method docs.
3. Optionally run `yarn test:ts` — no type changes expected, but confirms the branch is healthy.

**Note for reviewers:** `content-manager` still invokes `registerContentManagerMcpTools()` from `bootstrap.ts` today. That call site is out of scope for this docs fix and should be addressed in a follow-up PR to move registration into the register phase.

### Related issue(s)/PR(s)

- #26371
