### PR TITLE
ci: publish experimental prerelease on labeled PR updates

### DIFF
--- a/.github/workflows/publish-pr-experimental.yml
+++ b/.github/workflows/publish-pr-experimental.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Update experimental build comment
         if: success()
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        uses: thollander/actions-comment-pull-request@v2
         with:
-          header: experimental-pr-build
+          comment_tag: experimental-pr-build
           message: |
             ## Experimental build
 

--- a/.github/workflows/publish-pr-experimental.yml
+++ b/.github/workflows/publish-pr-experimental.yml
@@ -30,14 +30,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: yarn
+      - run: yarn install --immutable
+        env:
+          YARN_ENABLE_SCRIPTS: 'false'
 
       - name: Publish prerelease
         run: ./scripts/pre-publish.sh --yes
@@ -50,8 +52,7 @@ jobs:
         run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Update experimental build comment
-        if: success()
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2
         with:
           comment_tag: experimental-pr-build
           message: |
@@ -64,7 +65,7 @@ jobs:
             | **Commit** | [`${{ steps.meta.outputs.short }}`](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) |
 
             ```bash
-            npm install @strapi/strapi@0.0.0-experimental.${{ github.event.pull_request.head.sha }}
+            npx create-strapi-app@0.0.0-experimental.${{ github.event.pull_request.head.sha }} my-project --non-interactive --skip-cloud --no-run
             ```
 
-            All `@strapi/*` packages must be installed at the same version.
+            To upgrade an existing app, install all `@strapi/*` packages at the same version.

--- a/.github/workflows/publish-pr-experimental.yml
+++ b/.github/workflows/publish-pr-experimental.yml
@@ -1,0 +1,68 @@
+name: 'Publish PR Experimental'
+
+# Publishes an experimental prerelease when the `publish-experimental` label is present.
+# Uses the same version scheme and dist tag as the manual Publish Prerelease workflow.
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: experimental-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: 'Publish experimental'
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'strapi/strapi' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'publish-experimental') &&
+      (github.event.action == 'synchronize' || github.event.label.name == 'publish-experimental')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - run: yarn
+
+      - name: Publish prerelease
+        run: ./scripts/pre-publish.sh --yes
+        env:
+          VERSION: '0.0.0-experimental.${{ github.event.pull_request.head.sha }}'
+          DIST_TAG: experimental
+
+      - name: Resolve commit metadata
+        id: meta
+        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Update experimental build comment
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: experimental-pr-build
+          message: |
+            ## Experimental build
+
+            | | |
+            |---|---|
+            | **Version** | `0.0.0-experimental.${{ github.event.pull_request.head.sha }}` |
+            | **Dist tag** | `experimental` |
+            | **Commit** | [`${{ steps.meta.outputs.short }}`](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) |
+
+            ```bash
+            npm install @strapi/strapi@0.0.0-experimental.${{ github.event.pull_request.head.sha }}
+            ```
+
+            All `@strapi/*` packages must be installed at the same version.

--- a/.github/workflows/publish-pr-experimental.yml
+++ b/.github/workflows/publish-pr-experimental.yml
@@ -2,6 +2,8 @@ name: 'Publish PR Experimental'
 
 # Publishes an experimental prerelease when the `publish-experimental` label is present.
 # Uses the same version scheme and dist tag as the manual Publish Prerelease workflow.
+# npm only — pre-publish.sh disables git tags and changelog; this workflow must NEVER create
+# GitHub Releases or git tags on the repository.
 on:
   pull_request:
     types: [labeled, synchronize]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,7 @@ yarn prettier:check # check only
 - Use parameterized queries — never interpolate user input into raw SQL or database queries.
 - Validate and sanitize all user input at controller/service boundaries.
 - When working with EE-gated features, do not bypass license checks.
