### PR TITLE
fix(content-manager): serve live preview script from server endpoint

### DIFF
--- a/docs/docs/docs/01-core/content-manager/06-preview.md
+++ b/docs/docs/docs/01-core/content-manager/06-preview.md
@@ -19,13 +19,18 @@ Instead, the preview script is defined inside Strapi and sent to the frontend vi
 
 ### Self-contained constraint
 
-The preview script (`packages/core/content-manager/admin/src/preview/utils/previewScript.ts`) is stringified before being sent to the iframe:
+The preview script (`packages/core/content-manager/server/src/preview/controllers/previewScript.js`) is served verbatim from a server endpoint (`GET /content-manager/preview/script`). The admin fetches it, wraps it with its runtime config, and posts the result to the iframe:
 
 ```ts
-const script = `(${previewScript.toString()})(${JSON.stringify(config)})`;
+const previewScriptSource = await fetch('/content-manager/preview/script').then((res) =>
+  res.text()
+);
+const script = `(${previewScriptSource})(${JSON.stringify(config)})`;
 ```
 
 Because of this, it **cannot import dependencies or reference external variables**. All logic must be self-contained. The only external code (`@vercel/stega` for decoding) is loaded dynamically from a CDN at runtime.
+
+It lives in a standalone `.js` file served as-is rather than being bundled with the admin: a bundler wraps the module in helper code that breaks once the function is stringified and injected into the iframe. The file is still type-checked via `@ts-check` and JSDoc.
 
 This is why the file has an unusual structure with many functions defined inline.
 

