### PR TITLE
docs: fix spelling typos in content-manager relations guide

### DIFF
--- a/docs/docs/docs/01-core/content-manager/04-relations.mdx
+++ b/docs/docs/docs/01-core/content-manager/04-relations.mdx
@@ -96,7 +96,7 @@ Inside the reducer we reduce the array of `relationalFieldPaths` to an object wi
 as the base. If there is `modifiedData` in the browser i.e. you've made changes to the entity and saved those changes,
 we just replace the first level of the field with the `modifiedData` so the data structure is preserved and we're not
 loosing the relations we had already loaded in the component. If the first part of the path is highlighted as the
-`relationalField` then we simply replace that intial object with an empty array.
+`relationalField` then we simply replace that initial object with an empty array.
 
 However, if the first part of the path is either a repeatable component, a dynamic zone or a regular component then we
 recursively find the relation fields and replace the object with an array. This is handled by the `findLeafByPathAndReplace`
@@ -119,7 +119,7 @@ the beginning of the list. This is the expected behaviour, to keep the order of 
 :::
 
 The `RelationInput` component takes the field in `modifiedData` as its source of truth. You could therefore consider this to
-be the `browserState` and `initialData` to be the `serverState`. When relations are loaded they're added to both the `intialData`
+be the `browserState` and `initialData` to be the `serverState`. When relations are loaded they're added to both the `initialData`
 and `modifiedData` objects, but when you connect/disconnect only the `modifiedData` is updated. This is useful when we're preparing
 data for the api.
 

--- a/docs/docs/docs/01-core/content-manager/04-relations.mdx
+++ b/docs/docs/docs/01-core/content-manager/04-relations.mdx
@@ -53,7 +53,7 @@ following conditions:
 - The field is a repeatable component
 - The field is a dynamic zone
 
-These paths _do not_ take into account index values. So if you have a repetable component field where the schema looks like:
+These paths _do not_ take into account index values. So if you have a repeatable component field where the schema looks like:
 
 ```json
 {
@@ -93,18 +93,18 @@ Then the path to the relation field would be `repeatable_single_component_relati
 relations are added the path to the field in the redux store would be `repeatable_single_component_relation.0.categories`.
 
 Inside the reducer we reduce the array of `relationalFieldPaths` to an object with the `initialValues` clone as
-as the base. If there is `modifiedData` in the browser i.e. you've made changes to the entity and saved those changes,
+the base. If there is `modifiedData` in the browser i.e. you've made changes to the entity and saved those changes,
 we just replace the first level of the field with the `modifiedData` so the data structure is preserved and we're not
-loosing the relations we had already loaded in the component. If the first part of the path is highlighted as the
+losing the relations we had already loaded in the component. If the first part of the path is highlighted as the
 `relationalField` then we simply replace that initial object with an empty array.
 
 However, if the first part of the path is either a repeatable component, a dynamic zone or a regular component then we
 recursively find the relation fields and replace the object with an array. This is handled by the `findLeafByPathAndReplace`
 utility function. This function in short, takes an end path (in this case the relational field) and a primitive to replace
 when it finds the endpath (an empty array in this case). It then recursively reduces the paths to the relational field mapping
-through arrays if necessary (in the instance of repetable components for example) replacing the endpath with the primitive.
+through arrays if necessary (in the instance of repeatable components for example) replacing the endpath with the primitive.
 
-When this is done, we have sucessfully prepared our initial data for usage with relations.
+When this is done, we have successfully prepared our initial data for usage with relations.
 
 ### Handling updates to relation fields
 
@@ -121,7 +121,7 @@ the beginning of the list. This is the expected behaviour, to keep the order of 
 The `RelationInput` component takes the field in `modifiedData` as its source of truth. You could therefore consider this to
 be the `browserState` and `initialData` to be the `serverState`. When relations are loaded they're added to both the `initialData`
 and `modifiedData` objects, but when you connect/disconnect only the `modifiedData` is updated. This is useful when we're preparing
-data for the api.
+data for the API.
 
 ### Cleaning data to be posted to the API
 

--- a/docs/docs/guides/05-type-system/01-philosophy.md
+++ b/docs/docs/guides/05-type-system/01-philosophy.md
@@ -46,7 +46,7 @@ The main challenge faced by the type system is being able to maintain a high-qua
 
 #### For Contributors
 
-Contributors expect to create and/or use APIs that handle very generic data structures in the context of Strapi internals, which become context-aware and strongly typed when used by a user withing their application.
+Contributors expect to create and/or use APIs that handle very generic data structures in the context of Strapi internals, which become context-aware and strongly typed when used by a user within their application.
 
 #### For Users
 


### PR DESCRIPTION
Fixes spelling typos and a duplicated word in the contributor documentation.

**`docs/docs/docs/01-core/content-manager/04-relations.mdx`**
- `intial` → `initial`; `intialData` → `initialData` (matches the correctly-spelled `initialData` used earlier in the same sentence)
- `loosing` → `losing`
- `sucessfully` → `successfully`
- `repetable` → `repeatable` (2 occurrences)
- removed a duplicated "as" ("... clone as / as the base")
- `api` → `API` for consistency with the rest of the docs

**`docs/docs/guides/05-type-system/01-philosophy.md`**
- `withing` → `within`

Docs-only change. Thanks to the automated review for catching the extra typos — they're included now.