### PR TITLE
chore: removing coderabbit status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,7 +14,7 @@ reviews:
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   poem: false
-  review_status: true
+  review_status: false
   collapse_walkthrough: false
   # Surface a sequence diagram for non-trivial control-flow changes.
   sequence_diagrams: true


### PR DESCRIPTION
### What does it do?

Removes the coderabbit status by default. 

### Why is it needed?

The status creates unnecessary noise. Coderabbit is available using the label, so the status report does not serve any purpose.
