### PR TITLE
fix(cloud): hide deploy menu in production using currentEnvironment

### DIFF
--- a/packages/core/admin/admin/src/hooks/useMenu.ts
+++ b/packages/core/admin/admin/src/hooks/useMenu.ts
@@ -6,6 +6,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { useTypedSelector } from '../core/store/hooks';
 import { useAuth, AuthContextValue } from '../features/Auth';
 import { StrapiAppContextValue, useStrapiApp } from '../features/StrapiApp';
+import { hideCloudDeployMenuLinkInProduction } from '../utils/widgetVisibility';
 
 /* -------------------------------------------------------------------------------------------------
  * useMenu
@@ -28,7 +29,7 @@ export interface Menu {
   isLoading: boolean;
 }
 
-const useMenu = (shouldUpdateStrapi: boolean) => {
+const useMenu = (shouldUpdateStrapi: boolean, currentEnvironment?: string) => {
   const checkUserHasPermissions = useAuth('useMenu', (state) => state.checkUserHasPermissions);
   const rawMenu = useStrapiApp('useMenu', (state) => state.menu);
   const menu = React.useMemo(() => normalizeMenuLinks(rawMenu), [rawMenu]);
@@ -110,7 +111,10 @@ const useMenu = (shouldUpdateStrapi: boolean) => {
       setMenuWithUserPermissions((state) => ({
         ...state,
         generalSectionLinks: authorizedGeneralSectionLinks,
-        pluginsSectionLinks: authorizedPluginSectionLinks,
+        pluginsSectionLinks: hideCloudDeployMenuLinkInProduction(
+          authorizedPluginSectionLinks,
+          currentEnvironment
+        ),
         isLoading: false,
       }));
     }
@@ -123,6 +127,7 @@ const useMenu = (shouldUpdateStrapi: boolean) => {
     permissions,
     shouldUpdateStrapi,
     checkUserHasPermissions,
+    currentEnvironment,
   ]);
 
   return menuWithUserPermissions;

--- a/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
+++ b/packages/core/admin/admin/src/layouts/AuthenticatedLayout.tsx
@@ -75,7 +75,7 @@ const AdminLayout = () => {
     pluginsSectionLinks,
     topMobileNavigation,
     burgerMobileNavigation,
-  } = useMenu(checkLatestStrapiVersion(strapiVersion, tagName));
+  } = useMenu(checkLatestStrapiVersion(strapiVersion, tagName), appInfo?.currentEnvironment);
 
   const getAllWidgets = useStrapiApp('TrackingProvider', (state) => state.widgets.getAll);
   const projectId = appInfo?.projectId;

--- a/packages/core/admin/admin/src/utils/tests/widgetVisibility.test.ts
+++ b/packages/core/admin/admin/src/utils/tests/widgetVisibility.test.ts
@@ -1,4 +1,9 @@
-import { hideDeployNowWidgetInProduction, DEPLOY_NOW_WIDGET_UID } from '../widgetVisibility';
+import {
+  hideCloudDeployMenuLinkInProduction,
+  hideDeployNowWidgetInProduction,
+  CLOUD_DEPLOY_MENU_LINK,
+  DEPLOY_NOW_WIDGET_UID,
+} from '../widgetVisibility';
 
 import type { WidgetWithUID } from '../../core/apis/Widgets';
 
@@ -35,5 +40,24 @@ describe('hideDeployNowWidgetInProduction', () => {
     expect(hideDeployNowWidgetInProduction(widgetsWithDeploy, undefined)).toEqual(
       widgetsWithDeploy
     );
+  });
+});
+
+describe('hideCloudDeployMenuLinkInProduction', () => {
+  const menuLinks = [
+    { to: 'plugins/upload', intlLabel: { id: 'upload', defaultMessage: 'Media Library' } },
+    { to: CLOUD_DEPLOY_MENU_LINK, intlLabel: { id: 'cloud', defaultMessage: 'Deploy' } },
+  ];
+
+  it('removes the cloud deploy menu link in production', () => {
+    expect(hideCloudDeployMenuLinkInProduction(menuLinks, 'production')).toEqual([menuLinks[0]]);
+  });
+
+  it('keeps the cloud deploy menu link outside production', () => {
+    expect(hideCloudDeployMenuLinkInProduction(menuLinks, 'development')).toEqual(menuLinks);
+  });
+
+  it('keeps the cloud deploy menu link when the environment is unknown', () => {
+    expect(hideCloudDeployMenuLinkInProduction(menuLinks, undefined)).toEqual(menuLinks);
   });
 });

--- a/packages/core/admin/admin/src/utils/widgetVisibility.ts
+++ b/packages/core/admin/admin/src/utils/widgetVisibility.ts
@@ -11,6 +11,14 @@ import type { WidgetWithUID } from '../core/apis/Widgets';
 export const DEPLOY_NOW_WIDGET_UID = 'plugin::admin.deploy-now';
 
 /**
+ * Sidebar route for the Strapi Cloud deploy upsell page.
+ */
+export const CLOUD_DEPLOY_MENU_LINK = 'plugins/cloud';
+
+export const isProductionEnvironment = (currentEnvironment?: string): boolean =>
+  currentEnvironment === 'production';
+
+/**
  * Hides the deploy-now upsell widget when the project runs in production.
  *
  * The widget promotes deploying the project for the first time, which is no longer
@@ -22,9 +30,23 @@ export const hideDeployNowWidgetInProduction = (
   widgets: WidgetWithUID[],
   currentEnvironment?: string
 ): WidgetWithUID[] => {
-  if (currentEnvironment !== 'production') {
+  if (!isProductionEnvironment(currentEnvironment)) {
     return widgets;
   }
 
   return widgets.filter((widget) => widget.uid !== DEPLOY_NOW_WIDGET_UID);
+};
+
+/**
+ * Hides the Strapi Cloud deploy sidebar link when the project runs in production.
+ */
+export const hideCloudDeployMenuLinkInProduction = <T extends { to: string }>(
+  menuLinks: T[],
+  currentEnvironment?: string
+): T[] => {
+  if (!isProductionEnvironment(currentEnvironment)) {
+    return menuLinks;
+  }
+
+  return menuLinks.filter((link) => link.to !== CLOUD_DEPLOY_MENU_LINK);
 };

