### PR TITLE
Fix: 25780 release relation sync

### DIFF
--- a/jest.config.api.js
+++ b/jest.config.api.js
@@ -35,5 +35,5 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['.cache'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
 };

--- a/jest.config.cli.js
+++ b/jest.config.cli.js
@@ -14,5 +14,5 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['.cache'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
 };

--- a/packages/core/core/src/services/document-service/entries.ts
+++ b/packages/core/core/src/services/document-service/entries.ts
@@ -8,7 +8,7 @@ import { transformParamsDocumentId } from './transform/id-transform';
 import { transformParamsToQuery } from './transform/query';
 import { pickSelectionParams } from './params';
 import { applyTransforms } from './attributes';
-import { transformData } from './transform/data';
+import { clearTransformDataRequestCache, transformData } from './transform/data';
 
 const createEntriesService = (
   uid: UID.ContentType,
@@ -126,11 +126,19 @@ const createEntriesService = (
   }
 
   async function publishEntry(entry: any, params = {} as any) {
+    clearTransformDataRequestCache();
+
     return async.pipe(
       omit('id'),
       assoc('publishedAt', new Date()),
       (draft) => {
-        const opts = { uid, locale: draft.locale, status: 'published', allowMissingId: true };
+        const opts = {
+          uid,
+          locale: draft.locale,
+          status: 'published',
+          allowMissingId: true,
+          useRequestCache: false,
+        };
         return transformData(draft, opts);
       },
       // Create the published entry
@@ -139,11 +147,19 @@ const createEntriesService = (
   }
 
   async function discardDraftEntry(entry: any, params = {} as any) {
+    clearTransformDataRequestCache();
+
     return async.pipe(
       omit('id'),
       assoc('publishedAt', null),
       (entry) => {
-        const opts = { uid, locale: entry.locale, status: 'draft', allowMissingId: true };
+        const opts = {
+          uid,
+          locale: entry.locale,
+          status: 'draft',
+          allowMissingId: true,
+          useRequestCache: false,
+        };
         return transformData(entry, opts);
       },
       // Create the draft entry

--- a/packages/core/core/src/services/document-service/transform/__tests__/data-request-cache.test.ts
+++ b/packages/core/core/src/services/document-service/transform/__tests__/data-request-cache.test.ts
@@ -1,6 +1,6 @@
 import type { Core } from '@strapi/types';
 
-import { transformData } from '../data';
+import { clearTransformDataRequestCache, transformData } from '../data';
 import { createIdMap } from '../id-map';
 
 jest.mock('../id-map', () => ({
@@ -20,6 +20,8 @@ jest.mock('../relations/transform/default-locale', () => ({
 }));
 
 describe('transformData request cache', () => {
+  let idMap: { clear: jest.Mock; load: jest.Mock };
+
   beforeEach(() => {
     jest.clearAllMocks();
     const requestState = {};
@@ -30,9 +32,12 @@ describe('transformData request cache', () => {
       },
     } as unknown as Core.Strapi;
 
-    (createIdMap as jest.Mock).mockReturnValue({
+    idMap = {
+      clear: jest.fn(),
       load: jest.fn(async () => undefined),
-    });
+    };
+
+    (createIdMap as jest.Mock).mockReturnValue(idMap);
   });
 
   it('reuses the same idMap across calls within a request', async () => {
@@ -40,5 +45,20 @@ describe('transformData request cache', () => {
     await transformData({ foo: 'baz' }, { uid: 'api::test.test' });
 
     expect(createIdMap).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses the request cache when disabled', async () => {
+    await transformData({ foo: 'bar' }, { uid: 'api::test.test', useRequestCache: false });
+    await transformData({ foo: 'baz' }, { uid: 'api::test.test', useRequestCache: false });
+
+    expect(createIdMap).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the request cache when invalidated', async () => {
+    await transformData({ foo: 'bar' }, { uid: 'api::test.test' });
+
+    clearTransformDataRequestCache();
+
+    expect(idMap.clear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/core/src/services/document-service/transform/data.ts
+++ b/packages/core/core/src/services/document-service/transform/data.ts
@@ -3,14 +3,27 @@ import { extractDataIds as extractDataRelationIds } from './relations/extract/da
 import { transformDataIdsVisitor as transformRelationDataIds } from './relations/transform/data-ids';
 import { setDefaultLocaleToRelations } from './relations/transform/default-locale';
 
+type TransformDataOptions = {
+  useRequestCache?: boolean;
+};
+
+const getRequestState = () =>
+  strapi.requestContext?.get?.()?.state as
+    | { __documentServiceIdMap?: ReturnType<typeof createIdMap> }
+    | undefined;
+
+const clearTransformDataRequestCache = () => {
+  getRequestState()?.__documentServiceIdMap?.clear();
+};
+
 /**
  * Transforms input data, containing relation document ids, to entity ids.
  */
 export const transformData = async (data: any, opts: any) => {
+  const shouldUseRequestCache = (opts as TransformDataOptions).useRequestCache !== false;
+
   // Store cache on request state so repeated calls in one request can reuse it
-  const requestState = strapi.requestContext?.get?.()?.state as
-    | { __documentServiceIdMap?: ReturnType<typeof createIdMap> }
-    | undefined;
+  const requestState = shouldUseRequestCache ? getRequestState() : undefined;
 
   if (requestState && !requestState.__documentServiceIdMap) {
     requestState.__documentServiceIdMap = createIdMap({ strapi });
@@ -30,3 +43,5 @@ export const transformData = async (data: any, opts: any) => {
   // Transform any relation ids to entity ids
   return transformRelationDataIds(idMap, transformedData, opts);
 };
+
+export { clearTransformDataRequestCache };

--- a/tests/api/plugins/content-releases/releases.test.api.ts
+++ b/tests/api/plugins/content-releases/releases.test.api.ts
@@ -733,6 +733,69 @@ describeOnCondition(edition === 'EE')('Content Releases API', () => {
       expect(categoryName).toBe('Tech');
     });
 
+    test('publishes a release when a self-relation target was modified between related sources', async () => {
+      const parentPage = await createEntry(pageUID, { title: 'Initial Parent Page' });
+      await strapi.documents(pageUID).publish({ documentId: parentPage.data.documentId });
+      const firstChildPage = await createEntry(pageUID, {
+        title: 'First child with modified relation target',
+        parent: { documentId: parentPage.data.documentId, locale: null },
+      });
+      const secondChildPage = await createEntry(pageUID, {
+        title: 'Second child with modified relation target',
+        parent: { documentId: parentPage.data.documentId, locale: null },
+      });
+
+      const createReleaseRes = await createRelease();
+      const release = createReleaseRes.body.data;
+
+      await createReleaseAction(release.id, {
+        contentType: pageUID,
+        entryDocumentId: firstChildPage.data.documentId,
+        type: 'publish',
+      });
+
+      await strapi.documents(pageUID).update({
+        documentId: parentPage.data.documentId,
+        data: { title: 'Updated Parent Page' },
+      });
+
+      await createReleaseAction(release.id, {
+        contentType: pageUID,
+        entryDocumentId: parentPage.data.documentId,
+        type: 'publish',
+      });
+
+      await createReleaseAction(release.id, {
+        contentType: pageUID,
+        entryDocumentId: secondChildPage.data.documentId,
+        type: 'publish',
+      });
+
+      const publishRes = await rq({
+        method: 'POST',
+        url: `/content-releases/${release.id}/publish`,
+      });
+
+      expect(publishRes.statusCode).toBe(200);
+      expect(publishRes.body.data.status).toBe('done');
+
+      const firstPublishedChildRes = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/${pageUID}/${firstChildPage.data.documentId}`,
+        qs: { status: 'published' },
+      });
+      const secondPublishedChildRes = await rq({
+        method: 'GET',
+        url: `/content-manager/collection-types/${pageUID}/${secondChildPage.data.documentId}`,
+        qs: { status: 'published' },
+      });
+
+      expect(firstPublishedChildRes.statusCode).toBe(200);
+      expect(firstPublishedChildRes.body.data.parent).toMatchObject({ count: 1 });
+      expect(secondPublishedChildRes.statusCode).toBe(200);
+      expect(secondPublishedChildRes.body.data.parent).toMatchObject({ count: 1 });
+    });
+
     test('publishes self-related parent and child in one release and preserves relation', async () => {
       const parentPage = await createEntry(pageUID, { title: 'Parent Page' });
       const childPage = await createEntry(pageUID, {

--- a/tests/cli/jest.config.js
+++ b/tests/cli/jest.config.js
@@ -10,7 +10,7 @@ const config = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['.cache'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
 };
 
 module.exports = config;


### PR DESCRIPTION
### What does it do?
Prevents Document Service publish/discard transforms from reusing stale request-scoped documentId-to-entityId mappings after rows are deleted and recreated.

### Why is it needed?
Content Releases can publish multiple related documents in one request. A stale cached numeric entity ID can point to a deleted published row and cause relation validation to fail.

### How to test it?
Run the focused unit tests for the Document Service transform cache and the EE content-releases API regression.

### Related issue(s)/PR(s)
Fixes #25780 
