### PR TITLE
fix(users-permissions): accept documentId for the role relation on user create/update

### DIFF
--- a/packages/plugins/users-permissions/server/controllers/validation/user.js
+++ b/packages/plugins/users-permissions/server/controllers/validation/user.js
@@ -6,6 +6,17 @@ const deleteRoleSchema = yup.object().shape({
   role: yup.strapiID().required(),
 });
 
+// A role relation entry may be referenced by numeric `id` (legacy) or by
+// `documentId` (the v5 default), but must carry at least one of them.
+const roleRelationEntrySchema = yup
+  .object()
+  .shape({ id: yup.strapiID(), documentId: yup.strapiID() })
+  .test(
+    'id-or-documentId',
+    'Relation entry must include an id or documentId',
+    (entry) => !!entry && (entry.id != null || entry.documentId != null)
+  );
+
 const createUserBodySchema = yup.object().shape({
   email: yup.string().email().required(),
   username: yup.string().min(1).required(),
@@ -17,7 +28,7 @@ const createUserBodySchema = yup.object().shape({
           .shape({
             connect: yup
               .array()
-              .of(yup.object().shape({ id: yup.strapiID().required() }))
+              .of(roleRelationEntrySchema)
               .min(1, 'Users must have a role')
               .required(),
           })
@@ -44,20 +55,22 @@ const updateUserBodySchema = yup.object().shape({
   role: yup.lazy((value) =>
     typeof value === 'object'
       ? yup.object().shape({
-          connect: yup
-            .array()
-            .of(yup.object().shape({ id: yup.strapiID().required() }))
-            .required(),
+          // connect/disconnect are each optional (matching core relation inputs),
+          // but a role must remain: reject disconnecting every role without
+          // connecting a replacement.
+          connect: yup.array().of(roleRelationEntrySchema),
           disconnect: yup
             .array()
-            .test('CheckDisconnect', 'Cannot remove role', function test(disconnectValue) {
-              if (value.connect.length === 0 && disconnectValue.length > 0) {
+            .of(roleRelationEntrySchema)
+            .test('CheckDisconnect', 'Cannot remove role', function test(disconnect) {
+              const connectValue = value.connect || [];
+              const disconnectValue = disconnect || [];
+              if (connectValue.length === 0 && disconnectValue.length > 0) {
                 return false;
               }
 
               return true;
-            })
-            .required(),
+            }),
         })
       : yup.strapiID()
   ),

--- a/packages/plugins/users-permissions/server/routes/content-api/validation.js
+++ b/packages/plugins/users-permissions/server/routes/content-api/validation.js
@@ -4,22 +4,33 @@ const { AbstractRouteValidator } = require('@strapi/utils');
 const z = require('zod/v4');
 
 // A single role relation entry, referenced by numeric `id` (legacy) or by
-// `documentId` (the v5 default). The detailed rules (min one role on create,
-// cannot remove the last role on update) stay in the Yup controller validator.
-const roleRelationEntry = z.object({
-  id: z.union([z.number(), z.string()]).optional(),
-  documentId: z.string().optional(),
-});
+// `documentId` (the v5 default), but must carry at least one of them. The
+// detailed rules (min one role on create, cannot remove the last role on
+// update) stay in the Yup controller validator.
+const roleRelationEntry = z
+  .object({
+    id: z.union([z.number(), z.string()]).optional(),
+    documentId: z.string().optional(),
+  })
+  .refine((entry) => entry.id != null || entry.documentId != null, {
+    message: 'Relation entry must include an id or documentId',
+  });
 
 // The `role` relation input: shorthand scalar (numeric id or documentId) or the
-// longhand connect/disconnect object, matching every other v5 relation.
+// longhand connect/disconnect object, matching every other v5 relation. The
+// object form must carry at least one of connect/disconnect (an empty object is
+// a no-op and almost certainly a mistake).
 const roleRelationInput = z.union([
   z.number(),
   z.string(),
-  z.object({
-    connect: z.array(roleRelationEntry).optional(),
-    disconnect: z.array(roleRelationEntry).optional(),
-  }),
+  z
+    .object({
+      connect: z.array(roleRelationEntry).optional(),
+      disconnect: z.array(roleRelationEntry).optional(),
+    })
+    .refine((input) => input.connect != null || input.disconnect != null, {
+      message: 'Relation input must include connect or disconnect',
+    }),
 ]);
 
 class UsersPermissionsRouteValidator extends AbstractRouteValidator {

--- a/packages/plugins/users-permissions/server/routes/content-api/validation.js
+++ b/packages/plugins/users-permissions/server/routes/content-api/validation.js
@@ -3,6 +3,25 @@
 const { AbstractRouteValidator } = require('@strapi/utils');
 const z = require('zod/v4');
 
+// A single role relation entry, referenced by numeric `id` (legacy) or by
+// `documentId` (the v5 default). The detailed rules (min one role on create,
+// cannot remove the last role on update) stay in the Yup controller validator.
+const roleRelationEntry = z.object({
+  id: z.union([z.number(), z.string()]).optional(),
+  documentId: z.string().optional(),
+});
+
+// The `role` relation input: shorthand scalar (numeric id or documentId) or the
+// longhand connect/disconnect object, matching every other v5 relation.
+const roleRelationInput = z.union([
+  z.number(),
+  z.string(),
+  z.object({
+    connect: z.array(roleRelationEntry).optional(),
+    disconnect: z.array(roleRelationEntry).optional(),
+  }),
+]);
+
 class UsersPermissionsRouteValidator extends AbstractRouteValidator {
   constructor(strapi) {
     super();
@@ -201,7 +220,7 @@ class UsersPermissionsRouteValidator extends AbstractRouteValidator {
       username: z.string(),
       email: z.email(),
       password: z.string(),
-      role: z.number().optional(),
+      role: roleRelationInput.optional(),
     });
   }
 
@@ -210,7 +229,7 @@ class UsersPermissionsRouteValidator extends AbstractRouteValidator {
       username: z.string().optional(),
       email: z.email().optional(),
       password: z.string().optional(),
-      role: z.number().optional(),
+      role: roleRelationInput.optional(),
     });
   }
 

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -423,4 +423,80 @@ describe('U&P users REST relation handling (issue 26606)', () => {
       });
     });
   });
+
+  // Follow-up to https://github.com/strapi/strapi/issues/24343 — the `role`
+  // relation carried its own numeric-only validation gate, so unlike every other
+  // relation it could not be referenced by `documentId` (nor via the longhand
+  // connect/disconnect object) at the REST boundary. These lock in full parity.
+  describe('role relation by documentId + longhand', () => {
+    const postUser = (body) => rq({ method: 'POST', url: '/users', body });
+    let roleSeq = 0;
+    const uniqueUser = () => {
+      roleSeq += 1;
+      return {
+        username: `roleuser${roleSeq}`,
+        email: `roleuser${roleSeq}@strapi.io`,
+        password: 'password123',
+      };
+    };
+
+    test('POST /users sets the role by documentId shorthand', async () => {
+      const res = await postUser({ ...uniqueUser(), role: authenticatedRole.documentId });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.role.id).toBe(authenticatedRole.id);
+    });
+
+    test('POST /users sets the role via longhand connect by documentId', async () => {
+      const res = await postUser({
+        ...uniqueUser(),
+        role: { connect: [{ documentId: publicRole.documentId }] },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.role.id).toBe(publicRole.id);
+    });
+
+    test('PUT changes the role by documentId shorthand', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, { role: publicRole.documentId });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.role.id).toBe(publicRole.id);
+    });
+
+    test('PUT changes the role via longhand connect by documentId', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, {
+        role: { connect: [{ documentId: publicRole.documentId }] },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.role.id).toBe(publicRole.id);
+    });
+
+    test('PUT changes the role via longhand connect by numeric id', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, { role: { connect: [{ id: publicRole.id }] } });
+
+      expect(res.statusCode).toBe(200);
+      const after = await readUser(user.id);
+      expect(after.role.id).toBe(publicRole.id);
+    });
+
+    test('PUT rejects disconnecting the last role (must keep a role)', async () => {
+      const user = await createUser();
+
+      const res = await putUser(user.id, {
+        role: { connect: [], disconnect: [{ documentId: authenticatedRole.documentId }] },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
+++ b/tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js
@@ -498,5 +498,30 @@ describe('U&P users REST relation handling (issue 26606)', () => {
 
       expect(res.statusCode).toBe(400);
     });
+
+    describe('invalid role relation input', () => {
+      test('POST /users rejects an empty role object', async () => {
+        const res = await postUser({ ...uniqueUser(), role: {} });
+
+        expect(res.statusCode).toBe(400);
+      });
+
+      test('POST /users rejects a connect entry with neither id nor documentId', async () => {
+        const res = await postUser({
+          ...uniqueUser(),
+          role: { connect: [{}] },
+        });
+
+        expect(res.statusCode).toBe(400);
+      });
+
+      test('PUT rejects a connect entry with neither id nor documentId', async () => {
+        const user = await createUser();
+
+        const res = await putUser(user.id, { role: { connect: [{}] } });
+
+        expect(res.statusCode).toBe(400);
+      });
+    });
   });
 });

