### PR TITLE
fix(strapi): resolve admin Vite aliases from @strapi/admin closure

### DIFF
--- a/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/admin-vite-aliases.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import readPkgUp from 'read-pkg-up';
+
+import {
+  ADMIN_PINNED_ALIAS_MODULES,
+  ADMIN_VITE_ALIAS_MODULES,
+  ADMIN_VITE_DEDUPE_MODULES,
+} from '../admin-vite-alias-modules';
+import { buildAdminViteResolveAliases } from '../admin-vite-aliases';
+import { getModulePath } from '../resolve-module';
+
+const adminDeps = require('@strapi/admin/package.json').dependencies as Record<string, string>;
+
+describe('buildAdminViteResolveAliases', () => {
+  it('sets an alias for every admin vite alias module via getModulePath', () => {
+    const alias = buildAdminViteResolveAliases();
+
+    for (const mod of ADMIN_VITE_ALIAS_MODULES) {
+      expect(alias[mod]).toBe(getModulePath(mod));
+    }
+  });
+
+  it('uses the same module list for aliases and vite resolve.dedupe', () => {
+    expect(ADMIN_VITE_DEDUPE_MODULES).toBe(ADMIN_VITE_ALIAS_MODULES);
+  });
+
+  it.each(ADMIN_PINNED_ALIAS_MODULES)(
+    'aliases %s to the version pinned by @strapi/admin',
+    (mod) => {
+      const alias = buildAdminViteResolveAliases();
+      const pkg = readPkgUp.sync({ cwd: alias[mod] });
+
+      expect(pkg?.packageJson?.version).toBe(adminDeps[mod]);
+    }
+  );
+});

--- a/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-var-requires, node/no-missing-require */
+import path from 'node:path';
+import readPkgUp from 'read-pkg-up';
+
+const actualResolveFrom = jest.requireActual<typeof import('resolve-from')>('resolve-from');
+const adminPkgDir = path.dirname(require.resolve('@strapi/admin/package.json'));
+const adminDeps = require('@strapi/admin/package.json').dependencies as Record<string, string>;
+
+const loadGetModulePath = (
+  resolveImpl: (from: string, mod: string) => string = actualResolveFrom
+) => {
+  jest.resetModules();
+  const resolveFromMock = jest.fn(resolveImpl);
+  jest.doMock('resolve-from', () => resolveFromMock);
+  const getModulePath = require('../resolve-module').getModulePath as (mod: string) => string;
+
+  return { getModulePath, resolveFromMock };
+};
+
+describe('getModulePath', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('resolve-from');
+    jest.dontMock('read-pkg-up');
+  });
+
+  it('resolves admin modules from @strapi/admin dependency context', () => {
+    const { getModulePath, resolveFromMock } = loadGetModulePath();
+
+    getModulePath('@reduxjs/toolkit');
+
+    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, '@reduxjs/toolkit');
+  });
+
+  it('resolves react-redux from @strapi/admin dependency context', () => {
+    const { getModulePath, resolveFromMock } = loadGetModulePath();
+
+    getModulePath('react-redux');
+
+    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, 'react-redux');
+  });
+
+  it('resolves @reduxjs/toolkit to the version pinned by @strapi/admin', () => {
+    const { getModulePath } = loadGetModulePath();
+    const pkgRoot = getModulePath('@reduxjs/toolkit');
+    const pkg = readPkgUp.sync({ cwd: pkgRoot });
+
+    expect(pkg?.packageJson?.version).toBe(adminDeps['@reduxjs/toolkit']);
+  });
+
+  it('prefers @strapi/admin closure over a hoisted incompatible major (pnpm monorepo)', () => {
+    const adminRtkEntry =
+      '/tmp/pnpm-store/@reduxjs+toolkit@1.9.7/node_modules/@reduxjs/toolkit/dist/index.js';
+    const adminRtkRoot = path.dirname(path.dirname(adminRtkEntry));
+
+    jest.resetModules();
+    const resolveFromMock = jest.fn((from: string, mod: string) => {
+      if (from === adminPkgDir && mod === '@reduxjs/toolkit') {
+        return adminRtkEntry;
+      }
+
+      return actualResolveFrom(from, mod);
+    });
+    const readPkgUpMock = jest.fn(() => ({
+      path: path.join(adminRtkRoot, 'package.json'),
+      packageJson: { name: '@reduxjs/toolkit', version: '1.9.7' },
+    }));
+
+    jest.doMock('resolve-from', () => resolveFromMock);
+    jest.doMock('read-pkg-up', () => ({ sync: readPkgUpMock }));
+
+    const getModulePath = require('../resolve-module').getModulePath as (mod: string) => string;
+
+    expect(getModulePath('@reduxjs/toolkit')).toBe(adminRtkRoot);
+    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, '@reduxjs/toolkit');
+  });
+});

