### PR TITLE
fix(generators): detect plugin language from output path

### DIFF
--- a/packages/generators/generators/src/index.ts
+++ b/packages/generators/generators/src/index.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import handlebars from 'handlebars';
 import fs from 'fs-extra';
 
@@ -40,6 +40,8 @@ export const generate = async <T extends Record<string, any>>(
   options: T,
   { dir = process.cwd(), plopFile = 'plopfile.js' }: GenerateOptions = {}
 ) => {
+  const resolvedDir = resolve(dir);
+
   // Resolve the absolute path to the plopfile (generator definitions)
   const plopfilePath = join(__dirname, plopFile);
   // Dynamically require the plopfile module.
@@ -62,7 +64,7 @@ export const generate = async <T extends Record<string, any>>(
       helpers[name] = fn;
     },
     getDestBasePath() {
-      return join(dir, 'src');
+      return join(resolvedDir, 'src');
     },
     setWelcomeMessage() {}, // no-op
   };
@@ -85,7 +87,7 @@ export const generate = async <T extends Record<string, any>>(
   const actions: GeneratorAction[] =
     typeof generator.actions === 'function' ? generator.actions(options) : generator.actions || [];
 
-  await executeActions(actions, options, dir);
+  await executeActions(actions, options, resolvedDir);
 
   return { success: true };
 };

--- a/packages/generators/generators/src/plops/api.ts
+++ b/packages/generators/generators/src/plops/api.ts
@@ -1,10 +1,10 @@
 import { join } from 'path';
 import type { ActionType, NodePlopAPI } from 'plop';
 import fs from 'fs-extra';