--- a/tests/api/plugins/users-permissions/users-graphql.test.api.js
+++ b/tests/api/plugins/users-permissions/users-graphql.test.api.js
@@ -182,6 +182,13 @@ describe('Simple Test GraphQL Users API End to End', () => {
       expect(res.statusCode).toBe(200);
       expect(body.errors).toBeUndefined();
       expect(body.data.updateUsersPermissionsUser.data.attributes.username).toBe('User Test');
+
+      // Verify the role was actually assigned (not just that the mutation
+      // returned without error).
+      const updated = await strapi.db
+        .query('plugin::users-permissions.user')
+        .findOne({ where: { id: data.user.id }, populate: ['role'] });
+      expect(updated.role.id).toBe(role.id);
     });
 
     test('Delete a user', async () => {

--- a/tests/api/plugins/users-permissions/users-graphql.test.api.js
+++ b/tests/api/plugins/users-permissions/users-graphql.test.api.js
@@ -150,6 +150,40 @@ describe('Simple Test GraphQL Users API End to End', () => {
       });
     });
 
+    // Regression for https://github.com/strapi/strapi/issues/24343 — the `role`
+    // relation is exposed as an `ID` scalar in GraphQL, so it must accept a
+    // `documentId` string (the v5 default), consistent with REST. A numeric id
+    // worked already; a documentId previously failed validation downstream.
+    test('Update a user role by documentId', async () => {
+      const role = await strapi.db
+        .query('plugin::users-permissions.role')
+        .findOne({ where: { type: 'authenticated' } });
+
+      const res = await graphqlQuery({
+        query: /* GraphQL */ `
+          mutation updateUser($id: ID!, $data: UsersPermissionsUserInput!) {
+            updateUsersPermissionsUser(id: $id, data: $data) {
+              data {
+                attributes {
+                  username
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          id: data.user.id,
+          data: { role: role.documentId },
+        },
+      });
+
+      const { body } = res;
+
+      expect(res.statusCode).toBe(200);
+      expect(body.errors).toBeUndefined();
+      expect(body.data.updateUsersPermissionsUser.data.attributes.username).toBe('User Test');
+    });
+
     test('Delete a user', async () => {
       const res = await graphqlQuery({
         query: /* GraphQL */ `

--- a/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/openapi-generate.test.cli.ts.snap
@@ -26321,7 +26321,64 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
                     "type": "string",
                   },
                   "role": {
-                    "type": "number",
+                    "anyOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "connect": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "documentId": {
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number",
+                                    },
+                                    {
+                                      "type": "string",
+                                    },
+                                  ],
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "disconnect": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "documentId": {
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number",
+                                    },
+                                    {
+                                      "type": "string",
+                                    },
+                                  ],
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "type": "object",
+                      },
+                    ],
                   },
                   "username": {
                     "type": "string",
@@ -27646,7 +27703,64 @@ exports[`openapi:generate should generate a spec describing i18n and users-permi
                     "type": "string",
                   },
                   "role": {
-                    "type": "number",
+                    "anyOf": [
+                      {
+                        "type": "number",
+                      },
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "connect": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "documentId": {
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number",
+                                    },
+                                    {
+                                      "type": "string",
+                                    },
+                                  ],
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "disconnect": {
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "documentId": {
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number",
+                                    },
+                                    {
+                                      "type": "string",
+                                    },
+                                  ],
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "type": "object",
+                      },
+                    ],
                   },
                   "username": {
                     "type": "string",


### PR DESCRIPTION
### What does it do?

Lets the `role` relation accept a `documentId` (the v5 default) on `POST /api/users` and `PUT /api/users/:id`, in addition to the legacy numeric `id` — bringing it in line with every other v5 relation input.

The data path (controller → user service → Document Service) already resolves `documentId` for relations; the only blockers were the validators:

- **Zod route body validator** (`server/routes/content-api/validation.js`): `role` was `z.number()`. It now accepts a numeric id, a `documentId` string (shorthand), or the longhand `{ connect, disconnect }` object — matching core relation inputs.
- **Yup controller validator** (`server/controllers/validation/user.js`): connect/disconnect entries now accept `id` **or** `documentId`. On update, `connect`/`disconnect` are each optional (previously both required, which blocked the connect-only form), while the "a user must keep a role" guard (`CheckDisconnect`) is preserved.

Numeric `id` continues to work, so the change is non-breaking. GraphQL already exposed `role` as an `ID` scalar and routed through the same controller, so it accepted a `documentId` already; a regression test locks that in.

### Why is it needed?

The users-permissions `role` relation was the only v5 surface still requiring a numeric `id`. Passing the `documentId` that read queries return (the v5 convention) was rejected at validation, inconsistent with the rest of the API.

### How to test it?

```bash
yarn test:generate-app
yarn test:api tests/api/plugins/users-permissions
```

New/extended coverage:
- `tests/api/plugins/users-permissions/content-api/user-update-relations.test.api.js` — REST `role` by documentId (shorthand) and longhand connect (documentId and numeric) on create/update, plus the last-role-disconnect guard still returns 400.
- `tests/api/plugins/users-permissions/users-graphql.test.api.js` — GraphQL `role` by documentId regression.

Manual (examples/getstarted, U&P enabled): `POST /api/users` with `{ "role": "<documentId>" }` now returns 201; `PUT` with `{ "role": { "connect": [{ "documentId": "<id>" }] } }` and with `{ "role": <numericId> }` both return 200.

### Related issue(s)/PR(s)

Related to #24343 and #26606.