--- a/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
+++ b/packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts
@@ -2,6 +2,8 @@
 import path from 'node:path';
 import readPkgUp from 'read-pkg-up';
 
+import { ADMIN_PINNED_ALIAS_MODULES, ADMIN_VITE_ALIAS_MODULES } from '../admin-vite-alias-modules';
+
 const actualResolveFrom = jest.requireActual<typeof import('resolve-from')>('resolve-from');
 const adminPkgDir = path.dirname(require.resolve('@strapi/admin/package.json'));
 const adminDeps = require('@strapi/admin/package.json').dependencies as Record<string, string>;
@@ -24,29 +26,24 @@ describe('getModulePath', () => {
     jest.dontMock('read-pkg-up');
   });
 
-  it('resolves admin modules from @strapi/admin dependency context', () => {
+  it.each(ADMIN_VITE_ALIAS_MODULES)('resolves %s from @strapi/admin dependency context', (mod) => {
     const { getModulePath, resolveFromMock } = loadGetModulePath();
 
-    getModulePath('@reduxjs/toolkit');
+    getModulePath(mod);
 
-    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, '@reduxjs/toolkit');
+    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, mod);
   });
 
-  it('resolves react-redux from @strapi/admin dependency context', () => {
-    const { getModulePath, resolveFromMock } = loadGetModulePath();
+  it.each(ADMIN_PINNED_ALIAS_MODULES)(
+    'resolves %s to the version pinned by @strapi/admin',
+    (mod) => {
+      const { getModulePath } = loadGetModulePath();
+      const pkgRoot = getModulePath(mod);
+      const pkg = readPkgUp.sync({ cwd: pkgRoot });
 
-    getModulePath('react-redux');
-
-    expect(resolveFromMock).toHaveBeenCalledWith(adminPkgDir, 'react-redux');
-  });
-
-  it('resolves @reduxjs/toolkit to the version pinned by @strapi/admin', () => {
-    const { getModulePath } = loadGetModulePath();
-    const pkgRoot = getModulePath('@reduxjs/toolkit');
-    const pkg = readPkgUp.sync({ cwd: pkgRoot });
-
-    expect(pkg?.packageJson?.version).toBe(adminDeps['@reduxjs/toolkit']);
-  });
+      expect(pkg?.packageJson?.version).toBe(adminDeps[mod]);
+    }
+  );
 
   it('prefers @strapi/admin closure over a hoisted incompatible major (pnpm monorepo)', () => {
     const adminRtkEntry =

--- a/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-alias-modules.ts
@@ -1,0 +1,32 @@
+/**
+ * Modules given explicit Vite resolve aliases (and included in resolve.dedupe) for the admin bundle.
+ * Single source of truth for resolution contract tests.
+ *
+ * @internal
+ */
+export const ADMIN_VITE_ALIAS_MODULES = [
+  'react',
+  'react-dom',
+  'react-router-dom',
+  'styled-components',
+  'react-redux',
+  '@reduxjs/toolkit',
+  '@strapi/design-system',
+  '@radix-ui/react-tooltip',
+  'lodash',
+] as const;
+
+export type AdminViteAliasModule = (typeof ADMIN_VITE_ALIAS_MODULES)[number];
+
+/** Same modules passed to Vite resolve.dedupe */
+export const ADMIN_VITE_DEDUPE_MODULES = ADMIN_VITE_ALIAS_MODULES;
+
+/**
+ * Alias modules with exact versions declared in @strapi/admin dependencies (not peers).
+ */
+export const ADMIN_PINNED_ALIAS_MODULES = [
+  '@reduxjs/toolkit',
+  'react-redux',
+  '@strapi/design-system',
+  'lodash',
+] as const satisfies readonly AdminViteAliasModule[];

--- a/packages/core/strapi/src/node/core/admin-vite-aliases.ts
+++ b/packages/core/strapi/src/node/core/admin-vite-aliases.ts
@@ -1,0 +1,10 @@
+import { ADMIN_VITE_ALIAS_MODULES } from './admin-vite-alias-modules';
+import { getModulePath } from './resolve-module';
+
+/**
+ * Vite resolve.alias entries for the admin bundle — every path comes from @strapi/admin's closure.
+ *
+ * @internal
+ */
+export const buildAdminViteResolveAliases = (): Record<string, string> =>
+  Object.fromEntries(ADMIN_VITE_ALIAS_MODULES.map((mod) => [mod, getModulePath(mod)]));

--- a/packages/core/strapi/src/node/core/resolve-module.ts
+++ b/packages/core/strapi/src/node/core/resolve-module.ts
@@ -1,5 +1,21 @@
 import path from 'node:path';
 import readPkgUp from 'read-pkg-up';
+import resolveFrom from 'resolve-from';
+
+let adminPkgDir: string | undefined;
+
+/**
+ * Package root of @strapi/admin — admin Vite aliases must resolve from here so pnpm
+ * workspaces cannot pick up a hoisted incompatible major from another package
+ * (e.g. @reduxjs/toolkit@2.x elsewhere while admin pins 1.9.x).
+ */
+const getAdminPkgDir = (): string => {
+  if (!adminPkgDir) {
+    adminPkgDir = path.dirname(require.resolve('@strapi/admin/package.json'));
+  }
+
+  return adminPkgDir;
+};
 
 /**
  * Resolve module to package root for use in aliases.
@@ -8,7 +24,7 @@ import readPkgUp from 'read-pkg-up';
  * @internal
  */
 export const getModulePath = (mod: string): string => {
-  const modulePath = require.resolve(mod);
+  const modulePath = resolveFrom(getAdminPkgDir(), mod);
   const pkg = readPkgUp.sync({ cwd: path.dirname(modulePath) });
   return pkg ? path.dirname(pkg.path) : modulePath;
 };

--- a/packages/core/strapi/src/node/vite/config.ts
+++ b/packages/core/strapi/src/node/vite/config.ts
@@ -2,7 +2,8 @@ import type { InlineConfig, UserConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 import { getUserConfig } from '../core/config';
-import { getModulePath } from '../core/resolve-module';
+import { ADMIN_VITE_DEDUPE_MODULES } from '../core/admin-vite-alias-modules';
+import { buildAdminViteResolveAliases } from '../core/admin-vite-aliases';
 import { isDesignSystemLinked } from '../core/linked-packages';
 import { loadStrapiMonorepo } from '../core/monorepo';
 import { getMonorepoAliases } from '../core/aliases';
@@ -124,30 +125,10 @@ const resolveBaseConfig = async (ctx: BuildContext): Promise<InlineConfig> => {
     resolve: {
       // https://react.dev/warnings/invalid-hook-call-warning#duplicate-react
       // Include design-system so plugin chunks use the same instance and inherit root context
-      dedupe: [
-        'react',
-        'react-dom',
-        'react-router-dom',
-        'styled-components',
-        'react-redux',
-        '@reduxjs/toolkit',
-        '@strapi/design-system',
-        '@radix-ui/react-tooltip',
-        'lodash',
-      ],
+      dedupe: [...ADMIN_VITE_DEDUPE_MODULES],
       // Explicit aliases ensure resolution under pnpm's strict dependency isolation,
       // where packages imported by plugins may not be resolvable from plugin chunks
-      alias: {
-        react: getModulePath('react'),
-        'react-dom': getModulePath('react-dom'),
-        'react-router-dom': getModulePath('react-router-dom'),
-        'styled-components': getModulePath('styled-components'),
-        'react-redux': getModulePath('react-redux'),
-        '@reduxjs/toolkit': getModulePath('@reduxjs/toolkit'),
-        '@strapi/design-system': getModulePath('@strapi/design-system'),
-        '@radix-ui/react-tooltip': getModulePath('@radix-ui/react-tooltip'),
-        lodash: getModulePath('lodash'),
-      },
+      alias: buildAdminViteResolveAliases(),
     },
     plugins: [react(), buildFilesPlugin(ctx)],
   };


### PR DESCRIPTION
### What does it do?

Scopes `getModulePath` to resolve admin bundle dependencies from `@strapi/admin`'s package directory (via `resolve-from`) instead of bare `require.resolve`, which walked from `@strapi/strapi`'s location.

Adds unit tests in `packages/core/strapi/src/node/core/__tests__/resolve-module.test.ts`.

### Why is it needed?

Fixes a regression in **5.48.1** from strapi/strapi#26249: in pnpm monorepos where another workspace package depends on `@reduxjs/toolkit@^2`, bare resolution could alias the admin Vite build to hoisted RTK 2.x while `@strapi/admin` pins 1.9.x. RTK 2's `configureStore` then throws *"Duplicate middleware references found"*, leaving the admin panel blank.

Fixes strapi/strapi#26755

### oHow to test it?

1. Run `yarn workspace @strapi/strapi test:unit --testPathPattern=resolve-module.test` from repo root.
2. Reproduce locally in a pnpm workspace with Strapi 5.48.1+ and a sibling app on `@reduxjs/toolkit@^2` — admin should load without the Redux middleware error (or apply this branch and confirm the fix).

### Related issue(s)/PR(s)

Fixes strapi/strapi#26755<br>Related to strapi/strapi#26249