### PR TITLE
fix(types): add explicit return types to recursive functions

### DIFF
--- a/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
+++ b/packages/core/content-manager/admin/src/pages/ListView/components/BulkActions/PublishAction.tsx
@@ -71,7 +71,7 @@ export const formatErrorMessages = (
   errors: FormErrors,
   parentKey: string,
   formatMessage: IntlShape['formatMessage']
-) => {
+): string[] => {
   if (!errors) return [];
 
   const messages: string[] = [];

--- a/packages/core/content-manager/server/src/controllers/utils/clone.ts
+++ b/packages/core/content-manager/server/src/controllers/utils/clone.ts
@@ -82,7 +82,7 @@ const getProhibitedCloningFields = (
  * remove the fields that the user can't create.
  */
 const excludeNotCreatableFields =
-  (uid: any, permissionChecker: any) =>
+  (uid: any, permissionChecker: any): ((body: any, path?: any[]) => any) =>
   (body: any, path = []): any => {
     const model = strapi.getModel(uid);
     const canCreate = (path: any) => permissionChecker.can.create(null, path);

--- a/packages/core/content-manager/server/src/services/utils/count.ts
+++ b/packages/core/content-manager/server/src/services/utils/count.ts
@@ -21,7 +21,7 @@ function getCountForRelation(
   return entity ? { count: 1 } : { count: 0 };
 }
 
-function getCountForDZ(entity: any) {
+function getCountForDZ(entity: any): Document[] {
   return entity.map((component: any) => {
     return getDeepRelationsCount(component, component.__component);
   });

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -84,7 +84,7 @@ function getPopulateForDZ(
   attribute: Schema.Attribute.DynamicZone,
   options: PopulateOptions,
   level: number
-) {
+): { on: { [key: string]: { populate: { [key: string]: boolean | object } } } } {
   // Use fragments to populate the dynamic zone components
   const populatedComponents = (attribute.components || []).reduce(
     (acc: any, componentUID: UID.Component) => ({
@@ -162,7 +162,7 @@ const getDeepPopulate = (
     maxLevel = Infinity,
   }: PopulateOptions = {},
   level = 1
-) => {
+): { [key: string]: boolean | object } => {
   if (level > maxLevel) {
     return {};
   }

--- a/packages/core/content-manager/server/src/services/utils/populate.ts
+++ b/packages/core/content-manager/server/src/services/utils/populate.ts
@@ -302,7 +302,7 @@ const getPopulateForValidation = (uid: UID.Schema): Record<string, any> => {
  */
 const draftCountPopulateCache = new Map<string, { populate: any; hasRelations: boolean }>();
 
-const getDeepPopulateDraftCount = (uid: UID.Schema) => {
+const getDeepPopulateDraftCount = (uid: UID.Schema): { populate: any; hasRelations: boolean } => {
   const cached = draftCountPopulateCache.get(uid);
   if (cached) {
     return cached;

--- a/packages/core/content-type-builder/admin/src/utils/getMaxDepth.ts
+++ b/packages/core/content-type-builder/admin/src/utils/getMaxDepth.ts
@@ -22,7 +22,7 @@ export const getChildrenMaxDepth = (
   componentUid: Internal.UID.Component,
   components: Array<ComponentWithChildren>,
   currentDepth = 0
-) => {
+): number => {
   const component = findComponent(componentUid, components);
 
   // If the component doesn't exist or has no child components, return the current depth.

--- a/packages/core/content-type-builder/server/src/services/api-handler.ts
+++ b/packages/core/content-type-builder/server/src/services/api-handler.ts
@@ -100,7 +100,10 @@ const createDeleteApiFunction = (baseName: string) => {
  * Deletes a folder recursively using a delete function
  * @param {string} folder folder to delete
  */
-const recursiveRemoveFiles = async (folder: string, deleteFn: (file: string) => unknown) => {
+const recursiveRemoveFiles = async (
+  folder: string,
+  deleteFn: (file: string) => unknown
+): Promise<void> => {
   const filesName = await fse.readdir(folder);
 
   for (const fileName of filesName) {

--- a/packages/core/content-type-builder/server/src/services/components.ts
+++ b/packages/core/content-type-builder/server/src/services/components.ts
@@ -3,6 +3,7 @@ import { get, has } from 'lodash';
 
 import { formatAttributes, replaceTemporaryUIDs } from '../utils/attributes';
 import createBuilder from './schema-builder';
+import type { SchemaHandler } from './schema-builder/schema-handler';
 
 /**
  * Formats a component attributes
@@ -29,7 +30,10 @@ export const formatComponent = (component: any) => {
 /**
  * Creates a component and handle the nested components sent with it
  */
-export const createComponent = async ({ component, components = [] }: any) => {
+export const createComponent = async ({
+  component,
+  components = [],
+}: any): Promise<SchemaHandler> => {
   const builder = createBuilder();
 
   const uidMap = builder.createNewComponentUIDMap(components);
@@ -60,7 +64,7 @@ type ComponentToCreate = {
 export const editComponent = async (
   uid: Internal.UID.Component,
   { component, components = [] }: ComponentToCreate
-) => {
+): Promise<SchemaHandler> => {
   const builder = createBuilder();
 
   const uidMap = builder.createNewComponentUIDMap(components);

--- a/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
+++ b/packages/core/content-type-builder/server/src/services/schema-builder/schema-handler.ts
@@ -15,6 +15,8 @@ export type Infos = {
   schema?: Struct.ContentTypeSchema;
 };
 
+export type SchemaHandler = ReturnType<typeof createSchemaHandler>;
+
 export default function createSchemaHandler(infos: Infos) {
   const { category, modelName, plugin, uid, dir, filename, schema } = infos;
 

--- a/packages/core/core/src/services/document-service/components.ts
+++ b/packages/core/core/src/services/document-service/components.ts
@@ -373,7 +373,10 @@ const deleteComponents = async <TUID extends UID.Schema, TEntity extends Data.En
 ************************** */
 
 // components can have nested compos so this must be recursive
-const createComponent = async <TUID extends UID.Component>(uid: TUID, data: Input<TUID>) => {
+const createComponent = async <TUID extends UID.Component>(
+  uid: TUID,
+  data: Input<TUID>
+): Promise<Data.Component<TUID>> => {
   const schema = strapi.getModel(uid);
 
   const componentData = await createComponents(uid, data);

--- a/packages/core/core/src/services/document-service/internationalization.ts
+++ b/packages/core/core/src/services/document-service/internationalization.ts
@@ -99,7 +99,7 @@ const localeToData: Transform = (contentType, params) => {
 const normalizeMediaIds = (
   schema: Schema.ContentType | Schema.Component,
   data: Record<string, any>
-) => {
+): Record<string, any> => {
   if (!schema?.attributes || !data || typeof data !== 'object') {
     return data;
   }

--- a/packages/core/core/src/services/document-service/utils/populate.ts
+++ b/packages/core/core/src/services/document-service/utils/populate.ts
@@ -10,7 +10,7 @@ interface Options {
 const deepPopulateCache = new Map<string, any>();
 
 // We want to build a populate object based on the schema
-export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}) => {
+export const getDeepPopulate = (uid: UID.Schema, opts: Options = {}): Record<string, unknown> => {
   const cacheKey = `${uid}::${JSON.stringify(opts)}`;
   const cached = deepPopulateCache.get(cacheKey);
   if (cached) {

--- a/packages/core/core/src/services/entity-validator/index.ts
+++ b/packages/core/core/src/services/entity-validator/index.ts
@@ -145,7 +145,7 @@ const createComponentValidator =
       componentContext,
     }: ValidatorMeta<Schema.Attribute.Component<UID.Component, boolean>>,
     { isDraft }: ValidatorContext
-  ) => {
+  ): strapiUtils.yup.AnySchema => {
     const model = strapi.getModel(attr.component);
     if (!model) {
       throw new Error('Validation failed: Model not found');
@@ -196,7 +196,10 @@ const createComponentValidator =
 
 const createDzValidator =
   (createOrUpdate: CreateOrUpdate) =>
-  ({ attr, updatedAttribute, componentContext }: ValidatorMeta, { isDraft }: ValidatorContext) => {
+  (
+    { attr, updatedAttribute, componentContext }: ValidatorMeta,
+    { isDraft }: ValidatorContext
+  ): strapiUtils.yup.AnySchema => {
     let validator;
 
     validator = yup.array().of(
@@ -266,7 +269,8 @@ const createScalarAttributeValidator =
   };
 
 const createAttributeValidator =
-  (createOrUpdate: CreateOrUpdate) => (metas: ValidatorMetas, options: ValidatorContext) => {
+  (createOrUpdate: CreateOrUpdate) =>
+  (metas: ValidatorMetas, options: ValidatorContext): strapiUtils.yup.AnySchema => {
     let validator = yup.mixed();
 
     // If field is conditionally invisible, skip all validation for it
@@ -344,7 +348,10 @@ const createAttributeValidator =
 
 const createModelValidator =
   (createOrUpdate: CreateOrUpdate) =>
-  ({ componentContext, model, data, entity }: ModelValidatorMetas, options: ValidatorContext) => {
+  (
+    { componentContext, model, data, entity }: ModelValidatorMetas,
+    options: ValidatorContext
+  ): strapiUtils.yup.AnyObjectSchema => {
     const writableAttributes = model ? getWritableAttributes(model as any) : [];
 
     const schema = writableAttributes.reduce(

--- a/packages/core/database/src/query/helpers/where.ts
+++ b/packages/core/database/src/query/helpers/where.ts
@@ -224,7 +224,12 @@ type Operator =
   | '$jsonSupersetOf';
 
 // TODO: add type casting per operator at some point
-const applyOperator = (qb: Knex.QueryBuilder, column: any, operator: Operator, value: any) => {
+const applyOperator = (
+  qb: Knex.QueryBuilder,
+  column: any,
+  operator: Operator,
+  value: any
+): Knex.QueryBuilder | undefined => {
   if (Array.isArray(value) && !isOperatorOfType('array', operator)) {
     return qb.where((subQB) => {
       value.forEach((subValue) =>
@@ -411,7 +416,7 @@ type Where =
     }
   | Array<Where>;
 
-const applyWhere = (qb: Knex.QueryBuilder, where: Where) => {
+const applyWhere = (qb: Knex.QueryBuilder, where: Where): Knex.QueryBuilder | undefined => {
   if (!isArray(where) && !isRecord(where)) {
     throw new Error('Where must be an array or an object');
   }

--- a/packages/core/utils/src/traverse-entity.ts
+++ b/packages/core/utils/src/traverse-entity.ts
@@ -59,7 +59,11 @@ export interface Parent {
   schema: Model;
 }
 
-const traverseEntity = async (visitor: Visitor, options: TraverseOptions, entity: Data) => {
+const traverseEntity = async (
+  visitor: Visitor,
+  options: TraverseOptions,
+  entity: Data
+): Promise<Data> => {
   const {
     path = { raw: null, attribute: null, rawWithIndices: null },
     schema,

--- a/packages/generators/generators/src/plops/utils/extend-plugin-index-files.ts
+++ b/packages/generators/generators/src/plops/utils/extend-plugin-index-files.ts
@@ -277,7 +277,10 @@ const handleEmptyFile = (root: jscodeshift.Collection<any>, firstStatement: any)
 };
 
 // Helper to find the exported object regardless of export pattern
-const findExportedObject = (root: jscodeshift.Collection<any>, exportedValue: any): any => {
+const findExportedObject = (
+  root: jscodeshift.Collection<any>,
+  exportedValue: any
+): jscodeshift.ObjectExpression | null => {
   // Case 1: Direct object export
   if (j.ObjectExpression.check(exportedValue)) {
     return exportedValue;

--- a/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
+++ b/packages/plugins/documentation/server/src/services/helpers/utils/clean-schema-attributes.ts
@@ -32,7 +32,7 @@ const convertComponentName = (component: string, isRef = false): string => {
 const cleanSchemaAttributes = (
   attributes: Struct.SchemaAttributes,
   { typeMap = new Map(), isRequest = false, didAddStrapiComponentsToSchemas }: Options
-) => {
+): Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> => {
   const schemaAttributes: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> = {};
 
   for (const prop of Object.keys(attributes)) {

--- a/packages/plugins/i18n/server/src/services/content-types.ts
+++ b/packages/plugins/i18n/server/src/services/content-types.ts
@@ -72,9 +72,9 @@ const removeId = (value: any) => {
 
 const removeIds = (model: any) => (entry: any) => removeIdsMut(model, cloneDeep(entry));
 
-const removeIdsMut = (model: any, entry: any) => {
+const removeIdsMut = (model: any, entry: any): Record<string, any> => {
   if (isNil(entry)) {
-    return entry;
+    return entry as unknown as Record<string, any>;
   }
 
   removeId(entry);
@@ -150,7 +150,7 @@ const fillNonLocalizedAttributes = (entry: any, relatedEntry: any, { model }: an
  * build the populate param to
  * @param {String} modelUID uid of the model, could be of a content-type or a component
  */
-const getNestedPopulateOfNonLocalizedAttributes = (modelUID: any) => {
+const getNestedPopulateOfNonLocalizedAttributes = (modelUID: any): string[] => {
   const schema = strapi.getModel(modelUID);
   const scalarAttributes = getScalarAttributes(schema);
   const nonLocalizedAttributes = getNonLocalizedAttributes(schema);

--- a/packages/plugins/i18n/server/src/services/localizations.ts
+++ b/packages/plugins/i18n/server/src/services/localizations.ts
@@ -11,7 +11,7 @@ import { getService } from '../utils';
 const normalizeMediaIds = (
   schema: Schema.ContentType | Schema.Component,
   data: Record<string, any>
-) => {
+): Record<string, any> => {
   if (!schema?.attributes || !data || typeof data !== 'object') {
     return data;
   }


### PR DESCRIPTION
### What does it do?

Adds explicit return-type annotations to **directly-recursive** functions across the monorepo that were missing them.

A recursive function whose return type TypeScript has to *infer* can defeat declaration emit (`tsc --emitDeclarationOnly` via each package's `build:types`): the inferred type falls back to `any` (TS7022 / TS2742) and that `any` leaks into the published `.d.ts`. Pinning an explicit return type breaks the inference cycle at emit time.

Done in two passes: **(1) direct recursion** — every self-recursive function missing an annotation; **(2) high-value mutual recursion** — functions inside mutual-recursion cycles whose inferred type was actively poor (`{}`, `any`, or a giant inlined expansion). **18 files, signature-only changes — no runtime behavior altered.**

#### Findings — inferred (before) vs. explicit (after)

Measured with the TypeScript checker on the un-annotated tree.

| Function | Package | Before (inferred) | After (explicit) |
|---|---|---|---|
| `getDeepPopulate` | core/core | **`any`** | `Record<string, unknown>` |
| `removeIdsMut` | i18n/server | **`any`** | `Record<string, any>` |
| `findExportedObject` | generators | **`any`** (hand-written) | `jscodeshift.ObjectExpression \| null` |
| `excludeNotCreatableFields` | content-manager/server | `(body: any, path?: never[]) => any` | `(body: any, path?: any[]) => any` |
| `formatErrorMessages` | content-manager/admin | `string[]` | `string[]` |
| `getDeepPopulateDraftCount` | content-manager/server | `{ populate: any; hasRelations: boolean }` | `{ populate: any; hasRelations: boolean }` |
| `getChildrenMaxDepth` | content-type-builder/admin | `number` | `number` |
| `recursiveRemoveFiles` | content-type-builder/server | `Promise<void>` | `Promise<void>` |
| `normalizeMediaIds` | core/core | `Record<string, any>` | `Record<string, any>` |
| `applyOperator` | database | `Knex.QueryBuilder<any, any> \| undefined` | `Knex.QueryBuilder \| undefined` |
| `applyWhere` | database | `Knex.QueryBuilder<any, any> \| undefined` | `Knex.QueryBuilder \| undefined` |
| `traverseEntity` | core/utils | `Promise<Data>` | `Promise<Data>` |
| `cleanSchemaAttributes` | documentation/server | `Record<string, OpenAPIV3.SchemaObject \| OpenAPIV3.ReferenceObject>` | _(same)_ |
| `getNestedPopulateOfNonLocalizedAttributes` | i18n/server | `string[]` | `string[]` |
| `normalizeMediaIds` | i18n/server | `Record<string, any>` | `Record<string, any>` |

- **3 real fixes** (`getDeepPopulate`, `removeIdsMut`, `findExportedObject`): the checker inferred `any`; now concrete.
- **The rest** pin a type the checker already inferred correctly — a guard against drift and against `any` fallback during the stricter *declaration emit* (which can bail where the checker resolves).

> Note: the `any` retained in a few return types mirrors pre-existing `any` parameter/cache types in that code; tightening them further would require changing logic and is out of scope.

#### Mutual recursion (pass 2)

The scan also surfaced **27 mutual-recursion cycles**. Most emit declarations fine (inference succeeds), but a handful inferred actively poor types — those are now annotated:

| Function | Package | Before | After |
|---|---|---|---|
| `getDeepPopulate` | content-manager/server | `{}` | `{ [key: string]: boolean \| object }` |
| `getPopulateForDZ` | content-manager/server | `{ on: any }` | explicit `{ on: { … } }` |
| `getCountForDZ` | content-manager/server | `any` | `Document[]` |
| `createComponent` / `editComponent` | content-type-builder/server | giant / `Promise<any>` | `Promise<SchemaHandler>` ‡ |
| `createComponent` | core/core (document-service) | `Promise<any>` | `Promise<Data.Component<TUID>>` |
| `createComponentValidator` / `createAttributeValidator` / `createDzValidator` | core/core (entity-validator) | giant `yup` expansion | `strapiUtils.yup.AnySchema` |
| `createModelValidator` | core/core (entity-validator) | giant `yup` expansion | `strapiUtils.yup.AnyObjectSchema` |

‡ Introduces a named alias `SchemaHandler = ReturnType<typeof createSchemaHandler>` instead of reproducing the ~20-member inline type.

**Deliberately skipped:** `updateComponent` / `updateOrCreateComponent` (core/core document-service). Their correct type is `Promise<Data.Component<TUID>> | null`, but annotating them surfaces two **pre-existing latent type gaps** (`null` assigned into `ComponentBody`, whose value type forbids it) that the prior `any` was masking — fixing those needs logic changes, out of scope for a signature-only PR.

The remaining cycle members already infer correct types and emit clean `.d.ts`; they're left as-is (pinning them would add no value).

### Why is it needed?

Prevents `any` from silently leaking into emitted type declarations for recursive functions, which weakens type safety for every consumer of these packages and can trigger TS7022/TS2742 during `build:types`.

### How to test it?

```bash
yarn build:types   # 35 projects, emits .d.ts via each tsconfig.build.json
yarn test:ts       # full type check (front + back + packages)
```

Both pass on this branch (`build:types` 35/35, `test:ts` exit 0). No measurable change in `build:types` wall time (cold, `nx reset` before each: ~94s before, ~97s after — within run-to-run noise; this is a correctness change, not a perf one).

#### Detection script

Recursive functions were located with a [`ts-morph`](https://ts-morph.com/) pass over every workspace's `tsconfig.build.json`. Direct recursion is detected **precisely** — a call counts only if the callee symbol's declaration resolves to the enclosing function node (no same-name false positives) — and mutual recursion via DFS over the name-level call graph.

```ts
import { Project, SyntaxKind, Node } from 'ts-morph';

// Run once per workspace tsconfig.build.json.
function analyze(configPath: string) {
  const project = new Project({ tsConfigFilePath: configPath });
  const direct: { name: string; loc: string }[] = [];
  const calls = new Map<string, Set<string>>(); // name -> callee names (for mutual recursion)

  // The node whose self-call we look for, given a resolved callee declaration.
  const funcLike = (decl?: Node) => {
    const fd = decl?.asKind(SyntaxKind.FunctionDeclaration);
    if (fd?.getName()) return { node: fd, name: fd.getName()! };
    const md = decl?.asKind(SyntaxKind.MethodDeclaration);
    if (md) return { node: md, name: md.getName() };
    const vd = decl?.asKind(SyntaxKind.VariableDeclaration);
    const init = vd?.getInitializer();
    if (
      init &&
      (init.getKind() === SyntaxKind.ArrowFunction ||
        init.getKind() === SyntaxKind.FunctionExpression)
    ) {
      return { node: vd!, name: vd!.getName() };
    }
    return undefined;
  };

  const scan = (selfNode: Node, body: Node, name: string) => {
    const callees = calls.get(name) ?? new Set<string>();
    let isDirect = false;
    body.getDescendantsOfKind(SyntaxKind.CallExpression).forEach((c) => {
      const info = funcLike(c.getExpression().getSymbol()?.getDeclarations()?.[0]);
      if (!info) return;
      callees.add(info.name);
      if (info.node === selfNode) isDirect = true; // precise: callee IS this function
    });
    calls.set(name, callees);
    if (isDirect) {
      const sf = selfNode.getSourceFile();
      direct.push({ name, loc: `${sf.getFilePath()}:${sf.getLineAndColumnAtPos(selfNode.getStart()).line}` });
    }
  };

  for (const sf of project.getSourceFiles()) {
    if (sf.getFilePath().includes('node_modules')) continue;
    sf.getFunctions().forEach((fn) => fn.getName() && scan(fn, fn, fn.getName()!));
    sf.getVariableDeclarations().forEach((vd) => {
      const init = vd.getInitializer();
      if (
        init &&
        (init.getKind() === SyntaxKind.ArrowFunction ||
          init.getKind() === SyntaxKind.FunctionExpression)
      ) {
        scan(vd, init, vd.getName());
      }
    });
    sf.getClasses().forEach((cls) => cls.getMethods().forEach((m) => scan(m, m, m.getName())));
  }

  // Mutual recursion: cycles of size > 1 via DFS (color marking) over `calls`.
  const cycles: string[][] = [];
  const color = new Map<string, number>();
  const stack: string[] = [];
  const dfs = (u: string) => {
    color.set(u, 1);
    stack.push(u);
    for (const v of calls.get(u) ?? []) {
      if (v === u || !calls.has(v)) continue;
      const c = color.get(v) ?? 0;
      if (c === 1) {
        const cyc = stack.slice(stack.lastIndexOf(v));
        if (cyc.length > 1) cycles.push(cyc);
      } else if (c === 0) dfs(v);
    }
    stack.pop();
    color.set(u, 2);
  };
  for (const k of calls.keys()) if ((color.get(k) ?? 0) === 0) dfs(k);

  return { direct, cycles };
}
```

The before/after inferred types in the table above were read with `node.getReturnType().getText(node)` on the un-annotated tree.

### Related issue(s)/PR(s)

_None — internal type-safety hardening._



