### PR TITLE
fix(create-strapi-app): scaffold pnpm 11 allowBuilds for Strapi Cloud

### DIFF
--- a/packages/cli/create-strapi-app/src/create-strapi.ts
+++ b/packages/cli/create-strapi-app/src/create-strapi.ts
@@ -11,6 +11,7 @@ import { copyTemplate } from './utils/template';
 import { tryGitInit } from './utils/git';
 import { trackUsage } from './utils/usage';
 import { createPackageJSON } from './utils/package-json';
+import { writePnpmWorkspaceConfig } from './utils/pnpm-config';
 import { generateDotEnv } from './utils/dot-env';
 import { isStderrError } from './types';
 
@@ -51,6 +52,24 @@ const shouldWriteYarnNodeModulesConfig = async (packageManager: Scope['packageMa
     return normalizedVersion ? semver.gte(normalizedVersion, '3.0.0') : false;
   } catch {
     return false;
+  }
+};
+
+const resolvePnpmVersion = async (packageManager: Scope['packageManager']) => {
+  if (packageManager !== 'pnpm') {
+    return null;
+  }
+
+  const userAgentVersion = getUserAgentPackageManagerVersion(packageManager);
+
+  if (userAgentVersion) {
+    return userAgentVersion;
+  }
+
+  try {
+    return await getPackageManagerVersion(packageManager);
+  } catch {
+    return null;
   }
 };
 
