### PR TITLE
fix(i18n): add Norwegian locale and show ISO codes in locale picker

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -45,7 +45,7 @@
   },
   {
     "code": "aig",
-    "name": "Antigua and Barbuda Creole English"
+    "name": "Antigua and Barbuda Creole English (aig)"
   },
   {
     "code": "ar",
@@ -185,7 +185,7 @@
   },
   {
     "code": "bah",
-    "name": "Bahamas Creole English"
+    "name": "Bahamas Creole English (bah)"
   },
   {
     "code": "bm",
@@ -265,19 +265,19 @@
   },
   {
     "code": "bs-Cyrl",
-    "name": "Bosnian (Cyrillic)"
+    "name": "Bosnian (Cyrillic) (bs-Cyrl)"
   },
   {
     "code": "bs-Cyrl-BA",
-    "name": "Bosnian (Cyrillic, Bosnia and Herzegovina)"
+    "name": "Bosnian (Cyrillic, Bosnia and Herzegovina) (bs-Cyrl-BA)"
   },
   {
     "code": "bs-Latn",
-    "name": "Bosnian (Latin)"
+    "name": "Bosnian (Latin) (bs-Latn)"
   },
   {
     "code": "bs-Latn-BA",
-    "name": "Bosnian (Latin, Bosnia and Herzegovina)"
+    "name": "Bosnian (Latin, Bosnia and Herzegovina) (bs-Latn-BA)"
   },
   {
     "code": "br",
@@ -345,7 +345,7 @@
   },
   {
     "code": "ny",
-    "name": "Chichewa"
+    "name": "Chichewa (ny)"
   },
   {
     "code": "cgg",
@@ -441,7 +441,7 @@
   },
   {
     "code": "dwr",
-    "name": "Dawro"
+    "name": "Dawro (dwr)"
   },
   {
     "code": "dua",
@@ -453,7 +453,7 @@
   },
   {
     "code": "dv",
-    "name": "Dhivehi (Maldives)"
+    "name": "Dhivehi (Maldives) (dv)"
   },
   {
     "code": "nl",
@@ -837,11 +837,11 @@
   },
   {
     "code": "svc",
-    "name": "Vincentian Creole English"
+    "name": "Vincentian Creole English (svc)"
   },
   {
     "code": "vic",
-    "name": "Virgin Islands Creole English"
+    "name": "Virgin Islands Creole English (vic)"
   },
   {
     "code": "en-SD",
@@ -1137,7 +1137,7 @@
   },
   {
     "code": "gmv",
-    "name": "Gamo"
+    "name": "Gamo (gmv)"
   },
   {
     "code": "lao",
@@ -1189,7 +1189,7 @@
   },
   {
     "code": "gof",
-    "name": "Gofa"
+    "name": "Gofa (gof)"
   },
   {
     "code": "el",
@@ -1241,7 +1241,7 @@
   },
   {
     "code": "ht",
-    "name": "Haitian"
+    "name": "Haitian (ht)"
   },
   {
     "code": "haw",
@@ -1293,11 +1293,11 @@
   },
   {
     "code": "smn",
-    "name": "Inari Sami"
+    "name": "Inari Sami (smn)"
   },
   {
     "code": "smn-FI",
-    "name": "Inari Sami (Finland)"
+    "name": "Inari Sami (Finland) (smn-FI)"
   },
   {
     "code": "id",
@@ -1493,7 +1493,7 @@
   },
   {
     "code": "lir",
-    "name": "Liberian English"
+    "name": "Liberian English (lir)"
   },
   {
     "code": "ln",
@@ -1657,7 +1657,7 @@
   },
   {
     "code": "mn-Cyrl",
-    "name": "Mongolian (Cyrillic)"
+    "name": "Mongolian (Cyrillic) (mn-Cyrl)"
   },
   {
     "code": "mfe",
@@ -1697,19 +1697,19 @@
   },
   {
     "code": "se",
-    "name": "Northern Sami"
+    "name": "Northern Sami (se)"
   },
   {
     "code": "se-FI",
-    "name": "Northern Sami (Finland)"
+    "name": "Northern Sami (Finland) (se-FI)"
   },
   {
     "code": "se-NO",
-    "name": "Northern Sami (Norway)"
+    "name": "Northern Sami (Norway) (se-NO)"
   },
   {
     "code": "se-SE",
-    "name": "Northern Sami (Sweden)"
+    "name": "Northern Sami (Sweden) (se-SE)"
   },
   {
     "code": "nd",
@@ -1734,6 +1734,14 @@
   {
     "code": "nn-NO",
     "name": "Norwegian Nynorsk (Norway) (nn-NO)"
+  },
+  {
+    "code": "no",
+    "name": "Norwegian (no)"
+  },
+  {
+    "code": "no-NO",
+    "name": "Norwegian (Norway) (no-NO)"
   },
   {
     "code": "nus",
@@ -1957,7 +1965,7 @@
   },
   {
     "code": "gd-GB",
-    "name": "Scottish Gaelic (United Kingdom)"
+    "name": "Scottish Gaelic (United Kingdom) (gd-GB)"
   },
   {
     "code": "seh",
@@ -2333,7 +2341,7 @@
   },
   {
     "code": "tch",
-    "name": "Turks And Caicos Creole English"
+    "name": "Turks And Caicos Creole English (tch)"
   },
   {
     "code": "uk",
@@ -2357,11 +2365,11 @@
   },
   {
     "code": "ug",
-    "name": "Uyghur"
+    "name": "Uyghur (ug)"
   },
   {
     "code": "ug-CN",
-    "name": "Uyghur (China)"
+    "name": "Uyghur (China) (ug-CN)"
   },
   {
     "code": "uz",

--- a/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
+++ b/packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap
@@ -48,7 +48,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "aig",
-    "name": "Antigua and Barbuda Creole English",
+    "name": "Antigua and Barbuda Creole English (aig)",
   },
   {
     "code": "ar",
@@ -188,7 +188,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "bah",
-    "name": "Bahamas Creole English",
+    "name": "Bahamas Creole English (bah)",
   },
   {
     "code": "bm",
@@ -268,19 +268,19 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "bs-Cyrl",
-    "name": "Bosnian (Cyrillic)",
+    "name": "Bosnian (Cyrillic) (bs-Cyrl)",
   },
   {
     "code": "bs-Cyrl-BA",
-    "name": "Bosnian (Cyrillic, Bosnia and Herzegovina)",
+    "name": "Bosnian (Cyrillic, Bosnia and Herzegovina) (bs-Cyrl-BA)",
   },
   {
     "code": "bs-Latn",
-    "name": "Bosnian (Latin)",
+    "name": "Bosnian (Latin) (bs-Latn)",
   },
   {
     "code": "bs-Latn-BA",
-    "name": "Bosnian (Latin, Bosnia and Herzegovina)",
+    "name": "Bosnian (Latin, Bosnia and Herzegovina) (bs-Latn-BA)",
   },
   {
     "code": "br",
@@ -348,7 +348,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "ny",
-    "name": "Chichewa",
+    "name": "Chichewa (ny)",
   },
   {
     "code": "cgg",
@@ -444,7 +444,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "dwr",
-    "name": "Dawro",
+    "name": "Dawro (dwr)",
   },
   {
     "code": "dua",
@@ -456,7 +456,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "dv",
-    "name": "Dhivehi (Maldives)",
+    "name": "Dhivehi (Maldives) (dv)",
   },
   {
     "code": "nl",
@@ -840,11 +840,11 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "svc",
-    "name": "Vincentian Creole English",
+    "name": "Vincentian Creole English (svc)",
   },
   {
     "code": "vic",
-    "name": "Virgin Islands Creole English",
+    "name": "Virgin Islands Creole English (vic)",
   },
   {
     "code": "en-SD",
@@ -1140,7 +1140,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "gmv",
-    "name": "Gamo",
+    "name": "Gamo (gmv)",
   },
   {
     "code": "lao",
@@ -1192,7 +1192,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "gof",
-    "name": "Gofa",
+    "name": "Gofa (gof)",
   },
   {
     "code": "el",
@@ -1244,7 +1244,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "ht",
-    "name": "Haitian",
+    "name": "Haitian (ht)",
   },
   {
     "code": "haw",
@@ -1296,11 +1296,11 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "smn",
-    "name": "Inari Sami",
+    "name": "Inari Sami (smn)",
   },
   {
     "code": "smn-FI",
-    "name": "Inari Sami (Finland)",
+    "name": "Inari Sami (Finland) (smn-FI)",
   },
   {
     "code": "id",
@@ -1496,7 +1496,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "lir",
-    "name": "Liberian English",
+    "name": "Liberian English (lir)",
   },
   {
     "code": "ln",
@@ -1660,7 +1660,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "mn-Cyrl",
-    "name": "Mongolian (Cyrillic)",
+    "name": "Mongolian (Cyrillic) (mn-Cyrl)",
   },
   {
     "code": "mfe",
@@ -1700,19 +1700,19 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "se",
-    "name": "Northern Sami",
+    "name": "Northern Sami (se)",
   },
   {
     "code": "se-FI",
-    "name": "Northern Sami (Finland)",
+    "name": "Northern Sami (Finland) (se-FI)",
   },
   {
     "code": "se-NO",
-    "name": "Northern Sami (Norway)",
+    "name": "Northern Sami (Norway) (se-NO)",
   },
   {
     "code": "se-SE",
-    "name": "Northern Sami (Sweden)",
+    "name": "Northern Sami (Sweden) (se-SE)",
   },
   {
     "code": "nd",
@@ -1737,6 +1737,14 @@ exports[`ISO locales getIsoLocales 1`] = `
   {
     "code": "nn-NO",
     "name": "Norwegian Nynorsk (Norway) (nn-NO)",
+  },
+  {
+    "code": "no",
+    "name": "Norwegian (no)",
+  },
+  {
+    "code": "no-NO",
+    "name": "Norwegian (Norway) (no-NO)",
   },
   {
     "code": "nus",
@@ -1960,7 +1968,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "gd-GB",
-    "name": "Scottish Gaelic (United Kingdom)",
+    "name": "Scottish Gaelic (United Kingdom) (gd-GB)",
   },
   {
     "code": "seh",
@@ -2336,7 +2344,7 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "tch",
-    "name": "Turks And Caicos Creole English",
+    "name": "Turks And Caicos Creole English (tch)",
   },
   {
     "code": "uk",
@@ -2360,11 +2368,11 @@ exports[`ISO locales getIsoLocales 1`] = `
   },
   {
     "code": "ug",
-    "name": "Uyghur",
+    "name": "Uyghur (ug)",
   },
   {
     "code": "ug-CN",
-    "name": "Uyghur (China)",
+    "name": "Uyghur (China) (ug-CN)",
   },
   {
     "code": "uz",


### PR DESCRIPTION
## Summary

Fixes #26712

Adds the missing Norwegian locale codes to the i18n plugin and improves locale display names in the admin "Add new locale" picker.

- Add `no` (Norwegian, ISO 639-1) and `no-NO` (Norwegian, Norway) to `iso-locales.json`
- Normalize display names for locales that previously omitted their ISO code in the label (e.g. `Northern Sami (Norway)` → `Northern Sami (Norway) (se-NO)`)
- Update the `iso-locales` Jest snapshot to match

### Files changed

| File | Change |
|------|--------|
| `packages/plugins/i18n/server/src/constants/iso-locales.json` | Add `no` / `no-NO`; append locale codes to ~28 existing entries |
| `packages/plugins/i18n/server/src/services/__tests__/__snapshots__/iso-locales.test.ts.snap` | Snapshot sync |

### Locales added

```json
{ "code": "no",  "name": "Norwegian (no)" }
{ "code": "no-NO", "name": "Norwegian (Norway) (no-NO)" }