### PR TITLE
fix: redirect to NoPermissions page on unauthorized locale

### DIFF
--- a/packages/core/content-manager/admin/src/layout.tsx
+++ b/packages/core/content-manager/admin/src/layout.tsx
@@ -53,7 +53,7 @@ const Layout = () => {
     supportedModelsToDisplay.length > 0 &&
     pathname !== '/content-manager/403'
   ) {
-    return <Navigate to="/403" />;
+    return <Navigate to="/content-manager/403" />;
   }
 
   // Redirect the user to the create content type page


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

<img width="1375" height="860" alt="fix-26707" src="https://github.com/user-attachments/assets/bb4ef3a5-baf4-4a59-86dc-598aadcffc05" />

  Changes the Content Manager layout redirect target from `/403` to `/content-manager/403` in `packages/core/content-manager/admin/src/layout.tsx`. When a user has no authorized models for the active locale, the layout now navigates to the `NoPermissions` page that is actually registered in the Content Manager router (`/content-manager/403`), instead of `/403` (which resolves to `/admin/403` — an unregistered route).

### Why is it needed?

  When an admin user's role is scoped to specific locales (i18n locale permissions) and they reach a localized entry in a locale they're not allowed to access, the i18n RBAC middleware strips the relevant permission, leaving no authorized models for that locale. The layout then redirected to `/403`, which has no registered route, so the admin's catch-all rendered the generic "Page not found" screen. The user should instead see the "You don't have the permissions to access that content" (`NoPermissions`) page. Note the guard condition on the same block already references `/content-manager/403`, confirming `/403` was an oversight.

### How to test it?

The steps provided to reproduce the issue are correct and remain the same when testing the changes made

### Related issue(s)/PR(s)

fixes #26707
