### PR TITLE
ci: revert `preactjs/compressed-size-action` to `v2`

### DIFF
--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           install-script: 'sh /tmp/install-and-build.sh'
-          build-script: 'yarn run build:size'
+          build-script: 'build:size'
           pattern: '**/build/**/*.{js,css,html,svg}'
           strip-hash: "-([-\\w]{8})(\\.\\w+)$"
           minimum-change-threshold: '5%'

--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/yarn-nm-install
 
       - name: Create install-and-build script
-        run: printf '#!/bin/sh\nset -e\nyarn install\nyarn build\n' > /tmp/install-and-build.sh
+        run: printf '#!/bin/sh\nset -e\nyarn install\nyarn nx reset\nyarn build\n' > /tmp/install-and-build.sh
 
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/adminBundleSize.yml
+++ b/.github/workflows/adminBundleSize.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create install-and-build script
         run: printf '#!/bin/sh\nset -e\nyarn install\nyarn build\n' > /tmp/install-and-build.sh
 
-      - uses: preactjs/compressed-size-action@v3
+      - uses: preactjs/compressed-size-action@v2
         with:
           install-script: 'sh /tmp/install-and-build.sh'
           build-script: 'yarn run build:size'


### PR DESCRIPTION
### What does it do?

Reverts the Admin bundle-size workflow to `preactjs/compressed-size-action@v2` and restores the v2 `build-script` value (`build:size`, which the action runs as `yarn run build:size`). This matches the configuration that worked before the Dependabot bump to v3.

### Why is it needed?

The **Admin bundle-size** check fails at startup on pull requests that touch admin sources, translations, or `yarn.lock`. GitHub blocks the workflow before any job runs because `preactjs/compressed-size-action@v3` is not on the Strapi org's allowed-actions list, while `@v2` is. The v3 upgrade (#26498) and follow-up build-script adjustment (#26556) did not account for that policy.

Until infra adds v3 to the allowlist, staying on v2 restores bundle-size feedback on affected PRs. The `@v2` tag resolves to the latest 2.x release (currently 2.10).

### How to test it?

1. Open or sync a pull request against `develop` that changes a path matched by the workflow trigger (for example an admin `*.js` file or `yarn.lock`).
2. Confirm the **Admin bundle-size** workflow starts and completes instead of failing with a startup / allowlist error.
3. Confirm the PR receives a compressed-size comparison comment (or stdout output for fork PRs).

### Related issue(s)/PR(s)

- Fix #26709
- Introduced by #26498, adjusted in #26556