### PR TITLE
fix(content-manager): duplicate MCP tool names crash bootstrap when plugin has multiple content types

### DIFF
--- a/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
+++ b/packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
@@ -296,12 +296,57 @@ jest.mock('@strapi/utils', () => {
 });
 
 // ---------------------------------------------------------------------------
+// slugifyUidForMcpToolName
+// ---------------------------------------------------------------------------
+
+describe('slugifyUidForMcpToolName', () => {
+  it('maps api UIDs to the first model-name segment only', () => {
+    expect(slugifyUidForMcpToolName('api::article.article')).toBe('article');
+  });
+
+  it('maps plugin UIDs to namespace-model_content-type per documented format', () => {
+    expect(slugifyUidForMcpToolName('plugin::i18n.locale')).toBe('plugin-i18n_locale');
+  });
+
+  it('includes the content-type suffix so plugin models with the same prefix stay unique', () => {
+    expect(slugifyUidForMcpToolName('plugin::cms-basics.page')).toBe('plugin-cms-basics_page');
+    expect(slugifyUidForMcpToolName('plugin::cms-basics.settings')).toBe(
+      'plugin-cms-basics_settings'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tool structure tests (unchanged from original)
 // ---------------------------------------------------------------------------
 
 describe('deriveDisplayedContentTypeMcpToolDefinitions', () => {
-  it('maps uid segments into a stable tool name slug', () => {
-    expect(slugifyUidForMcpToolName('api::article.article')).toBe('article');
+  it('derives unique tool names for plugin content types that share a model-name prefix', () => {
+    const models = [
+      baseModel({
+        uid: 'plugin::cms-basics.page',
+        apiID: 'page',
+        kind: 'collectionType',
+      }),
+      baseModel({
+        uid: 'plugin::cms-basics.settings',
+        apiID: 'settings',
+        kind: 'singleType',
+      }),
+    ];
+
+    const tools = deriveDisplayedContentTypeMcpToolDefinitions(mockStrapi, models);
+    const names = tools.map((tool) => tool.name);
+    const uniqueNames = new Set(names);
+
+    expect(uniqueNames.size).toBe(names.length);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'list_plugin-cms-basics_page',
+        'get_plugin-cms-basics_settings',
+        'write_plugin-cms-basics_settings',
+      ])
+    );
   });
 
   it('emits list/get with explorer.read for a collection type', () => {

--- a/packages/core/content-manager/server/src/mcp/utils.ts
+++ b/packages/core/content-manager/server/src/mcp/utils.ts
@@ -10,11 +10,13 @@ import { shapeRelationsForMcp } from './sanitizers/shape-relations';
  */
 export const slugifyUidForMcpToolName = (uid: string): string => {
   const [namespace, modelName] = uid.split('::');
-  const modelNameParts = modelName.split('.').map((part) => part.toLowerCase());
+  const parts = modelName.split('.').map((part) => part.toLowerCase());
+
   if (namespace === 'api') {
-    return `${modelNameParts[0]}`;
+    return parts[0];
   }
-  return `${namespace.toLowerCase()}_${modelNameParts[0]}`;
+
+  return `${namespace.toLowerCase()}-${parts.join('_')}`;
 };
 
 type McpPermissionChecker = {


### PR DESCRIPTION
### What does it do?

Fixes `slugifyUidForMcpToolName` in `packages/core/content-manager/server/src/mcp/utils.ts` to include the full model-name suffix when generating MCP tool-name segments for non-`api` namespaces.

Previously the function returned only `namespace_pluginName` (e.g. `plugin_cms-basics`) for any UID of the form `plugin::cms-basics.*`, dropping the content-type suffix entirely. It now returns `namespace-pluginName_contentType` (e.g. `plugin-cms-basics_page`, `plugin-cms-basics_settings`), matching the documented format and ensuring every registered tool name is unique.

### Why is it needed?

Fixes #26706. `slugifyUidForMcpToolName` was dropping the model-name suffix for non-`api` namespaces — returning `plugin_cms-basics` for both `plugin::cms-basics.page` and `plugin::cms-basics.settings`. This produced duplicate MCP tool names, causing `McpCapabilityDefinitionRegistry` to throw a fatal "Names must be unique" error during bootstrap whenever a plugin exposed more than one content type under the same namespace prefix.

### How to test it?

**Unit tests**

```
yarn test:unit -- packages/core/content-manager/server/src/mcp/__tests__/derive-content-type-mcp-tools.test.ts
```

All 178 tests pass.

**Regression — issue #26706 (duplicate MCP tool names crashing bootstrap)**

Before this fix, a plugin exposing multiple content types under the same namespace (e.g. `plugin::cms-basics.page` and `plugin::cms-basics.settings`) caused Strapi to crash on startup because both UIDs resolved to the same tool name (`plugin_cms-basics`), triggering a "Names must be unique" error from `McpCapabilityDefinitionRegistry`.

To verify the regression is gone:
1. Create (or use) a Strapi project with a plugin that registers at least two content types sharing a namespace prefix — e.g. `plugin::cms-basics.page` and `plugin::cms-basics.settings`.
2. Enable the MCP feature.
3. Start the application — it must boot cleanly with no duplicate-name error.
4. Inspect the registered MCP tools: the two content types must appear as distinct tool-name segments (`plugin-cms-basics_page` and `plugin-cms-basics_settings`).

### Related issue(s)/PR(s)

- Fixes #26706