### PR TITLE
fix(test): tighten jest ignore patterns to match path segments

### DIFF
--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -25,7 +25,7 @@ module.exports = {
   moduleNameMapper,
   /* Tells jest to ignore duplicated manual mock files, such as index.js */
   modulePathIgnorePatterns: ['.*__mocks__.*'],
-  testPathIgnorePatterns: ['node_modules/', 'dist/'],
+  testPathIgnorePatterns: ['[/\\\\]node_modules[/\\\\]', '[/\\\\]dist[/\\\\]'],
   globalSetup: '@strapi/admin-test-utils/global-setup',
   setupFiles: ['@strapi/admin-test-utils/setup'],
   setupFilesAfterEnv: ['@strapi/admin-test-utils/after-env'],

--- a/jest-preset.front.js
+++ b/jest-preset.front.js
@@ -24,7 +24,7 @@ module.exports = {
   rootDir: __dirname,
   moduleNameMapper,
   /* Tells jest to ignore duplicated manual mock files, such as index.js */
-  modulePathIgnorePatterns: ['.*__mocks__.*'],
+  modulePathIgnorePatterns: ['[/\\\\]__mocks__[/\\\\]'],
   testPathIgnorePatterns: ['[/\\\\]node_modules[/\\\\]', '[/\\\\]dist[/\\\\]'],
   globalSetup: '@strapi/admin-test-utils/global-setup',
   setupFiles: ['@strapi/admin-test-utils/setup'],

--- a/jest-preset.unit.js
+++ b/jest-preset.unit.js
@@ -2,11 +2,11 @@
 
 module.exports = {
   setupFilesAfterEnv: [__dirname + '/tests/setup/unit.setup.js'],
-  modulePathIgnorePatterns: ['.cache', 'dist'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
   testPathIgnorePatterns: [
     '.testdata.{js,ts}',
     '.test.utils.{js,ts}',
-    '.d.ts',
+    '\\.d\\.ts$',
     '__tests__/resources',
     'tests/resources',
     // Prevent Jest from running Vitest test files

--- a/jest.config.api.js
+++ b/jest.config.api.js
@@ -35,5 +35,5 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
 };

--- a/jest.config.cli.js
+++ b/jest.config.cli.js
@@ -14,5 +14,5 @@ module.exports = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
 };

--- a/packages/core/admin/jest.config.front.js
+++ b/packages/core/admin/jest.config.front.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   preset: '../../../jest-preset.front.js',
-  collectCoverageFrom: ['<rootDir>/packages/core/admin/admin/**/*.js'],
   displayName: 'Core admin',
   moduleNameMapper: {
     '^@tests/(.*)$': '<rootDir>/admin/tests/$1',

--- a/packages/core/content-manager/jest.config.front.js
+++ b/packages/core/content-manager/jest.config.front.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   preset: '../../../jest-preset.front.js',
-  collectCoverageFrom: ['<rootDir>/packages/core/admin/admin/**/*.js'],
   displayName: 'Core content-manager',
   moduleNameMapper: {
     '^@tests/(.*)$': '<rootDir>/admin/tests/$1',

--- a/tests/cli/jest.config.js
+++ b/tests/cli/jest.config.js
@@ -10,7 +10,7 @@ const config = {
   transform: {
     '^.+\\.ts$': ['@swc/jest'],
   },
-  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]'],
+  modulePathIgnorePatterns: ['[/\\\\]\\.cache[/\\\\]', '[/\\\\]dist[/\\\\]'],
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary

### Jest ignore patterns (unit, front, API, CLI)

- Fix `jest-preset.unit.js` `modulePathIgnorePatterns`: bare `dist` and `.cache` were unanchored regexes used during Jest's haste-map crawl, so any path containing `dist` as a substring (e.g. `status-sort-distinct.test.ts`) was silently excluded from unit test discovery.
- Escape `testPathIgnorePatterns` `.d.ts` to `\\.d\\.ts$` so it only ignores TypeScript declaration files, not arbitrary matches.
- Align `jest-preset.front.js` `testPathIgnorePatterns`: replace loose `node_modules/` and `dist/` with path-segment patterns (the old `dist/` pattern also matched paths like `redist/…`).
- Tighten `jest-preset.front.js` `modulePathIgnorePatterns` for `__mocks__` to a path-segment pattern instead of `.*__mocks__.*`.
- Add `[/\\]dist[/\\]` to `modulePathIgnorePatterns` in API/CLI jest configs for consistency with the unit preset and `.cache` handling.

### Front coverage overrides

- Remove broken `collectCoverageFrom` overrides from `packages/core/admin/jest.config.front.js` and `packages/core/content-manager/jest.config.front.js`. Both pointed at `<rootDir>/packages/core/admin/admin/**/*.js` — wrong path under package `rootDir`, JS-only — so new `.ts`/`.tsx` files (e.g. `SessionsPage.tsx`) were never included in lcov. Packages now inherit the correct globs from `jest-preset.front.js`.

### Related PRs (test discovery / coverage)

- **#26751** / **#26746** — unit test `status-sort-distinct.test.ts` was not discovered until the unit preset fix.
- **#26628** — admin `SessionsPage.tsx` front tests ran, but broken `collectCoverageFrom` excluded `.tsx` sources from lcov (SonarCloud coverage gap).

## Test plan

- [x] `yarn test:unit --selectProjects 'Core database'` passes (20 suites, 218 tests)
- [x] Verified `status-sort-distinct.test.ts` is listed by `jest --listTests` when present (was skipped before the unit preset change)
- [x] Verified admin front coverage lcov `SF:` paths resolve under `admin/src/…` after removing the override
- [ ] CI unit + front test jobs