--- a/packages/plugins/cloud/admin/src/index.ts
+++ b/packages/plugins/cloud/admin/src/index.ts
@@ -13,29 +13,23 @@ const pluginName = 'Deploy';
 // eslint-disable-next-line import/no-default-export
 export default {
   register(app: StrapiApp) {
-    const { backendURL } = window.strapi;
+    app.addMenuLink({
+      to: `plugins/${pluginId}`,
+      icon: Cloud,
+      intlLabel: {
+        id: `${pluginId}.Plugin.name`,
+        defaultMessage: pluginName,
+      },
+      Component: () => import('./pages/App').then((mod) => ({ default: mod.App })),
+      permissions: [],
+    });
 
-    // Only add the plugin menu link and registering it if the project is on development (localhost).
-    if (backendURL?.includes('localhost')) {
-      app.addMenuLink({
-        to: `plugins/${pluginId}`,
-        icon: Cloud,
-        intlLabel: {
-          id: `${pluginId}.Plugin.name`,
-          defaultMessage: pluginName,
-        },
-        Component: () => import('./pages/App').then((mod) => ({ default: mod.App })),
-        permissions: [],
-      });
-      const plugin = {
-        id: pluginId,
-        initializer: Initializer,
-        isReady: false,
-        name: pluginName,
-      };
-
-      app.registerPlugin(plugin);
-    }
+    app.registerPlugin({
+      id: pluginId,
+      initializer: Initializer,
+      isReady: false,
+      name: pluginName,
+    });
   },
 
   async registerTrads(app: any) {

--- a/packages/plugins/cloud/admin/src/pages/App.tsx
+++ b/packages/plugins/cloud/admin/src/pages/App.tsx
@@ -5,12 +5,18 @@
  *
  */
 
-import { Page } from '@strapi/strapi/admin';
-import { Routes, Route } from 'react-router-dom';
+import { Page, useAppInfo } from '@strapi/strapi/admin';
+import { Navigate, Routes, Route } from 'react-router-dom';
 
 import { HomePage } from './HomePage';
 
 const App = () => {
+  const currentEnvironment = useAppInfo('CloudApp', (state) => state.currentEnvironment);
+
+  if (currentEnvironment === 'production') {
+    return <Navigate to="/" replace />;
+  }
+
   return (
     <div>
       <Routes>

--- a/tests/e2e/tests/admin/home.spec.ts
+++ b/tests/e2e/tests/admin/home.spec.ts
@@ -286,7 +286,7 @@ test.describe('Home as super admin', () => {
   });
 
   test('a super admin should see the deploy now widget', async ({ page }) => {
-    const deployWidget = page.getByLabel(/Deploy/i, { exact: true });
+    const deployWidget = page.locator('[data-strapi-widget-id="plugin::admin.deploy-now"]');
     await expect(deployWidget).toBeVisible();
     await expect(deployWidget.getByText('Ready to go live')).toBeVisible();
     await expect(deployWidget.getByText('Deploy with Strapi Cloud')).toBeVisible();
@@ -309,7 +309,7 @@ test.describe('Home as editor', () => {
   });
 
   test('a user should see the deploy now widget regardless of their role', async ({ page }) => {
-    const deployWidget = page.getByLabel(/Deploy/i, { exact: true });
+    const deployWidget = page.locator('[data-strapi-widget-id="plugin::admin.deploy-now"]');
     await expect(deployWidget).toBeVisible();
     await expect(deployWidget.getByRole('link', { name: /deploy now/i })).toBeVisible();
   });


### PR DESCRIPTION
### What does it do?

Completes the production deploy-upsell hiding started in #26660 by aligning the **cloud plugin Deploy sidebar** with the same `currentEnvironment` check used for the homepage deploy-now widget.

- Removes the cloud plugin's `backendURL.includes('localhost')` gate at registration time.
- Filters the `plugins/cloud` sidebar link in `useMenu` when `currentEnvironment === 'production'` (fail-open when unknown).
- Redirects direct navigation to the cloud deploy page away from production.
- Extends `widgetVisibility.ts` with shared helpers and tests.

Follow-up to [@Sheryoo's comment on #26549](https://github.com/strapi/strapi/pull/26549#issuecomment-4761353948).

### Why is it needed?

#26660 hid the deploy-now homepage widget in production, but the cloud plugin's Deploy page/menu still relied on a fragile localhost URL heuristic. That left inconsistent behaviour (e.g. production on localhost still showed the sidebar deploy page) and didn't match the intent of hiding Strapi Cloud upsell UI once a project is live.

### How to test it?

1. Run in development — **Deploy** appears in the sidebar and the deploy-now widget is on the homepage.
2. Run in production (`NODE_ENV=production`) — the sidebar **Deploy** link is absent and `/plugins/cloud` redirects to home; deploy-now widget remains hidden.
3. Unit tests: `yarn workspace @strapi/admin test:front src/utils/tests/widgetVisibility.test.ts`

### Related issue(s)/PR(s)

- Follow-up to #26660
- Addresses feedback on #26549
- Fixes CMS-1247