@@ -124,8 +143,11 @@ async function createApp(scope: Scope) {
 
   await trackUsage({ event: 'didCopyProjectFiles', scope });
 
+  const pnpmVersion = await resolvePnpmVersion(packageManager);
+  const scopeWithPnpmVersion = { ...scope, pnpmVersion };
+
   try {
-    await createPackageJSON(scope);
+    await createPackageJSON(scopeWithPnpmVersion);
 
     await trackUsage({ event: 'didWritePackageJSON', scope });
 
@@ -141,6 +163,8 @@ async function createApp(scope: Scope) {
     ) {
       await fse.writeFile(join(rootPath, '.yarnrc.yml'), yarnNodeModulesConfig);
     }
+
+    await writePnpmWorkspaceConfig(scopeWithPnpmVersion, pnpmVersion);
 
     await trackUsage({ event: 'didCopyConfigurationFiles', scope });
   } catch (err) {

--- a/packages/cli/create-strapi-app/src/types.ts
+++ b/packages/cli/create-strapi-app/src/types.ts
@@ -65,6 +65,8 @@ export interface Scope {
   useExample?: boolean;
   gitInit?: boolean;
   shouldCreateGrowthSsoTrial: boolean;
+  /** Resolved at scaffold time when packageManager is pnpm (npm_config_user_agent or pnpm --version). */
+  pnpmVersion?: string | null;
 }
 
 export type ClientName = 'mysql' | 'postgres' | 'sqlite';

--- a/packages/cli/create-strapi-app/src/utils/package-json.ts
+++ b/packages/cli/create-strapi-app/src/utils/package-json.ts
@@ -3,6 +3,7 @@ import { kebabCase, mergeWith } from 'lodash';
 import fse from 'fs-extra';
 
 import { engines } from './engines';
+import { getPnpmOnlyBuiltDependencies, shouldUsePackageJsonPnpmConfig } from './pnpm-config';
 import type { Scope } from '../types';
 
 type PnpmPackageConfig = {
@@ -24,8 +25,8 @@ const mergePackageJson = (existingPkg: PackageJson, pkg: PackageJson) =>
     return undefined;
   });
 
-const getPnpmOnlyBuiltDependencies = (scope: Scope, existingPkg: PackageJson) => {
-  if (scope.packageManager !== 'pnpm' || scope.database.client !== 'sqlite') {
+const getPnpmPackageJsonConfig = (scope: Scope, existingPkg: PackageJson) => {
+  if (scope.packageManager !== 'pnpm' || !shouldUsePackageJsonPnpmConfig(scope.pnpmVersion)) {
     return {};
   }
 
@@ -36,9 +37,7 @@ const getPnpmOnlyBuiltDependencies = (scope: Scope, existingPkg: PackageJson) =>
   return {
     pnpm: {
       ...(existingPkg.pnpm ?? {}),
-      onlyBuiltDependencies: Array.from(
-        new Set([...existingOnlyBuiltDependencies, 'better-sqlite3'])
-      ).sort(),
+      onlyBuiltDependencies: getPnpmOnlyBuiltDependencies(scope, existingOnlyBuiltDependencies),
     },
   };
 };
@@ -63,7 +62,7 @@ export async function createPackageJSON(scope: Scope) {
       installId: scope.installId,
     },
     engines,
-    ...getPnpmOnlyBuiltDependencies(scope, existingPkg),
+    ...getPnpmPackageJsonConfig(scope, existingPkg),
   };
 
   // copy templates

--- a/packages/cli/create-strapi-app/src/utils/pnpm-config.ts
+++ b/packages/cli/create-strapi-app/src/utils/pnpm-config.ts
@@ -1,0 +1,128 @@
+import { join } from 'node:path';
+import fse from 'fs-extra';
+import semver from 'semver';
+
+import type { Scope } from '../types';
+
+/** allowBuilds in pnpm-workspace.yaml (pnpm >= 10.26). */
+export const PNPM_WORKSPACE_CONFIG_MIN_VERSION = '10.26.0';
+
+/** pnpm 11 reads project settings from pnpm-workspace.yaml only. */
+export const PNPM11_MIN_VERSION = '11.0.0';
+
+/**
+ * Native / tooling packages Strapi needs to run postinstall scripts for (admin build, upload, sqlite).
+ */
+export const PNPM_STRAPI_BUILD_PACKAGES = [
+  '@swc/core',
+  'core-js-pure',
+  'esbuild',
+  'sharp',
+] as const;
+
+export const PNPM_SQLITE_BUILD_PACKAGE = 'better-sqlite3';
+
+export const shouldUsePnpmWorkspaceConfig = (pnpmVersion: string | null | undefined): boolean => {
+  const normalized = pnpmVersion ? semver.coerce(pnpmVersion)?.version : null;
+
+  return normalized ? semver.gte(normalized, PNPM_WORKSPACE_CONFIG_MIN_VERSION) : true;
+};
+
+export const shouldUsePackageJsonPnpmConfig = (pnpmVersion: string | null | undefined): boolean => {
+  const normalized = pnpmVersion ? semver.coerce(pnpmVersion)?.version : null;
+
+  if (!normalized) {
+    return false;
+  }
+
+  return semver.lt(normalized, PNPM_WORKSPACE_CONFIG_MIN_VERSION);
+};
+
+export const getPnpmBuildPackageNames = (scope: Scope): string[] => {
+  const packages = new Set<string>(PNPM_STRAPI_BUILD_PACKAGES);
+
+  if (scope.database.client === 'sqlite') {
+    packages.add(PNPM_SQLITE_BUILD_PACKAGE);
+  }
+
+  return Array.from(packages).sort();
+};
+
+export const getPnpmAllowBuilds = (scope: Scope): Record<string, true> => {
+  return Object.fromEntries(getPnpmBuildPackageNames(scope).map((name) => [name, true])) as Record<
+    string,
+    true
+  >;
+};
+
+export const getPnpmOnlyBuiltDependencies = (scope: Scope, existing: string[] = []): string[] => {
+  return Array.from(new Set([...existing, ...getPnpmBuildPackageNames(scope)])).sort();
+};
+
+const quoteYamlKey = (key: string): string => {
+  if (/^[a-z0-9_-]+$/.test(key)) {
+    return key;
+  }
+
+  return `'${key}'`;
+};
+
+export const formatPnpmWorkspaceYaml = (scope: Scope, pnpmVersion: string | null): string => {
+  const allowBuilds = getPnpmAllowBuilds(scope);
+  const normalized = pnpmVersion ? semver.coerce(pnpmVersion)?.version : null;
+  const isPnpm11 = normalized ? semver.gte(normalized, PNPM11_MIN_VERSION) : true;
+
+  const lines = ['packages:', "  - '.'", ''];
+
+  if (isPnpm11) {
+    lines.push(
+      '# Allow day-0 @strapi/* npm publishes while keeping pnpm 11 supply-chain defaults for other deps.',
+      'minimumReleaseAgeExclude:',
+      "  - '@strapi/*'",
+      ''
+    );
+  }
+
+  lines.push('allowBuilds:');
+  for (const name of Object.keys(allowBuilds).sort()) {
+    lines.push(`  ${quoteYamlKey(name)}: true`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+};
+
+const hasParentPnpmWorkspace = async (rootPath: string): Promise<boolean> => {
+  let dir = join(rootPath, '..');
+
+  while (dir !== join(dir, '..')) {
+    if (await fse.pathExists(join(dir, 'pnpm-workspace.yaml'))) {
+      return true;
+    }
+
+    dir = join(dir, '..');
+  }
+
+  return false;
+};
+
+export const writePnpmWorkspaceConfig = async (
+  scope: Scope,
+  pnpmVersion: string | null
+): Promise<void> => {
+  if (scope.packageManager !== 'pnpm' || !shouldUsePnpmWorkspaceConfig(pnpmVersion)) {
+    return;
+  }
+
+  const workspaceFile = join(scope.rootPath, 'pnpm-workspace.yaml');
+
+  if (await hasParentPnpmWorkspace(scope.rootPath)) {
+    return;
+  }
+
+  if (await fse.pathExists(workspaceFile)) {
+    return;
+  }
+
+  await fse.writeFile(workspaceFile, formatPnpmWorkspaceYaml(scope, pnpmVersion));
+};

--- a/tests/cli/tests/create-strapi-app/package-json.test.cli.ts
+++ b/tests/cli/tests/create-strapi-app/package-json.test.cli.ts
@@ -27,6 +27,7 @@ function makeScope(rootPath: string, overrides: Partial<Scope> = {}): Scope {
     dependencies: {
       'better-sqlite3': '11.0.0',
     },
+    pnpmVersion: '11.8.0',
     ...overrides,
   };
 }
@@ -43,7 +44,24 @@ describe('createPackageJSON', () => {
     }
   });
 
-  it('replaces onlyBuiltDependencies instead of merging arrays by index', async () => {
+  it('writes pnpm-workspace.yaml allowBuilds for pnpm 11 instead of package.json pnpm config', async () => {
+    const projectDir = mkProjectDir();
+
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ scripts: { develop: 'strapi develop' } })
+      );
+
+      await createPackageJSON(makeScope(projectDir, { pnpmVersion: '11.8.0' }));
+
+      expect(readPkg(projectDir).pnpm).toBeUndefined();
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('replaces onlyBuiltDependencies for pnpm 10 instead of merging arrays by index', async () => {
     const projectDir = mkProjectDir();
 
     try {
@@ -57,10 +75,12 @@ describe('createPackageJSON', () => {
         })
       );
 
-      await createPackageJSON(makeScope(projectDir));
+      await createPackageJSON(makeScope(projectDir, { pnpmVersion: '10.25.0' }));
 
       expect(readPkg(projectDir).pnpm.onlyBuiltDependencies).toEqual([
+        '@swc/core',
         'better-sqlite3',
+        'core-js-pure',
         'esbuild',
         'sharp',
       ]);
@@ -69,7 +89,7 @@ describe('createPackageJSON', () => {
     }
   });
 
-  it('filters non-string onlyBuiltDependencies entries from existing package.json', async () => {
+  it('filters non-string onlyBuiltDependencies entries from existing package.json on pnpm 10', async () => {
     const projectDir = mkProjectDir();
 
     try {
@@ -83,10 +103,40 @@ describe('createPackageJSON', () => {
         })
       );
 
-      await createPackageJSON(makeScope(projectDir));
+      await createPackageJSON(makeScope(projectDir, { pnpmVersion: '10.25.0' }));
 
       expect(readPkg(projectDir).pnpm.onlyBuiltDependencies).toEqual([
+        '@swc/core',
         'better-sqlite3',
+        'core-js-pure',
+        'esbuild',
+        'sharp',
+      ]);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits better-sqlite3 from pnpm 10 onlyBuiltDependencies for non-sqlite databases', async () => {
+    const projectDir = mkProjectDir();
+
+    try {
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ scripts: { develop: 'strapi develop' } })
+      );
+
+      await createPackageJSON(
+        makeScope(projectDir, {
+          pnpmVersion: '10.25.0',
+          database: { client: 'postgres' },
+          dependencies: { '@strapi/strapi': '5.48.0' },
+        })
+      );
+
+      expect(readPkg(projectDir).pnpm.onlyBuiltDependencies).toEqual([
+        '@swc/core',
+        'core-js-pure',
         'esbuild',
         'sharp',
       ]);

--- a/tests/cli/tests/create-strapi-app/pnpm-config.test.cli.ts
+++ b/tests/cli/tests/create-strapi-app/pnpm-config.test.cli.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  formatPnpmWorkspaceYaml,
+  getPnpmAllowBuilds,
+  getPnpmBuildPackageNames,
+  shouldUsePackageJsonPnpmConfig,
+  shouldUsePnpmWorkspaceConfig,
+  writePnpmWorkspaceConfig,
+} from '../../../../packages/cli/create-strapi-app/src/utils/pnpm-config';
+import type { Scope } from '../../../../packages/cli/create-strapi-app/src/types';
+
+function mkProjectDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'strapi-csa-pnpm-config-test-'));
+}
+
+function makeScope(rootPath: string, overrides: Partial<Scope> = {}): Scope {
+  return {
+    name: 'My App',
+    rootPath,
+    packageManager: 'pnpm',
+    database: { client: 'sqlite' },
+    shouldCreateGrowthSsoTrial: false,
+    uuid: 'test-uuid',
+    installId: 'test-install-id',
+    ...overrides,
+  };
+}
+
+describe('pnpm-config', () => {
+  it('uses pnpm-workspace.yaml for pnpm 10.26+ and package.json for older pnpm', () => {
+    expect(shouldUsePnpmWorkspaceConfig('10.25.9')).toBe(false);
+    expect(shouldUsePnpmWorkspaceConfig('10.26.0')).toBe(true);
+    expect(shouldUsePnpmWorkspaceConfig('11.8.0')).toBe(true);
+    expect(shouldUsePnpmWorkspaceConfig(null)).toBe(true);
+
+    expect(shouldUsePackageJsonPnpmConfig('10.25.9')).toBe(true);
+    expect(shouldUsePackageJsonPnpmConfig('10.26.0')).toBe(false);
+    expect(shouldUsePackageJsonPnpmConfig('11.8.0')).toBe(false);
+    expect(shouldUsePackageJsonPnpmConfig(null)).toBe(false);
+  });
+
+  it('includes Strapi native build packages and sqlite only for sqlite projects', () => {
+    const sqliteDir = mkProjectDir();
+    const postgresDir = mkProjectDir();
+
+    try {
+      expect(getPnpmBuildPackageNames(makeScope(sqliteDir))).toEqual([
+        '@swc/core',
+        'better-sqlite3',
+        'core-js-pure',
+        'esbuild',
+        'sharp',
+      ]);
+      expect(
+        getPnpmBuildPackageNames(makeScope(postgresDir, { database: { client: 'postgres' } }))
+      ).toEqual(['@swc/core', 'core-js-pure', 'esbuild', 'sharp']);
+    } finally {
+      fs.rmSync(sqliteDir, { recursive: true, force: true });
+      fs.rmSync(postgresDir, { recursive: true, force: true });
+    }
+  });
+
+  it('formats pnpm-workspace.yaml with allowBuilds and @strapi release-age exclude on pnpm 11', () => {
+    const projectDir = mkProjectDir();
+
+    try {
+      const yaml = formatPnpmWorkspaceYaml(makeScope(projectDir), '11.8.0');
+
+      expect(yaml).toContain("packages:\n  - '.'");
+      expect(yaml).toContain("minimumReleaseAgeExclude:\n  - '@strapi/*'");
+      expect(yaml).toContain("'@swc/core': true");
+      expect(yaml).toContain('better-sqlite3: true');
+      expect(yaml).toContain('sharp: true');
+      expect(getPnpmAllowBuilds(makeScope(projectDir))).toMatchObject({
+        '@swc/core': true,
+        'better-sqlite3': true,
+      });
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits minimumReleaseAgeExclude for pnpm 10.26', () => {
+    const projectDir = mkProjectDir();
+
+    try {
+      const yaml = formatPnpmWorkspaceYaml(makeScope(projectDir), '10.26.0');
+
+      expect(yaml).not.toContain('minimumReleaseAgeExclude');
+      expect(yaml).toContain('allowBuilds:');
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes pnpm-workspace.yaml for standalone pnpm projects', async () => {
+    const projectDir = mkProjectDir();
+
+    try {
+      await writePnpmWorkspaceConfig(makeScope(projectDir), '11.8.0');
+
+      expect(fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'))).toBe(true);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write pnpm-workspace.yaml inside an existing pnpm workspace', async () => {
+    const monorepoDir = mkProjectDir();
+    const projectDir = path.join(monorepoDir, 'apps', 'strapi');
+
+    try {
+      fs.mkdirSync(projectDir, { recursive: true });
+      fs.writeFileSync(path.join(monorepoDir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n");
+
+      await writePnpmWorkspaceConfig(makeScope(projectDir), '11.8.0');
+
+      expect(fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'))).toBe(false);
+    } finally {
+      fs.rmSync(monorepoDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
+++ b/tests/cli/tests/create-strapi-app/scaffold.test.cli.js
@@ -121,17 +121,45 @@ describe('create-strapi-app', () => {
     }
   });
 
-  it('allows pnpm to build better-sqlite3 for SQLite projects', async () => {
+  it('scaffolds pnpm-workspace.yaml allowBuilds for SQLite projects on pnpm 11', async () => {
     const projectDir = mkProjectDir();
     try {
-      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-pnpm'])
+      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-pnpm'], {
+        npm_config_user_agent: 'pnpm/11.8.0 npm/? node/v24.12.0 darwin arm64',
+      })
+        .expect('code', 0)
+        .end();
+
+      const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8'));
+      const workspace = fs.readFileSync(path.join(projectDir, 'pnpm-workspace.yaml'), 'utf8');
+
+      expect(pkg.dependencies).toMatchObject({ 'better-sqlite3': expect.any(String) });
+      expect(pkg.pnpm).toBeUndefined();
+      expect(workspace).toContain('allowBuilds:');
+      expect(workspace).toContain('better-sqlite3: true');
+      expect(workspace).toContain('sharp: true');
+      expect(workspace).toContain("'@swc/core': true");
+      expect(workspace).toContain("minimumReleaseAgeExclude:\n  - '@strapi/*'");
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes package.json onlyBuiltDependencies for pnpm 10', async () => {
+    const projectDir = mkProjectDir();
+    try {
+      await spawnCsa([projectDir, ...baseScaffoldArgs, '--use-pnpm'], {
+        npm_config_user_agent: 'pnpm/10.25.0 npm/? node/v24.12.0 darwin arm64',
+      })
         .expect('code', 0)
         .end();
 
       const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8'));
 
-      expect(pkg.dependencies).toMatchObject({ 'better-sqlite3': expect.any(String) });
-      expect(pkg.pnpm).toMatchObject({ onlyBuiltDependencies: ['better-sqlite3'] });
+      expect(pkg.pnpm.onlyBuiltDependencies).toEqual(
+        expect.arrayContaining(['@swc/core', 'better-sqlite3', 'esbuild', 'sharp'])
+      );
+      expect(fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'))).toBe(false);
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
### What does it do?

Scaffolds pnpm-compatible native dependency build config for new Strapi apps:

- **pnpm >= 10.26** (incl. 11): writes `pnpm-workspace.yaml` with `allowBuilds` for Strapi tooling (`@swc/core`, `esbuild`, `sharp`, `core-js-pure`, and `better-sqlite3` for SQLite projects).
- **pnpm < 10.26**: keeps `package.json#pnpm.onlyBuiltDependencies` (legacy allowlist API).
- **pnpm 11+**: adds `minimumReleaseAgeExclude: ['@strapi/*']` so day-0 Strapi npm releases remain installable on Cloud while keeping pnpm's supply-chain defaults for other packages.

Detects pnpm version from `npm_config_user_agent` or `pnpm --version` at scaffold time.

### Why is it needed?

pnpm 11 no longer reads `package.json#pnpm` settings. Our scaffold only wrote `onlyBuiltDependencies: ['better-sqlite3']`, which is ignored on pnpm 11. With `strictDepBuilds`, installs on Strapi Cloud (and local pnpm 11) fail because native/tooling postinstall scripts for `sharp`, `esbuild`, `@swc/core`, etc. never run.

Reported internally (Giulio Montagner) — related to pnpm 11 + Cloud deploy failures, distinct from #26755 (admin Vite alias resolution).

### How to test it?

```bash
yarn nx build create-strapi-app
yarn test:cli --testPathPattern="create-strapi-app/(package-json|pnpm-config|scaffold)"
```

Manual:
1. `npx create-strapi-app@latest my-app --use-pnpm --no-install`
2. Confirm `pnpm-workspace.yaml` contains `allowBuilds` entries on pnpm 11.
3. `cd my-app && pnpm install && pnpm run build`

### Related issue(s)/PR(s)

Related to #26755 (separate admin bundle issue)