+- **Never create GitHub Releases, prereleases, or git tags** on this repo (see [Notes for Agents](#notes-for-agents)).
 
 ---
 
@@ -236,3 +237,4 @@ yarn prettier:check # check only
 - **Workspace deps** — internal `packages/` deps reference each other with pinned semver versions (e.g. `"5.42.0"`), not `workspace:*`. The `workspace:*` protocol is only used in `examples/` apps and some root devDeps.
 - **Entity Service is deprecated** — always use the Document Service (`strapi.documents`) for content operations.
 - **Lifecycle phases** — `strapi.isLoaded` must be `true` before accessing services. Plugins and DB are not available until after the `load()` phase.
+- **No ad-hoc GitHub Releases or tags** — Never run `gh release create`, `gh release upload`, or push git tags to `strapi/strapi` for agent/PR work (screenshots, experimental builds, temp assets, etc.). Official semver releases go through `publish-release.yml` / `publish.sh` only. Experimental npm builds use `pre-publish.sh` with `--git-tag false --changelog false` (npm dist-tag only — no GitHub Release). For PR images, ask the user to drag-and-drop into the GitHub PR editor, or commit under `docs/` — do not host files on Releases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,6 @@ yarn prettier:check # check only
 - Use parameterized queries — never interpolate user input into raw SQL or database queries.
 - Validate and sanitize all user input at controller/service boundaries.
 - When working with EE-gated features, do not bypass license checks.
-- **Never run `gh release`** — not `create`, `delete`, `upload`, `edit`, or any other subcommand; not for screenshots, assets, experiments, or “just checking”. Official GitHub Releases are created only by `publish-release.yml` / release engineers. See [Notes for Agents](#notes-for-agents).
 
 ---
 
@@ -237,4 +236,3 @@ yarn prettier:check # check only
 - **Workspace deps** — internal `packages/` deps reference each other with pinned semver versions (e.g. `"5.42.0"`), not `workspace:*`. The `workspace:*` protocol is only used in `examples/` apps and some root devDeps.
 - **Entity Service is deprecated** — always use the Document Service (`strapi.documents`) for content operations.
 - **Lifecycle phases** — `strapi.isLoaded` must be `true` before accessing services. Plugins and DB are not available until after the `load()` phase.
-- **Never run `gh release`** — Under no circumstances run any `gh release` subcommand (`create`, `delete`, `upload`, `edit`, `download`, `view`, etc.). Do not use GitHub Releases or ad-hoc git tags for agent/PR work (screenshots, experimental builds, temp assets, image hosting, cleanup, or anything else). Official semver releases are handled only by `publish-release.yml` / `publish.sh`. Experimental npm builds use `pre-publish.sh` with `--git-tag false --changelog false` (npm dist-tag only). For PR images, ask the user to drag-and-drop into the GitHub PR editor, or commit under `docs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ yarn prettier:check # check only
 - Use parameterized queries — never interpolate user input into raw SQL or database queries.
 - Validate and sanitize all user input at controller/service boundaries.
 - When working with EE-gated features, do not bypass license checks.
-- **Never create GitHub Releases, prereleases, or git tags** on this repo (see [Notes for Agents](#notes-for-agents)).
+- **Never run `gh release`** — not `create`, `delete`, `upload`, `edit`, or any other subcommand; not for screenshots, assets, experiments, or “just checking”. Official GitHub Releases are created only by `publish-release.yml` / release engineers. See [Notes for Agents](#notes-for-agents).
 
 ---
 
@@ -237,4 +237,4 @@ yarn prettier:check # check only
 - **Workspace deps** — internal `packages/` deps reference each other with pinned semver versions (e.g. `"5.42.0"`), not `workspace:*`. The `workspace:*` protocol is only used in `examples/` apps and some root devDeps.
 - **Entity Service is deprecated** — always use the Document Service (`strapi.documents`) for content operations.
 - **Lifecycle phases** — `strapi.isLoaded` must be `true` before accessing services. Plugins and DB are not available until after the `load()` phase.
-- **No ad-hoc GitHub Releases or tags** — Never run `gh release create`, `gh release upload`, or push git tags to `strapi/strapi` for agent/PR work (screenshots, experimental builds, temp assets, etc.). Official semver releases go through `publish-release.yml` / `publish.sh` only. Experimental npm builds use `pre-publish.sh` with `--git-tag false --changelog false` (npm dist-tag only — no GitHub Release). For PR images, ask the user to drag-and-drop into the GitHub PR editor, or commit under `docs/` — do not host files on Releases.
+- **Never run `gh release`** — Under no circumstances run any `gh release` subcommand (`create`, `delete`, `upload`, `edit`, `download`, `view`, etc.). Do not use GitHub Releases or ad-hoc git tags for agent/PR work (screenshots, experimental builds, temp assets, image hosting, cleanup, or anything else). Official semver releases are handled only by `publish-release.yml` / `publish.sh`. Experimental npm builds use `pre-publish.sh` with `--git-tag false --changelog false` (npm dist-tag only). For PR images, ask the user to drag-and-drop into the GitHub PR editor, or commit under `docs/`.


### PR DESCRIPTION
## Summary

- Adds a `publish-experimental` label-gated GitHub Action that runs the existing `./scripts/pre-publish.sh` prerelease path on each PR push (same `0.0.0-experimental.<sha>` version and `experimental` dist tag as the manual **Publish Prerelease** workflow).
- Updates a sticky PR comment with the exact version and install instructions after a successful publish.
- Restricts to same-repo PRs only; never touches the release publish flow.

## Test plan

- [ ] Create the `publish-experimental` label on the repo (if it does not exist yet).
- [ ] Open a draft PR from this branch and add the `publish-experimental` label.
- [ ] Confirm the workflow runs, publishes to npm, and posts/updates the sticky comment.
- [ ] Push another commit and confirm the comment updates with the new SHA/version.
- [ ] Confirm fork PRs and PRs without the label do not trigger a publish.

### Related issue(s)/PR(s)

Fixes CMS-1248