-import tsUtils from '@strapi/typescript-utils';
 
 import validateInput from './utils/validate-input';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import { appendToFile } from './utils/extend-plugin-index-files';
 
 export default (plop: NodePlopAPI) => {
@@ -54,19 +54,7 @@ export default (plop: NodePlopAPI) => {
       const filePath = getFilePath(
         answers.destination || (answers.isPluginApi && answers.plugin ? 'plugin' : 'api')
       );
-      const currentDir = process.cwd();
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/content-type.ts
+++ b/packages/generators/generators/src/plops/content-type.ts
@@ -3,10 +3,10 @@ import type { NodePlopAPI, ActionType } from 'plop';
 import slugify from '@sindresorhus/slugify';
 import fs from 'fs-extra';
 import { strings } from '@strapi/utils';
-import tsUtils from '@strapi/typescript-utils';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import ctNamesPrompts from './prompts/ct-names-prompts';
 import kindPrompts from './prompts/kind-prompts';
 import getAttributesPrompts from './prompts/get-attributes-prompts';
@@ -81,19 +81,7 @@ export default (plop: NodePlopAPI) => {
       }, {});
 
       const filePath = getFilePath(answers.destination);
-      const currentDir = process.cwd();
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/controller.ts
+++ b/packages/generators/generators/src/plops/controller.ts
@@ -1,10 +1,10 @@
 import type { ActionType, NodePlopAPI } from 'plop';
-import tsUtils from '@strapi/typescript-utils';
 import { join } from 'path';
 import fs from 'fs';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import validateInput from './utils/validate-input';
 import { appendToFile } from './utils/extend-plugin-index-files';
 
@@ -27,19 +27,7 @@ export default (plop: NodePlopAPI) => {
       }
 
       const filePath = getFilePath(answers.destination);
-      const currentDir = process.cwd();
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/middleware.ts
+++ b/packages/generators/generators/src/plops/middleware.ts
@@ -1,11 +1,11 @@
 import type { ActionType, NodePlopAPI } from 'plop';
-import tsUtils from '@strapi/typescript-utils';
 import { join } from 'path';
 import fs from 'fs';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';
 import validateInput from './utils/validate-input';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import { appendToFile } from './utils/extend-plugin-index-files';
 
 export default (plop: NodePlopAPI) => {
@@ -27,19 +27,7 @@ export default (plop: NodePlopAPI) => {
       }
 
       const filePath = getFilePath(answers.destination);
-      const currentDir = process.cwd();
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/policy.ts
+++ b/packages/generators/generators/src/plops/policy.ts
@@ -1,11 +1,11 @@
 import type { ActionType, NodePlopAPI } from 'plop';
-import tsUtils from '@strapi/typescript-utils';
 import { join } from 'path';
 import fs from 'fs';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';
 import validateInput from './utils/validate-input';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import { appendToFile } from './utils/extend-plugin-index-files';
 
 export default (plop: NodePlopAPI) => {
@@ -26,20 +26,8 @@ export default (plop: NodePlopAPI) => {
         return [];
       }
 
-      const currentDir = process.cwd();
       const filePath = getFilePath(answers.destination);
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/service.ts
+++ b/packages/generators/generators/src/plops/service.ts
@@ -1,10 +1,10 @@
 import type { ActionType, NodePlopAPI } from 'plop';
-import tsUtils from '@strapi/typescript-utils';
 import { join } from 'path';
 import fs from 'fs';
 
 import getDestinationPrompts from './prompts/get-destination-prompts';
 import getFilePath from './utils/get-file-path';
+import getGeneratorLanguage from './utils/get-generator-language';
 import { appendToFile } from './utils/extend-plugin-index-files';
 
 export default (plop: NodePlopAPI) => {
@@ -25,19 +25,7 @@ export default (plop: NodePlopAPI) => {
       }
 
       const filePath = getFilePath(answers?.destination);
-      const currentDir = process.cwd();
-      let language = tsUtils.isUsingTypeScriptSync(currentDir) ? 'ts' : 'js';
-
-      if (answers.plugin) {
-        // The tsconfig in plugins is located just outside the server src, not in the root of the plugin.
-        const pluginServerDir = join(
-          currentDir,
-          'src',
-          filePath.replace('{{ plugin }}', answers.plugin),
-          '../'
-        );
-        language = tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
-      }
+      const language = getGeneratorLanguage({ plugin: answers.plugin, filePath }, plop);
 
       const baseActions: Array<ActionType> = [
         {

--- a/packages/generators/generators/src/plops/utils/__tests__/get-generator-language.test.ts
+++ b/packages/generators/generators/src/plops/utils/__tests__/get-generator-language.test.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+import tsUtils from '@strapi/typescript-utils';
+
+import getGeneratorLanguage from '../get-generator-language';
+
+describe('getGeneratorLanguage', () => {
+  const appRoot = '/app';
+  const appPlop = {
+    getDestBasePath: () => path.join(appRoot, 'src'),
+  };
+  let isUsingTypeScriptSyncSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    isUsingTypeScriptSyncSpy = jest.spyOn(tsUtils, 'isUsingTypeScriptSync');
+  });
+
+  afterEach(() => {
+    isUsingTypeScriptSyncSpy.mockRestore();
+  });
+
+  test('non-plugin generation checks the generate dir', () => {
+    isUsingTypeScriptSyncSpy.mockReturnValue(true);
+
+    const language = getGeneratorLanguage({ filePath: 'api/{{ id }}' }, appPlop);
+
+    expect(language).toBe('ts');
+    expect(isUsingTypeScriptSyncSpy).toHaveBeenCalledWith(appRoot);
+  });
+
+  test('in-app plugin generation checks the plugin server directory', () => {
+    isUsingTypeScriptSyncSpy.mockReturnValue(true);
+
+    const language = getGeneratorLanguage(
+      { plugin: 'my-plugin', filePath: 'plugins/{{ plugin }}/server/src' },
+      appPlop
+    );
+
+    expect(language).toBe('ts');
+    expect(isUsingTypeScriptSyncSpy).toHaveBeenCalledWith(
+      path.join(appRoot, 'src', 'plugins', 'my-plugin', 'server')
+    );
+  });
+
+  test('standalone plugin generation checks the server directory from dir option', () => {
+    const standalonePlop = {
+      getDestBasePath: () => path.join('/plugin', 'server', 'src'),
+    };
+
+    isUsingTypeScriptSyncSpy.mockReturnValue(true);
+
+    const language = getGeneratorLanguage({ plugin: 'my-plugin', filePath: '.' }, standalonePlop);
+
+    expect(language).toBe('ts');
+    expect(isUsingTypeScriptSyncSpy).toHaveBeenCalledWith(path.join('/plugin', 'server'));
+  });
+
+  test('returns js when no tsconfig is found', () => {
+    isUsingTypeScriptSyncSpy.mockReturnValue(false);
+
+    const language = getGeneratorLanguage({ filePath: 'api/{{ id }}' }, appPlop);
+
+    expect(language).toBe('js');
+  });
+});

--- a/packages/generators/generators/src/plops/utils/get-generator-language.ts
+++ b/packages/generators/generators/src/plops/utils/get-generator-language.ts
@@ -1,0 +1,31 @@
+import { dirname, join } from 'node:path';
+import tsUtils from '@strapi/typescript-utils';
+import type { NodePlopAPI } from 'plop';
+
+type GetGeneratorLanguageOptions = {
+  plugin?: string;
+  filePath: string;
+};
+
+/**
+ * Detect whether generated files should use TypeScript or JavaScript templates.
+ *
+ * For plugin generation, the check is scoped to the plugin server directory derived
+ * from the generator output path. For everything else, it checks the `dir` option
+ * passed to `generate()` (via `getDestBasePath()`).
+ */
+const getGeneratorLanguage = (
+  { plugin, filePath }: GetGeneratorLanguageOptions,
+  plop: Pick<NodePlopAPI, 'getDestBasePath'>
+): 'ts' | 'js' => {
+  if (plugin) {
+    const resolvedFilePath = filePath.replace('{{ plugin }}', plugin);
+    const pluginServerDir = join(plop.getDestBasePath(), resolvedFilePath, '..');
+
+    return tsUtils.isUsingTypeScriptSync(pluginServerDir) ? 'ts' : 'js';
+  }
+
+  return tsUtils.isUsingTypeScriptSync(dirname(plop.getDestBasePath())) ? 'ts' : 'js';
+};
+
+export default getGeneratorLanguage;


### PR DESCRIPTION
## Summary

- Add `getGeneratorLanguage` util that derives TypeScript vs JavaScript template selection from the generator output coordinates (`getDestBasePath()` + `filePath`) instead of `process.cwd()`
- Resolve the `dir` option to an absolute path in `generate()` so relative paths like `server` work reliably
- Replace duplicated language-detection logic across all plugin generators

Fixes standalone plugin generation always emitting JavaScript files when callers pass `dir: 'server'` to the programmatic `generate()` API.

Unblocks [strapi/sdk-plugin#98](https://github.com/strapi/sdk-plugin/pull/98).

## Context

`@strapi/sdk-plugin` adds a `strapi-plugin generate` command that reuses `@strapi/generators`. Standalone TypeScript plugins keep `tsconfig.json` in `server/`, but language detection was checking the plugin root (via `process.cwd()`), so templates were always `.js`.

## Test plan

- [x] Unit tests for `getGeneratorLanguage` (in-app plugin, standalone plugin, non-plugin)
- [x] Existing `@strapi/generators` test suite passes
- [ ] After sdk-plugin bumps `@strapi/generators`, run `strapi-plugin generate` in a TypeScript standalone plugin and confirm `.ts` files are created


### Related issue(s)/PR(s)

Fixes CMS-1319