--- a/docs/docs/docs/01-core/content-manager/06-preview.md
+++ b/docs/docs/docs/01-core/content-manager/06-preview.md
@@ -25,6 +25,10 @@ The preview script (`packages/core/content-manager/server/src/preview/controller
 const previewScriptSource = await fetch('/content-manager/preview/script').then((res) =>
   res.text()
 );
+const config = {
+  colors: previewHighlightColors,
+  events: INTERNAL_EVENTS,
+};
 const script = `(${previewScriptSource})(${JSON.stringify(config)})`;
 ```
 

--- a/docs/docs/docs/01-core/content-manager/06-preview.md
+++ b/docs/docs/docs/01-core/content-manager/06-preview.md
@@ -22,12 +22,13 @@ Instead, the preview script is defined inside Strapi and sent to the frontend vi
 The preview script (`packages/core/content-manager/server/src/preview/controllers/previewScript.js`) is served verbatim from a server endpoint (`GET /content-manager/preview/script`). The admin fetches it, wraps it with its runtime config, and posts the result to the iframe:
 
 ```ts
-const previewScriptSource = await fetch('/content-manager/preview/script').then((res) =>
-  res.text()
-);
+const previewScriptSource = await fetch(
+  `${window.strapi.backendURL}/content-manager/preview/script`
+).then((res) => res.text());
 const config = {
   colors: previewHighlightColors,
   events: INTERNAL_EVENTS,
+  parentOrigin: window.location.origin,
 };
 const script = `(${previewScriptSource})(${JSON.stringify(config)})`;
 ```

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -100,7 +100,7 @@ const getPreviewScript = (() => {
   let previewScript = '';
   return async (previewHighlightColors: PreviewHighlightColors) => {
     if (!previewScript) {
-      const resp = await fetch('/content-manager/preview/script');
+      const resp = await fetch(`${window.strapi.backendURL}/content-manager/preview/script`);
 
       if (!resp.ok) {
         throw new Error('Could not retrieve preview script from server.');
@@ -116,6 +116,7 @@ const getPreviewScript = (() => {
     return `(${previewScript})(${JSON.stringify({
       colors: previewHighlightColors,
       events: INTERNAL_EVENTS,
+      parentOrigin: window.location.origin,
     })})`;
   };
 })();

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -36,9 +36,8 @@ import { createYupSchema } from '../../utils/validation';
 import { InputPopover } from '../components/InputPopover';
 import { PreviewHeader } from '../components/PreviewHeader';
 import { useGetPreviewUrlQuery } from '../services/preview';
-import { PUBLIC_EVENTS } from '../utils/constants';
+import { INTERNAL_EVENTS, PUBLIC_EVENTS } from '../utils/constants';
 import { getSendMessage } from '../utils/getSendMessage';
-import { previewScript } from '../utils/previewScript';
 
 import type { Schema, UID } from '@strapi/types';
 
@@ -90,7 +89,36 @@ interface PreviewContextValue {
   setPopoverField: (value: PopoverField | null) => void;
 }
 
+type PreviewHighlightColors = {
+  highlightHoverColor: string;
+  highlightActiveColor: string;
+};
+
 const [PreviewProvider, usePreviewContext] = createContext<PreviewContextValue>('PreviewPage');
+
+const getPreviewScript = (() => {
+  let previewScript = '';
+  return async (previewHighlightColors: PreviewHighlightColors) => {
+    if (!previewScript) {
+      const resp = await fetch('/content-manager/preview/script');
+
+      if (!resp.ok) {
+        throw new Error('Could not retrieve preview script from server.');
+      }
+
+      previewScript = await resp.text();
+
+      if (!previewScript) {
+        throw new Error('Could not retrieve preview script from server.');
+      }
+    }
+
+    return `(${previewScript})(${JSON.stringify({
+      colors: previewHighlightColors,
+      events: INTERNAL_EVENTS,
+    })})`;
+  };
+})();
 
 /* -------------------------------------------------------------------------------------------------
  * PreviewPage
@@ -134,14 +162,14 @@ const PreviewPage = () => {
   );
   const device = DEVICES.find((d) => d.name === deviceName) ?? DEVICES[0];
 
-  const previewHighlightColors = {
+  const previewHighlightColors: PreviewHighlightColors = {
     highlightHoverColor: theme.colors.primary500,
     highlightActiveColor: theme.colors.primary600,
   };
 
   // Listen for ready message from iframe before injecting script
   React.useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
+    const handleMessage = async (event: MessageEvent) => {
       // Only listen to events from the preview iframe
       if (iframeRef.current) {
         const previewOrigin = new URL(iframeRef.current?.src).origin;
@@ -151,10 +179,8 @@ const PreviewPage = () => {
       }
 
       if (event.data?.type === PUBLIC_EVENTS.PREVIEW_READY) {
-        const script = `(${previewScript.toString()})(${JSON.stringify({
-          shouldRun: true,
-          colors: previewHighlightColors,
-        })})`;
+        const script = await getPreviewScript(previewHighlightColors);
+
         const sendMessage = getSendMessage(iframeRef);
         sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
       }

--- a/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
+++ b/packages/core/content-manager/admin/src/preview/pages/Preview.tsx
@@ -179,10 +179,21 @@ const PreviewPage = () => {
       }
 
       if (event.data?.type === PUBLIC_EVENTS.PREVIEW_READY) {
-        const script = await getPreviewScript(previewHighlightColors);
+        try {
+          const script = await getPreviewScript(previewHighlightColors);
 
-        const sendMessage = getSendMessage(iframeRef);
-        sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
+          const sendMessage = getSendMessage(iframeRef);
+          sendMessage(PUBLIC_EVENTS.STRAPI_SCRIPT, { script });
+        } catch {
+          toggleNotification({
+            type: 'danger',
+            message: formatMessage({
+              id: 'content-manager.preview.error.script-failed',
+              defaultMessage:
+                'Could not load the live preview script. Visual editing may not be available.',
+            }),
+          });
+        }
       }
     };
 
@@ -191,7 +202,7 @@ const PreviewPage = () => {
     return () => {
       window.removeEventListener('message', handleMessage);
     };
-  }, [documentId, toggleNotification, theme]);
+  }, [documentId, toggleNotification, theme, formatMessage]);
 
   if (!collectionType) {
     throw new Error('Could not find collectionType in url params');

--- a/packages/core/content-manager/admin/src/preview/utils/constants.ts
+++ b/packages/core/content-manager/admin/src/preview/utils/constants.ts
@@ -1,21 +1,16 @@
 import { NotificationConfig } from '@strapi/admin/strapi-admin';
 import { MessageDescriptor } from 'react-intl';
 
-import { previewScript } from './previewScript';
-
-export const PREVIEW_HIGHLIGHT_COLORS = {
-  highlightHoverColor: 'transparent',
-  highlightActiveColor: 'transparent',
-} as const;
-
-const scriptResponse = previewScript({ shouldRun: false, colors: PREVIEW_HIGHLIGHT_COLORS });
-
 /**
- * These events can be changed safely. They're used by the content manager admin on one side, and by
- * the preview script on the other. We own both ends, and they're not documented to users, so we can
- * do what we want with them.
+ * These events are not part of the public API, changing them is not a breaking change.
  */
-export const INTERNAL_EVENTS = scriptResponse!.INTERNAL_EVENTS;
+export const INTERNAL_EVENTS = {
+  STRAPI_FIELD_FOCUS: 'strapiFieldFocus',
+  STRAPI_FIELD_BLUR: 'strapiFieldBlur',
+  STRAPI_FIELD_CHANGE: 'strapiFieldChange',
+  STRAPI_FIELD_FOCUS_INTENT: 'strapiFieldFocusIntent',
+  STRAPI_FIELD_SINGLE_CLICK_HINT: 'strapiFieldSingleClickHint',
+} as const;
 
 /**
  * These events are documented to users, and will be hardcoded in their frontends.

--- a/packages/core/content-manager/admin/src/translations/en.json
+++ b/packages/core/content-manager/admin/src/translations/en.json
@@ -278,6 +278,7 @@
   "preview.error.relations-not-handled": "Inline editing for relations is not currently supported.",
   "preview.error.incomplete-strapi-source": "This field is missing some required preview information",
   "preview.error.different-document": "This field comes from a different document",
+  "preview.error.script-failed": "Could not load the live preview script. Visual editing may not be available.",
   "relation.create": "Create a relation",
   "relation.add": "Add or create a relation",
   "relation.disconnect": "Remove",

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -59,7 +59,7 @@
     "clean": "run -T rimraf ./dist",
     "lint": "run -T eslint .",
     "test:front": "run -T cross-env IS_EE=true jest --config ./jest.config.front.js",
-    "test:ts:back": "run -T tsc --noEmit -p server/tsconfig.json",
+    "test:ts:back": "run -T tsc --noEmit -p server/tsconfig.json && run -T tsc --noEmit -p server/tsconfig.preview-script.json",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
     "test:unit": "run -T jest",
     "test:unit:watch": "run -T jest --watch",

--- a/packages/core/content-manager/rollup.config.mjs
+++ b/packages/core/content-manager/rollup.config.mjs
@@ -1,14 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { defineConfig } from 'rollup';
 import { baseConfig } from '../../../rollup.utils.mjs';
 
+/**
+ * The preview script (server/src/preview/controllers/previewScript.js) is a standalone
+ * artifact injected into the user's site inside the preview iframe.
+ *
+ * It must NOT be bundled to avoid any wrapper code or hoisting. That's why we simply
+ * copy it verbatim into the dist folder, and let a controller serve it as-is.
+ */
+const copyPreviewScript = () => ({
+  name: 'copy-preview-script',
+  writeBundle() {
+    const src = path.resolve('server/src/preview/controllers/previewScript.js');
+    const dest = path.resolve('dist/server/preview/controllers/previewScript.js');
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  },
+});
+
+const serverConfig = baseConfig({
+  input: {
+    index: './server/src/index.ts',
+  },
+  rootDir: './server/src',
+  outDir: './dist/server',
+});
+serverConfig.plugins = [...serverConfig.plugins, copyPreviewScript()];
+
 export default defineConfig([
-  baseConfig({
-    input: {
-      index: './server/src/index.ts',
-    },
-    rootDir: './server/src',
-    outDir: './dist/server',
-  }),
+  serverConfig,
   baseConfig({
     input: {
       index: './admin/src/index.ts',

--- a/packages/core/content-manager/server/src/preview/controllers/preview.ts
+++ b/packages/core/content-manager/server/src/preview/controllers/preview.ts
@@ -1,9 +1,20 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 import type { Core, UID } from '@strapi/types';
 
 import { Preview } from '../../../../shared/contracts';
 
 import { getService } from '../utils';
 import { validatePreviewUrl } from './validation/preview';
+
+let previewScriptContent: string | null = null;
+const getPreviewScriptContent = () => {
+  if (previewScriptContent === null) {
+    previewScriptContent = readFileSync(join(__dirname, 'previewScript.js'), 'utf8');
+  }
+  return previewScriptContent;
+};
 
 const createPreviewController = () => {
   return {
@@ -32,6 +43,15 @@ const createPreviewController = () => {
       return {
         data: { url: url || undefined },
       } satisfies Preview.GetPreviewUrl.Response;
+    },
+
+    /**
+     * Serves the standalone preview script verbatim as JavaScript. The admin fetches
+     * this, injects the config, and posts it to the preview iframe
+     */
+    getPreviewScript(ctx) {
+      ctx.type = 'application/javascript';
+      ctx.body = getPreviewScriptContent();
     },
   } satisfies Core.Controller;
 };

--- a/packages/core/content-manager/server/src/preview/controllers/preview.ts
+++ b/packages/core/content-manager/server/src/preview/controllers/preview.ts
@@ -1,20 +1,12 @@
-import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import type { Core, UID } from '@strapi/types';
 
+import { readFile } from 'fs/promises';
 import { Preview } from '../../../../shared/contracts';
 
 import { getService } from '../utils';
 import { validatePreviewUrl } from './validation/preview';
-
-let previewScriptContent: string | null = null;
-const getPreviewScriptContent = () => {
-  if (previewScriptContent === null) {
-    previewScriptContent = readFileSync(join(__dirname, 'previewScript.js'), 'utf8');
-  }
-  return previewScriptContent;
-};
 
 const createPreviewController = () => {
   return {
@@ -49,9 +41,9 @@ const createPreviewController = () => {
      * Serves the standalone preview script verbatim as JavaScript. The admin fetches
      * this, injects the config, and posts it to the preview iframe
      */
-    getPreviewScript(ctx) {
+    async getPreviewScript(ctx) {
       ctx.type = 'application/javascript';
-      ctx.body = getPreviewScriptContent();
+      ctx.body = await readFile(join(__dirname, 'previewScript.js'), 'utf8');
     },
   } satisfies Core.Controller;
 };

--- a/packages/core/content-manager/server/src/preview/controllers/previewScript.js
+++ b/packages/core/content-manager/server/src/preview/controllers/previewScript.js
@@ -11,7 +11,7 @@
  * Because it runs in the user's page, it CANNOT use any imports or refer to any
  * variable outside of its own scope. Everything it needs is either defined within
  * `previewScript` or passed in through the `config` argument that the admin injects
- * at invocation time. Writting in JS and keeping it out of any bundler is deliberate:
+ * at invocation time. Writing in JS and keeping it out of any bundler is deliberate:
  * it guarantees the served text is exactly what's written here (no helper hoisting, no wrapping),
  * which is what makes it safe to evaluate as-is in the iframe.
  */

--- a/packages/core/content-manager/server/src/preview/controllers/previewScript.js
+++ b/packages/core/content-manager/server/src/preview/controllers/previewScript.js
@@ -210,6 +210,28 @@ function previewScript(config) {
     }
   };
 
+  const SAFE_MEDIA_URL_PROTOCOLS = new Set(['http:', 'https:', 'data:']);
+
+  /**
+   * Reject dangerous URL schemes before assigning media `src` attributes.
+   *
+   * @param {string | null | undefined} url
+   * @returns {string | null}
+   */
+  const sanitizeMediaUrl = (url) => {
+    if (!url) return null;
+
+    try {
+      const parsed = new URL(url, window.location.href);
+      if (!SAFE_MEDIA_URL_PROTOCOLS.has(parsed.protocol)) {
+        return null;
+      }
+      return parsed.href;
+    } catch {
+      return url.startsWith('/') ? url : null;
+    }
+  };
+
   /**
    * Extract a recognizable media filename from a URL string. Works for
    * direct backend URLs, relative paths, and proxy URLs that embed the
@@ -1118,11 +1140,15 @@ function previewScript(config) {
       // Resolve relative form-value URLs against the existing src's origin
       // so the swap targets the Strapi backend, not the iframe origin.
       const resolvedUrl = resolveMediaUrl(original, url);
+      const safeUrl = sanitizeMediaUrl(resolvedUrl);
+      if (!safeUrl) {
+        return;
+      }
 
       // No mime info — fall back to updating whatever's active
       if (!desiredTag) {
-        if (active.getAttribute('src') !== resolvedUrl) {
-          active.setAttribute('src', resolvedUrl);
+        if (active.getAttribute('src') !== safeUrl) {
+          active.setAttribute('src', safeUrl);
         }
         active.style.display = '';
         return;
@@ -1131,8 +1157,8 @@ function previewScript(config) {
       // Original's tag matches: restore it (removing any previous injection)
       if (original.tagName === desiredTag) {
         removeInjection();
-        if (original.getAttribute('src') !== resolvedUrl) {
-          original.setAttribute('src', resolvedUrl);
+        if (original.getAttribute('src') !== safeUrl) {
+          original.setAttribute('src', safeUrl);
         }
         original.style.display = '';
         return;
@@ -1140,8 +1166,8 @@ function previewScript(config) {
 
       // Existing injection of the right tag: just update its src
       if (injection && injection.tagName === desiredTag) {
-        if (injection.getAttribute('src') !== resolvedUrl) {
-          injection.setAttribute('src', resolvedUrl);
+        if (injection.getAttribute('src') !== safeUrl) {
+          injection.setAttribute('src', safeUrl);
         }
         return;
       }
@@ -1165,7 +1191,7 @@ function previewScript(config) {
         if (isAudio && skipForAudio.has(attr.name)) return;
         newInjection.setAttribute(attr.name, attr.value);
       });
-      newInjection.setAttribute('src', resolvedUrl);
+      newInjection.setAttribute('src', safeUrl);
       if (desiredTag === 'VIDEO' || desiredTag === 'AUDIO') {
         newInjection.setAttribute('controls', '');
       }

--- a/packages/core/content-manager/server/src/preview/controllers/previewScript.js
+++ b/packages/core/content-manager/server/src/preview/controllers/previewScript.js
@@ -30,6 +30,7 @@
  * @typedef {Object} PreviewScriptConfig
  * @property {PreviewScriptColors} colors
  * @property {InternalEvents} events Internal event names, owned by the admin (INTERNAL_EVENTS).
+ * @property {string} parentOrigin Admin panel origin used to validate and target postMessage traffic.
  */
 
 /**
@@ -44,7 +45,7 @@
  * @param {PreviewScriptConfig} config
  */
 function previewScript(config) {
-  const { colors, events: INTERNAL_EVENTS } = config;
+  const { colors, events: INTERNAL_EVENTS, parentOrigin } = config;
 
   /** @type {typeof window & WindowExtensions} */
   const win = window;
@@ -71,7 +72,7 @@ function previewScript(config) {
    * @param {unknown} payload
    */
   const sendMessage = (type, payload) => {
-    window.parent.postMessage({ type, payload }, '*');
+    window.parent.postMessage({ type, payload }, parentOrigin);
   };
 
   /**
@@ -273,12 +274,19 @@ function previewScript(config) {
       return;
     }
 
-    // The specifier is a plain external URL. This file is never bundled, so the
-    // import is left exactly as written and evaluated natively inside the iframe.
-    const { vercelStegaDecode: stegaDecode, vercelStegaClean: stegaClean } = await import(
-      // @ts-ignore it's not a local dependency
-      'https://cdn.jsdelivr.net/npm/@vercel/stega@0.1.2/+esm'
-    );
+    let stegaDecode;
+    let stegaClean;
+
+    try {
+      // The specifier is a plain external URL. This file is never bundled, so the
+      // import is left exactly as written and evaluated natively inside the iframe.
+      ({ vercelStegaDecode: stegaDecode, vercelStegaClean: stegaClean } = await import(
+        // @ts-ignore it's not a local dependency
+        'https://cdn.jsdelivr.net/npm/@vercel/stega@0.1.2/+esm'
+      ));
+    } catch {
+      return;
+    }
 
     /**
      * @param {Element} element
@@ -959,6 +967,7 @@ function previewScript(config) {
         if (mutation.type === 'attributes' && mutation.attributeName === SOURCE_ATTRIBUTE) {
           const target = /** @type {HTMLElement} */ (mutation.target);
           if (target.hasAttribute(SOURCE_ATTRIBUTE)) {
+            highlightManager.removeHighlightForElement(target);
             highlightManager.createHighlightForElement(target);
             observeElementForResize(target);
           } else {
@@ -990,6 +999,9 @@ function previewScript(config) {
             if (node.nodeType === Node.ELEMENT_NODE) {
               const element = /** @type {Element} */ (node);
               highlightManager.removeHighlightForElement(element);
+              element.querySelectorAll(`[${SOURCE_ATTRIBUTE}]`).forEach((childElement) => {
+                highlightManager.removeHighlightForElement(childElement);
+              });
 
               // If a tracked media original (or its ancestor) was removed —
               // typically when the host framework re-renders after save and
@@ -1174,6 +1186,7 @@ function previewScript(config) {
      */
     const handleMessage = (event) => {
       if (!event.data?.type) return;
+      if (event.source !== window.parent || event.origin !== parentOrigin) return;
 
       // The user typed in an input, reflect the change in the preview
       if (event.data.type === INTERNAL_EVENTS.STRAPI_FIELD_CHANGE) {
@@ -1264,7 +1277,7 @@ function previewScript(config) {
               const mime = typeof value === 'object' && value !== null ? value.mime : undefined;
               setMediaElement(element, url || null, mime);
             } else {
-              element.textContent = value || '';
+              element.textContent = value == null ? '' : String(value);
             }
           });
         }
@@ -1292,7 +1305,7 @@ function previewScript(config) {
               const propertyName = elementPath.slice(field.length + 1);
               const propertyValue = value[propertyName];
               if (element instanceof HTMLElement && propertyValue !== undefined) {
-                element.textContent = propertyValue || '';
+                element.textContent = propertyValue == null ? '' : String(propertyValue);
               }
             }
           });
@@ -1397,13 +1410,15 @@ function previewScript(config) {
    * Orchestration
    * ---------------------------------------------------------------------------------------------*/
 
-  setupStegaDOMObserver().then((stegaObserver) => {
-    createHighlightStyles();
-    const overlay = createOverlaySystem();
-    const highlightManager = createHighlightManager(overlay);
-    const observers = setupObservers(highlightManager, stegaObserver);
-    const scrollManager = setupScrollManagement(highlightManager);
-    const eventHandlers = setupEventHandlers(highlightManager);
-    createCleanupSystem(overlay, observers, scrollManager, eventHandlers, highlightManager);
-  });
+  setupStegaDOMObserver()
+    .catch(() => undefined)
+    .then((stegaObserver) => {
+      createHighlightStyles();
+      const overlay = createOverlaySystem();
+      const highlightManager = createHighlightManager(overlay);
+      const observers = setupObservers(highlightManager, stegaObserver);
+      const scrollManager = setupScrollManagement(highlightManager);
+      const eventHandlers = setupEventHandlers(highlightManager);
+      createCleanupSystem(overlay, observers, scrollManager, eventHandlers, highlightManager);
+    });
 }

--- a/packages/core/content-manager/server/src/preview/controllers/previewScript.js
+++ b/packages/core/content-manager/server/src/preview/controllers/previewScript.js
@@ -1,78 +1,91 @@
-// NOTE: This override is for the properties on _user's site_, it's not about Strapi Admin.
-declare global {
-  interface Window {
-    __strapi_previewCleanup?: () => void;
-    STRAPI_HIGHLIGHT_HOVER_COLOR?: string;
-    STRAPI_HIGHLIGHT_ACTIVE_COLOR?: string;
-    STRAPI_DISABLE_STEGA_DECODING?: boolean;
-  }
-}
+/* eslint-disable */
+// @ts-check
 
 /**
- * previewScript will be injected into the preview iframe after being stringified.
- * Therefore it CANNOT use any imports, or refer to any variables outside of its own scope.
- * It's why many functions are defined within previewScript, it's the only way to avoid going full spaghetti.
- * To get a better overview of everything previewScript does, go to the orchestration part at its end.
+ * STANDALONE PREVIEW SCRIPT
+ *
+ * This file is NOT bundled. It is served verbatim by the content-manager server
+ * (GET /content-manager/preview/script) and injected into the user's site inside
+ * the preview iframe by the admin (over postMessage, the STRAPI_SCRIPT event).
+ *
+ * Because it runs in the user's page, it CANNOT use any imports or refer to any
+ * variable outside of its own scope. Everything it needs is either defined within
+ * `previewScript` or passed in through the `config` argument that the admin injects
+ * at invocation time. Writting in JS and keeping it out of any bundler is deliberate:
+ * it guarantees the served text is exactly what's written here (no helper hoisting, no wrapping),
+ * which is what makes it safe to evaluate as-is in the iframe.
  */
-type PreviewScriptColors = {
-  highlightHoverColor: string;
-  highlightActiveColor: string;
-};
 
-type PreviewScriptConfig = {
-  shouldRun?: boolean;
-  colors: PreviewScriptColors;
-};
+/**
+ * @typedef {Object} PreviewScriptColors
+ * @property {string} highlightHoverColor
+ * @property {string} highlightActiveColor
+ */
 
-const previewScript = (config: PreviewScriptConfig) => {
-  const { shouldRun = true, colors } = config;
+/**
+ * @typedef {typeof import('../../../../admin/src/preview/utils/constants').INTERNAL_EVENTS} InternalEvents
+ */
+
+/**
+ * @typedef {Object} PreviewScriptConfig
+ * @property {PreviewScriptColors} colors
+ * @property {InternalEvents} events Internal event names, owned by the admin (INTERNAL_EVENTS).
+ */
+
+/**
+ * @typedef {Object} WindowExtensions
+ * @property {string} [STRAPI_HIGHLIGHT_HOVER_COLOR] Optional override for the highlight hover color, injected by the admin.
+ * @property {string} [STRAPI_HIGHLIGHT_ACTIVE_COLOR] Optional override for the highlight active color, injected by the admin.
+ * @property {boolean} [STRAPI_DISABLE_STEGA_DECODING] Optional flag to disable steganography decoding, injected by the admin.
+ * @property {() => void} [__strapi_previewCleanup] Optional cleanup function, injected by the admin.
+ */
+
+/**
+ * @param {PreviewScriptConfig} config
+ */
+function previewScript(config) {
+  const { colors, events: INTERNAL_EVENTS } = config;
+
+  /** @type {typeof window & WindowExtensions} */
+  const win = window;
 
   /* -----------------------------------------------------------------------------------------------
    * Params
    * ---------------------------------------------------------------------------------------------*/
   const HIGHLIGHT_PADDING = 2; // in pixels
-  const HIGHLIGHT_HOVER_COLOR = window.STRAPI_HIGHLIGHT_HOVER_COLOR ?? colors.highlightHoverColor;
-  const HIGHLIGHT_ACTIVE_COLOR =
-    window.STRAPI_HIGHLIGHT_ACTIVE_COLOR ?? colors.highlightActiveColor;
+  const HIGHLIGHT_HOVER_COLOR = win.STRAPI_HIGHLIGHT_HOVER_COLOR ?? colors.highlightHoverColor;
+  const HIGHLIGHT_ACTIVE_COLOR = win.STRAPI_HIGHLIGHT_ACTIVE_COLOR ?? colors.highlightActiveColor;
   const HIGHLIGHT_STYLES_ID = 'strapi-preview-highlight-styles';
   const DOUBLE_CLICK_TIMEOUT = 300; // milliseconds to wait for potential double-click
 
-  const DISABLE_STEGA_DECODING = window.STRAPI_DISABLE_STEGA_DECODING ?? false;
+  const DISABLE_STEGA_DECODING = win.STRAPI_DISABLE_STEGA_DECODING ?? false;
   const SOURCE_ATTRIBUTE = 'data-strapi-source';
   const OVERLAY_ID = 'strapi-preview-overlay';
-  const INTERNAL_EVENTS = {
-    STRAPI_FIELD_FOCUS: 'strapiFieldFocus',
-    STRAPI_FIELD_BLUR: 'strapiFieldBlur',
-    STRAPI_FIELD_CHANGE: 'strapiFieldChange',
-    STRAPI_FIELD_FOCUS_INTENT: 'strapiFieldFocusIntent',
-    STRAPI_FIELD_SINGLE_CLICK_HINT: 'strapiFieldSingleClickHint',
-  } as const;
-
-  /**
-   * Calling the function in no-run mode lets us retrieve the constants from other files and keep
-   * a single source of truth for them. It's the only way to do this because this script can't
-   * refer to any variables outside of its own scope, because it's stringified before it's run.
-   */
-  if (!shouldRun) {
-    return { INTERNAL_EVENTS };
-  }
 
   /* -----------------------------------------------------------------------------------------------
    * Utils
    * ---------------------------------------------------------------------------------------------*/
 
-  const sendMessage = (
-    type: (typeof INTERNAL_EVENTS)[keyof typeof INTERNAL_EVENTS],
-    payload: unknown
-  ) => {
+  /**
+   * @param {InternalEvents[keyof InternalEvents]} type
+   * @param {unknown} payload
+   */
+  const sendMessage = (type, payload) => {
     window.parent.postMessage({ type, payload }, '*');
   };
 
-  const getElementsByPath = (path: string) => {
+  /**
+   * @param {string} path
+   */
+  const getElementsByPath = (path) => {
     return document.querySelectorAll(`[${SOURCE_ATTRIBUTE}*="path=${path}"]`);
   };
 
-  const isMediaElement = (element: Element): boolean => {
+  /**
+   * @param {Element} element
+   * @returns {boolean}
+   */
+  const isMediaElement = (element) => {
     return element.tagName === 'IMG' || element.tagName === 'VIDEO' || element.tagName === 'AUDIO';
   };
 
@@ -89,16 +102,26 @@ const previewScript = (config: PreviewScriptConfig) => {
    * which is what was producing duplicate previews. The childList observer
    * below uses these maps to drop the injection whenever its associated
    * original is removed.
+   *
+   * @type {Map<HTMLElement, HTMLElement>}
    */
-  const originalToInjection = new Map<HTMLElement, HTMLElement>();
-  const injectionToOriginal = new Map<HTMLElement, HTMLElement>();
+  const originalToInjection = new Map();
+  /** @type {Map<HTMLElement, HTMLElement>} */
+  const injectionToOriginal = new Map();
 
-  const trackInjection = (original: HTMLElement, injection: HTMLElement) => {
+  /**
+   * @param {HTMLElement} original
+   * @param {HTMLElement} injection
+   */
+  const trackInjection = (original, injection) => {
     originalToInjection.set(original, injection);
     injectionToOriginal.set(injection, original);
   };
 
-  const untrackInjection = (injection: HTMLElement) => {
+  /**
+   * @param {HTMLElement} injection
+   */
+  const untrackInjection = (injection) => {
     const original = injectionToOriginal.get(injection);
     if (original) originalToInjection.delete(original);
     injectionToOriginal.delete(injection);
@@ -133,7 +156,13 @@ const previewScript = (config: PreviewScriptConfig) => {
    * so cleanup removes the wrapper rather than leaving an empty cell.
    */
   const CLONE_WRAPPER_ATTRIBUTE = 'data-strapi-media-clone-wrapper';
-  const createMediaPlaceholder = (sourceAttr: string, rect: DOMRect): HTMLElement => {
+
+  /**
+   * @param {string} sourceAttr
+   * @param {DOMRect} rect
+   * @returns {HTMLElement}
+   */
+  const createMediaPlaceholder = (sourceAttr, rect) => {
     const placeholder = document.createElement('div');
     placeholder.setAttribute(PLACEHOLDER_ATTRIBUTE, '');
     placeholder.setAttribute(SOURCE_ATTRIBUTE, sourceAttr);
@@ -161,8 +190,12 @@ const previewScript = (config: PreviewScriptConfig) => {
    * value as src, the browser resolves it against the iframe origin and
    * fails to load. Resolve against the original element's existing src
    * origin so the swap targets the same backend.
+   *
+   * @param {HTMLElement} originalEl
+   * @param {string} rawUrl
+   * @returns {string}
    */
-  const resolveMediaUrl = (originalEl: HTMLElement, rawUrl: string): string => {
+  const resolveMediaUrl = (originalEl, rawUrl) => {
     if (/^(?:[a-z]+:)?\/\//i.test(rawUrl) || rawUrl.startsWith('data:')) {
       return rawUrl;
     }
@@ -183,8 +216,11 @@ const previewScript = (config: PreviewScriptConfig) => {
    * Used to detect whether the rendered element already shows the same
    * asset as the form value, so we can skip src updates that would only
    * substitute one URL representation for another.
+   *
+   * @param {string} raw
+   * @returns {string}
    */
-  const getMediaFilename = (raw: string): string => {
+  const getMediaFilename = (raw) => {
     if (!raw) return '';
     let decoded = raw;
     try {
@@ -203,9 +239,13 @@ const previewScript = (config: PreviewScriptConfig) => {
    *   attribute was copied from the post-normalization media element, so it's already correct
    * - For non-media elements with model=plugin::upload.file (e.g., caption text): strip the last
    *   segment to focus the parent media field (e.g., "hero.caption" -> "hero")
+   *
+   * @param {string} sourceAttr
+   * @param {Element} element
+   * @returns {string}
    */
-  const getFieldPathForMedia = (sourceAttr: string, element: Element): string => {
-    if (isMediaElement(element) || injectionToOriginal.has(element as HTMLElement)) {
+  const getFieldPathForMedia = (sourceAttr, element) => {
+    if (isMediaElement(element) || injectionToOriginal.has(/** @type {HTMLElement} */ (element))) {
       return sourceAttr;
     }
 
@@ -233,13 +273,17 @@ const previewScript = (config: PreviewScriptConfig) => {
       return;
     }
 
+    // The specifier is a plain external URL. This file is never bundled, so the
+    // import is left exactly as written and evaluated natively inside the iframe.
     const { vercelStegaDecode: stegaDecode, vercelStegaClean: stegaClean } = await import(
-      // @ts-expect-error it's not a local dependency
-      // eslint-disable-next-line import/no-unresolved
+      // @ts-ignore it's not a local dependency
       'https://cdn.jsdelivr.net/npm/@vercel/stega@0.1.2/+esm'
     );
 
-    const applyStegaToElement = (element: Element) => {
+    /**
+     * @param {Element} element
+     */
+    const applyStegaToElement = (element) => {
       // Handle img and video tags - check src attribute for stega encoding
       if (isMediaElement(element)) {
         const src = element.getAttribute('src');
@@ -248,7 +292,7 @@ const previewScript = (config: PreviewScriptConfig) => {
             const result = stegaDecode(src);
             if (result && 'strapiSource' in result) {
               // Parse the source and remove .url suffix to point to the media field
-              const sourceValue = result.strapiSource as string;
+              const sourceValue = result.strapiSource;
               const pathMatch = sourceValue.match(/path=([^&]+)/);
               if (pathMatch) {
                 const originalPath = pathMatch[1];
@@ -306,7 +350,7 @@ const previewScript = (config: PreviewScriptConfig) => {
         if (mutation.type === 'childList') {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
-              const element = node as Element;
+              const element = /** @type {Element} */ (node);
               // Process the added element
               applyStegaToElement(element);
               // Process all child elements
@@ -323,7 +367,7 @@ const previewScript = (config: PreviewScriptConfig) => {
 
         // Handle src attribute changes for img/video elements
         if (mutation.type === 'attributes' && mutation.attributeName === 'src') {
-          const target = mutation.target as Element;
+          const target = /** @type {Element} */ (mutation.target);
           if (isMediaElement(target)) {
             applyStegaToElement(target);
           }
@@ -378,7 +422,7 @@ const previewScript = (config: PreviewScriptConfig) => {
 
   const createOverlaySystem = () => {
     // Clean up before creating a new overlay so we can safely call previewScript multiple times
-    window.__strapi_previewCleanup?.();
+    win.__strapi_previewCleanup?.();
     document.getElementById(OVERLAY_ID)?.remove();
 
     const overlay = document.createElement('div');
@@ -397,11 +441,10 @@ const previewScript = (config: PreviewScriptConfig) => {
     return overlay;
   };
 
-  type EventListenersList = Array<{
-    element: HTMLElement | Window;
-    type: keyof HTMLElementEventMap | 'message';
-    handler: EventListener;
-  }>;
+  /**
+   * @typedef {{ element: HTMLElement | Window; type: keyof HTMLElementEventMap | 'message'; handler: EventListener; }} EventListenerEntry
+   * @typedef {EventListenerEntry[]} EventListenersList
+   */
 
   /**
    * Group all elements that share the exact same `data-strapi-source` value
@@ -411,21 +454,31 @@ const previewScript = (config: PreviewScriptConfig) => {
    * grouping is keyed off the source string so other accidental same-source
    * renders (e.g. the title rendered twice) also collapse to one highlight,
    * which matches how the focused state already behaves.
+   *
+   * @typedef {{ highlight: HTMLElement; elements: Set<HTMLElement>; }} HighlightGroup
    */
-  type HighlightGroup = {
-    highlight: HTMLElement;
-    elements: Set<HTMLElement>;
-  };
 
-  const createHighlightManager = (overlay: HTMLElement) => {
-    const groups = new Map<string, HighlightGroup>();
-    const elementToGroupKey = new Map<HTMLElement, string>();
-    const eventListeners: EventListenersList = [];
-    const focusedHighlights: HTMLElement[] = [];
-    const pendingClicks = new Map<HighlightGroup, number>();
-    let focusedField: string | null = null;
+  /**
+   * @param {HTMLElement} overlay
+   */
+  const createHighlightManager = (overlay) => {
+    /** @type {Map<string, HighlightGroup>} */
+    const groups = new Map();
+    /** @type {Map<HTMLElement, string>} */
+    const elementToGroupKey = new Map();
+    /** @type {EventListenersList} */
+    const eventListeners = [];
+    /** @type {HTMLElement[]} */
+    const focusedHighlights = [];
+    /** @type {Map<HighlightGroup, number>} */
+    const pendingClicks = new Map();
+    /** @type {string | null} */
+    let focusedField = null;
 
-    const computeGroupRect = (group: HighlightGroup) => {
+    /**
+     * @param {HighlightGroup} group
+     */
+    const computeGroupRect = (group) => {
       let minLeft = Infinity;
       let minTop = Infinity;
       let maxRight = -Infinity;
@@ -449,7 +502,10 @@ const previewScript = (config: PreviewScriptConfig) => {
       };
     };
 
-    const drawGroup = (group: HighlightGroup) => {
+    /**
+     * @param {HighlightGroup} group
+     */
+    const drawGroup = (group) => {
       const rect = computeGroupRect(group);
       if (!rect) {
         group.highlight.style.display = 'none';
@@ -469,12 +525,13 @@ const previewScript = (config: PreviewScriptConfig) => {
      * Pick the underlying source element under the pointer so single-click
      * redispatch hits the specific item the user clicked, even when the group
      * highlight covers several elements (multi-media gallery).
+     *
+     * @param {HighlightGroup} group
+     * @param {number} x
+     * @param {number} y
+     * @returns {HTMLElement | null}
      */
-    const pickElementAtPoint = (
-      group: HighlightGroup,
-      x: number,
-      y: number
-    ): HTMLElement | null => {
+    const pickElementAtPoint = (group, x, y) => {
       for (const el of group.elements) {
         const r = el.getBoundingClientRect();
         if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
@@ -485,13 +542,21 @@ const previewScript = (config: PreviewScriptConfig) => {
       return first ?? null;
     };
 
-    const createGroup = (groupKey: string): HighlightGroup => {
+    /**
+     * @param {string} groupKey
+     * @returns {HighlightGroup}
+     */
+    const createGroup = (groupKey) => {
       const highlight = document.createElement('div');
       highlight.className = 'strapi-highlight';
-      const group: HighlightGroup = { highlight, elements: new Set() };
+      /** @type {HighlightGroup} */
+      const group = { highlight, elements: new Set() };
 
-      const clickHandler = (event: MouseEvent) => {
-        if ((event as any).__strapi_redispatched) {
+      /**
+       * @param {MouseEvent} event
+       */
+      const clickHandler = (event) => {
+        if (/** @type {any} */ (event).__strapi_redispatched) {
           return;
         }
 
@@ -514,7 +579,8 @@ const previewScript = (config: PreviewScriptConfig) => {
           const underlying = pickElementAtPoint(group, event.clientX, event.clientY);
           if (!underlying) return;
 
-          let targetElement: HTMLElement = underlying;
+          /** @type {HTMLElement} */
+          let targetElement = underlying;
           if (isMediaElement(underlying)) {
             let parent = underlying.parentElement;
             while (parent) {
@@ -546,14 +612,17 @@ const previewScript = (config: PreviewScriptConfig) => {
             shiftKey: event.shiftKey,
             metaKey: event.metaKey,
           });
-          (newEvent as any).__strapi_redispatched = true;
+          /** @type {any} */ (newEvent).__strapi_redispatched = true;
           targetElement.dispatchEvent(newEvent);
         }, DOUBLE_CLICK_TIMEOUT);
 
         pendingClicks.set(group, timeout);
       };
 
-      const doubleClickHandler = (event: MouseEvent) => {
+      /**
+       * @param {MouseEvent} event
+       */
+      const doubleClickHandler = (event) => {
         event.preventDefault();
         event.stopPropagation();
 
@@ -583,7 +652,10 @@ const previewScript = (config: PreviewScriptConfig) => {
         });
       };
 
-      const mouseDownHandler = (event: MouseEvent) => {
+      /**
+       * @param {MouseEvent} event
+       */
+      const mouseDownHandler = (event) => {
         if (event.detail >= 2) {
           event.preventDefault();
         }
@@ -594,9 +666,17 @@ const previewScript = (config: PreviewScriptConfig) => {
       highlight.addEventListener('mousedown', mouseDownHandler);
 
       eventListeners.push(
-        { element: highlight, type: 'click', handler: clickHandler as EventListener },
-        { element: highlight, type: 'dblclick', handler: doubleClickHandler as EventListener },
-        { element: highlight, type: 'mousedown', handler: mouseDownHandler as EventListener }
+        { element: highlight, type: 'click', handler: /** @type {EventListener} */ (clickHandler) },
+        {
+          element: highlight,
+          type: 'dblclick',
+          handler: /** @type {EventListener} */ (doubleClickHandler),
+        },
+        {
+          element: highlight,
+          type: 'mousedown',
+          handler: /** @type {EventListener} */ (mouseDownHandler),
+        }
       );
 
       overlay.appendChild(highlight);
@@ -604,7 +684,11 @@ const previewScript = (config: PreviewScriptConfig) => {
       return group;
     };
 
-    const destroyGroup = (groupKey: string, group: HighlightGroup) => {
+    /**
+     * @param {string} groupKey
+     * @param {HighlightGroup} group
+     */
+    const destroyGroup = (groupKey, group) => {
       const pendingTimeout = pendingClicks.get(group);
       if (pendingTimeout) {
         window.clearTimeout(pendingTimeout);
@@ -633,7 +717,10 @@ const previewScript = (config: PreviewScriptConfig) => {
       groups.delete(groupKey);
     };
 
-    const createHighlightForElement = (element: HTMLElement) => {
+    /**
+     * @param {HTMLElement} element
+     */
+    const createHighlightForElement = (element) => {
       if (elementToGroupKey.has(element)) {
         return;
       }
@@ -654,9 +741,12 @@ const previewScript = (config: PreviewScriptConfig) => {
         !injectionToOriginal.has(element) &&
         !element.hasAttribute(CLONE_ATTRIBUTE)
       ) {
-        const ghostInjections: HTMLElement[] = [];
-        const ghostPlaceholders: HTMLElement[] = [];
-        const ghostClones: HTMLElement[] = [];
+        /** @type {HTMLElement[]} */
+        const ghostInjections = [];
+        /** @type {HTMLElement[]} */
+        const ghostPlaceholders = [];
+        /** @type {HTMLElement[]} */
+        const ghostClones = [];
         group.elements.forEach((el) => {
           if (injectionToOriginal.has(el)) {
             ghostInjections.push(el);
@@ -673,7 +763,9 @@ const previewScript = (config: PreviewScriptConfig) => {
             // Tag-swap injection of a clone (e.g. user added a video as
             // the new item, swapping our cloned IMG for a VIDEO). Remove
             // the wrapper so we don't leave an empty layout cell behind.
-            const wrapper = orig.closest(`[${CLONE_WRAPPER_ATTRIBUTE}]`) as HTMLElement | null;
+            const wrapper = /** @type {HTMLElement | null} */ (
+              orig.closest(`[${CLONE_WRAPPER_ATTRIBUTE}]`)
+            );
             (wrapper ?? orig).remove();
           } else if (orig?.hasAttribute(PLACEHOLDER_ATTRIBUTE)) {
             orig.remove();
@@ -694,7 +786,9 @@ const previewScript = (config: PreviewScriptConfig) => {
         ghostClones.forEach((clone) => {
           group?.elements.delete(clone);
           elementToGroupKey.delete(clone);
-          const wrapper = clone.closest(`[${CLONE_WRAPPER_ATTRIBUTE}]`) as HTMLElement | null;
+          const wrapper = /** @type {HTMLElement | null} */ (
+            clone.closest(`[${CLONE_WRAPPER_ATTRIBUTE}]`)
+          );
           (wrapper ?? clone).remove();
         });
       }
@@ -707,14 +801,17 @@ const previewScript = (config: PreviewScriptConfig) => {
       drawGroup(group);
     };
 
-    const removeHighlightForElement = (element: Element) => {
-      const groupKey = elementToGroupKey.get(element as HTMLElement);
+    /**
+     * @param {Element} element
+     */
+    const removeHighlightForElement = (element) => {
+      const groupKey = elementToGroupKey.get(/** @type {HTMLElement} */ (element));
       if (!groupKey) return;
       const group = groups.get(groupKey);
       if (!group) return;
 
-      group.elements.delete(element as HTMLElement);
-      elementToGroupKey.delete(element as HTMLElement);
+      group.elements.delete(/** @type {HTMLElement} */ (element));
+      elementToGroupKey.delete(/** @type {HTMLElement} */ (element));
 
       if (group.elements.size === 0) {
         destroyGroup(groupKey, group);
@@ -728,11 +825,15 @@ const previewScript = (config: PreviewScriptConfig) => {
      * to `getElementsByPath` so this preserves the same loose substring match
      * the highlight system has always used (e.g. focusing `hero` matches
      * `hero.caption` too).
+     *
+     * @param {string} path
+     * @returns {HighlightGroup[]}
      */
-    const findGroupForPath = (path: string): HighlightGroup[] => {
-      const matched = new Set<HighlightGroup>();
+    const findGroupForPath = (path) => {
+      /** @type {Set<HighlightGroup>} */
+      const matched = new Set();
       getElementsByPath(path).forEach((el) => {
-        const key = elementToGroupKey.get(el as HTMLElement);
+        const key = elementToGroupKey.get(/** @type {HTMLElement} */ (el));
         if (!key) return;
         const group = groups.get(key);
         if (group) matched.add(group);
@@ -761,7 +862,8 @@ const previewScript = (config: PreviewScriptConfig) => {
       createHighlightForElement,
       removeHighlightForElement,
       findGroupForPath,
-      setFocusedField: (field: string | null) => {
+      /** @param {string | null} field */
+      setFocusedField: (field) => {
         focusedField = field;
       },
       getFocusedField: () => focusedField,
@@ -772,19 +874,24 @@ const previewScript = (config: PreviewScriptConfig) => {
     };
   };
 
-  type HighlightManager = ReturnType<typeof createHighlightManager>;
+  /**
+   * @typedef {ReturnType<typeof createHighlightManager>} HighlightManager
+   */
 
   /**
    * We need to track scroll in all the element parents in order to keep the highlight position
    * in sync with the element position. Listening to window scroll is not enough because the
    * element can be inside one or more scrollable containers.
+   *
+   * @param {HighlightManager} highlightManager
    */
-  const setupScrollManagement = (highlightManager: HighlightManager) => {
+  const setupScrollManagement = (highlightManager) => {
     const updateOnScroll = () => {
       highlightManager.updateAllHighlights();
     };
 
-    const scrollableElements = new Set<Element | Window>();
+    /** @type {Set<Element | Window>} */
+    const scrollableElements = new Set();
     scrollableElements.add(window);
 
     // Find all scrollable ancestors for all tracked elements and set up scroll listeners
@@ -818,7 +925,7 @@ const previewScript = (config: PreviewScriptConfig) => {
           window.removeEventListener('scroll', updateOnScroll);
           window.removeEventListener('resize', updateOnScroll);
         } else {
-          (element as Element).removeEventListener('scroll', updateOnScroll);
+          /** @type {Element} */ (element).removeEventListener('scroll', updateOnScroll);
         }
       });
     };
@@ -826,15 +933,19 @@ const previewScript = (config: PreviewScriptConfig) => {
     return { cleanup };
   };
 
-  const setupObservers = (
-    highlightManager: HighlightManager,
-    stegaObserver: MutationObserver | undefined
-  ) => {
+  /**
+   * @param {HighlightManager} highlightManager
+   * @param {MutationObserver | undefined} stegaObserver
+   */
+  const setupObservers = (highlightManager, stegaObserver) => {
     const resizeObserver = new ResizeObserver(() => {
       highlightManager.updateAllHighlights();
     });
 
-    const observeElementForResize = (element: Element) => {
+    /**
+     * @param {Element} element
+     */
+    const observeElementForResize = (element) => {
       resizeObserver.observe(element);
     };
 
@@ -846,7 +957,7 @@ const previewScript = (config: PreviewScriptConfig) => {
     const highlightObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === 'attributes' && mutation.attributeName === SOURCE_ATTRIBUTE) {
-          const target = mutation.target as HTMLElement;
+          const target = /** @type {HTMLElement} */ (mutation.target);
           if (target.hasAttribute(SOURCE_ATTRIBUTE)) {
             highlightManager.createHighlightForElement(target);
             observeElementForResize(target);
@@ -858,7 +969,7 @@ const previewScript = (config: PreviewScriptConfig) => {
         if (mutation.type === 'childList') {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
-              const element = node as Element;
+              const element = /** @type {Element} */ (node);
               // Check if the added element has source attribute
               if (element.hasAttribute(SOURCE_ATTRIBUTE) && element instanceof HTMLElement) {
                 highlightManager.createHighlightForElement(element);
@@ -877,7 +988,7 @@ const previewScript = (config: PreviewScriptConfig) => {
 
           mutation.removedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
-              const element = node as Element;
+              const element = /** @type {Element} */ (node);
               highlightManager.removeHighlightForElement(element);
 
               // If a tracked media original (or its ancestor) was removed —
@@ -916,8 +1027,16 @@ const previewScript = (config: PreviewScriptConfig) => {
     };
   };
 
-  const setupEventHandlers = (highlightManager: HighlightManager) => {
-    const setMediaElement = (el: HTMLElement, url: string | null, mime?: string) => {
+  /**
+   * @param {HighlightManager} highlightManager
+   */
+  const setupEventHandlers = (highlightManager) => {
+    /**
+     * @param {HTMLElement} el
+     * @param {string | null} url
+     * @param {string} [mime]
+     */
+    const setMediaElement = (el, url, mime) => {
       const original = injectionToOriginal.get(el) ?? el;
       const injection = originalToInjection.get(original) ?? null;
 
@@ -1018,7 +1137,7 @@ const previewScript = (config: PreviewScriptConfig) => {
       // Need a fresh injection of the correct tag
       removeInjection();
 
-      const newInjection = document.createElement(desiredTag) as HTMLElement;
+      const newInjection = /** @type {HTMLElement} */ (document.createElement(desiredTag));
       // Mirror the original's attributes so styling/classes carry over.
       // Skip src/srcset — those carry the *previous* media's URL and would
       // make the new element try to load it (a video element fed an image
@@ -1050,7 +1169,10 @@ const previewScript = (config: PreviewScriptConfig) => {
       trackInjection(original, newInjection);
     };
 
-    const handleMessage = (event: MessageEvent) => {
+    /**
+     * @param {MessageEvent} event
+     */
+    const handleMessage = (event) => {
       if (!event.data?.type) return;
 
       // The user typed in an input, reflect the change in the preview
@@ -1058,8 +1180,8 @@ const previewScript = (config: PreviewScriptConfig) => {
         const { field, value } = event.data.payload;
         if (!field) return;
 
-        const matchedElements = Array.from(getElementsByPath(field)).filter(
-          (el): el is HTMLElement => el instanceof HTMLElement
+        const matchedElements = /** @type {HTMLElement[]} */ (
+          Array.from(getElementsByPath(field)).filter((el) => el instanceof HTMLElement)
         );
 
         // A cleared media field is represented by a placeholder div sitting
@@ -1069,9 +1191,12 @@ const previewScript = (config: PreviewScriptConfig) => {
         // placeholders (those whose original was unmounted by the host
         // framework after save) are not in the injection maps but still
         // need to be matchable.
-        const isMediaTarget = (el: Element) =>
+        /**
+         * @param {Element} el
+         */
+        const isMediaTarget = (el) =>
           isMediaElement(el) ||
-          injectionToOriginal.has(el as HTMLElement) ||
+          injectionToOriginal.has(/** @type {HTMLElement} */ (el)) ||
           el.hasAttribute(PLACEHOLDER_ATTRIBUTE);
 
         // Multi-media field: value is an array of media items. After the
@@ -1087,8 +1212,10 @@ const previewScript = (config: PreviewScriptConfig) => {
             // Walk up until we reach an ancestor whose parent lays out
             // children as siblings (flex/grid). Record indices so we can
             // re-find the media element inside each cloned wrapper.
-            const indices: number[] = [];
-            let template: HTMLElement = lastEl;
+            /** @type {number[]} */
+            const indices = [];
+            /** @type {HTMLElement} */
+            let template = lastEl;
             let parent = template.parentElement;
             const SIBLING_LAYOUTS = new Set(['flex', 'inline-flex', 'grid', 'inline-grid']);
             const MAX_DEPTH = 5;
@@ -1101,12 +1228,14 @@ const previewScript = (config: PreviewScriptConfig) => {
               parent = parent.parentElement;
             }
 
-            let insertAfter: HTMLElement = template;
+            /** @type {HTMLElement} */
+            let insertAfter = template;
             for (let i = mediaEls.length; i < value.length; i++) {
-              const wrapperClone = template.cloneNode(true) as HTMLElement;
-              let cloneMedia: HTMLElement = wrapperClone;
+              const wrapperClone = /** @type {HTMLElement} */ (template.cloneNode(true));
+              /** @type {HTMLElement} */
+              let cloneMedia = wrapperClone;
               for (let j = indices.length - 1; j >= 0; j--) {
-                cloneMedia = cloneMedia.children[indices[j]] as HTMLElement;
+                cloneMedia = /** @type {HTMLElement} */ (cloneMedia.children[indices[j]]);
               }
               cloneMedia.setAttribute(CLONE_ATTRIBUTE, '');
               cloneMedia.removeAttribute('id');
@@ -1121,8 +1250,8 @@ const previewScript = (config: PreviewScriptConfig) => {
           mediaEls.forEach((el, index) => {
             const item = value[index];
             if (item && typeof item === 'object') {
-              const url = (item as any).url as string | undefined;
-              const mime = (item as any).mime as string | undefined;
+              const url = item.url;
+              const mime = item.mime;
               setMediaElement(el, url || null, mime);
             } else {
               setMediaElement(el, null);
@@ -1132,10 +1261,7 @@ const previewScript = (config: PreviewScriptConfig) => {
           matchedElements.forEach((element) => {
             if (isMediaTarget(element)) {
               const url = typeof value === 'object' && value !== null ? value.url : value;
-              const mime =
-                typeof value === 'object' && value !== null
-                  ? (value.mime as string | undefined)
-                  : undefined;
+              const mime = typeof value === 'object' && value !== null ? value.mime : undefined;
               setMediaElement(element, url || null, mime);
             } else {
               element.textContent = value || '';
@@ -1183,7 +1309,7 @@ const previewScript = (config: PreviewScriptConfig) => {
         if (!field) return;
 
         // Clear existing focused highlights
-        highlightManager.focusedHighlights.forEach((highlight: HTMLElement) => {
+        highlightManager.focusedHighlights.forEach((highlight) => {
           highlight.classList.remove('strapi-highlight-focused');
         });
         highlightManager.focusedHighlights.length = 0;
@@ -1207,7 +1333,7 @@ const previewScript = (config: PreviewScriptConfig) => {
         const { field } = event.data.payload;
         if (field !== highlightManager.getFocusedField()) return;
 
-        highlightManager.focusedHighlights.forEach((highlight: HTMLElement) => {
+        highlightManager.focusedHighlights.forEach((highlight) => {
           highlight.classList.remove('strapi-highlight-focused');
         });
         highlightManager.focusedHighlights.length = 0;
@@ -1220,21 +1346,28 @@ const previewScript = (config: PreviewScriptConfig) => {
     // Add the message handler to the cleanup list
     const messageEventListener = {
       element: window,
-      type: 'message' as keyof HTMLElementEventMap,
-      handler: handleMessage as EventListener,
+      type: /** @type {keyof HTMLElementEventMap} */ ('message'),
+      handler: /** @type {EventListener} */ (handleMessage),
     };
 
     return [...highlightManager.eventListeners, messageEventListener];
   };
 
+  /**
+   * @param {HTMLElement} overlay
+   * @param {ReturnType<typeof setupObservers>} observers
+   * @param {ReturnType<typeof setupScrollManagement>} scrollManager
+   * @param {EventListenersList} eventHandlers
+   * @param {HighlightManager} highlightManager
+   */
   const createCleanupSystem = (
-    overlay: HTMLElement,
-    observers: ReturnType<typeof setupObservers>,
-    scrollManager: ReturnType<typeof setupScrollManagement>,
-    eventHandlers: EventListenersList,
-    highlightManager: HighlightManager
+    overlay,
+    observers,
+    scrollManager,
+    eventHandlers,
+    highlightManager
   ) => {
-    window.__strapi_previewCleanup = () => {
+    win.__strapi_previewCleanup = () => {
       observers.resizeObserver.disconnect();
       observers.highlightObserver.disconnect();
       observers.stegaObserver?.disconnect();
@@ -1273,6 +1406,4 @@ const previewScript = (config: PreviewScriptConfig) => {
     const eventHandlers = setupEventHandlers(highlightManager);
     createCleanupSystem(overlay, observers, scrollManager, eventHandlers, highlightManager);
   });
-};
-
-export { previewScript };
+}

--- a/packages/core/content-manager/server/src/preview/routes/preview.ts
+++ b/packages/core/content-manager/server/src/preview/routes/preview.ts
@@ -14,6 +14,17 @@ const previewRouter: Plugin.LoadedPlugin['routes'][string] = {
         policies: ['admin::isAuthenticatedAdmin'],
       },
     },
+    {
+      method: 'GET',
+      info,
+      path: '/preview/script',
+      handler: 'preview.getPreviewScript',
+      // Public: the script is non-sensitive (it runs on the user's public site) and
+      // is convenience-fetched by the admin to inject into the preview iframe.
+      config: {
+        auth: false,
+      },
+    },
   ],
 };
 

--- a/packages/core/content-manager/server/tsconfig.preview-script.json
+++ b/packages/core/content-manager/server/tsconfig.preview-script.json
@@ -1,0 +1,11 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": []
+  },
+  "include": ["./src/preview/controllers/previewScript.js"]
+}

--- a/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
+++ b/tests/cli/tests/strapi/strapi/__snapshots__/routes-list.test.cli.js.snap
@@ -225,6 +225,7 @@ exports[`routes:list should output list of routes 1`] = `
 │ HEAD|GET           │ /content-manager/collection-types/:model/:id/actions/countDraftRelations        │
 │ HEAD|GET           │ /content-manager/collection-types/:model/actions/countManyEntriesDraftRelations │
 │ HEAD|GET           │ /content-manager/preview/url/:contentType                                       │
+│ HEAD|GET           │ /content-manager/preview/script                                                 │
 │ HEAD|GET           │ /content-manager/homepage/recent-documents                                      │
 │ HEAD|GET           │ /content-manager/homepage/count-documents                                       │
 │ HEAD|GET           │ /content-type-builder/reserved-names                                            │


### PR DESCRIPTION

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

It moves the preview highlight script out of the admin bundle because the bundler introduces wrapper code that breaks the script when injected into the preview iframe.

Now the script is directly written in js (still typescript validated), served from a server endpoint and injected into the preview iframe at runtime.

Status: **DRAFT** while I'm testing Launchpad with an experimental of this branch

### Why is it needed?

Fix the live preview.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Fixes https://github.com/strapi/LaunchPad/issues/135
